### PR TITLE
feat(clients): adopt model controls, session management, and keyboard history recall on iOS

### DIFF
--- a/apps/.i18n/apple-translation-contradictions.json
+++ b/apps/.i18n/apple-translation-contradictions.json
@@ -2129,6 +2129,46 @@
       ]
     },
     {
+      "locale": "ar",
+      "source": "Delete Thread",
+      "translations": [
+        "حذف المحادثة",
+        "حذف سلسلة المحادثة"
+      ]
+    },
+    {
+      "locale": "sv",
+      "source": "Delete Thread",
+      "translations": [
+        "Radera tråd",
+        "Ta bort tråd"
+      ]
+    },
+    {
+      "locale": "tr",
+      "source": "Delete Thread",
+      "translations": [
+        "İleti Dizisini Sil",
+        "İş Parçacığını Sil"
+      ]
+    },
+    {
+      "locale": "zh-CN",
+      "source": "Delete Thread",
+      "translations": [
+        "删除对话",
+        "删除话题"
+      ]
+    },
+    {
+      "locale": "zh-TW",
+      "source": "Delete Thread",
+      "translations": [
+        "刪除對話串",
+        "刪除討論串"
+      ]
+    },
+    {
       "locale": "fr",
       "source": "Delete “%@”?",
       "translations": [
@@ -3021,11 +3061,20 @@
       ]
     },
     {
+      "locale": "fr",
+      "source": "Fork",
+      "translations": [
+        "Bifurquer",
+        "Dupliquer"
+      ]
+    },
+    {
       "locale": "hi",
       "source": "Fork",
       "translations": [
         "Fork",
-        "फ़ोर्क करें"
+        "फ़ोर्क करें",
+        "फोर्क"
       ]
     },
     {
@@ -3033,6 +3082,7 @@
       "source": "Fork",
       "translations": [
         "Buat Cabang",
+        "Cabangkan",
         "Fork"
       ]
     },
@@ -3041,6 +3091,7 @@
       "source": "Fork",
       "translations": [
         "Crea fork",
+        "Dirama",
         "Duplica",
         "Fork"
       ]
@@ -3064,6 +3115,14 @@
       ]
     },
     {
+      "locale": "pt-BR",
+      "source": "Fork",
+      "translations": [
+        "Bifurcar",
+        "Ramificar"
+      ]
+    },
+    {
       "locale": "ru",
       "source": "Fork",
       "translations": [
@@ -3077,7 +3136,16 @@
       "source": "Fork",
       "translations": [
         "แยกสาขา",
-        "แยกเซสชัน"
+        "แยกเซสชัน",
+        "แยกแขนง"
+      ]
+    },
+    {
+      "locale": "tr",
+      "source": "Fork",
+      "translations": [
+        "Dallandır",
+        "Çatalla"
       ]
     },
     {
@@ -3104,6 +3172,14 @@
         "分叉",
         "分支",
         "创建分支"
+      ]
+    },
+    {
+      "locale": "zh-TW",
+      "source": "Fork",
+      "translations": [
+        "分支",
+        "建立分支"
       ]
     },
     {
@@ -5029,6 +5105,54 @@
     },
     {
       "locale": "ar",
+      "source": "New Thread",
+      "translations": [
+        "سلسلة محادثة جديدة",
+        "محادثة جديدة"
+      ]
+    },
+    {
+      "locale": "fr",
+      "source": "New Thread",
+      "translations": [
+        "Nouveau fil",
+        "Nouveau fil de discussion"
+      ]
+    },
+    {
+      "locale": "ja-JP",
+      "source": "New Thread",
+      "translations": [
+        "新しいスレッド",
+        "新規スレッド"
+      ]
+    },
+    {
+      "locale": "nl",
+      "source": "New Thread",
+      "translations": [
+        "Nieuw gesprek",
+        "Nieuwe thread"
+      ]
+    },
+    {
+      "locale": "tr",
+      "source": "New Thread",
+      "translations": [
+        "Yeni İleti Dizisi",
+        "Yeni İş Parçacığı"
+      ]
+    },
+    {
+      "locale": "zh-CN",
+      "source": "New Thread",
+      "translations": [
+        "新建对话",
+        "新建话题"
+      ]
+    },
+    {
+      "locale": "ar",
       "source": "No approvals waiting",
       "translations": [
         "لا توجد موافقات بانتظار المراجعة",
@@ -5113,6 +5237,46 @@
       "translations": [
         "沒有待核准項目",
         "沒有待處理的核准"
+      ]
+    },
+    {
+      "locale": "fr",
+      "source": "No archived threads",
+      "translations": [
+        "Aucun fil archivé",
+        "Aucun fil de discussion archivé"
+      ]
+    },
+    {
+      "locale": "nl",
+      "source": "No archived threads",
+      "translations": [
+        "Geen gearchiveerde gesprekken",
+        "Geen gearchiveerde threads"
+      ]
+    },
+    {
+      "locale": "uk",
+      "source": "No archived threads",
+      "translations": [
+        "Немає архівних гілок",
+        "Немає архівованих гілок"
+      ]
+    },
+    {
+      "locale": "vi",
+      "source": "No archived threads",
+      "translations": [
+        "Không có luồng nào đã lưu trữ",
+        "Không có luồng nào được lưu trữ"
+      ]
+    },
+    {
+      "locale": "zh-TW",
+      "source": "No archived threads",
+      "translations": [
+        "沒有已封存的對話串",
+        "沒有已封存的討論串"
       ]
     },
     {
@@ -5537,6 +5701,14 @@
       "translations": [
         "OK",
         "ОК"
+      ]
+    },
+    {
+      "locale": "zh-CN",
+      "source": "OK",
+      "translations": [
+        "好",
+        "确定"
       ]
     },
     {
@@ -7106,6 +7278,62 @@
       "translations": [
         "Groep hernoemen",
         "Groepsnaam wijzigen"
+      ]
+    },
+    {
+      "locale": "ar",
+      "source": "Rename Thread",
+      "translations": [
+        "إعادة تسمية المحادثة",
+        "إعادة تسمية سلسلة المحادثة"
+      ]
+    },
+    {
+      "locale": "es",
+      "source": "Rename Thread",
+      "translations": [
+        "Cambiar el nombre del hilo",
+        "Renombrar hilo"
+      ]
+    },
+    {
+      "locale": "fr",
+      "source": "Rename Thread",
+      "translations": [
+        "Renommer le fil",
+        "Renommer le fil de discussion"
+      ]
+    },
+    {
+      "locale": "nl",
+      "source": "Rename Thread",
+      "translations": [
+        "Gesprek hernoemen",
+        "Thread hernoemen"
+      ]
+    },
+    {
+      "locale": "tr",
+      "source": "Rename Thread",
+      "translations": [
+        "İleti Dizisini Yeniden Adlandır",
+        "İş Parçacığını Yeniden Adlandır"
+      ]
+    },
+    {
+      "locale": "zh-CN",
+      "source": "Rename Thread",
+      "translations": [
+        "重命名对话",
+        "重命名话题"
+      ]
+    },
+    {
+      "locale": "zh-TW",
+      "source": "Rename Thread",
+      "translations": [
+        "重新命名對話串",
+        "重新命名討論串"
       ]
     },
     {
@@ -8878,6 +9106,214 @@
       "translations": [
         "Час виконання цієї автоматизації ще не настав.",
         "Час запуску цієї автоматизації ще не настав."
+      ]
+    },
+    {
+      "locale": "fr",
+      "source": "Thread",
+      "translations": [
+        "Fil",
+        "Fil de discussion"
+      ]
+    },
+    {
+      "locale": "it",
+      "source": "Thread",
+      "translations": [
+        "Conversazione",
+        "Thread"
+      ]
+    },
+    {
+      "locale": "nl",
+      "source": "Thread",
+      "translations": [
+        "Gesprek",
+        "Thread"
+      ]
+    },
+    {
+      "locale": "tr",
+      "source": "Thread",
+      "translations": [
+        "Dizi",
+        "Konu"
+      ]
+    },
+    {
+      "locale": "vi",
+      "source": "Thread",
+      "translations": [
+        "Chuỗi",
+        "Luồng"
+      ]
+    },
+    {
+      "locale": "zh-CN",
+      "source": "Thread",
+      "translations": [
+        "对话串",
+        "话题串"
+      ]
+    },
+    {
+      "locale": "zh-TW",
+      "source": "Thread",
+      "translations": [
+        "對話串",
+        "討論串"
+      ]
+    },
+    {
+      "locale": "ar",
+      "source": "Thread name",
+      "translations": [
+        "اسم المحادثة",
+        "اسم سلسلة المحادثة"
+      ]
+    },
+    {
+      "locale": "fr",
+      "source": "Thread name",
+      "translations": [
+        "Nom du fil",
+        "Nom du fil de discussion"
+      ]
+    },
+    {
+      "locale": "nl",
+      "source": "Thread name",
+      "translations": [
+        "Gespreksnaam",
+        "Threadnaam"
+      ]
+    },
+    {
+      "locale": "tr",
+      "source": "Thread name",
+      "translations": [
+        "İleti dizisi adı",
+        "İş parçacığı adı"
+      ]
+    },
+    {
+      "locale": "zh-CN",
+      "source": "Thread name",
+      "translations": [
+        "对话名称",
+        "话题名称"
+      ]
+    },
+    {
+      "locale": "zh-TW",
+      "source": "Thread name",
+      "translations": [
+        "對話串名稱",
+        "討論串名稱"
+      ]
+    },
+    {
+      "locale": "fr",
+      "source": "Threads",
+      "translations": [
+        "Fils",
+        "Fils de discussion"
+      ]
+    },
+    {
+      "locale": "it",
+      "source": "Threads",
+      "translations": [
+        "Conversazioni",
+        "Thread"
+      ]
+    },
+    {
+      "locale": "nl",
+      "source": "Threads",
+      "translations": [
+        "Gesprekken",
+        "Threads"
+      ]
+    },
+    {
+      "locale": "tr",
+      "source": "Threads",
+      "translations": [
+        "Diziler",
+        "İş Parçacıkları"
+      ]
+    },
+    {
+      "locale": "vi",
+      "source": "Threads",
+      "translations": [
+        "Chuỗi",
+        "Luồng"
+      ]
+    },
+    {
+      "locale": "zh-CN",
+      "source": "Threads",
+      "translations": [
+        "对话",
+        "话题串"
+      ]
+    },
+    {
+      "locale": "zh-TW",
+      "source": "Threads",
+      "translations": [
+        "對話串",
+        "討論串"
+      ]
+    },
+    {
+      "locale": "ar",
+      "source": "Threads…",
+      "translations": [
+        "المحادثات…",
+        "سلاسل المحادثات…"
+      ]
+    },
+    {
+      "locale": "it",
+      "source": "Threads…",
+      "translations": [
+        "Conversazioni…",
+        "Thread…"
+      ]
+    },
+    {
+      "locale": "nl",
+      "source": "Threads…",
+      "translations": [
+        "Gesprekken…",
+        "Threads…"
+      ]
+    },
+    {
+      "locale": "tr",
+      "source": "Threads…",
+      "translations": [
+        "İletişim Dizileri…",
+        "İş Parçacıkları…"
+      ]
+    },
+    {
+      "locale": "zh-CN",
+      "source": "Threads…",
+      "translations": [
+        "会话…",
+        "对话…"
+      ]
+    },
+    {
+      "locale": "zh-TW",
+      "source": "Threads…",
+      "translations": [
+        "對話串…",
+        "討論串…"
       ]
     },
     {

--- a/apps/.i18n/apple-translation-contradictions.json
+++ b/apps/.i18n/apple-translation-contradictions.json
@@ -1975,6 +1975,30 @@
       ]
     },
     {
+      "locale": "fa",
+      "source": "Default (inherited)",
+      "translations": [
+        "پیش‌فرض (ارث‌بری‌شده)",
+        "پیش‌فرض (به‌ارث‌رسیده)"
+      ]
+    },
+    {
+      "locale": "pl",
+      "source": "Default (inherited)",
+      "translations": [
+        "Domyślne (dziedziczone)",
+        "Domyślne (odziedziczone)"
+      ]
+    },
+    {
+      "locale": "th",
+      "source": "Default (inherited)",
+      "translations": [
+        "ค่าเริ่มต้น (สืบทอด)",
+        "ค่าเริ่มต้น (สืบทอดมา)"
+      ]
+    },
+    {
       "locale": "ko",
       "source": "Default Agent",
       "translations": [
@@ -2972,6 +2996,22 @@
       ]
     },
     {
+      "locale": "ko",
+      "source": "Fast",
+      "translations": [
+        "빠르게",
+        "빠름"
+      ]
+    },
+    {
+      "locale": "pl",
+      "source": "Fast",
+      "translations": [
+        "Szybkie",
+        "Szybko"
+      ]
+    },
+    {
       "locale": "ar",
       "source": "Forget Gateway",
       "translations": [
@@ -3147,6 +3187,7 @@
       "source": "Full",
       "translations": [
         "Pełna",
+        "Pełne",
         "Pełny"
       ]
     },
@@ -3155,6 +3196,7 @@
       "source": "Full",
       "translations": [
         "Полная",
+        "Полное",
         "Полный"
       ]
     },
@@ -3171,6 +3213,7 @@
       "source": "Full",
       "translations": [
         "Повна",
+        "Повне",
         "Повний"
       ]
     },
@@ -5077,6 +5120,22 @@
       ]
     },
     {
+      "locale": "pt-BR",
+      "source": "New Session Options…",
+      "translations": [
+        "Opções da nova sessão…",
+        "Opções de Nova Sessão…"
+      ]
+    },
+    {
+      "locale": "zh-CN",
+      "source": "New Session Options…",
+      "translations": [
+        "新会话选项…",
+        "新建会话选项…"
+      ]
+    },
+    {
       "locale": "ar",
       "source": "No approvals waiting",
       "translations": [
@@ -5800,6 +5859,14 @@
       ]
     },
     {
+      "locale": "uk",
+      "source": "Off",
+      "translations": [
+        "Вимк.",
+        "Вимкнено"
+      ]
+    },
+    {
       "locale": "zh-TW",
       "source": "Off",
       "translations": [
@@ -5967,6 +6034,14 @@
       "translations": [
         "Ativado",
         "Ligado"
+      ]
+    },
+    {
+      "locale": "uk",
+      "source": "On",
+      "translations": [
+        "Увімк.",
+        "Увімкнено"
       ]
     },
     {
@@ -6562,6 +6637,14 @@
       ]
     },
     {
+      "locale": "ja-JP",
+      "source": "Pinned",
+      "translations": [
+        "ピン留め",
+        "ピン留め済み"
+      ]
+    },
+    {
       "locale": "pl",
       "source": "Pinned",
       "translations": [
@@ -6574,7 +6657,8 @@
       "source": "Pinned",
       "translations": [
         "Fixada",
-        "Fixado"
+        "Fixado",
+        "Fixados"
       ]
     },
     {
@@ -6917,6 +7001,7 @@
       "locale": "hi",
       "source": "Recent",
       "translations": [
+        "हाल के",
         "हाल ही के",
         "हालिया"
       ]
@@ -6927,6 +7012,22 @@
       "translations": [
         "Son",
         "Son Kullanılanlar"
+      ]
+    },
+    {
+      "locale": "uk",
+      "source": "Recent",
+      "translations": [
+        "Нещодавні",
+        "Останні"
+      ]
+    },
+    {
+      "locale": "zh-TW",
+      "source": "Recent",
+      "translations": [
+        "最近",
+        "最近使用"
       ]
     },
     {
@@ -8812,6 +8913,7 @@
       "locale": "de",
       "source": "Thinking",
       "translations": [
+        "Denkmodus",
         "Denkprozess",
         "Denkt nach",
         "Nachdenken"
@@ -8838,7 +8940,8 @@
       "source": "Thinking",
       "translations": [
         "विचार प्रक्रिया",
-        "सोच रहा है"
+        "सोच रहा है",
+        "सोच-विचार"
       ]
     },
     {
@@ -8880,6 +8983,7 @@
       "translations": [
         "Aan het nadenken",
         "Denken",
+        "Denkmodus",
         "Redeneren"
       ]
     },
@@ -9656,6 +9760,30 @@
       "translations": [
         "Dùng Thiết lập thủ công",
         "Sử dụng thiết lập thủ công"
+      ]
+    },
+    {
+      "locale": "fr",
+      "source": "Verbosity",
+      "translations": [
+        "Niveau de détail",
+        "Verbosité"
+      ]
+    },
+    {
+      "locale": "pt-BR",
+      "source": "Verbosity",
+      "translations": [
+        "Nível de detalhe",
+        "Nível de detalhes"
+      ]
+    },
+    {
+      "locale": "tr",
+      "source": "Verbosity",
+      "translations": [
+        "Ayrıntı Düzeyi",
+        "Ayrıntı düzeyi"
       ]
     },
     {

--- a/apps/.i18n/apple-translation-contradictions.json
+++ b/apps/.i18n/apple-translation-contradictions.json
@@ -2129,54 +2129,6 @@
       ]
     },
     {
-      "locale": "fa",
-      "source": "Delete Thread",
-      "translations": [
-        "حذف رشته",
-        "حذف گفت‌وگو"
-      ]
-    },
-    {
-      "locale": "fr",
-      "source": "Delete Thread",
-      "translations": [
-        "Supprimer la discussion",
-        "Supprimer le fil"
-      ]
-    },
-    {
-      "locale": "nl",
-      "source": "Delete Thread",
-      "translations": [
-        "Gesprek verwijderen",
-        "Thread verwijderen"
-      ]
-    },
-    {
-      "locale": "ru",
-      "source": "Delete Thread",
-      "translations": [
-        "Удалить ветку",
-        "Удалить обсуждение"
-      ]
-    },
-    {
-      "locale": "tr",
-      "source": "Delete Thread",
-      "translations": [
-        "Konuyu Sil",
-        "Yazışmayı Sil"
-      ]
-    },
-    {
-      "locale": "vi",
-      "source": "Delete Thread",
-      "translations": [
-        "Xóa cuộc trò chuyện",
-        "Xóa luồng"
-      ]
-    },
-    {
       "locale": "fr",
       "source": "Delete “%@”?",
       "translations": [
@@ -3047,7 +2999,6 @@
       "locale": "ar",
       "source": "Fork",
       "translations": [
-        "إنشاء فرع",
         "تشعيب",
         "تفريع",
         "تفرّع"
@@ -3070,20 +3021,11 @@
       ]
     },
     {
-      "locale": "fr",
-      "source": "Fork",
-      "translations": [
-        "Bifurquer",
-        "Dupliquer"
-      ]
-    },
-    {
       "locale": "hi",
       "source": "Fork",
       "translations": [
         "Fork",
-        "फ़ोर्क करें",
-        "फोर्क"
+        "फ़ोर्क करें"
       ]
     },
     {
@@ -3098,18 +3040,9 @@
       "locale": "it",
       "source": "Fork",
       "translations": [
-        "Crea diramazione",
         "Crea fork",
         "Duplica",
         "Fork"
-      ]
-    },
-    {
-      "locale": "ko",
-      "source": "Fork",
-      "translations": [
-        "분기",
-        "포크"
       ]
     },
     {
@@ -3144,8 +3077,7 @@
       "source": "Fork",
       "translations": [
         "แยกสาขา",
-        "แยกเซสชัน",
-        "แยกแขนง"
+        "แยกเซสชัน"
       ]
     },
     {
@@ -5096,46 +5028,6 @@
       ]
     },
     {
-      "locale": "fa",
-      "source": "New Thread",
-      "translations": [
-        "رشته جدید",
-        "گفت‌وگوی جدید"
-      ]
-    },
-    {
-      "locale": "fr",
-      "source": "New Thread",
-      "translations": [
-        "Nouveau fil",
-        "Nouvelle conversation"
-      ]
-    },
-    {
-      "locale": "vi",
-      "source": "New Thread",
-      "translations": [
-        "Cuộc trò chuyện mới",
-        "Luồng mới"
-      ]
-    },
-    {
-      "locale": "pt-BR",
-      "source": "New Session Options…",
-      "translations": [
-        "Opções da nova sessão…",
-        "Opções de Nova Sessão…"
-      ]
-    },
-    {
-      "locale": "zh-CN",
-      "source": "New Session Options…",
-      "translations": [
-        "新会话选项…",
-        "新建会话选项…"
-      ]
-    },
-    {
       "locale": "ar",
       "source": "No approvals waiting",
       "translations": [
@@ -5221,54 +5113,6 @@
       "translations": [
         "沒有待核准項目",
         "沒有待處理的核准"
-      ]
-    },
-    {
-      "locale": "fa",
-      "source": "No archived threads",
-      "translations": [
-        "رشته بایگانی‌شده‌ای وجود ندارد",
-        "هیچ رشته بایگانی‌شده‌ای وجود ندارد"
-      ]
-    },
-    {
-      "locale": "fr",
-      "source": "No archived threads",
-      "translations": [
-        "Aucune conversation archivée",
-        "Aucune discussion archivée"
-      ]
-    },
-    {
-      "locale": "nl",
-      "source": "No archived threads",
-      "translations": [
-        "Geen gearchiveerde gesprekken",
-        "Geen gearchiveerde threads"
-      ]
-    },
-    {
-      "locale": "ru",
-      "source": "No archived threads",
-      "translations": [
-        "Нет архивных веток",
-        "Нет архивных обсуждений"
-      ]
-    },
-    {
-      "locale": "tr",
-      "source": "No archived threads",
-      "translations": [
-        "Arşivlenmiş konu yok",
-        "Arşivlenmiş yazışma yok"
-      ]
-    },
-    {
-      "locale": "vi",
-      "source": "No archived threads",
-      "translations": [
-        "Không có luồng nào đã lưu trữ",
-        "Không có luồng đã lưu trữ"
       ]
     },
     {
@@ -5489,78 +5333,6 @@
     },
     {
       "locale": "ar",
-      "source": "No recent threads",
-      "translations": [
-        "لا توجد سلاسل محادثات حديثة",
-        "لا توجد محادثات حديثة"
-      ]
-    },
-    {
-      "locale": "de",
-      "source": "No recent threads",
-      "translations": [
-        "Keine aktuellen Threads",
-        "Keine neuen Threads"
-      ]
-    },
-    {
-      "locale": "fa",
-      "source": "No recent threads",
-      "translations": [
-        "رشته اخیری وجود ندارد",
-        "هیچ رشتهٔ اخیری وجود ندارد"
-      ]
-    },
-    {
-      "locale": "fr",
-      "source": "No recent threads",
-      "translations": [
-        "Aucun fil de discussion récent",
-        "Aucune discussion récente"
-      ]
-    },
-    {
-      "locale": "hi",
-      "source": "No recent threads",
-      "translations": [
-        "कोई हाल का थ्रेड नहीं",
-        "कोई हालिया थ्रेड नहीं"
-      ]
-    },
-    {
-      "locale": "ru",
-      "source": "No recent threads",
-      "translations": [
-        "Нет недавних веток",
-        "Нет недавних обсуждений"
-      ]
-    },
-    {
-      "locale": "tr",
-      "source": "No recent threads",
-      "translations": [
-        "Son yazışma yok",
-        "Yakın zamanda konu yok"
-      ]
-    },
-    {
-      "locale": "uk",
-      "source": "No recent threads",
-      "translations": [
-        "Немає нещодавніх гілок",
-        "Немає останніх гілок"
-      ]
-    },
-    {
-      "locale": "zh-TW",
-      "source": "No recent threads",
-      "translations": [
-        "沒有最近的對話串",
-        "沒有最近的討論串"
-      ]
-    },
-    {
-      "locale": "ar",
       "source": "No skills found",
       "translations": [
         "لم يتم العثور على Skills",
@@ -5765,22 +5537,6 @@
       "translations": [
         "OK",
         "ОК"
-      ]
-    },
-    {
-      "locale": "uk",
-      "source": "OK",
-      "translations": [
-        "OK",
-        "ОК"
-      ]
-    },
-    {
-      "locale": "zh-CN",
-      "source": "OK",
-      "translations": [
-        "好",
-        "确定"
       ]
     },
     {
@@ -7353,71 +7109,6 @@
       ]
     },
     {
-      "locale": "es",
-      "source": "Rename Thread",
-      "translations": [
-        "Cambiar el nombre del hilo",
-        "Renombrar hilo"
-      ]
-    },
-    {
-      "locale": "fa",
-      "source": "Rename Thread",
-      "translations": [
-        "تغییر نام رشته",
-        "تغییر نام گفت‌وگو"
-      ]
-    },
-    {
-      "locale": "fr",
-      "source": "Rename Thread",
-      "translations": [
-        "Renommer la conversation",
-        "Renommer la discussion",
-        "Renommer le fil"
-      ]
-    },
-    {
-      "locale": "id",
-      "source": "Rename Thread",
-      "translations": [
-        "Ganti Nama Utas",
-        "Ubah Nama Utas"
-      ]
-    },
-    {
-      "locale": "nl",
-      "source": "Rename Thread",
-      "translations": [
-        "Gesprek hernoemen",
-        "Thread hernoemen"
-      ]
-    },
-    {
-      "locale": "ru",
-      "source": "Rename Thread",
-      "translations": [
-        "Переименовать ветку",
-        "Переименовать обсуждение"
-      ]
-    },
-    {
-      "locale": "tr",
-      "source": "Rename Thread",
-      "translations": [
-        "Konuyu Yeniden Adlandır",
-        "Yazışmayı Yeniden Adlandır"
-      ]
-    },
-    {
-      "locale": "vi",
-      "source": "Rename Thread",
-      "translations": [
-        "Đổi tên cuộc trò chuyện",
-        "Đổi tên luồng"
-      ]
-    },
-    {
       "locale": "ar",
       "source": "Rename…",
       "translations": [
@@ -8250,22 +7941,6 @@
       "translations": [
         "搜索 agent",
         "搜索代理"
-      ]
-    },
-    {
-      "locale": "pt-BR",
-      "source": "Search threads",
-      "translations": [
-        "Buscar conversas",
-        "Pesquisar conversas"
-      ]
-    },
-    {
-      "locale": "zh-TW",
-      "source": "Search threads",
-      "translations": [
-        "搜尋對話串",
-        "搜尋討論串"
       ]
     },
     {
@@ -9203,274 +8878,6 @@
       "translations": [
         "Час виконання цієї автоматизації ще не настав.",
         "Час запуску цієї автоматизації ще не настав."
-      ]
-    },
-    {
-      "locale": "ar",
-      "source": "Thread",
-      "translations": [
-        "المحادثة",
-        "سلسلة المحادثة"
-      ]
-    },
-    {
-      "locale": "fr",
-      "source": "Thread",
-      "translations": [
-        "Conversation",
-        "Fil de discussion"
-      ]
-    },
-    {
-      "locale": "nl",
-      "source": "Thread",
-      "translations": [
-        "Gesprek",
-        "Thread"
-      ]
-    },
-    {
-      "locale": "zh-TW",
-      "source": "Thread",
-      "translations": [
-        "對話串",
-        "討論串"
-      ]
-    },
-    {
-      "locale": "de",
-      "source": "Thread name",
-      "translations": [
-        "Thread-Name",
-        "Threadname"
-      ]
-    },
-    {
-      "locale": "fa",
-      "source": "Thread name",
-      "translations": [
-        "نام رشته",
-        "نام گفت‌وگو"
-      ]
-    },
-    {
-      "locale": "fr",
-      "source": "Thread name",
-      "translations": [
-        "Nom de la conversation",
-        "Nom de la discussion",
-        "Nom du fil"
-      ]
-    },
-    {
-      "locale": "it",
-      "source": "Thread name",
-      "translations": [
-        "Nome conversazione",
-        "Nome della conversazione"
-      ]
-    },
-    {
-      "locale": "nl",
-      "source": "Thread name",
-      "translations": [
-        "Gespreksnaam",
-        "Threadnaam"
-      ]
-    },
-    {
-      "locale": "ru",
-      "source": "Thread name",
-      "translations": [
-        "Название ветки",
-        "Название обсуждения"
-      ]
-    },
-    {
-      "locale": "sv",
-      "source": "Thread name",
-      "translations": [
-        "Trådens namn",
-        "Trådnamn"
-      ]
-    },
-    {
-      "locale": "tr",
-      "source": "Thread name",
-      "translations": [
-        "Konu adı",
-        "Yazışma adı"
-      ]
-    },
-    {
-      "locale": "vi",
-      "source": "Thread name",
-      "translations": [
-        "Tên cuộc trò chuyện",
-        "Tên luồng"
-      ]
-    },
-    {
-      "locale": "ar",
-      "source": "Threads",
-      "translations": [
-        "المحادثات",
-        "سلاسل المحادثات"
-      ]
-    },
-    {
-      "locale": "fa",
-      "source": "Threads",
-      "translations": [
-        "رشته‌ها",
-        "گفت‌وگوها"
-      ]
-    },
-    {
-      "locale": "fr",
-      "source": "Threads",
-      "translations": [
-        "Conversations",
-        "Discussions",
-        "Fils",
-        "Fils de discussion"
-      ]
-    },
-    {
-      "locale": "nl",
-      "source": "Threads",
-      "translations": [
-        "Gesprekken",
-        "Threads"
-      ]
-    },
-    {
-      "locale": "ru",
-      "source": "Threads",
-      "translations": [
-        "Ветки",
-        "Обсуждения"
-      ]
-    },
-    {
-      "locale": "tr",
-      "source": "Threads",
-      "translations": [
-        "Konular",
-        "Yazışmalar"
-      ]
-    },
-    {
-      "locale": "vi",
-      "source": "Threads",
-      "translations": [
-        "Cuộc trò chuyện",
-        "Các luồng",
-        "Luồng"
-      ]
-    },
-    {
-      "locale": "zh-TW",
-      "source": "Threads",
-      "translations": [
-        "對話串",
-        "討論串"
-      ]
-    },
-    {
-      "locale": "ar",
-      "source": "Threads unavailable",
-      "translations": [
-        "المحادثات غير متاحة",
-        "سلاسل المحادثات غير متاحة"
-      ]
-    },
-    {
-      "locale": "fr",
-      "source": "Threads unavailable",
-      "translations": [
-        "Discussions indisponibles",
-        "Fils de discussion indisponibles"
-      ]
-    },
-    {
-      "locale": "ru",
-      "source": "Threads unavailable",
-      "translations": [
-        "Ветки недоступны",
-        "Обсуждения недоступны"
-      ]
-    },
-    {
-      "locale": "sv",
-      "source": "Threads unavailable",
-      "translations": [
-        "Trådar är inte tillgängliga",
-        "Trådarna är inte tillgängliga"
-      ]
-    },
-    {
-      "locale": "th",
-      "source": "Threads unavailable",
-      "translations": [
-        "เธรดไม่พร้อมใช้งาน",
-        "ไม่สามารถใช้งานเธรดได้"
-      ]
-    },
-    {
-      "locale": "tr",
-      "source": "Threads unavailable",
-      "translations": [
-        "Konular kullanılamıyor",
-        "Yazışmalar kullanılamıyor"
-      ]
-    },
-    {
-      "locale": "zh-TW",
-      "source": "Threads unavailable",
-      "translations": [
-        "無法使用對話串",
-        "討論串無法使用"
-      ]
-    },
-    {
-      "locale": "fr",
-      "source": "Threads…",
-      "translations": [
-        "Conversations…",
-        "Discussions…"
-      ]
-    },
-    {
-      "locale": "nl",
-      "source": "Threads…",
-      "translations": [
-        "Gesprekken…",
-        "Threads…"
-      ]
-    },
-    {
-      "locale": "ru",
-      "source": "Threads…",
-      "translations": [
-        "Ветки…",
-        "Обсуждения…"
-      ]
-    },
-    {
-      "locale": "tr",
-      "source": "Threads…",
-      "translations": [
-        "Konular…",
-        "Yazışmalar…"
-      ]
-    },
-    {
-      "locale": "vi",
-      "source": "Threads…",
-      "translations": [
-        "Các luồng…",
-        "Luồng…"
       ]
     },
     {

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -36571,7 +36571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 859,
+      "line": 858,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Loading commands",
       "surface": "apple",
@@ -36579,7 +36579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 868,
+      "line": 867,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Commands unavailable",
       "surface": "apple",
@@ -36587,7 +36587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 877,
+      "line": 876,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Retry",
       "surface": "apple",
@@ -36595,7 +36595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 886,
+      "line": 885,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "No matching commands",
       "surface": "apple",
@@ -36603,7 +36603,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1118,
+      "line": 1117,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop response",
       "surface": "apple",
@@ -36611,7 +36611,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1143,
+      "line": 1142,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Send message",
       "surface": "apple",
@@ -36619,7 +36619,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1157,
+      "line": 1156,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -36627,7 +36627,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1291,
+      "line": 1290,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -36635,7 +36635,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1291,
+      "line": 1290,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Gateway connected",
       "surface": "apple",
@@ -36643,7 +36643,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1300,
+      "line": 1299,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Message…",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -691,7 +691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 169,
+      "line": 170,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Resolution outcome unknown. Actions stay disabled until the Gateway record is verified.",
       "surface": "android",
@@ -699,7 +699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 171,
+      "line": 172,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The Gateway still shows this approval as pending. Review it before trying again.",
       "surface": "android",
@@ -707,7 +707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 173,
+      "line": 174,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load approval details. Refresh and try again.",
       "surface": "android",
@@ -715,7 +715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 175,
+      "line": 176,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load approvals.",
       "surface": "android",
@@ -723,7 +723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 177,
+      "line": 178,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not resolve approval. Refresh and try again.",
       "surface": "android",
@@ -731,7 +731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 192,
+      "line": 193,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Proposal applied.",
       "surface": "android",
@@ -739,7 +739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 192,
+      "line": 193,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "apply",
       "surface": "android",
@@ -747,7 +747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 193,
+      "line": 194,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Proposal rejected.",
       "surface": "android",
@@ -755,7 +755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 193,
+      "line": 194,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "reject",
       "surface": "android",
@@ -763,7 +763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 194,
+      "line": 195,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Proposal quarantined.",
       "surface": "android",
@@ -771,7 +771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 194,
+      "line": 195,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "quarantine",
       "surface": "android",
@@ -779,7 +779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 201,
+      "line": 202,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "unknown",
       "surface": "android",
@@ -787,7 +787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 202,
+      "line": 203,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway returned status '$statusLabel' after ${action.verb}.",
       "surface": "android",
@@ -795,7 +795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 210,
+      "line": 211,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not ${action.verb} Skill Workshop proposal.",
       "surface": "android",
@@ -803,7 +803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 392,
+      "line": 393,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected (node offline)",
       "surface": "android",
@@ -811,7 +811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 393,
+      "line": 394,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected (operator offline)",
       "surface": "android",
@@ -819,7 +819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 395,
+      "line": 396,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Reconnecting…",
       "surface": "android",
@@ -827,7 +827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 403,
+      "line": 404,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected (operator: $operator)",
       "surface": "android",
@@ -835,7 +835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1945,
+      "line": 1964,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This automation already has a queued run.",
       "surface": "android",
@@ -843,7 +843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1975,
+      "line": 1994,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation run queued.",
       "surface": "android",
@@ -851,7 +851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1975,
+      "line": 1994,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation started.",
       "surface": "android",
@@ -859,7 +859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1988,
+      "line": 2007,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway rejected the automation run.",
       "surface": "android",
@@ -867,7 +867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2019,
+      "line": 2038,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation enabled.",
       "surface": "android",
@@ -875,7 +875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2019,
+      "line": 2038,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation paused.",
       "surface": "android",
@@ -883,7 +883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2041,
+      "line": 2060,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This automation changed on the gateway. Review the latest version before saving again.",
       "surface": "android",
@@ -891,7 +891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2047,
+      "line": 2066,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation updated.",
       "surface": "android",
@@ -899,7 +899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2062,
+      "line": 2081,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation deleted.",
       "surface": "android",
@@ -907,7 +907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2267,
+      "line": 2286,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Node offline. Reconnect and retry.",
       "surface": "android",
@@ -915,7 +915,7 @@
     },
     {
       "kind": "ui-named-argument-concatenated",
-      "line": 2278,
+      "line": 2297,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Restore canvas now for session=$sessionKey source=$source. If existing A2UI state exists, replay it immediately. If not, create and render a compact mobile-friendly dashboard in Canvas.",
       "surface": "android",
@@ -923,7 +923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2299,
+      "line": 2318,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed to request restore. Tap to retry.",
       "surface": "android",
@@ -931,7 +931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2310,
+      "line": 2329,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "No canvas update yet. Tap to retry.",
       "surface": "android",
@@ -939,7 +939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3246,
+      "line": 3273,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect to a Gateway to save wake words",
       "surface": "android",
@@ -947,7 +947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3274,
+      "line": 3301,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Wake words saved",
       "surface": "android",
@@ -955,7 +955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3283,
+      "line": 3310,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not save wake words",
       "surface": "android",
@@ -963,7 +963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3975,
+      "line": 4002,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: no secure gateway endpoint was detected. Enable gateway TLS or Tailscale Serve, or use a trusted private LAN address with Unencrypted selected.",
       "surface": "android",
@@ -971,7 +971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3979,
+      "line": 4006,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -979,7 +979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3983,
+      "line": 4010,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -987,7 +987,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 4027,
+      "line": 4054,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -995,7 +995,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 4210,
+      "line": 4237,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Offline",
       "surface": "android",
@@ -1003,7 +1003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4944,
+      "line": 4971,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load provider catalog.",
       "surface": "android",
@@ -1011,7 +1011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4975,
+      "line": 5002,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Update your Gateway to view provider model config.",
       "surface": "android",
@@ -1019,7 +1019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4977,
+      "line": 5004,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load provider model config.",
       "surface": "android",
@@ -1027,7 +1027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4993,
+      "line": 5020,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Provider models loaded, but readiness is unavailable.",
       "surface": "android",
@@ -1035,7 +1035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5080,
+      "line": 5107,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automations.",
       "surface": "android",
@@ -1043,7 +1043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5166,
+      "line": 5193,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect automations.",
       "surface": "android",
@@ -1051,7 +1051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5176,
+      "line": 5203,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway returned an invalid automation.",
       "surface": "android",
@@ -1059,7 +1059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5180,
+      "line": 5207,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automation.",
       "surface": "android",
@@ -1067,7 +1067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5192,
+      "line": 5219,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect automation run history.",
       "surface": "android",
@@ -1075,7 +1075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5223,
+      "line": 5250,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automation run history.",
       "surface": "android",
@@ -1083,7 +1083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5240,
+      "line": 5267,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron changes require operator.admin access.",
       "surface": "android",
@@ -1091,7 +1091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5249,
+      "line": 5276,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to manage automations.",
       "surface": "android",
@@ -1099,7 +1099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5261,
+      "line": 5288,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Another cron action is still finishing.",
       "surface": "android",
@@ -1107,7 +1107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5308,
+      "line": 5335,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron action failed.",
       "surface": "android",
@@ -1115,7 +1115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5435,
+      "line": 5462,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load usage.",
       "surface": "android",
@@ -1123,7 +1123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5470,
+      "line": 5497,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load skills.",
       "surface": "android",
@@ -1131,7 +1131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5483,
+      "line": 5510,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to update skills.",
       "surface": "android",
@@ -1139,7 +1139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5487,
+      "line": 5514,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This gateway connection needs operator.admin to update skills.",
       "surface": "android",
@@ -1147,7 +1147,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5502,
+      "line": 5529,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not disable skill.",
       "surface": "android",
@@ -1155,7 +1155,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5502,
+      "line": 5529,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not enable skill.",
       "surface": "android",
@@ -1163,7 +1163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5520,
+      "line": 5547,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to search ClawHub skills.",
       "surface": "android",
@@ -1171,7 +1171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5566,
+      "line": 5593,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not search ClawHub skills.",
       "surface": "android",
@@ -1179,7 +1179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5579,
+      "line": 5606,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect ClawHub skills.",
       "surface": "android",
@@ -1187,7 +1187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5612,
+      "line": 5639,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "ClawHub did not return an installable version for ${skill.slug}.",
       "surface": "android",
@@ -1195,7 +1195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5628,
+      "line": 5655,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load ClawHub details for ${skill.slug}.",
       "surface": "android",
@@ -1203,7 +1203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5644,
+      "line": 5671,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to install ClawHub skills.",
       "surface": "android",
@@ -1211,7 +1211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5660,
+      "line": 5687,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This gateway connection needs operator.admin to install ClawHub skills.",
       "surface": "android",
@@ -1219,7 +1219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5750,
+      "line": 5777,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Installed $slug.",
       "surface": "android",
@@ -1227,7 +1227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5757,
+      "line": 5784,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not install ${slug} from ClawHub.",
       "surface": "android",
@@ -1235,7 +1235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5797,
+      "line": 5824,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to load Skill Workshop proposals.",
       "surface": "android",
@@ -1243,7 +1243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5837,
+      "line": 5864,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load Skill Workshop proposals.",
       "surface": "android",
@@ -1251,7 +1251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5857,
+      "line": 5884,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect Skill Workshop proposals.",
       "surface": "android",
@@ -1259,7 +1259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5909,
+      "line": 5936,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not inspect Skill Workshop proposal.",
       "surface": "android",
@@ -1267,7 +1267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5929,
+      "line": 5956,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Skill Workshop proposal actions require operator.admin scope.",
       "surface": "android",
@@ -1275,7 +1275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5934,
+      "line": 5961,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to update Skill Workshop proposals.",
       "surface": "android",
@@ -1283,7 +1283,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 6093,
+      "line": 6120,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected",
       "surface": "android",
@@ -1291,7 +1291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6119,
+      "line": 6146,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load nodes and devices.",
       "surface": "android",
@@ -1299,7 +1299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6777,
+      "line": 6804,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load channels.",
       "surface": "android",
@@ -1307,7 +1307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6807,
+      "line": 6834,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load dreaming.",
       "surface": "android",
@@ -1315,7 +1315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6844,
+      "line": 6871,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load gateway logs.",
       "surface": "android",
@@ -1323,7 +1323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7301,
+      "line": 7328,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "One time",
       "surface": "android",
@@ -1331,7 +1331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7310,
+      "line": 7337,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron",
       "surface": "android",
@@ -1339,7 +1339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7311,
+      "line": 7338,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Scheduled",
       "surface": "android",
@@ -1347,7 +1347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7319,
+      "line": 7346,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${days}d",
       "surface": "android",
@@ -1355,7 +1355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7320,
+      "line": 7347,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${hours}h",
       "surface": "android",
@@ -1363,7 +1363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7321,
+      "line": 7348,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${minutes}m",
       "surface": "android",
@@ -1371,7 +1371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7322,
+      "line": 7349,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Repeating",
       "surface": "android",
@@ -1379,7 +1379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7338,
+      "line": 7365,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "No prompt",
       "surface": "android",
@@ -1387,7 +1387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7355,
+      "line": 7382,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway",
       "surface": "android",
@@ -1395,7 +1395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7363,
+      "line": 7390,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected to $gatewayLabel",
       "surface": "android",
@@ -1403,7 +1403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7364,
+      "line": 7391,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Your agents are ready",
       "surface": "android",
@@ -1411,7 +1411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7366,
+      "line": 7393,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This phone stays dormant until the gateway needs it, then wakes, syncs, and goes back to sleep.",
       "surface": "android",
@@ -1419,7 +1419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7370,
+      "line": 7397,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Selected on this phone",
       "surface": "android",
@@ -1427,7 +1427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7373,
+      "line": 7400,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The overview refreshes on reconnect and when this screen opens.",
       "surface": "android",
@@ -1435,7 +1435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7378,
+      "line": 7405,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Reconnecting",
       "surface": "android",
@@ -1443,7 +1443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7379,
+      "line": 7406,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "OpenClaw is syncing back up",
       "surface": "android",
@@ -1451,7 +1451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7381,
+      "line": 7408,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The gateway session is coming back online. Agent shortcuts should settle automatically in a moment.",
       "surface": "android",
@@ -1459,7 +1459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7385,
+      "line": 7412,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway session in progress",
       "surface": "android",
@@ -1467,7 +1467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7388,
+      "line": 7415,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "If the gateway is reachable, reconnect should complete without intervention.",
       "surface": "android",
@@ -1475,7 +1475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7393,
+      "line": 7420,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Welcome to OpenClaw",
       "surface": "android",
@@ -1483,7 +1483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7394,
+      "line": 7421,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Your phone stays quiet until it is needed",
       "surface": "android",
@@ -1491,7 +1491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7396,
+      "line": 7423,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Pair this device to your gateway to wake it only for real work, keep a live agent overview handy, and avoid battery-draining background loops.",
       "surface": "android",
@@ -1499,7 +1499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7400,
+      "line": 7427,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect to load your agents",
       "surface": "android",
@@ -1507,7 +1507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7403,
+      "line": 7430,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "When connected, the gateway can wake the phone with a silent push instead of holding an always-on session.",
       "surface": "android",
@@ -1515,7 +1515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7435,
+      "line": 7462,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Main",
       "surface": "android",
@@ -1523,7 +1523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7450,
+      "line": 7477,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Active on this phone",
       "surface": "android",
@@ -1531,7 +1531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7451,
+      "line": 7478,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Default agent",
       "surface": "android",
@@ -1539,7 +1539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7452,
+      "line": 7479,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Ready",
       "surface": "android",
@@ -1547,7 +1547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8011,
+      "line": 8038,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Dream",
       "surface": "android",
@@ -11443,7 +11443,55 @@
     },
     {
       "kind": "ui-call",
-      "line": 151,
+      "line": 111,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatInlineWidgetView.kt",
+      "source": "Could not copy widget image",
+      "surface": "android",
+      "id": "native.android.5bbcfd75bf605de8"
+    },
+    {
+      "kind": "ui-call",
+      "line": 112,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatInlineWidgetView.kt",
+      "source": "Could not save widget image",
+      "surface": "android",
+      "id": "native.android.43d98caa4a9fa44c"
+    },
+    {
+      "kind": "ui-call",
+      "line": 113,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatInlineWidgetView.kt",
+      "source": "Widget image copied",
+      "surface": "android",
+      "id": "native.android.88e52d3ea4d2059a"
+    },
+    {
+      "kind": "ui-call",
+      "line": 114,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatInlineWidgetView.kt",
+      "source": "Widget image saved to Downloads",
+      "surface": "android",
+      "id": "native.android.04b164bc44c08e38"
+    },
+    {
+      "kind": "ui-call",
+      "line": 215,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatInlineWidgetView.kt",
+      "source": "Copy image",
+      "surface": "android",
+      "id": "native.android.a29e724e9e3b5cc9"
+    },
+    {
+      "kind": "ui-call",
+      "line": 220,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatInlineWidgetView.kt",
+      "source": "Save image",
+      "surface": "android",
+      "id": "native.android.6b45a391b1289aa5"
+    },
+    {
+      "kind": "ui-call",
+      "line": 230,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatInlineWidgetView.kt",
       "source": "Widget unavailable",
       "surface": "android",
@@ -11883,7 +11931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 322,
+      "line": 323,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Model",
       "surface": "android",
@@ -11891,7 +11939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 415,
+      "line": 416,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Some shared images were omitted or could not be added.",
       "surface": "android",
@@ -11899,7 +11947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 556,
+      "line": 557,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat needs attention",
       "surface": "android",
@@ -11907,7 +11955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 835,
+      "line": 836,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "All",
       "surface": "android",
@@ -11915,7 +11963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 917,
+      "line": 918,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Working",
       "surface": "android",
@@ -11923,7 +11971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 918,
+      "line": 919,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready",
       "surface": "android",
@@ -11931,7 +11979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 919,
+      "line": 920,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Offline",
       "surface": "android",
@@ -11939,7 +11987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 932,
+      "line": 933,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat actions",
       "surface": "android",
@@ -11947,7 +11995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 937,
+      "line": 938,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Refresh chat",
       "surface": "android",
@@ -11955,7 +12003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 945,
+      "line": 946,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Background tasks",
       "surface": "android",
@@ -11963,7 +12011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 966,
+      "line": 967,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -11971,7 +12019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1113,
+      "line": 1114,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Messages to recover",
       "surface": "android",
@@ -11979,7 +12027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1115,
+      "line": 1116,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows.",
       "surface": "android",
@@ -11987,7 +12035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1143,
+      "line": 1144,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Loading session",
       "surface": "android",
@@ -11995,7 +12043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1170,
+      "line": 1177,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Jump to latest",
       "surface": "android",
@@ -12003,7 +12051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1196,
+      "line": 1207,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready when you are",
       "surface": "android",
@@ -12011,7 +12059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1200,
+      "line": 1211,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Start with a prompt, or use voice.",
       "surface": "android",
@@ -12019,7 +12067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1202,
+      "line": 1213,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Use the recovery options below to reconnect.",
       "surface": "android",
@@ -12027,7 +12075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1204,
+      "line": 1215,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat is checking Gateway health.",
       "surface": "android",
@@ -12035,7 +12083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1227,
+      "line": 1238,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Fix connection",
       "surface": "android",
@@ -12043,7 +12091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1228,
+      "line": 1239,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Copy diagnostics",
       "surface": "android",
@@ -12051,7 +12099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1287,
+      "line": 1298,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Catch me up",
       "surface": "android",
@@ -12059,7 +12107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1288,
+      "line": 1299,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Summarize recent sessions and next steps.",
       "surface": "android",
@@ -12067,7 +12115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1289,
+      "line": 1300,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
       "surface": "android",
@@ -12075,7 +12123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1293,
+      "line": 1304,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Plan the work",
       "surface": "android",
@@ -12083,7 +12131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1294,
+      "line": 1305,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Turn a goal into an actionable checklist.",
       "surface": "android",
@@ -12091,7 +12139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1295,
+      "line": 1306,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Help me turn this goal into a practical checklist: ",
       "surface": "android",
@@ -12099,7 +12147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1299,
+      "line": 1310,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Use this phone",
       "surface": "android",
@@ -12107,7 +12155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1300,
+      "line": 1311,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ask OpenClaw to use Android capabilities.",
       "surface": "android",
@@ -12115,7 +12163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1301,
+      "line": 1312,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "What can you help me do from this phone right now?",
       "surface": "android",
@@ -12123,7 +12171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1366,
+      "line": 1377,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw · Live",
       "surface": "android",
@@ -12131,7 +12179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1367,
+      "line": 1378,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "You",
       "surface": "android",
@@ -12139,7 +12187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1368,
+      "line": 1379,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "System",
       "surface": "android",
@@ -12147,7 +12195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1369,
+      "line": 1380,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -12155,7 +12203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1389,
+      "line": 1400,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attachment",
       "surface": "android",
@@ -12163,7 +12211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1442,
+      "line": 1453,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Preparing audio…",
       "surface": "android",
@@ -12171,7 +12219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1442,
+      "line": 1453,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Speaking…",
       "surface": "android",
@@ -12179,7 +12227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1463,
+      "line": 1474,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Tools running",
       "surface": "android",
@@ -12187,7 +12235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1465,
+      "line": 1476,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is working",
       "surface": "android",
@@ -12195,7 +12243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1468,
+      "line": 1479,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "+${toolCalls.size - 4} more",
       "surface": "android",
@@ -12203,7 +12251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1478,
+      "line": 1489,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Thinking",
       "surface": "android",
@@ -12211,7 +12259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1479,
+      "line": 1490,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is preparing a response.",
       "surface": "android",
@@ -12219,7 +12267,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1544,
+      "line": 1555,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$completedCount/${steps.size}",
       "surface": "android",
@@ -12227,7 +12275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1551,
+      "line": 1562,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Collapse plan checklist",
       "surface": "android",
@@ -12235,7 +12283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1551,
+      "line": 1562,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Expand plan checklist",
       "surface": "android",
@@ -12243,7 +12291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1682,
+      "line": 1693,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Dismiss shared-image warning",
       "surface": "android",
@@ -12251,7 +12299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1784,
+      "line": 1795,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Stop",
       "surface": "android",
@@ -12259,7 +12307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1882,
+      "line": 1893,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Default",
       "surface": "android",
@@ -12267,7 +12315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1948,
+      "line": 1959,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Pin model",
       "surface": "android",
@@ -12275,7 +12323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1948,
+      "line": 1959,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Unpin model",
       "surface": "android",
@@ -12283,7 +12331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1965,
+      "line": 1976,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "No commands found",
       "surface": "android",
@@ -12291,7 +12339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2007,
+      "line": 2018,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Command",
       "surface": "android",
@@ -12299,7 +12347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2027,
+      "line": 2038,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway offline",
       "surface": "android",
@@ -12307,7 +12355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2073,
+      "line": 2084,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Close thinking level selector",
       "surface": "android",
@@ -12315,7 +12363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2073,
+      "line": 2084,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Open thinking level selector",
       "surface": "android",
@@ -12323,7 +12371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2137,
+      "line": 2148,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attach image",
       "surface": "android",
@@ -12331,7 +12379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2168,
+      "line": 2179,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Message OpenClaw",
       "surface": "android",
@@ -12339,7 +12387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2197,
+      "line": 2208,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "End Talk",
       "surface": "android",
@@ -12347,7 +12395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2197,
+      "line": 2208,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Start Talk",
       "surface": "android",
@@ -12355,7 +12403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2282,
+      "line": 2293,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Voice note · ${formatVoiceNoteDuration(duration)}",
       "surface": "android",
@@ -12363,7 +12411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2291,
+      "line": 2302,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Remove attachment",
       "surface": "android",
@@ -12371,7 +12419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2303,
+      "line": 2314,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "New chat",
       "surface": "android",
@@ -12379,7 +12427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2312,
+      "line": 2323,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Main",
       "surface": "android",
@@ -12387,7 +12435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2313,
+      "line": 2324,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Current",
       "surface": "android",
@@ -12395,7 +12443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2320,
+      "line": 2331,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$emoji $name",
       "surface": "android",
@@ -12403,7 +12451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2379,
+      "line": 2390,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Send",
       "surface": "android",
@@ -12411,7 +12459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2390,
+      "line": 2401,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat is still checking Gateway health.",
       "surface": "android",
@@ -12419,7 +12467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2391,
+      "line": 2402,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway is offline. Fix the connection below or copy diagnostics.",
       "surface": "android",
@@ -12427,7 +12475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2392,
+      "line": 2403,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway authentication needs attention.",
       "surface": "android",
@@ -12435,7 +12483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2411,
+      "line": 2422,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Context ${(it * 100).roundToInt()}%",
       "surface": "android",
@@ -12443,7 +12491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2412,
+      "line": 2423,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Context --",
       "surface": "android",
@@ -12451,7 +12499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2413,
+      "line": 2424,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$contextLabel · ${contextMeterThinkingLabel(thinkingLevel)}",
       "surface": "android",
@@ -12459,7 +12507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2452,
+      "line": 2463,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Off",
       "surface": "android",
@@ -12467,7 +12515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2453,
+      "line": 2464,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Minimal",
       "surface": "android",
@@ -12475,7 +12523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2454,
+      "line": 2465,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Low",
       "surface": "android",
@@ -12483,7 +12531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2455,
+      "line": 2466,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Medium",
       "surface": "android",
@@ -12491,7 +12539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2456,
+      "line": 2467,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "High",
       "surface": "android",
@@ -12499,7 +12547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2457,
+      "line": 2468,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Xhigh",
       "surface": "android",
@@ -12507,7 +12555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2458,
+      "line": 2469,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Adaptive",
       "surface": "android",
@@ -12515,7 +12563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2459,
+      "line": 2470,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Max",
       "surface": "android",
@@ -16963,7 +17011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 225,
+      "line": 231,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "The session attaches once the gateway is ready.",
       "surface": "apple",
@@ -16971,7 +17019,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 313,
+      "line": 319,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Collapsed",
       "surface": "apple",
@@ -16979,7 +17027,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 313,
+      "line": 319,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Expanded",
       "surface": "apple",
@@ -16987,7 +17035,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 383,
+      "line": 389,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Opens Settings / Gateway",
       "surface": "apple",
@@ -16995,7 +17043,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 386,
+      "line": 392,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Hides the gateway status label",
       "surface": "apple",
@@ -17003,7 +17051,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 387,
+      "line": 393,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Shows the full gateway status label",
       "surface": "apple",
@@ -17011,7 +17059,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 406,
+      "line": 412,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Voice off",
       "surface": "apple",
@@ -17019,7 +17067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 547,
+      "line": 553,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "New Chat",
       "surface": "apple",
@@ -17027,7 +17075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 560,
+      "line": 566,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "New Chat in Worktree",
       "surface": "apple",
@@ -17035,7 +17083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 573,
+      "line": 579,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "New Session Options…",
       "surface": "apple",
@@ -17043,7 +17091,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 585,
+      "line": 591,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Sessions…",
       "surface": "apple",
@@ -17051,7 +17099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 603,
+      "line": 609,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Background Tasks",
       "surface": "apple",
@@ -17059,7 +17107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 615,
+      "line": 621,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Export Transcript",
       "surface": "apple",
@@ -17067,7 +17115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 628,
+      "line": 634,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Gateway Settings",
       "surface": "apple",
@@ -17075,7 +17123,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 639,
+      "line": 645,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Show reasoning & tool activity",
       "surface": "apple",
@@ -17083,7 +17131,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 648,
+      "line": 654,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Chat actions",
       "surface": "apple",
@@ -17091,7 +17139,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 742,
+      "line": 756,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Connected",
       "surface": "apple",
@@ -17099,7 +17147,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 742,
+      "line": 756,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Unavailable",
       "surface": "apple",
@@ -17107,7 +17155,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 755,
+      "line": 769,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Message %@...",
       "surface": "apple",
@@ -17115,7 +17163,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 760,
+      "line": 774,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Message %@; sends when connected",
       "surface": "apple",
@@ -17123,7 +17171,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 763,
+      "line": 777,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Connect to a gateway",
       "surface": "apple",
@@ -17131,7 +17179,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 852,
+      "line": 866,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Check OpenClaw status",
       "surface": "apple",
@@ -17139,7 +17187,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 853,
+      "line": 867,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Summarize the current OpenClaw status and tell me what needs attention.",
       "surface": "apple",
@@ -17147,7 +17195,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 856,
+      "line": 870,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "What can I control here?",
       "surface": "apple",
@@ -17155,7 +17203,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 857,
+      "line": 871,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Show me which phone controls and device capabilities are available right now.",
       "surface": "apple",
@@ -17163,7 +17211,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 860,
+      "line": 874,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Help me start voice chat",
       "surface": "apple",
@@ -17171,7 +17219,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 861,
+      "line": 875,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Help me start a realtime voice session from this phone.",
       "surface": "apple",
@@ -23491,7 +23539,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4065,
+      "line": 4088,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval needed",
       "surface": "apple",
@@ -23499,7 +23547,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4066,
+      "line": 4089,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Action required",
       "surface": "apple",
@@ -23507,7 +23555,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4781,
+      "line": 4804,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -23515,7 +23563,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4782,
+      "line": 4805,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting...",
       "surface": "apple",
@@ -23523,7 +23571,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5134,
+      "line": 5157,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connected",
       "surface": "apple",
@@ -23531,7 +23579,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5134,
+      "line": 5157,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Offline",
       "surface": "apple",
@@ -23539,7 +23587,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6304,
+      "line": 6327,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "No chat messages yet",
       "surface": "apple",
@@ -23547,7 +23595,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6503,
+      "line": 6526,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting…",
       "surface": "apple",
@@ -23555,7 +23603,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6503,
+      "line": 6526,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting…",
       "surface": "apple",
@@ -23563,7 +23611,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8912,
+      "line": 8935,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval",
       "surface": "apple",
@@ -23571,7 +23619,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8912,
+      "line": 8935,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "This approval was already",
       "surface": "apple",
@@ -23579,7 +23627,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8918,
+      "line": 8941,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "This approval was already set to Always Allow.",
       "surface": "apple",
@@ -23587,7 +23635,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8919,
+      "line": 8942,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval set to Always Allow.",
       "surface": "apple",
@@ -23595,7 +23643,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 10257,
+      "line": 10280,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "\\(urlText.prefix(500))…",
       "surface": "apple",
@@ -33883,7 +33931,63 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 616,
+      "line": 484,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatController.swift",
+      "source": "Microphone and speech recognition permission required.",
+      "surface": "apple",
+      "id": "native.apple.237f02309f0b9aeb"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 512,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatController.swift",
+      "source": "Dictation stopped because speech recognition failed.",
+      "surface": "apple",
+      "id": "native.apple.6f2679049010dae7"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 517,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatController.swift",
+      "source": "Couldn't start dictation.",
+      "surface": "apple",
+      "id": "native.apple.fd0469907ed8a50c"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 546,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatController.swift",
+      "source": "No app is available to paste into.",
+      "surface": "apple",
+      "id": "native.apple.ec789bf13bcffb61"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 553,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatController.swift",
+      "source": "Choose another app before pasting.",
+      "surface": "apple",
+      "id": "native.apple.bd2b8e99eee923b4"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 568,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatController.swift",
+      "source": "Accessibility permission is required to paste.",
+      "surface": "apple",
+      "id": "native.apple.f7aeeb401f9a4cd1"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 594,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatController.swift",
+      "source": "Couldn't paste the reply.",
+      "surface": "apple",
+      "id": "native.apple.14e9c9f41a9523c0"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 865,
       "path": "apps/macos/Sources/OpenClaw/QuickChatController.swift",
       "source": "Capture Window…",
       "surface": "apple",
@@ -33891,7 +33995,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 617,
+      "line": 866,
       "path": "apps/macos/Sources/OpenClaw/QuickChatController.swift",
       "source": "Capture Area…",
       "surface": "apple",
@@ -34003,7 +34107,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 154,
+      "line": 164,
       "path": "apps/macos/Sources/OpenClaw/QuickChatModel.swift",
       "source": "focused app",
       "surface": "apple",
@@ -34011,7 +34115,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 466,
+      "line": 614,
       "path": "apps/macos/Sources/OpenClaw/QuickChatModel.swift",
       "source": "Couldn't capture that image.",
       "surface": "apple",
@@ -34019,7 +34123,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 488,
+      "line": 636,
       "path": "apps/macos/Sources/OpenClaw/QuickChatModel.swift",
       "source": "Screenshot: \\(label)",
       "surface": "apple",
@@ -34027,11 +34131,83 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 549,
+      "line": 697,
       "path": "apps/macos/Sources/OpenClaw/QuickChatModel.swift",
       "source": "Context from \\(context.appName) — \\(context.windowTitle)",
       "surface": "apple",
       "id": "native.apple.72e5bffb7ee89f19"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 1030,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatModel.swift",
+      "source": "Auto",
+      "surface": "apple",
+      "id": "native.apple.d82159d749697338"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 1038,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatModel.swift",
+      "source": "\\(model) · \\(thinking)",
+      "surface": "apple",
+      "id": "native.apple.4e02ff977e48dfcb"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 1062,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatModel.swift",
+      "source": "Selected reasoning is unavailable for this target.",
+      "surface": "apple",
+      "id": "native.apple.07bd035ae7e799c5"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 1195,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatModel.swift",
+      "source": "Couldn't load model settings.",
+      "surface": "apple",
+      "id": "native.apple.2eb721ed8bffe9aa"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 1206,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatModel.swift",
+      "source": "Couldn't change the model.",
+      "surface": "apple",
+      "id": "native.apple.ef6f4c54f9cfac08"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 44,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatModelMenu.swift",
+      "source": "Model",
+      "surface": "apple",
+      "id": "native.apple.82b81bd0670b0cef"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 51,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatModelMenu.swift",
+      "source": "Session default",
+      "surface": "apple",
+      "id": "native.apple.2eb4c724364c7583"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 80,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatModelMenu.swift",
+      "source": "Reasoning",
+      "surface": "apple",
+      "id": "native.apple.9f1c4db792611774"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 86,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatModelMenu.swift",
+      "source": "Auto",
+      "surface": "apple",
+      "id": "native.apple.25a01f61b4e33ece"
     },
     {
       "kind": "ui-localized-call",
@@ -34043,7 +34219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 75,
+      "line": 80,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Reply in \\(override.displayName)",
       "surface": "apple",
@@ -34051,7 +34227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 77,
+      "line": 82,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Message \\(self.model.agentDisplay.name)",
       "surface": "apple",
@@ -34059,7 +34235,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 116,
+      "line": 130,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Continue a recent conversation",
       "surface": "apple",
@@ -34067,7 +34243,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 135,
+      "line": 170,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Attach text from \\(self.model.frontmostAppName)",
       "surface": "apple",
@@ -34075,7 +34251,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 146,
+      "line": 181,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Capture a screenshot",
       "surface": "apple",
@@ -34083,15 +34259,31 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 170,
+      "line": 205,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Send message",
       "surface": "apple",
       "id": "native.apple.136cef9f750d3803"
     },
     {
+      "kind": "ui-modifier",
+      "line": 247,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
+      "source": "Choose model and reasoning",
+      "surface": "apple",
+      "id": "native.apple.b520a305b56a6387"
+    },
+    {
+      "kind": "ui-modifier",
+      "line": 248,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
+      "source": "Model and reasoning",
+      "surface": "apple",
+      "id": "native.apple.1dd50e6126da7179"
+    },
+    {
       "kind": "ui-call",
-      "line": 228,
+      "line": 289,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Needs additional permissions",
       "surface": "apple",
@@ -34099,7 +34291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 235,
+      "line": 296,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Grant",
       "surface": "apple",
@@ -34107,7 +34299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 241,
+      "line": 302,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Not now",
       "surface": "apple",
@@ -34115,7 +34307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 255,
+      "line": 316,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) chars)",
       "surface": "apple",
@@ -34123,11 +34315,35 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 264,
+      "line": 325,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Remove attached text context",
       "surface": "apple",
       "id": "native.apple.66ec93e9eefd9bd7"
+    },
+    {
+      "kind": "ui-call",
+      "line": 364,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
+      "source": "Paste to \\(self.model.frontmostAppName)",
+      "surface": "apple",
+      "id": "native.apple.00b46fe92d9bb1d4"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 417,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
+      "source": "Stop dictation",
+      "surface": "apple",
+      "id": "native.apple.d2aa2e60ec2f62d8"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 418,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
+      "source": "Start dictation",
+      "surface": "apple",
+      "id": "native.apple.8c4a27a4361d0572"
     },
     {
       "kind": "ui-localized-call",
@@ -36563,7 +36779,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 810,
+      "line": 813,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Talk",
       "surface": "apple",
@@ -36571,7 +36787,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 881,
+      "line": 884,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Start realtime chat",
       "surface": "apple",
@@ -36579,7 +36795,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 881,
+      "line": 884,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop realtime chat",
       "surface": "apple",
@@ -36587,7 +36803,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 915,
+      "line": 918,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Start",
       "surface": "apple",
@@ -36595,7 +36811,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 915,
+      "line": 918,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop",
       "surface": "apple",
@@ -36603,7 +36819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1045,
+      "line": 1048,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Loading commands",
       "surface": "apple",
@@ -36611,7 +36827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1054,
+      "line": 1057,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Commands unavailable",
       "surface": "apple",
@@ -36619,7 +36835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1063,
+      "line": 1066,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Retry",
       "surface": "apple",
@@ -36627,7 +36843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1072,
+      "line": 1075,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "No matching commands",
       "surface": "apple",
@@ -36635,7 +36851,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1304,
+      "line": 1307,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop response",
       "surface": "apple",
@@ -36643,7 +36859,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1329,
+      "line": 1332,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Send message",
       "surface": "apple",
@@ -36651,7 +36867,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1343,
+      "line": 1346,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -36659,7 +36875,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1468,
+      "line": 1471,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -36667,7 +36883,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1468,
+      "line": 1471,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Gateway connected",
       "surface": "apple",
@@ -36675,7 +36891,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1477,
+      "line": 1480,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Message…",
       "surface": "apple",
@@ -38699,47 +38915,55 @@
     },
     {
       "kind": "ui-call",
-      "line": 282,
+      "line": 301,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/CleanChatComposerControls.swift",
       "source": "Record Voice Note",
       "surface": "apple",
       "id": "native.apple.e33210feaa3da016"
     },
     {
-      "kind": "conditional-branch",
-      "line": 332,
+      "kind": "ui-call",
+      "line": 371,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/CleanChatComposerControls.swift",
       "source": "Dictate message",
       "surface": "apple",
       "id": "native.apple.00f0e15858e38d19"
     },
     {
-      "kind": "conditional-branch",
-      "line": 333,
+      "kind": "ui-call",
+      "line": 375,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/CleanChatComposerControls.swift",
       "source": "Listening",
       "surface": "apple",
       "id": "native.apple.96f20175f61a2b29"
     },
     {
-      "kind": "conditional-branch",
-      "line": 333,
+      "kind": "ui-call",
+      "line": 376,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/CleanChatComposerControls.swift",
       "source": "Not listening",
       "surface": "apple",
       "id": "native.apple.eaa9047db6cfb67e"
     },
     {
-      "kind": "conditional-branch",
-      "line": 335,
+      "kind": "ui-call",
+      "line": 380,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/CleanChatComposerControls.swift",
       "source": "Finish dictation",
       "surface": "apple",
       "id": "native.apple.4185df7a940f09ef"
     },
     {
-      "kind": "conditional-branch",
-      "line": 335,
+      "kind": "ui-call",
+      "line": 381,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/CleanChatComposerControls.swift",
+      "source": "Cancel",
+      "surface": "apple",
+      "id": "native.apple.95eeae0399fbc990"
+    },
+    {
+      "kind": "ui-call",
+      "line": 382,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/CleanChatComposerControls.swift",
       "source": "Transcribe speech into the message",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -523,7 +523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 218,
+      "line": 201,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainActivity.kt",
       "source": "Too many shares are waiting to be added.",
       "surface": "android",
@@ -531,7 +531,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 341,
+      "line": 322,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainActivity.kt",
       "source": "OPENCLAW",
       "surface": "android",
@@ -539,7 +539,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 465,
+      "line": 464,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Searching…",
       "surface": "android",
@@ -547,7 +547,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 597,
+      "line": 586,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Mic off",
       "surface": "android",
@@ -555,7 +555,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 611,
+      "line": 600,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Off",
       "surface": "android",
@@ -691,7 +691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 174,
+      "line": 169,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Resolution outcome unknown. Actions stay disabled until the Gateway record is verified.",
       "surface": "android",
@@ -699,7 +699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 176,
+      "line": 171,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The Gateway still shows this approval as pending. Review it before trying again.",
       "surface": "android",
@@ -707,7 +707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 178,
+      "line": 173,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load approval details. Refresh and try again.",
       "surface": "android",
@@ -715,7 +715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 180,
+      "line": 175,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load approvals.",
       "surface": "android",
@@ -723,7 +723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 182,
+      "line": 177,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not resolve approval. Refresh and try again.",
       "surface": "android",
@@ -731,31 +731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 279,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
-      "source": "Device approved.",
-      "surface": "android",
-      "id": "native.android.ab7de09b2e9bafd2"
-    },
-    {
-      "kind": "ui-call",
-      "line": 280,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
-      "source": "Pairing request rejected.",
-      "surface": "android",
-      "id": "native.android.0f3b1e2ce6f0aed5"
-    },
-    {
-      "kind": "ui-call",
-      "line": 281,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
-      "source": "Paired device removed.",
-      "surface": "android",
-      "id": "native.android.e98062fe81b36c4a"
-    },
-    {
-      "kind": "ui-call",
-      "line": 342,
+      "line": 192,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Proposal applied.",
       "surface": "android",
@@ -763,7 +739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 342,
+      "line": 192,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "apply",
       "surface": "android",
@@ -771,7 +747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 343,
+      "line": 193,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Proposal rejected.",
       "surface": "android",
@@ -779,7 +755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 343,
+      "line": 193,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "reject",
       "surface": "android",
@@ -787,7 +763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 344,
+      "line": 194,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Proposal quarantined.",
       "surface": "android",
@@ -795,7 +771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 344,
+      "line": 194,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "quarantine",
       "surface": "android",
@@ -803,7 +779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 351,
+      "line": 201,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "unknown",
       "surface": "android",
@@ -811,7 +787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 352,
+      "line": 202,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway returned status '$statusLabel' after ${action.verb}.",
       "surface": "android",
@@ -819,7 +795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 360,
+      "line": 210,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not ${action.verb} Skill Workshop proposal.",
       "surface": "android",
@@ -827,7 +803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 542,
+      "line": 392,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected (node offline)",
       "surface": "android",
@@ -835,7 +811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 543,
+      "line": 393,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected (operator offline)",
       "surface": "android",
@@ -843,7 +819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 545,
+      "line": 395,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Reconnecting…",
       "surface": "android",
@@ -851,7 +827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 553,
+      "line": 403,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected (operator: $operator)",
       "surface": "android",
@@ -859,7 +835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2147,
+      "line": 1945,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This automation already has a queued run.",
       "surface": "android",
@@ -867,7 +843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2177,
+      "line": 1975,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation run queued.",
       "surface": "android",
@@ -875,7 +851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2177,
+      "line": 1975,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation started.",
       "surface": "android",
@@ -883,7 +859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2190,
+      "line": 1988,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway rejected the automation run.",
       "surface": "android",
@@ -891,7 +867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2221,
+      "line": 2019,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation enabled.",
       "surface": "android",
@@ -899,7 +875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2221,
+      "line": 2019,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation paused.",
       "surface": "android",
@@ -907,7 +883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2243,
+      "line": 2041,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This automation changed on the gateway. Review the latest version before saving again.",
       "surface": "android",
@@ -915,7 +891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2249,
+      "line": 2047,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation updated.",
       "surface": "android",
@@ -923,7 +899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2264,
+      "line": 2062,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation deleted.",
       "surface": "android",
@@ -931,7 +907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2514,
+      "line": 2267,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Node offline. Reconnect and retry.",
       "surface": "android",
@@ -939,7 +915,7 @@
     },
     {
       "kind": "ui-named-argument-concatenated",
-      "line": 2525,
+      "line": 2278,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Restore canvas now for session=$sessionKey source=$source. If existing A2UI state exists, replay it immediately. If not, create and render a compact mobile-friendly dashboard in Canvas.",
       "surface": "android",
@@ -947,7 +923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2546,
+      "line": 2299,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed to request restore. Tap to retry.",
       "surface": "android",
@@ -955,7 +931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2557,
+      "line": 2310,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "No canvas update yet. Tap to retry.",
       "surface": "android",
@@ -963,7 +939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3515,
+      "line": 3244,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect to a Gateway to save wake words",
       "surface": "android",
@@ -971,7 +947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3543,
+      "line": 3272,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Wake words saved",
       "surface": "android",
@@ -979,7 +955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3552,
+      "line": 3281,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not save wake words",
       "surface": "android",
@@ -987,7 +963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4266,
+      "line": 3973,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: no secure gateway endpoint was detected. Enable gateway TLS or Tailscale Serve, or use a trusted private LAN address with Unencrypted selected.",
       "surface": "android",
@@ -995,7 +971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4270,
+      "line": 3977,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -1003,7 +979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4274,
+      "line": 3981,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -1011,7 +987,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 4318,
+      "line": 4025,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -1019,7 +995,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 4501,
+      "line": 4208,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Offline",
       "surface": "android",
@@ -1027,7 +1003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5235,
+      "line": 4942,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load provider catalog.",
       "surface": "android",
@@ -1035,7 +1011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5266,
+      "line": 4973,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Update your Gateway to view provider model config.",
       "surface": "android",
@@ -1043,7 +1019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5268,
+      "line": 4975,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load provider model config.",
       "surface": "android",
@@ -1051,7 +1027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5284,
+      "line": 4991,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Provider models loaded, but readiness is unavailable.",
       "surface": "android",
@@ -1059,7 +1035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5371,
+      "line": 5078,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automations.",
       "surface": "android",
@@ -1067,7 +1043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5457,
+      "line": 5164,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect automations.",
       "surface": "android",
@@ -1075,7 +1051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5467,
+      "line": 5174,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway returned an invalid automation.",
       "surface": "android",
@@ -1083,7 +1059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5471,
+      "line": 5178,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automation.",
       "surface": "android",
@@ -1091,7 +1067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5483,
+      "line": 5190,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect automation run history.",
       "surface": "android",
@@ -1099,7 +1075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5514,
+      "line": 5221,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automation run history.",
       "surface": "android",
@@ -1107,7 +1083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5531,
+      "line": 5238,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron changes require operator.admin access.",
       "surface": "android",
@@ -1115,7 +1091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5540,
+      "line": 5247,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to manage automations.",
       "surface": "android",
@@ -1123,7 +1099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5552,
+      "line": 5259,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Another cron action is still finishing.",
       "surface": "android",
@@ -1131,7 +1107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5599,
+      "line": 5306,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron action failed.",
       "surface": "android",
@@ -1139,7 +1115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5726,
+      "line": 5433,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load usage.",
       "surface": "android",
@@ -1147,7 +1123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5761,
+      "line": 5468,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load skills.",
       "surface": "android",
@@ -1155,7 +1131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5774,
+      "line": 5481,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to update skills.",
       "surface": "android",
@@ -1163,7 +1139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5778,
+      "line": 5485,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This gateway connection needs operator.admin to update skills.",
       "surface": "android",
@@ -1171,7 +1147,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5793,
+      "line": 5500,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not disable skill.",
       "surface": "android",
@@ -1179,7 +1155,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5793,
+      "line": 5500,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not enable skill.",
       "surface": "android",
@@ -1187,7 +1163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5811,
+      "line": 5518,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to search ClawHub skills.",
       "surface": "android",
@@ -1195,7 +1171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5857,
+      "line": 5564,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not search ClawHub skills.",
       "surface": "android",
@@ -1203,7 +1179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5870,
+      "line": 5577,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect ClawHub skills.",
       "surface": "android",
@@ -1211,7 +1187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5903,
+      "line": 5610,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "ClawHub did not return an installable version for ${skill.slug}.",
       "surface": "android",
@@ -1219,7 +1195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5919,
+      "line": 5626,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load ClawHub details for ${skill.slug}.",
       "surface": "android",
@@ -1227,7 +1203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5935,
+      "line": 5642,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to install ClawHub skills.",
       "surface": "android",
@@ -1235,7 +1211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5951,
+      "line": 5658,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This gateway connection needs operator.admin to install ClawHub skills.",
       "surface": "android",
@@ -1243,7 +1219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6041,
+      "line": 5748,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Installed $slug.",
       "surface": "android",
@@ -1251,7 +1227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6048,
+      "line": 5755,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not install ${slug} from ClawHub.",
       "surface": "android",
@@ -1259,7 +1235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6088,
+      "line": 5795,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to load Skill Workshop proposals.",
       "surface": "android",
@@ -1267,7 +1243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6128,
+      "line": 5835,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load Skill Workshop proposals.",
       "surface": "android",
@@ -1275,7 +1251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6148,
+      "line": 5855,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect Skill Workshop proposals.",
       "surface": "android",
@@ -1283,7 +1259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6200,
+      "line": 5907,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not inspect Skill Workshop proposal.",
       "surface": "android",
@@ -1291,7 +1267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6220,
+      "line": 5927,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Skill Workshop proposal actions require operator.admin scope.",
       "surface": "android",
@@ -1299,23 +1275,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 6225,
+      "line": 5932,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to update Skill Workshop proposals.",
       "surface": "android",
       "id": "native.android.df0d071809dfbbb3"
     },
     {
-      "kind": "ui-call",
-      "line": 6415,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
-      "source": "Could not verify the device pairing change. Refresh and try again.",
-      "surface": "android",
-      "id": "native.android.9481b642ee32ed95"
-    },
-    {
       "kind": "ui-named-argument",
-      "line": 6497,
+      "line": 6091,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected",
       "surface": "android",
@@ -1323,7 +1291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6527,
+      "line": 6117,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load nodes and devices.",
       "surface": "android",
@@ -1331,7 +1299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7185,
+      "line": 6775,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load channels.",
       "surface": "android",
@@ -1339,7 +1307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7215,
+      "line": 6805,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load dreaming.",
       "surface": "android",
@@ -1347,7 +1315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7252,
+      "line": 6842,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load gateway logs.",
       "surface": "android",
@@ -1355,7 +1323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7721,
+      "line": 7299,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "One time",
       "surface": "android",
@@ -1363,7 +1331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7730,
+      "line": 7308,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron",
       "surface": "android",
@@ -1371,7 +1339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7731,
+      "line": 7309,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Scheduled",
       "surface": "android",
@@ -1379,7 +1347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7739,
+      "line": 7317,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${days}d",
       "surface": "android",
@@ -1387,7 +1355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7740,
+      "line": 7318,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${hours}h",
       "surface": "android",
@@ -1395,7 +1363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7741,
+      "line": 7319,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${minutes}m",
       "surface": "android",
@@ -1403,7 +1371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7742,
+      "line": 7320,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Repeating",
       "surface": "android",
@@ -1411,7 +1379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7758,
+      "line": 7336,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "No prompt",
       "surface": "android",
@@ -1419,7 +1387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7775,
+      "line": 7353,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway",
       "surface": "android",
@@ -1427,7 +1395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7783,
+      "line": 7361,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected to $gatewayLabel",
       "surface": "android",
@@ -1435,7 +1403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7784,
+      "line": 7362,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Your agents are ready",
       "surface": "android",
@@ -1443,7 +1411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7786,
+      "line": 7364,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This phone stays dormant until the gateway needs it, then wakes, syncs, and goes back to sleep.",
       "surface": "android",
@@ -1451,7 +1419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7790,
+      "line": 7368,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Selected on this phone",
       "surface": "android",
@@ -1459,7 +1427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7793,
+      "line": 7371,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The overview refreshes on reconnect and when this screen opens.",
       "surface": "android",
@@ -1467,7 +1435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7798,
+      "line": 7376,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Reconnecting",
       "surface": "android",
@@ -1475,7 +1443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7799,
+      "line": 7377,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "OpenClaw is syncing back up",
       "surface": "android",
@@ -1483,7 +1451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7801,
+      "line": 7379,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The gateway session is coming back online. Agent shortcuts should settle automatically in a moment.",
       "surface": "android",
@@ -1491,7 +1459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7805,
+      "line": 7383,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway session in progress",
       "surface": "android",
@@ -1499,7 +1467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7808,
+      "line": 7386,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "If the gateway is reachable, reconnect should complete without intervention.",
       "surface": "android",
@@ -1507,7 +1475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7813,
+      "line": 7391,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Welcome to OpenClaw",
       "surface": "android",
@@ -1515,7 +1483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7814,
+      "line": 7392,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Your phone stays quiet until it is needed",
       "surface": "android",
@@ -1523,7 +1491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7816,
+      "line": 7394,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Pair this device to your gateway to wake it only for real work, keep a live agent overview handy, and avoid battery-draining background loops.",
       "surface": "android",
@@ -1531,7 +1499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7820,
+      "line": 7398,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect to load your agents",
       "surface": "android",
@@ -1539,7 +1507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7823,
+      "line": 7401,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "When connected, the gateway can wake the phone with a silent push instead of holding an always-on session.",
       "surface": "android",
@@ -1547,7 +1515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7855,
+      "line": 7433,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Main",
       "surface": "android",
@@ -1555,7 +1523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7870,
+      "line": 7448,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Active on this phone",
       "surface": "android",
@@ -1563,7 +1531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7871,
+      "line": 7449,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Default agent",
       "surface": "android",
@@ -1571,7 +1539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7872,
+      "line": 7450,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Ready",
       "surface": "android",
@@ -1579,7 +1547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8437,
+      "line": 8009,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Dream",
       "surface": "android",
@@ -1755,7 +1723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1041,
+      "line": 1036,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Wait for the current response to finish before starting a new chat.",
       "surface": "android",
@@ -1763,7 +1731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1174,
+      "line": 1169,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Could not update model.",
       "surface": "android",
@@ -1771,7 +1739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1239,
+      "line": 1234,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Could not update thinking level.",
       "surface": "android",
@@ -1779,7 +1747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1732,
+      "line": 1727,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Chat failed before the run started; try again.",
       "surface": "android",
@@ -1787,7 +1755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3173,
+      "line": 3009,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Could not stage an attachment for sending.",
       "surface": "android",
@@ -1795,7 +1763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3206,
+      "line": 3042,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Offline queue is full ($OUTBOX_MAX_QUEUED messages); delete queued items first.",
       "surface": "android",
@@ -1803,7 +1771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3212,
+      "line": 3048,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Attachments are too large to queue for one message; remove some and try again.",
       "surface": "android",
@@ -1811,7 +1779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3218,
+      "line": 3054,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Offline attachment storage is full; delete queued items first.",
       "surface": "android",
@@ -1819,7 +1787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3223,
+      "line": 3059,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Gateway health not OK; cannot send",
       "surface": "android",
@@ -1827,7 +1795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3230,
+      "line": 3066,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Could not queue message for later delivery.",
       "surface": "android",
@@ -1835,7 +1803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3947,
+      "line": 3783,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Chat failed",
       "surface": "android",
@@ -1843,7 +1811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4085,
+      "line": 3921,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Event stream interrupted; try refreshing.",
       "surface": "android",
@@ -1851,7 +1819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4222,
+      "line": 4058,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Timed out waiting for a reply; try again or refresh.",
       "surface": "android",
@@ -1859,7 +1827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4432,
+      "line": 4268,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Timed out confirming the sent message; refresh to check delivery.",
       "surface": "android",
@@ -1875,7 +1843,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1563,
+      "line": 1530,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -1883,7 +1851,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1563,
+      "line": 1530,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Reconnecting…",
       "surface": "android",
@@ -2285,9 +2253,9 @@
       "kind": "ui-call",
       "line": 95,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
-      "source": "Browse Threads",
+      "source": "Browse Sessions",
       "surface": "android",
-      "id": "native.android.e2cf5a38587382cb"
+      "id": "native.android.5876e15e5e92fd45"
     },
     {
       "kind": "ui-call",
@@ -2373,33 +2341,33 @@
       "kind": "ui-call",
       "line": 146,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
-      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
+      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
       "surface": "android",
-      "id": "native.android.bc70a4ac965b82ba"
+      "id": "native.android.48ad0ae0e930e02b"
     },
     {
       "kind": "ui-call",
       "line": 155,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
-      "source": "Threads",
+      "source": "Sessions",
       "surface": "android",
-      "id": "native.android.670121e54dbe286f"
+      "id": "native.android.d4fbd1ee4f55a5db"
     },
     {
       "kind": "ui-call",
       "line": 162,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
-      "source": "Connect the Gateway to search threads.",
+      "source": "Connect the Gateway to search sessions.",
       "surface": "android",
-      "id": "native.android.d38be650b1bce4a0"
+      "id": "native.android.207c2170504e99e6"
     },
     {
       "kind": "ui-call",
       "line": 162,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
-      "source": "No matching threads yet.",
+      "source": "No matching sessions yet.",
       "surface": "android",
-      "id": "native.android.3d7754721f776ef8"
+      "id": "native.android.25d2c2d792c952fe"
     },
     {
       "kind": "ui-call",
@@ -2413,17 +2381,17 @@
       "kind": "ui-call",
       "line": 177,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
-      "source": "OpenClaw thread",
+      "source": "OpenClaw session",
       "surface": "android",
-      "id": "native.android.9a839f6e3e05a744"
+      "id": "native.android.8f8384286317f5c9"
     },
     {
       "kind": "ui-call",
       "line": 310,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
-      "source": "Open thread",
+      "source": "Open session",
       "surface": "android",
-      "id": "native.android.d83f82a1e4a5ed99"
+      "id": "native.android.15799e57704b20c6"
     },
     {
       "kind": "ui-call",
@@ -2461,9 +2429,9 @@
       "kind": "ui-call",
       "line": 377,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
-      "source": "Main thread",
+      "source": "Main session",
       "surface": "android",
-      "id": "native.android.8a1c5365c0538908"
+      "id": "native.android.73e6ab1a168fd381"
     },
     {
       "kind": "ui-call",
@@ -3795,7 +3763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 74,
+      "line": 58,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Nodes & Devices",
       "surface": "android",
@@ -3803,7 +3771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 75,
+      "line": 59,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Live nodes, paired phones, and pending device requests.",
       "surface": "android",
@@ -3811,7 +3779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 84,
+      "line": 68,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Admin",
       "surface": "android",
@@ -3819,7 +3787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 84,
+      "line": 68,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Devices",
       "surface": "android",
@@ -3827,7 +3795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 85,
+      "line": 69,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Pending",
       "surface": "android",
@@ -3835,7 +3803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 90,
+      "line": 74,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Refresh",
       "surface": "android",
@@ -3843,7 +3811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 90,
+      "line": 74,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Refreshing",
       "surface": "android",
@@ -3851,7 +3819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 109,
+      "line": 88,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Connect the gateway to load nodes and paired devices.",
       "surface": "android",
@@ -3859,7 +3827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 114,
+      "line": 93,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "No nodes or paired devices.",
       "surface": "android",
@@ -3867,7 +3835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 115,
+      "line": 94,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Linked phones and node hosts will appear here after pairing.",
       "surface": "android",
@@ -3875,7 +3843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 172,
+      "line": 114,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Node approval required",
       "surface": "android",
@@ -3883,7 +3851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 173,
+      "line": 115,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Run on the Gateway host:",
       "surface": "android",
@@ -3891,7 +3859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 188,
+      "line": 130,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Pending Requests",
       "surface": "android",
@@ -3899,7 +3867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 207,
+      "line": 140,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Nodes",
       "surface": "android",
@@ -3907,7 +3875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 217,
+      "line": 150,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Paired Devices",
       "surface": "android",
@@ -3915,143 +3883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 256,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
-      "source": "Approve device?",
-      "surface": "android",
-      "id": "native.android.8c6f23f9b2a2f5c3"
-    },
-    {
-      "kind": "ui-call",
-      "line": 257,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
-      "source": "Reject pairing request?",
-      "surface": "android",
-      "id": "native.android.61e56e7c2425c765"
-    },
-    {
-      "kind": "ui-call",
-      "line": 258,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
-      "source": "Remove paired device?",
-      "surface": "android",
-      "id": "native.android.a233e379d3281626"
-    },
-    {
-      "kind": "ui-call",
-      "line": 276,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
-      "source": "Verify this requesting device before granting access.",
-      "surface": "android",
-      "id": "native.android.84789f373ff7e379"
-    },
-    {
-      "kind": "ui-call",
-      "line": 281,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
-      "source": "$label: $value",
-      "surface": "android",
-      "id": "native.android.80f2666384538867"
-    },
-    {
-      "kind": "ui-call",
-      "line": 291,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
-      "source": "Reject the pairing request from this device?",
-      "surface": "android",
-      "id": "native.android.857fc6dbd43c147c"
-    },
-    {
-      "kind": "ui-call",
-      "line": 293,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
-      "source": "This device will lose its trusted Gateway access.",
-      "surface": "android",
-      "id": "native.android.a0cb7097dac32274"
-    },
-    {
-      "kind": "ui-call",
-      "line": 303,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
-      "source": "Cancel",
-      "surface": "android",
-      "id": "native.android.d62bd835e46f047f"
-    },
-    {
-      "kind": "ui-call",
-      "line": 311,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
-      "source": "Name",
-      "surface": "android",
-      "id": "native.android.54bc27d84e77fdeb"
-    },
-    {
-      "kind": "ui-call",
-      "line": 312,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
-      "source": "Device ID",
-      "surface": "android",
-      "id": "native.android.549fcca19ab575e8"
-    },
-    {
-      "kind": "ui-call",
-      "line": 313,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
-      "source": "Public key",
-      "surface": "android",
-      "id": "native.android.0a2b46e9ba9a43a7"
-    },
-    {
-      "kind": "ui-call",
-      "line": 317,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
-      "source": "Platform",
-      "surface": "android",
-      "id": "native.android.3029d9b112d91460"
-    },
-    {
-      "kind": "ui-call",
-      "line": 321,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
-      "source": "Client",
-      "surface": "android",
-      "id": "native.android.34495d4163dd2b0d"
-    },
-    {
-      "kind": "ui-call",
-      "line": 322,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
-      "source": "Origin",
-      "surface": "android",
-      "id": "native.android.9d5173f45aa99bc9"
-    },
-    {
-      "kind": "ui-call",
-      "line": 323,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
-      "source": "Remote IP",
-      "surface": "android",
-      "id": "native.android.1690971a387e62fa"
-    },
-    {
-      "kind": "ui-call",
-      "line": 327,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
-      "source": "Roles",
-      "surface": "android",
-      "id": "native.android.e478d6d87813a30a"
-    },
-    {
-      "kind": "ui-call",
-      "line": 331,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
-      "source": "Scopes",
-      "surface": "android",
-      "id": "native.android.d390e77c38097584"
-    },
-    {
-      "kind": "ui-call",
-      "line": 415,
+      "line": 201,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "New device",
       "surface": "android",
@@ -4059,7 +3891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 417,
+      "line": 203,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Repair",
       "surface": "android",
@@ -4067,7 +3899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 417,
+      "line": 203,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Review",
       "surface": "android",
@@ -4075,23 +3907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 427,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
-      "source": "Reject",
-      "surface": "android",
-      "id": "native.android.caa6c7dea18d5127"
-    },
-    {
-      "kind": "ui-call",
-      "line": 432,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
-      "source": "Approve",
-      "surface": "android",
-      "id": "native.android.ef8a2c38eba42e89"
-    },
-    {
-      "kind": "ui-call",
-      "line": 450,
+      "line": 212,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Paired device",
       "surface": "android",
@@ -4099,15 +3915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 461,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
-      "source": "Remove",
-      "surface": "android",
-      "id": "native.android.ce8e5c5a934ed2aa"
-    },
-    {
-      "kind": "ui-call",
-      "line": 488,
+      "line": 239,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Node host",
       "surface": "android",
@@ -4115,7 +3923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 490,
+      "line": 241,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Unpaired",
       "surface": "android",
@@ -4123,7 +3931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 502,
+      "line": 253,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Needs approval",
       "surface": "android",
@@ -4131,7 +3939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 503,
+      "line": 254,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Needs reapproval",
       "surface": "android",
@@ -4139,7 +3947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 504,
+      "line": 255,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Unapproved",
       "surface": "android",
@@ -4147,7 +3955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 505,
+      "line": 256,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Offline",
       "surface": "android",
@@ -4155,7 +3963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 505,
+      "line": 256,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Online",
       "surface": "android",
@@ -4163,7 +3971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 522,
+      "line": 273,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Approved",
       "surface": "android",
@@ -4171,7 +3979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 523,
+      "line": 274,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Capability approval pending",
       "surface": "android",
@@ -4179,7 +3987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 524,
+      "line": 275,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Capability reapproval pending",
       "surface": "android",
@@ -4187,7 +3995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 525,
+      "line": 276,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Capability unapproved",
       "surface": "android",
@@ -4195,15 +4003,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 532,
+      "line": 283,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
-      "source": "Device pairing actions are unavailable in this Gateway session. Run openclaw devices list on the Gateway host and manage the request there. Node capability approval is separate and still uses nodes approve <request id>.",
+      "source": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>.",
       "surface": "android",
-      "id": "native.android.8b55ed05cd70b8d9"
+      "id": "native.android.13024ff403917bfe"
     },
     {
       "kind": "ui-call",
-      "line": 539,
+      "line": 290,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "requested ${relativeDeviceTime(it)}",
       "surface": "android",
@@ -4211,7 +4019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 547,
+      "line": 298,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "${device.tokens.count { !it.revoked }}/${device.tokens.size} active tokens",
       "surface": "android",
@@ -4219,7 +4027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 557,
+      "line": 308,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Paired",
       "surface": "android",
@@ -4227,7 +4035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 558,
+      "line": 309,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Active",
       "surface": "android",
@@ -4235,7 +4043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 559,
+      "line": 310,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Needs Token",
       "surface": "android",
@@ -4243,7 +4051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 583,
+      "line": 334,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "${values.size} roles",
       "surface": "android",
@@ -4251,7 +4059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 584,
+      "line": 335,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "${values.size} scopes",
       "surface": "android",
@@ -4259,7 +4067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 602,
+      "line": 353,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "now",
       "surface": "android",
@@ -4267,7 +4075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 603,
+      "line": 354,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "${minutes}m ago",
       "surface": "android",
@@ -4275,7 +4083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 605,
+      "line": 356,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "${hours}h ago",
       "surface": "android",
@@ -4283,7 +4091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 607,
+      "line": 358,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "${days}d ago",
       "surface": "android",
@@ -4291,7 +4099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 272,
+      "line": 270,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Enter the setup code from openclaw qr.",
       "surface": "android",
@@ -4299,7 +4107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 273,
+      "line": 271,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup code was not accepted. Generate a fresh code with openclaw qr.",
       "surface": "android",
@@ -4307,7 +4115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 275,
+      "line": 273,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "That QR code is not an OpenClaw setup QR. Generate a fresh code with openclaw qr, then try again.",
       "surface": "android",
@@ -4315,7 +4123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 277,
+      "line": 275,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "That looks like a setup code. Go back and choose Setup Gateway, then Use setup code.",
       "surface": "android",
@@ -4323,7 +4131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 279,
+      "line": 277,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Could not read that image. Choose a clear screenshot or image of the QR from openclaw qr.",
       "surface": "android",
@@ -4331,7 +4139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 281,
+      "line": 279,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "No setup QR code was found in that image. Choose the QR generated by openclaw qr, or enter the setup code manually.",
       "surface": "android",
@@ -4339,7 +4147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 283,
+      "line": 281,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Could not read a QR code from that image. Choose a clearer image or enter the setup code manually.",
       "surface": "android",
@@ -4347,7 +4155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 285,
+      "line": 283,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Could not start the camera. Choose a QR image from gallery or enter the setup code manually.",
       "surface": "android",
@@ -4355,31 +4163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 832,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
-      "source": "The gateway certificate could not be read automatically. Paste the SHA-256 fingerprint obtained on the gateway host.",
-      "surface": "android",
-      "id": "native.android.7a18be21a62739bf"
-    },
-    {
-      "kind": "ui-call",
-      "line": 852,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
-      "source": "This gateway now presents a certificate trusted by this device.",
-      "surface": "android",
-      "id": "native.android.aa489429ad39aa39"
-    },
-    {
-      "kind": "ui-call",
-      "line": 862,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
-      "source": "SHA-256 fingerprint",
-      "surface": "android",
-      "id": "native.android.b3db82f1162808ad"
-    },
-    {
-      "kind": "ui-call",
-      "line": 875,
+      "line": 838,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Trust",
       "surface": "android",
@@ -4387,15 +4171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 882,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
-      "source": "Use system trust",
-      "surface": "android",
-      "id": "native.android.09245320d3878458"
-    },
-    {
-      "kind": "ui-call",
-      "line": 886,
+      "line": 843,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Cancel",
       "surface": "android",
@@ -4403,7 +4179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1082,
+      "line": 1038,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Welcome to OpenClaw",
       "surface": "android",
@@ -4411,7 +4187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1083,
+      "line": 1039,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Turn this device into a secure OpenClaw node for chat, voice, camera, and device tools.",
       "surface": "android",
@@ -4419,7 +4195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1114,
+      "line": 1070,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "OpenClaw logo",
       "surface": "android",
@@ -4427,7 +4203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1173,
+      "line": 1129,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connect to your Gateway",
       "surface": "android",
@@ -4435,7 +4211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1174,
+      "line": 1130,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Choose device permissions",
       "surface": "android",
@@ -4443,7 +4219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1175,
+      "line": 1131,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Use OpenClaw from your phone",
       "surface": "android",
@@ -4451,7 +4227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1197,
+      "line": 1153,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Security notice",
       "surface": "android",
@@ -4459,7 +4235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1199,
+      "line": 1155,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "The connected OpenClaw agent can use device capabilities you enable. Continue only if you trust the Gateway and agent you connect to.",
       "surface": "android",
@@ -4467,7 +4243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1240,
+      "line": 1196,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connect Gateway",
       "surface": "android",
@@ -4475,7 +4251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1241,
+      "line": 1197,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Scan a QR code or use the setup code from your OpenClaw Gateway.",
       "surface": "android",
@@ -4483,7 +4259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1250,
+      "line": 1206,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Could not open setup guide.",
       "surface": "android",
@@ -4491,7 +4267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1258,
+      "line": 1214,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Scan QR or setup code",
       "surface": "android",
@@ -4499,7 +4275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1264,
+      "line": 1220,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Set up manually",
       "surface": "android",
@@ -4507,7 +4283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1286,
+      "line": 1242,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Before you start",
       "surface": "android",
@@ -4515,7 +4291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1292,
+      "line": 1248,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Access to the Gateway device",
       "surface": "android",
@@ -4523,7 +4299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1293,
+      "line": 1249,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Have a terminal open on the device running OpenClaw.",
       "surface": "android",
@@ -4531,7 +4307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1296,
+      "line": 1252,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Phone can reach the Gateway",
       "surface": "android",
@@ -4539,7 +4315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1297,
+      "line": 1253,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Use the same network, or a secure remote Gateway URL.",
       "surface": "android",
@@ -4547,7 +4323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1303,
+      "line": 1259,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Android setup guide",
       "surface": "android",
@@ -4555,7 +4331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1346,
+      "line": 1302,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup Gateway",
       "surface": "android",
@@ -4563,7 +4339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1351,
+      "line": 1307,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Step 1",
       "surface": "android",
@@ -4571,7 +4347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1352,
+      "line": 1308,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Start your Gateway.",
       "surface": "android",
@@ -4579,7 +4355,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1353,
+      "line": 1309,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "openclaw gateway",
       "surface": "android",
@@ -4587,7 +4363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1357,
+      "line": 1313,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Step 2",
       "surface": "android",
@@ -4595,7 +4371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1358,
+      "line": 1314,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Generate a QR code.",
       "surface": "android",
@@ -4603,7 +4379,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1359,
+      "line": 1315,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "openclaw qr",
       "surface": "android",
@@ -4611,7 +4387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1382,
+      "line": 1338,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Choose from gallery",
       "surface": "android",
@@ -4619,7 +4395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1437,
+      "line": 1393,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "QR code not accepted",
       "surface": "android",
@@ -4627,7 +4403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1456,
+      "line": 1412,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Choose another image",
       "surface": "android",
@@ -4635,7 +4411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1509,
+      "line": 1465,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Scan QR code",
       "surface": "android",
@@ -4643,7 +4419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1511,
+      "line": 1467,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Open the camera and frame the code from openclaw qr.",
       "surface": "android",
@@ -4651,7 +4427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1545,
+      "line": 1501,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Align the QR code inside the square.",
       "surface": "android",
@@ -4659,7 +4435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1563,
+      "line": 1519,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Camera access is needed to scan the setup QR.",
       "surface": "android",
@@ -4667,7 +4443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1568,
+      "line": 1524,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Allow camera",
       "surface": "android",
@@ -4675,7 +4451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1589,
+      "line": 1545,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Close scanner",
       "surface": "android",
@@ -4683,7 +4459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1752,
+      "line": 1708,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Enter setup code",
       "surface": "android",
@@ -4691,7 +4467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1758,
+      "line": 1714,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup code",
       "surface": "android",
@@ -4699,7 +4475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1762,
+      "line": 1718,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Paste setup code",
       "surface": "android",
@@ -4707,7 +4483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1770,
+      "line": 1726,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Use setup code",
       "surface": "android",
@@ -4715,7 +4491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1810,
+      "line": 1766,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Manual setup",
       "surface": "android",
@@ -4723,7 +4499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1813,
+      "line": 1769,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway URL",
       "surface": "android",
@@ -4731,7 +4507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1822,
+      "line": 1778,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Host",
       "surface": "android",
@@ -4739,7 +4515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1823,
+      "line": 1779,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Port",
       "surface": "android",
@@ -4747,7 +4523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1828,
+      "line": 1784,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Use the Gateway computer's LAN address or secure remote hostname.",
       "surface": "android",
@@ -4755,7 +4531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1835,
+      "line": 1791,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Token",
       "surface": "android",
@@ -4763,7 +4539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1836,
+      "line": 1792,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Paste token",
       "surface": "android",
@@ -4771,7 +4547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1838,
+      "line": 1794,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Paste a shared Gateway token or operator-issued token.",
       "surface": "android",
@@ -4779,7 +4555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1845,
+      "line": 1801,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Password",
       "surface": "android",
@@ -4787,7 +4563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1846,
+      "line": 1802,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Password optional",
       "surface": "android",
@@ -4795,7 +4571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1850,
+      "line": 1806,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connection security",
       "surface": "android",
@@ -4803,7 +4579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1872,
+      "line": 1828,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Unencrypted",
       "surface": "android",
@@ -4811,7 +4587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1878,
+      "line": 1834,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Secure (TLS)",
       "surface": "android",
@@ -4819,7 +4595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1901,
+      "line": 1857,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Could not test connection",
       "surface": "android",
@@ -4827,7 +4603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1906,
+      "line": 1862,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Test connection",
       "surface": "android",
@@ -4835,7 +4611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1993,
+      "line": 1949,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup code was not accepted",
       "surface": "android",
@@ -4843,7 +4619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1999,
+      "line": 1955,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Your phone is paired with ${recoveryGatewayName(serverName = serverName, attemptedGatewayName = attemptedGatewayName)}. Continue to finish node access.",
       "surface": "android",
@@ -4851,7 +4627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2051,
+      "line": 2007,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway paired",
       "surface": "android",
@@ -4859,7 +4635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2052,
+      "line": 2008,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Pair Gateway",
       "surface": "android",
@@ -4867,7 +4643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2104,
+      "line": 2060,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "View details",
       "surface": "android",
@@ -4875,7 +4651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2137,
+      "line": 2093,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connection details",
       "surface": "android",
@@ -4883,7 +4659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2149,
+      "line": 2105,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Copy",
       "surface": "android",
@@ -4891,7 +4667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2154,
+      "line": 2110,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Close",
       "surface": "android",
@@ -4899,7 +4675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2166,
+      "line": 2122,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Details copied",
       "surface": "android",
@@ -4907,7 +4683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2211,
+      "line": 2167,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Approve node access",
       "surface": "android",
@@ -4915,7 +4691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2218,
+      "line": 2174,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway pairing is complete. Approve this phone as a node so OpenClaw can use the device capabilities you enable.",
       "surface": "android",
@@ -4923,7 +4699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2226,
+      "line": 2182,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "On the Gateway computer, run:",
       "surface": "android",
@@ -4931,7 +4707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2235,
+      "line": 2191,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Use the requestId from the pending command in the approve command.",
       "surface": "android",
@@ -4939,7 +4715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2246,
+      "line": 2202,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "I have approved",
       "surface": "android",
@@ -4947,7 +4723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2247,
+      "line": 2203,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Checking approval…",
       "surface": "android",
@@ -4955,7 +4731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2259,
+      "line": 2215,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Still waiting for approval",
       "surface": "android",
@@ -4963,7 +4739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2262,
+      "line": 2218,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Run the approve command on the Gateway computer, then check again.",
       "surface": "android",
@@ -4971,7 +4747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2269,
+      "line": 2225,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "OK",
       "surface": "android",
@@ -4979,7 +4755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2419,
+      "line": 2375,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Copy approval command",
       "surface": "android",
@@ -4987,7 +4763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2450,
+      "line": 2406,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Only enable access you are comfortable letting OpenClaw use while this phone is connected. You can change these later in Android Settings.",
       "surface": "android",
@@ -4995,7 +4771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2489,
+      "line": 2445,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Back",
       "surface": "android",
@@ -5003,7 +4779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2540,
+      "line": 2496,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Permissions",
       "surface": "android",
@@ -5011,7 +4787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2601,
+      "line": 2557,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connected",
       "surface": "android",
@@ -5019,7 +4795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2602,
+      "line": 2558,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Your Gateway is ready.",
       "surface": "android",
@@ -5027,7 +4803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2606,
+      "line": 2562,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Approve this phone on the gateway.\nThen retry the connection.",
       "surface": "android",
@@ -5035,7 +4811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2609,
+      "line": 2565,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Node Approval Pending",
       "surface": "android",
@@ -5043,7 +4819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2610,
+      "line": 2566,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway pairing worked.\nApprove this phone's node capabilities from an operator UI.",
       "surface": "android",
@@ -5051,7 +4827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2613,
+      "line": 2569,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Pairing Gateway",
       "surface": "android",
@@ -5059,7 +4835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2614,
+      "line": 2570,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Approval is in progress.\nOpenClaw will reconnect automatically.",
       "surface": "android",
@@ -5067,7 +4843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2617,
+      "line": 2573,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connecting Gateway",
       "surface": "android",
@@ -5075,7 +4851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2618,
+      "line": 2574,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "OpenClaw is checking gateway and node access.",
       "surface": "android",
@@ -5083,7 +4859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2621,
+      "line": 2577,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Still connecting",
       "surface": "android",
@@ -5091,7 +4867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2622,
+      "line": 2578,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "This is taking longer than expected.\nCheck that the Gateway is running and reachable.",
       "surface": "android",
@@ -5099,7 +4875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2625,
+      "line": 2581,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connection issue",
       "surface": "android",
@@ -5107,7 +4883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2626,
+      "line": 2582,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "We could not reach your Gateway.\nLet's fix this.",
       "surface": "android",
@@ -5115,7 +4891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2634,
+      "line": 2590,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Continue",
       "surface": "android",
@@ -5123,7 +4899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2635,
+      "line": 2591,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Retry connection",
       "surface": "android",
@@ -5131,7 +4907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2636,
+      "line": 2592,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Go back",
       "surface": "android",
@@ -5139,7 +4915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2732,
+      "line": 2688,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway received this phone",
       "surface": "android",
@@ -5147,7 +4923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2733,
+      "line": 2689,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Waiting for device approval",
       "surface": "android",
@@ -5155,7 +4931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2734,
+      "line": 2690,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Retrying automatically",
       "surface": "android",
@@ -5163,7 +4939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2738,
+      "line": 2694,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway needs device approval",
       "surface": "android",
@@ -5171,7 +4947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2739,
+      "line": 2695,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Run the approval command on the Gateway",
       "surface": "android",
@@ -5179,7 +4955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2755,
+      "line": 2711,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Opening Gateway connection",
       "surface": "android",
@@ -5187,7 +4963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2764,
+      "line": 2720,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Checking pairing access",
       "surface": "android",
@@ -5195,7 +4971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2772,
+      "line": 2728,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Checking node access",
       "surface": "android",
@@ -5203,7 +4979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2841,
+      "line": 2797,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Ready for chat and voice",
       "surface": "android",
@@ -5211,7 +4987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2843,
+      "line": 2799,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway paired. Waiting for node capability approval.",
       "surface": "android",
@@ -5219,7 +4995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2846,
+      "line": 2802,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway approval is pending. Run this on the gateway host:",
       "surface": "android",
@@ -5227,7 +5003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2847,
+      "line": 2803,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway approval is pending. Run openclaw devices list on the gateway host, approve this phone, then retry.",
       "surface": "android",
@@ -5235,7 +5011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2855,
+      "line": 2811,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway paired. Checking node capability approval.",
       "surface": "android",
@@ -5243,7 +5019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2857,
+      "line": 2813,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway paired. Waiting for operator access.",
       "surface": "android",
@@ -5251,7 +5027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2859,
+      "line": 2815,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway approval is in progress. OpenClaw will retry automatically.",
       "surface": "android",
@@ -5259,7 +5035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2861,
+      "line": 2817,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway unreachable",
       "surface": "android",
@@ -5267,7 +5043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2867,
+      "line": 2823,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "The code may have expired or been generated for another Gateway.",
       "surface": "android",
@@ -5275,7 +5051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2871,
+      "line": 2827,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway password is required. Enter it again or edit this connection.",
       "surface": "android",
@@ -5283,7 +5059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2872,
+      "line": 2828,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway password is invalid. Re-enter it or reset this gateway connection.",
       "surface": "android",
@@ -5291,7 +5067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2873,
+      "line": 2829,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway token is required. Enter it again or edit this connection.",
       "surface": "android",
@@ -5299,7 +5075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2876,
+      "line": 2832,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway requires this device identity. Re-authenticate or reset this gateway connection.",
       "surface": "android",
@@ -5307,7 +5083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2879,
+      "line": 2835,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Saved authentication is invalid. Re-authenticate or reset this gateway connection.",
       "surface": "android",
@@ -5315,7 +5091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2880,
+      "line": 2836,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway authentication is not configured. Edit this connection and try again.",
       "surface": "android",
@@ -5323,7 +5099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2881,
+      "line": 2837,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway authentication needs review. Check gateway settings, then retry.",
       "surface": "android",
@@ -5331,7 +5107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2882,
+      "line": 2838,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway authentication needs attention.",
       "surface": "android",
@@ -5339,7 +5115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2893,
+      "line": 2849,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "This app is older than the Gateway. Update OpenClaw on this device, then retry.",
       "surface": "android",
@@ -5347,7 +5123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2895,
+      "line": 2851,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "The Gateway is older than this app. Update OpenClaw on the Gateway host, then retry.",
       "surface": "android",
@@ -5355,7 +5131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2896,
+      "line": 2852,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "The app and Gateway use incompatible protocol versions. Update OpenClaw on both, then retry.",
       "surface": "android",
@@ -5363,7 +5139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2898,
+      "line": 2854,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "$summary $details",
       "surface": "android",
@@ -5371,7 +5147,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2933,
+      "line": 2889,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "openclaw devices approve $requestId",
       "surface": "android",
@@ -5379,7 +5155,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2935,
+      "line": 2891,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "openclaw devices list",
       "surface": "android",
@@ -5387,7 +5163,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2942,
+      "line": 2898,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "openclaw nodes approve $requestId",
       "surface": "android",
@@ -5395,7 +5171,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2944,
+      "line": 2900,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "openclaw nodes approve REQUEST_ID",
       "surface": "android",
@@ -5403,7 +5179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3029,
+      "line": 2985,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Approval command copied",
       "surface": "android",
@@ -5411,7 +5187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3038,
+      "line": 2994,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Command copied",
       "surface": "android",
@@ -5419,7 +5195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3105,
+      "line": 3061,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Enabled",
       "surface": "android",
@@ -5427,7 +5203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3106,
+      "line": 3062,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Off",
       "surface": "android",
@@ -5435,7 +5211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3107,
+      "line": 3063,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Not allowed",
       "surface": "android",
@@ -5443,7 +5219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3115,
+      "line": 3071,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Granted",
       "surface": "android",
@@ -5451,7 +5227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3115,
+      "line": 3071,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Not granted",
       "surface": "android",
@@ -5459,7 +5235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3241,
+      "line": 3197,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Transcribe voice prompts",
       "surface": "android",
@@ -5467,7 +5243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3241,
+      "line": 3197,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Voice",
       "surface": "android",
@@ -5475,7 +5251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3246,
+      "line": 3202,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Camera",
       "surface": "android",
@@ -5483,7 +5259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3247,
+      "line": 3203,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Capture photos and clips from this phone",
       "surface": "android",
@@ -5491,7 +5267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3256,
+      "line": 3212,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Location",
       "surface": "android",
@@ -5499,7 +5275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3256,
+      "line": 3212,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Read this phone's location",
       "surface": "android",
@@ -5507,7 +5283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3260,
+      "line": 3216,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Photos",
       "surface": "android",
@@ -5515,7 +5291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3260,
+      "line": 3216,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Read recent photos and media",
       "surface": "android",
@@ -5523,7 +5299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3266,
+      "line": 3222,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Contacts",
       "surface": "android",
@@ -5531,7 +5307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3266,
+      "line": 3222,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Find people and contact details",
       "surface": "android",
@@ -5539,7 +5315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3269,
+      "line": 3225,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Calendar",
       "surface": "android",
@@ -5547,7 +5323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3269,
+      "line": 3225,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Read and update events",
       "surface": "android",
@@ -5555,7 +5331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3272,
+      "line": 3228,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Notifications",
       "surface": "android",
@@ -5563,7 +5339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3272,
+      "line": 3228,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Show OpenClaw alerts",
       "surface": "android",
@@ -5571,7 +5347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3275,
+      "line": 3231,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Notification listener",
       "surface": "android",
@@ -5579,7 +5355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3275,
+      "line": 3231,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Read selected app notifications",
       "surface": "android",
@@ -5587,7 +5363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3279,
+      "line": 3235,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Motion",
       "surface": "android",
@@ -5595,7 +5371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3279,
+      "line": 3235,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Share steps and activity",
       "surface": "android",
@@ -5603,7 +5379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3286,
+      "line": 3242,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Device access; Gateway opt-in still required",
       "surface": "android",
@@ -5611,7 +5387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3286,
+      "line": 3242,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "SMS",
       "surface": "android",
@@ -5619,7 +5395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3293,
+      "line": 3249,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Call Log",
       "surface": "android",
@@ -5627,7 +5403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3293,
+      "line": 3249,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Show recent call history",
       "surface": "android",
@@ -5885,17 +5661,17 @@
       "kind": "ui-call",
       "line": 186,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "Threads",
+      "source": "Sessions",
       "surface": "android",
-      "id": "native.android.a5845742daecb4ba"
+      "id": "native.android.0e3157c15c56944f"
     },
     {
       "kind": "ui-call",
       "line": 189,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "Focus thread search",
+      "source": "Focus session search",
       "surface": "android",
-      "id": "native.android.439b324280869527"
+      "id": "native.android.70f5d0507d34b5c8"
     },
     {
       "kind": "ui-call",
@@ -5917,17 +5693,17 @@
       "kind": "ui-call",
       "line": 211,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "Search threads",
+      "source": "Search sessions",
       "surface": "android",
-      "id": "native.android.03981341841b04ac"
+      "id": "native.android.b9cf34c137e4cf03"
     },
     {
       "kind": "ui-call",
       "line": 216,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "Clear thread search",
+      "source": "Clear session search",
       "surface": "android",
-      "id": "native.android.99570c528a41fa72"
+      "id": "native.android.10cb26723e9990fc"
     },
     {
       "kind": "ui-call",
@@ -5957,9 +5733,9 @@
       "kind": "ui-call",
       "line": 285,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "Toggle thread layout",
+      "source": "Toggle session layout",
       "surface": "android",
-      "id": "native.android.fd67be543e321cc9"
+      "id": "native.android.c6bf8751e2a7f5c7"
     },
     {
       "kind": "ui-call",
@@ -5981,17 +5757,17 @@
       "kind": "ui-call",
       "line": 300,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "Searching threads",
+      "source": "Searching sessions",
       "surface": "android",
-      "id": "native.android.ebd17565e0ffd8eb"
+      "id": "native.android.69b79a3c2c987cd4"
     },
     {
       "kind": "ui-call",
       "line": 303,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "No matching threads",
+      "source": "No matching sessions",
       "surface": "android",
-      "id": "native.android.472d46ae8669f860"
+      "id": "native.android.dd587d341af44212"
     },
     {
       "kind": "ui-call",
@@ -6021,25 +5797,25 @@
       "kind": "ui-call",
       "line": 342,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "Current thread",
+      "source": "Current session",
       "surface": "android",
-      "id": "native.android.ff81ad1bee00d384"
+      "id": "native.android.f10d4df7cbc6df4f"
     },
     {
       "kind": "ui-call",
       "line": 342,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "OpenClaw thread",
+      "source": "OpenClaw session",
       "surface": "android",
-      "id": "native.android.fc145645b9620e57"
+      "id": "native.android.8f0482425838ae64"
     },
     {
       "kind": "ui-call",
       "line": 397,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "Rename thread",
+      "source": "Rename session",
       "surface": "android",
-      "id": "native.android.71cbb8dde8bf138b"
+      "id": "native.android.786774c8a76e50d7"
     },
     {
       "kind": "ui-call",
@@ -6085,25 +5861,25 @@
       "kind": "ui-call",
       "line": 477,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
+      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
       "surface": "android",
-      "id": "native.android.691e92cfe5cf106e"
+      "id": "native.android.3455fc2f77d564e3"
     },
     {
       "kind": "ui-call",
       "line": 500,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "Delete thread?",
+      "source": "Delete session?",
       "surface": "android",
-      "id": "native.android.d87a8217ab56999b"
+      "id": "native.android.4805fb9d6623e8c0"
     },
     {
       "kind": "ui-call",
       "line": 501,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "This permanently deletes the thread and its transcript.",
+      "source": "This permanently deletes the session and its transcript.",
       "surface": "android",
-      "id": "native.android.930de97ff47113a8"
+      "id": "native.android.0c3283a2b2445eae"
     },
     {
       "kind": "ui-call",
@@ -6301,25 +6077,25 @@
       "kind": "ui-call",
       "line": 958,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "No threads yet",
+      "source": "No sessions yet",
       "surface": "android",
-      "id": "native.android.8e21a70428def6e0"
+      "id": "native.android.db243d71d056afa4"
     },
     {
       "kind": "ui-call",
       "line": 959,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "No current thread",
+      "source": "No current session",
       "surface": "android",
-      "id": "native.android.cda4c5ad8b17e394"
+      "id": "native.android.5b4eee6a8092925e"
     },
     {
       "kind": "ui-call",
       "line": 960,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "No archived threads",
+      "source": "No archived sessions",
       "surface": "android",
-      "id": "native.android.be84f061047aa2da"
+      "id": "native.android.acbcc9c9ea53d8c0"
     },
     {
       "kind": "ui-call",
@@ -6333,17 +6109,17 @@
       "kind": "ui-call",
       "line": 967,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "Open Chat to start or resume the current thread.",
+      "source": "Open Chat to start or resume the current session.",
       "surface": "android",
-      "id": "native.android.f289d03e1d3eee98"
+      "id": "native.android.56fcd605dc7be3c0"
     },
     {
       "kind": "ui-call",
       "line": 968,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "Archived threads will show up here.",
+      "source": "Archived sessions will show up here.",
       "surface": "android",
-      "id": "native.android.504b71386e76c6ae"
+      "id": "native.android.085515989f8a2022"
     },
     {
       "kind": "ui-call",
@@ -6381,13 +6157,13 @@
       "kind": "ui-call",
       "line": 990,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "Main thread",
+      "source": "Main session",
       "surface": "android",
-      "id": "native.android.ee4c727cdafbe963"
+      "id": "native.android.3d4fa07acbc015c5"
     },
     {
       "kind": "ui-call",
-      "line": 255,
+      "line": 251,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Provider limits and quota health.",
       "surface": "android",
@@ -6395,7 +6171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 255,
+      "line": 251,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Usage",
       "surface": "android",
@@ -6403,7 +6179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 259,
+      "line": 255,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Providers",
       "surface": "android",
@@ -6411,7 +6187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 275,
+      "line": 271,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load usage.",
       "surface": "android",
@@ -6419,7 +6195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 280,
+      "line": 276,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No usage data yet.",
       "surface": "android",
@@ -6427,7 +6203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 281,
+      "line": 277,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Provider limits will appear here when your gateway reports them.",
       "surface": "android",
@@ -6435,7 +6211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 320,
+      "line": 316,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scheduled OpenClaw work from your gateway.",
       "surface": "android",
@@ -6443,7 +6219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 325,
+      "line": 321,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Automations",
       "surface": "android",
@@ -6451,7 +6227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 333,
+      "line": 329,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Search automations",
       "surface": "android",
@@ -6459,7 +6235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 334,
+      "line": 330,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Search",
       "surface": "android",
@@ -6467,7 +6243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 350,
+      "line": 346,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open an automation to inspect its configuration and run history. Admin-scoped connections can also run, edit, enable, disable, or delete it.",
       "surface": "android",
@@ -6475,7 +6251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 360,
+      "line": 356,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load automations.",
       "surface": "android",
@@ -6483,7 +6259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 365,
+      "line": 361,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No automations yet.",
       "surface": "android",
@@ -6491,7 +6267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 366,
+      "line": 362,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scheduled work created on the gateway will appear here.",
       "surface": "android",
@@ -6499,7 +6275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 371,
+      "line": 367,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No matching automations.",
       "surface": "android",
@@ -6507,7 +6283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 470,
+      "line": 466,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Automation",
       "surface": "android",
@@ -6515,7 +6291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 471,
+      "line": 467,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Inspect and manage scheduled gateway work.",
       "surface": "android",
@@ -6523,7 +6299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 492,
+      "line": 488,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to inspect automations.",
       "surface": "android",
@@ -6531,7 +6307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 500,
+      "line": 496,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Automation not loaded.",
       "surface": "android",
@@ -6539,7 +6315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 500,
+      "line": 496,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Loading automation…",
       "surface": "android",
@@ -6547,7 +6323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 551,
+      "line": 547,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Choose and inspect the assistants available on this gateway.",
       "surface": "android",
@@ -6555,7 +6331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 555,
+      "line": 551,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Available",
       "surface": "android",
@@ -6563,7 +6339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 562,
+      "line": 558,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load agents.",
       "surface": "android",
@@ -6571,7 +6347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 566,
+      "line": 562,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No agents loaded yet.",
       "surface": "android",
@@ -6579,7 +6355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 593,
+      "line": 589,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Approvals",
       "surface": "android",
@@ -6587,7 +6363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 593,
+      "line": 589,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Review actions that need your attention.",
       "surface": "android",
@@ -6595,7 +6371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 597,
+      "line": 593,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway Pending",
       "surface": "android",
@@ -6603,15 +6379,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 598,
+      "line": 594,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
-      "source": "Thread Activity",
+      "source": "Session Activity",
       "surface": "android",
-      "id": "native.android.da78209effb11cfd"
+      "id": "native.android.2d8d049afe99f751"
     },
     {
       "kind": "ui-call",
-      "line": 599,
+      "line": 595,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Issues",
       "surface": "android",
@@ -6619,7 +6395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 600,
+      "line": 596,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Active Runs",
       "surface": "android",
@@ -6627,7 +6403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 604,
+      "line": 600,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Refresh",
       "surface": "android",
@@ -6635,7 +6411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 604,
+      "line": 600,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Refreshing",
       "surface": "android",
@@ -6643,7 +6419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 622,
+      "line": 618,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway disconnected.",
       "surface": "android",
@@ -6651,7 +6427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 623,
+      "line": 619,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load approval requests in the app.",
       "surface": "android",
@@ -6659,7 +6435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 629,
+      "line": 625,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No gateway approvals.",
       "surface": "android",
@@ -6667,7 +6443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 630,
+      "line": 626,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Exec approval requests will appear here while this phone is connected.",
       "surface": "android",
@@ -6675,23 +6451,23 @@
     },
     {
       "kind": "ui-call",
-      "line": 640,
+      "line": 636,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
-      "source": "Thread activity",
+      "source": "Session activity",
       "surface": "android",
-      "id": "native.android.f615712dfb56319a"
+      "id": "native.android.dc3e7ca5a491103a"
     },
     {
       "kind": "ui-call",
-      "line": 641,
+      "line": 637,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
-      "source": "Chat tool calls waiting in the active thread remain visible here.",
+      "source": "Chat tool calls waiting in the active session remain visible here.",
       "surface": "android",
-      "id": "native.android.6c93973c13db43ae"
+      "id": "native.android.8551e02b060bd7d8"
     },
     {
       "kind": "ui-call",
-      "line": 655,
+      "line": 651,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "How this phone appears to OpenClaw.",
       "surface": "android",
@@ -6699,7 +6475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 655,
+      "line": 651,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Profile",
       "surface": "android",
@@ -6707,7 +6483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 658,
+      "line": 654,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Device name",
       "surface": "android",
@@ -6715,7 +6491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 659,
+      "line": 655,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Save Profile",
       "surface": "android",
@@ -6723,7 +6499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 718,
+      "line": 703,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Configure wake words, talk, and playback.",
       "surface": "android",
@@ -6731,7 +6507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 718,
+      "line": 703,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Voice",
       "surface": "android",
@@ -6739,7 +6515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 720,
+      "line": 705,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Voice Wake",
       "surface": "android",
@@ -6747,7 +6523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 725,
+      "line": 710,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Listen for wake words",
       "surface": "android",
@@ -6755,7 +6531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 728,
+      "line": 713,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Runs on-device while OpenClaw is visible.",
       "surface": "android",
@@ -6763,7 +6539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 730,
+      "line": 715,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "On-device speech recognition is unavailable.",
       "surface": "android",
@@ -6771,7 +6547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 740,
+      "line": 725,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Wake listener",
       "surface": "android",
@@ -6779,7 +6555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 742,
+      "line": 727,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last command: $command",
       "surface": "android",
@@ -6787,7 +6563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 743,
+      "line": 728,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Pauses during other voice activity.",
       "surface": "android",
@@ -6795,7 +6571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 750,
+      "line": 735,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Wake words",
       "surface": "android",
@@ -6803,7 +6579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 752,
+      "line": 737,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Add one wake word or phrase per field. Then say one before your command.",
       "surface": "android",
@@ -6811,7 +6587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 767,
+      "line": 752,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Wake word or phrase",
       "surface": "android",
@@ -6819,7 +6595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 774,
+      "line": 759,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Remove wake phrase",
       "surface": "android",
@@ -6827,7 +6603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 783,
+      "line": 768,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Add wake phrase",
       "surface": "android",
@@ -6835,7 +6611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 790,
+      "line": 775,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Save wake words",
       "surface": "android",
@@ -6843,7 +6619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 790,
+      "line": 775,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Saving…",
       "surface": "android",
@@ -6851,7 +6627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 795,
+      "line": 780,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect to a Gateway to save wake words",
       "surface": "android",
@@ -6859,7 +6635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 800,
+      "line": 785,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Talk Provider Setup",
       "surface": "android",
@@ -6867,15 +6643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 802,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
-      "source": "Microphone",
-      "surface": "android",
-      "id": "native.android.23b638094c34b916"
-    },
-    {
-      "kind": "ui-call",
-      "line": 809,
+      "line": 787,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Audio Test",
       "surface": "android",
@@ -6883,7 +6651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 810,
+      "line": 788,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check that OpenClaw can speak clearly on this phone.",
       "surface": "android",
@@ -6891,7 +6659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 813,
+      "line": 791,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enable speaker",
       "surface": "android",
@@ -6899,7 +6667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 813,
+      "line": 791,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Mute speaker",
       "surface": "android",
@@ -6907,7 +6675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 814,
+      "line": 792,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Assistant speech muted",
       "surface": "android",
@@ -6915,7 +6683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 814,
+      "line": 792,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replies play aloud",
       "surface": "android",
@@ -6923,7 +6691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 816,
+      "line": 794,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Muted",
       "surface": "android",
@@ -6931,7 +6699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 816,
+      "line": 794,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "On",
       "surface": "android",
@@ -6939,7 +6707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 820,
+      "line": 798,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Done",
       "surface": "android",
@@ -6947,103 +6715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 838,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
-      "source": "Automatic",
-      "surface": "android",
-      "id": "native.android.8d9ecdfdd916b780"
-    },
-    {
-      "kind": "ui-call",
-      "line": 841,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
-      "source": "Preferred microphone unavailable; using automatic routing.",
-      "surface": "android",
-      "id": "native.android.c1626a6700a570f6"
-    },
-    {
-      "kind": "ui-call",
-      "line": 843,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
-      "source": "Prioritizes connected Bluetooth microphones.",
-      "surface": "android",
-      "id": "native.android.820bc5d0ce571d8b"
-    },
-    {
-      "kind": "ui-call",
-      "line": 852,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
-      "source": "Preferred microphone",
-      "surface": "android",
-      "id": "native.android.11e48038d5e8bff6"
-    },
-    {
-      "kind": "ui-call",
-      "line": 853,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
-      "source": "Unavailable",
-      "surface": "android",
-      "id": "native.android.eaa4d7563a46d307"
-    },
-    {
-      "kind": "ui-call",
-      "line": 885,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
-      "source": "Next session",
-      "surface": "android",
-      "id": "native.android.9f5ebf17eb405ba8"
-    },
-    {
-      "kind": "ui-call",
-      "line": 907,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
-      "source": "Built-in microphone",
-      "surface": "android",
-      "id": "native.android.8c4e91f53928efb2"
-    },
-    {
-      "kind": "ui-call",
-      "line": 908,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
-      "source": "Bluetooth microphone",
-      "surface": "android",
-      "id": "native.android.14b613cb6e2446b4"
-    },
-    {
-      "kind": "ui-call",
-      "line": 909,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
-      "source": "Bluetooth LE microphone",
-      "surface": "android",
-      "id": "native.android.c885247b2d7ce271"
-    },
-    {
-      "kind": "ui-call",
-      "line": 910,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
-      "source": "Wired headset microphone",
-      "surface": "android",
-      "id": "native.android.b6a4e674c5fb441a"
-    },
-    {
-      "kind": "ui-call",
-      "line": 914,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
-      "source": "USB microphone",
-      "surface": "android",
-      "id": "native.android.9c8becb3b0fb5a90"
-    },
-    {
-      "kind": "ui-call",
-      "line": 915,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
-      "source": "External microphone",
-      "surface": "android",
-      "id": "native.android.ba46258fadec7a39"
-    },
-    {
-      "kind": "ui-call",
-      "line": 923,
+      "line": 808,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Realtime Talk",
       "surface": "android",
@@ -7051,7 +6723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 924,
+      "line": 809,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Dictation",
       "surface": "android",
@@ -7059,7 +6731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1094,
+      "line": 979,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Choose what reaches OpenClaw.",
       "surface": "android",
@@ -7067,7 +6739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1094,
+      "line": 979,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Notifications",
       "surface": "android",
@@ -7075,7 +6747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1098,
+      "line": 983,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Alerts stay on this phone.",
       "surface": "android",
@@ -7083,7 +6755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1098,
+      "line": 983,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forward Notifications",
       "surface": "android",
@@ -7091,7 +6763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1098,
+      "line": 983,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw can receive selected alerts.",
       "surface": "android",
@@ -7099,7 +6771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1100,
+      "line": 985,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Quiet Hours",
       "surface": "android",
@@ -7107,7 +6779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1101,
+      "line": 986,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$quietStart to $quietEnd",
       "surface": "android",
@@ -7115,7 +6787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1113,
+      "line": 998,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Policy",
       "surface": "android",
@@ -7123,7 +6795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1114,
+      "line": 999,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Selected Apps",
       "surface": "android",
@@ -7131,7 +6803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1115,
+      "line": 1000,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Rate Limit",
       "surface": "android",
@@ -7139,7 +6811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1116,
+      "line": 1001,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Granted",
       "surface": "android",
@@ -7147,7 +6819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1116,
+      "line": 1001,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup",
       "surface": "android",
@@ -7155,7 +6827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1121,
+      "line": 1006,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check Access",
       "surface": "android",
@@ -7163,7 +6835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1121,
+      "line": 1006,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open System Access",
       "surface": "android",
@@ -7171,7 +6843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1130,
+      "line": 1015,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forwarding Mode",
       "surface": "android",
@@ -7179,7 +6851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1132,
+      "line": 1017,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Blocklist",
       "surface": "android",
@@ -7187,7 +6859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1136,
+      "line": 1021,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allowlist",
       "surface": "android",
@@ -7195,7 +6867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1185,
+      "line": 1070,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App Filter",
       "surface": "android",
@@ -7203,7 +6875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1192,
+      "line": 1077,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Close App Picker",
       "surface": "android",
@@ -7211,7 +6883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1192,
+      "line": 1077,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open App Picker",
       "surface": "android",
@@ -7219,7 +6891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1197,
+      "line": 1082,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Search apps",
       "surface": "android",
@@ -7227,7 +6899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1200,
+      "line": 1085,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Show System Apps",
       "surface": "android",
@@ -7235,7 +6907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1201,
+      "line": 1086,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Include Android and background packages.",
       "surface": "android",
@@ -7243,7 +6915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1208,
+      "line": 1093,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No matching apps.",
       "surface": "android",
@@ -7251,7 +6923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1219,
+      "line": 1104,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Showing ${visibleApps.size} of ${apps.size}. Refine search for more.",
       "surface": "android",
@@ -7259,7 +6931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1466,
+      "line": 1351,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Choose what this phone can share.",
       "surface": "android",
@@ -7267,7 +6939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1466,
+      "line": 1351,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Phone Capabilities",
       "surface": "android",
@@ -7275,7 +6947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1470,
+      "line": 1355,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow camera tools when requested.",
       "surface": "android",
@@ -7283,7 +6955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1470,
+      "line": 1355,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Camera",
       "surface": "android",
@@ -7291,7 +6963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1471,
+      "line": 1356,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Precise Location",
       "surface": "android",
@@ -7299,7 +6971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1471,
+      "line": 1356,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Share precise location while location is enabled.",
       "surface": "android",
@@ -7307,7 +6979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1474,
+      "line": 1359,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Photos",
       "surface": "android",
@@ -7315,7 +6987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1475,
+      "line": 1360,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow photo library access.",
       "surface": "android",
@@ -7323,7 +6995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1475,
+      "line": 1360,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Selected or full photo access granted.",
       "surface": "android",
@@ -7331,7 +7003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1484,
+      "line": 1369,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Installed Apps",
       "surface": "android",
@@ -7339,7 +7011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1485,
+      "line": 1370,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App list stays on this phone.",
       "surface": "android",
@@ -7347,7 +7019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1485,
+      "line": 1370,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw can list launcher-visible apps.",
       "surface": "android",
@@ -7355,7 +7027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1490,
+      "line": 1375,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Keep Awake",
       "surface": "android",
@@ -7363,7 +7035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1490,
+      "line": 1375,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Keep the node available during active work.",
       "surface": "android",
@@ -7371,7 +7043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1491,
+      "line": 1376,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Canvas Status",
       "surface": "android",
@@ -7379,7 +7051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1491,
+      "line": 1376,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Show screen-sharing debug state.",
       "surface": "android",
@@ -7387,7 +7059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1496,
+      "line": 1381,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Location",
       "surface": "android",
@@ -7395,7 +7067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1504,
+      "line": 1389,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Always allows requested location checks while OpenClaw is in the background; Android shows this in the persistent node notification.",
       "surface": "android",
@@ -7403,7 +7075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1539,
+      "line": 1424,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow background location?",
       "surface": "android",
@@ -7411,7 +7083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1542,
+      "line": 1427,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background.",
       "surface": "android",
@@ -7419,7 +7091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1556,
+      "line": 1441,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open Settings",
       "surface": "android",
@@ -7427,7 +7099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1575,
+      "line": 1460,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Share installed app information?",
       "surface": "android",
@@ -7435,7 +7107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1579,
+      "line": 1464,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw collects and sends the names, package IDs, and status of apps visible on this phone when your paired OpenClaw Gateway asks for them. This lets your assistant answer questions and take actions using installed apps.",
       "surface": "android",
@@ -7443,7 +7115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1582,
+      "line": 1467,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Your phone sends this information to your Gateway, not to a server run by OpenClaw. Your Gateway may include it in requests to the AI provider you chose.",
       "surface": "android",
@@ -7451,7 +7123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1588,
+      "line": 1473,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agree and Enable",
       "surface": "android",
@@ -7459,7 +7131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1593,
+      "line": 1478,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not Now",
       "surface": "android",
@@ -7467,7 +7139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1646,
+      "line": 1531,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replace gateway setup?",
       "surface": "android",
@@ -7475,7 +7147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1661,
+      "line": 1546,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replace setup",
       "surface": "android",
@@ -7483,7 +7155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1675,
+      "line": 1560,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "this gateway",
       "surface": "android",
@@ -7491,7 +7163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1678,
+      "line": 1563,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forget gateway?",
       "surface": "android",
@@ -7499,7 +7171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1681,
+      "line": 1566,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Remove $gatewayName and its saved credentials from this phone?",
       "surface": "android",
@@ -7507,7 +7179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1698,
+      "line": 1583,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Cancel",
       "surface": "android",
@@ -7515,7 +7187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1736,
+      "line": 1621,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection between this phone and OpenClaw.",
       "surface": "android",
@@ -7523,7 +7195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1750,
+      "line": 1635,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connected",
       "surface": "android",
@@ -7531,7 +7203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1750,
+      "line": 1635,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection",
       "surface": "android",
@@ -7539,7 +7211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1750,
+      "line": 1635,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Offline",
       "surface": "android",
@@ -7547,7 +7219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1751,
+      "line": 1636,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not paired",
       "surface": "android",
@@ -7555,7 +7227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1751,
+      "line": 1636,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Online",
       "surface": "android",
@@ -7563,7 +7235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1753,
+      "line": 1638,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Access",
       "surface": "android",
@@ -7571,7 +7243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1760,
+      "line": 1645,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Address",
       "surface": "android",
@@ -7579,7 +7251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1765,
+      "line": 1650,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Discovered",
       "surface": "android",
@@ -7587,7 +7259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1766,
+      "line": 1651,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default Agent",
       "surface": "android",
@@ -7595,7 +7267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1767,
+      "line": 1652,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agents",
       "surface": "android",
@@ -7603,7 +7275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1768,
+      "line": 1653,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Instance ID",
       "surface": "android",
@@ -7611,7 +7283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1774,
+      "line": 1659,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scan QR to Pair",
       "surface": "android",
@@ -7619,7 +7291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1784,
+      "line": 1669,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Limited Gateway access",
       "surface": "android",
@@ -7627,7 +7299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1797,
+      "line": 1682,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Reconnect",
       "surface": "android",
@@ -7635,7 +7307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1798,
+      "line": 1683,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Disconnect",
       "surface": "android",
@@ -7643,7 +7315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1801,
+      "line": 1686,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Diagnose",
       "surface": "android",
@@ -7651,7 +7323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1814,
+      "line": 1699,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Add Gateway",
       "surface": "android",
@@ -7659,7 +7331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1816,
+      "line": 1701,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scan or paste a setup code to add another gateway.",
       "surface": "android",
@@ -7667,7 +7339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1822,
+      "line": 1707,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scan QR",
       "surface": "android",
@@ -7675,7 +7347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1823,
+      "line": 1708,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup code",
       "surface": "android",
@@ -7683,7 +7355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1826,
+      "line": 1711,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Where do I get a setup code?",
       "surface": "android",
@@ -7691,7 +7363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1830,
+      "line": 1715,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Android can scan or paste an existing setup code, but this gateway does not expose setup-code generation to the app yet. Generate the QR/code on the gateway host with openclaw qr, then scan it here or paste the setup code below.",
       "surface": "android",
@@ -7699,7 +7371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1837,
+      "line": 1722,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No gateways found yet. Use manual setup if discovery is blocked.",
       "surface": "android",
@@ -7707,7 +7379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1850,
+      "line": 1735,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect",
       "surface": "android",
@@ -7715,7 +7387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1861,
+      "line": 1746,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateways",
       "surface": "android",
@@ -7723,7 +7395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1863,
+      "line": 1748,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No paired gateways.",
       "surface": "android",
@@ -7731,7 +7403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1883,
+      "line": 1768,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forget",
       "surface": "android",
@@ -7739,7 +7411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1899,
+      "line": 1784,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Manual Gateway",
       "surface": "android",
@@ -7747,7 +7419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1901,
+      "line": 1786,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Host",
       "surface": "android",
@@ -7755,7 +7427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1902,
+      "line": 1787,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Port",
       "surface": "android",
@@ -7763,7 +7435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1904,
+      "line": 1789,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection security",
       "surface": "android",
@@ -7771,7 +7443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1908,
+      "line": 1793,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Unencrypted",
       "surface": "android",
@@ -7779,7 +7451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1912,
+      "line": 1797,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Secure (TLS)",
       "surface": "android",
@@ -7787,7 +7459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1925,
+      "line": 1810,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Token",
       "surface": "android",
@@ -7795,7 +7467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1926,
+      "line": 1811,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Bootstrap",
       "surface": "android",
@@ -7803,7 +7475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1928,
+      "line": 1813,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Password",
       "surface": "android",
@@ -7811,7 +7483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1933,
+      "line": 1818,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Save & Connect",
       "surface": "android",
@@ -7819,7 +7491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1950,
+      "line": 1835,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enter a valid setup code or gateway address.",
       "surface": "android",
@@ -7827,7 +7499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1971,
+      "line": 1856,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not available",
       "surface": "android",
@@ -7835,7 +7507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1972,
+      "line": 1857,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Full",
       "surface": "android",
@@ -7843,7 +7515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1973,
+      "line": 1858,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Limited",
       "surface": "android",
@@ -7851,7 +7523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1977,
+      "line": 1862,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Use a secure wss:// or Tailscale Serve Gateway, generate a full-access setup code in the Control UI or with openclaw qr, then scan or paste it below and reconnect to enable settings and upgrades.",
       "surface": "android",
@@ -7859,7 +7531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1991,
+      "line": 1876,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Appearance",
       "surface": "android",
@@ -7867,7 +7539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1991,
+      "line": 1876,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Theme and translated Android text.",
       "surface": "android",
@@ -7875,7 +7547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1996,
+      "line": 1881,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Language",
       "surface": "android",
@@ -7883,7 +7555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1997,
+      "line": 1882,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Contrast",
       "surface": "android",
@@ -7891,7 +7563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1997,
+      "line": 1882,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "High",
       "surface": "android",
@@ -7899,7 +7571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1998,
+      "line": 1883,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Readable",
       "surface": "android",
@@ -7907,7 +7579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1998,
+      "line": 1883,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Typography",
       "surface": "android",
@@ -7915,7 +7587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2003,
+      "line": 1888,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Theme",
       "surface": "android",
@@ -7923,7 +7595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2013,
+      "line": 1898,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App language",
       "surface": "android",
@@ -7931,7 +7603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2047,
+      "line": 1932,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Selected",
       "surface": "android",
@@ -7939,7 +7611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2059,
+      "line": 1944,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "System",
       "surface": "android",
@@ -7947,7 +7619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2087,
+      "line": 1972,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "While Using",
       "surface": "android",
@@ -7955,7 +7627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2088,
+      "line": 1973,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Always",
       "surface": "android",
@@ -7963,7 +7635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2100,
+      "line": 1985,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connecting...",
       "surface": "android",
@@ -7971,7 +7643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2101,
+      "line": 1986,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Pairing needed",
       "surface": "android",
@@ -7979,7 +7651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2102,
+      "line": 1987,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Authentication needed",
       "surface": "android",
@@ -7987,7 +7659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2103,
+      "line": 1988,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "TLS timed out",
       "surface": "android",
@@ -7995,7 +7667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2104,
+      "line": 1989,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No TLS endpoint",
       "surface": "android",
@@ -8003,7 +7675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2105,
+      "line": 1990,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Certificate review needed",
       "surface": "android",
@@ -8011,7 +7683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2106,
+      "line": 1991,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Cannot reach gateway",
       "surface": "android",
@@ -8019,7 +7691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2127,
+      "line": 2012,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "About",
       "surface": "android",
@@ -8027,7 +7699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2127,
+      "line": 2012,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw for Android.",
       "surface": "android",
@@ -8035,7 +7707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2139,
+      "line": 2024,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Channel",
       "surface": "android",
@@ -8043,7 +7715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2140,
+      "line": 2025,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not connected",
       "surface": "android",
@@ -8051,7 +7723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2145,
+      "line": 2030,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Home Gateway",
       "surface": "android",
@@ -8059,7 +7731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2147,
+      "line": 2032,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Runtime",
       "surface": "android",
@@ -8067,7 +7739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2147,
+      "line": 2032,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting",
       "surface": "android",
@@ -8075,7 +7747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2150,
+      "line": 2035,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Update",
       "surface": "android",
@@ -8083,7 +7755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2151,
+      "line": 2036,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Up to date",
       "surface": "android",
@@ -8091,7 +7763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2151,
+      "line": 2036,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "v$it available",
       "surface": "android",
@@ -8099,7 +7771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2161,
+      "line": 2046,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "© 2026 OpenClaw Foundation — MIT License.",
       "surface": "android",
@@ -8107,7 +7779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2178,
+      "line": 2063,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw logo",
       "surface": "android",
@@ -8115,7 +7787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2180,
+      "line": 2065,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -8123,7 +7795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2181,
+      "line": 2066,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Personal AI on your devices",
       "surface": "android",
@@ -8131,7 +7803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2240,
+      "line": 2125,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Licenses",
       "surface": "android",
@@ -8139,7 +7811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2241,
+      "line": 2126,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw appreciates its partners in the open-source community.",
       "surface": "android",
@@ -8147,7 +7819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2250,
+      "line": 2135,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No license notices are packaged in this build.",
       "surface": "android",
@@ -8155,7 +7827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2276,
+      "line": 2161,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open ${license.title}",
       "surface": "android",
@@ -8163,7 +7835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2287,
+      "line": 2172,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Third-party",
       "surface": "android",
@@ -8171,7 +7843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2288,
+      "line": 2173,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Unknown",
       "surface": "android",
@@ -8179,7 +7851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2294,
+      "line": 2179,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Website",
       "surface": "android",
@@ -8187,7 +7859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2295,
+      "line": 2180,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Docs",
       "surface": "android",
@@ -8195,7 +7867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2299,
+      "line": 2184,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow all the time",
       "surface": "android",
@@ -8203,7 +7875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2302,
+      "line": 2187,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code.",
       "surface": "android",
@@ -8211,7 +7883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2321,
+      "line": 2206,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check",
       "surface": "android",
@@ -8219,15 +7891,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 2328,
+      "line": 2213,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
       "surface": "android",
-      "id": "native.android.c971506716c96e91"
+      "id": "native.android.5a540761383fa474"
     },
     {
       "kind": "ui-call",
-      "line": 2330,
+      "line": 2215,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready.",
       "surface": "android",
@@ -8235,7 +7907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2355,
+      "line": 2240,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Back",
       "surface": "android",
@@ -8243,7 +7915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2429,
+      "line": 2314,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Command approval",
       "surface": "android",
@@ -8251,7 +7923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2434,
+      "line": 2319,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Sending",
       "surface": "android",
@@ -8259,7 +7931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2494,
+      "line": 2379,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow Once",
       "surface": "android",
@@ -8267,7 +7939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2495,
+      "line": 2380,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow Always",
       "surface": "android",
@@ -8275,7 +7947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2496,
+      "line": 2381,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Deny",
       "surface": "android",
@@ -8283,7 +7955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2517,
+      "line": 2402,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Approval ${notice.approvalId}",
       "surface": "android",
@@ -8291,7 +7963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2524,
+      "line": 2409,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Dismiss approval notice",
       "surface": "android",
@@ -8299,7 +7971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2543,
+      "line": 2428,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Review",
       "surface": "android",
@@ -8307,7 +7979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2583,
+      "line": 2468,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open automation detail",
       "surface": "android",
@@ -8315,7 +7987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2626,
+      "line": 2511,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enabled",
       "surface": "android",
@@ -8323,7 +7995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2626,
+      "line": 2511,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Status",
       "surface": "android",
@@ -8331,7 +8003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2627,
+      "line": 2512,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Schedule",
       "surface": "android",
@@ -8339,7 +8011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2628,
+      "line": 2513,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Next Wake",
       "surface": "android",
@@ -8347,7 +8019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2629,
+      "line": 2514,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last Run",
       "surface": "android",
@@ -8355,7 +8027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2636,
+      "line": 2521,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Description",
       "surface": "android",
@@ -8363,7 +8035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2637,
+      "line": 2522,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Schedule Detail",
       "surface": "android",
@@ -8371,7 +8043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2638,
+      "line": 2523,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Session Target",
       "surface": "android",
@@ -8379,7 +8051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2639,
+      "line": 2524,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Wake Mode",
       "surface": "android",
@@ -8387,7 +8059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2640,
+      "line": 2525,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Delete After Run",
       "surface": "android",
@@ -8395,7 +8067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2640,
+      "line": 2525,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No",
       "surface": "android",
@@ -8403,7 +8075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2640,
+      "line": 2525,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Yes",
       "surface": "android",
@@ -8411,7 +8083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2641,
+      "line": 2526,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Payload",
       "surface": "android",
@@ -8419,7 +8091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2642,
+      "line": 2527,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Delivery",
       "surface": "android",
@@ -8427,7 +8099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2643,
+      "line": 2528,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Failure Alert",
       "surface": "android",
@@ -8435,7 +8107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2644,
+      "line": 2529,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Created",
       "surface": "android",
@@ -8443,7 +8115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2645,
+      "line": 2530,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Updated",
       "surface": "android",
@@ -8451,7 +8123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2646,
+      "line": 2531,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Running Since",
       "surface": "android",
@@ -8459,7 +8131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2647,
+      "line": 2532,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last Status",
       "surface": "android",
@@ -8467,7 +8139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2649,
+      "line": 2534,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last Duration",
       "surface": "android",
@@ -8475,7 +8147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2650,
+      "line": 2535,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${durationMs}ms",
       "surface": "android",
@@ -8483,7 +8155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2652,
+      "line": 2537,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Consecutive Errors",
       "surface": "android",
@@ -8491,7 +8163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2653,
+      "line": 2538,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Consecutive Skips",
       "surface": "android",
@@ -8499,7 +8171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2654,
+      "line": 2539,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Delivery Status",
       "surface": "android",
@@ -8507,7 +8179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2661,
+      "line": 2546,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last Error",
       "surface": "android",
@@ -8515,7 +8187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2664,
+      "line": 2549,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Delivery Error",
       "surface": "android",
@@ -8523,7 +8195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2680,
+      "line": 2565,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Copy ${row.title}",
       "surface": "android",
@@ -8531,7 +8203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2705,
+      "line": 2590,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Tap to copy",
       "surface": "android",
@@ -8539,7 +8211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2720,
+      "line": 2605,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$title copied",
       "surface": "android",
@@ -8547,7 +8219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2758,
+      "line": 2643,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default assistant",
       "surface": "android",
@@ -8555,7 +8227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2764,
+      "line": 2649,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default",
       "surface": "android",
@@ -8563,7 +8235,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2772,
+      "line": 2657,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${endpoint.host}:${endpoint.port}",
       "surface": "android",
@@ -8571,7 +8243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2818,
+      "line": 2703,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Action Request",
       "surface": "android",
@@ -8579,7 +8251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2826,
+      "line": 2711,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Needs attention",
       "surface": "android",
@@ -8587,7 +8259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2829,
+      "line": 2714,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting ${minutes}m",
       "surface": "android",
@@ -8595,7 +8267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2829,
+      "line": 2714,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting for review",
       "surface": "android",
@@ -8603,7 +8275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2840,
+      "line": 2725,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Node ${nodeId}",
       "surface": "android",
@@ -8611,7 +8283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2842,
+      "line": 2727,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Node",
       "surface": "android",
@@ -8619,7 +8291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2845,
+      "line": 2730,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway",
       "surface": "android",
@@ -8627,7 +8299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2850,
+      "line": 2735,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agent ${agentId}",
       "surface": "android",
@@ -8635,7 +8307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2855,
+      "line": 2740,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting ${duration}",
       "surface": "android",
@@ -8643,7 +8315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2860,
+      "line": 2745,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Expires ${duration}",
       "surface": "android",
@@ -8651,7 +8323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2870,
+      "line": 2755,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "soon",
       "surface": "android",
@@ -8659,7 +8331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2878,
+      "line": 2763,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Main",
       "surface": "android",
@@ -8667,7 +8339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2879,
+      "line": 2764,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Isolated",
       "surface": "android",
@@ -8675,7 +8347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2880,
+      "line": 2765,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Current",
       "surface": "android",
@@ -8683,7 +8355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2886,
+      "line": 2771,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}",
       "surface": "android",
@@ -8691,7 +8363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2902,
+      "line": 2787,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "All",
       "surface": "android",
@@ -8699,7 +8371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2903,
+      "line": 2788,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Active",
       "surface": "android",
@@ -8707,7 +8379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2904,
+      "line": 2789,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Paused",
       "surface": "android",
@@ -8715,7 +8387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2937,
+      "line": 2822,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${remaining}% left ${label}",
       "surface": "android",
@@ -8723,7 +8395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2940,
+      "line": 2825,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No limits reported",
       "surface": "android",
@@ -8731,7 +8403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2951,
+      "line": 2836,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Never",
       "surface": "android",
@@ -8739,7 +8411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2956,
+      "line": 2841,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Now",
       "surface": "android",
@@ -8747,7 +8419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2978,
+      "line": 2863,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Off",
       "surface": "android",
@@ -8755,7 +8427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2980,
+      "line": 2865,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Issue",
       "surface": "android",
@@ -8763,7 +8435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2982,
+      "line": 2867,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Skipped",
       "surface": "android",
@@ -8771,7 +8443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2983,
+      "line": 2868,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Ready",
       "surface": "android",
@@ -8779,7 +8451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2999,
+      "line": 2884,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "System Event Text",
       "surface": "android",
@@ -8787,7 +8459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3000,
+      "line": 2885,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agent Prompt",
       "surface": "android",
@@ -8795,7 +8467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3001,
+      "line": 2886,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Command",
       "surface": "android",
@@ -8803,7 +8475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3002,
+      "line": 2887,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Payload Text",
       "surface": "android",
@@ -8811,7 +8483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3032,
+      "line": 2917,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No apps selected. Nothing forwards until you add apps.",
       "surface": "android",
@@ -8819,7 +8491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3034,
+      "line": 2919,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$selectedCount app allowed to forward.",
       "surface": "android",
@@ -8827,7 +8499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3036,
+      "line": 2921,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$selectedCount apps allowed to forward.",
       "surface": "android",
@@ -8835,7 +8507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3040,
+      "line": 2925,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No apps blocked. Apps can forward unless you add blocks.",
       "surface": "android",
@@ -8843,7 +8515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3042,
+      "line": 2927,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$selectedCount app blocked from forwarding.",
       "surface": "android",
@@ -8851,7 +8523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3044,
+      "line": 2929,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$selectedCount apps blocked from forwarding.",
       "surface": "android",
@@ -8859,7 +8531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3070,
+      "line": 2955,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Due",
       "surface": "android",
@@ -8867,7 +8539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3075,
+      "line": 2960,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${days}d",
       "surface": "android",
@@ -8875,7 +8547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3076,
+      "line": 2961,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${hours}h",
       "surface": "android",
@@ -8883,7 +8555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3077,
+      "line": 2962,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${minutes}m",
       "surface": "android",
@@ -8891,7 +8563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3078,
+      "line": 2963,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Soon",
       "surface": "android",
@@ -8899,7 +8571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3083,
+      "line": 2968,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "None",
       "surface": "android",
@@ -8907,7 +8579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 134,
+      "line": 132,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Home",
       "surface": "android",
@@ -8915,7 +8587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 364,
+      "line": 361,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Close Canvas",
       "surface": "android",
@@ -8923,39 +8595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 394,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
-      "source": "The gateway certificate could not be read automatically. Paste the SHA-256 fingerprint obtained on the gateway host.",
-      "surface": "android",
-      "id": "native.android.846fe5afd08b8089"
-    },
-    {
-      "kind": "ui-call",
-      "line": 422,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
-      "source": "This gateway now presents a certificate trusted by this device.",
-      "surface": "android",
-      "id": "native.android.b263dca13f55dad9"
-    },
-    {
-      "kind": "ui-call",
-      "line": 432,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
-      "source": "SHA-256 fingerprint",
-      "surface": "android",
-      "id": "native.android.dca0f8814b658170"
-    },
-    {
-      "kind": "ui-call",
-      "line": 452,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
-      "source": "Use system trust",
-      "surface": "android",
-      "id": "native.android.bb5d50fcdd5ebafe"
-    },
-    {
-      "kind": "ui-call",
-      "line": 557,
+      "line": 509,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Overview",
       "surface": "android",
@@ -8963,7 +8603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 604,
+      "line": 556,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Start a chat and your active OpenClaw conversations will appear here.",
       "surface": "android",
@@ -8971,7 +8611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 605,
+      "line": 557,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Start Chat",
       "surface": "android",
@@ -8979,7 +8619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 659,
+      "line": 611,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Search",
       "surface": "android",
@@ -8987,7 +8627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 712,
+      "line": 664,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "ACTIVE AGENT",
       "surface": "android",
@@ -8995,7 +8635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 717,
+      "line": 669,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$agentName is working",
       "surface": "android",
@@ -9003,7 +8643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 721,
+      "line": 673,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "View",
       "surface": "android",
@@ -9011,7 +8651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 724,
+      "line": 676,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$pendingRunCount active",
       "surface": "android",
@@ -9019,7 +8659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 724,
+      "line": 676,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Idle",
       "surface": "android",
@@ -9027,7 +8667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 724,
+      "line": 676,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Runs",
       "surface": "android",
@@ -9035,7 +8675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 725,
+      "line": 677,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$sessionCount recent",
       "surface": "android",
@@ -9043,7 +8683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 726,
+      "line": 678,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Cron",
       "surface": "android",
@@ -9051,7 +8691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 729,
+      "line": 681,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -9059,7 +8699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 733,
+      "line": 685,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Reconnect gateway",
       "surface": "android",
@@ -9067,7 +8707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 884,
+      "line": 836,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open ${card.title}",
       "surface": "android",
@@ -9075,7 +8715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 964,
+      "line": 916,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Talk",
       "surface": "android",
@@ -9083,7 +8723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 965,
+      "line": 917,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open Talk",
       "surface": "android",
@@ -9091,7 +8731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 967,
+      "line": 919,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Talk settings",
       "surface": "android",
@@ -9099,15 +8739,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 975,
+      "line": 927,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
-      "source": "Recent Threads",
+      "source": "Recent Sessions",
       "surface": "android",
-      "id": "native.android.36f78c8c85dc283f"
+      "id": "native.android.73f07a5d54915259"
     },
     {
       "kind": "ui-call",
-      "line": 985,
+      "line": 937,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "View all",
       "surface": "android",
@@ -9115,7 +8755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1103,
+      "line": 1055,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Online",
       "surface": "android",
@@ -9123,7 +8763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1104,
+      "line": 1056,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Healthy",
       "surface": "android",
@@ -9131,7 +8771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1108,
+      "line": 1060,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Reconnect to continue",
       "surface": "android",
@@ -9139,7 +8779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1109,
+      "line": 1061,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Review highlighted items",
       "surface": "android",
@@ -9147,7 +8787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1110,
+      "line": 1062,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "All systems nominal",
       "surface": "android",
@@ -9155,7 +8795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1123,
+      "line": 1075,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Nodes",
       "surface": "android",
@@ -9163,7 +8803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1124,
+      "line": 1076,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$onlineNodes/$nodeCount",
       "surface": "android",
@@ -9171,7 +8811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1124,
+      "line": 1076,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "None",
       "surface": "android",
@@ -9179,7 +8819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1127,
+      "line": 1079,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Review node access",
       "surface": "android",
@@ -9187,7 +8827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1129,
+      "line": 1081,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online",
       "surface": "android",
@@ -9195,23 +8835,23 @@
     },
     {
       "kind": "ui-call",
-      "line": 1157,
+      "line": 1109,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
-      "source": "Threads",
+      "source": "Sessions",
       "surface": "android",
-      "id": "native.android.57177017a6a93826"
+      "id": "native.android.16c3425d3a594481"
     },
     {
       "kind": "ui-call",
-      "line": 1159,
+      "line": 1111,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
-      "source": "No recent threads",
+      "source": "No recent sessions",
       "surface": "android",
-      "id": "native.android.43320b54a68b00a1"
+      "id": "native.android.a5c0f8b3112aa58c"
     },
     {
       "kind": "ui-call",
-      "line": 1159,
+      "line": 1111,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Recent conversations",
       "surface": "android",
@@ -9219,7 +8859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1165,
+      "line": 1117,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Files",
       "surface": "android",
@@ -9227,7 +8867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1166,
+      "line": 1118,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Browse",
       "surface": "android",
@@ -9235,7 +8875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1166,
+      "line": 1118,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Offline",
       "surface": "android",
@@ -9243,7 +8883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1167,
+      "line": 1119,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Agent workspace files",
       "surface": "android",
@@ -9251,7 +8891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1225,
+      "line": 1177,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Working · 1 active run",
       "surface": "android",
@@ -9259,7 +8899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1227,
+      "line": 1179,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Working · $pendingRunCount active runs",
       "surface": "android",
@@ -9267,23 +8907,23 @@
     },
     {
       "kind": "ui-call",
-      "line": 1231,
+      "line": 1183,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
-      "source": "Monitoring · 1 thread",
+      "source": "Monitoring · 1 session",
       "surface": "android",
-      "id": "native.android.e24db059480f1e6a"
+      "id": "native.android.2c89da708b12a522"
     },
     {
       "kind": "ui-call",
-      "line": 1232,
+      "line": 1184,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
-      "source": "Monitoring · $sessionCount threads",
+      "source": "Monitoring · $sessionCount sessions",
       "surface": "android",
-      "id": "native.android.5a475f37d80e02bc"
+      "id": "native.android.8b6ee382dcb64e1f"
     },
     {
       "kind": "ui-call",
-      "line": 1233,
+      "line": 1185,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Monitoring · 1 scheduled job",
       "surface": "android",
@@ -9291,7 +8931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1234,
+      "line": 1186,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Monitoring · $cronJobCount scheduled jobs",
       "surface": "android",
@@ -9299,7 +8939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1284,
+      "line": 1236,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -9307,7 +8947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1316,
+      "line": 1268,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Connect before chat, voice, and live status.",
       "surface": "android",
@@ -9315,7 +8955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1340,
+      "line": 1292,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No ready providers",
       "surface": "android",
@@ -9323,7 +8963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1340,
+      "line": 1292,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Providers",
       "surface": "android",
@@ -9331,15 +8971,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 1535,
+      "line": 1487,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
-      "source": "Open thread",
+      "source": "Open session",
       "surface": "android",
-      "id": "native.android.358c5e0e838d5423"
+      "id": "native.android.a65477861c7203aa"
     },
     {
       "kind": "ui-call",
-      "line": 1633,
+      "line": 1585,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Back",
       "surface": "android",
@@ -9347,7 +8987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1636,
+      "line": 1588,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Settings",
       "surface": "android",
@@ -9355,7 +8995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1639,
+      "line": 1591,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Search settings",
       "surface": "android",
@@ -9363,7 +9003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1652,
+      "line": 1604,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Gateway",
       "surface": "android",
@@ -9371,7 +9011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1658,
+      "line": 1610,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Nodes & Devices",
       "surface": "android",
@@ -9379,7 +9019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1659,
+      "line": 1611,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Channels",
       "surface": "android",
@@ -9387,7 +9027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1660,
+      "line": 1612,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "${agents.size} available",
       "surface": "android",
@@ -9395,7 +9035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1660,
+      "line": 1612,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Agents",
       "surface": "android",
@@ -9403,7 +9043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1660,
+      "line": 1612,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Load from gateway",
       "surface": "android",
@@ -9411,7 +9051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1662,
+      "line": 1614,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Providers & Models",
       "surface": "android",
@@ -9419,7 +9059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1664,
+      "line": 1616,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$readyProviderCount ready",
       "surface": "android",
@@ -9427,7 +9067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1665,
+      "line": 1617,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Availability unknown",
       "surface": "android",
@@ -9435,7 +9075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1666,
+      "line": 1618,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Review readiness",
       "surface": "android",
@@ -9443,7 +9083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1678,
+      "line": 1630,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Approvals",
       "surface": "android",
@@ -9451,7 +9091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1679,
+      "line": 1631,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Automations",
       "surface": "android",
@@ -9459,7 +9099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1680,
+      "line": 1632,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Usage",
       "surface": "android",
@@ -9467,7 +9107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1681,
+      "line": 1633,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Skills",
       "surface": "android",
@@ -9475,7 +9115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1683,
+      "line": 1635,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Skill Workshop",
       "surface": "android",
@@ -9483,7 +9123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1689,
+      "line": 1641,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Dreaming",
       "surface": "android",
@@ -9491,7 +9131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1690,
+      "line": 1642,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Shell in the agent workspace",
       "surface": "android",
@@ -9499,7 +9139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1690,
+      "line": 1642,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Terminal",
       "surface": "android",
@@ -9507,7 +9147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1691,
+      "line": 1643,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Speaker muted",
       "surface": "android",
@@ -9515,7 +9155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1691,
+      "line": 1643,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Speaker on",
       "surface": "android",
@@ -9523,7 +9163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1691,
+      "line": 1643,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Voice",
       "surface": "android",
@@ -9531,7 +9171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1692,
+      "line": 1644,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Canvas",
       "surface": "android",
@@ -9539,7 +9179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1692,
+      "line": 1644,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Screen surface",
       "surface": "android",
@@ -9547,7 +9187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1693,
+      "line": 1645,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Notifications",
       "surface": "android",
@@ -9555,7 +9195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1693,
+      "line": 1645,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Smart delivery",
       "surface": "android",
@@ -9563,7 +9203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1694,
+      "line": 1646,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Camera enabled",
       "surface": "android",
@@ -9571,7 +9211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1694,
+      "line": 1646,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Locked",
       "surface": "android",
@@ -9579,7 +9219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1694,
+      "line": 1646,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Phone Capabilities",
       "surface": "android",
@@ -9587,7 +9227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1696,
+      "line": 1648,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Appearance",
       "surface": "android",
@@ -9595,7 +9235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1704,
+      "line": 1656,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "About",
       "surface": "android",
@@ -9603,7 +9243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1704,
+      "line": 1656,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Version and update",
       "surface": "android",
@@ -9611,7 +9251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1705,
+      "line": 1657,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Health",
       "surface": "android",
@@ -9619,7 +9259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1718,
+      "line": 1670,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Account",
       "surface": "android",
@@ -9627,7 +9267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1722,
+      "line": 1674,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Return to setup",
       "surface": "android",
@@ -9635,7 +9275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1722,
+      "line": 1674,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Sign Out",
       "surface": "android",
@@ -9643,7 +9283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1733,
+      "line": 1685,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Licenses",
       "surface": "android",
@@ -9651,7 +9291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1744,
+      "line": 1696,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
       "surface": "android",
@@ -9659,7 +9299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1747,
+      "line": 1699,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "All systems operational",
       "surface": "android",
@@ -9667,7 +9307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1747,
+      "line": 1699,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Gateway not connected",
       "surface": "android",
@@ -9675,7 +9315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1761,
+      "line": 1713,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No pending approvals",
       "surface": "android",
@@ -9683,7 +9323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1763,
+      "line": 1715,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$count pending",
       "surface": "android",
@@ -9691,7 +9331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1771,
+      "line": 1723,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No scheduled jobs",
       "surface": "android",
@@ -9699,7 +9339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1772,
+      "line": 1724,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 scheduled",
       "surface": "android",
@@ -9707,7 +9347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1773,
+      "line": 1725,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$count scheduled",
       "surface": "android",
@@ -9715,7 +9355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1779,
+      "line": 1731,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No provider usage",
       "surface": "android",
@@ -9723,7 +9363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1780,
+      "line": 1732,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 provider",
       "surface": "android",
@@ -9731,7 +9371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1781,
+      "line": 1733,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$count providers",
       "surface": "android",
@@ -9739,7 +9379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1791,
+      "line": 1743,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No skills",
       "surface": "android",
@@ -9747,7 +9387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1793,
+      "line": 1745,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$ready/${skills.size} ready",
       "surface": "android",
@@ -9755,7 +9395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1812,
+      "line": 1764,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$pending pending",
       "surface": "android",
@@ -9763,7 +9403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1812,
+      "line": 1764,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 pending",
       "surface": "android",
@@ -9771,7 +9411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1816,
+      "line": 1768,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No proposals",
       "surface": "android",
@@ -9779,7 +9419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1817,
+      "line": 1769,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$held held",
       "surface": "android",
@@ -9787,7 +9427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1817,
+      "line": 1769,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 held",
       "surface": "android",
@@ -9795,7 +9435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1818,
+      "line": 1770,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$applied applied",
       "surface": "android",
@@ -9803,7 +9443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1818,
+      "line": 1770,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 applied",
       "surface": "android",
@@ -9811,7 +9451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1819,
+      "line": 1771,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "${summary.proposals.size} proposals",
       "surface": "android",
@@ -9819,7 +9459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1836,
+      "line": 1788,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "${summary.pendingDevices.size} pending",
       "surface": "android",
@@ -9827,7 +9467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1837,
+      "line": 1789,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Node approval pending",
       "surface": "android",
@@ -9835,7 +9475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1838,
+      "line": 1790,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$online/${summary.nodes.size} online",
       "surface": "android",
@@ -9843,7 +9483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1839,
+      "line": 1791,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$devices paired",
       "surface": "android",
@@ -9851,7 +9491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1840,
+      "line": 1792,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No devices",
       "surface": "android",
@@ -9859,7 +9499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1866,
+      "line": 1818,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 issue",
       "surface": "android",
@@ -9867,7 +9507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1867,
+      "line": 1819,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$issueCount issues",
       "surface": "android",
@@ -9875,7 +9515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1868,
+      "line": 1820,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$connected/${summary.channels.size} connected",
       "surface": "android",
@@ -9883,7 +9523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1869,
+      "line": 1821,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No channels",
       "surface": "android",
@@ -9891,7 +9531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1885,
+      "line": 1837,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Needs attention",
       "surface": "android",
@@ -9899,7 +9539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1886,
+      "line": 1838,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "${summary.shortTermCount} waiting",
       "surface": "android",
@@ -9907,7 +9547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1887,
+      "line": 1839,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Off",
       "surface": "android",
@@ -9915,7 +9555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1931,
+      "line": 1883,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Connection",
       "surface": "android",
@@ -9923,7 +9563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1942,
+      "line": 1894,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Agents & automation",
       "surface": "android",
@@ -9931,7 +9571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1948,
+      "line": 1900,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Phone context & privacy",
       "surface": "android",
@@ -9939,7 +9579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1954,
+      "line": 1906,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Profile & device",
       "surface": "android",
@@ -9947,7 +9587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1957,
+      "line": 1909,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Diagnostics",
       "surface": "android",
@@ -9955,7 +9595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2003,
+      "line": 1955,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "OpenClaw mobile",
       "surface": "android",
@@ -9963,7 +9603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2007,
+      "line": 1959,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open profile",
       "surface": "android",
@@ -9971,7 +9611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2087,
+      "line": 2039,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open ${row.title}",
       "surface": "android",
@@ -9979,7 +9619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2095,
+      "line": 2047,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "now",
       "surface": "android",
@@ -9987,7 +9627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2096,
+      "line": 2048,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "${minutes}m",
       "surface": "android",
@@ -9995,7 +9635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2098,
+      "line": 2050,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "${hours}h",
       "surface": "android",
@@ -10003,7 +9643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2100,
+      "line": 2052,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "${days}d",
       "surface": "android",
@@ -10011,15 +9651,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 2103,
+      "line": 2055,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
-      "source": "Main thread",
+      "source": "Main session",
       "surface": "android",
-      "id": "native.android.28a1a1acc5a0959f"
+      "id": "native.android.22d755834386db07"
     },
     {
       "kind": "ui-call",
-      "line": 2110,
+      "line": 2062,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Online and ready",
       "surface": "android",
@@ -10027,7 +9667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2113,
+      "line": 2065,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Connecting...",
       "surface": "android",
@@ -10035,7 +9675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2114,
+      "line": 2066,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Waiting for pairing",
       "surface": "android",
@@ -10043,7 +9683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2115,
+      "line": 2067,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Authentication needed",
       "surface": "android",
@@ -10051,7 +9691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2116,
+      "line": 2068,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "TLS timed out",
       "surface": "android",
@@ -10059,7 +9699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2117,
+      "line": 2069,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No TLS endpoint",
       "surface": "android",
@@ -10067,7 +9707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2118,
+      "line": 2070,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Certificate review needed",
       "surface": "android",
@@ -10075,7 +9715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2119,
+      "line": 2071,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Not connected",
       "surface": "android",
@@ -10971,7 +10611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 244,
+      "line": 220,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Your voice command center.",
       "surface": "android",
@@ -10979,7 +10619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 348,
+      "line": 324,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Transcribe then send",
       "surface": "android",
@@ -10987,7 +10627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 350,
+      "line": 326,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Dictation settings",
       "surface": "android",
@@ -10995,7 +10635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 361,
+      "line": 337,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Sending to chat...",
       "surface": "android",
@@ -11003,7 +10643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 361,
+      "line": 337,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Start speaking...",
       "surface": "android",
@@ -11011,7 +10651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 393,
+      "line": 369,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Speech provider",
       "surface": "android",
@@ -11019,7 +10659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 445,
+      "line": 421,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Tip: stop listening to send the captured turn.",
       "surface": "android",
@@ -11027,7 +10667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 455,
+      "line": 431,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Cancel",
       "surface": "android",
@@ -11035,7 +10675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 456,
+      "line": 432,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Send to Chat",
       "surface": "android",
@@ -11043,7 +10683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 490,
+      "line": 463,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Back to voice",
       "surface": "android",
@@ -11051,7 +10691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 499,
+      "line": 472,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "OpenClaw speaking",
       "surface": "android",
@@ -11059,7 +10699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 501,
+      "line": 474,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Realtime voice",
       "surface": "android",
@@ -11067,7 +10707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 503,
+      "line": 476,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Connected",
       "surface": "android",
@@ -11075,7 +10715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 510,
+      "line": 483,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Talk settings",
       "surface": "android",
@@ -11083,7 +10723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 534,
+      "line": 507,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Live transcript",
       "surface": "android",
@@ -11091,7 +10731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 545,
+      "line": 518,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Mute",
       "surface": "android",
@@ -11099,7 +10739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 545,
+      "line": 518,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Unmute",
       "surface": "android",
@@ -11107,23 +10747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 552,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
-      "source": "Back camera",
-      "surface": "android",
-      "id": "native.android.cb608d82c5b3352a"
-    },
-    {
-      "kind": "ui-call",
-      "line": 552,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
-      "source": "Front camera",
-      "surface": "android",
-      "id": "native.android.e89a0e780eed2e1e"
-    },
-    {
-      "kind": "ui-call",
-      "line": 559,
+      "line": 524,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "End",
       "surface": "android",
@@ -11131,7 +10755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 582,
+      "line": 547,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Listening for your next turn.",
       "surface": "android",
@@ -11139,7 +10763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 590,
+      "line": 555,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Listening response...",
       "surface": "android",
@@ -11147,7 +10771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 677,
+      "line": 642,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Search voice",
       "surface": "android",
@@ -11155,7 +10779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 685,
+      "line": 650,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Voice",
       "surface": "android",
@@ -11163,7 +10787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 696,
+      "line": 661,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Mute speaker",
       "surface": "android",
@@ -11171,7 +10795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 696,
+      "line": 661,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Unmute speaker",
       "surface": "android",
@@ -11179,7 +10803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 741,
+      "line": 706,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "OpenClaw is replying",
       "surface": "android",
@@ -11187,7 +10811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 744,
+      "line": 709,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Dictation is listening",
       "surface": "android",
@@ -11195,7 +10819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 775,
+      "line": 740,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Realtime Talk",
       "surface": "android",
@@ -11203,7 +10827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 778,
+      "line": 743,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Conversation is live",
       "surface": "android",
@@ -11211,7 +10835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 787,
+      "line": 752,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Dictation",
       "surface": "android",
@@ -11219,7 +10843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 787,
+      "line": 752,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Stop Dictation",
       "surface": "android",
@@ -11227,7 +10851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 790,
+      "line": 755,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Listening for one turn",
       "surface": "android",
@@ -11235,7 +10859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 792,
+      "line": 757,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Connect gateway to start",
       "surface": "android",
@@ -11243,7 +10867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 809,
+      "line": 774,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "End Talk",
       "surface": "android",
@@ -11251,7 +10875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 810,
+      "line": 775,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Set Up Talk",
       "surface": "android",
@@ -11259,7 +10883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 811,
+      "line": 776,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Start Talk",
       "surface": "android",
@@ -11267,7 +10891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 812,
+      "line": 777,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Connect Gateway",
       "surface": "android",
@@ -11275,7 +10899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 924,
+      "line": 889,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Voice setup",
       "surface": "android",
@@ -11283,7 +10907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 956,
+      "line": 921,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Ready",
       "surface": "android",
@@ -11291,7 +10915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 957,
+      "line": 922,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Setup",
       "surface": "android",
@@ -11299,7 +10923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 958,
+      "line": 923,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Attention",
       "surface": "android",
@@ -11307,7 +10931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 959,
+      "line": 924,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Unverified",
       "surface": "android",
@@ -11315,7 +10939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 960,
+      "line": 925,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Offline",
       "surface": "android",
@@ -11323,7 +10947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 978,
+      "line": 943,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Talk: ${gatewayTalkSetupDescription(readiness.realtimeTalk)}",
       "surface": "android",
@@ -11331,7 +10955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 979,
+      "line": 944,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Dictation: ${gatewayTalkSetupDescription(readiness.dictation)}",
       "surface": "android",
@@ -11339,7 +10963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1085,
+      "line": 1050,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -11347,7 +10971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1085,
+      "line": 1050,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "You",
       "surface": "android",
@@ -11355,7 +10979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1092,
+      "line": 1057,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Listening...",
       "surface": "android",
@@ -11363,7 +10987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1108,
+      "line": 1073,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Sending",
       "surface": "android",
@@ -11371,7 +10995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1110,
+      "line": 1075,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "OpenClaw is preparing a response.",
       "surface": "android",
@@ -11379,7 +11003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1125,
+      "line": 1090,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Permission needed",
       "surface": "android",
@@ -11387,7 +11011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1126,
+      "line": 1091,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Microphone access is needed.",
       "surface": "android",
@@ -11395,7 +11019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1128,
+      "line": 1093,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "OpenClaw only listens when you start Talk or Dictation.",
       "surface": "android",
@@ -11403,7 +11027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1132,
+      "line": 1097,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Enable Microphone",
       "surface": "android",
@@ -11411,7 +11035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1200,
+      "line": 1165,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "OpenClaw is speaking",
       "surface": "android",
@@ -11419,7 +11043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1202,
+      "line": 1167,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Talk is live",
       "surface": "android",
@@ -11427,7 +11051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1203,
+      "line": 1168,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Sending dictation",
       "surface": "android",
@@ -11435,7 +11059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1204,
+      "line": 1169,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Listening",
       "surface": "android",
@@ -11443,7 +11067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1205,
+      "line": 1170,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "$micQueuedMessages queued",
       "surface": "android",
@@ -11451,7 +11075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1206,
+      "line": 1171,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Gateway offline",
       "surface": "android",
@@ -11459,7 +11083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1207,
+      "line": 1172,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Ready to talk",
       "surface": "android",
@@ -11467,7 +11091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1262,
+      "line": 1227,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Realtime voice provider is not configured.",
       "surface": "android",
@@ -11475,7 +11099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1265,
+      "line": 1230,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Realtime transcription provider is not configured.",
       "surface": "android",
@@ -11483,7 +11107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1268,
+      "line": 1233,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Microphone permission is required.",
       "surface": "android",
@@ -11491,7 +11115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1278,
+      "line": 1243,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Connected and ready",
       "surface": "android",
@@ -11499,7 +11123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1278,
+      "line": 1243,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Gateway not connected",
       "surface": "android",
@@ -11819,55 +11443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 111,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatInlineWidgetView.kt",
-      "source": "Could not copy widget image",
-      "surface": "android",
-      "id": "native.android.5bbcfd75bf605de8"
-    },
-    {
-      "kind": "ui-call",
-      "line": 112,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatInlineWidgetView.kt",
-      "source": "Could not save widget image",
-      "surface": "android",
-      "id": "native.android.43d98caa4a9fa44c"
-    },
-    {
-      "kind": "ui-call",
-      "line": 113,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatInlineWidgetView.kt",
-      "source": "Widget image copied",
-      "surface": "android",
-      "id": "native.android.88e52d3ea4d2059a"
-    },
-    {
-      "kind": "ui-call",
-      "line": 114,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatInlineWidgetView.kt",
-      "source": "Widget image saved to Downloads",
-      "surface": "android",
-      "id": "native.android.04b164bc44c08e38"
-    },
-    {
-      "kind": "ui-call",
-      "line": 215,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatInlineWidgetView.kt",
-      "source": "Copy image",
-      "surface": "android",
-      "id": "native.android.a29e724e9e3b5cc9"
-    },
-    {
-      "kind": "ui-call",
-      "line": 220,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatInlineWidgetView.kt",
-      "source": "Save image",
-      "surface": "android",
-      "id": "native.android.6b45a391b1289aa5"
-    },
-    {
-      "kind": "ui-call",
-      "line": 230,
+      "line": 151,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatInlineWidgetView.kt",
       "source": "Widget unavailable",
       "surface": "android",
@@ -12235,7 +11811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 173,
+      "line": 131,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatQuestionCard.kt",
       "source": "Other answer",
       "surface": "android",
@@ -12243,23 +11819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 203,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatQuestionCard.kt",
-      "source": "Skip",
-      "surface": "android",
-      "id": "native.android.de591e6e2e440ecb"
-    },
-    {
-      "kind": "ui-call",
-      "line": 211,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatQuestionCard.kt",
-      "source": "Submitting…",
-      "surface": "android",
-      "id": "native.android.92dfa7979d04989c"
-    },
-    {
-      "kind": "ui-call",
-      "line": 213,
+      "line": 160,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatQuestionCard.kt",
       "source": "Submit",
       "surface": "android",
@@ -12267,31 +11827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 229,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatQuestionCard.kt",
-      "source": "Skipped",
-      "surface": "android",
-      "id": "native.android.7da074848cacfe4b"
-    },
-    {
-      "kind": "ui-call",
-      "line": 230,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatQuestionCard.kt",
-      "source": "Expired",
-      "surface": "android",
-      "id": "native.android.1a0e6b33059a63aa"
-    },
-    {
-      "kind": "ui-call",
-      "line": 231,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatQuestionCard.kt",
-      "source": "Unavailable",
-      "surface": "android",
-      "id": "native.android.86c8d6113d07ef82"
-    },
-    {
-      "kind": "ui-call",
-      "line": 235,
+      "line": 170,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatQuestionCard.kt",
       "source": "Answered",
       "surface": "android",
@@ -12299,7 +11835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 235,
+      "line": 171,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatQuestionCard.kt",
       "source": "Answered elsewhere",
       "surface": "android",
@@ -12307,7 +11843,55 @@
     },
     {
       "kind": "ui-call",
-      "line": 327,
+      "line": 172,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatQuestionCard.kt",
+      "source": "Expired",
+      "surface": "android",
+      "id": "native.android.1a0e6b33059a63aa"
+    },
+    {
+      "kind": "ui-call",
+      "line": 173,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatQuestionCard.kt",
+      "source": "Cancelled",
+      "surface": "android",
+      "id": "native.android.d6d8fc83cec68418"
+    },
+    {
+      "kind": "ui-call",
+      "line": 174,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatQuestionCard.kt",
+      "source": "Pending",
+      "surface": "android",
+      "id": "native.android.73f64d0d54b7f9c0"
+    },
+    {
+      "kind": "ui-call",
+      "line": 175,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatQuestionCard.kt",
+      "source": "Submitting…",
+      "surface": "android",
+      "id": "native.android.92dfa7979d04989c"
+    },
+    {
+      "kind": "ui-call",
+      "line": 192,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatQuestionCard.kt",
+      "source": "Expires in ${seconds / 60}m ${seconds % 60}s",
+      "surface": "android",
+      "id": "native.android.c5e9ee99f9d9c612"
+    },
+    {
+      "kind": "ui-call",
+      "line": 194,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatQuestionCard.kt",
+      "source": "Expires in ${seconds}s",
+      "surface": "android",
+      "id": "native.android.2ca602fbdf96f1e7"
+    },
+    {
+      "kind": "ui-call",
+      "line": 322,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Model",
       "surface": "android",
@@ -12315,7 +11899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 450,
+      "line": 415,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Some shared images were omitted or could not be added.",
       "surface": "android",
@@ -12323,7 +11907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 591,
+      "line": 556,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat needs attention",
       "surface": "android",
@@ -12331,7 +11915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 876,
+      "line": 834,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "All",
       "surface": "android",
@@ -12339,7 +11923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 958,
+      "line": 916,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Working",
       "surface": "android",
@@ -12347,7 +11931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 959,
+      "line": 917,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready",
       "surface": "android",
@@ -12355,7 +11939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 960,
+      "line": 918,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Offline",
       "surface": "android",
@@ -12363,7 +11947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 973,
+      "line": 931,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat actions",
       "surface": "android",
@@ -12371,7 +11955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 978,
+      "line": 936,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Refresh chat",
       "surface": "android",
@@ -12379,7 +11963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 986,
+      "line": 944,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Background tasks",
       "surface": "android",
@@ -12387,7 +11971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1007,
+      "line": 965,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -12395,7 +11979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1154,
+      "line": 1111,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Messages to recover",
       "surface": "android",
@@ -12403,7 +11987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1156,
+      "line": 1113,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows.",
       "surface": "android",
@@ -12411,15 +11995,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 1184,
+      "line": 1141,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Loading thread",
+      "source": "Loading session",
       "surface": "android",
-      "id": "native.android.0c74bc30a994dd33"
+      "id": "native.android.882cc14a58e7e105"
     },
     {
       "kind": "ui-call",
-      "line": 1217,
+      "line": 1168,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Jump to latest",
       "surface": "android",
@@ -12427,7 +12011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1247,
+      "line": 1194,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready when you are",
       "surface": "android",
@@ -12435,7 +12019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1251,
+      "line": 1198,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Start with a prompt, or use voice.",
       "surface": "android",
@@ -12443,7 +12027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1253,
+      "line": 1200,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Use the recovery options below to reconnect.",
       "surface": "android",
@@ -12451,7 +12035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1255,
+      "line": 1202,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat is checking Gateway health.",
       "surface": "android",
@@ -12459,7 +12043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1278,
+      "line": 1225,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Fix connection",
       "surface": "android",
@@ -12467,7 +12051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1279,
+      "line": 1226,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Copy diagnostics",
       "surface": "android",
@@ -12475,7 +12059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1338,
+      "line": 1285,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Catch me up",
       "surface": "android",
@@ -12483,23 +12067,23 @@
     },
     {
       "kind": "ui-call",
-      "line": 1339,
+      "line": 1286,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Summarize recent threads and next steps.",
+      "source": "Summarize recent sessions and next steps.",
       "surface": "android",
-      "id": "native.android.cf40df9739f78f27"
+      "id": "native.android.1e5add56e48c99f9"
     },
     {
       "kind": "ui-call",
-      "line": 1340,
+      "line": 1287,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
+      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
       "surface": "android",
-      "id": "native.android.ebe49a8b8df80bd3"
+      "id": "native.android.06d515351bb79576"
     },
     {
       "kind": "ui-call",
-      "line": 1344,
+      "line": 1291,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Plan the work",
       "surface": "android",
@@ -12507,7 +12091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1345,
+      "line": 1292,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Turn a goal into an actionable checklist.",
       "surface": "android",
@@ -12515,7 +12099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1346,
+      "line": 1293,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Help me turn this goal into a practical checklist: ",
       "surface": "android",
@@ -12523,7 +12107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1350,
+      "line": 1297,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Use this phone",
       "surface": "android",
@@ -12531,7 +12115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1351,
+      "line": 1298,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ask OpenClaw to use Android capabilities.",
       "surface": "android",
@@ -12539,7 +12123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1352,
+      "line": 1299,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "What can you help me do from this phone right now?",
       "surface": "android",
@@ -12547,7 +12131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1417,
+      "line": 1364,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw · Live",
       "surface": "android",
@@ -12555,7 +12139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1418,
+      "line": 1365,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "You",
       "surface": "android",
@@ -12563,7 +12147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1419,
+      "line": 1366,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "System",
       "surface": "android",
@@ -12571,7 +12155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1420,
+      "line": 1367,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -12579,175 +12163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1493,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Preparing audio…",
-      "surface": "android",
-      "id": "native.android.5aafbef3744d86f3"
-    },
-    {
-      "kind": "ui-call",
-      "line": 1493,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Speaking…",
-      "surface": "android",
-      "id": "native.android.d7919c440a82f426"
-    },
-    {
-      "kind": "ui-call",
-      "line": 1514,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Tools running",
-      "surface": "android",
-      "id": "native.android.781f84dfaf7da9d6"
-    },
-    {
-      "kind": "ui-call",
-      "line": 1516,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "OpenClaw is working",
-      "surface": "android",
-      "id": "native.android.d851a32f367f8b31"
-    },
-    {
-      "kind": "ui-call",
-      "line": 1519,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "+${toolCalls.size - 4} more",
-      "surface": "android",
-      "id": "native.android.0fd6b75cadc0ce75"
-    },
-    {
-      "kind": "ui-call",
-      "line": 1529,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Thinking",
-      "surface": "android",
-      "id": "native.android.7e0aea1dca378135"
-    },
-    {
-      "kind": "ui-call",
-      "line": 1530,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "OpenClaw is preparing a response.",
-      "surface": "android",
-      "id": "native.android.98a0d4d5bba788c4"
-    },
-    {
-      "kind": "ui-named-argument",
-      "line": 1595,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "$completedCount/${steps.size}",
-      "surface": "android",
-      "id": "native.android.22d747642a3887cd"
-    },
-    {
-      "kind": "ui-call",
-      "line": 1602,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Collapse plan checklist",
-      "surface": "android",
-      "id": "native.android.5d9378441e3bb86e"
-    },
-    {
-      "kind": "ui-call",
-      "line": 1602,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Expand plan checklist",
-      "surface": "android",
-      "id": "native.android.cc46adc71637695d"
-    },
-    {
-      "kind": "ui-call",
-      "line": 1734,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Dismiss shared-image warning",
-      "surface": "android",
-      "id": "native.android.f3806d79e43f568f"
-    },
-    {
-      "kind": "ui-call",
-      "line": 1837,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Stop",
-      "surface": "android",
-      "id": "native.android.76d574acfac94fee"
-    },
-    {
-      "kind": "ui-call",
-      "line": 1935,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Default",
-      "surface": "android",
-      "id": "native.android.2cb3ec7379426dfe"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2001,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Pin model",
-      "surface": "android",
-      "id": "native.android.f8d0f6ba7608abc3"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2001,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Unpin model",
-      "surface": "android",
-      "id": "native.android.09a13ed8f039a9c3"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2018,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "No commands found",
-      "surface": "android",
-      "id": "native.android.5953c956ff208e6e"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2060,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Command",
-      "surface": "android",
-      "id": "native.android.b1a0dca9f421aaaa"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2080,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Gateway offline",
-      "surface": "android",
-      "id": "native.android.8e3e367df24cae4b"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2126,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Close thinking level selector",
-      "surface": "android",
-      "id": "native.android.36ed01582459bc10"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2126,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Open thinking level selector",
-      "surface": "android",
-      "id": "native.android.82d6389036a1e211"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2191,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Attach image",
-      "surface": "android",
-      "id": "native.android.623e434c83e3c020"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2196,
+      "line": 1387,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attachment",
       "surface": "android",
@@ -12755,7 +12171,175 @@
     },
     {
       "kind": "ui-call",
-      "line": 2227,
+      "line": 1440,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Preparing audio…",
+      "surface": "android",
+      "id": "native.android.5aafbef3744d86f3"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1440,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Speaking…",
+      "surface": "android",
+      "id": "native.android.d7919c440a82f426"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1461,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Tools running",
+      "surface": "android",
+      "id": "native.android.781f84dfaf7da9d6"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1463,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "OpenClaw is working",
+      "surface": "android",
+      "id": "native.android.d851a32f367f8b31"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1466,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "+${toolCalls.size - 4} more",
+      "surface": "android",
+      "id": "native.android.0fd6b75cadc0ce75"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1476,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Thinking",
+      "surface": "android",
+      "id": "native.android.7e0aea1dca378135"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1477,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "OpenClaw is preparing a response.",
+      "surface": "android",
+      "id": "native.android.98a0d4d5bba788c4"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 1542,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "$completedCount/${steps.size}",
+      "surface": "android",
+      "id": "native.android.22d747642a3887cd"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1549,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Collapse plan checklist",
+      "surface": "android",
+      "id": "native.android.5d9378441e3bb86e"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1549,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Expand plan checklist",
+      "surface": "android",
+      "id": "native.android.cc46adc71637695d"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1680,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Dismiss shared-image warning",
+      "surface": "android",
+      "id": "native.android.f3806d79e43f568f"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1782,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Stop",
+      "surface": "android",
+      "id": "native.android.76d574acfac94fee"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1880,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Default",
+      "surface": "android",
+      "id": "native.android.2cb3ec7379426dfe"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1946,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Pin model",
+      "surface": "android",
+      "id": "native.android.f8d0f6ba7608abc3"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1946,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Unpin model",
+      "surface": "android",
+      "id": "native.android.09a13ed8f039a9c3"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1963,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "No commands found",
+      "surface": "android",
+      "id": "native.android.5953c956ff208e6e"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2005,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Command",
+      "surface": "android",
+      "id": "native.android.b1a0dca9f421aaaa"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2025,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Gateway offline",
+      "surface": "android",
+      "id": "native.android.8e3e367df24cae4b"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2071,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Close thinking level selector",
+      "surface": "android",
+      "id": "native.android.36ed01582459bc10"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2071,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Open thinking level selector",
+      "surface": "android",
+      "id": "native.android.82d6389036a1e211"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2135,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Attach image",
+      "surface": "android",
+      "id": "native.android.623e434c83e3c020"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2166,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Message OpenClaw",
       "surface": "android",
@@ -12763,7 +12347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2256,
+      "line": 2195,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "End Talk",
       "surface": "android",
@@ -12771,7 +12355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2256,
+      "line": 2195,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Start Talk",
       "surface": "android",
@@ -12779,7 +12363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2341,
+      "line": 2280,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Voice note · ${formatVoiceNoteDuration(duration)}",
       "surface": "android",
@@ -12787,7 +12371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2350,
+      "line": 2289,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Remove attachment",
       "surface": "android",
@@ -12795,7 +12379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2362,
+      "line": 2301,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "New chat",
       "surface": "android",
@@ -12803,7 +12387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2371,
+      "line": 2310,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Main",
       "surface": "android",
@@ -12811,7 +12395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2372,
+      "line": 2311,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Current",
       "surface": "android",
@@ -12819,7 +12403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2379,
+      "line": 2318,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$emoji $name",
       "surface": "android",
@@ -12827,7 +12411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2438,
+      "line": 2377,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Send",
       "surface": "android",
@@ -12835,7 +12419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2449,
+      "line": 2388,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat is still checking Gateway health.",
       "surface": "android",
@@ -12843,7 +12427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2450,
+      "line": 2389,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway is offline. Fix the connection below or copy diagnostics.",
       "surface": "android",
@@ -12851,7 +12435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2451,
+      "line": 2390,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway authentication needs attention.",
       "surface": "android",
@@ -12859,7 +12443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2470,
+      "line": 2409,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Context ${(it * 100).roundToInt()}%",
       "surface": "android",
@@ -12867,7 +12451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2471,
+      "line": 2410,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Context --",
       "surface": "android",
@@ -12875,7 +12459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2472,
+      "line": 2411,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$contextLabel · ${contextMeterThinkingLabel(thinkingLevel)}",
       "surface": "android",
@@ -12883,7 +12467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2511,
+      "line": 2450,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Off",
       "surface": "android",
@@ -12891,7 +12475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2512,
+      "line": 2451,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Minimal",
       "surface": "android",
@@ -12899,7 +12483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2513,
+      "line": 2452,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Low",
       "surface": "android",
@@ -12907,7 +12491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2514,
+      "line": 2453,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Medium",
       "surface": "android",
@@ -12915,7 +12499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2515,
+      "line": 2454,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "High",
       "surface": "android",
@@ -12923,7 +12507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2516,
+      "line": 2455,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Xhigh",
       "surface": "android",
@@ -12931,7 +12515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2517,
+      "line": 2456,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Adaptive",
       "surface": "android",
@@ -12939,7 +12523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2518,
+      "line": 2457,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Max",
       "surface": "android",
@@ -13037,9 +12621,9 @@
       "kind": "ui-named-argument",
       "line": 615,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
-      "source": "Threads",
+      "source": "Sessions",
       "surface": "android",
-      "id": "native.android.6cf5d6fa8a4186d5"
+      "id": "native.android.81931886b9caf3ab"
     },
     {
       "kind": "ui-named-argument",
@@ -13155,7 +12739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 236,
+      "line": 232,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Speaking · waiting for reply",
       "surface": "android",
@@ -13163,7 +12747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 236,
+      "line": 232,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Speaking…",
       "surface": "android",
@@ -13171,7 +12755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 378,
+      "line": 374,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Voice request failed",
       "surface": "android",
@@ -13179,7 +12763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 388,
+      "line": 384,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Response aborted",
       "surface": "android",
@@ -13187,7 +12771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 402,
+      "line": 398,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Microphone permission required",
       "surface": "android",
@@ -13195,7 +12779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 407,
+      "line": 403,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Mic on · waiting for gateway",
       "surface": "android",
@@ -13203,7 +12787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 432,
+      "line": 428,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Transcription unavailable: $message",
       "surface": "android",
@@ -13211,7 +12795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 471,
+      "line": 467,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Mic off · sending…",
       "surface": "android",
@@ -13219,7 +12803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 524,
+      "line": 520,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Mic off",
       "surface": "android",
@@ -13227,7 +12811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 537,
+      "line": 533,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Sending queued voice",
       "surface": "android",
@@ -13235,7 +12819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 562,
+      "line": 558,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Send failed: Chat failed before the run started; try again.",
       "surface": "android",
@@ -13243,7 +12827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 584,
+      "line": 580,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Send failed: $message",
       "surface": "android",
@@ -13251,7 +12835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 605,
+      "line": 601,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Voice reply timed out; retrying queued turn",
       "surface": "android",
@@ -13259,7 +12843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 625,
+      "line": 621,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "${queuedMessageCount()} queued · waiting for gateway",
       "surface": "android",
@@ -13267,7 +12851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 833,
+      "line": 817,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Transcription failed: $message",
       "surface": "android",
@@ -13275,7 +12859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 840,
+      "line": 824,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Listening · sending queued voice",
       "surface": "android",
@@ -13283,7 +12867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 841,
+      "line": 825,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Listening · ${queuedMessageCount()} queued",
       "surface": "android",
@@ -13291,7 +12875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 842,
+      "line": 826,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Listening",
       "surface": "android",
@@ -13299,7 +12883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 602,
+      "line": 529,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Speech recognizer unavailable",
       "surface": "android",
@@ -13307,127 +12891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 800,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
-      "source": "Ready",
-      "surface": "android",
-      "id": "native.android.47a59f8798682ea0"
-    },
-    {
-      "kind": "ui-call",
-      "line": 1018,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
-      "source": "Start failed: $message",
-      "surface": "android",
-      "id": "native.android.8532cc9537b69224"
-    },
-    {
-      "kind": "ui-call",
-      "line": 1114,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
-      "source": "Connecting…",
-      "surface": "android",
-      "id": "native.android.a9216e087452b75b"
-    },
-    {
-      "kind": "ui-call",
-      "line": 1183,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
-      "source": "Off",
-      "surface": "android",
-      "id": "native.android.24bc808758b925ca"
-    },
-    {
-      "kind": "ui-call",
-      "line": 1186,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
-      "source": "Talk failed: Realtime provider closed unexpectedly.",
-      "surface": "android",
-      "id": "native.android.fcd38b57e71b0a44"
-    },
-    {
-      "kind": "ui-call",
-      "line": 1191,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
-      "source": "Talk failed: Realtime provider closed: $reason",
-      "surface": "android",
-      "id": "native.android.508073ba8ce8dbab"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2546,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
-      "source": "Thinking…",
-      "surface": "android",
-      "id": "native.android.9f0677f24e9dcd77"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2563,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
-      "source": "Gateway not connected",
-      "surface": "android",
-      "id": "native.android.e4d0911aa66a7d0a"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2576,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
-      "source": "Aborted",
-      "surface": "android",
-      "id": "native.android.a052faac05102427"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2576,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
-      "source": "Chat error",
-      "surface": "android",
-      "id": "native.android.d74e945c050d1270"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2593,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
-      "source": "No reply",
-      "surface": "android",
-      "id": "native.android.0e48d3c2b82ca21f"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2609,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
-      "source": "Talk failed: $message",
-      "surface": "android",
-      "id": "native.android.13a84ef8eb52312d"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2902,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
-      "source": "Generating voice…",
-      "surface": "android",
-      "id": "native.android.bd863d5e8979cd79"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2930,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
-      "source": "Speak failed: $message",
-      "surface": "android",
-      "id": "native.android.8ad4e794e6404e53"
-    },
-    {
-      "kind": "ui-call",
-      "line": 3079,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
-      "source": "Speaking…",
-      "surface": "android",
-      "id": "native.android.92409eac33327a8d"
-    },
-    {
-      "kind": "ui-call",
-      "line": 3430,
+      "line": 593,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Listening (PTT)",
       "surface": "android",
@@ -13435,7 +12899,127 @@
     },
     {
       "kind": "ui-call",
-      "line": 3441,
+      "line": 690,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
+      "source": "Ready",
+      "surface": "android",
+      "id": "native.android.47a59f8798682ea0"
+    },
+    {
+      "kind": "ui-call",
+      "line": 908,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
+      "source": "Start failed: $message",
+      "surface": "android",
+      "id": "native.android.8532cc9537b69224"
+    },
+    {
+      "kind": "ui-call",
+      "line": 998,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
+      "source": "Connecting…",
+      "surface": "android",
+      "id": "native.android.a9216e087452b75b"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1067,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
+      "source": "Off",
+      "surface": "android",
+      "id": "native.android.24bc808758b925ca"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1070,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
+      "source": "Talk failed: Realtime provider closed unexpectedly.",
+      "surface": "android",
+      "id": "native.android.fcd38b57e71b0a44"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1075,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
+      "source": "Talk failed: Realtime provider closed: $reason",
+      "surface": "android",
+      "id": "native.android.508073ba8ce8dbab"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2201,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
+      "source": "Thinking…",
+      "surface": "android",
+      "id": "native.android.9f0677f24e9dcd77"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2218,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
+      "source": "Gateway not connected",
+      "surface": "android",
+      "id": "native.android.e4d0911aa66a7d0a"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2231,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
+      "source": "Aborted",
+      "surface": "android",
+      "id": "native.android.a052faac05102427"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2231,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
+      "source": "Chat error",
+      "surface": "android",
+      "id": "native.android.d74e945c050d1270"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2248,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
+      "source": "No reply",
+      "surface": "android",
+      "id": "native.android.0e48d3c2b82ca21f"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2264,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
+      "source": "Talk failed: $message",
+      "surface": "android",
+      "id": "native.android.13a84ef8eb52312d"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2489,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
+      "source": "Generating voice…",
+      "surface": "android",
+      "id": "native.android.bd863d5e8979cd79"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2517,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
+      "source": "Speak failed: $message",
+      "surface": "android",
+      "id": "native.android.8ad4e794e6404e53"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2666,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
+      "source": "Speaking…",
+      "surface": "android",
+      "id": "native.android.92409eac33327a8d"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2983,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Microphone permission required",
       "surface": "android",
@@ -13443,7 +13027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3447,
+      "line": 2989,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Audio error",
       "surface": "android",
@@ -13451,7 +13035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3448,
+      "line": 2990,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Client error",
       "surface": "android",
@@ -13459,7 +13043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3449,
+      "line": 2991,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Network error",
       "surface": "android",
@@ -13467,7 +13051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3450,
+      "line": 2992,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Network timeout",
       "surface": "android",
@@ -13475,7 +13059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3452,
+      "line": 2994,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Recognizer busy",
       "surface": "android",
@@ -13483,7 +13067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3453,
+      "line": 2995,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Server error",
       "surface": "android",
@@ -13491,7 +13075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3454,
+      "line": 2996,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Listening",
       "surface": "android",
@@ -13499,7 +13083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3455,
+      "line": 2997,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Speech error ($error)",
       "surface": "android",
@@ -13787,15 +13371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 18,
-      "path": "apps/ios/ActivityWidget/OpenClawLiveActivity.swift",
-      "source": "OPENCLAW",
-      "surface": "apple",
-      "id": "native.apple.093081590556db7f"
-    },
-    {
-      "kind": "ui-call",
-      "line": 55,
+      "line": 39,
       "path": "apps/ios/ActivityWidget/OpenClawLiveActivity.swift",
       "source": "OpenClaw",
       "surface": "apple",
@@ -13803,15 +13379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 132,
-      "path": "apps/ios/ActivityWidget/OpenClawLiveActivity.swift",
-      "source": "LIVE",
-      "surface": "apple",
-      "id": "native.apple.9fd01bdb5a753f3e"
-    },
-    {
-      "kind": "ui-call",
-      "line": 210,
+      "line": 96,
       "path": "apps/ios/ActivityWidget/OpenClawLiveActivity.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -13819,7 +13387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 211,
+      "line": 97,
       "path": "apps/ios/ActivityWidget/OpenClawLiveActivity.swift",
       "source": "Reconnecting...",
       "surface": "apple",
@@ -13827,7 +13395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 212,
+      "line": 98,
       "path": "apps/ios/ActivityWidget/OpenClawLiveActivity.swift",
       "source": "Approval needed",
       "surface": "apple",
@@ -13835,63 +13403,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 213,
+      "line": 99,
       "path": "apps/ios/ActivityWidget/OpenClawLiveActivity.swift",
       "source": "Action required",
       "surface": "apple",
       "id": "native.apple.c619843217c15317"
     },
     {
-      "kind": "ui-localized-call",
-      "line": 216,
-      "path": "apps/ios/ActivityWidget/OpenClawLiveActivity.swift",
-      "source": "Using %@",
-      "surface": "apple",
-      "id": "native.apple.275026f681242715"
-    },
-    {
       "kind": "ui-call",
-      "line": 218,
-      "path": "apps/ios/ActivityWidget/OpenClawLiveActivity.swift",
-      "source": "Using a tool",
-      "surface": "apple",
-      "id": "native.apple.360d0d0fc0df9eb2"
-    },
-    {
-      "kind": "ui-call",
-      "line": 220,
-      "path": "apps/ios/ActivityWidget/OpenClawLiveActivity.swift",
-      "source": "Listening",
-      "surface": "apple",
-      "id": "native.apple.0d0ee660962ea840"
-    },
-    {
-      "kind": "ui-call",
-      "line": 221,
-      "path": "apps/ios/ActivityWidget/OpenClawLiveActivity.swift",
-      "source": "Speaking",
-      "surface": "apple",
-      "id": "native.apple.095ebf1496feb2ad"
-    },
-    {
-      "kind": "ui-call",
-      "line": 222,
-      "path": "apps/ios/ActivityWidget/OpenClawLiveActivity.swift",
-      "source": "Voice active",
-      "surface": "apple",
-      "id": "native.apple.63c98d2ca6a5b09c"
-    },
-    {
-      "kind": "ui-call",
-      "line": 223,
-      "path": "apps/ios/ActivityWidget/OpenClawLiveActivity.swift",
-      "source": "Paused",
-      "surface": "apple",
-      "id": "native.apple.02470f4b5348f97c"
-    },
-    {
-      "kind": "ui-call",
-      "line": 224,
+      "line": 100,
       "path": "apps/ios/ActivityWidget/OpenClawLiveActivity.swift",
       "source": "Connected",
       "surface": "apple",
@@ -13899,7 +13419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 225,
+      "line": 101,
       "path": "apps/ios/ActivityWidget/OpenClawLiveActivity.swift",
       "source": "Disconnected",
       "surface": "apple",
@@ -13923,7 +13443,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 193,
+      "line": 189,
       "path": "apps/ios/Sources/Camera/CameraController.swift",
       "source": "Camera",
       "surface": "apple",
@@ -13931,7 +13451,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 193,
+      "line": 189,
       "path": "apps/ios/Sources/Camera/CameraController.swift",
       "source": "Microphone",
       "surface": "apple",
@@ -17266,8 +16786,96 @@
       "id": "native.apple.e2c229b2828a7152"
     },
     {
+      "kind": "ui-call",
+      "line": 32,
+      "path": "apps/ios/Sources/Design/ChatModelControlsMenu.swift",
+      "source": "Pinned",
+      "surface": "apple",
+      "id": "native.apple.29cacb53ea5e77fc"
+    },
+    {
+      "kind": "ui-call",
+      "line": 37,
+      "path": "apps/ios/Sources/Design/ChatModelControlsMenu.swift",
+      "source": "Recent",
+      "surface": "apple",
+      "id": "native.apple.940062cfdce9211b"
+    },
+    {
+      "kind": "ui-call",
+      "line": 57,
+      "path": "apps/ios/Sources/Design/ChatModelControlsMenu.swift",
+      "source": "Model",
+      "surface": "apple",
+      "id": "native.apple.a0980128426308a9"
+    },
+    {
+      "kind": "ui-call",
+      "line": 77,
+      "path": "apps/ios/Sources/Design/ChatModelControlsMenu.swift",
+      "source": "Thinking",
+      "surface": "apple",
+      "id": "native.apple.9520e60f21535dde"
+    },
+    {
+      "kind": "ui-call",
+      "line": 99,
+      "path": "apps/ios/Sources/Design/ChatModelControlsMenu.swift",
+      "source": "Fast",
+      "surface": "apple",
+      "id": "native.apple.8b321f3ffce97429"
+    },
+    {
+      "kind": "ui-call",
+      "line": 113,
+      "path": "apps/ios/Sources/Design/ChatModelControlsMenu.swift",
+      "source": "Default (inherited)",
+      "surface": "apple",
+      "id": "native.apple.989b70d64e328d55"
+    },
+    {
+      "kind": "ui-call",
+      "line": 116,
+      "path": "apps/ios/Sources/Design/ChatModelControlsMenu.swift",
+      "source": "Off",
+      "surface": "apple",
+      "id": "native.apple.f4114e73b07eb9ae"
+    },
+    {
+      "kind": "ui-call",
+      "line": 119,
+      "path": "apps/ios/Sources/Design/ChatModelControlsMenu.swift",
+      "source": "On",
+      "surface": "apple",
+      "id": "native.apple.7ed231b28d16312f"
+    },
+    {
+      "kind": "ui-call",
+      "line": 122,
+      "path": "apps/ios/Sources/Design/ChatModelControlsMenu.swift",
+      "source": "Full",
+      "surface": "apple",
+      "id": "native.apple.412a74802320a037"
+    },
+    {
+      "kind": "ui-call",
+      "line": 126,
+      "path": "apps/ios/Sources/Design/ChatModelControlsMenu.swift",
+      "source": "Verbosity",
+      "surface": "apple",
+      "id": "native.apple.299f21a2071ff9fc"
+    },
+    {
+      "kind": "ui-call",
+      "line": 138,
+      "path": "apps/ios/Sources/Design/ChatModelControlsMenu.swift",
+      "source": "Default",
+      "surface": "apple",
+      "id": "native.apple.faf0ef05e1496de7"
+    },
+    {
       "kind": "ui-localized-call",
-      "line": 174,
+      "line": 167,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Unable to Export Transcript",
       "surface": "apple",
@@ -17275,7 +16883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 178,
+      "line": 171,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "OK",
       "surface": "apple",
@@ -17283,7 +16891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 182,
+      "line": 175,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "OpenClaw could not prepare the Markdown file.",
       "surface": "apple",
@@ -17291,7 +16899,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 204,
+      "line": 197,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "What would you like to work on?",
       "surface": "apple",
@@ -17299,63 +16907,23 @@
     },
     {
       "kind": "ui-call",
-      "line": 224,
+      "line": 210,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
-      "source": "The thread attaches once the gateway is ready.",
+      "source": "The session attaches once the gateway is ready.",
       "surface": "apple",
-      "id": "native.apple.4da775013ac9b123"
+      "id": "native.apple.32179ce0b6d4543f"
     },
     {
-      "kind": "conditional-branch",
-      "line": 312,
-      "path": "apps/ios/Sources/Design/ChatProTab.swift",
-      "source": "Collapsed",
-      "surface": "apple",
-      "id": "native.apple.02611ddddef7295a"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 312,
-      "path": "apps/ios/Sources/Design/ChatProTab.swift",
-      "source": "Expanded",
-      "surface": "apple",
-      "id": "native.apple.1f4911f4a05230b5"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 382,
+      "kind": "ui-modifier",
+      "line": 338,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Opens Settings / Gateway",
       "surface": "apple",
       "id": "native.apple.d19c9577e0fdfea7"
     },
     {
-      "kind": "ui-localized-call",
-      "line": 385,
-      "path": "apps/ios/Sources/Design/ChatProTab.swift",
-      "source": "Hides the gateway status label",
-      "surface": "apple",
-      "id": "native.apple.b59e690104ae3e24"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 386,
-      "path": "apps/ios/Sources/Design/ChatProTab.swift",
-      "source": "Shows the full gateway status label",
-      "surface": "apple",
-      "id": "native.apple.5fcf9d462463dd27"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 405,
-      "path": "apps/ios/Sources/Design/ChatProTab.swift",
-      "source": "Voice off",
-      "surface": "apple",
-      "id": "native.apple.592b1e673e42df50"
-    },
-    {
       "kind": "ui-call",
-      "line": 568,
+      "line": 363,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "New Chat",
       "surface": "apple",
@@ -17363,23 +16931,31 @@
     },
     {
       "kind": "ui-call",
-      "line": 581,
+      "line": 376,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "New Chat in Worktree",
       "surface": "apple",
       "id": "native.apple.1876037e64a74110"
     },
     {
-      "kind": "ui-localized-call",
-      "line": 594,
+      "kind": "ui-call",
+      "line": 389,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
-      "source": "Threads…",
+      "source": "New Session Options…",
       "surface": "apple",
-      "id": "native.apple.003b25ddafeb18e9"
+      "id": "native.apple.ce6ebe91fc597015"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 401,
+      "path": "apps/ios/Sources/Design/ChatProTab.swift",
+      "source": "Sessions…",
+      "surface": "apple",
+      "id": "native.apple.a1b0d289758e2213"
     },
     {
       "kind": "ui-call",
-      "line": 607,
+      "line": 419,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Background Tasks",
       "surface": "apple",
@@ -17387,23 +16963,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 619,
+      "line": 431,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Export Transcript",
       "surface": "apple",
       "id": "native.apple.ced228bb4d20a726"
     },
     {
-      "kind": "ui-call",
-      "line": 632,
-      "path": "apps/ios/Sources/Design/ChatProTab.swift",
-      "source": "Gateway Settings",
-      "surface": "apple",
-      "id": "native.apple.d510e012c91b24ed"
-    },
-    {
       "kind": "ui-localized-call",
-      "line": 643,
+      "line": 441,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Show reasoning & tool activity",
       "surface": "apple",
@@ -17411,7 +16979,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 652,
+      "line": 450,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Chat actions",
       "surface": "apple",
@@ -17419,7 +16987,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 754,
+      "line": 519,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Connected",
       "surface": "apple",
@@ -17427,7 +16995,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 754,
+      "line": 519,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Unavailable",
       "surface": "apple",
@@ -17435,7 +17003,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 767,
+      "line": 532,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Message %@...",
       "surface": "apple",
@@ -17443,7 +17011,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 772,
+      "line": 537,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Message %@; sends when connected",
       "surface": "apple",
@@ -17451,7 +17019,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 775,
+      "line": 540,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Connect to a gateway",
       "surface": "apple",
@@ -17459,7 +17027,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 864,
+      "line": 638,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Check OpenClaw status",
       "surface": "apple",
@@ -17467,7 +17035,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 865,
+      "line": 639,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Summarize the current OpenClaw status and tell me what needs attention.",
       "surface": "apple",
@@ -17475,7 +17043,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 868,
+      "line": 642,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "What can I control here?",
       "surface": "apple",
@@ -17483,7 +17051,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 869,
+      "line": 643,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Show me which phone controls and device capabilities are available right now.",
       "surface": "apple",
@@ -17491,7 +17059,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 872,
+      "line": 646,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Help me start voice chat",
       "surface": "apple",
@@ -17499,7 +17067,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 873,
+      "line": 647,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Help me start a realtime voice session from this phone.",
       "surface": "apple",
@@ -17637,17 +17205,17 @@
       "kind": "ui-modifier",
       "line": 209,
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
-      "source": "Delete Thread?",
+      "source": "Delete Session?",
       "surface": "apple",
-      "id": "native.apple.31d5c7287cfb3abe"
+      "id": "native.apple.f488b9caf6e51ac3"
     },
     {
       "kind": "ui-call",
       "line": 216,
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
-      "source": "Delete Thread",
+      "source": "Delete Session",
       "surface": "apple",
-      "id": "native.apple.d3395564809f1120"
+      "id": "native.apple.8634b17be9b111bc"
     },
     {
       "kind": "ui-call",
@@ -17661,9 +17229,9 @@
       "kind": "ui-call",
       "line": 224,
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
-      "source": "This permanently deletes the thread and its transcript.",
+      "source": "This permanently deletes the session and its transcript.",
       "surface": "apple",
-      "id": "native.apple.092659256d26cb03"
+      "id": "native.apple.4a9568ac9b18d8d3"
     },
     {
       "kind": "ui-call",
@@ -17709,9 +17277,9 @@
       "kind": "ui-localized-call",
       "line": 269,
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
-      "source": "Rename Thread",
+      "source": "Rename Session",
       "surface": "apple",
-      "id": "native.apple.683032464c497bbd"
+      "id": "native.apple.5bccdc23a1640895"
     },
     {
       "kind": "ui-localized-call",
@@ -17725,9 +17293,9 @@
       "kind": "ui-localized-call",
       "line": 275,
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
-      "source": "Thread name",
+      "source": "Session name",
       "surface": "apple",
-      "id": "native.apple.f887aa956588f237"
+      "id": "native.apple.af789b2d2fda0f67"
     },
     {
       "kind": "ui-call",
@@ -17789,17 +17357,17 @@
       "kind": "ui-named-argument",
       "line": 219,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
-      "source": "Agent thread",
+      "source": "Agent session",
       "surface": "apple",
-      "id": "native.apple.7c8231b7b1ca480f"
+      "id": "native.apple.a3bde8045fe9224a"
     },
     {
       "kind": "ui-named-argument",
       "line": 234,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
-      "source": "Recent threads",
+      "source": "Recent sessions",
       "surface": "apple",
-      "id": "native.apple.b3c553614f762a58"
+      "id": "native.apple.27f775de30b37ff8"
     },
     {
       "kind": "conditional-branch",
@@ -17813,9 +17381,9 @@
       "kind": "conditional-branch",
       "line": 239,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
-      "source": "No recent threads",
+      "source": "No recent sessions",
       "surface": "apple",
-      "id": "native.apple.5aa32afda85064ea"
+      "id": "native.apple.28c97cf23665ee01"
     },
     {
       "kind": "conditional-branch",
@@ -17973,17 +17541,17 @@
       "kind": "ui-call",
       "line": 797,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
-      "source": "Threads",
+      "source": "Sessions",
       "surface": "apple",
-      "id": "native.apple.b6855cf19a50f477"
+      "id": "native.apple.9f2fd65953013b7c"
     },
     {
       "kind": "ui-localized-call",
       "line": 812,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
-      "source": "Archived threads",
+      "source": "Archived sessions",
       "surface": "apple",
-      "id": "native.apple.9b1d0ef27a1333b0"
+      "id": "native.apple.0422818cc95d5071"
     },
     {
       "kind": "ui-call",
@@ -17997,49 +17565,49 @@
       "kind": "ui-named-argument",
       "line": 836,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
-      "source": "Threads unavailable",
+      "source": "Sessions unavailable",
       "surface": "apple",
-      "id": "native.apple.98167401c7267735"
+      "id": "native.apple.b272115c83f7ef58"
     },
     {
       "kind": "ui-localized-call",
       "line": 875,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
-      "source": "Loading archived threads",
+      "source": "Loading archived sessions",
       "surface": "apple",
-      "id": "native.apple.4d28a7def2337b9f"
+      "id": "native.apple.54f8260c9b863087"
     },
     {
       "kind": "ui-localized-call",
       "line": 876,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
-      "source": "Loading recent threads",
+      "source": "Loading recent sessions",
       "surface": "apple",
-      "id": "native.apple.777d7b706933bd7b"
+      "id": "native.apple.9b305868873dade2"
     },
     {
       "kind": "ui-localized-call",
       "line": 883,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
-      "source": "^[\\(count) thread](inflect: true)",
+      "source": "^[\\(count) session](inflect: true)",
       "surface": "apple",
-      "id": "native.apple.22f81ea94bef8410"
+      "id": "native.apple.207dad20d09f3160"
     },
     {
       "kind": "ui-localized-call",
       "line": 913,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
-      "source": "No archived threads",
+      "source": "No archived sessions",
       "surface": "apple",
-      "id": "native.apple.1cad51e14db59bf9"
+      "id": "native.apple.1f4501a6bf2bae4c"
     },
     {
       "kind": "ui-localized-call",
       "line": 919,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
-      "source": "Archived threads will appear here.",
+      "source": "Archived sessions will appear here.",
       "surface": "apple",
-      "id": "native.apple.18ef832d3a7ddcf8"
+      "id": "native.apple.2a1ba7a5e1979c9e"
     },
     {
       "kind": "ui-call",
@@ -18173,9 +17741,9 @@
       "kind": "ui-named-argument",
       "line": 115,
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
-      "source": "Loading threads",
+      "source": "Loading sessions",
       "surface": "apple",
-      "id": "native.apple.21d9208d86a4d1fe"
+      "id": "native.apple.2360d25fe6ae9946"
     },
     {
       "kind": "ui-named-argument",
@@ -18189,25 +17757,25 @@
       "kind": "ui-named-argument",
       "line": 125,
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
-      "source": "Threads unavailable",
+      "source": "Sessions unavailable",
       "surface": "apple",
-      "id": "native.apple.4be1f79aa2b230ff"
+      "id": "native.apple.c334f2e86702a7b8"
     },
     {
       "kind": "conditional-branch",
       "line": 135,
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
-      "source": "No recent threads",
+      "source": "No recent sessions",
       "surface": "apple",
-      "id": "native.apple.98b348873556bc46"
+      "id": "native.apple.6cc6efb7a03960b6"
     },
     {
       "kind": "conditional-branch",
       "line": 135,
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
-      "source": "Thread activity offline",
+      "source": "Session activity offline",
       "surface": "apple",
-      "id": "native.apple.7396d205574d279f"
+      "id": "native.apple.08483af2d043bee6"
     },
     {
       "kind": "conditional-branch",
@@ -18941,9 +18509,9 @@
       "kind": "ui-call",
       "line": 1319,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
-      "source": "Open Thread",
+      "source": "Open Session",
       "surface": "apple",
-      "id": "native.apple.c9ec1b0e18074d8a"
+      "id": "native.apple.93eeaedb2ff61043"
     },
     {
       "kind": "ui-call",
@@ -19219,7 +18787,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 616,
+      "line": 626,
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "OpenClaw",
       "surface": "apple",
@@ -19227,7 +18795,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 646,
+      "line": 656,
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "Gateway %@",
       "surface": "apple",
@@ -19235,7 +18803,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 653,
+      "line": 663,
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "Online",
       "surface": "apple",
@@ -19243,7 +18811,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 655,
+      "line": 665,
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "Connecting",
       "surface": "apple",
@@ -19251,7 +18819,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 657,
+      "line": 667,
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "Attention",
       "surface": "apple",
@@ -19259,7 +18827,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 659,
+      "line": 669,
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "Offline",
       "surface": "apple",
@@ -19283,7 +18851,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 97,
+      "line": 100,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Agent chat and recent work.",
       "surface": "apple",
@@ -19291,7 +18859,15 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 166,
+      "line": 103,
+      "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
+      "source": "Realtime voice and controls.",
+      "surface": "apple",
+      "id": "native.apple.a30d0a950d0a77aa"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 173,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Overview",
       "surface": "apple",
@@ -19299,7 +18875,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 188,
+      "line": 195,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Instances",
       "surface": "apple",
@@ -19307,7 +18883,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 197,
+      "line": 204,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Files",
       "surface": "apple",
@@ -19315,7 +18891,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 202,
+      "line": 209,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Dreaming",
       "surface": "apple",
@@ -19323,7 +18899,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 207,
+      "line": 214,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Usage",
       "surface": "apple",
@@ -19331,7 +18907,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 212,
+      "line": 219,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Automations",
       "surface": "apple",
@@ -19339,7 +18915,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 277,
+      "line": 284,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Default Agent",
       "surface": "apple",
@@ -19347,7 +18923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 292,
+      "line": 299,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Gateway",
       "surface": "apple",
@@ -19355,7 +18931,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 300,
+      "line": 307,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Gateway %1$@, %2$@, %3$@",
       "surface": "apple",
@@ -19363,7 +18939,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 307,
+      "line": 314,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Gateway %1$@, %2$@",
       "surface": "apple",
@@ -19371,7 +18947,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 316,
+      "line": 323,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Online",
       "surface": "apple",
@@ -19379,7 +18955,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 317,
+      "line": 324,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Connecting",
       "surface": "apple",
@@ -19387,7 +18963,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 318,
+      "line": 325,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Attention",
       "surface": "apple",
@@ -19395,7 +18971,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 319,
+      "line": 326,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Offline",
       "surface": "apple",
@@ -20107,7 +19683,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 405,
+      "line": 404,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Opening QR scanner...",
       "surface": "apple",
@@ -20115,7 +19691,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 411,
+      "line": 410,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "QR loaded. Closing scanner...",
       "surface": "apple",
@@ -20123,7 +19699,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 441,
+      "line": 440,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Apple Review demo mode enabled.",
       "surface": "apple",
@@ -20131,7 +19707,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 492,
+      "line": 491,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Failed: host required",
       "surface": "apple",
@@ -20139,7 +19715,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 500,
+      "line": 499,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Failed: invalid port",
       "surface": "apple",
@@ -20147,7 +19723,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 558,
+      "line": 557,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Tailscale is off on this device. Turn it on, then try again.",
       "surface": "apple",
@@ -20155,7 +19731,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 935,
+      "line": 934,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Gateway",
       "surface": "apple",
@@ -20163,7 +19739,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 936,
+      "line": 935,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Apple Watch",
       "surface": "apple",
@@ -20171,7 +19747,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 937,
+      "line": 936,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Approvals",
       "surface": "apple",
@@ -20179,7 +19755,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 938,
+      "line": 937,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Permissions",
       "surface": "apple",
@@ -20187,7 +19763,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 939,
+      "line": 938,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Channels",
       "surface": "apple",
@@ -20195,7 +19771,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 940,
+      "line": 939,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Skills",
       "surface": "apple",
@@ -20203,7 +19779,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 941,
+      "line": 940,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Voice & Talk",
       "surface": "apple",
@@ -20211,7 +19787,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 942,
+      "line": 941,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Diagnostics",
       "surface": "apple",
@@ -20219,7 +19795,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 943,
+      "line": 942,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Privacy",
       "surface": "apple",
@@ -20227,7 +19803,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 945,
+      "line": 944,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Licenses",
       "surface": "apple",
@@ -20235,7 +19811,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 946,
+      "line": 945,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "About",
       "surface": "apple",
@@ -20243,7 +19819,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 953,
+      "line": 952,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Preparing one-time setup…",
       "surface": "apple",
@@ -20251,7 +19827,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 958,
+      "line": 957,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Setup sent. Open OpenClaw on the watch to connect.",
       "surface": "apple",
@@ -20259,7 +19835,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 960,
+      "line": 959,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
       "surface": "apple",
@@ -20267,7 +19843,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1050,
+      "line": 1049,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "This gateway is on your tailnet. Turn on Tailscale on this device, then tap Connect.",
       "surface": "apple",
@@ -20275,7 +19851,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1057,
+      "line": 1056,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Pairing required. Run /pair approve in your OpenClaw chat, then connect again.",
       "surface": "apple",
@@ -20283,7 +19859,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1060,
+      "line": 1059,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Secure handshake failed. Check Tailscale, then connect again.",
       "surface": "apple",
@@ -20291,7 +19867,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1069,
+      "line": 1068,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Connection timed out. Make sure Tailscale is connected, then try again.",
       "surface": "apple",
@@ -20299,7 +19875,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1073,
+      "line": 1072,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Connected, but some controls are restricted for nodes. This is expected.",
       "surface": "apple",
@@ -20307,7 +19883,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1080,
+      "line": 1079,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Setup code applied. Connecting...",
       "surface": "apple",
@@ -20315,7 +19891,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1081,
+      "line": 1080,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Checking gateway reachability...",
       "surface": "apple",
@@ -20323,7 +19899,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1082,
+      "line": 1081,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "QR loaded. Connecting to %@:%@...",
       "surface": "apple",
@@ -20331,7 +19907,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1145,
+      "line": 1144,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Not loaded",
       "surface": "apple",
@@ -20339,7 +19915,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1148,
+      "line": 1147,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Configured",
       "surface": "apple",
@@ -20347,7 +19923,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1149,
+      "line": 1148,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Not configured",
       "surface": "apple",
@@ -20355,7 +19931,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1156,
+      "line": 1155,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Not active",
       "surface": "apple",
@@ -20363,7 +19939,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1192,
+      "line": 1191,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Apple Review demo mode",
       "surface": "apple",
@@ -20371,7 +19947,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1195,
+      "line": 1194,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Connected",
       "surface": "apple",
@@ -20379,7 +19955,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1201,
+      "line": 1200,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "offline",
       "surface": "apple",
@@ -20387,7 +19963,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1201,
+      "line": 1200,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "online",
       "surface": "apple",
@@ -20395,7 +19971,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1219,
+      "line": 1218,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Live gateway requests are disabled in demo mode.",
       "surface": "apple",
@@ -20403,7 +19979,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1223,
+      "line": 1222,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Foreground approvals still appear while OpenClaw is connected.",
       "surface": "apple",
@@ -20411,7 +19987,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1226,
+      "line": 1225,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Gateway requests will appear here.",
       "surface": "apple",
@@ -20419,7 +19995,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1227,
+      "line": 1226,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Connect to the gateway.",
       "surface": "apple",
@@ -20427,7 +20003,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1231,
+      "line": 1230,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Demo mode only",
       "surface": "apple",
@@ -20435,7 +20011,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1238,
+      "line": 1237,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "loaded",
       "surface": "apple",
@@ -20443,7 +20019,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1239,
+      "line": 1238,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "missing",
       "surface": "apple",
@@ -20451,7 +20027,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1248,
+      "line": 1247,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Waiting for gateway",
       "surface": "apple",
@@ -20459,7 +20035,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1265,
+      "line": 1264,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "1 waiting",
       "surface": "apple",
@@ -20467,7 +20043,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1268,
+      "line": 1267,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "%@ waiting",
       "surface": "apple",
@@ -20475,7 +20051,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1279,
+      "line": 1278,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Review gateway action",
       "surface": "apple",
@@ -20483,7 +20059,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1281,
+      "line": 1280,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Agent: %@",
       "surface": "apple",
@@ -20491,7 +20067,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1290,
+      "line": 1289,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Resolving",
       "surface": "apple",
@@ -20499,7 +20075,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1291,
+      "line": 1290,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "High",
       "surface": "apple",
@@ -20507,7 +20083,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1297,
+      "line": 1296,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Permission can be saved",
       "surface": "apple",
@@ -20515,7 +20091,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1298,
+      "line": 1297,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "One-time approval",
       "surface": "apple",
@@ -20523,7 +20099,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1301,
+      "line": 1300,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Medium",
       "surface": "apple",
@@ -20531,7 +20107,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1302,
+      "line": 1301,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Review",
       "surface": "apple",
@@ -20539,7 +20115,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1308,
+      "line": 1307,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Talk + Wake",
       "surface": "apple",
@@ -20547,7 +20123,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1309,
+      "line": 1308,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Talk on",
       "surface": "apple",
@@ -20555,7 +20131,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1310,
+      "line": 1309,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Wake on",
       "surface": "apple",
@@ -20563,7 +20139,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1311,
+      "line": 1310,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Off",
       "surface": "apple",
@@ -20571,7 +20147,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1315,
+      "line": 1314,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "demo",
       "surface": "apple",
@@ -20579,7 +20155,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1316,
+      "line": 1315,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "ready",
       "surface": "apple",
@@ -20587,7 +20163,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1317,
+      "line": 1316,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "check",
       "surface": "apple",
@@ -20595,7 +20171,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1318,
+      "line": 1317,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "partial",
       "surface": "apple",
@@ -20603,7 +20179,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1322,
+      "line": 1321,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "pending",
       "surface": "apple",
@@ -20611,7 +20187,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1324,
+      "line": 1323,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "pass",
       "surface": "apple",
@@ -20619,7 +20195,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1335,
+      "line": 1334,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Requesting iOS location permission…",
       "surface": "apple",
@@ -20627,7 +20203,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1401,
+      "line": 1400,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "This build uses OpenClaw's hosted push relay at %@ for notification delivery data.",
       "surface": "apple",
@@ -20635,7 +20211,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1405,
+      "line": 1404,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "This build is not configured to use OpenClaw's hosted push relay.",
       "surface": "apple",
@@ -20643,7 +20219,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1410,
+      "line": 1409,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Enabling this sends delivery data through OpenClaw's hosted push relay.",
       "surface": "apple",
@@ -21325,9 +20901,9 @@
       "kind": "ui-call",
       "line": 1048,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
-      "source": "Used for new Chat threads and Talk sessions.",
+      "source": "Used for new Chat and Talk sessions.",
       "surface": "apple",
-      "id": "native.apple.f4ae5664c3eda95d"
+      "id": "native.apple.3de045f17ea3c6d0"
     },
     {
       "kind": "ui-named-argument",
@@ -22626,6 +22202,238 @@
       "id": "native.apple.7a5a1b9342f01954"
     },
     {
+      "kind": "ui-modifier",
+      "line": 62,
+      "path": "apps/ios/Sources/Design/TalkProTab.swift",
+      "source": "Enable Talk",
+      "surface": "apple",
+      "id": "native.apple.798c3584ad95f8da"
+    },
+    {
+      "kind": "ui-call",
+      "line": 68,
+      "path": "apps/ios/Sources/Design/TalkProTab.swift",
+      "source": "Not Now",
+      "surface": "apple",
+      "id": "native.apple.c6e171128190d131"
+    },
+    {
+      "kind": "ui-modifier",
+      "line": 107,
+      "path": "apps/ios/Sources/Design/TalkProTab.swift",
+      "source": "Talk",
+      "surface": "apple",
+      "id": "native.apple.e4b15aef3c2e3da7"
+    },
+    {
+      "kind": "ui-call",
+      "line": 161,
+      "path": "apps/ios/Sources/Design/TalkProTab.swift",
+      "source": "Conversation",
+      "surface": "apple",
+      "id": "native.apple.ab3381742bdff650"
+    },
+    {
+      "kind": "ui-call",
+      "line": 162,
+      "path": "apps/ios/Sources/Design/TalkProTab.swift",
+      "source": "Agent",
+      "surface": "apple",
+      "id": "native.apple.7af100f6640c6a69"
+    },
+    {
+      "kind": "ui-call",
+      "line": 163,
+      "path": "apps/ios/Sources/Design/TalkProTab.swift",
+      "source": "Session",
+      "surface": "apple",
+      "id": "native.apple.49c4de60117b1a98"
+    },
+    {
+      "kind": "ui-call",
+      "line": 164,
+      "path": "apps/ios/Sources/Design/TalkProTab.swift",
+      "source": "Runtime",
+      "surface": "apple",
+      "id": "native.apple.37c29d2506b955e9"
+    },
+    {
+      "kind": "ui-call",
+      "line": 169,
+      "path": "apps/ios/Sources/Design/TalkProTab.swift",
+      "source": "Voice Mode",
+      "surface": "apple",
+      "id": "native.apple.13e0ad79b141576e"
+    },
+    {
+      "kind": "ui-call",
+      "line": 170,
+      "path": "apps/ios/Sources/Design/TalkProTab.swift",
+      "source": "Configured",
+      "surface": "apple",
+      "id": "native.apple.e8035b71bab833c7"
+    },
+    {
+      "kind": "ui-call",
+      "line": 173,
+      "path": "apps/ios/Sources/Design/TalkProTab.swift",
+      "source": "Active",
+      "surface": "apple",
+      "id": "native.apple.1b2845ec89d20eef"
+    },
+    {
+      "kind": "ui-call",
+      "line": 174,
+      "path": "apps/ios/Sources/Design/TalkProTab.swift",
+      "source": "Transport",
+      "surface": "apple",
+      "id": "native.apple.a82c07df64d13b23"
+    },
+    {
+      "kind": "ui-call",
+      "line": 176,
+      "path": "apps/ios/Sources/Design/TalkProTab.swift",
+      "source": "Last issue",
+      "surface": "apple",
+      "id": "native.apple.384e097278f76954"
+    },
+    {
+      "kind": "ui-call",
+      "line": 178,
+      "path": "apps/ios/Sources/Design/TalkProTab.swift",
+      "source": "Permission",
+      "surface": "apple",
+      "id": "native.apple.a6d8fc7bfd98836f"
+    },
+    {
+      "kind": "ui-call",
+      "line": 179,
+      "path": "apps/ios/Sources/Design/TalkProTab.swift",
+      "source": "Speech language",
+      "surface": "apple",
+      "id": "native.apple.983bdcd5e3f1baa8"
+    },
+    {
+      "kind": "ui-call",
+      "line": 184,
+      "path": "apps/ios/Sources/Design/TalkProTab.swift",
+      "source": "Controls",
+      "surface": "apple",
+      "id": "native.apple.32e7fa2b1798e9c3"
+    },
+    {
+      "kind": "ui-call",
+      "line": 186,
+      "path": "apps/ios/Sources/Design/TalkProTab.swift",
+      "source": "Speakerphone",
+      "surface": "apple",
+      "id": "native.apple.0eb012a5d3d81b32"
+    },
+    {
+      "kind": "ui-call",
+      "line": 191,
+      "path": "apps/ios/Sources/Design/TalkProTab.swift",
+      "source": "Background listening",
+      "surface": "apple",
+      "id": "native.apple.ef8699e2718346da"
+    },
+    {
+      "kind": "ui-call",
+      "line": 197,
+      "path": "apps/ios/Sources/Design/TalkProTab.swift",
+      "source": "Voice & Talk Settings",
+      "surface": "apple",
+      "id": "native.apple.1e6938a09b4fbe77"
+    },
+    {
+      "kind": "ui-call",
+      "line": 225,
+      "path": "apps/ios/Sources/Design/TalkProTab.swift",
+      "source": "Gateway approval is required before this phone can capture voice.",
+      "surface": "apple",
+      "id": "native.apple.c7a591fd5bb6687e"
+    },
+    {
+      "kind": "ui-call",
+      "line": 228,
+      "path": "apps/ios/Sources/Design/TalkProTab.swift",
+      "source": "Voice is disabled in Apple Review demo mode.",
+      "surface": "apple",
+      "id": "native.apple.9d40e75e55ed39eb"
+    },
+    {
+      "kind": "ui-call",
+      "line": 231,
+      "path": "apps/ios/Sources/Design/TalkProTab.swift",
+      "source": "Connect to your gateway to start a voice conversation.",
+      "surface": "apple",
+      "id": "native.apple.3ef69bf916177799"
+    },
+    {
+      "kind": "ui-call",
+      "line": 234,
+      "path": "apps/ios/Sources/Design/TalkProTab.swift",
+      "source": "Open Voice settings after the gateway loads Talk configuration.",
+      "surface": "apple",
+      "id": "native.apple.ed03af7c68841a5d"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 241,
+      "path": "apps/ios/Sources/Design/TalkProTab.swift",
+      "source": "Routes voice to %@.",
+      "surface": "apple",
+      "id": "native.apple.883a251978601b96"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 254,
+      "path": "apps/ios/Sources/Design/TalkProTab.swift",
+      "source": "Not loaded",
+      "surface": "apple",
+      "id": "native.apple.877fb5c1abfaafa1"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 263,
+      "path": "apps/ios/Sources/Design/TalkProTab.swift",
+      "source": "Not active",
+      "surface": "apple",
+      "id": "native.apple.d3ccb092936551fc"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 441,
+      "path": "apps/ios/Sources/Design/TalkProTab.swift",
+      "source": "Open Gateway Settings",
+      "surface": "apple",
+      "id": "native.apple.1620f7cb3deea133"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 441,
+      "path": "apps/ios/Sources/Design/TalkProTab.swift",
+      "source": "Open Voice Settings",
+      "surface": "apple",
+      "id": "native.apple.3fd2706ef0f14fd2"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 442,
+      "path": "apps/ios/Sources/Design/TalkProTab.swift",
+      "source": "Demo Mode Only",
+      "surface": "apple",
+      "id": "native.apple.3cc9cd23a67db077"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 442,
+      "path": "apps/ios/Sources/Design/TalkProTab.swift",
+      "source": "Waiting for Approval",
+      "surface": "apple",
+      "id": "native.apple.12c9d8231777366c"
+    },
+    {
       "kind": "ui-named-argument",
       "line": 17,
       "path": "apps/ios/Sources/Design/TalkRuntimeIssueBanner.swift",
@@ -22899,7 +22707,7 @@
     },
     {
       "kind": "ui-localized-call-multiline",
-      "line": 1283,
+      "line": 1281,
       "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
       "source": "Can't reach gateway at %1$@:%2$@. Verify Tailscale Serve is enabled and publishes this Gateway.",
       "surface": "apple",
@@ -22907,7 +22715,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1292,
+      "line": 1290,
       "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
       "source": "Can't reach gateway at %1$@:%2$@. Check Tailscale or LAN.",
       "surface": "apple",
@@ -22915,7 +22723,7 @@
     },
     {
       "kind": "ui-localized-call-multiline",
-      "line": 1298,
+      "line": 1296,
       "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
       "source": "TLS fingerprint verification timed out for %1$@:%2$@. Secure endpoint was reached, but TLS did not finish in time.",
       "surface": "apple",
@@ -22923,7 +22731,7 @@
     },
     {
       "kind": "ui-localized-call-multiline",
-      "line": 1306,
+      "line": 1304,
       "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
       "source": "No secure gateway endpoint was detected at %1$@:%2$@. Enable gateway TLS or Tailscale Serve, or use a trusted private LAN address with Unencrypted selected.",
       "surface": "apple",
@@ -22931,7 +22739,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1316,
+      "line": 1314,
       "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
       "source": "Could not read the TLS certificate from %1$@:%2$@.",
       "surface": "apple",
@@ -23499,7 +23307,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 565,
+      "line": 169,
       "path": "apps/ios/Sources/LiveActivity/LiveActivityManager.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -23507,7 +23315,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 568,
+      "line": 172,
       "path": "apps/ios/Sources/LiveActivity/LiveActivityManager.swift",
       "source": "Reconnecting...",
       "surface": "apple",
@@ -23515,7 +23323,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 575,
+      "line": 179,
       "path": "apps/ios/Sources/LiveActivity/LiveActivityManager.swift",
       "source": "Approval needed",
       "surface": "apple",
@@ -23523,67 +23331,11 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 578,
+      "line": 182,
       "path": "apps/ios/Sources/LiveActivity/LiveActivityManager.swift",
       "source": "Action required",
       "surface": "apple",
       "id": "native.apple.8faaac6dab276c0a"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 596,
-      "path": "apps/ios/Sources/LiveActivity/LiveActivityManager.swift",
-      "source": "Listening",
-      "surface": "apple",
-      "id": "native.apple.7205f0822706cb55"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 597,
-      "path": "apps/ios/Sources/LiveActivity/LiveActivityManager.swift",
-      "source": "Listening (PTT)",
-      "surface": "apple",
-      "id": "native.apple.8b10cb1dc21e42af"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 598,
-      "path": "apps/ios/Sources/LiveActivity/LiveActivityManager.swift",
-      "source": "Listening (Realtime)",
-      "surface": "apple",
-      "id": "native.apple.939c7ec55636c67f"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 602,
-      "path": "apps/ios/Sources/LiveActivity/LiveActivityManager.swift",
-      "source": "Speaking…",
-      "surface": "apple",
-      "id": "native.apple.86f203ebb2453d15"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 603,
-      "path": "apps/ios/Sources/LiveActivity/LiveActivityManager.swift",
-      "source": "Speaking (System)…",
-      "surface": "apple",
-      "id": "native.apple.1e3ff6b56ae3828d"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 604,
-      "path": "apps/ios/Sources/LiveActivity/LiveActivityManager.swift",
-      "source": "Generating voice…",
-      "surface": "apple",
-      "id": "native.apple.37a5fedaefb8ebf3"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 607,
-      "path": "apps/ios/Sources/LiveActivity/LiveActivityManager.swift",
-      "source": "Ready",
-      "surface": "apple",
-      "id": "native.apple.47003f094346c660"
     },
     {
       "kind": "conditional-branch",
@@ -23819,7 +23571,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4112,
+      "line": 3864,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval needed",
       "surface": "apple",
@@ -23827,7 +23579,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4113,
+      "line": 3865,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Action required",
       "surface": "apple",
@@ -23835,7 +23587,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4828,
+      "line": 4564,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -23843,7 +23595,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4829,
+      "line": 4565,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting...",
       "surface": "apple",
@@ -23851,7 +23603,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5181,
+      "line": 4909,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connected",
       "surface": "apple",
@@ -23859,7 +23611,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5181,
+      "line": 4909,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Offline",
       "surface": "apple",
@@ -23867,7 +23619,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6351,
+      "line": 6075,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "No chat messages yet",
       "surface": "apple",
@@ -23875,7 +23627,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6550,
+      "line": 6274,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting…",
       "surface": "apple",
@@ -23883,7 +23635,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6550,
+      "line": 6274,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting…",
       "surface": "apple",
@@ -23891,7 +23643,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8959,
+      "line": 8683,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval",
       "surface": "apple",
@@ -23899,7 +23651,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8959,
+      "line": 8683,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "This approval was already",
       "surface": "apple",
@@ -23907,7 +23659,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8965,
+      "line": 8689,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "This approval was already set to Always Allow.",
       "surface": "apple",
@@ -23915,7 +23667,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8966,
+      "line": 8690,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval set to Always Allow.",
       "surface": "apple",
@@ -23923,7 +23675,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 10303,
+      "line": 10028,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "\\(urlText.prefix(500))…",
       "surface": "apple",
@@ -24899,159 +24651,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 249,
+      "line": 174,
       "path": "apps/ios/Sources/RootTabs.swift",
-      "source": "OpenClaw",
+      "source": "Talk",
       "surface": "apple",
-      "id": "native.apple.c23d35de8d70863f"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 281,
-      "path": "apps/ios/Sources/RootTabs.swift",
-      "source": "OpenClaw %@",
-      "surface": "apple",
-      "id": "native.apple.9e781c0183b79a76"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 288,
-      "path": "apps/ios/Sources/RootTabs.swift",
-      "source": "Online",
-      "surface": "apple",
-      "id": "native.apple.f4eea6473f43388d"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 290,
-      "path": "apps/ios/Sources/RootTabs.swift",
-      "source": "Connecting",
-      "surface": "apple",
-      "id": "native.apple.9e2aea6088887f1f"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 292,
-      "path": "apps/ios/Sources/RootTabs.swift",
-      "source": "Needs attention",
-      "surface": "apple",
-      "id": "native.apple.3624978c7d43335a"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 294,
-      "path": "apps/ios/Sources/RootTabs.swift",
-      "source": "Offline",
-      "surface": "apple",
-      "id": "native.apple.7da053dd774cb201"
-    },
-    {
-      "kind": "ui-named-argument",
-      "line": 373,
-      "path": "apps/ios/Sources/RootTabs.swift",
-      "source": "Chat",
-      "surface": "apple",
-      "id": "native.apple.a4256b2ab523ee60"
-    },
-    {
-      "kind": "ui-named-argument",
-      "line": 380,
-      "path": "apps/ios/Sources/RootTabs.swift",
-      "source": "Overview",
-      "surface": "apple",
-      "id": "native.apple.64d7dc062ef4cc81"
-    },
-    {
-      "kind": "ui-named-argument",
-      "line": 404,
-      "path": "apps/ios/Sources/RootTabs.swift",
-      "source": "Agents",
-      "surface": "apple",
-      "id": "native.apple.11f98fe0650d52f5"
-    },
-    {
-      "kind": "ui-named-argument",
-      "line": 411,
-      "path": "apps/ios/Sources/RootTabs.swift",
-      "source": "Instances",
-      "surface": "apple",
-      "id": "native.apple.47426e84372bc0a5"
-    },
-    {
-      "kind": "ui-named-argument",
-      "line": 422,
-      "path": "apps/ios/Sources/RootTabs.swift",
-      "source": "Files",
-      "surface": "apple",
-      "id": "native.apple.d1a5c9b0c4acbfe2"
-    },
-    {
-      "kind": "ui-named-argument",
-      "line": 429,
-      "path": "apps/ios/Sources/RootTabs.swift",
-      "source": "Dreaming",
-      "surface": "apple",
-      "id": "native.apple.ad3c65353227b63e"
-    },
-    {
-      "kind": "ui-named-argument",
-      "line": 436,
-      "path": "apps/ios/Sources/RootTabs.swift",
-      "source": "Usage",
-      "surface": "apple",
-      "id": "native.apple.a3ba593df67a8673"
-    },
-    {
-      "kind": "ui-named-argument",
-      "line": 443,
-      "path": "apps/ios/Sources/RootTabs.swift",
-      "source": "Automations",
-      "surface": "apple",
-      "id": "native.apple.8c4e07b06e938527"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 555,
-      "path": "apps/ios/Sources/RootTabs.swift",
-      "source": "Show Sidebar",
-      "surface": "apple",
-      "id": "native.apple.20f4753fc51c5341"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 566,
-      "path": "apps/ios/Sources/RootTabs.swift",
-      "source": "Back to %@",
-      "surface": "apple",
-      "id": "native.apple.bb0ea6d61a32c7c2"
-    },
-    {
-      "kind": "ui-modifier",
-      "line": 591,
-      "path": "apps/ios/Sources/RootTabs.swift",
-      "source": "Hide Sidebar",
-      "surface": "apple",
-      "id": "native.apple.72fab75688479b3e"
-    },
-    {
-      "kind": "ui-modifier",
-      "line": 709,
-      "path": "apps/ios/Sources/RootTabs.swift",
-      "source": "Close canvas",
-      "surface": "apple",
-      "id": "native.apple.8af43f59602ec0d8"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 916,
-      "path": "apps/ios/Sources/RootTabs.swift",
-      "source": "Chat, voice active",
-      "surface": "apple",
-      "id": "native.apple.a1db6ce0aed1d18e"
+      "id": "native.apple.f2ea327bfea8b8e3"
     },
     {
       "kind": "ui-call",
-      "line": 926,
+      "line": 187,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Control",
       "surface": "apple",
@@ -25059,7 +24667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 935,
+      "line": 196,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Agent",
       "surface": "apple",
@@ -25067,11 +24675,155 @@
     },
     {
       "kind": "ui-call",
-      "line": 948,
+      "line": 209,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Settings",
       "surface": "apple",
       "id": "native.apple.22d107db5b905ef4"
+    },
+    {
+      "kind": "ui-call",
+      "line": 308,
+      "path": "apps/ios/Sources/RootTabs.swift",
+      "source": "OpenClaw",
+      "surface": "apple",
+      "id": "native.apple.c23d35de8d70863f"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 340,
+      "path": "apps/ios/Sources/RootTabs.swift",
+      "source": "OpenClaw %@",
+      "surface": "apple",
+      "id": "native.apple.9e781c0183b79a76"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 347,
+      "path": "apps/ios/Sources/RootTabs.swift",
+      "source": "Online",
+      "surface": "apple",
+      "id": "native.apple.f4eea6473f43388d"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 349,
+      "path": "apps/ios/Sources/RootTabs.swift",
+      "source": "Connecting",
+      "surface": "apple",
+      "id": "native.apple.9e2aea6088887f1f"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 351,
+      "path": "apps/ios/Sources/RootTabs.swift",
+      "source": "Needs attention",
+      "surface": "apple",
+      "id": "native.apple.3624978c7d43335a"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 353,
+      "path": "apps/ios/Sources/RootTabs.swift",
+      "source": "Offline",
+      "surface": "apple",
+      "id": "native.apple.7da053dd774cb201"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 432,
+      "path": "apps/ios/Sources/RootTabs.swift",
+      "source": "Chat",
+      "surface": "apple",
+      "id": "native.apple.a4256b2ab523ee60"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 445,
+      "path": "apps/ios/Sources/RootTabs.swift",
+      "source": "Overview",
+      "surface": "apple",
+      "id": "native.apple.64d7dc062ef4cc81"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 469,
+      "path": "apps/ios/Sources/RootTabs.swift",
+      "source": "Agents",
+      "surface": "apple",
+      "id": "native.apple.11f98fe0650d52f5"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 476,
+      "path": "apps/ios/Sources/RootTabs.swift",
+      "source": "Instances",
+      "surface": "apple",
+      "id": "native.apple.47426e84372bc0a5"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 487,
+      "path": "apps/ios/Sources/RootTabs.swift",
+      "source": "Files",
+      "surface": "apple",
+      "id": "native.apple.d1a5c9b0c4acbfe2"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 494,
+      "path": "apps/ios/Sources/RootTabs.swift",
+      "source": "Dreaming",
+      "surface": "apple",
+      "id": "native.apple.ad3c65353227b63e"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 501,
+      "path": "apps/ios/Sources/RootTabs.swift",
+      "source": "Usage",
+      "surface": "apple",
+      "id": "native.apple.a3ba593df67a8673"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 508,
+      "path": "apps/ios/Sources/RootTabs.swift",
+      "source": "Automations",
+      "surface": "apple",
+      "id": "native.apple.8c4e07b06e938527"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 620,
+      "path": "apps/ios/Sources/RootTabs.swift",
+      "source": "Show Sidebar",
+      "surface": "apple",
+      "id": "native.apple.20f4753fc51c5341"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 631,
+      "path": "apps/ios/Sources/RootTabs.swift",
+      "source": "Back to %@",
+      "surface": "apple",
+      "id": "native.apple.bb0ea6d61a32c7c2"
+    },
+    {
+      "kind": "ui-modifier",
+      "line": 656,
+      "path": "apps/ios/Sources/RootTabs.swift",
+      "source": "Hide Sidebar",
+      "surface": "apple",
+      "id": "native.apple.72fab75688479b3e"
+    },
+    {
+      "kind": "ui-modifier",
+      "line": 774,
+      "path": "apps/ios/Sources/RootTabs.swift",
+      "source": "Close canvas",
+      "surface": "apple",
+      "id": "native.apple.8af43f59602ec0d8"
     },
     {
       "kind": "conditional-branch",
@@ -25115,7 +24867,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 62,
+      "line": 64,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Chat",
       "surface": "apple",
@@ -25123,7 +24875,15 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 63,
+      "line": 65,
+      "path": "apps/ios/Sources/RootTabsNavigation.swift",
+      "source": "Talk",
+      "surface": "apple",
+      "id": "native.apple.febca7528af94342"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 66,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Overview",
       "surface": "apple",
@@ -25131,7 +24891,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 64,
+      "line": 67,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Activity",
       "surface": "apple",
@@ -25139,7 +24899,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 65,
+      "line": 68,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Agents",
       "surface": "apple",
@@ -25147,7 +24907,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 66,
+      "line": 69,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Workboard",
       "surface": "apple",
@@ -25155,7 +24915,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 67,
+      "line": 70,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Skill Workshop",
       "surface": "apple",
@@ -25163,7 +24923,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 68,
+      "line": 71,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Instances",
       "surface": "apple",
@@ -25171,15 +24931,15 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 69,
+      "line": 72,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
-      "source": "Threads",
+      "source": "Sessions",
       "surface": "apple",
-      "id": "native.apple.11fe8b9941954dfb"
+      "id": "native.apple.3579cf2750470a22"
     },
     {
       "kind": "ui-localized-call",
-      "line": 70,
+      "line": 73,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Files",
       "surface": "apple",
@@ -25187,7 +24947,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 71,
+      "line": 74,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Dreaming",
       "surface": "apple",
@@ -25195,7 +24955,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 72,
+      "line": 75,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Usage",
       "surface": "apple",
@@ -25203,7 +24963,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 73,
+      "line": 76,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Automations",
       "surface": "apple",
@@ -25211,7 +24971,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 74,
+      "line": 77,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Terminal",
       "surface": "apple",
@@ -25219,7 +24979,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 75,
+      "line": 78,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Docs",
       "surface": "apple",
@@ -25227,7 +24987,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 76,
+      "line": 79,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Settings",
       "surface": "apple",
@@ -25235,7 +24995,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 77,
+      "line": 80,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Settings / Gateway",
       "surface": "apple",
@@ -25243,7 +25003,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 83,
+      "line": 86,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Connection",
       "surface": "apple",
@@ -25667,7 +25427,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 608,
+      "line": 581,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Gateway relay ready",
       "surface": "apple",
@@ -25675,7 +25435,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 610,
+      "line": 583,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Realtime Voice, Gateway relay ready",
       "surface": "apple",
@@ -25683,7 +25443,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 612,
+      "line": 585,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Listening starts from this phone",
       "surface": "apple",
@@ -25691,7 +25451,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 852,
+      "line": 825,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Off",
       "surface": "apple",
@@ -25699,7 +25459,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 855,
+      "line": 828,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Not active",
       "surface": "apple",
@@ -25707,7 +25467,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1041,
+      "line": 1005,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Requesting permissions…",
       "surface": "apple",
@@ -25715,15 +25475,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1070,
-      "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
-      "source": "Start failed: %@",
-      "surface": "apple",
-      "id": "native.apple.198f59c97d7afe11"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 1326,
+      "line": 1013,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Microphone permission denied",
       "surface": "apple",
@@ -25731,7 +25483,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1336,
+      "line": 1022,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Speech recognition",
       "surface": "apple",
@@ -25739,7 +25491,15 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1467,
+      "line": 1058,
+      "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
+      "source": "Start failed: %@",
+      "surface": "apple",
+      "id": "native.apple.198f59c97d7afe11"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 1373,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Offline",
       "surface": "apple",
@@ -25747,7 +25507,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1666,
+      "line": 1572,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Speech error: %@",
       "surface": "apple",
@@ -25755,7 +25515,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1981,
+      "line": 1881,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Gateway not connected",
       "surface": "apple",
@@ -25763,7 +25523,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2025,
+      "line": 1925,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Aborted",
       "surface": "apple",
@@ -25771,7 +25531,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2025,
+      "line": 1925,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Chat error",
       "surface": "apple",
@@ -25779,7 +25539,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 2053,
+      "line": 1953,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Talk failed: %@",
       "surface": "apple",
@@ -25787,7 +25547,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 2157,
+      "line": 2057,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "No reply",
       "surface": "apple",
@@ -25795,7 +25555,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 2252,
+      "line": 2149,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Paused",
       "surface": "apple",
@@ -25803,7 +25563,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 2664,
+      "line": 2559,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Generating voice…",
       "surface": "apple",
@@ -25811,7 +25571,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 2802,
+      "line": 2697,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Speak failed: %@",
       "surface": "apple",
@@ -25819,7 +25579,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 2901,
+      "line": 2796,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Speaking (System)…",
       "surface": "apple",
@@ -25827,7 +25587,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3782,
+      "line": 3669,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "iOS System Voice",
       "surface": "apple",
@@ -25835,7 +25595,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3784,
+      "line": 3671,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Realtime Voice",
       "surface": "apple",
@@ -25843,7 +25603,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3788,
+      "line": 3675,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Gateway Default",
       "surface": "apple",
@@ -25851,7 +25611,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3847,
+      "line": 3734,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Listening (Realtime)",
       "surface": "apple",
@@ -25859,7 +25619,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3849,
+      "line": 3736,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Thinking",
       "surface": "apple",
@@ -25867,7 +25627,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3851,
+      "line": 3738,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Thinking…",
       "surface": "apple",
@@ -25875,7 +25635,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3853,
+      "line": 3740,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Asking OpenClaw",
       "surface": "apple",
@@ -25883,7 +25643,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3855,
+      "line": 3742,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Still asking OpenClaw",
       "surface": "apple",
@@ -25891,7 +25651,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3857,
+      "line": 3744,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Updating OpenClaw",
       "surface": "apple",
@@ -25899,7 +25659,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3859,
+      "line": 3746,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Speaking",
       "surface": "apple",
@@ -25907,7 +25667,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3861,
+      "line": 3748,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Speaking…",
       "surface": "apple",
@@ -25915,7 +25675,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3863,
+      "line": 3750,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Connecting",
       "surface": "apple",
@@ -25923,7 +25683,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3865,
+      "line": 3752,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Connecting realtime…",
       "surface": "apple",
@@ -25931,7 +25691,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3867,
+      "line": 3754,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Waiting for realtime…",
       "surface": "apple",
@@ -25939,7 +25699,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3869,
+      "line": 3756,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Ready",
       "surface": "apple",
@@ -25947,7 +25707,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3871,
+      "line": 3758,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Reconnecting",
       "surface": "apple",
@@ -25955,7 +25715,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3873,
+      "line": 3760,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Reconnecting…",
       "surface": "apple",
@@ -25963,7 +25723,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3875,
+      "line": 3762,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Realtime failed before connecting",
       "surface": "apple",
@@ -25971,7 +25731,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3877,
+      "line": 3764,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Realtime disconnected",
       "surface": "apple",
@@ -25979,7 +25739,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3879,
+      "line": 3766,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "OpenClaw unavailable",
       "surface": "apple",
@@ -25987,7 +25747,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3919,
+      "line": 3806,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "iOS Speech + TTS",
       "surface": "apple",
@@ -25995,7 +25755,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3921,
+      "line": 3808,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Listening",
       "surface": "apple",
@@ -26003,7 +25763,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3925,
+      "line": 3812,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "iOS Speech fallback",
       "surface": "apple",
@@ -26011,7 +25771,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4186,
+      "line": 4073,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Gateway Relay",
       "surface": "apple",
@@ -26019,7 +25779,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4188,
+      "line": 4075,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Native WebRTC",
       "surface": "apple",
@@ -26027,7 +25787,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4189,
+      "line": 4076,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Native",
       "surface": "apple",
@@ -26035,7 +25795,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4250,
+      "line": 4137,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Gateway permission required",
       "surface": "apple",
@@ -26043,7 +25803,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4272,
+      "line": 4159,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Not loaded",
       "surface": "apple",
@@ -26051,7 +25811,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4290,
+      "line": 4177,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Approval requested",
       "surface": "apple",
@@ -26059,7 +25819,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4729,
+      "line": 4603,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Realtime unavailable",
       "surface": "apple",
@@ -26067,11 +25827,107 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4751,
+      "line": 4625,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Listening (PTT)",
       "surface": "apple",
       "id": "native.apple.2970f0510ac6b396"
+    },
+    {
+      "kind": "ui-call",
+      "line": 65,
+      "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
+      "source": "Request ID",
+      "surface": "apple",
+      "id": "native.apple.0189269b6a863dc2"
+    },
+    {
+      "kind": "ui-call",
+      "line": 76,
+      "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
+      "source": "Sending...",
+      "surface": "apple",
+      "id": "native.apple.f9d69f27f9d7f4de"
+    },
+    {
+      "kind": "ui-call",
+      "line": 92,
+      "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
+      "source": "Retry",
+      "surface": "apple",
+      "id": "native.apple.0c5336129f70faed"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 138,
+      "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
+      "source": "Sending approval request",
+      "surface": "apple",
+      "id": "native.apple.7b23f0a89d3ad411"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 140,
+      "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
+      "source": "Approval sent",
+      "surface": "apple",
+      "id": "native.apple.55db7317a2542e51"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 142,
+      "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
+      "source": "Could not request approval",
+      "surface": "apple",
+      "id": "native.apple.06330f62ab254a0e"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 144,
+      "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
+      "source": "Enable Talk",
+      "surface": "apple",
+      "id": "native.apple.6580d3d1cdda682d"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 151,
+      "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
+      "source": "Sending a new pairing request to your gateway...",
+      "surface": "apple",
+      "id": "native.apple.abbfc1ba85a230b4"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 153,
+      "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
+      "source": "Approve this request on your gateway. Talk will start automatically when approval lands.",
+      "surface": "apple",
+      "id": "native.apple.2880deb53ea2fd86"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 155,
+      "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
+      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider.",
+      "surface": "apple",
+      "id": "native.apple.80faa829f543c03c"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 161,
+      "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
+      "source": "Request Again",
+      "surface": "apple",
+      "id": "native.apple.88b0a2e2986fcebf"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 161,
+      "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
+      "source": "Send Approval Request",
+      "surface": "apple",
+      "id": "native.apple.5a3faae3472b4b86"
     },
     {
       "kind": "conditional-branch",
@@ -30469,9 +30325,9 @@
       "kind": "ui-named-argument",
       "line": 109,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
-      "source": "Global shortcut that opens a floating chat bar for the main thread.",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
       "surface": "apple",
-      "id": "native.apple.94dd793cd7d7d555"
+      "id": "native.apple.6ae77665b5f4490f"
     },
     {
       "kind": "ui-call",
@@ -31397,9 +31253,9 @@
       "kind": "ui-call",
       "line": 106,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
-      "source": "New Thread",
+      "source": "New Session",
       "surface": "apple",
-      "id": "native.apple.13f96467014cf344"
+      "id": "native.apple.75102378a6775180"
     },
     {
       "kind": "ui-call",
@@ -31835,7 +31691,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 389,
+      "line": 385,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Main",
       "surface": "apple",
@@ -31843,7 +31699,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 389,
+      "line": 385,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Other",
       "surface": "apple",
@@ -31851,7 +31707,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 463,
+      "line": 459,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Show pairing requests",
       "surface": "apple",
@@ -31859,7 +31715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 488,
+      "line": 484,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Refreshing microphones…",
       "surface": "apple",
@@ -31867,7 +31723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 495,
+      "line": 491,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Microphone",
       "surface": "apple",
@@ -31875,7 +31731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 520,
+      "line": 516,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Disconnected (using System default)",
       "surface": "apple",
@@ -32019,7 +31875,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 436,
+      "line": 435,
       "path": "apps/macos/Sources/OpenClaw/NodePairingApprovalPrompter.swift",
       "source": "Node pairing approved",
       "surface": "apple",
@@ -32027,7 +31883,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 436,
+      "line": 435,
       "path": "apps/macos/Sources/OpenClaw/NodePairingApprovalPrompter.swift",
       "source": "Node pairing rejected",
       "surface": "apple",
@@ -34211,286 +34067,6 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 484,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatController.swift",
-      "source": "Microphone and speech recognition permission required.",
-      "surface": "apple",
-      "id": "native.apple.237f02309f0b9aeb"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 512,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatController.swift",
-      "source": "Dictation stopped because speech recognition failed.",
-      "surface": "apple",
-      "id": "native.apple.6f2679049010dae7"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 517,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatController.swift",
-      "source": "Couldn't start dictation.",
-      "surface": "apple",
-      "id": "native.apple.fd0469907ed8a50c"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 546,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatController.swift",
-      "source": "No app is available to paste into.",
-      "surface": "apple",
-      "id": "native.apple.ec789bf13bcffb61"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 553,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatController.swift",
-      "source": "Choose another app before pasting.",
-      "surface": "apple",
-      "id": "native.apple.bd2b8e99eee923b4"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 568,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatController.swift",
-      "source": "Accessibility permission is required to paste.",
-      "surface": "apple",
-      "id": "native.apple.f7aeeb401f9a4cd1"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 594,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatController.swift",
-      "source": "Couldn't paste the reply.",
-      "surface": "apple",
-      "id": "native.apple.14e9c9f41a9523c0"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 865,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatController.swift",
-      "source": "Capture Window…",
-      "surface": "apple",
-      "id": "native.apple.0a4fcdf09c5e7b3f"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 866,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatController.swift",
-      "source": "Capture Area…",
-      "surface": "apple",
-      "id": "native.apple.d7ac1580e29304af"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 203,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
-      "source": "focused app",
-      "surface": "apple",
-      "id": "native.apple.33adb82aa3c53c00"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 208,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
-      "source": "No focused application is available.",
-      "surface": "apple",
-      "id": "native.apple.5d20c8bd1235a43c"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 212,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
-      "source": "Focused app",
-      "surface": "apple",
-      "id": "native.apple.3c1a2f1ac3b50de0"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 216,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
-      "source": "Focus another app before attaching its text.",
-      "surface": "apple",
-      "id": "native.apple.511248f39affffc4"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 227,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
-      "source": "Accessibility access is required to attach text from \\(appName).",
-      "surface": "apple",
-      "id": "native.apple.1c94e8c0010021d9"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 252,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
-      "source": "No focused window is available in \\(appName).",
-      "surface": "apple",
-      "id": "native.apple.a3e3d4b0ab6e94d9"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 264,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
-      "source": "Focused Window",
-      "surface": "apple",
-      "id": "native.apple.a2a454a96a011397"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 299,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
-      "source": "\\(appName) is not responding to Accessibility requests.",
-      "surface": "apple",
-      "id": "native.apple.67d183bf2f9e4c2c"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 302,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
-      "source": "No readable text was found in \\(appName).",
-      "surface": "apple",
-      "id": "native.apple.2f56bc484453a456"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 313,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
-      "source": "Allow OpenClaw to read text from \\(appName)",
-      "surface": "apple",
-      "id": "native.apple.507c2d9c7e94716f"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 314,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
-      "source": "Attaching focused-window text uses macOS Accessibility access.",
-      "surface": "apple",
-      "id": "native.apple.c5313d544a833af0"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 315,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
-      "source": "Grant Access",
-      "surface": "apple",
-      "id": "native.apple.e68aeef0995a7d00"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 316,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
-      "source": "Cancel",
-      "surface": "apple",
-      "id": "native.apple.43dd985a6d9ec004"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 164,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatModel.swift",
-      "source": "focused app",
-      "surface": "apple",
-      "id": "native.apple.a8880557335b5a25"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 614,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatModel.swift",
-      "source": "Couldn't capture that image.",
-      "surface": "apple",
-      "id": "native.apple.6af15237e49bd0bd"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 636,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatModel.swift",
-      "source": "Screenshot: \\(label)",
-      "surface": "apple",
-      "id": "native.apple.b31041aa0da3768c"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 697,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatModel.swift",
-      "source": "Context from \\(context.appName) — \\(context.windowTitle)",
-      "surface": "apple",
-      "id": "native.apple.72e5bffb7ee89f19"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 1030,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatModel.swift",
-      "source": "Auto",
-      "surface": "apple",
-      "id": "native.apple.d82159d749697338"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 1038,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatModel.swift",
-      "source": "\\(model) · \\(thinking)",
-      "surface": "apple",
-      "id": "native.apple.4e02ff977e48dfcb"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 1062,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatModel.swift",
-      "source": "Selected reasoning is unavailable for this target.",
-      "surface": "apple",
-      "id": "native.apple.07bd035ae7e799c5"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 1195,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatModel.swift",
-      "source": "Couldn't load model settings.",
-      "surface": "apple",
-      "id": "native.apple.2eb721ed8bffe9aa"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 1206,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatModel.swift",
-      "source": "Couldn't change the model.",
-      "surface": "apple",
-      "id": "native.apple.ef6f4c54f9cfac08"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 44,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatModelMenu.swift",
-      "source": "Model",
-      "surface": "apple",
-      "id": "native.apple.82b81bd0670b0cef"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 51,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatModelMenu.swift",
-      "source": "Session default",
-      "surface": "apple",
-      "id": "native.apple.2eb4c724364c7583"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 80,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatModelMenu.swift",
-      "source": "Reasoning",
-      "surface": "apple",
-      "id": "native.apple.9f1c4db792611774"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 86,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatModelMenu.swift",
-      "source": "Auto",
-      "surface": "apple",
-      "id": "native.apple.25a01f61b4e33ece"
-    },
-    {
-      "kind": "ui-localized-call",
       "line": 22,
       "path": "apps/macos/Sources/OpenClaw/QuickChatRecents.swift",
       "source": "New message to \\(agentName)",
@@ -34499,7 +34075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 80,
+      "line": 67,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Reply in \\(override.displayName)",
       "surface": "apple",
@@ -34507,7 +34083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 82,
+      "line": 69,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Message \\(self.model.agentDisplay.name)",
       "surface": "apple",
@@ -34515,55 +34091,31 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 130,
+      "line": 108,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Continue a recent conversation",
       "surface": "apple",
       "id": "native.apple.da0b9bd07a337bda"
     },
     {
-      "kind": "ui-localized-call",
-      "line": 170,
+      "kind": "ui-modifier",
+      "line": 121,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
-      "source": "Attach text from \\(self.model.frontmostAppName)",
+      "source": "Send a window screenshot",
       "surface": "apple",
-      "id": "native.apple.c76e52d21bef75ba"
+      "id": "native.apple.edf12ff583307f43"
     },
     {
       "kind": "ui-modifier",
-      "line": 181,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
-      "source": "Capture a screenshot",
-      "surface": "apple",
-      "id": "native.apple.aedd7e9870c3579a"
-    },
-    {
-      "kind": "ui-modifier",
-      "line": 205,
+      "line": 145,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Send message",
       "surface": "apple",
       "id": "native.apple.136cef9f750d3803"
     },
     {
-      "kind": "ui-modifier",
-      "line": 247,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
-      "source": "Choose model and reasoning",
-      "surface": "apple",
-      "id": "native.apple.b520a305b56a6387"
-    },
-    {
-      "kind": "ui-modifier",
-      "line": 248,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
-      "source": "Model and reasoning",
-      "surface": "apple",
-      "id": "native.apple.1dd50e6126da7179"
-    },
-    {
       "kind": "ui-call",
-      "line": 289,
+      "line": 203,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Needs additional permissions",
       "surface": "apple",
@@ -34571,7 +34123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 296,
+      "line": 210,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Grant",
       "surface": "apple",
@@ -34579,99 +34131,11 @@
     },
     {
       "kind": "ui-call",
-      "line": 302,
+      "line": 216,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Not now",
       "surface": "apple",
       "id": "native.apple.a3332fa4db187973"
-    },
-    {
-      "kind": "ui-call",
-      "line": 316,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
-      "source": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) chars)",
-      "surface": "apple",
-      "id": "native.apple.1962232c9bc52e12"
-    },
-    {
-      "kind": "ui-modifier",
-      "line": 325,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
-      "source": "Remove attached text context",
-      "surface": "apple",
-      "id": "native.apple.66ec93e9eefd9bd7"
-    },
-    {
-      "kind": "ui-call",
-      "line": 364,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
-      "source": "Paste to \\(self.model.frontmostAppName)",
-      "surface": "apple",
-      "id": "native.apple.00b46fe92d9bb1d4"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 417,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
-      "source": "Stop dictation",
-      "surface": "apple",
-      "id": "native.apple.d2aa2e60ec2f62d8"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 418,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
-      "source": "Start dictation",
-      "surface": "apple",
-      "id": "native.apple.8c4a27a4361d0572"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 221,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatWindowPicker.swift",
-      "source": "Allow OpenClaw to capture windows",
-      "surface": "apple",
-      "id": "native.apple.88d0123c86b06144"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 222,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatWindowPicker.swift",
-      "source": "Allow OpenClaw to capture a screen area",
-      "surface": "apple",
-      "id": "native.apple.677c5733cd132aed"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 223,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatWindowPicker.swift",
-      "source": "Sending a screenshot uses macOS Screen Recording access.",
-      "surface": "apple",
-      "id": "native.apple.529a6fc5aeba03b0"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 224,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatWindowPicker.swift",
-      "source": "Grant Access",
-      "surface": "apple",
-      "id": "native.apple.615245bf05ed3234"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 225,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatWindowPicker.swift",
-      "source": "Cancel",
-      "surface": "apple",
-      "id": "native.apple.2a64131ba32d175d"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 503,
-      "path": "apps/macos/Sources/OpenClaw/QuickChatWindowPicker.swift",
-      "source": "Selected area",
-      "surface": "apple",
-      "id": "native.apple.6521871fc0ddc987"
     },
     {
       "kind": "conditional-branch",
@@ -34859,7 +34323,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 250,
+      "line": 187,
       "path": "apps/macos/Sources/OpenClaw/RemotePortTunnel.swift",
       "source": "ssh tunnel exited before listening",
       "surface": "apple",
@@ -34867,7 +34331,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 264,
+      "line": 203,
       "path": "apps/macos/Sources/OpenClaw/RemotePortTunnel.swift",
       "source": "ssh tunnel did not open local port \\(localPort)",
       "surface": "apple",
@@ -34875,7 +34339,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 264,
+      "line": 203,
       "path": "apps/macos/Sources/OpenClaw/RemotePortTunnel.swift",
       "source": "ssh tunnel failed: \\(stderr)",
       "surface": "apple",
@@ -34883,7 +34347,7 @@
     },
     {
       "kind": "plist-string",
-      "line": 47,
+      "line": 45,
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw needs notification permission to show alerts for agent actions.",
       "surface": "apple",
@@ -34891,7 +34355,7 @@
     },
     {
       "kind": "plist-string",
-      "line": 49,
+      "line": 47,
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw captures the screen when the agent needs screenshots for context.",
       "surface": "apple",
@@ -34899,7 +34363,7 @@
     },
     {
       "kind": "plist-string",
-      "line": 51,
+      "line": 49,
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw can capture photos or short video clips when requested by the agent.",
       "surface": "apple",
@@ -34907,7 +34371,7 @@
     },
     {
       "kind": "plist-string",
-      "line": 57,
+      "line": 55,
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw can share your location when requested by the agent.",
       "surface": "apple",
@@ -34915,7 +34379,7 @@
     },
     {
       "kind": "plist-string",
-      "line": 59,
+      "line": 57,
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw uses the local network to connect to your remote OpenClaw gateway over LAN, Tailnet, or SSH.",
       "surface": "apple",
@@ -34923,7 +34387,7 @@
     },
     {
       "kind": "plist-string",
-      "line": 61,
+      "line": 59,
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw needs the mic for Voice Wake tests and agent audio capture.",
       "surface": "apple",
@@ -34931,7 +34395,7 @@
     },
     {
       "kind": "plist-string",
-      "line": 63,
+      "line": 61,
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw uses speech recognition to detect your Voice Wake trigger phrase.",
       "surface": "apple",
@@ -34939,7 +34403,7 @@
     },
     {
       "kind": "plist-string",
-      "line": 65,
+      "line": 63,
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw needs Automation (AppleScript) permission to drive Terminal and other apps for agent actions.",
       "surface": "apple",
@@ -34947,7 +34411,7 @@
     },
     {
       "kind": "plist-string",
-      "line": 67,
+      "line": 65,
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw can access Reminders when requested by the agent for the apple-reminders skill.",
       "surface": "apple",
@@ -35061,9 +34525,9 @@
       "kind": "ui-call",
       "line": 39,
       "path": "apps/macos/Sources/OpenClaw/SessionsSettings.swift",
-      "source": "Threads",
+      "source": "Sessions",
       "surface": "apple",
-      "id": "native.apple.3ec2afcbc298c673"
+      "id": "native.apple.1ff8aec0044934c3"
     },
     {
       "kind": "ui-call",
@@ -35077,9 +34541,9 @@
       "kind": "ui-call",
       "line": 56,
       "path": "apps/macos/Sources/OpenClaw/SessionsSettings.swift",
-      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
+      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
       "surface": "apple",
-      "id": "native.apple.14ccb32cd8ed1c81"
+      "id": "native.apple.bab897f3252b134c"
     },
     {
       "kind": "ui-call",
@@ -35213,9 +34677,9 @@
       "kind": "conditional-branch",
       "line": 483,
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
-      "source": "Threads",
+      "source": "Sessions",
       "surface": "apple",
-      "id": "native.apple.52e37e3a44ae516c"
+      "id": "native.apple.64a6dc7d49e8fb57"
     },
     {
       "kind": "conditional-branch",
@@ -36723,7 +36187,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 826,
+      "line": 816,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Talk mode off",
       "surface": "apple",
@@ -36731,7 +36195,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 827,
+      "line": 817,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Talk mode paused",
       "surface": "apple",
@@ -36739,7 +36203,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 829,
+      "line": 819,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Talk mode ready",
       "surface": "apple",
@@ -36747,7 +36211,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 830,
+      "line": 820,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Listening",
       "surface": "apple",
@@ -36755,7 +36219,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 831,
+      "line": 821,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Thinking",
       "surface": "apple",
@@ -36763,7 +36227,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 832,
+      "line": 822,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Speaking",
       "surface": "apple",
@@ -36771,7 +36235,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 836,
+      "line": 826,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "What would you like to work on?",
       "surface": "apple",
@@ -36779,7 +36243,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 840,
+      "line": 830,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Check OpenClaw status",
       "surface": "apple",
@@ -36787,7 +36251,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 841,
+      "line": 831,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Summarize the current OpenClaw status and tell me what needs attention.",
       "surface": "apple",
@@ -36795,7 +36259,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 844,
+      "line": 834,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "What can you do?",
       "surface": "apple",
@@ -36803,7 +36267,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 845,
+      "line": 835,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Show me what you can help with on this Mac right now.",
       "surface": "apple",
@@ -36811,7 +36275,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 848,
+      "line": 838,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Catch me up",
       "surface": "apple",
@@ -36819,11 +36283,11 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 849,
+      "line": 839,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
-      "source": "Summarize what happened in my threads since yesterday.",
+      "source": "Summarize what happened in my sessions since yesterday.",
       "surface": "apple",
-      "id": "native.apple.fc4ce810900ec0b6"
+      "id": "native.apple.234ec45f4231edc4"
     },
     {
       "kind": "conditional-branch",
@@ -36867,7 +36331,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 460,
+      "line": 455,
       "path": "apps/macos/Sources/OpenClawMacCLI/WizardCommand.swift",
       "source": " [\\(initial)]",
       "surface": "apple",
@@ -36875,7 +36339,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 507,
+      "line": 502,
       "path": "apps/macos/Sources/OpenClawMacCLI/WizardCommand.swift",
       "source": " — \\(option.hint!)",
       "surface": "apple",
@@ -36883,7 +36347,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 514,
+      "line": 509,
       "path": "apps/macos/Sources/OpenClawMacCLI/WizardCommand.swift",
       "source": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]",
       "surface": "apple",
@@ -36907,79 +36371,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 36,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift",
-      "source": "Switch to back camera",
-      "surface": "apple",
-      "id": "native.apple.fc5931c1f0a6bbec"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 38,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift",
-      "source": "Switch to front camera",
-      "surface": "apple",
-      "id": "native.apple.cce3b539e31701c0"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 40,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift",
-      "source": "Flip camera",
-      "surface": "apple",
-      "id": "native.apple.f397daffdfd02ee0"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 73,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift",
-      "source": "Stop",
-      "surface": "apple",
-      "id": "native.apple.11f8de87ca3fcb11"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 73,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift",
-      "source": "Talk",
-      "surface": "apple",
-      "id": "native.apple.7c92bec1c8a83e43"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 118,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift",
-      "source": "Start realtime chat",
-      "surface": "apple",
-      "id": "native.apple.dae61543f9b416ca"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 118,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift",
-      "source": "Stop realtime chat",
-      "surface": "apple",
-      "id": "native.apple.d376b015a90792a9"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 203,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift",
-      "source": "Connecting...",
-      "surface": "apple",
-      "id": "native.apple.ac48dbe25ac4d40d"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 203,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift",
-      "source": "Gateway connected",
-      "surface": "apple",
-      "id": "native.apple.ccce98756eb1dacd"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 415,
+      "line": 251,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Context %@%% used",
       "surface": "apple",
@@ -36987,7 +36379,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 429,
+      "line": 265,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "%@ (override)",
       "surface": "apple",
@@ -36995,7 +36387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 435,
+      "line": 271,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Thinking",
       "surface": "apple",
@@ -37003,7 +36395,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 455,
+      "line": 291,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Full",
       "surface": "apple",
@@ -37011,7 +36403,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 462,
+      "line": 298,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Verbosity",
       "surface": "apple",
@@ -37019,7 +36411,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 471,
+      "line": 307,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Default (inherited)",
       "surface": "apple",
@@ -37027,7 +36419,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 473,
+      "line": 309,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "On",
       "surface": "apple",
@@ -37035,7 +36427,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 474,
+      "line": 310,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Off",
       "surface": "apple",
@@ -37043,7 +36435,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 476,
+      "line": 312,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Fast",
       "surface": "apple",
@@ -37051,7 +36443,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 481,
+      "line": 317,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Fast responses",
       "surface": "apple",
@@ -37059,7 +36451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 500,
+      "line": 336,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Pinned",
       "surface": "apple",
@@ -37067,7 +36459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 508,
+      "line": 344,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Recent",
       "surface": "apple",
@@ -37075,7 +36467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 527,
+      "line": 363,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Model",
       "surface": "apple",
@@ -37083,7 +36475,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 544,
+      "line": 380,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Default",
       "surface": "apple",
@@ -37091,7 +36483,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 561,
+      "line": 397,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Pin model",
       "surface": "apple",
@@ -37099,7 +36491,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 561,
+      "line": 397,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Unpin model",
       "surface": "apple",
@@ -37107,15 +36499,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 575,
+      "line": 411,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
-      "source": "Thread",
+      "source": "Session",
       "surface": "apple",
-      "id": "native.apple.4edb66657f5aca1f"
+      "id": "native.apple.5dfc0700d8dff8de"
     },
     {
       "kind": "ui-modifier",
-      "line": 631,
+      "line": 466,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Add Image",
       "surface": "apple",
@@ -37123,15 +36515,47 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 632,
+      "line": 467,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Attachments",
       "surface": "apple",
       "id": "native.apple.1963dfa3285cb715"
     },
     {
+      "kind": "ui-call",
+      "line": 494,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
+      "source": "Voice note",
+      "surface": "apple",
+      "id": "native.apple.f8dda832ed76441d"
+    },
+    {
       "kind": "conditional-branch",
-      "line": 821,
+      "line": 647,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
+      "source": "Talk",
+      "surface": "apple",
+      "id": "native.apple.ee2c0d22f5861159"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 694,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
+      "source": "Start realtime chat",
+      "surface": "apple",
+      "id": "native.apple.5d5041aefe6dfddd"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 694,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
+      "source": "Stop realtime chat",
+      "surface": "apple",
+      "id": "native.apple.21a7d3a3386a2218"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 728,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Start",
       "surface": "apple",
@@ -37139,7 +36563,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 821,
+      "line": 728,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop",
       "surface": "apple",
@@ -37147,7 +36571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 919,
+      "line": 859,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Loading commands",
       "surface": "apple",
@@ -37155,7 +36579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 928,
+      "line": 868,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Commands unavailable",
       "surface": "apple",
@@ -37163,7 +36587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 937,
+      "line": 877,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Retry",
       "surface": "apple",
@@ -37171,7 +36595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 946,
+      "line": 886,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "No matching commands",
       "surface": "apple",
@@ -37179,7 +36603,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1178,
+      "line": 1118,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop response",
       "surface": "apple",
@@ -37187,7 +36611,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1203,
+      "line": 1143,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Send message",
       "surface": "apple",
@@ -37195,7 +36619,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1217,
+      "line": 1157,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -37203,7 +36627,23 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1343,
+      "line": 1291,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
+      "source": "Connecting...",
+      "surface": "apple",
+      "id": "native.apple.6c984c0e3ed3a69e"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 1291,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
+      "source": "Gateway connected",
+      "surface": "apple",
+      "id": "native.apple.898849eb2bcb0b53"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 1300,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Message…",
       "surface": "apple",
@@ -37363,83 +36803,11 @@
     },
     {
       "kind": "ui-call",
-      "line": 349,
+      "line": 328,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift",
       "source": "Widget unavailable",
       "surface": "apple",
       "id": "native.apple.2c865ac4a69645d3"
-    },
-    {
-      "kind": "ui-modifier",
-      "line": 368,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift",
-      "source": "Widget export failed",
-      "surface": "apple",
-      "id": "native.apple.d640691fd196f338"
-    },
-    {
-      "kind": "ui-call",
-      "line": 372,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift",
-      "source": "OK",
-      "surface": "apple",
-      "id": "native.apple.533c6e22a11e88de"
-    },
-    {
-      "kind": "ui-call",
-      "line": 413,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift",
-      "source": "Copy image",
-      "surface": "apple",
-      "id": "native.apple.e1fb28a2a9756402"
-    },
-    {
-      "kind": "ui-call",
-      "line": 421,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift",
-      "source": "Save image…",
-      "surface": "apple",
-      "id": "native.apple.ebd7bc92e1b12235"
-    },
-    {
-      "kind": "ui-call",
-      "line": 424,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift",
-      "source": "Save image",
-      "surface": "apple",
-      "id": "native.apple.742c46d4cf2db134"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 439,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift",
-      "source": "The widget image could not be captured.",
-      "surface": "apple",
-      "id": "native.apple.0589cce608418f90"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 469,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift",
-      "source": "The widget image could not be copied.",
-      "surface": "apple",
-      "id": "native.apple.dfe24e827fdbe9c5"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 476,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift",
-      "source": "The widget image could not be encoded as PNG.",
-      "surface": "apple",
-      "id": "native.apple.9e611e3a80e71408"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 488,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift",
-      "source": "The widget image could not be saved.",
-      "surface": "apple",
-      "id": "native.apple.9a6e8afbe24a262b"
     },
     {
       "kind": "conditional-branch",
@@ -37466,8 +36834,16 @@
       "id": "native.apple.fccc8a9ba3da1426"
     },
     {
+      "kind": "ui-named-argument",
+      "line": 357,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
+      "source": "\\(display.emoji) \\(display.title)",
+      "surface": "apple",
+      "id": "native.apple.8509385953c19619"
+    },
+    {
       "kind": "ui-localized-call",
-      "line": 368,
+      "line": 371,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Message usage",
       "surface": "apple",
@@ -37475,15 +36851,31 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 554,
+      "line": 544,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Voice note",
       "surface": "apple",
       "id": "native.apple.3c8c3679fd99c074"
     },
     {
+      "kind": "conditional-branch",
+      "line": 630,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
+      "source": "Show full output",
+      "surface": "apple",
+      "id": "native.apple.aff6385b0a8dd0ac"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 630,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
+      "source": "Show less",
+      "surface": "apple",
+      "id": "native.apple.b9c78020ae8be34a"
+    },
+    {
       "kind": "ui-call",
-      "line": 599,
+      "line": 689,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Writing",
       "surface": "apple",
@@ -37491,7 +36883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 625,
+      "line": 715,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Preparing audio…",
       "surface": "apple",
@@ -37499,7 +36891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 628,
+      "line": 718,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Speaking…",
       "surface": "apple",
@@ -37507,7 +36899,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 636,
+      "line": 726,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Preparing audio, tap to cancel",
       "surface": "apple",
@@ -37515,11 +36907,19 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 637,
+      "line": 727,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Speaking, tap to stop",
       "surface": "apple",
       "id": "native.apple.142c01bf6b97e380"
+    },
+    {
+      "kind": "ui-call",
+      "line": 896,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
+      "source": "Running tools…",
+      "surface": "apple",
+      "id": "native.apple.6b18ea1d85b5d3a2"
     },
     {
       "kind": "ui-localized-call",
@@ -37546,64 +36946,8 @@
       "id": "native.apple.b6b3b9af4c618060"
     },
     {
-      "kind": "ui-localized-call",
-      "line": 258,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatQuestionCard.swift",
-      "source": "Answered",
-      "surface": "apple",
-      "id": "native.apple.ce899320a84d4086"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 261,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatQuestionCard.swift",
-      "source": "Answered elsewhere",
-      "surface": "apple",
-      "id": "native.apple.f019b6a07d5a33d8"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 263,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatQuestionCard.swift",
-      "source": "Skipped",
-      "surface": "apple",
-      "id": "native.apple.ebdedeffad570c43"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 265,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatQuestionCard.swift",
-      "source": "Expired",
-      "surface": "apple",
-      "id": "native.apple.8dde2eaaf6b0dfa9"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 267,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatQuestionCard.swift",
-      "source": "Unavailable",
-      "surface": "apple",
-      "id": "native.apple.6dff9e9194347f3b"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 269,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatQuestionCard.swift",
-      "source": "Pending",
-      "surface": "apple",
-      "id": "native.apple.b34cd890366824f0"
-    },
-    {
-      "kind": "ui-modifier",
-      "line": 367,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatQuestionCard.swift",
-      "source": "Question summary",
-      "surface": "apple",
-      "id": "native.apple.b97da55b7e16e60c"
-    },
-    {
       "kind": "ui-call",
-      "line": 381,
+      "line": 234,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatQuestionCard.swift",
       "source": "Other answer",
       "surface": "apple",
@@ -37611,7 +36955,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 439,
+      "line": 273,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatQuestionCard.swift",
       "source": "Not selected",
       "surface": "apple",
@@ -37619,43 +36963,43 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 439,
+      "line": 273,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatQuestionCard.swift",
       "source": "Selected",
       "surface": "apple",
       "id": "native.apple.bd4335213464d4be"
     },
     {
-      "kind": "ui-call",
-      "line": 456,
+      "kind": "conditional-branch",
+      "line": 285,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatQuestionCard.swift",
-      "source": "Skipping…",
+      "source": "Submit",
       "surface": "apple",
-      "id": "native.apple.1bbbbfd1ad3842ce"
+      "id": "native.apple.e3095b651fc46b52"
     },
     {
-      "kind": "ui-call",
-      "line": 459,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatQuestionCard.swift",
-      "source": "Skip",
-      "surface": "apple",
-      "id": "native.apple.14a4bf7b6b7d40dc"
-    },
-    {
-      "kind": "ui-call",
-      "line": 470,
+      "kind": "conditional-branch",
+      "line": 285,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatQuestionCard.swift",
       "source": "Submitting…",
       "surface": "apple",
       "id": "native.apple.6c1adc16e0a846e5"
     },
     {
-      "kind": "ui-call",
-      "line": 473,
+      "kind": "conditional-branch",
+      "line": 306,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatQuestionCard.swift",
-      "source": "Submit",
+      "source": "Expires in \\(seconds / 60)m \\(seconds % 60)s",
       "surface": "apple",
-      "id": "native.apple.e3095b651fc46b52"
+      "id": "native.apple.698bdb0d6537edb6"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 306,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatQuestionCard.swift",
+      "source": "Expires in \\(seconds)s",
+      "surface": "apple",
+      "id": "native.apple.30e1c342b3345290"
     },
     {
       "kind": "conditional-branch",
@@ -37669,25 +37013,25 @@
       "kind": "ui-localized-call",
       "line": 30,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionManagementViews.swift",
-      "source": "This thread cannot be archived while it is active or running.",
+      "source": "This session cannot be archived while it is active or running.",
       "surface": "apple",
-      "id": "native.apple.9d0cba09d92ee669"
+      "id": "native.apple.b1cdcb906a43d5d6"
     },
     {
       "kind": "ui-localized-call",
       "line": 32,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionManagementViews.swift",
-      "source": "The main thread cannot be deleted.",
+      "source": "The main session cannot be deleted.",
       "surface": "apple",
-      "id": "native.apple.8952a111a1075051"
+      "id": "native.apple.5817e3f3dab1ee19"
     },
     {
       "kind": "ui-localized-call",
       "line": 34,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionManagementViews.swift",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
       "surface": "apple",
-      "id": "native.apple.90d0ccf80ca28717"
+      "id": "native.apple.a6b8df3f18171c91"
     },
     {
       "kind": "ui-localized-call",
@@ -37909,9 +37253,9 @@
       "kind": "ui-modifier",
       "line": 244,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionManagementViews.swift",
-      "source": "Thread Info",
+      "source": "Session Info",
       "surface": "apple",
-      "id": "native.apple.bbccb4c8db5cac12"
+      "id": "native.apple.cd7c3095a22f80a9"
     },
     {
       "kind": "ui-call",
@@ -37965,9 +37309,9 @@
       "kind": "ui-modifier",
       "line": 412,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionManagementViews.swift",
-      "source": "Thread Groups",
+      "source": "Session Groups",
       "surface": "apple",
-      "id": "native.apple.7b641fed5bace855"
+      "id": "native.apple.23d628606fe0734f"
     },
     {
       "kind": "ui-call",
@@ -38037,9 +37381,9 @@
       "kind": "ui-call",
       "line": 453,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionManagementViews.swift",
-      "source": "Threads in this group become ungrouped.",
+      "source": "Sessions in this group become ungrouped.",
       "surface": "apple",
-      "id": "native.apple.56401c79410a310d"
+      "id": "native.apple.b049c8a4d2805e08"
     },
     {
       "kind": "ui-localized-call",
@@ -38051,7 +37395,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 555,
+      "line": 560,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionManagementViews.swift",
       "source": "No agents are available on this gateway.",
       "surface": "apple",
@@ -38059,15 +37403,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 570,
+      "line": 575,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionManagementViews.swift",
-      "source": "New Thread Options",
+      "source": "New Session Options",
       "surface": "apple",
-      "id": "native.apple.2d96aa7d3d12f85b"
+      "id": "native.apple.6c89f35d53506406"
     },
     {
       "kind": "ui-call",
-      "line": 572,
+      "line": 577,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionManagementViews.swift",
       "source": "Agent",
       "surface": "apple",
@@ -38075,7 +37419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 580,
+      "line": 585,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionManagementViews.swift",
       "source": "Create in a worktree",
       "surface": "apple",
@@ -38083,7 +37427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 584,
+      "line": 589,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionManagementViews.swift",
       "source": "Base ref (optional)",
       "surface": "apple",
@@ -38091,7 +37435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 594,
+      "line": 599,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionManagementViews.swift",
       "source": "Retry",
       "surface": "apple",
@@ -38099,7 +37443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 600,
+      "line": 605,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionManagementViews.swift",
       "source": "Create",
       "surface": "apple",
@@ -38107,27 +37451,27 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 618,
+      "line": 623,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionManagementViews.swift",
-      "source": "The thread could not be created.",
+      "source": "The session could not be created.",
       "surface": "apple",
-      "id": "native.apple.87ef57319d1ddc85"
+      "id": "native.apple.795ba37f6782cf28"
     },
     {
       "kind": "ui-localized-call",
       "line": 64,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
-      "source": "Search threads",
+      "source": "Search sessions",
       "surface": "apple",
-      "id": "native.apple.6bd91c435b69d638"
+      "id": "native.apple.8ec708a3605a2cc3"
     },
     {
       "kind": "ui-localized-call",
       "line": 69,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
-      "source": "No Threads",
+      "source": "No Sessions",
       "surface": "apple",
-      "id": "native.apple.6fde4bdf9d5b9191"
+      "id": "native.apple.23b069b4e7f97039"
     },
     {
       "kind": "ui-localized-call",
@@ -38141,41 +37485,41 @@
       "kind": "ui-call",
       "line": 81,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
-      "source": "New Thread",
+      "source": "New Session",
       "surface": "apple",
-      "id": "native.apple.a02fd99740d29bd3"
+      "id": "native.apple.0058923f2ce8a3ec"
     },
     {
       "kind": "ui-localized-call",
       "line": 83,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
-      "source": "New thread",
+      "source": "New session",
       "surface": "apple",
-      "id": "native.apple.b625801dd04b09f2"
+      "id": "native.apple.66ba42960eb4135b"
     },
     {
       "kind": "ui-localized-call",
       "line": 89,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
-      "source": "New thread options",
+      "source": "New session options",
       "surface": "apple",
-      "id": "native.apple.851be81fcc933608"
+      "id": "native.apple.2ef0e34db02ad255"
     },
     {
       "kind": "ui-localized-call",
       "line": 117,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
-      "source": "Rename Thread",
+      "source": "Rename Session",
       "surface": "apple",
-      "id": "native.apple.9ce8a4aba7b444b2"
+      "id": "native.apple.36753ef2f1ed4264"
     },
     {
       "kind": "ui-localized-call",
       "line": 120,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
-      "source": "Thread name",
+      "source": "Session name",
       "surface": "apple",
-      "id": "native.apple.1dd067c44511c7f0"
+      "id": "native.apple.c9de0a1510ef475f"
     },
     {
       "kind": "ui-localized-call",
@@ -38197,17 +37541,17 @@
       "kind": "ui-localized-call",
       "line": 132,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
-      "source": "Delete Thread",
+      "source": "Delete Session",
       "surface": "apple",
-      "id": "native.apple.618073d6ab3f2721"
+      "id": "native.apple.afb4e6c99c63a28d"
     },
     {
       "kind": "ui-localized-call",
       "line": 139,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
-      "source": "The thread and its transcript are removed from the gateway.",
+      "source": "The session and its transcript are removed from the gateway.",
       "surface": "apple",
-      "id": "native.apple.10a5e72bba3cbccc"
+      "id": "native.apple.3d4ef32e42f136a4"
     },
     {
       "kind": "ui-localized-call",
@@ -38221,17 +37565,17 @@
       "kind": "ui-localized-call",
       "line": 215,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
-      "source": "Thread running",
+      "source": "Session running",
       "surface": "apple",
-      "id": "native.apple.ac71e3b2aa496a2c"
+      "id": "native.apple.9a7dca238fba628d"
     },
     {
       "kind": "ui-localized-call",
       "line": 220,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
-      "source": "Thread failed",
+      "source": "Session failed",
       "surface": "apple",
-      "id": "native.apple.c775e87f997278b2"
+      "id": "native.apple.fcfbfe5e97a95e9c"
     },
     {
       "kind": "ui-localized-call",
@@ -38325,9 +37669,9 @@
       "kind": "ui-localized-call",
       "line": 292,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
-      "source": "Delete Thread…",
+      "source": "Delete Session…",
       "surface": "apple",
-      "id": "native.apple.f4998cfb572f23ff"
+      "id": "native.apple.4aeb7c14c26dabac"
     },
     {
       "kind": "ui-localized-call",
@@ -38349,9 +37693,9 @@
       "kind": "ui-localized-call",
       "line": 346,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
-      "source": "Retry thread groups",
+      "source": "Retry session groups",
       "surface": "apple",
-      "id": "native.apple.8802e9576ffd0f65"
+      "id": "native.apple.79f708b3bc1d3a6c"
     },
     {
       "kind": "ui-named-argument",
@@ -38379,7 +37723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 76,
+      "line": 80,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Scope",
       "surface": "apple",
@@ -38387,39 +37731,39 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 88,
+      "line": 92,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
-      "source": "Search threads",
+      "source": "Search sessions",
       "surface": "apple",
-      "id": "native.apple.b313b80def4bda52"
+      "id": "native.apple.2c37581c7b88f741"
     },
     {
       "kind": "ui-modifier",
-      "line": 89,
+      "line": 93,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
-      "source": "Threads",
+      "source": "Sessions",
       "surface": "apple",
-      "id": "native.apple.c0cc6acc36f413ce"
+      "id": "native.apple.43be8a2336e42faf"
     },
     {
       "kind": "ui-modifier",
-      "line": 146,
+      "line": 150,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
-      "source": "Rename Thread",
+      "source": "Rename Session",
       "surface": "apple",
-      "id": "native.apple.854d3928fe5a557c"
+      "id": "native.apple.0b379cdfcbd3247f"
     },
     {
       "kind": "ui-call",
-      "line": 152,
+      "line": 156,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
-      "source": "Thread name",
+      "source": "Session name",
       "surface": "apple",
-      "id": "native.apple.9d0d3f20096cc4da"
+      "id": "native.apple.54b6fbd9e41db009"
     },
     {
       "kind": "ui-call",
-      "line": 167,
+      "line": 171,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Cancel",
       "surface": "apple",
@@ -38427,31 +37771,31 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 178,
+      "line": 182,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
-      "source": "Delete selected threads?",
+      "source": "Delete selected sessions?",
       "surface": "apple",
-      "id": "native.apple.dc00eb94f33bae15"
-    },
-    {
-      "kind": "ui-call",
-      "line": 183,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
-      "source": "Delete Threads",
-      "surface": "apple",
-      "id": "native.apple.2053fc9f74dc3158"
+      "id": "native.apple.751e0f6b81cd374a"
     },
     {
       "kind": "ui-call",
       "line": 187,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
-      "source": "Each selected thread and its transcript will be removed from the gateway.",
+      "source": "Delete Sessions",
       "surface": "apple",
-      "id": "native.apple.0970247871a834a0"
+      "id": "native.apple.aa679276581b0058"
     },
     {
       "kind": "ui-call",
-      "line": 216,
+      "line": 191,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
+      "source": "Each selected session and its transcript will be removed from the gateway.",
+      "surface": "apple",
+      "id": "native.apple.f837129cbee23297"
+    },
+    {
+      "kind": "ui-call",
+      "line": 220,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Groups",
       "surface": "apple",
@@ -38459,15 +37803,15 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 222,
+      "line": 226,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
-      "source": "Manage thread groups",
+      "source": "Manage session groups",
       "surface": "apple",
-      "id": "native.apple.6f8acab2256728b5"
+      "id": "native.apple.64013cfee5e25305"
     },
     {
       "kind": "conditional-branch",
-      "line": 226,
+      "line": 230,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Done",
       "surface": "apple",
@@ -38475,7 +37819,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 226,
+      "line": 230,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Select",
       "surface": "apple",
@@ -38483,23 +37827,23 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 241,
+      "line": 245,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
-      "source": "No archived threads",
+      "source": "No archived sessions",
       "surface": "apple",
-      "id": "native.apple.692972314d04b184"
+      "id": "native.apple.b67eaecec1b423ac"
     },
     {
       "kind": "conditional-branch",
-      "line": 241,
+      "line": 245,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
-      "source": "No threads found",
+      "source": "No sessions found",
       "surface": "apple",
-      "id": "native.apple.d6a4b5711dcd26e7"
+      "id": "native.apple.b2435a79abf0c794"
     },
     {
       "kind": "ui-localized-call",
-      "line": 260,
+      "line": 264,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Restore",
       "surface": "apple",
@@ -38507,7 +37851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 310,
+      "line": 314,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Get Info…",
       "surface": "apple",
@@ -38515,7 +37859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 317,
+      "line": 321,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Rename",
       "surface": "apple",
@@ -38523,7 +37867,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 346,
+      "line": 350,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Fork",
       "surface": "apple",
@@ -38531,7 +37875,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 355,
+      "line": 359,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Mark Read",
       "surface": "apple",
@@ -38539,7 +37883,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 356,
+      "line": 360,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Mark Unread",
       "surface": "apple",
@@ -38547,7 +37891,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 387,
+      "line": 391,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Pinned",
       "surface": "apple",
@@ -38555,7 +37899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 394,
+      "line": 398,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Pin",
       "surface": "apple",
@@ -38563,7 +37907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 395,
+      "line": 399,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Unpin",
       "surface": "apple",
@@ -38571,7 +37915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 396,
+      "line": 400,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Archive",
       "surface": "apple",
@@ -38579,7 +37923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 398,
+      "line": 402,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Delete",
       "surface": "apple",
@@ -38608,54 +37952,6 @@
       "source": "System Default",
       "surface": "apple",
       "id": "native.apple.e7beeef6043ffd2a"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 80,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift",
-      "source": "Running",
-      "surface": "apple",
-      "id": "native.apple.f390b84397c0d240"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 129,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift",
-      "source": "Collapse tool result",
-      "surface": "apple",
-      "id": "native.apple.e2e7faa7c9c5c61f"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 129,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift",
-      "source": "Expand tool result",
-      "surface": "apple",
-      "id": "native.apple.4e7850fe95fcd898"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 165,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift",
-      "source": "Show less",
-      "surface": "apple",
-      "id": "native.apple.d65ae0776d6b86ce"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 167,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift",
-      "source": "Show all %lld lines",
-      "surface": "apple",
-      "id": "native.apple.065f4da5ddaf14a1"
-    },
-    {
-      "kind": "ui-call",
-      "line": 256,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift",
-      "source": "Collapsed",
-      "surface": "apple",
-      "id": "native.apple.f80bb83a659d23f4"
     },
     {
       "kind": "conditional-branch",
@@ -38699,7 +37995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 515,
+      "line": 489,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Retry Send",
       "surface": "apple",
@@ -38707,7 +38003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 529,
+      "line": 503,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Delete",
       "surface": "apple",
@@ -38715,7 +38011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 565,
+      "line": 537,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Stop Listening",
       "surface": "apple",
@@ -38723,7 +38019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 568,
+      "line": 540,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Listen",
       "surface": "apple",
@@ -38731,7 +38027,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 665,
+      "line": 631,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Jump to latest reply",
       "surface": "apple",
@@ -38739,7 +38035,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 685,
+      "line": 651,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -38747,7 +38043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1083,
+      "line": 1038,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Copy Message",
       "surface": "apple",
@@ -38755,31 +38051,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 1106,
+      "line": 1061,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Open Full Message",
       "surface": "apple",
       "id": "native.apple.90bc8a8045e7017e"
     },
     {
-      "kind": "ui-call",
-      "line": 1125,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
-      "source": "Rewind to Here",
-      "surface": "apple",
-      "id": "native.apple.002bfcede229ad4b"
-    },
-    {
-      "kind": "ui-call",
-      "line": 1145,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
-      "source": "Fork from Here",
-      "surface": "apple",
-      "id": "native.apple.14df2e4997689fb3"
-    },
-    {
       "kind": "ui-localized-call",
-      "line": 1173,
+      "line": 1082,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Reply",
       "surface": "apple",
@@ -38787,7 +38067,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1183,
+      "line": 1092,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "You",
       "surface": "apple",
@@ -38795,7 +38075,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1185,
+      "line": 1094,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Assistant",
       "surface": "apple",
@@ -38803,7 +38083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1251,
+      "line": 1160,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Loading chat",
       "surface": "apple",
@@ -38811,7 +38091,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1331,
+      "line": 1240,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Dismiss",
       "surface": "apple",
@@ -38819,15 +38099,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 74,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift",
-      "source": "Remove attachments or wait for delivery to resolve before starting a new chat.",
-      "surface": "apple",
-      "id": "native.apple.3892b7f55d9d1f0a"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 112,
+      "line": 27,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift",
       "source": "Could not attach voice note: %@",
       "surface": "apple",
@@ -38835,7 +38107,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 118,
+      "line": 33,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift",
       "source": "Voice note exceeds the 5 MB attachment limit",
       "surface": "apple",
@@ -38843,7 +38115,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 180,
+      "line": 79,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift",
       "source": "Only image attachments are supported right now",
       "surface": "apple",
@@ -38851,7 +38123,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 192,
+      "line": 90,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift",
       "source": "Could not process %1$@: %2$@",
       "surface": "apple",
@@ -38859,7 +38131,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 203,
+      "line": 98,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift",
       "source": "Attachment %@ exceeds 5 MB limit after resizing",
       "surface": "apple",
@@ -38867,7 +38139,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 210,
+      "line": 105,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift",
       "source": "\\(baseName).jpg",
       "surface": "apple",
@@ -38875,7 +38147,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 66,
+      "line": 43,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift",
       "source": "\\(invocation) ",
       "surface": "apple",
@@ -38883,7 +38155,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 324,
+      "line": 295,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift",
       "source": "See attached.",
       "surface": "apple",
@@ -38891,7 +38163,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 735,
+      "line": 700,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift",
       "source": "delivery unconfirmed",
       "surface": "apple",
@@ -38899,7 +38171,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 735,
+      "line": 700,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift",
       "source": "queued after route change",
       "surface": "apple",
@@ -38917,13 +38189,21 @@
       "kind": "ui-localized-call",
       "line": 229,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionActions.swift",
-      "source": "Gateway changed before the thread operation started.",
+      "source": "Gateway changed before the session operation started.",
       "surface": "apple",
-      "id": "native.apple.e0f045151c8d3137"
+      "id": "native.apple.980f552bb0f96c0f"
     },
     {
       "kind": "ui-localized-call",
-      "line": 1085,
+      "line": 773,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
+      "source": "Remove attachments or wait for delivery to resolve before starting a new chat.",
+      "surface": "apple",
+      "id": "native.apple.d93e6fe16ec1b0e5"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 1156,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "Remove attachments or wait for delivery to resolve before switching chats.",
       "surface": "apple",
@@ -38933,9 +38213,9 @@
       "kind": "ui-modifier",
       "line": 78,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Clear this thread's history?",
+      "source": "Clear this session's history?",
       "surface": "apple",
-      "id": "native.apple.0a5c4e15466c3acc"
+      "id": "native.apple.87ba543b42696b92"
     },
     {
       "kind": "ui-call",
@@ -38957,17 +38237,17 @@
       "kind": "ui-localized-call",
       "line": 95,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Rename Thread",
+      "source": "Rename Session",
       "surface": "apple",
-      "id": "native.apple.67ac221dbe7179f0"
+      "id": "native.apple.a92e96bed98bd553"
     },
     {
       "kind": "ui-localized-call",
       "line": 96,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Thread name",
+      "source": "Session name",
       "surface": "apple",
-      "id": "native.apple.cf0f7e049603f518"
+      "id": "native.apple.848e2388f3466f40"
     },
     {
       "kind": "ui-localized-call",
@@ -38997,9 +38277,9 @@
       "kind": "ui-call",
       "line": 152,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Threads",
+      "source": "Sessions",
       "surface": "apple",
-      "id": "native.apple.c0ada47504425f23"
+      "id": "native.apple.4af0f566d39d7041"
     },
     {
       "kind": "ui-localized-call",
@@ -39117,17 +38397,17 @@
       "kind": "ui-call",
       "line": 348,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "New Thread",
+      "source": "New Session",
       "surface": "apple",
-      "id": "native.apple.1a765291943599e5"
+      "id": "native.apple.eb58552e43c8dde2"
     },
     {
       "kind": "ui-call",
       "line": 355,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "New Thread Options…",
+      "source": "New Session Options…",
       "surface": "apple",
-      "id": "native.apple.c7a3a6d5e43dd98f"
+      "id": "native.apple.a7119fbf9d25df5e"
     },
     {
       "kind": "ui-call",
@@ -39141,25 +38421,25 @@
       "kind": "ui-call",
       "line": 369,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Threads…",
+      "source": "Sessions…",
       "surface": "apple",
-      "id": "native.apple.0e710b81808e5dcf"
+      "id": "native.apple.2bcff4a8fa503739"
     },
     {
       "kind": "ui-localized-call",
       "line": 381,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Rename Thread…",
+      "source": "Rename Session…",
       "surface": "apple",
-      "id": "native.apple.faad8f92b6bef166"
+      "id": "native.apple.c36e008b051adb38"
     },
     {
       "kind": "ui-localized-call",
       "line": 389,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Fork",
+      "source": "Fork Session",
       "surface": "apple",
-      "id": "native.apple.23b61d6cd26ac112"
+      "id": "native.apple.ea0ef95a159bffe0"
     },
     {
       "kind": "ui-localized-call",
@@ -39253,129 +38533,33 @@
       "kind": "ui-call",
       "line": 492,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Thread",
+      "source": "Session",
       "surface": "apple",
-      "id": "native.apple.8b4f1c5107ea8a0e"
+      "id": "native.apple.920fe8a7a33f9e92"
     },
     {
       "kind": "ui-modifier",
       "line": 500,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Thread actions",
+      "source": "Session actions",
       "surface": "apple",
-      "id": "native.apple.4d7750c9bf699469"
+      "id": "native.apple.185a401f78328b0f"
     },
     {
       "kind": "ui-localized-call",
       "line": 534,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Thread cost %@",
+      "source": "Session cost %@",
       "surface": "apple",
-      "id": "native.apple.bb2f22cc43c97f8e"
+      "id": "native.apple.9f9dedf599b2619b"
     },
     {
       "kind": "ui-call",
       "line": 540,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Compact Thread",
+      "source": "Compact Session",
       "surface": "apple",
-      "id": "native.apple.6239ced0b86e86f8"
-    },
-    {
-      "kind": "ui-call",
-      "line": 70,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/CleanChatComposerControls.swift",
-      "source": "Voice note",
-      "surface": "apple",
-      "id": "native.apple.fa10740f9e272e83"
-    },
-    {
-      "kind": "ui-call",
-      "line": 120,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/CleanChatComposerControls.swift",
-      "source": "Photo Library",
-      "surface": "apple",
-      "id": "native.apple.e4de5afc37981d6c"
-    },
-    {
-      "kind": "ui-call",
-      "line": 132,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/CleanChatComposerControls.swift",
-      "source": "Camera",
-      "surface": "apple",
-      "id": "native.apple.37c19a66626b21fa"
-    },
-    {
-      "kind": "ui-call",
-      "line": 145,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/CleanChatComposerControls.swift",
-      "source": "Choose Image File",
-      "surface": "apple",
-      "id": "native.apple.333682684163ba6b"
-    },
-    {
-      "kind": "ui-modifier",
-      "line": 156,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/CleanChatComposerControls.swift",
-      "source": "Add attachment",
-      "surface": "apple",
-      "id": "native.apple.534246792690968d"
-    },
-    {
-      "kind": "ui-call",
-      "line": 301,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/CleanChatComposerControls.swift",
-      "source": "Record Voice Note",
-      "surface": "apple",
-      "id": "native.apple.e33210feaa3da016"
-    },
-    {
-      "kind": "ui-call",
-      "line": 371,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/CleanChatComposerControls.swift",
-      "source": "Dictate message",
-      "surface": "apple",
-      "id": "native.apple.00f0e15858e38d19"
-    },
-    {
-      "kind": "ui-call",
-      "line": 375,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/CleanChatComposerControls.swift",
-      "source": "Listening",
-      "surface": "apple",
-      "id": "native.apple.96f20175f61a2b29"
-    },
-    {
-      "kind": "ui-call",
-      "line": 376,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/CleanChatComposerControls.swift",
-      "source": "Not listening",
-      "surface": "apple",
-      "id": "native.apple.eaa9047db6cfb67e"
-    },
-    {
-      "kind": "ui-call",
-      "line": 380,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/CleanChatComposerControls.swift",
-      "source": "Finish dictation",
-      "surface": "apple",
-      "id": "native.apple.4185df7a940f09ef"
-    },
-    {
-      "kind": "ui-call",
-      "line": 381,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/CleanChatComposerControls.swift",
-      "source": "Cancel",
-      "surface": "apple",
-      "id": "native.apple.95eeae0399fbc990"
-    },
-    {
-      "kind": "ui-call",
-      "line": 382,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/CleanChatComposerControls.swift",
-      "source": "Transcribe speech into the message",
-      "surface": "apple",
-      "id": "native.apple.5a0793d2827b9399"
+      "id": "native.apple.f0a4720df5f5f403"
     },
     {
       "kind": "ui-call",
@@ -39403,7 +38587,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 64,
+      "line": 63,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteComposerViews.swift",
       "source": "Recording",
       "surface": "apple",
@@ -39411,7 +38595,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 79,
+      "line": 78,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteComposerViews.swift",
       "source": "Cancel voice note",
       "surface": "apple",
@@ -39419,7 +38603,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 88,
+      "line": 87,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteComposerViews.swift",
       "source": "Finish voice note",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -523,7 +523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 201,
+      "line": 218,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainActivity.kt",
       "source": "Too many shares are waiting to be added.",
       "surface": "android",
@@ -531,7 +531,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 322,
+      "line": 341,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainActivity.kt",
       "source": "OPENCLAW",
       "surface": "android",
@@ -539,7 +539,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 466,
+      "line": 465,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Searching…",
       "surface": "android",
@@ -547,7 +547,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 592,
+      "line": 597,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Mic off",
       "surface": "android",
@@ -555,7 +555,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 606,
+      "line": 611,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Off",
       "surface": "android",
@@ -691,7 +691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 170,
+      "line": 174,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Resolution outcome unknown. Actions stay disabled until the Gateway record is verified.",
       "surface": "android",
@@ -699,7 +699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 172,
+      "line": 176,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The Gateway still shows this approval as pending. Review it before trying again.",
       "surface": "android",
@@ -707,7 +707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 174,
+      "line": 178,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load approval details. Refresh and try again.",
       "surface": "android",
@@ -715,7 +715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 176,
+      "line": 180,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load approvals.",
       "surface": "android",
@@ -723,7 +723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 178,
+      "line": 182,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not resolve approval. Refresh and try again.",
       "surface": "android",
@@ -731,7 +731,31 @@
     },
     {
       "kind": "ui-call",
-      "line": 193,
+      "line": 279,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
+      "source": "Device approved.",
+      "surface": "android",
+      "id": "native.android.ab7de09b2e9bafd2"
+    },
+    {
+      "kind": "ui-call",
+      "line": 280,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
+      "source": "Pairing request rejected.",
+      "surface": "android",
+      "id": "native.android.0f3b1e2ce6f0aed5"
+    },
+    {
+      "kind": "ui-call",
+      "line": 281,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
+      "source": "Paired device removed.",
+      "surface": "android",
+      "id": "native.android.e98062fe81b36c4a"
+    },
+    {
+      "kind": "ui-call",
+      "line": 342,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Proposal applied.",
       "surface": "android",
@@ -739,7 +763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 193,
+      "line": 342,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "apply",
       "surface": "android",
@@ -747,7 +771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 194,
+      "line": 343,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Proposal rejected.",
       "surface": "android",
@@ -755,7 +779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 194,
+      "line": 343,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "reject",
       "surface": "android",
@@ -763,7 +787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 195,
+      "line": 344,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Proposal quarantined.",
       "surface": "android",
@@ -771,7 +795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 195,
+      "line": 344,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "quarantine",
       "surface": "android",
@@ -779,7 +803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 202,
+      "line": 351,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "unknown",
       "surface": "android",
@@ -787,7 +811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 203,
+      "line": 352,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway returned status '$statusLabel' after ${action.verb}.",
       "surface": "android",
@@ -795,7 +819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 211,
+      "line": 360,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not ${action.verb} Skill Workshop proposal.",
       "surface": "android",
@@ -803,7 +827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 393,
+      "line": 542,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected (node offline)",
       "surface": "android",
@@ -811,7 +835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 394,
+      "line": 543,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected (operator offline)",
       "surface": "android",
@@ -819,7 +843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 396,
+      "line": 545,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Reconnecting…",
       "surface": "android",
@@ -827,7 +851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 404,
+      "line": 553,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected (operator: $operator)",
       "surface": "android",
@@ -835,7 +859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1978,
+      "line": 2147,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This automation already has a queued run.",
       "surface": "android",
@@ -843,7 +867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2008,
+      "line": 2177,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation run queued.",
       "surface": "android",
@@ -851,7 +875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2008,
+      "line": 2177,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation started.",
       "surface": "android",
@@ -859,7 +883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2021,
+      "line": 2190,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway rejected the automation run.",
       "surface": "android",
@@ -867,7 +891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2052,
+      "line": 2221,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation enabled.",
       "surface": "android",
@@ -875,7 +899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2052,
+      "line": 2221,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation paused.",
       "surface": "android",
@@ -883,7 +907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2074,
+      "line": 2243,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This automation changed on the gateway. Review the latest version before saving again.",
       "surface": "android",
@@ -891,7 +915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2080,
+      "line": 2249,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation updated.",
       "surface": "android",
@@ -899,7 +923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2095,
+      "line": 2264,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation deleted.",
       "surface": "android",
@@ -907,7 +931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2300,
+      "line": 2514,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Node offline. Reconnect and retry.",
       "surface": "android",
@@ -915,7 +939,7 @@
     },
     {
       "kind": "ui-named-argument-concatenated",
-      "line": 2311,
+      "line": 2525,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Restore canvas now for session=$sessionKey source=$source. If existing A2UI state exists, replay it immediately. If not, create and render a compact mobile-friendly dashboard in Canvas.",
       "surface": "android",
@@ -923,7 +947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2332,
+      "line": 2546,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed to request restore. Tap to retry.",
       "surface": "android",
@@ -931,7 +955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2343,
+      "line": 2557,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "No canvas update yet. Tap to retry.",
       "surface": "android",
@@ -939,7 +963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3301,
+      "line": 3515,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect to a Gateway to save wake words",
       "surface": "android",
@@ -947,7 +971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3329,
+      "line": 3543,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Wake words saved",
       "surface": "android",
@@ -955,7 +979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3338,
+      "line": 3552,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not save wake words",
       "surface": "android",
@@ -963,7 +987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4031,
+      "line": 4266,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: no secure gateway endpoint was detected. Enable gateway TLS or Tailscale Serve, or use a trusted private LAN address with Unencrypted selected.",
       "surface": "android",
@@ -971,7 +995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4035,
+      "line": 4270,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -979,7 +1003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4039,
+      "line": 4274,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -987,7 +1011,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 4083,
+      "line": 4318,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -995,7 +1019,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 4266,
+      "line": 4501,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Offline",
       "surface": "android",
@@ -1003,7 +1027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5000,
+      "line": 5235,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load provider catalog.",
       "surface": "android",
@@ -1011,7 +1035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5031,
+      "line": 5266,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Update your Gateway to view provider model config.",
       "surface": "android",
@@ -1019,7 +1043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5033,
+      "line": 5268,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load provider model config.",
       "surface": "android",
@@ -1027,7 +1051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5049,
+      "line": 5284,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Provider models loaded, but readiness is unavailable.",
       "surface": "android",
@@ -1035,7 +1059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5136,
+      "line": 5371,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automations.",
       "surface": "android",
@@ -1043,7 +1067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5222,
+      "line": 5457,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect automations.",
       "surface": "android",
@@ -1051,7 +1075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5232,
+      "line": 5467,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway returned an invalid automation.",
       "surface": "android",
@@ -1059,7 +1083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5236,
+      "line": 5471,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automation.",
       "surface": "android",
@@ -1067,7 +1091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5248,
+      "line": 5483,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect automation run history.",
       "surface": "android",
@@ -1075,7 +1099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5279,
+      "line": 5514,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automation run history.",
       "surface": "android",
@@ -1083,7 +1107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5296,
+      "line": 5531,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron changes require operator.admin access.",
       "surface": "android",
@@ -1091,7 +1115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5305,
+      "line": 5540,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to manage automations.",
       "surface": "android",
@@ -1099,7 +1123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5317,
+      "line": 5552,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Another cron action is still finishing.",
       "surface": "android",
@@ -1107,7 +1131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5364,
+      "line": 5599,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron action failed.",
       "surface": "android",
@@ -1115,7 +1139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5491,
+      "line": 5726,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load usage.",
       "surface": "android",
@@ -1123,7 +1147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5526,
+      "line": 5761,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load skills.",
       "surface": "android",
@@ -1131,7 +1155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5539,
+      "line": 5774,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to update skills.",
       "surface": "android",
@@ -1139,7 +1163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5543,
+      "line": 5778,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This gateway connection needs operator.admin to update skills.",
       "surface": "android",
@@ -1147,7 +1171,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5558,
+      "line": 5793,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not disable skill.",
       "surface": "android",
@@ -1155,7 +1179,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5558,
+      "line": 5793,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not enable skill.",
       "surface": "android",
@@ -1163,7 +1187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5576,
+      "line": 5811,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to search ClawHub skills.",
       "surface": "android",
@@ -1171,7 +1195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5622,
+      "line": 5857,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not search ClawHub skills.",
       "surface": "android",
@@ -1179,7 +1203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5635,
+      "line": 5870,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect ClawHub skills.",
       "surface": "android",
@@ -1187,7 +1211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5668,
+      "line": 5903,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "ClawHub did not return an installable version for ${skill.slug}.",
       "surface": "android",
@@ -1195,7 +1219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5684,
+      "line": 5919,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load ClawHub details for ${skill.slug}.",
       "surface": "android",
@@ -1203,7 +1227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5700,
+      "line": 5935,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to install ClawHub skills.",
       "surface": "android",
@@ -1211,7 +1235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5716,
+      "line": 5951,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This gateway connection needs operator.admin to install ClawHub skills.",
       "surface": "android",
@@ -1219,7 +1243,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5806,
+      "line": 6041,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Installed $slug.",
       "surface": "android",
@@ -1227,7 +1251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5813,
+      "line": 6048,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not install ${slug} from ClawHub.",
       "surface": "android",
@@ -1235,7 +1259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5853,
+      "line": 6088,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to load Skill Workshop proposals.",
       "surface": "android",
@@ -1243,7 +1267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5893,
+      "line": 6128,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load Skill Workshop proposals.",
       "surface": "android",
@@ -1251,7 +1275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5913,
+      "line": 6148,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect Skill Workshop proposals.",
       "surface": "android",
@@ -1259,7 +1283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5965,
+      "line": 6200,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not inspect Skill Workshop proposal.",
       "surface": "android",
@@ -1267,7 +1291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5985,
+      "line": 6220,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Skill Workshop proposal actions require operator.admin scope.",
       "surface": "android",
@@ -1275,15 +1299,23 @@
     },
     {
       "kind": "ui-call",
-      "line": 5990,
+      "line": 6225,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to update Skill Workshop proposals.",
       "surface": "android",
       "id": "native.android.df0d071809dfbbb3"
     },
     {
+      "kind": "ui-call",
+      "line": 6415,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
+      "source": "Could not verify the device pairing change. Refresh and try again.",
+      "surface": "android",
+      "id": "native.android.9481b642ee32ed95"
+    },
+    {
       "kind": "ui-named-argument",
-      "line": 6149,
+      "line": 6497,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected",
       "surface": "android",
@@ -1291,7 +1323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6175,
+      "line": 6527,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load nodes and devices.",
       "surface": "android",
@@ -1299,7 +1331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6833,
+      "line": 7185,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load channels.",
       "surface": "android",
@@ -1307,7 +1339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6863,
+      "line": 7215,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load dreaming.",
       "surface": "android",
@@ -1315,7 +1347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6900,
+      "line": 7252,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load gateway logs.",
       "surface": "android",
@@ -1323,7 +1355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7357,
+      "line": 7721,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "One time",
       "surface": "android",
@@ -1331,7 +1363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7366,
+      "line": 7730,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron",
       "surface": "android",
@@ -1339,7 +1371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7367,
+      "line": 7731,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Scheduled",
       "surface": "android",
@@ -1347,7 +1379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7375,
+      "line": 7739,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${days}d",
       "surface": "android",
@@ -1355,7 +1387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7376,
+      "line": 7740,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${hours}h",
       "surface": "android",
@@ -1363,7 +1395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7377,
+      "line": 7741,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${minutes}m",
       "surface": "android",
@@ -1371,7 +1403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7378,
+      "line": 7742,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Repeating",
       "surface": "android",
@@ -1379,7 +1411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7394,
+      "line": 7758,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "No prompt",
       "surface": "android",
@@ -1387,7 +1419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7411,
+      "line": 7775,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway",
       "surface": "android",
@@ -1395,7 +1427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7419,
+      "line": 7783,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected to $gatewayLabel",
       "surface": "android",
@@ -1403,7 +1435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7420,
+      "line": 7784,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Your agents are ready",
       "surface": "android",
@@ -1411,7 +1443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7422,
+      "line": 7786,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This phone stays dormant until the gateway needs it, then wakes, syncs, and goes back to sleep.",
       "surface": "android",
@@ -1419,7 +1451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7426,
+      "line": 7790,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Selected on this phone",
       "surface": "android",
@@ -1427,7 +1459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7429,
+      "line": 7793,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The overview refreshes on reconnect and when this screen opens.",
       "surface": "android",
@@ -1435,7 +1467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7434,
+      "line": 7798,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Reconnecting",
       "surface": "android",
@@ -1443,7 +1475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7435,
+      "line": 7799,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "OpenClaw is syncing back up",
       "surface": "android",
@@ -1451,7 +1483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7437,
+      "line": 7801,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The gateway session is coming back online. Agent shortcuts should settle automatically in a moment.",
       "surface": "android",
@@ -1459,7 +1491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7441,
+      "line": 7805,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway session in progress",
       "surface": "android",
@@ -1467,7 +1499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7444,
+      "line": 7808,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "If the gateway is reachable, reconnect should complete without intervention.",
       "surface": "android",
@@ -1475,7 +1507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7449,
+      "line": 7813,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Welcome to OpenClaw",
       "surface": "android",
@@ -1483,7 +1515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7450,
+      "line": 7814,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Your phone stays quiet until it is needed",
       "surface": "android",
@@ -1491,7 +1523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7452,
+      "line": 7816,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Pair this device to your gateway to wake it only for real work, keep a live agent overview handy, and avoid battery-draining background loops.",
       "surface": "android",
@@ -1499,7 +1531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7456,
+      "line": 7820,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect to load your agents",
       "surface": "android",
@@ -1507,7 +1539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7459,
+      "line": 7823,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "When connected, the gateway can wake the phone with a silent push instead of holding an always-on session.",
       "surface": "android",
@@ -1515,7 +1547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7491,
+      "line": 7855,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Main",
       "surface": "android",
@@ -1523,7 +1555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7506,
+      "line": 7870,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Active on this phone",
       "surface": "android",
@@ -1531,7 +1563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7507,
+      "line": 7871,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Default agent",
       "surface": "android",
@@ -1539,7 +1571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7508,
+      "line": 7872,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Ready",
       "surface": "android",
@@ -1547,7 +1579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8067,
+      "line": 8437,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Dream",
       "surface": "android",
@@ -3763,7 +3795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 58,
+      "line": 74,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Nodes & Devices",
       "surface": "android",
@@ -3771,7 +3803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 59,
+      "line": 75,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Live nodes, paired phones, and pending device requests.",
       "surface": "android",
@@ -3779,7 +3811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 68,
+      "line": 84,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Admin",
       "surface": "android",
@@ -3787,7 +3819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 68,
+      "line": 84,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Devices",
       "surface": "android",
@@ -3795,7 +3827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 69,
+      "line": 85,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Pending",
       "surface": "android",
@@ -3803,7 +3835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 74,
+      "line": 90,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Refresh",
       "surface": "android",
@@ -3811,7 +3843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 74,
+      "line": 90,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Refreshing",
       "surface": "android",
@@ -3819,7 +3851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 88,
+      "line": 109,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Connect the gateway to load nodes and paired devices.",
       "surface": "android",
@@ -3827,7 +3859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 93,
+      "line": 114,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "No nodes or paired devices.",
       "surface": "android",
@@ -3835,7 +3867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 94,
+      "line": 115,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Linked phones and node hosts will appear here after pairing.",
       "surface": "android",
@@ -3843,7 +3875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 114,
+      "line": 172,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Node approval required",
       "surface": "android",
@@ -3851,7 +3883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 115,
+      "line": 173,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Run on the Gateway host:",
       "surface": "android",
@@ -3859,7 +3891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 130,
+      "line": 188,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Pending Requests",
       "surface": "android",
@@ -3867,7 +3899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 140,
+      "line": 207,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Nodes",
       "surface": "android",
@@ -3875,7 +3907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 150,
+      "line": 217,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Paired Devices",
       "surface": "android",
@@ -3883,7 +3915,143 @@
     },
     {
       "kind": "ui-call",
-      "line": 201,
+      "line": 256,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
+      "source": "Approve device?",
+      "surface": "android",
+      "id": "native.android.8c6f23f9b2a2f5c3"
+    },
+    {
+      "kind": "ui-call",
+      "line": 257,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
+      "source": "Reject pairing request?",
+      "surface": "android",
+      "id": "native.android.61e56e7c2425c765"
+    },
+    {
+      "kind": "ui-call",
+      "line": 258,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
+      "source": "Remove paired device?",
+      "surface": "android",
+      "id": "native.android.a233e379d3281626"
+    },
+    {
+      "kind": "ui-call",
+      "line": 276,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
+      "source": "Verify this requesting device before granting access.",
+      "surface": "android",
+      "id": "native.android.84789f373ff7e379"
+    },
+    {
+      "kind": "ui-call",
+      "line": 281,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
+      "source": "$label: $value",
+      "surface": "android",
+      "id": "native.android.80f2666384538867"
+    },
+    {
+      "kind": "ui-call",
+      "line": 291,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
+      "source": "Reject the pairing request from this device?",
+      "surface": "android",
+      "id": "native.android.857fc6dbd43c147c"
+    },
+    {
+      "kind": "ui-call",
+      "line": 293,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
+      "source": "This device will lose its trusted Gateway access.",
+      "surface": "android",
+      "id": "native.android.a0cb7097dac32274"
+    },
+    {
+      "kind": "ui-call",
+      "line": 303,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
+      "source": "Cancel",
+      "surface": "android",
+      "id": "native.android.d62bd835e46f047f"
+    },
+    {
+      "kind": "ui-call",
+      "line": 311,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
+      "source": "Name",
+      "surface": "android",
+      "id": "native.android.54bc27d84e77fdeb"
+    },
+    {
+      "kind": "ui-call",
+      "line": 312,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
+      "source": "Device ID",
+      "surface": "android",
+      "id": "native.android.549fcca19ab575e8"
+    },
+    {
+      "kind": "ui-call",
+      "line": 313,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
+      "source": "Public key",
+      "surface": "android",
+      "id": "native.android.0a2b46e9ba9a43a7"
+    },
+    {
+      "kind": "ui-call",
+      "line": 317,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
+      "source": "Platform",
+      "surface": "android",
+      "id": "native.android.3029d9b112d91460"
+    },
+    {
+      "kind": "ui-call",
+      "line": 321,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
+      "source": "Client",
+      "surface": "android",
+      "id": "native.android.34495d4163dd2b0d"
+    },
+    {
+      "kind": "ui-call",
+      "line": 322,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
+      "source": "Origin",
+      "surface": "android",
+      "id": "native.android.9d5173f45aa99bc9"
+    },
+    {
+      "kind": "ui-call",
+      "line": 323,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
+      "source": "Remote IP",
+      "surface": "android",
+      "id": "native.android.1690971a387e62fa"
+    },
+    {
+      "kind": "ui-call",
+      "line": 327,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
+      "source": "Roles",
+      "surface": "android",
+      "id": "native.android.e478d6d87813a30a"
+    },
+    {
+      "kind": "ui-call",
+      "line": 331,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
+      "source": "Scopes",
+      "surface": "android",
+      "id": "native.android.d390e77c38097584"
+    },
+    {
+      "kind": "ui-call",
+      "line": 415,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "New device",
       "surface": "android",
@@ -3891,7 +4059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 203,
+      "line": 417,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Repair",
       "surface": "android",
@@ -3899,7 +4067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 203,
+      "line": 417,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Review",
       "surface": "android",
@@ -3907,7 +4075,23 @@
     },
     {
       "kind": "ui-call",
-      "line": 212,
+      "line": 427,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
+      "source": "Reject",
+      "surface": "android",
+      "id": "native.android.caa6c7dea18d5127"
+    },
+    {
+      "kind": "ui-call",
+      "line": 432,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
+      "source": "Approve",
+      "surface": "android",
+      "id": "native.android.ef8a2c38eba42e89"
+    },
+    {
+      "kind": "ui-call",
+      "line": 450,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Paired device",
       "surface": "android",
@@ -3915,7 +4099,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 239,
+      "line": 461,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
+      "source": "Remove",
+      "surface": "android",
+      "id": "native.android.ce8e5c5a934ed2aa"
+    },
+    {
+      "kind": "ui-call",
+      "line": 488,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Node host",
       "surface": "android",
@@ -3923,7 +4115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 241,
+      "line": 490,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Unpaired",
       "surface": "android",
@@ -3931,7 +4123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 253,
+      "line": 502,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Needs approval",
       "surface": "android",
@@ -3939,7 +4131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 254,
+      "line": 503,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Needs reapproval",
       "surface": "android",
@@ -3947,7 +4139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 255,
+      "line": 504,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Unapproved",
       "surface": "android",
@@ -3955,7 +4147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 256,
+      "line": 505,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Offline",
       "surface": "android",
@@ -3963,7 +4155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 256,
+      "line": 505,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Online",
       "surface": "android",
@@ -3971,7 +4163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 273,
+      "line": 522,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Approved",
       "surface": "android",
@@ -3979,7 +4171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 274,
+      "line": 523,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Capability approval pending",
       "surface": "android",
@@ -3987,7 +4179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 275,
+      "line": 524,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Capability reapproval pending",
       "surface": "android",
@@ -3995,7 +4187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 276,
+      "line": 525,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Capability unapproved",
       "surface": "android",
@@ -4003,15 +4195,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 283,
+      "line": 532,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
-      "source": "This gateway sign-in can list connected nodes, but it cannot approve new phone pairing. Pair new phones from a gateway admin session. Node capability approval is separate and still uses nodes approve <request id>.",
+      "source": "Device pairing actions are unavailable in this Gateway session. Run openclaw devices list on the Gateway host and manage the request there. Node capability approval is separate and still uses nodes approve <request id>.",
       "surface": "android",
-      "id": "native.android.13024ff403917bfe"
+      "id": "native.android.8b55ed05cd70b8d9"
     },
     {
       "kind": "ui-call",
-      "line": 290,
+      "line": 539,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "requested ${relativeDeviceTime(it)}",
       "surface": "android",
@@ -4019,7 +4211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 298,
+      "line": 547,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "${device.tokens.count { !it.revoked }}/${device.tokens.size} active tokens",
       "surface": "android",
@@ -4027,7 +4219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 308,
+      "line": 557,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Paired",
       "surface": "android",
@@ -4035,7 +4227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 309,
+      "line": 558,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Active",
       "surface": "android",
@@ -4043,7 +4235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 310,
+      "line": 559,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "Needs Token",
       "surface": "android",
@@ -4051,7 +4243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 334,
+      "line": 583,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "${values.size} roles",
       "surface": "android",
@@ -4059,7 +4251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 335,
+      "line": 584,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "${values.size} scopes",
       "surface": "android",
@@ -4067,7 +4259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 353,
+      "line": 602,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "now",
       "surface": "android",
@@ -4075,7 +4267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 354,
+      "line": 603,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "${minutes}m ago",
       "surface": "android",
@@ -4083,7 +4275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 356,
+      "line": 605,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "${hours}h ago",
       "surface": "android",
@@ -4091,7 +4283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 358,
+      "line": 607,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
       "source": "${days}d ago",
       "surface": "android",
@@ -4099,7 +4291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 270,
+      "line": 272,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Enter the setup code from openclaw qr.",
       "surface": "android",
@@ -4107,7 +4299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 271,
+      "line": 273,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup code was not accepted. Generate a fresh code with openclaw qr.",
       "surface": "android",
@@ -4115,7 +4307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 273,
+      "line": 275,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "That QR code is not an OpenClaw setup QR. Generate a fresh code with openclaw qr, then try again.",
       "surface": "android",
@@ -4123,7 +4315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 275,
+      "line": 277,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "That looks like a setup code. Go back and choose Setup Gateway, then Use setup code.",
       "surface": "android",
@@ -4131,7 +4323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 277,
+      "line": 279,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Could not read that image. Choose a clear screenshot or image of the QR from openclaw qr.",
       "surface": "android",
@@ -4139,7 +4331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 279,
+      "line": 281,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "No setup QR code was found in that image. Choose the QR generated by openclaw qr, or enter the setup code manually.",
       "surface": "android",
@@ -4147,7 +4339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 281,
+      "line": 283,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Could not read a QR code from that image. Choose a clearer image or enter the setup code manually.",
       "surface": "android",
@@ -4155,7 +4347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 283,
+      "line": 285,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Could not start the camera. Choose a QR image from gallery or enter the setup code manually.",
       "surface": "android",
@@ -4163,7 +4355,31 @@
     },
     {
       "kind": "ui-call",
-      "line": 838,
+      "line": 832,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
+      "source": "The gateway certificate could not be read automatically. Paste the SHA-256 fingerprint obtained on the gateway host.",
+      "surface": "android",
+      "id": "native.android.7a18be21a62739bf"
+    },
+    {
+      "kind": "ui-call",
+      "line": 852,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
+      "source": "This gateway now presents a certificate trusted by this device.",
+      "surface": "android",
+      "id": "native.android.aa489429ad39aa39"
+    },
+    {
+      "kind": "ui-call",
+      "line": 862,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
+      "source": "SHA-256 fingerprint",
+      "surface": "android",
+      "id": "native.android.b3db82f1162808ad"
+    },
+    {
+      "kind": "ui-call",
+      "line": 875,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Trust",
       "surface": "android",
@@ -4171,7 +4387,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 843,
+      "line": 882,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
+      "source": "Use system trust",
+      "surface": "android",
+      "id": "native.android.09245320d3878458"
+    },
+    {
+      "kind": "ui-call",
+      "line": 886,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Cancel",
       "surface": "android",
@@ -4179,7 +4403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1038,
+      "line": 1082,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Welcome to OpenClaw",
       "surface": "android",
@@ -4187,7 +4411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1039,
+      "line": 1083,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Turn this device into a secure OpenClaw node for chat, voice, camera, and device tools.",
       "surface": "android",
@@ -4195,7 +4419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1070,
+      "line": 1114,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "OpenClaw logo",
       "surface": "android",
@@ -4203,7 +4427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1129,
+      "line": 1173,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connect to your Gateway",
       "surface": "android",
@@ -4211,7 +4435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1130,
+      "line": 1174,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Choose device permissions",
       "surface": "android",
@@ -4219,7 +4443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1131,
+      "line": 1175,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Use OpenClaw from your phone",
       "surface": "android",
@@ -4227,7 +4451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1153,
+      "line": 1197,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Security notice",
       "surface": "android",
@@ -4235,7 +4459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1155,
+      "line": 1199,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "The connected OpenClaw agent can use device capabilities you enable. Continue only if you trust the Gateway and agent you connect to.",
       "surface": "android",
@@ -4243,7 +4467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1196,
+      "line": 1240,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connect Gateway",
       "surface": "android",
@@ -4251,7 +4475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1197,
+      "line": 1241,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Scan a QR code or use the setup code from your OpenClaw Gateway.",
       "surface": "android",
@@ -4259,7 +4483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1206,
+      "line": 1250,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Could not open setup guide.",
       "surface": "android",
@@ -4267,7 +4491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1214,
+      "line": 1258,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Scan QR or setup code",
       "surface": "android",
@@ -4275,7 +4499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1220,
+      "line": 1264,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Set up manually",
       "surface": "android",
@@ -4283,7 +4507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1242,
+      "line": 1286,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Before you start",
       "surface": "android",
@@ -4291,7 +4515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1248,
+      "line": 1292,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Access to the Gateway device",
       "surface": "android",
@@ -4299,7 +4523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1249,
+      "line": 1293,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Have a terminal open on the device running OpenClaw.",
       "surface": "android",
@@ -4307,7 +4531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1252,
+      "line": 1296,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Phone can reach the Gateway",
       "surface": "android",
@@ -4315,7 +4539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1253,
+      "line": 1297,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Use the same network, or a secure remote Gateway URL.",
       "surface": "android",
@@ -4323,7 +4547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1259,
+      "line": 1303,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Android setup guide",
       "surface": "android",
@@ -4331,7 +4555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1302,
+      "line": 1346,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup Gateway",
       "surface": "android",
@@ -4339,7 +4563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1307,
+      "line": 1351,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Step 1",
       "surface": "android",
@@ -4347,7 +4571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1308,
+      "line": 1352,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Start your Gateway.",
       "surface": "android",
@@ -4355,7 +4579,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1309,
+      "line": 1353,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "openclaw gateway",
       "surface": "android",
@@ -4363,7 +4587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1313,
+      "line": 1357,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Step 2",
       "surface": "android",
@@ -4371,7 +4595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1314,
+      "line": 1358,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Generate a QR code.",
       "surface": "android",
@@ -4379,7 +4603,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1315,
+      "line": 1359,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "openclaw qr",
       "surface": "android",
@@ -4387,7 +4611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1338,
+      "line": 1382,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Choose from gallery",
       "surface": "android",
@@ -4395,7 +4619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1393,
+      "line": 1437,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "QR code not accepted",
       "surface": "android",
@@ -4403,7 +4627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1412,
+      "line": 1456,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Choose another image",
       "surface": "android",
@@ -4411,7 +4635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1465,
+      "line": 1509,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Scan QR code",
       "surface": "android",
@@ -4419,7 +4643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1467,
+      "line": 1511,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Open the camera and frame the code from openclaw qr.",
       "surface": "android",
@@ -4427,7 +4651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1501,
+      "line": 1545,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Align the QR code inside the square.",
       "surface": "android",
@@ -4435,7 +4659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1519,
+      "line": 1563,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Camera access is needed to scan the setup QR.",
       "surface": "android",
@@ -4443,7 +4667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1524,
+      "line": 1568,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Allow camera",
       "surface": "android",
@@ -4451,7 +4675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1545,
+      "line": 1589,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Close scanner",
       "surface": "android",
@@ -4459,7 +4683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1708,
+      "line": 1752,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Enter setup code",
       "surface": "android",
@@ -4467,7 +4691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1714,
+      "line": 1758,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup code",
       "surface": "android",
@@ -4475,7 +4699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1718,
+      "line": 1762,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Paste setup code",
       "surface": "android",
@@ -4483,7 +4707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1726,
+      "line": 1770,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Use setup code",
       "surface": "android",
@@ -4491,7 +4715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1766,
+      "line": 1810,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Manual setup",
       "surface": "android",
@@ -4499,7 +4723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1769,
+      "line": 1813,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway URL",
       "surface": "android",
@@ -4507,7 +4731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1778,
+      "line": 1822,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Host",
       "surface": "android",
@@ -4515,7 +4739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1779,
+      "line": 1823,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Port",
       "surface": "android",
@@ -4523,7 +4747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1784,
+      "line": 1828,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Use the Gateway computer's LAN address or secure remote hostname.",
       "surface": "android",
@@ -4531,7 +4755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1791,
+      "line": 1835,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Token",
       "surface": "android",
@@ -4539,7 +4763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1792,
+      "line": 1836,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Paste token",
       "surface": "android",
@@ -4547,7 +4771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1794,
+      "line": 1838,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Paste a shared Gateway token or operator-issued token.",
       "surface": "android",
@@ -4555,7 +4779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1801,
+      "line": 1845,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Password",
       "surface": "android",
@@ -4563,7 +4787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1802,
+      "line": 1846,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Password optional",
       "surface": "android",
@@ -4571,7 +4795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1806,
+      "line": 1850,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connection security",
       "surface": "android",
@@ -4579,7 +4803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1828,
+      "line": 1872,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Unencrypted",
       "surface": "android",
@@ -4587,7 +4811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1834,
+      "line": 1878,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Secure (TLS)",
       "surface": "android",
@@ -4595,7 +4819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1857,
+      "line": 1901,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Could not test connection",
       "surface": "android",
@@ -4603,7 +4827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1862,
+      "line": 1906,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Test connection",
       "surface": "android",
@@ -4611,7 +4835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1949,
+      "line": 1993,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup code was not accepted",
       "surface": "android",
@@ -4619,7 +4843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1955,
+      "line": 1999,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Your phone is paired with ${recoveryGatewayName(serverName = serverName, attemptedGatewayName = attemptedGatewayName)}. Continue to finish node access.",
       "surface": "android",
@@ -4627,7 +4851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2007,
+      "line": 2051,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway paired",
       "surface": "android",
@@ -4635,7 +4859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2008,
+      "line": 2052,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Pair Gateway",
       "surface": "android",
@@ -4643,7 +4867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2060,
+      "line": 2104,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "View details",
       "surface": "android",
@@ -4651,7 +4875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2093,
+      "line": 2137,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connection details",
       "surface": "android",
@@ -4659,7 +4883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2105,
+      "line": 2149,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Copy",
       "surface": "android",
@@ -4667,7 +4891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2110,
+      "line": 2154,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Close",
       "surface": "android",
@@ -4675,7 +4899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2122,
+      "line": 2166,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Details copied",
       "surface": "android",
@@ -4683,7 +4907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2167,
+      "line": 2211,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Approve node access",
       "surface": "android",
@@ -4691,7 +4915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2174,
+      "line": 2218,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway pairing is complete. Approve this phone as a node so OpenClaw can use the device capabilities you enable.",
       "surface": "android",
@@ -4699,7 +4923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2182,
+      "line": 2226,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "On the Gateway computer, run:",
       "surface": "android",
@@ -4707,7 +4931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2191,
+      "line": 2235,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Use the requestId from the pending command in the approve command.",
       "surface": "android",
@@ -4715,7 +4939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2202,
+      "line": 2246,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "I have approved",
       "surface": "android",
@@ -4723,7 +4947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2203,
+      "line": 2247,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Checking approval…",
       "surface": "android",
@@ -4731,7 +4955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2215,
+      "line": 2259,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Still waiting for approval",
       "surface": "android",
@@ -4739,7 +4963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2218,
+      "line": 2262,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Run the approve command on the Gateway computer, then check again.",
       "surface": "android",
@@ -4747,7 +4971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2225,
+      "line": 2269,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "OK",
       "surface": "android",
@@ -4755,7 +4979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2375,
+      "line": 2419,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Copy approval command",
       "surface": "android",
@@ -4763,7 +4987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2406,
+      "line": 2450,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Only enable access you are comfortable letting OpenClaw use while this phone is connected. You can change these later in Android Settings.",
       "surface": "android",
@@ -4771,7 +4995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2445,
+      "line": 2489,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Back",
       "surface": "android",
@@ -4779,7 +5003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2496,
+      "line": 2540,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Permissions",
       "surface": "android",
@@ -4787,7 +5011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2557,
+      "line": 2601,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connected",
       "surface": "android",
@@ -4795,7 +5019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2558,
+      "line": 2602,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Your Gateway is ready.",
       "surface": "android",
@@ -4803,7 +5027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2562,
+      "line": 2606,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Approve this phone on the gateway.\nThen retry the connection.",
       "surface": "android",
@@ -4811,7 +5035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2565,
+      "line": 2609,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Node Approval Pending",
       "surface": "android",
@@ -4819,7 +5043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2566,
+      "line": 2610,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway pairing worked.\nApprove this phone's node capabilities from an operator UI.",
       "surface": "android",
@@ -4827,7 +5051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2569,
+      "line": 2613,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Pairing Gateway",
       "surface": "android",
@@ -4835,7 +5059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2570,
+      "line": 2614,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Approval is in progress.\nOpenClaw will reconnect automatically.",
       "surface": "android",
@@ -4843,7 +5067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2573,
+      "line": 2617,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connecting Gateway",
       "surface": "android",
@@ -4851,7 +5075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2574,
+      "line": 2618,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "OpenClaw is checking gateway and node access.",
       "surface": "android",
@@ -4859,7 +5083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2577,
+      "line": 2621,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Still connecting",
       "surface": "android",
@@ -4867,7 +5091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2578,
+      "line": 2622,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "This is taking longer than expected.\nCheck that the Gateway is running and reachable.",
       "surface": "android",
@@ -4875,7 +5099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2581,
+      "line": 2625,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connection issue",
       "surface": "android",
@@ -4883,7 +5107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2582,
+      "line": 2626,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "We could not reach your Gateway.\nLet's fix this.",
       "surface": "android",
@@ -4891,7 +5115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2590,
+      "line": 2634,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Continue",
       "surface": "android",
@@ -4899,7 +5123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2591,
+      "line": 2635,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Retry connection",
       "surface": "android",
@@ -4907,7 +5131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2592,
+      "line": 2636,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Go back",
       "surface": "android",
@@ -4915,7 +5139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2688,
+      "line": 2732,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway received this phone",
       "surface": "android",
@@ -4923,7 +5147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2689,
+      "line": 2733,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Waiting for device approval",
       "surface": "android",
@@ -4931,7 +5155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2690,
+      "line": 2734,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Retrying automatically",
       "surface": "android",
@@ -4939,7 +5163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2694,
+      "line": 2738,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway needs device approval",
       "surface": "android",
@@ -4947,7 +5171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2695,
+      "line": 2739,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Run the approval command on the Gateway",
       "surface": "android",
@@ -4955,7 +5179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2711,
+      "line": 2755,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Opening Gateway connection",
       "surface": "android",
@@ -4963,7 +5187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2720,
+      "line": 2764,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Checking pairing access",
       "surface": "android",
@@ -4971,7 +5195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2728,
+      "line": 2772,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Checking node access",
       "surface": "android",
@@ -4979,7 +5203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2797,
+      "line": 2841,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Ready for chat and voice",
       "surface": "android",
@@ -4987,7 +5211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2799,
+      "line": 2843,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway paired. Waiting for node capability approval.",
       "surface": "android",
@@ -4995,7 +5219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2802,
+      "line": 2846,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway approval is pending. Run this on the gateway host:",
       "surface": "android",
@@ -5003,7 +5227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2803,
+      "line": 2847,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway approval is pending. Run openclaw devices list on the gateway host, approve this phone, then retry.",
       "surface": "android",
@@ -5011,7 +5235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2811,
+      "line": 2855,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway paired. Checking node capability approval.",
       "surface": "android",
@@ -5019,7 +5243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2813,
+      "line": 2857,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway paired. Waiting for operator access.",
       "surface": "android",
@@ -5027,7 +5251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2815,
+      "line": 2859,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway approval is in progress. OpenClaw will retry automatically.",
       "surface": "android",
@@ -5035,7 +5259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2817,
+      "line": 2861,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway unreachable",
       "surface": "android",
@@ -5043,7 +5267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2823,
+      "line": 2867,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "The code may have expired or been generated for another Gateway.",
       "surface": "android",
@@ -5051,7 +5275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2827,
+      "line": 2871,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway password is required. Enter it again or edit this connection.",
       "surface": "android",
@@ -5059,7 +5283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2828,
+      "line": 2872,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway password is invalid. Re-enter it or reset this gateway connection.",
       "surface": "android",
@@ -5067,7 +5291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2829,
+      "line": 2873,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway token is required. Enter it again or edit this connection.",
       "surface": "android",
@@ -5075,7 +5299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2832,
+      "line": 2876,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway requires this device identity. Re-authenticate or reset this gateway connection.",
       "surface": "android",
@@ -5083,7 +5307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2835,
+      "line": 2879,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Saved authentication is invalid. Re-authenticate or reset this gateway connection.",
       "surface": "android",
@@ -5091,7 +5315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2836,
+      "line": 2880,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway authentication is not configured. Edit this connection and try again.",
       "surface": "android",
@@ -5099,7 +5323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2837,
+      "line": 2881,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway authentication needs review. Check gateway settings, then retry.",
       "surface": "android",
@@ -5107,7 +5331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2838,
+      "line": 2882,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway authentication needs attention.",
       "surface": "android",
@@ -5115,7 +5339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2849,
+      "line": 2893,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "This app is older than the Gateway. Update OpenClaw on this device, then retry.",
       "surface": "android",
@@ -5123,7 +5347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2851,
+      "line": 2895,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "The Gateway is older than this app. Update OpenClaw on the Gateway host, then retry.",
       "surface": "android",
@@ -5131,7 +5355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2852,
+      "line": 2896,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "The app and Gateway use incompatible protocol versions. Update OpenClaw on both, then retry.",
       "surface": "android",
@@ -5139,7 +5363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2854,
+      "line": 2898,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "$summary $details",
       "surface": "android",
@@ -5147,7 +5371,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2889,
+      "line": 2933,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "openclaw devices approve $requestId",
       "surface": "android",
@@ -5155,7 +5379,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2891,
+      "line": 2935,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "openclaw devices list",
       "surface": "android",
@@ -5163,7 +5387,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2898,
+      "line": 2942,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "openclaw nodes approve $requestId",
       "surface": "android",
@@ -5171,7 +5395,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2900,
+      "line": 2944,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "openclaw nodes approve REQUEST_ID",
       "surface": "android",
@@ -5179,7 +5403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2985,
+      "line": 3029,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Approval command copied",
       "surface": "android",
@@ -5187,7 +5411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2994,
+      "line": 3038,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Command copied",
       "surface": "android",
@@ -5195,7 +5419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3061,
+      "line": 3105,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Enabled",
       "surface": "android",
@@ -5203,7 +5427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3062,
+      "line": 3106,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Off",
       "surface": "android",
@@ -5211,7 +5435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3063,
+      "line": 3107,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Not allowed",
       "surface": "android",
@@ -5219,7 +5443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3071,
+      "line": 3115,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Granted",
       "surface": "android",
@@ -5227,7 +5451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3071,
+      "line": 3115,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Not granted",
       "surface": "android",
@@ -5235,7 +5459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3197,
+      "line": 3241,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Transcribe voice prompts",
       "surface": "android",
@@ -5243,7 +5467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3197,
+      "line": 3241,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Voice",
       "surface": "android",
@@ -5251,7 +5475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3202,
+      "line": 3246,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Camera",
       "surface": "android",
@@ -5259,7 +5483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3203,
+      "line": 3247,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Capture photos and clips from this phone",
       "surface": "android",
@@ -5267,7 +5491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3212,
+      "line": 3256,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Location",
       "surface": "android",
@@ -5275,7 +5499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3212,
+      "line": 3256,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Read this phone's location",
       "surface": "android",
@@ -5283,7 +5507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3216,
+      "line": 3260,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Photos",
       "surface": "android",
@@ -5291,7 +5515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3216,
+      "line": 3260,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Read recent photos and media",
       "surface": "android",
@@ -5299,7 +5523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3222,
+      "line": 3266,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Contacts",
       "surface": "android",
@@ -5307,7 +5531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3222,
+      "line": 3266,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Find people and contact details",
       "surface": "android",
@@ -5315,7 +5539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3225,
+      "line": 3269,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Calendar",
       "surface": "android",
@@ -5323,7 +5547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3225,
+      "line": 3269,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Read and update events",
       "surface": "android",
@@ -5331,7 +5555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3228,
+      "line": 3272,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Notifications",
       "surface": "android",
@@ -5339,7 +5563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3228,
+      "line": 3272,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Show OpenClaw alerts",
       "surface": "android",
@@ -5347,7 +5571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3231,
+      "line": 3275,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Notification listener",
       "surface": "android",
@@ -5355,7 +5579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3231,
+      "line": 3275,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Read selected app notifications",
       "surface": "android",
@@ -5363,7 +5587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3235,
+      "line": 3279,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Motion",
       "surface": "android",
@@ -5371,7 +5595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3235,
+      "line": 3279,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Share steps and activity",
       "surface": "android",
@@ -5379,7 +5603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3242,
+      "line": 3286,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Device access; Gateway opt-in still required",
       "surface": "android",
@@ -5387,7 +5611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3242,
+      "line": 3286,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "SMS",
       "surface": "android",
@@ -5395,7 +5619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3249,
+      "line": 3293,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Call Log",
       "surface": "android",
@@ -5403,7 +5627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3249,
+      "line": 3293,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Show recent call history",
       "surface": "android",
@@ -8683,7 +8907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 132,
+      "line": 134,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Home",
       "surface": "android",
@@ -8691,7 +8915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 361,
+      "line": 364,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Close Canvas",
       "surface": "android",
@@ -8699,7 +8923,39 @@
     },
     {
       "kind": "ui-call",
-      "line": 509,
+      "line": 394,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
+      "source": "The gateway certificate could not be read automatically. Paste the SHA-256 fingerprint obtained on the gateway host.",
+      "surface": "android",
+      "id": "native.android.846fe5afd08b8089"
+    },
+    {
+      "kind": "ui-call",
+      "line": 422,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
+      "source": "This gateway now presents a certificate trusted by this device.",
+      "surface": "android",
+      "id": "native.android.b263dca13f55dad9"
+    },
+    {
+      "kind": "ui-call",
+      "line": 432,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
+      "source": "SHA-256 fingerprint",
+      "surface": "android",
+      "id": "native.android.dca0f8814b658170"
+    },
+    {
+      "kind": "ui-call",
+      "line": 452,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
+      "source": "Use system trust",
+      "surface": "android",
+      "id": "native.android.bb5d50fcdd5ebafe"
+    },
+    {
+      "kind": "ui-call",
+      "line": 557,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Overview",
       "surface": "android",
@@ -8707,7 +8963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 556,
+      "line": 604,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Start a chat and your active OpenClaw conversations will appear here.",
       "surface": "android",
@@ -8715,7 +8971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 557,
+      "line": 605,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Start Chat",
       "surface": "android",
@@ -8723,7 +8979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 611,
+      "line": 659,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Search",
       "surface": "android",
@@ -8731,7 +8987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 664,
+      "line": 712,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "ACTIVE AGENT",
       "surface": "android",
@@ -8739,7 +8995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 669,
+      "line": 717,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$agentName is working",
       "surface": "android",
@@ -8747,7 +9003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 673,
+      "line": 721,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "View",
       "surface": "android",
@@ -8755,7 +9011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 676,
+      "line": 724,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$pendingRunCount active",
       "surface": "android",
@@ -8763,7 +9019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 676,
+      "line": 724,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Idle",
       "surface": "android",
@@ -8771,7 +9027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 676,
+      "line": 724,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Runs",
       "surface": "android",
@@ -8779,7 +9035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 677,
+      "line": 725,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$sessionCount recent",
       "surface": "android",
@@ -8787,7 +9043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 678,
+      "line": 726,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Cron",
       "surface": "android",
@@ -8795,7 +9051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 681,
+      "line": 729,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -8803,7 +9059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 685,
+      "line": 733,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Reconnect gateway",
       "surface": "android",
@@ -8811,7 +9067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 836,
+      "line": 884,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open ${card.title}",
       "surface": "android",
@@ -8819,7 +9075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 916,
+      "line": 964,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Talk",
       "surface": "android",
@@ -8827,7 +9083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 917,
+      "line": 965,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open Talk",
       "surface": "android",
@@ -8835,7 +9091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 919,
+      "line": 967,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Talk settings",
       "surface": "android",
@@ -8843,7 +9099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 927,
+      "line": 975,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Recent Threads",
       "surface": "android",
@@ -8851,7 +9107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 937,
+      "line": 985,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "View all",
       "surface": "android",
@@ -8859,7 +9115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1055,
+      "line": 1103,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Online",
       "surface": "android",
@@ -8867,7 +9123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1056,
+      "line": 1104,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Healthy",
       "surface": "android",
@@ -8875,7 +9131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1060,
+      "line": 1108,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Reconnect to continue",
       "surface": "android",
@@ -8883,7 +9139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1061,
+      "line": 1109,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Review highlighted items",
       "surface": "android",
@@ -8891,7 +9147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1062,
+      "line": 1110,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "All systems nominal",
       "surface": "android",
@@ -8899,7 +9155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1075,
+      "line": 1123,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Nodes",
       "surface": "android",
@@ -8907,7 +9163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1076,
+      "line": 1124,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$onlineNodes/$nodeCount",
       "surface": "android",
@@ -8915,7 +9171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1076,
+      "line": 1124,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "None",
       "surface": "android",
@@ -8923,7 +9179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1079,
+      "line": 1127,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Review node access",
       "surface": "android",
@@ -8931,7 +9187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1081,
+      "line": 1129,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online",
       "surface": "android",
@@ -8939,7 +9195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1109,
+      "line": 1157,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Threads",
       "surface": "android",
@@ -8947,7 +9203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1111,
+      "line": 1159,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No recent threads",
       "surface": "android",
@@ -8955,7 +9211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1111,
+      "line": 1159,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Recent conversations",
       "surface": "android",
@@ -8963,7 +9219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1117,
+      "line": 1165,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Files",
       "surface": "android",
@@ -8971,7 +9227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1118,
+      "line": 1166,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Browse",
       "surface": "android",
@@ -8979,7 +9235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1118,
+      "line": 1166,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Offline",
       "surface": "android",
@@ -8987,7 +9243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1119,
+      "line": 1167,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Agent workspace files",
       "surface": "android",
@@ -8995,7 +9251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1177,
+      "line": 1225,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Working · 1 active run",
       "surface": "android",
@@ -9003,7 +9259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1179,
+      "line": 1227,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Working · $pendingRunCount active runs",
       "surface": "android",
@@ -9011,7 +9267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1183,
+      "line": 1231,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Monitoring · 1 thread",
       "surface": "android",
@@ -9019,7 +9275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1184,
+      "line": 1232,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Monitoring · $sessionCount threads",
       "surface": "android",
@@ -9027,7 +9283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1185,
+      "line": 1233,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Monitoring · 1 scheduled job",
       "surface": "android",
@@ -9035,7 +9291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1186,
+      "line": 1234,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Monitoring · $cronJobCount scheduled jobs",
       "surface": "android",
@@ -9043,7 +9299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1236,
+      "line": 1284,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -9051,7 +9307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1268,
+      "line": 1316,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Connect before chat, voice, and live status.",
       "surface": "android",
@@ -9059,7 +9315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1292,
+      "line": 1340,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No ready providers",
       "surface": "android",
@@ -9067,7 +9323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1292,
+      "line": 1340,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Providers",
       "surface": "android",
@@ -9075,7 +9331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1487,
+      "line": 1535,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open thread",
       "surface": "android",
@@ -9083,7 +9339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1585,
+      "line": 1633,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Back",
       "surface": "android",
@@ -9091,7 +9347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1588,
+      "line": 1636,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Settings",
       "surface": "android",
@@ -9099,7 +9355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1591,
+      "line": 1639,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Search settings",
       "surface": "android",
@@ -9107,7 +9363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1604,
+      "line": 1652,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Gateway",
       "surface": "android",
@@ -9115,7 +9371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1610,
+      "line": 1658,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Nodes & Devices",
       "surface": "android",
@@ -9123,7 +9379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1611,
+      "line": 1659,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Channels",
       "surface": "android",
@@ -9131,7 +9387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1612,
+      "line": 1660,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "${agents.size} available",
       "surface": "android",
@@ -9139,7 +9395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1612,
+      "line": 1660,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Agents",
       "surface": "android",
@@ -9147,7 +9403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1612,
+      "line": 1660,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Load from gateway",
       "surface": "android",
@@ -9155,7 +9411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1614,
+      "line": 1662,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Providers & Models",
       "surface": "android",
@@ -9163,7 +9419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1616,
+      "line": 1664,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$readyProviderCount ready",
       "surface": "android",
@@ -9171,7 +9427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1617,
+      "line": 1665,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Availability unknown",
       "surface": "android",
@@ -9179,7 +9435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1618,
+      "line": 1666,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Review readiness",
       "surface": "android",
@@ -9187,7 +9443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1630,
+      "line": 1678,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Approvals",
       "surface": "android",
@@ -9195,7 +9451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1631,
+      "line": 1679,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Automations",
       "surface": "android",
@@ -9203,7 +9459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1632,
+      "line": 1680,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Usage",
       "surface": "android",
@@ -9211,7 +9467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1633,
+      "line": 1681,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Skills",
       "surface": "android",
@@ -9219,7 +9475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1635,
+      "line": 1683,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Skill Workshop",
       "surface": "android",
@@ -9227,7 +9483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1641,
+      "line": 1689,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Dreaming",
       "surface": "android",
@@ -9235,7 +9491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1642,
+      "line": 1690,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Shell in the agent workspace",
       "surface": "android",
@@ -9243,7 +9499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1642,
+      "line": 1690,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Terminal",
       "surface": "android",
@@ -9251,7 +9507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1643,
+      "line": 1691,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Speaker muted",
       "surface": "android",
@@ -9259,7 +9515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1643,
+      "line": 1691,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Speaker on",
       "surface": "android",
@@ -9267,7 +9523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1643,
+      "line": 1691,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Voice",
       "surface": "android",
@@ -9275,7 +9531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1644,
+      "line": 1692,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Canvas",
       "surface": "android",
@@ -9283,7 +9539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1644,
+      "line": 1692,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Screen surface",
       "surface": "android",
@@ -9291,7 +9547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1645,
+      "line": 1693,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Notifications",
       "surface": "android",
@@ -9299,7 +9555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1645,
+      "line": 1693,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Smart delivery",
       "surface": "android",
@@ -9307,7 +9563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1646,
+      "line": 1694,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Camera enabled",
       "surface": "android",
@@ -9315,7 +9571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1646,
+      "line": 1694,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Locked",
       "surface": "android",
@@ -9323,7 +9579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1646,
+      "line": 1694,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Phone Capabilities",
       "surface": "android",
@@ -9331,7 +9587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1648,
+      "line": 1696,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Appearance",
       "surface": "android",
@@ -9339,7 +9595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1656,
+      "line": 1704,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "About",
       "surface": "android",
@@ -9347,7 +9603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1656,
+      "line": 1704,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Version and update",
       "surface": "android",
@@ -9355,7 +9611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1657,
+      "line": 1705,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Health",
       "surface": "android",
@@ -9363,7 +9619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1670,
+      "line": 1718,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Account",
       "surface": "android",
@@ -9371,7 +9627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1674,
+      "line": 1722,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Return to setup",
       "surface": "android",
@@ -9379,7 +9635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1674,
+      "line": 1722,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Sign Out",
       "surface": "android",
@@ -9387,7 +9643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1685,
+      "line": 1733,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Licenses",
       "surface": "android",
@@ -9395,7 +9651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1696,
+      "line": 1744,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
       "surface": "android",
@@ -9403,7 +9659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1699,
+      "line": 1747,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "All systems operational",
       "surface": "android",
@@ -9411,7 +9667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1699,
+      "line": 1747,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Gateway not connected",
       "surface": "android",
@@ -9419,7 +9675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1713,
+      "line": 1761,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No pending approvals",
       "surface": "android",
@@ -9427,7 +9683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1715,
+      "line": 1763,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$count pending",
       "surface": "android",
@@ -9435,7 +9691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1723,
+      "line": 1771,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No scheduled jobs",
       "surface": "android",
@@ -9443,7 +9699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1724,
+      "line": 1772,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 scheduled",
       "surface": "android",
@@ -9451,7 +9707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1725,
+      "line": 1773,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$count scheduled",
       "surface": "android",
@@ -9459,7 +9715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1731,
+      "line": 1779,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No provider usage",
       "surface": "android",
@@ -9467,7 +9723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1732,
+      "line": 1780,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 provider",
       "surface": "android",
@@ -9475,7 +9731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1733,
+      "line": 1781,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$count providers",
       "surface": "android",
@@ -9483,7 +9739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1743,
+      "line": 1791,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No skills",
       "surface": "android",
@@ -9491,7 +9747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1745,
+      "line": 1793,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$ready/${skills.size} ready",
       "surface": "android",
@@ -9499,7 +9755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1764,
+      "line": 1812,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$pending pending",
       "surface": "android",
@@ -9507,7 +9763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1764,
+      "line": 1812,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 pending",
       "surface": "android",
@@ -9515,7 +9771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1768,
+      "line": 1816,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No proposals",
       "surface": "android",
@@ -9523,7 +9779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1769,
+      "line": 1817,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$held held",
       "surface": "android",
@@ -9531,7 +9787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1769,
+      "line": 1817,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 held",
       "surface": "android",
@@ -9539,7 +9795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1770,
+      "line": 1818,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$applied applied",
       "surface": "android",
@@ -9547,7 +9803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1770,
+      "line": 1818,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 applied",
       "surface": "android",
@@ -9555,7 +9811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1771,
+      "line": 1819,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "${summary.proposals.size} proposals",
       "surface": "android",
@@ -9563,7 +9819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1788,
+      "line": 1836,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "${summary.pendingDevices.size} pending",
       "surface": "android",
@@ -9571,7 +9827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1789,
+      "line": 1837,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Node approval pending",
       "surface": "android",
@@ -9579,7 +9835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1790,
+      "line": 1838,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$online/${summary.nodes.size} online",
       "surface": "android",
@@ -9587,7 +9843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1791,
+      "line": 1839,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$devices paired",
       "surface": "android",
@@ -9595,7 +9851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1792,
+      "line": 1840,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No devices",
       "surface": "android",
@@ -9603,7 +9859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1818,
+      "line": 1866,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 issue",
       "surface": "android",
@@ -9611,7 +9867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1819,
+      "line": 1867,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$issueCount issues",
       "surface": "android",
@@ -9619,7 +9875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1820,
+      "line": 1868,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$connected/${summary.channels.size} connected",
       "surface": "android",
@@ -9627,7 +9883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1821,
+      "line": 1869,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No channels",
       "surface": "android",
@@ -9635,7 +9891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1837,
+      "line": 1885,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Needs attention",
       "surface": "android",
@@ -9643,7 +9899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1838,
+      "line": 1886,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "${summary.shortTermCount} waiting",
       "surface": "android",
@@ -9651,7 +9907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1839,
+      "line": 1887,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Off",
       "surface": "android",
@@ -9659,7 +9915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1883,
+      "line": 1931,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Connection",
       "surface": "android",
@@ -9667,7 +9923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1894,
+      "line": 1942,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Agents & automation",
       "surface": "android",
@@ -9675,7 +9931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1900,
+      "line": 1948,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Phone context & privacy",
       "surface": "android",
@@ -9683,7 +9939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1906,
+      "line": 1954,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Profile & device",
       "surface": "android",
@@ -9691,7 +9947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1909,
+      "line": 1957,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Diagnostics",
       "surface": "android",
@@ -9699,7 +9955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1955,
+      "line": 2003,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "OpenClaw mobile",
       "surface": "android",
@@ -9707,7 +9963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1959,
+      "line": 2007,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open profile",
       "surface": "android",
@@ -9715,7 +9971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2039,
+      "line": 2087,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open ${row.title}",
       "surface": "android",
@@ -9723,7 +9979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2047,
+      "line": 2095,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "now",
       "surface": "android",
@@ -9731,7 +9987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2048,
+      "line": 2096,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "${minutes}m",
       "surface": "android",
@@ -9739,7 +9995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2050,
+      "line": 2098,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "${hours}h",
       "surface": "android",
@@ -9747,7 +10003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2052,
+      "line": 2100,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "${days}d",
       "surface": "android",
@@ -9755,7 +10011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2055,
+      "line": 2103,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Main thread",
       "surface": "android",
@@ -9763,7 +10019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2062,
+      "line": 2110,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Online and ready",
       "surface": "android",
@@ -9771,7 +10027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2065,
+      "line": 2113,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Connecting...",
       "surface": "android",
@@ -9779,7 +10035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2066,
+      "line": 2114,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Waiting for pairing",
       "surface": "android",
@@ -9787,7 +10043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2067,
+      "line": 2115,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Authentication needed",
       "surface": "android",
@@ -9795,7 +10051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2068,
+      "line": 2116,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "TLS timed out",
       "surface": "android",
@@ -9803,7 +10059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2069,
+      "line": 2117,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No TLS endpoint",
       "surface": "android",
@@ -9811,7 +10067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2070,
+      "line": 2118,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Certificate review needed",
       "surface": "android",
@@ -9819,7 +10075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2071,
+      "line": 2119,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Not connected",
       "surface": "android",
@@ -12051,7 +12307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 323,
+      "line": 327,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Model",
       "surface": "android",
@@ -12059,7 +12315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 416,
+      "line": 450,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Some shared images were omitted or could not be added.",
       "surface": "android",
@@ -12067,7 +12323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 557,
+      "line": 591,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat needs attention",
       "surface": "android",
@@ -12075,7 +12331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 836,
+      "line": 876,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "All",
       "surface": "android",
@@ -12083,7 +12339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 918,
+      "line": 958,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Working",
       "surface": "android",
@@ -12091,7 +12347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 919,
+      "line": 959,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready",
       "surface": "android",
@@ -12099,7 +12355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 920,
+      "line": 960,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Offline",
       "surface": "android",
@@ -12107,7 +12363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 933,
+      "line": 973,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat actions",
       "surface": "android",
@@ -12115,7 +12371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 938,
+      "line": 978,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Refresh chat",
       "surface": "android",
@@ -12123,7 +12379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 946,
+      "line": 986,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Background tasks",
       "surface": "android",
@@ -12131,7 +12387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 967,
+      "line": 1007,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -12139,7 +12395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1114,
+      "line": 1154,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Messages to recover",
       "surface": "android",
@@ -12147,7 +12403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1116,
+      "line": 1156,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows.",
       "surface": "android",
@@ -12155,7 +12411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1144,
+      "line": 1184,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Loading thread",
       "surface": "android",
@@ -12163,7 +12419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1177,
+      "line": 1217,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Jump to latest",
       "surface": "android",
@@ -12171,7 +12427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1207,
+      "line": 1247,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready when you are",
       "surface": "android",
@@ -12179,7 +12435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1211,
+      "line": 1251,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Start with a prompt, or use voice.",
       "surface": "android",
@@ -12187,7 +12443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1213,
+      "line": 1253,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Use the recovery options below to reconnect.",
       "surface": "android",
@@ -12195,7 +12451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1215,
+      "line": 1255,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat is checking Gateway health.",
       "surface": "android",
@@ -12203,7 +12459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1238,
+      "line": 1278,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Fix connection",
       "surface": "android",
@@ -12211,7 +12467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1239,
+      "line": 1279,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Copy diagnostics",
       "surface": "android",
@@ -12219,7 +12475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1298,
+      "line": 1338,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Catch me up",
       "surface": "android",
@@ -12227,7 +12483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1299,
+      "line": 1339,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Summarize recent threads and next steps.",
       "surface": "android",
@@ -12235,7 +12491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1300,
+      "line": 1340,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
       "surface": "android",
@@ -12243,7 +12499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1304,
+      "line": 1344,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Plan the work",
       "surface": "android",
@@ -12251,7 +12507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1305,
+      "line": 1345,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Turn a goal into an actionable checklist.",
       "surface": "android",
@@ -12259,7 +12515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1306,
+      "line": 1346,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Help me turn this goal into a practical checklist: ",
       "surface": "android",
@@ -12267,7 +12523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1310,
+      "line": 1350,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Use this phone",
       "surface": "android",
@@ -12275,7 +12531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1311,
+      "line": 1351,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ask OpenClaw to use Android capabilities.",
       "surface": "android",
@@ -12283,7 +12539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1312,
+      "line": 1352,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "What can you help me do from this phone right now?",
       "surface": "android",
@@ -12291,7 +12547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1377,
+      "line": 1417,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw · Live",
       "surface": "android",
@@ -12299,7 +12555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1378,
+      "line": 1418,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "You",
       "surface": "android",
@@ -12307,7 +12563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1379,
+      "line": 1419,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "System",
       "surface": "android",
@@ -12315,7 +12571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1380,
+      "line": 1420,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -12323,15 +12579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1400,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Attachment",
-      "surface": "android",
-      "id": "native.android.e695e7b72d13e9e5"
-    },
-    {
-      "kind": "ui-call",
-      "line": 1453,
+      "line": 1493,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Preparing audio…",
       "surface": "android",
@@ -12339,7 +12587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1453,
+      "line": 1493,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Speaking…",
       "surface": "android",
@@ -12347,7 +12595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1474,
+      "line": 1514,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Tools running",
       "surface": "android",
@@ -12355,7 +12603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1476,
+      "line": 1516,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is working",
       "surface": "android",
@@ -12363,7 +12611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1479,
+      "line": 1519,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "+${toolCalls.size - 4} more",
       "surface": "android",
@@ -12371,7 +12619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1489,
+      "line": 1529,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Thinking",
       "surface": "android",
@@ -12379,7 +12627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1490,
+      "line": 1530,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is preparing a response.",
       "surface": "android",
@@ -12387,7 +12635,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1555,
+      "line": 1595,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$completedCount/${steps.size}",
       "surface": "android",
@@ -12395,7 +12643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1562,
+      "line": 1602,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Collapse plan checklist",
       "surface": "android",
@@ -12403,7 +12651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1562,
+      "line": 1602,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Expand plan checklist",
       "surface": "android",
@@ -12411,7 +12659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1693,
+      "line": 1734,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Dismiss shared-image warning",
       "surface": "android",
@@ -12419,7 +12667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1795,
+      "line": 1837,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Stop",
       "surface": "android",
@@ -12427,7 +12675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1893,
+      "line": 1935,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Default",
       "surface": "android",
@@ -12435,7 +12683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1959,
+      "line": 2001,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Pin model",
       "surface": "android",
@@ -12443,7 +12691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1959,
+      "line": 2001,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Unpin model",
       "surface": "android",
@@ -12451,7 +12699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1976,
+      "line": 2018,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "No commands found",
       "surface": "android",
@@ -12459,7 +12707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2018,
+      "line": 2060,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Command",
       "surface": "android",
@@ -12467,7 +12715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2038,
+      "line": 2080,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway offline",
       "surface": "android",
@@ -12475,7 +12723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2084,
+      "line": 2126,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Close thinking level selector",
       "surface": "android",
@@ -12483,7 +12731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2084,
+      "line": 2126,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Open thinking level selector",
       "surface": "android",
@@ -12491,7 +12739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2148,
+      "line": 2191,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attach image",
       "surface": "android",
@@ -12499,7 +12747,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 2179,
+      "line": 2196,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Attachment",
+      "surface": "android",
+      "id": "native.android.e695e7b72d13e9e5"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2227,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Message OpenClaw",
       "surface": "android",
@@ -12507,7 +12763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2208,
+      "line": 2256,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "End Talk",
       "surface": "android",
@@ -12515,7 +12771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2208,
+      "line": 2256,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Start Talk",
       "surface": "android",
@@ -12523,7 +12779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2293,
+      "line": 2341,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Voice note · ${formatVoiceNoteDuration(duration)}",
       "surface": "android",
@@ -12531,7 +12787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2302,
+      "line": 2350,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Remove attachment",
       "surface": "android",
@@ -12539,7 +12795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2314,
+      "line": 2362,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "New chat",
       "surface": "android",
@@ -12547,7 +12803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2323,
+      "line": 2371,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Main",
       "surface": "android",
@@ -12555,7 +12811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2324,
+      "line": 2372,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Current",
       "surface": "android",
@@ -12563,7 +12819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2331,
+      "line": 2379,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$emoji $name",
       "surface": "android",
@@ -12571,7 +12827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2390,
+      "line": 2438,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Send",
       "surface": "android",
@@ -12579,7 +12835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2401,
+      "line": 2449,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat is still checking Gateway health.",
       "surface": "android",
@@ -12587,7 +12843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2402,
+      "line": 2450,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway is offline. Fix the connection below or copy diagnostics.",
       "surface": "android",
@@ -12595,7 +12851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2403,
+      "line": 2451,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway authentication needs attention.",
       "surface": "android",
@@ -12603,7 +12859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2422,
+      "line": 2470,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Context ${(it * 100).roundToInt()}%",
       "surface": "android",
@@ -12611,7 +12867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2423,
+      "line": 2471,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Context --",
       "surface": "android",
@@ -12619,7 +12875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2424,
+      "line": 2472,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$contextLabel · ${contextMeterThinkingLabel(thinkingLevel)}",
       "surface": "android",
@@ -12627,7 +12883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2463,
+      "line": 2511,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Off",
       "surface": "android",
@@ -12635,7 +12891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2464,
+      "line": 2512,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Minimal",
       "surface": "android",
@@ -12643,7 +12899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2465,
+      "line": 2513,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Low",
       "surface": "android",
@@ -12651,7 +12907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2466,
+      "line": 2514,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Medium",
       "surface": "android",
@@ -12659,7 +12915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2467,
+      "line": 2515,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "High",
       "surface": "android",
@@ -12667,7 +12923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2468,
+      "line": 2516,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Xhigh",
       "surface": "android",
@@ -12675,7 +12931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2469,
+      "line": 2517,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Adaptive",
       "surface": "android",
@@ -12683,7 +12939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2470,
+      "line": 2518,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Max",
       "surface": "android",
@@ -13043,7 +13299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 532,
+      "line": 602,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Speech recognizer unavailable",
       "surface": "android",
@@ -13051,15 +13307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 596,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
-      "source": "Listening (PTT)",
-      "surface": "android",
-      "id": "native.android.0faf9df3e5f708df"
-    },
-    {
-      "kind": "ui-call",
-      "line": 693,
+      "line": 800,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Ready",
       "surface": "android",
@@ -13067,7 +13315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 911,
+      "line": 1018,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Start failed: $message",
       "surface": "android",
@@ -13075,7 +13323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1001,
+      "line": 1114,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -13083,7 +13331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1070,
+      "line": 1183,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Off",
       "surface": "android",
@@ -13091,7 +13339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1073,
+      "line": 1186,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Talk failed: Realtime provider closed unexpectedly.",
       "surface": "android",
@@ -13099,7 +13347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1078,
+      "line": 1191,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Talk failed: Realtime provider closed: $reason",
       "surface": "android",
@@ -13107,7 +13355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2216,
+      "line": 2546,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Thinking…",
       "surface": "android",
@@ -13115,7 +13363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2233,
+      "line": 2563,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Gateway not connected",
       "surface": "android",
@@ -13123,7 +13371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2246,
+      "line": 2576,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Aborted",
       "surface": "android",
@@ -13131,7 +13379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2246,
+      "line": 2576,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Chat error",
       "surface": "android",
@@ -13139,7 +13387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2263,
+      "line": 2593,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "No reply",
       "surface": "android",
@@ -13147,7 +13395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2279,
+      "line": 2609,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Talk failed: $message",
       "surface": "android",
@@ -13155,7 +13403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2504,
+      "line": 2902,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Generating voice…",
       "surface": "android",
@@ -13163,7 +13411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2532,
+      "line": 2930,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Speak failed: $message",
       "surface": "android",
@@ -13171,7 +13419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2681,
+      "line": 3079,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Speaking…",
       "surface": "android",
@@ -13179,7 +13427,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 2998,
+      "line": 3430,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
+      "source": "Listening (PTT)",
+      "surface": "android",
+      "id": "native.android.0faf9df3e5f708df"
+    },
+    {
+      "kind": "ui-call",
+      "line": 3441,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Microphone permission required",
       "surface": "android",
@@ -13187,7 +13443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3004,
+      "line": 3447,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Audio error",
       "surface": "android",
@@ -13195,7 +13451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3005,
+      "line": 3448,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Client error",
       "surface": "android",
@@ -13203,7 +13459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3006,
+      "line": 3449,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Network error",
       "surface": "android",
@@ -13211,7 +13467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3007,
+      "line": 3450,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Network timeout",
       "surface": "android",
@@ -13219,7 +13475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3009,
+      "line": 3452,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Recognizer busy",
       "surface": "android",
@@ -13227,7 +13483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3010,
+      "line": 3453,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Server error",
       "surface": "android",
@@ -13235,7 +13491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3011,
+      "line": 3454,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Listening",
       "surface": "android",
@@ -13243,7 +13499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3012,
+      "line": 3455,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Speech error ($error)",
       "surface": "android",
@@ -13667,7 +13923,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 189,
+      "line": 193,
       "path": "apps/ios/Sources/Camera/CameraController.swift",
       "source": "Camera",
       "surface": "apple",
@@ -13675,7 +13931,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 189,
+      "line": 193,
       "path": "apps/ios/Sources/Camera/CameraController.swift",
       "source": "Microphone",
       "surface": "apple",
@@ -17099,7 +17355,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 181,
+      "line": 182,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Unable to Export Transcript",
       "surface": "apple",
@@ -17107,7 +17363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 185,
+      "line": 186,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "OK",
       "surface": "apple",
@@ -17115,7 +17371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 189,
+      "line": 190,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "OpenClaw could not prepare the Markdown file.",
       "surface": "apple",
@@ -17123,7 +17379,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 211,
+      "line": 212,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "What would you like to work on?",
       "surface": "apple",
@@ -17131,7 +17387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 231,
+      "line": 232,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "The thread attaches once the gateway is ready.",
       "surface": "apple",
@@ -17139,7 +17395,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 319,
+      "line": 320,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Collapsed",
       "surface": "apple",
@@ -17147,7 +17403,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 319,
+      "line": 320,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Expanded",
       "surface": "apple",
@@ -17155,7 +17411,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 389,
+      "line": 390,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Opens Settings / Gateway",
       "surface": "apple",
@@ -17163,7 +17419,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 392,
+      "line": 393,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Hides the gateway status label",
       "surface": "apple",
@@ -17171,7 +17427,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 393,
+      "line": 394,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Shows the full gateway status label",
       "surface": "apple",
@@ -17179,7 +17435,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 412,
+      "line": 413,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Voice off",
       "surface": "apple",
@@ -17187,7 +17443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 553,
+      "line": 576,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "New Chat",
       "surface": "apple",
@@ -17195,7 +17451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 566,
+      "line": 589,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "New Chat in Worktree",
       "surface": "apple",
@@ -17203,7 +17459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 579,
+      "line": 602,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "New Session Options…",
       "surface": "apple",
@@ -17211,7 +17467,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 591,
+      "line": 614,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Threads…",
       "surface": "apple",
@@ -17219,7 +17475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 609,
+      "line": 632,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Background Tasks",
       "surface": "apple",
@@ -17227,7 +17483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 621,
+      "line": 644,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Export Transcript",
       "surface": "apple",
@@ -17235,7 +17491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 634,
+      "line": 657,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Gateway Settings",
       "surface": "apple",
@@ -17243,7 +17499,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 645,
+      "line": 668,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Show reasoning & tool activity",
       "surface": "apple",
@@ -17251,7 +17507,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 654,
+      "line": 677,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Chat actions",
       "surface": "apple",
@@ -17259,7 +17515,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 756,
+      "line": 779,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Connected",
       "surface": "apple",
@@ -17267,7 +17523,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 756,
+      "line": 779,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Unavailable",
       "surface": "apple",
@@ -17275,7 +17531,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 769,
+      "line": 792,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Message %@...",
       "surface": "apple",
@@ -17283,7 +17539,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 774,
+      "line": 797,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Message %@; sends when connected",
       "surface": "apple",
@@ -17291,7 +17547,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 777,
+      "line": 800,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Connect to a gateway",
       "surface": "apple",
@@ -17299,7 +17555,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 866,
+      "line": 889,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Check OpenClaw status",
       "surface": "apple",
@@ -17307,7 +17563,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 867,
+      "line": 890,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Summarize the current OpenClaw status and tell me what needs attention.",
       "surface": "apple",
@@ -17315,7 +17571,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 870,
+      "line": 893,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "What can I control here?",
       "surface": "apple",
@@ -17323,7 +17579,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 871,
+      "line": 894,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Show me which phone controls and device capabilities are available right now.",
       "surface": "apple",
@@ -17331,7 +17587,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 874,
+      "line": 897,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Help me start voice chat",
       "surface": "apple",
@@ -17339,7 +17595,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 875,
+      "line": 898,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Help me start a realtime voice session from this phone.",
       "surface": "apple",
@@ -23659,7 +23915,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4087,
+      "line": 4112,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval needed",
       "surface": "apple",
@@ -23667,7 +23923,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4088,
+      "line": 4113,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Action required",
       "surface": "apple",
@@ -23675,7 +23931,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4803,
+      "line": 4828,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -23683,7 +23939,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4804,
+      "line": 4829,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting...",
       "surface": "apple",
@@ -23691,7 +23947,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5156,
+      "line": 5181,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connected",
       "surface": "apple",
@@ -23699,7 +23955,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5156,
+      "line": 5181,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Offline",
       "surface": "apple",
@@ -23707,7 +23963,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6326,
+      "line": 6351,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "No chat messages yet",
       "surface": "apple",
@@ -23715,7 +23971,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6525,
+      "line": 6550,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting…",
       "surface": "apple",
@@ -23723,7 +23979,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6525,
+      "line": 6550,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting…",
       "surface": "apple",
@@ -23731,7 +23987,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8934,
+      "line": 8959,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval",
       "surface": "apple",
@@ -23739,7 +23995,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8934,
+      "line": 8959,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "This approval was already",
       "surface": "apple",
@@ -23747,7 +24003,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8940,
+      "line": 8965,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "This approval was already set to Always Allow.",
       "surface": "apple",
@@ -23755,7 +24011,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8941,
+      "line": 8966,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval set to Always Allow.",
       "surface": "apple",
@@ -23763,7 +24019,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 10278,
+      "line": 10303,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "\\(urlText.prefix(500))…",
       "surface": "apple",
@@ -25507,7 +25763,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 591,
+      "line": 608,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Gateway relay ready",
       "surface": "apple",
@@ -25515,7 +25771,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 593,
+      "line": 610,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Realtime Voice, Gateway relay ready",
       "surface": "apple",
@@ -25523,7 +25779,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 595,
+      "line": 612,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Listening starts from this phone",
       "surface": "apple",
@@ -25531,7 +25787,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 835,
+      "line": 852,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Off",
       "surface": "apple",
@@ -25539,7 +25795,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 838,
+      "line": 855,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Not active",
       "surface": "apple",
@@ -25547,7 +25803,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1024,
+      "line": 1041,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Requesting permissions…",
       "surface": "apple",
@@ -25555,7 +25811,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1053,
+      "line": 1070,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Start failed: %@",
       "surface": "apple",
@@ -25563,7 +25819,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1309,
+      "line": 1326,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Microphone permission denied",
       "surface": "apple",
@@ -25571,7 +25827,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1319,
+      "line": 1336,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Speech recognition",
       "surface": "apple",
@@ -25579,7 +25835,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1450,
+      "line": 1467,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Offline",
       "surface": "apple",
@@ -25587,7 +25843,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1649,
+      "line": 1666,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Speech error: %@",
       "surface": "apple",
@@ -25595,7 +25851,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1964,
+      "line": 1981,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Gateway not connected",
       "surface": "apple",
@@ -25603,7 +25859,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2008,
+      "line": 2025,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Aborted",
       "surface": "apple",
@@ -25611,7 +25867,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2008,
+      "line": 2025,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Chat error",
       "surface": "apple",
@@ -25619,7 +25875,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 2036,
+      "line": 2053,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Talk failed: %@",
       "surface": "apple",
@@ -25627,7 +25883,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 2140,
+      "line": 2157,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "No reply",
       "surface": "apple",
@@ -25635,7 +25891,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 2232,
+      "line": 2252,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Paused",
       "surface": "apple",
@@ -25643,7 +25899,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 2644,
+      "line": 2664,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Generating voice…",
       "surface": "apple",
@@ -25651,7 +25907,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 2782,
+      "line": 2802,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Speak failed: %@",
       "surface": "apple",
@@ -25659,7 +25915,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 2881,
+      "line": 2901,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Speaking (System)…",
       "surface": "apple",
@@ -25667,7 +25923,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3762,
+      "line": 3782,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "iOS System Voice",
       "surface": "apple",
@@ -25675,7 +25931,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3764,
+      "line": 3784,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Realtime Voice",
       "surface": "apple",
@@ -25683,7 +25939,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3768,
+      "line": 3788,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Gateway Default",
       "surface": "apple",
@@ -25691,7 +25947,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3827,
+      "line": 3847,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Listening (Realtime)",
       "surface": "apple",
@@ -25699,7 +25955,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3829,
+      "line": 3849,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Thinking",
       "surface": "apple",
@@ -25707,7 +25963,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3831,
+      "line": 3851,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Thinking…",
       "surface": "apple",
@@ -25715,7 +25971,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3833,
+      "line": 3853,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Asking OpenClaw",
       "surface": "apple",
@@ -25723,7 +25979,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3835,
+      "line": 3855,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Still asking OpenClaw",
       "surface": "apple",
@@ -25731,7 +25987,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3837,
+      "line": 3857,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Updating OpenClaw",
       "surface": "apple",
@@ -25739,7 +25995,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3839,
+      "line": 3859,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Speaking",
       "surface": "apple",
@@ -25747,7 +26003,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3841,
+      "line": 3861,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Speaking…",
       "surface": "apple",
@@ -25755,7 +26011,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3843,
+      "line": 3863,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Connecting",
       "surface": "apple",
@@ -25763,7 +26019,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3845,
+      "line": 3865,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Connecting realtime…",
       "surface": "apple",
@@ -25771,7 +26027,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3847,
+      "line": 3867,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Waiting for realtime…",
       "surface": "apple",
@@ -25779,7 +26035,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3849,
+      "line": 3869,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Ready",
       "surface": "apple",
@@ -25787,7 +26043,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3851,
+      "line": 3871,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Reconnecting",
       "surface": "apple",
@@ -25795,7 +26051,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3853,
+      "line": 3873,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Reconnecting…",
       "surface": "apple",
@@ -25803,7 +26059,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3855,
+      "line": 3875,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Realtime failed before connecting",
       "surface": "apple",
@@ -25811,7 +26067,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3857,
+      "line": 3877,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Realtime disconnected",
       "surface": "apple",
@@ -25819,7 +26075,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3859,
+      "line": 3879,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "OpenClaw unavailable",
       "surface": "apple",
@@ -25827,7 +26083,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3899,
+      "line": 3919,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "iOS Speech + TTS",
       "surface": "apple",
@@ -25835,7 +26091,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3901,
+      "line": 3921,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Listening",
       "surface": "apple",
@@ -25843,7 +26099,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3905,
+      "line": 3925,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "iOS Speech fallback",
       "surface": "apple",
@@ -25851,7 +26107,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4166,
+      "line": 4186,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Gateway Relay",
       "surface": "apple",
@@ -25859,7 +26115,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4168,
+      "line": 4188,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Native WebRTC",
       "surface": "apple",
@@ -25867,7 +26123,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4169,
+      "line": 4189,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Native",
       "surface": "apple",
@@ -25875,7 +26131,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4230,
+      "line": 4250,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Gateway permission required",
       "surface": "apple",
@@ -25883,7 +26139,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4252,
+      "line": 4272,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Not loaded",
       "surface": "apple",
@@ -25891,7 +26147,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4270,
+      "line": 4290,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Approval requested",
       "surface": "apple",
@@ -25899,7 +26155,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4693,
+      "line": 4729,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Realtime unavailable",
       "surface": "apple",
@@ -25907,7 +26163,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4715,
+      "line": 4751,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Listening (PTT)",
       "surface": "apple",
@@ -36747,6 +37003,78 @@
     },
     {
       "kind": "ui-localized-call",
+      "line": 36,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift",
+      "source": "Switch to back camera",
+      "surface": "apple",
+      "id": "native.apple.fc5931c1f0a6bbec"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 38,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift",
+      "source": "Switch to front camera",
+      "surface": "apple",
+      "id": "native.apple.cce3b539e31701c0"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 40,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift",
+      "source": "Flip camera",
+      "surface": "apple",
+      "id": "native.apple.f397daffdfd02ee0"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 73,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift",
+      "source": "Stop",
+      "surface": "apple",
+      "id": "native.apple.11f8de87ca3fcb11"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 73,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift",
+      "source": "Talk",
+      "surface": "apple",
+      "id": "native.apple.7c92bec1c8a83e43"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 118,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift",
+      "source": "Start realtime chat",
+      "surface": "apple",
+      "id": "native.apple.dae61543f9b416ca"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 118,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift",
+      "source": "Stop realtime chat",
+      "surface": "apple",
+      "id": "native.apple.d376b015a90792a9"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 203,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift",
+      "source": "Connecting...",
+      "surface": "apple",
+      "id": "native.apple.ac48dbe25ac4d40d"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 203,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift",
+      "source": "Gateway connected",
+      "surface": "apple",
+      "id": "native.apple.ccce98756eb1dacd"
+    },
+    {
+      "kind": "ui-localized-call",
       "line": 415,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Context %@%% used",
@@ -36899,31 +37227,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 813,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
-      "source": "Talk",
-      "surface": "apple",
-      "id": "native.apple.ee2c0d22f5861159"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 884,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
-      "source": "Start realtime chat",
-      "surface": "apple",
-      "id": "native.apple.5d5041aefe6dfddd"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 884,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
-      "source": "Stop realtime chat",
-      "surface": "apple",
-      "id": "native.apple.21a7d3a3386a2218"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 918,
+      "line": 821,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Start",
       "surface": "apple",
@@ -36931,7 +37235,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 918,
+      "line": 821,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop",
       "surface": "apple",
@@ -36939,7 +37243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1048,
+      "line": 932,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Loading commands",
       "surface": "apple",
@@ -36947,7 +37251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1057,
+      "line": 941,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Commands unavailable",
       "surface": "apple",
@@ -36955,7 +37259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1066,
+      "line": 950,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Retry",
       "surface": "apple",
@@ -36963,7 +37267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1075,
+      "line": 959,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "No matching commands",
       "surface": "apple",
@@ -36971,7 +37275,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1307,
+      "line": 1191,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop response",
       "surface": "apple",
@@ -36979,7 +37283,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1332,
+      "line": 1216,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Send message",
       "surface": "apple",
@@ -36987,7 +37291,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1346,
+      "line": 1230,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -36995,23 +37299,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1471,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
-      "source": "Connecting...",
-      "surface": "apple",
-      "id": "native.apple.6c984c0e3ed3a69e"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 1471,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
-      "source": "Gateway connected",
-      "surface": "apple",
-      "id": "native.apple.898849eb2bcb0b53"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 1480,
+      "line": 1356,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Message…",
       "surface": "apple",
@@ -37283,7 +37571,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 553,
+      "line": 554,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Voice note",
       "surface": "apple",
@@ -37291,7 +37579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 598,
+      "line": 599,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Writing",
       "surface": "apple",
@@ -37299,7 +37587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 624,
+      "line": 625,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Preparing audio…",
       "surface": "apple",
@@ -37307,7 +37595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 627,
+      "line": 628,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Speaking…",
       "surface": "apple",
@@ -37315,7 +37603,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 635,
+      "line": 636,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Preparing audio, tap to cancel",
       "surface": "apple",
@@ -37323,7 +37611,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 636,
+      "line": 637,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Speaking, tap to stop",
       "surface": "apple",
@@ -38419,7 +38707,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 76,
+      "line": 80,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift",
       "source": "Running",
       "surface": "apple",
@@ -38427,7 +38715,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 109,
+      "line": 129,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift",
       "source": "Collapse tool result",
       "surface": "apple",
@@ -38435,7 +38723,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 109,
+      "line": 129,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift",
       "source": "Expand tool result",
       "surface": "apple",
@@ -38443,7 +38731,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 130,
+      "line": 165,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift",
       "source": "Show less",
       "surface": "apple",
@@ -38451,11 +38739,19 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 132,
+      "line": 167,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift",
       "source": "Show all %lld lines",
       "surface": "apple",
       "id": "native.apple.065f4da5ddaf14a1"
+    },
+    {
+      "kind": "ui-call",
+      "line": 256,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift",
+      "source": "Collapsed",
+      "surface": "apple",
+      "id": "native.apple.f80bb83a659d23f4"
     },
     {
       "kind": "conditional-branch",
@@ -38547,7 +38843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1080,
+      "line": 1083,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Copy Message",
       "surface": "apple",
@@ -38555,7 +38851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1103,
+      "line": 1106,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Open Full Message",
       "surface": "apple",
@@ -38563,7 +38859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1122,
+      "line": 1125,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Rewind to Here",
       "surface": "apple",
@@ -38571,7 +38867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1142,
+      "line": 1145,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Fork from Here",
       "surface": "apple",
@@ -38579,7 +38875,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1170,
+      "line": 1173,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Reply",
       "surface": "apple",
@@ -38587,7 +38883,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1180,
+      "line": 1183,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "You",
       "surface": "apple",
@@ -38595,7 +38891,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1182,
+      "line": 1185,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Assistant",
       "surface": "apple",
@@ -38603,7 +38899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1248,
+      "line": 1251,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Loading chat",
       "surface": "apple",
@@ -38611,7 +38907,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1328,
+      "line": 1331,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Dismiss",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -539,7 +539,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 464,
+      "line": 466,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Searching…",
       "surface": "android",
@@ -547,7 +547,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 586,
+      "line": 592,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Mic off",
       "surface": "android",
@@ -555,7 +555,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 600,
+      "line": 606,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Off",
       "surface": "android",
@@ -835,7 +835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1964,
+      "line": 1978,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This automation already has a queued run.",
       "surface": "android",
@@ -843,7 +843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1994,
+      "line": 2008,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation run queued.",
       "surface": "android",
@@ -851,7 +851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1994,
+      "line": 2008,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation started.",
       "surface": "android",
@@ -859,7 +859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2007,
+      "line": 2021,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway rejected the automation run.",
       "surface": "android",
@@ -867,7 +867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2038,
+      "line": 2052,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation enabled.",
       "surface": "android",
@@ -875,7 +875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2038,
+      "line": 2052,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation paused.",
       "surface": "android",
@@ -883,7 +883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2060,
+      "line": 2074,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This automation changed on the gateway. Review the latest version before saving again.",
       "surface": "android",
@@ -891,7 +891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2066,
+      "line": 2080,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation updated.",
       "surface": "android",
@@ -899,7 +899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2081,
+      "line": 2095,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation deleted.",
       "surface": "android",
@@ -907,7 +907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2286,
+      "line": 2300,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Node offline. Reconnect and retry.",
       "surface": "android",
@@ -915,7 +915,7 @@
     },
     {
       "kind": "ui-named-argument-concatenated",
-      "line": 2297,
+      "line": 2311,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Restore canvas now for session=$sessionKey source=$source. If existing A2UI state exists, replay it immediately. If not, create and render a compact mobile-friendly dashboard in Canvas.",
       "surface": "android",
@@ -923,7 +923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2318,
+      "line": 2332,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed to request restore. Tap to retry.",
       "surface": "android",
@@ -931,7 +931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2329,
+      "line": 2343,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "No canvas update yet. Tap to retry.",
       "surface": "android",
@@ -939,7 +939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3273,
+      "line": 3301,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect to a Gateway to save wake words",
       "surface": "android",
@@ -947,7 +947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3301,
+      "line": 3329,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Wake words saved",
       "surface": "android",
@@ -955,7 +955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3310,
+      "line": 3338,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not save wake words",
       "surface": "android",
@@ -963,7 +963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4002,
+      "line": 4031,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: no secure gateway endpoint was detected. Enable gateway TLS or Tailscale Serve, or use a trusted private LAN address with Unencrypted selected.",
       "surface": "android",
@@ -971,7 +971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4006,
+      "line": 4035,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -979,7 +979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4010,
+      "line": 4039,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -987,7 +987,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 4054,
+      "line": 4083,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -995,7 +995,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 4237,
+      "line": 4266,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Offline",
       "surface": "android",
@@ -1003,7 +1003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4971,
+      "line": 5000,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load provider catalog.",
       "surface": "android",
@@ -1011,7 +1011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5002,
+      "line": 5031,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Update your Gateway to view provider model config.",
       "surface": "android",
@@ -1019,7 +1019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5004,
+      "line": 5033,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load provider model config.",
       "surface": "android",
@@ -1027,7 +1027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5020,
+      "line": 5049,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Provider models loaded, but readiness is unavailable.",
       "surface": "android",
@@ -1035,7 +1035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5107,
+      "line": 5136,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automations.",
       "surface": "android",
@@ -1043,7 +1043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5193,
+      "line": 5222,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect automations.",
       "surface": "android",
@@ -1051,7 +1051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5203,
+      "line": 5232,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway returned an invalid automation.",
       "surface": "android",
@@ -1059,7 +1059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5207,
+      "line": 5236,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automation.",
       "surface": "android",
@@ -1067,7 +1067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5219,
+      "line": 5248,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect automation run history.",
       "surface": "android",
@@ -1075,7 +1075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5250,
+      "line": 5279,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automation run history.",
       "surface": "android",
@@ -1083,7 +1083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5267,
+      "line": 5296,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron changes require operator.admin access.",
       "surface": "android",
@@ -1091,7 +1091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5276,
+      "line": 5305,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to manage automations.",
       "surface": "android",
@@ -1099,7 +1099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5288,
+      "line": 5317,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Another cron action is still finishing.",
       "surface": "android",
@@ -1107,7 +1107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5335,
+      "line": 5364,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron action failed.",
       "surface": "android",
@@ -1115,7 +1115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5462,
+      "line": 5491,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load usage.",
       "surface": "android",
@@ -1123,7 +1123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5497,
+      "line": 5526,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load skills.",
       "surface": "android",
@@ -1131,7 +1131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5510,
+      "line": 5539,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to update skills.",
       "surface": "android",
@@ -1139,7 +1139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5514,
+      "line": 5543,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This gateway connection needs operator.admin to update skills.",
       "surface": "android",
@@ -1147,7 +1147,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5529,
+      "line": 5558,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not disable skill.",
       "surface": "android",
@@ -1155,7 +1155,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5529,
+      "line": 5558,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not enable skill.",
       "surface": "android",
@@ -1163,7 +1163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5547,
+      "line": 5576,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to search ClawHub skills.",
       "surface": "android",
@@ -1171,7 +1171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5593,
+      "line": 5622,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not search ClawHub skills.",
       "surface": "android",
@@ -1179,7 +1179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5606,
+      "line": 5635,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect ClawHub skills.",
       "surface": "android",
@@ -1187,7 +1187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5639,
+      "line": 5668,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "ClawHub did not return an installable version for ${skill.slug}.",
       "surface": "android",
@@ -1195,7 +1195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5655,
+      "line": 5684,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load ClawHub details for ${skill.slug}.",
       "surface": "android",
@@ -1203,7 +1203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5671,
+      "line": 5700,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to install ClawHub skills.",
       "surface": "android",
@@ -1211,7 +1211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5687,
+      "line": 5716,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This gateway connection needs operator.admin to install ClawHub skills.",
       "surface": "android",
@@ -1219,7 +1219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5777,
+      "line": 5806,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Installed $slug.",
       "surface": "android",
@@ -1227,7 +1227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5784,
+      "line": 5813,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not install ${slug} from ClawHub.",
       "surface": "android",
@@ -1235,7 +1235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5824,
+      "line": 5853,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to load Skill Workshop proposals.",
       "surface": "android",
@@ -1243,7 +1243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5864,
+      "line": 5893,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load Skill Workshop proposals.",
       "surface": "android",
@@ -1251,7 +1251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5884,
+      "line": 5913,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect Skill Workshop proposals.",
       "surface": "android",
@@ -1259,7 +1259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5936,
+      "line": 5965,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not inspect Skill Workshop proposal.",
       "surface": "android",
@@ -1267,7 +1267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5956,
+      "line": 5985,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Skill Workshop proposal actions require operator.admin scope.",
       "surface": "android",
@@ -1275,7 +1275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5961,
+      "line": 5990,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to update Skill Workshop proposals.",
       "surface": "android",
@@ -1283,7 +1283,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 6120,
+      "line": 6149,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected",
       "surface": "android",
@@ -1291,7 +1291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6146,
+      "line": 6175,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load nodes and devices.",
       "surface": "android",
@@ -1299,7 +1299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6804,
+      "line": 6833,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load channels.",
       "surface": "android",
@@ -1307,7 +1307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6834,
+      "line": 6863,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load dreaming.",
       "surface": "android",
@@ -1315,7 +1315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6871,
+      "line": 6900,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load gateway logs.",
       "surface": "android",
@@ -1323,7 +1323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7328,
+      "line": 7357,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "One time",
       "surface": "android",
@@ -1331,7 +1331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7337,
+      "line": 7366,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron",
       "surface": "android",
@@ -1339,7 +1339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7338,
+      "line": 7367,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Scheduled",
       "surface": "android",
@@ -1347,7 +1347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7346,
+      "line": 7375,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${days}d",
       "surface": "android",
@@ -1355,7 +1355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7347,
+      "line": 7376,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${hours}h",
       "surface": "android",
@@ -1363,7 +1363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7348,
+      "line": 7377,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${minutes}m",
       "surface": "android",
@@ -1371,7 +1371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7349,
+      "line": 7378,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Repeating",
       "surface": "android",
@@ -1379,7 +1379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7365,
+      "line": 7394,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "No prompt",
       "surface": "android",
@@ -1387,7 +1387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7382,
+      "line": 7411,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway",
       "surface": "android",
@@ -1395,7 +1395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7390,
+      "line": 7419,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected to $gatewayLabel",
       "surface": "android",
@@ -1403,7 +1403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7391,
+      "line": 7420,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Your agents are ready",
       "surface": "android",
@@ -1411,7 +1411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7393,
+      "line": 7422,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This phone stays dormant until the gateway needs it, then wakes, syncs, and goes back to sleep.",
       "surface": "android",
@@ -1419,7 +1419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7397,
+      "line": 7426,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Selected on this phone",
       "surface": "android",
@@ -1427,7 +1427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7400,
+      "line": 7429,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The overview refreshes on reconnect and when this screen opens.",
       "surface": "android",
@@ -1435,7 +1435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7405,
+      "line": 7434,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Reconnecting",
       "surface": "android",
@@ -1443,7 +1443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7406,
+      "line": 7435,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "OpenClaw is syncing back up",
       "surface": "android",
@@ -1451,7 +1451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7408,
+      "line": 7437,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The gateway session is coming back online. Agent shortcuts should settle automatically in a moment.",
       "surface": "android",
@@ -1459,7 +1459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7412,
+      "line": 7441,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway session in progress",
       "surface": "android",
@@ -1467,7 +1467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7415,
+      "line": 7444,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "If the gateway is reachable, reconnect should complete without intervention.",
       "surface": "android",
@@ -1475,7 +1475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7420,
+      "line": 7449,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Welcome to OpenClaw",
       "surface": "android",
@@ -1483,7 +1483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7421,
+      "line": 7450,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Your phone stays quiet until it is needed",
       "surface": "android",
@@ -1491,7 +1491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7423,
+      "line": 7452,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Pair this device to your gateway to wake it only for real work, keep a live agent overview handy, and avoid battery-draining background loops.",
       "surface": "android",
@@ -1499,7 +1499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7427,
+      "line": 7456,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect to load your agents",
       "surface": "android",
@@ -1507,7 +1507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7430,
+      "line": 7459,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "When connected, the gateway can wake the phone with a silent push instead of holding an always-on session.",
       "surface": "android",
@@ -1515,7 +1515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7462,
+      "line": 7491,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Main",
       "surface": "android",
@@ -1523,7 +1523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7477,
+      "line": 7506,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Active on this phone",
       "surface": "android",
@@ -1531,7 +1531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7478,
+      "line": 7507,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Default agent",
       "surface": "android",
@@ -1539,7 +1539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7479,
+      "line": 7508,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Ready",
       "surface": "android",
@@ -1547,7 +1547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8038,
+      "line": 8067,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Dream",
       "surface": "android",
@@ -1755,7 +1755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3152,
+      "line": 3173,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Could not stage an attachment for sending.",
       "surface": "android",
@@ -1763,7 +1763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3185,
+      "line": 3206,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Offline queue is full ($OUTBOX_MAX_QUEUED messages); delete queued items first.",
       "surface": "android",
@@ -1771,7 +1771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3191,
+      "line": 3212,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Attachments are too large to queue for one message; remove some and try again.",
       "surface": "android",
@@ -1779,7 +1779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3197,
+      "line": 3218,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Offline attachment storage is full; delete queued items first.",
       "surface": "android",
@@ -1787,7 +1787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3202,
+      "line": 3223,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Gateway health not OK; cannot send",
       "surface": "android",
@@ -1795,7 +1795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3209,
+      "line": 3230,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Could not queue message for later delivery.",
       "surface": "android",
@@ -1803,7 +1803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3926,
+      "line": 3947,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Chat failed",
       "surface": "android",
@@ -1811,7 +1811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4064,
+      "line": 4085,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Event stream interrupted; try refreshing.",
       "surface": "android",
@@ -1819,7 +1819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4201,
+      "line": 4222,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Timed out waiting for a reply; try again or refresh.",
       "surface": "android",
@@ -1827,7 +1827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4411,
+      "line": 4432,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Timed out confirming the sent message; refresh to check delivery.",
       "surface": "android",
@@ -1843,7 +1843,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1530,
+      "line": 1563,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -1851,7 +1851,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1530,
+      "line": 1563,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Reconnecting…",
       "surface": "android",
@@ -2253,9 +2253,9 @@
       "kind": "ui-call",
       "line": 95,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
-      "source": "Browse Sessions",
+      "source": "Browse Threads",
       "surface": "android",
-      "id": "native.android.5876e15e5e92fd45"
+      "id": "native.android.e2cf5a38587382cb"
     },
     {
       "kind": "ui-call",
@@ -2341,33 +2341,33 @@
       "kind": "ui-call",
       "line": 146,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
-      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
+      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
       "surface": "android",
-      "id": "native.android.48ad0ae0e930e02b"
+      "id": "native.android.bc70a4ac965b82ba"
     },
     {
       "kind": "ui-call",
       "line": 155,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
-      "source": "Sessions",
+      "source": "Threads",
       "surface": "android",
-      "id": "native.android.d4fbd1ee4f55a5db"
+      "id": "native.android.670121e54dbe286f"
     },
     {
       "kind": "ui-call",
       "line": 162,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
-      "source": "Connect the Gateway to search sessions.",
+      "source": "Connect the Gateway to search threads.",
       "surface": "android",
-      "id": "native.android.207c2170504e99e6"
+      "id": "native.android.d38be650b1bce4a0"
     },
     {
       "kind": "ui-call",
       "line": 162,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
-      "source": "No matching sessions yet.",
+      "source": "No matching threads yet.",
       "surface": "android",
-      "id": "native.android.25d2c2d792c952fe"
+      "id": "native.android.3d7754721f776ef8"
     },
     {
       "kind": "ui-call",
@@ -2381,17 +2381,17 @@
       "kind": "ui-call",
       "line": 177,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
-      "source": "OpenClaw session",
+      "source": "OpenClaw thread",
       "surface": "android",
-      "id": "native.android.8f8384286317f5c9"
+      "id": "native.android.9a839f6e3e05a744"
     },
     {
       "kind": "ui-call",
       "line": 310,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
-      "source": "Open session",
+      "source": "Open thread",
       "surface": "android",
-      "id": "native.android.15799e57704b20c6"
+      "id": "native.android.d83f82a1e4a5ed99"
     },
     {
       "kind": "ui-call",
@@ -2429,9 +2429,9 @@
       "kind": "ui-call",
       "line": 377,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
-      "source": "Main session",
+      "source": "Main thread",
       "surface": "android",
-      "id": "native.android.73e6ab1a168fd381"
+      "id": "native.android.8a1c5365c0538908"
     },
     {
       "kind": "ui-call",
@@ -5661,17 +5661,17 @@
       "kind": "ui-call",
       "line": 186,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "Sessions",
+      "source": "Threads",
       "surface": "android",
-      "id": "native.android.0e3157c15c56944f"
+      "id": "native.android.a5845742daecb4ba"
     },
     {
       "kind": "ui-call",
       "line": 189,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "Focus session search",
+      "source": "Focus thread search",
       "surface": "android",
-      "id": "native.android.70f5d0507d34b5c8"
+      "id": "native.android.439b324280869527"
     },
     {
       "kind": "ui-call",
@@ -5693,17 +5693,17 @@
       "kind": "ui-call",
       "line": 211,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "Search sessions",
+      "source": "Search threads",
       "surface": "android",
-      "id": "native.android.b9cf34c137e4cf03"
+      "id": "native.android.03981341841b04ac"
     },
     {
       "kind": "ui-call",
       "line": 216,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "Clear session search",
+      "source": "Clear thread search",
       "surface": "android",
-      "id": "native.android.10cb26723e9990fc"
+      "id": "native.android.99570c528a41fa72"
     },
     {
       "kind": "ui-call",
@@ -5733,9 +5733,9 @@
       "kind": "ui-call",
       "line": 285,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "Toggle session layout",
+      "source": "Toggle thread layout",
       "surface": "android",
-      "id": "native.android.c6bf8751e2a7f5c7"
+      "id": "native.android.fd67be543e321cc9"
     },
     {
       "kind": "ui-call",
@@ -5757,17 +5757,17 @@
       "kind": "ui-call",
       "line": 300,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "Searching sessions",
+      "source": "Searching threads",
       "surface": "android",
-      "id": "native.android.69b79a3c2c987cd4"
+      "id": "native.android.ebd17565e0ffd8eb"
     },
     {
       "kind": "ui-call",
       "line": 303,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "No matching sessions",
+      "source": "No matching threads",
       "surface": "android",
-      "id": "native.android.dd587d341af44212"
+      "id": "native.android.472d46ae8669f860"
     },
     {
       "kind": "ui-call",
@@ -5797,25 +5797,25 @@
       "kind": "ui-call",
       "line": 342,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "Current session",
+      "source": "Current thread",
       "surface": "android",
-      "id": "native.android.f10d4df7cbc6df4f"
+      "id": "native.android.ff81ad1bee00d384"
     },
     {
       "kind": "ui-call",
       "line": 342,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "OpenClaw session",
+      "source": "OpenClaw thread",
       "surface": "android",
-      "id": "native.android.8f0482425838ae64"
+      "id": "native.android.fc145645b9620e57"
     },
     {
       "kind": "ui-call",
       "line": 397,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "Rename session",
+      "source": "Rename thread",
       "surface": "android",
-      "id": "native.android.786774c8a76e50d7"
+      "id": "native.android.71cbb8dde8bf138b"
     },
     {
       "kind": "ui-call",
@@ -5861,25 +5861,25 @@
       "kind": "ui-call",
       "line": 477,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
+      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
       "surface": "android",
-      "id": "native.android.3455fc2f77d564e3"
+      "id": "native.android.691e92cfe5cf106e"
     },
     {
       "kind": "ui-call",
       "line": 500,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "Delete session?",
+      "source": "Delete thread?",
       "surface": "android",
-      "id": "native.android.4805fb9d6623e8c0"
+      "id": "native.android.d87a8217ab56999b"
     },
     {
       "kind": "ui-call",
       "line": 501,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "This permanently deletes the session and its transcript.",
+      "source": "This permanently deletes the thread and its transcript.",
       "surface": "android",
-      "id": "native.android.0c3283a2b2445eae"
+      "id": "native.android.930de97ff47113a8"
     },
     {
       "kind": "ui-call",
@@ -6077,25 +6077,25 @@
       "kind": "ui-call",
       "line": 958,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "No sessions yet",
+      "source": "No threads yet",
       "surface": "android",
-      "id": "native.android.db243d71d056afa4"
+      "id": "native.android.8e21a70428def6e0"
     },
     {
       "kind": "ui-call",
       "line": 959,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "No current session",
+      "source": "No current thread",
       "surface": "android",
-      "id": "native.android.5b4eee6a8092925e"
+      "id": "native.android.cda4c5ad8b17e394"
     },
     {
       "kind": "ui-call",
       "line": 960,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "No archived sessions",
+      "source": "No archived threads",
       "surface": "android",
-      "id": "native.android.acbcc9c9ea53d8c0"
+      "id": "native.android.be84f061047aa2da"
     },
     {
       "kind": "ui-call",
@@ -6109,17 +6109,17 @@
       "kind": "ui-call",
       "line": 967,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "Open Chat to start or resume the current session.",
+      "source": "Open Chat to start or resume the current thread.",
       "surface": "android",
-      "id": "native.android.56fcd605dc7be3c0"
+      "id": "native.android.f289d03e1d3eee98"
     },
     {
       "kind": "ui-call",
       "line": 968,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "Archived sessions will show up here.",
+      "source": "Archived threads will show up here.",
       "surface": "android",
-      "id": "native.android.085515989f8a2022"
+      "id": "native.android.504b71386e76c6ae"
     },
     {
       "kind": "ui-call",
@@ -6157,13 +6157,13 @@
       "kind": "ui-call",
       "line": 990,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "Main session",
+      "source": "Main thread",
       "surface": "android",
-      "id": "native.android.3d4fa07acbc015c5"
+      "id": "native.android.ee4c727cdafbe963"
     },
     {
       "kind": "ui-call",
-      "line": 251,
+      "line": 255,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Provider limits and quota health.",
       "surface": "android",
@@ -6171,7 +6171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 251,
+      "line": 255,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Usage",
       "surface": "android",
@@ -6179,7 +6179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 255,
+      "line": 259,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Providers",
       "surface": "android",
@@ -6187,7 +6187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 271,
+      "line": 275,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load usage.",
       "surface": "android",
@@ -6195,7 +6195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 276,
+      "line": 280,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No usage data yet.",
       "surface": "android",
@@ -6203,7 +6203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 277,
+      "line": 281,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Provider limits will appear here when your gateway reports them.",
       "surface": "android",
@@ -6211,7 +6211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 316,
+      "line": 320,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scheduled OpenClaw work from your gateway.",
       "surface": "android",
@@ -6219,7 +6219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 321,
+      "line": 325,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Automations",
       "surface": "android",
@@ -6227,7 +6227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 329,
+      "line": 333,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Search automations",
       "surface": "android",
@@ -6235,7 +6235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 330,
+      "line": 334,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Search",
       "surface": "android",
@@ -6243,7 +6243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 346,
+      "line": 350,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open an automation to inspect its configuration and run history. Admin-scoped connections can also run, edit, enable, disable, or delete it.",
       "surface": "android",
@@ -6251,7 +6251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 356,
+      "line": 360,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load automations.",
       "surface": "android",
@@ -6259,7 +6259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 361,
+      "line": 365,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No automations yet.",
       "surface": "android",
@@ -6267,7 +6267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 362,
+      "line": 366,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scheduled work created on the gateway will appear here.",
       "surface": "android",
@@ -6275,7 +6275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 367,
+      "line": 371,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No matching automations.",
       "surface": "android",
@@ -6283,7 +6283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 466,
+      "line": 470,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Automation",
       "surface": "android",
@@ -6291,7 +6291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 467,
+      "line": 471,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Inspect and manage scheduled gateway work.",
       "surface": "android",
@@ -6299,7 +6299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 488,
+      "line": 492,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to inspect automations.",
       "surface": "android",
@@ -6307,7 +6307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 496,
+      "line": 500,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Automation not loaded.",
       "surface": "android",
@@ -6315,7 +6315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 496,
+      "line": 500,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Loading automation…",
       "surface": "android",
@@ -6323,7 +6323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 547,
+      "line": 551,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Choose and inspect the assistants available on this gateway.",
       "surface": "android",
@@ -6331,7 +6331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 551,
+      "line": 555,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Available",
       "surface": "android",
@@ -6339,7 +6339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 558,
+      "line": 562,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load agents.",
       "surface": "android",
@@ -6347,7 +6347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 562,
+      "line": 566,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No agents loaded yet.",
       "surface": "android",
@@ -6355,7 +6355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 589,
+      "line": 593,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Approvals",
       "surface": "android",
@@ -6363,7 +6363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 589,
+      "line": 593,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Review actions that need your attention.",
       "surface": "android",
@@ -6371,7 +6371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 593,
+      "line": 597,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway Pending",
       "surface": "android",
@@ -6379,15 +6379,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 594,
+      "line": 598,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
-      "source": "Session Activity",
+      "source": "Thread Activity",
       "surface": "android",
-      "id": "native.android.2d8d049afe99f751"
+      "id": "native.android.da78209effb11cfd"
     },
     {
       "kind": "ui-call",
-      "line": 595,
+      "line": 599,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Issues",
       "surface": "android",
@@ -6395,7 +6395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 596,
+      "line": 600,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Active Runs",
       "surface": "android",
@@ -6403,7 +6403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 600,
+      "line": 604,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Refresh",
       "surface": "android",
@@ -6411,7 +6411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 600,
+      "line": 604,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Refreshing",
       "surface": "android",
@@ -6419,7 +6419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 618,
+      "line": 622,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway disconnected.",
       "surface": "android",
@@ -6427,7 +6427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 619,
+      "line": 623,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load approval requests in the app.",
       "surface": "android",
@@ -6435,7 +6435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 625,
+      "line": 629,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No gateway approvals.",
       "surface": "android",
@@ -6443,7 +6443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 626,
+      "line": 630,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Exec approval requests will appear here while this phone is connected.",
       "surface": "android",
@@ -6451,23 +6451,23 @@
     },
     {
       "kind": "ui-call",
-      "line": 636,
+      "line": 640,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
-      "source": "Session activity",
+      "source": "Thread activity",
       "surface": "android",
-      "id": "native.android.dc3e7ca5a491103a"
+      "id": "native.android.f615712dfb56319a"
     },
     {
       "kind": "ui-call",
-      "line": 637,
+      "line": 641,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
-      "source": "Chat tool calls waiting in the active session remain visible here.",
+      "source": "Chat tool calls waiting in the active thread remain visible here.",
       "surface": "android",
-      "id": "native.android.8551e02b060bd7d8"
+      "id": "native.android.6c93973c13db43ae"
     },
     {
       "kind": "ui-call",
-      "line": 651,
+      "line": 655,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "How this phone appears to OpenClaw.",
       "surface": "android",
@@ -6475,7 +6475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 651,
+      "line": 655,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Profile",
       "surface": "android",
@@ -6483,7 +6483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 654,
+      "line": 658,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Device name",
       "surface": "android",
@@ -6491,7 +6491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 655,
+      "line": 659,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Save Profile",
       "surface": "android",
@@ -6499,7 +6499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 703,
+      "line": 718,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Configure wake words, talk, and playback.",
       "surface": "android",
@@ -6507,7 +6507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 703,
+      "line": 718,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Voice",
       "surface": "android",
@@ -6515,7 +6515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 705,
+      "line": 720,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Voice Wake",
       "surface": "android",
@@ -6523,7 +6523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 710,
+      "line": 725,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Listen for wake words",
       "surface": "android",
@@ -6531,7 +6531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 713,
+      "line": 728,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Runs on-device while OpenClaw is visible.",
       "surface": "android",
@@ -6539,7 +6539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 715,
+      "line": 730,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "On-device speech recognition is unavailable.",
       "surface": "android",
@@ -6547,7 +6547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 725,
+      "line": 740,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Wake listener",
       "surface": "android",
@@ -6555,7 +6555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 727,
+      "line": 742,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last command: $command",
       "surface": "android",
@@ -6563,7 +6563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 728,
+      "line": 743,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Pauses during other voice activity.",
       "surface": "android",
@@ -6571,7 +6571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 735,
+      "line": 750,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Wake words",
       "surface": "android",
@@ -6579,7 +6579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 737,
+      "line": 752,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Add one wake word or phrase per field. Then say one before your command.",
       "surface": "android",
@@ -6587,7 +6587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 752,
+      "line": 767,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Wake word or phrase",
       "surface": "android",
@@ -6595,7 +6595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 759,
+      "line": 774,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Remove wake phrase",
       "surface": "android",
@@ -6603,7 +6603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 768,
+      "line": 783,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Add wake phrase",
       "surface": "android",
@@ -6611,7 +6611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 775,
+      "line": 790,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Save wake words",
       "surface": "android",
@@ -6619,7 +6619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 775,
+      "line": 790,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Saving…",
       "surface": "android",
@@ -6627,7 +6627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 780,
+      "line": 795,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect to a Gateway to save wake words",
       "surface": "android",
@@ -6635,7 +6635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 785,
+      "line": 800,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Talk Provider Setup",
       "surface": "android",
@@ -6643,7 +6643,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 787,
+      "line": 802,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Microphone",
+      "surface": "android",
+      "id": "native.android.23b638094c34b916"
+    },
+    {
+      "kind": "ui-call",
+      "line": 809,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Audio Test",
       "surface": "android",
@@ -6651,7 +6659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 788,
+      "line": 810,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check that OpenClaw can speak clearly on this phone.",
       "surface": "android",
@@ -6659,7 +6667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 791,
+      "line": 813,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enable speaker",
       "surface": "android",
@@ -6667,7 +6675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 791,
+      "line": 813,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Mute speaker",
       "surface": "android",
@@ -6675,7 +6683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 792,
+      "line": 814,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Assistant speech muted",
       "surface": "android",
@@ -6683,7 +6691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 792,
+      "line": 814,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replies play aloud",
       "surface": "android",
@@ -6691,7 +6699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 794,
+      "line": 816,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Muted",
       "surface": "android",
@@ -6699,7 +6707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 794,
+      "line": 816,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "On",
       "surface": "android",
@@ -6707,7 +6715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 798,
+      "line": 820,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Done",
       "surface": "android",
@@ -6715,7 +6723,103 @@
     },
     {
       "kind": "ui-call",
-      "line": 808,
+      "line": 838,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Automatic",
+      "surface": "android",
+      "id": "native.android.8d9ecdfdd916b780"
+    },
+    {
+      "kind": "ui-call",
+      "line": 841,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Preferred microphone unavailable; using automatic routing.",
+      "surface": "android",
+      "id": "native.android.c1626a6700a570f6"
+    },
+    {
+      "kind": "ui-call",
+      "line": 843,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Prioritizes connected Bluetooth microphones.",
+      "surface": "android",
+      "id": "native.android.820bc5d0ce571d8b"
+    },
+    {
+      "kind": "ui-call",
+      "line": 852,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Preferred microphone",
+      "surface": "android",
+      "id": "native.android.11e48038d5e8bff6"
+    },
+    {
+      "kind": "ui-call",
+      "line": 853,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Unavailable",
+      "surface": "android",
+      "id": "native.android.eaa4d7563a46d307"
+    },
+    {
+      "kind": "ui-call",
+      "line": 885,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Next session",
+      "surface": "android",
+      "id": "native.android.9f5ebf17eb405ba8"
+    },
+    {
+      "kind": "ui-call",
+      "line": 907,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Built-in microphone",
+      "surface": "android",
+      "id": "native.android.8c4e91f53928efb2"
+    },
+    {
+      "kind": "ui-call",
+      "line": 908,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Bluetooth microphone",
+      "surface": "android",
+      "id": "native.android.14b613cb6e2446b4"
+    },
+    {
+      "kind": "ui-call",
+      "line": 909,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Bluetooth LE microphone",
+      "surface": "android",
+      "id": "native.android.c885247b2d7ce271"
+    },
+    {
+      "kind": "ui-call",
+      "line": 910,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Wired headset microphone",
+      "surface": "android",
+      "id": "native.android.b6a4e674c5fb441a"
+    },
+    {
+      "kind": "ui-call",
+      "line": 914,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "USB microphone",
+      "surface": "android",
+      "id": "native.android.9c8becb3b0fb5a90"
+    },
+    {
+      "kind": "ui-call",
+      "line": 915,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "External microphone",
+      "surface": "android",
+      "id": "native.android.ba46258fadec7a39"
+    },
+    {
+      "kind": "ui-call",
+      "line": 923,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Realtime Talk",
       "surface": "android",
@@ -6723,7 +6827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 809,
+      "line": 924,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Dictation",
       "surface": "android",
@@ -6731,7 +6835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 979,
+      "line": 1094,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Choose what reaches OpenClaw.",
       "surface": "android",
@@ -6739,7 +6843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 979,
+      "line": 1094,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Notifications",
       "surface": "android",
@@ -6747,7 +6851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 983,
+      "line": 1098,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Alerts stay on this phone.",
       "surface": "android",
@@ -6755,7 +6859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 983,
+      "line": 1098,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forward Notifications",
       "surface": "android",
@@ -6763,7 +6867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 983,
+      "line": 1098,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw can receive selected alerts.",
       "surface": "android",
@@ -6771,7 +6875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 985,
+      "line": 1100,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Quiet Hours",
       "surface": "android",
@@ -6779,7 +6883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 986,
+      "line": 1101,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$quietStart to $quietEnd",
       "surface": "android",
@@ -6787,7 +6891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 998,
+      "line": 1113,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Policy",
       "surface": "android",
@@ -6795,7 +6899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 999,
+      "line": 1114,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Selected Apps",
       "surface": "android",
@@ -6803,7 +6907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1000,
+      "line": 1115,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Rate Limit",
       "surface": "android",
@@ -6811,7 +6915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1001,
+      "line": 1116,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Granted",
       "surface": "android",
@@ -6819,7 +6923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1001,
+      "line": 1116,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup",
       "surface": "android",
@@ -6827,7 +6931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1006,
+      "line": 1121,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check Access",
       "surface": "android",
@@ -6835,7 +6939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1006,
+      "line": 1121,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open System Access",
       "surface": "android",
@@ -6843,7 +6947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1015,
+      "line": 1130,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forwarding Mode",
       "surface": "android",
@@ -6851,7 +6955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1017,
+      "line": 1132,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Blocklist",
       "surface": "android",
@@ -6859,7 +6963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1021,
+      "line": 1136,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allowlist",
       "surface": "android",
@@ -6867,7 +6971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1070,
+      "line": 1185,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App Filter",
       "surface": "android",
@@ -6875,7 +6979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1077,
+      "line": 1192,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Close App Picker",
       "surface": "android",
@@ -6883,7 +6987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1077,
+      "line": 1192,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open App Picker",
       "surface": "android",
@@ -6891,7 +6995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1082,
+      "line": 1197,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Search apps",
       "surface": "android",
@@ -6899,7 +7003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1085,
+      "line": 1200,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Show System Apps",
       "surface": "android",
@@ -6907,7 +7011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1086,
+      "line": 1201,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Include Android and background packages.",
       "surface": "android",
@@ -6915,7 +7019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1093,
+      "line": 1208,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No matching apps.",
       "surface": "android",
@@ -6923,7 +7027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1104,
+      "line": 1219,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Showing ${visibleApps.size} of ${apps.size}. Refine search for more.",
       "surface": "android",
@@ -6931,7 +7035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1351,
+      "line": 1466,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Choose what this phone can share.",
       "surface": "android",
@@ -6939,7 +7043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1351,
+      "line": 1466,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Phone Capabilities",
       "surface": "android",
@@ -6947,7 +7051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1355,
+      "line": 1470,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow camera tools when requested.",
       "surface": "android",
@@ -6955,7 +7059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1355,
+      "line": 1470,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Camera",
       "surface": "android",
@@ -6963,7 +7067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1356,
+      "line": 1471,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Precise Location",
       "surface": "android",
@@ -6971,7 +7075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1356,
+      "line": 1471,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Share precise location while location is enabled.",
       "surface": "android",
@@ -6979,7 +7083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1359,
+      "line": 1474,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Photos",
       "surface": "android",
@@ -6987,7 +7091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1360,
+      "line": 1475,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow photo library access.",
       "surface": "android",
@@ -6995,7 +7099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1360,
+      "line": 1475,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Selected or full photo access granted.",
       "surface": "android",
@@ -7003,7 +7107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1369,
+      "line": 1484,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Installed Apps",
       "surface": "android",
@@ -7011,7 +7115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1370,
+      "line": 1485,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App list stays on this phone.",
       "surface": "android",
@@ -7019,7 +7123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1370,
+      "line": 1485,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw can list launcher-visible apps.",
       "surface": "android",
@@ -7027,7 +7131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1375,
+      "line": 1490,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Keep Awake",
       "surface": "android",
@@ -7035,7 +7139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1375,
+      "line": 1490,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Keep the node available during active work.",
       "surface": "android",
@@ -7043,7 +7147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1376,
+      "line": 1491,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Canvas Status",
       "surface": "android",
@@ -7051,7 +7155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1376,
+      "line": 1491,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Show screen-sharing debug state.",
       "surface": "android",
@@ -7059,7 +7163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1381,
+      "line": 1496,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Location",
       "surface": "android",
@@ -7067,7 +7171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1389,
+      "line": 1504,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Always allows requested location checks while OpenClaw is in the background; Android shows this in the persistent node notification.",
       "surface": "android",
@@ -7075,7 +7179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1424,
+      "line": 1539,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow background location?",
       "surface": "android",
@@ -7083,7 +7187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1427,
+      "line": 1542,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background.",
       "surface": "android",
@@ -7091,7 +7195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1441,
+      "line": 1556,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open Settings",
       "surface": "android",
@@ -7099,7 +7203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1460,
+      "line": 1575,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Share installed app information?",
       "surface": "android",
@@ -7107,7 +7211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1464,
+      "line": 1579,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw collects and sends the names, package IDs, and status of apps visible on this phone when your paired OpenClaw Gateway asks for them. This lets your assistant answer questions and take actions using installed apps.",
       "surface": "android",
@@ -7115,7 +7219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1467,
+      "line": 1582,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Your phone sends this information to your Gateway, not to a server run by OpenClaw. Your Gateway may include it in requests to the AI provider you chose.",
       "surface": "android",
@@ -7123,7 +7227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1473,
+      "line": 1588,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agree and Enable",
       "surface": "android",
@@ -7131,7 +7235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1478,
+      "line": 1593,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not Now",
       "surface": "android",
@@ -7139,7 +7243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1531,
+      "line": 1646,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replace gateway setup?",
       "surface": "android",
@@ -7147,7 +7251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1546,
+      "line": 1661,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replace setup",
       "surface": "android",
@@ -7155,7 +7259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1560,
+      "line": 1675,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "this gateway",
       "surface": "android",
@@ -7163,7 +7267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1563,
+      "line": 1678,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forget gateway?",
       "surface": "android",
@@ -7171,7 +7275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1566,
+      "line": 1681,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Remove $gatewayName and its saved credentials from this phone?",
       "surface": "android",
@@ -7179,7 +7283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1583,
+      "line": 1698,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Cancel",
       "surface": "android",
@@ -7187,7 +7291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1621,
+      "line": 1736,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection between this phone and OpenClaw.",
       "surface": "android",
@@ -7195,7 +7299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1635,
+      "line": 1750,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connected",
       "surface": "android",
@@ -7203,7 +7307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1635,
+      "line": 1750,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection",
       "surface": "android",
@@ -7211,7 +7315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1635,
+      "line": 1750,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Offline",
       "surface": "android",
@@ -7219,7 +7323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1636,
+      "line": 1751,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not paired",
       "surface": "android",
@@ -7227,7 +7331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1636,
+      "line": 1751,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Online",
       "surface": "android",
@@ -7235,7 +7339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1638,
+      "line": 1753,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Access",
       "surface": "android",
@@ -7243,7 +7347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1645,
+      "line": 1760,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Address",
       "surface": "android",
@@ -7251,7 +7355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1650,
+      "line": 1765,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Discovered",
       "surface": "android",
@@ -7259,7 +7363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1651,
+      "line": 1766,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default Agent",
       "surface": "android",
@@ -7267,7 +7371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1652,
+      "line": 1767,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agents",
       "surface": "android",
@@ -7275,7 +7379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1653,
+      "line": 1768,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Instance ID",
       "surface": "android",
@@ -7283,7 +7387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1659,
+      "line": 1774,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scan QR to Pair",
       "surface": "android",
@@ -7291,7 +7395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1669,
+      "line": 1784,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Limited Gateway access",
       "surface": "android",
@@ -7299,7 +7403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1682,
+      "line": 1797,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Reconnect",
       "surface": "android",
@@ -7307,7 +7411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1683,
+      "line": 1798,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Disconnect",
       "surface": "android",
@@ -7315,7 +7419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1686,
+      "line": 1801,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Diagnose",
       "surface": "android",
@@ -7323,7 +7427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1699,
+      "line": 1814,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Add Gateway",
       "surface": "android",
@@ -7331,7 +7435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1701,
+      "line": 1816,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scan or paste a setup code to add another gateway.",
       "surface": "android",
@@ -7339,7 +7443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1707,
+      "line": 1822,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scan QR",
       "surface": "android",
@@ -7347,7 +7451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1708,
+      "line": 1823,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup code",
       "surface": "android",
@@ -7355,7 +7459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1711,
+      "line": 1826,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Where do I get a setup code?",
       "surface": "android",
@@ -7363,7 +7467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1715,
+      "line": 1830,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Android can scan or paste an existing setup code, but this gateway does not expose setup-code generation to the app yet. Generate the QR/code on the gateway host with openclaw qr, then scan it here or paste the setup code below.",
       "surface": "android",
@@ -7371,7 +7475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1722,
+      "line": 1837,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No gateways found yet. Use manual setup if discovery is blocked.",
       "surface": "android",
@@ -7379,7 +7483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1735,
+      "line": 1850,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect",
       "surface": "android",
@@ -7387,7 +7491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1746,
+      "line": 1861,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateways",
       "surface": "android",
@@ -7395,7 +7499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1748,
+      "line": 1863,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No paired gateways.",
       "surface": "android",
@@ -7403,7 +7507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1768,
+      "line": 1883,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forget",
       "surface": "android",
@@ -7411,7 +7515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1784,
+      "line": 1899,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Manual Gateway",
       "surface": "android",
@@ -7419,7 +7523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1786,
+      "line": 1901,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Host",
       "surface": "android",
@@ -7427,7 +7531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1787,
+      "line": 1902,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Port",
       "surface": "android",
@@ -7435,7 +7539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1789,
+      "line": 1904,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection security",
       "surface": "android",
@@ -7443,7 +7547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1793,
+      "line": 1908,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Unencrypted",
       "surface": "android",
@@ -7451,7 +7555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1797,
+      "line": 1912,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Secure (TLS)",
       "surface": "android",
@@ -7459,7 +7563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1810,
+      "line": 1925,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Token",
       "surface": "android",
@@ -7467,7 +7571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1811,
+      "line": 1926,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Bootstrap",
       "surface": "android",
@@ -7475,7 +7579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1813,
+      "line": 1928,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Password",
       "surface": "android",
@@ -7483,7 +7587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1818,
+      "line": 1933,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Save & Connect",
       "surface": "android",
@@ -7491,7 +7595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1835,
+      "line": 1950,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enter a valid setup code or gateway address.",
       "surface": "android",
@@ -7499,7 +7603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1856,
+      "line": 1971,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not available",
       "surface": "android",
@@ -7507,7 +7611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1857,
+      "line": 1972,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Full",
       "surface": "android",
@@ -7515,7 +7619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1858,
+      "line": 1973,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Limited",
       "surface": "android",
@@ -7523,7 +7627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1862,
+      "line": 1977,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Use a secure wss:// or Tailscale Serve Gateway, generate a full-access setup code in the Control UI or with openclaw qr, then scan or paste it below and reconnect to enable settings and upgrades.",
       "surface": "android",
@@ -7531,7 +7635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1876,
+      "line": 1991,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Appearance",
       "surface": "android",
@@ -7539,7 +7643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1876,
+      "line": 1991,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Theme and translated Android text.",
       "surface": "android",
@@ -7547,7 +7651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1881,
+      "line": 1996,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Language",
       "surface": "android",
@@ -7555,7 +7659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1882,
+      "line": 1997,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Contrast",
       "surface": "android",
@@ -7563,7 +7667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1882,
+      "line": 1997,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "High",
       "surface": "android",
@@ -7571,7 +7675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1883,
+      "line": 1998,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Readable",
       "surface": "android",
@@ -7579,7 +7683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1883,
+      "line": 1998,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Typography",
       "surface": "android",
@@ -7587,7 +7691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1888,
+      "line": 2003,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Theme",
       "surface": "android",
@@ -7595,7 +7699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1898,
+      "line": 2013,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App language",
       "surface": "android",
@@ -7603,7 +7707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1932,
+      "line": 2047,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Selected",
       "surface": "android",
@@ -7611,7 +7715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1944,
+      "line": 2059,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "System",
       "surface": "android",
@@ -7619,7 +7723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1972,
+      "line": 2087,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "While Using",
       "surface": "android",
@@ -7627,7 +7731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1973,
+      "line": 2088,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Always",
       "surface": "android",
@@ -7635,7 +7739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1985,
+      "line": 2100,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connecting...",
       "surface": "android",
@@ -7643,7 +7747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1986,
+      "line": 2101,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Pairing needed",
       "surface": "android",
@@ -7651,7 +7755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1987,
+      "line": 2102,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Authentication needed",
       "surface": "android",
@@ -7659,7 +7763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1988,
+      "line": 2103,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "TLS timed out",
       "surface": "android",
@@ -7667,7 +7771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1989,
+      "line": 2104,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No TLS endpoint",
       "surface": "android",
@@ -7675,7 +7779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1990,
+      "line": 2105,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Certificate review needed",
       "surface": "android",
@@ -7683,7 +7787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1991,
+      "line": 2106,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Cannot reach gateway",
       "surface": "android",
@@ -7691,7 +7795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2012,
+      "line": 2127,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "About",
       "surface": "android",
@@ -7699,7 +7803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2012,
+      "line": 2127,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw for Android.",
       "surface": "android",
@@ -7707,7 +7811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2024,
+      "line": 2139,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Channel",
       "surface": "android",
@@ -7715,7 +7819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2025,
+      "line": 2140,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not connected",
       "surface": "android",
@@ -7723,7 +7827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2030,
+      "line": 2145,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Home Gateway",
       "surface": "android",
@@ -7731,7 +7835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2032,
+      "line": 2147,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Runtime",
       "surface": "android",
@@ -7739,7 +7843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2032,
+      "line": 2147,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting",
       "surface": "android",
@@ -7747,7 +7851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2035,
+      "line": 2150,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Update",
       "surface": "android",
@@ -7755,7 +7859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2036,
+      "line": 2151,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Up to date",
       "surface": "android",
@@ -7763,7 +7867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2036,
+      "line": 2151,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "v$it available",
       "surface": "android",
@@ -7771,7 +7875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2046,
+      "line": 2161,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "© 2026 OpenClaw Foundation — MIT License.",
       "surface": "android",
@@ -7779,7 +7883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2063,
+      "line": 2178,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw logo",
       "surface": "android",
@@ -7787,7 +7891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2065,
+      "line": 2180,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -7795,7 +7899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2066,
+      "line": 2181,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Personal AI on your devices",
       "surface": "android",
@@ -7803,7 +7907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2125,
+      "line": 2240,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Licenses",
       "surface": "android",
@@ -7811,7 +7915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2126,
+      "line": 2241,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw appreciates its partners in the open-source community.",
       "surface": "android",
@@ -7819,7 +7923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2135,
+      "line": 2250,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No license notices are packaged in this build.",
       "surface": "android",
@@ -7827,7 +7931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2161,
+      "line": 2276,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open ${license.title}",
       "surface": "android",
@@ -7835,7 +7939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2172,
+      "line": 2287,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Third-party",
       "surface": "android",
@@ -7843,7 +7947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2173,
+      "line": 2288,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Unknown",
       "surface": "android",
@@ -7851,7 +7955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2179,
+      "line": 2294,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Website",
       "surface": "android",
@@ -7859,7 +7963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2180,
+      "line": 2295,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Docs",
       "surface": "android",
@@ -7867,7 +7971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2184,
+      "line": 2299,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow all the time",
       "surface": "android",
@@ -7875,7 +7979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2187,
+      "line": 2302,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code.",
       "surface": "android",
@@ -7883,7 +7987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2206,
+      "line": 2321,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check",
       "surface": "android",
@@ -7891,15 +7995,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 2213,
+      "line": 2328,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
       "surface": "android",
-      "id": "native.android.5a540761383fa474"
+      "id": "native.android.c971506716c96e91"
     },
     {
       "kind": "ui-call",
-      "line": 2215,
+      "line": 2330,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready.",
       "surface": "android",
@@ -7907,7 +8011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2240,
+      "line": 2355,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Back",
       "surface": "android",
@@ -7915,7 +8019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2314,
+      "line": 2429,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Command approval",
       "surface": "android",
@@ -7923,7 +8027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2319,
+      "line": 2434,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Sending",
       "surface": "android",
@@ -7931,7 +8035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2379,
+      "line": 2494,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow Once",
       "surface": "android",
@@ -7939,7 +8043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2380,
+      "line": 2495,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow Always",
       "surface": "android",
@@ -7947,7 +8051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2381,
+      "line": 2496,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Deny",
       "surface": "android",
@@ -7955,7 +8059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2402,
+      "line": 2517,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Approval ${notice.approvalId}",
       "surface": "android",
@@ -7963,7 +8067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2409,
+      "line": 2524,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Dismiss approval notice",
       "surface": "android",
@@ -7971,7 +8075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2428,
+      "line": 2543,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Review",
       "surface": "android",
@@ -7979,7 +8083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2468,
+      "line": 2583,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open automation detail",
       "surface": "android",
@@ -7987,7 +8091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2511,
+      "line": 2626,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enabled",
       "surface": "android",
@@ -7995,7 +8099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2511,
+      "line": 2626,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Status",
       "surface": "android",
@@ -8003,7 +8107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2512,
+      "line": 2627,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Schedule",
       "surface": "android",
@@ -8011,7 +8115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2513,
+      "line": 2628,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Next Wake",
       "surface": "android",
@@ -8019,7 +8123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2514,
+      "line": 2629,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last Run",
       "surface": "android",
@@ -8027,7 +8131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2521,
+      "line": 2636,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Description",
       "surface": "android",
@@ -8035,7 +8139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2522,
+      "line": 2637,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Schedule Detail",
       "surface": "android",
@@ -8043,7 +8147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2523,
+      "line": 2638,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Session Target",
       "surface": "android",
@@ -8051,7 +8155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2524,
+      "line": 2639,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Wake Mode",
       "surface": "android",
@@ -8059,7 +8163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2525,
+      "line": 2640,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Delete After Run",
       "surface": "android",
@@ -8067,7 +8171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2525,
+      "line": 2640,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No",
       "surface": "android",
@@ -8075,7 +8179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2525,
+      "line": 2640,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Yes",
       "surface": "android",
@@ -8083,7 +8187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2526,
+      "line": 2641,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Payload",
       "surface": "android",
@@ -8091,7 +8195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2527,
+      "line": 2642,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Delivery",
       "surface": "android",
@@ -8099,7 +8203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2528,
+      "line": 2643,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Failure Alert",
       "surface": "android",
@@ -8107,7 +8211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2529,
+      "line": 2644,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Created",
       "surface": "android",
@@ -8115,7 +8219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2530,
+      "line": 2645,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Updated",
       "surface": "android",
@@ -8123,7 +8227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2531,
+      "line": 2646,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Running Since",
       "surface": "android",
@@ -8131,7 +8235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2532,
+      "line": 2647,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last Status",
       "surface": "android",
@@ -8139,7 +8243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2534,
+      "line": 2649,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last Duration",
       "surface": "android",
@@ -8147,7 +8251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2535,
+      "line": 2650,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${durationMs}ms",
       "surface": "android",
@@ -8155,7 +8259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2537,
+      "line": 2652,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Consecutive Errors",
       "surface": "android",
@@ -8163,7 +8267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2538,
+      "line": 2653,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Consecutive Skips",
       "surface": "android",
@@ -8171,7 +8275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2539,
+      "line": 2654,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Delivery Status",
       "surface": "android",
@@ -8179,7 +8283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2546,
+      "line": 2661,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last Error",
       "surface": "android",
@@ -8187,7 +8291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2549,
+      "line": 2664,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Delivery Error",
       "surface": "android",
@@ -8195,7 +8299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2565,
+      "line": 2680,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Copy ${row.title}",
       "surface": "android",
@@ -8203,7 +8307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2590,
+      "line": 2705,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Tap to copy",
       "surface": "android",
@@ -8211,7 +8315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2605,
+      "line": 2720,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$title copied",
       "surface": "android",
@@ -8219,7 +8323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2643,
+      "line": 2758,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default assistant",
       "surface": "android",
@@ -8227,7 +8331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2649,
+      "line": 2764,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default",
       "surface": "android",
@@ -8235,7 +8339,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2657,
+      "line": 2772,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${endpoint.host}:${endpoint.port}",
       "surface": "android",
@@ -8243,7 +8347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2703,
+      "line": 2818,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Action Request",
       "surface": "android",
@@ -8251,7 +8355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2711,
+      "line": 2826,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Needs attention",
       "surface": "android",
@@ -8259,7 +8363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2714,
+      "line": 2829,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting ${minutes}m",
       "surface": "android",
@@ -8267,7 +8371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2714,
+      "line": 2829,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting for review",
       "surface": "android",
@@ -8275,7 +8379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2725,
+      "line": 2840,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Node ${nodeId}",
       "surface": "android",
@@ -8283,7 +8387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2727,
+      "line": 2842,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Node",
       "surface": "android",
@@ -8291,7 +8395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2730,
+      "line": 2845,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway",
       "surface": "android",
@@ -8299,7 +8403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2735,
+      "line": 2850,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agent ${agentId}",
       "surface": "android",
@@ -8307,7 +8411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2740,
+      "line": 2855,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting ${duration}",
       "surface": "android",
@@ -8315,7 +8419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2745,
+      "line": 2860,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Expires ${duration}",
       "surface": "android",
@@ -8323,7 +8427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2755,
+      "line": 2870,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "soon",
       "surface": "android",
@@ -8331,7 +8435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2763,
+      "line": 2878,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Main",
       "surface": "android",
@@ -8339,7 +8443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2764,
+      "line": 2879,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Isolated",
       "surface": "android",
@@ -8347,7 +8451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2765,
+      "line": 2880,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Current",
       "surface": "android",
@@ -8355,7 +8459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2771,
+      "line": 2886,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}",
       "surface": "android",
@@ -8363,7 +8467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2787,
+      "line": 2902,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "All",
       "surface": "android",
@@ -8371,7 +8475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2788,
+      "line": 2903,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Active",
       "surface": "android",
@@ -8379,7 +8483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2789,
+      "line": 2904,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Paused",
       "surface": "android",
@@ -8387,7 +8491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2822,
+      "line": 2937,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${remaining}% left ${label}",
       "surface": "android",
@@ -8395,7 +8499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2825,
+      "line": 2940,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No limits reported",
       "surface": "android",
@@ -8403,7 +8507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2836,
+      "line": 2951,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Never",
       "surface": "android",
@@ -8411,7 +8515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2841,
+      "line": 2956,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Now",
       "surface": "android",
@@ -8419,7 +8523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2863,
+      "line": 2978,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Off",
       "surface": "android",
@@ -8427,7 +8531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2865,
+      "line": 2980,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Issue",
       "surface": "android",
@@ -8435,7 +8539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2867,
+      "line": 2982,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Skipped",
       "surface": "android",
@@ -8443,7 +8547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2868,
+      "line": 2983,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Ready",
       "surface": "android",
@@ -8451,7 +8555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2884,
+      "line": 2999,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "System Event Text",
       "surface": "android",
@@ -8459,7 +8563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2885,
+      "line": 3000,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agent Prompt",
       "surface": "android",
@@ -8467,7 +8571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2886,
+      "line": 3001,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Command",
       "surface": "android",
@@ -8475,7 +8579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2887,
+      "line": 3002,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Payload Text",
       "surface": "android",
@@ -8483,7 +8587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2917,
+      "line": 3032,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No apps selected. Nothing forwards until you add apps.",
       "surface": "android",
@@ -8491,7 +8595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2919,
+      "line": 3034,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$selectedCount app allowed to forward.",
       "surface": "android",
@@ -8499,7 +8603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2921,
+      "line": 3036,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$selectedCount apps allowed to forward.",
       "surface": "android",
@@ -8507,7 +8611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2925,
+      "line": 3040,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No apps blocked. Apps can forward unless you add blocks.",
       "surface": "android",
@@ -8515,7 +8619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2927,
+      "line": 3042,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$selectedCount app blocked from forwarding.",
       "surface": "android",
@@ -8523,7 +8627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2929,
+      "line": 3044,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$selectedCount apps blocked from forwarding.",
       "surface": "android",
@@ -8531,7 +8635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2955,
+      "line": 3070,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Due",
       "surface": "android",
@@ -8539,7 +8643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2960,
+      "line": 3075,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${days}d",
       "surface": "android",
@@ -8547,7 +8651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2961,
+      "line": 3076,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${hours}h",
       "surface": "android",
@@ -8555,7 +8659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2962,
+      "line": 3077,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${minutes}m",
       "surface": "android",
@@ -8563,7 +8667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2963,
+      "line": 3078,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Soon",
       "surface": "android",
@@ -8571,7 +8675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2968,
+      "line": 3083,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "None",
       "surface": "android",
@@ -8741,9 +8845,9 @@
       "kind": "ui-call",
       "line": 927,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
-      "source": "Recent Sessions",
+      "source": "Recent Threads",
       "surface": "android",
-      "id": "native.android.73f07a5d54915259"
+      "id": "native.android.36f78c8c85dc283f"
     },
     {
       "kind": "ui-call",
@@ -8837,17 +8941,17 @@
       "kind": "ui-call",
       "line": 1109,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
-      "source": "Sessions",
+      "source": "Threads",
       "surface": "android",
-      "id": "native.android.16c3425d3a594481"
+      "id": "native.android.57177017a6a93826"
     },
     {
       "kind": "ui-call",
       "line": 1111,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
-      "source": "No recent sessions",
+      "source": "No recent threads",
       "surface": "android",
-      "id": "native.android.a5c0f8b3112aa58c"
+      "id": "native.android.43320b54a68b00a1"
     },
     {
       "kind": "ui-call",
@@ -8909,17 +9013,17 @@
       "kind": "ui-call",
       "line": 1183,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
-      "source": "Monitoring · 1 session",
+      "source": "Monitoring · 1 thread",
       "surface": "android",
-      "id": "native.android.2c89da708b12a522"
+      "id": "native.android.e24db059480f1e6a"
     },
     {
       "kind": "ui-call",
       "line": 1184,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
-      "source": "Monitoring · $sessionCount sessions",
+      "source": "Monitoring · $sessionCount threads",
       "surface": "android",
-      "id": "native.android.8b6ee382dcb64e1f"
+      "id": "native.android.5a475f37d80e02bc"
     },
     {
       "kind": "ui-call",
@@ -8973,9 +9077,9 @@
       "kind": "ui-call",
       "line": 1487,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
-      "source": "Open session",
+      "source": "Open thread",
       "surface": "android",
-      "id": "native.android.a65477861c7203aa"
+      "id": "native.android.358c5e0e838d5423"
     },
     {
       "kind": "ui-call",
@@ -9653,9 +9757,9 @@
       "kind": "ui-call",
       "line": 2055,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
-      "source": "Main session",
+      "source": "Main thread",
       "surface": "android",
-      "id": "native.android.22d755834386db07"
+      "id": "native.android.28a1a1acc5a0959f"
     },
     {
       "kind": "ui-call",
@@ -10611,7 +10715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 220,
+      "line": 244,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Your voice command center.",
       "surface": "android",
@@ -10619,7 +10723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 324,
+      "line": 348,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Transcribe then send",
       "surface": "android",
@@ -10627,7 +10731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 326,
+      "line": 350,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Dictation settings",
       "surface": "android",
@@ -10635,7 +10739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 337,
+      "line": 361,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Sending to chat...",
       "surface": "android",
@@ -10643,7 +10747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 337,
+      "line": 361,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Start speaking...",
       "surface": "android",
@@ -10651,7 +10755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 369,
+      "line": 393,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Speech provider",
       "surface": "android",
@@ -10659,7 +10763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 421,
+      "line": 445,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Tip: stop listening to send the captured turn.",
       "surface": "android",
@@ -10667,7 +10771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 431,
+      "line": 455,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Cancel",
       "surface": "android",
@@ -10675,7 +10779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 432,
+      "line": 456,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Send to Chat",
       "surface": "android",
@@ -10683,7 +10787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 463,
+      "line": 490,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Back to voice",
       "surface": "android",
@@ -10691,7 +10795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 472,
+      "line": 499,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "OpenClaw speaking",
       "surface": "android",
@@ -10699,7 +10803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 474,
+      "line": 501,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Realtime voice",
       "surface": "android",
@@ -10707,7 +10811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 476,
+      "line": 503,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Connected",
       "surface": "android",
@@ -10715,7 +10819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 483,
+      "line": 510,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Talk settings",
       "surface": "android",
@@ -10723,7 +10827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 507,
+      "line": 534,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Live transcript",
       "surface": "android",
@@ -10731,7 +10835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 518,
+      "line": 545,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Mute",
       "surface": "android",
@@ -10739,7 +10843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 518,
+      "line": 545,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Unmute",
       "surface": "android",
@@ -10747,7 +10851,23 @@
     },
     {
       "kind": "ui-call",
-      "line": 524,
+      "line": 552,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
+      "source": "Back camera",
+      "surface": "android",
+      "id": "native.android.cb608d82c5b3352a"
+    },
+    {
+      "kind": "ui-call",
+      "line": 552,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
+      "source": "Front camera",
+      "surface": "android",
+      "id": "native.android.e89a0e780eed2e1e"
+    },
+    {
+      "kind": "ui-call",
+      "line": 559,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "End",
       "surface": "android",
@@ -10755,7 +10875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 547,
+      "line": 582,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Listening for your next turn.",
       "surface": "android",
@@ -10763,7 +10883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 555,
+      "line": 590,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Listening response...",
       "surface": "android",
@@ -10771,7 +10891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 642,
+      "line": 677,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Search voice",
       "surface": "android",
@@ -10779,7 +10899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 650,
+      "line": 685,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Voice",
       "surface": "android",
@@ -10787,7 +10907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 661,
+      "line": 696,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Mute speaker",
       "surface": "android",
@@ -10795,7 +10915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 661,
+      "line": 696,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Unmute speaker",
       "surface": "android",
@@ -10803,7 +10923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 706,
+      "line": 741,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "OpenClaw is replying",
       "surface": "android",
@@ -10811,7 +10931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 709,
+      "line": 744,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Dictation is listening",
       "surface": "android",
@@ -10819,7 +10939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 740,
+      "line": 775,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Realtime Talk",
       "surface": "android",
@@ -10827,7 +10947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 743,
+      "line": 778,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Conversation is live",
       "surface": "android",
@@ -10835,7 +10955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 752,
+      "line": 787,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Dictation",
       "surface": "android",
@@ -10843,7 +10963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 752,
+      "line": 787,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Stop Dictation",
       "surface": "android",
@@ -10851,7 +10971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 755,
+      "line": 790,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Listening for one turn",
       "surface": "android",
@@ -10859,7 +10979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 757,
+      "line": 792,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Connect gateway to start",
       "surface": "android",
@@ -10867,7 +10987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 774,
+      "line": 809,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "End Talk",
       "surface": "android",
@@ -10875,7 +10995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 775,
+      "line": 810,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Set Up Talk",
       "surface": "android",
@@ -10883,7 +11003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 776,
+      "line": 811,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Start Talk",
       "surface": "android",
@@ -10891,7 +11011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 777,
+      "line": 812,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Connect Gateway",
       "surface": "android",
@@ -10899,7 +11019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 889,
+      "line": 924,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Voice setup",
       "surface": "android",
@@ -10907,7 +11027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 921,
+      "line": 956,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Ready",
       "surface": "android",
@@ -10915,7 +11035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 922,
+      "line": 957,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Setup",
       "surface": "android",
@@ -10923,7 +11043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 923,
+      "line": 958,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Attention",
       "surface": "android",
@@ -10931,7 +11051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 924,
+      "line": 959,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Unverified",
       "surface": "android",
@@ -10939,7 +11059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 925,
+      "line": 960,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Offline",
       "surface": "android",
@@ -10947,7 +11067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 943,
+      "line": 978,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Talk: ${gatewayTalkSetupDescription(readiness.realtimeTalk)}",
       "surface": "android",
@@ -10955,7 +11075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 944,
+      "line": 979,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Dictation: ${gatewayTalkSetupDescription(readiness.dictation)}",
       "surface": "android",
@@ -10963,7 +11083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1050,
+      "line": 1085,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -10971,7 +11091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1050,
+      "line": 1085,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "You",
       "surface": "android",
@@ -10979,7 +11099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1057,
+      "line": 1092,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Listening...",
       "surface": "android",
@@ -10987,7 +11107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1073,
+      "line": 1108,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Sending",
       "surface": "android",
@@ -10995,7 +11115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1075,
+      "line": 1110,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "OpenClaw is preparing a response.",
       "surface": "android",
@@ -11003,7 +11123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1090,
+      "line": 1125,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Permission needed",
       "surface": "android",
@@ -11011,7 +11131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1091,
+      "line": 1126,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Microphone access is needed.",
       "surface": "android",
@@ -11019,7 +11139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1093,
+      "line": 1128,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "OpenClaw only listens when you start Talk or Dictation.",
       "surface": "android",
@@ -11027,7 +11147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1097,
+      "line": 1132,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Enable Microphone",
       "surface": "android",
@@ -11035,7 +11155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1165,
+      "line": 1200,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "OpenClaw is speaking",
       "surface": "android",
@@ -11043,7 +11163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1167,
+      "line": 1202,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Talk is live",
       "surface": "android",
@@ -11051,7 +11171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1168,
+      "line": 1203,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Sending dictation",
       "surface": "android",
@@ -11059,7 +11179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1169,
+      "line": 1204,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Listening",
       "surface": "android",
@@ -11067,7 +11187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1170,
+      "line": 1205,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "$micQueuedMessages queued",
       "surface": "android",
@@ -11075,7 +11195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1171,
+      "line": 1206,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Gateway offline",
       "surface": "android",
@@ -11083,7 +11203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1172,
+      "line": 1207,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Ready to talk",
       "surface": "android",
@@ -11091,7 +11211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1227,
+      "line": 1262,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Realtime voice provider is not configured.",
       "surface": "android",
@@ -11099,7 +11219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1230,
+      "line": 1265,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Realtime transcription provider is not configured.",
       "surface": "android",
@@ -11107,7 +11227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1233,
+      "line": 1268,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Microphone permission is required.",
       "surface": "android",
@@ -11115,7 +11235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1243,
+      "line": 1278,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Connected and ready",
       "surface": "android",
@@ -11123,7 +11243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1243,
+      "line": 1278,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceScreen.kt",
       "source": "Gateway not connected",
       "surface": "android",
@@ -12037,9 +12157,9 @@
       "kind": "ui-call",
       "line": 1144,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Loading session",
+      "source": "Loading thread",
       "surface": "android",
-      "id": "native.android.882cc14a58e7e105"
+      "id": "native.android.0c74bc30a994dd33"
     },
     {
       "kind": "ui-call",
@@ -12109,17 +12229,17 @@
       "kind": "ui-call",
       "line": 1299,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Summarize recent sessions and next steps.",
+      "source": "Summarize recent threads and next steps.",
       "surface": "android",
-      "id": "native.android.1e5add56e48c99f9"
+      "id": "native.android.cf40df9739f78f27"
     },
     {
       "kind": "ui-call",
       "line": 1300,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
+      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
       "surface": "android",
-      "id": "native.android.06d515351bb79576"
+      "id": "native.android.ebe49a8b8df80bd3"
     },
     {
       "kind": "ui-call",
@@ -12661,9 +12781,9 @@
       "kind": "ui-named-argument",
       "line": 615,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
-      "source": "Sessions",
+      "source": "Threads",
       "surface": "android",
-      "id": "native.android.81931886b9caf3ab"
+      "id": "native.android.6cf5d6fa8a4186d5"
     },
     {
       "kind": "ui-named-argument",
@@ -12779,7 +12899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 232,
+      "line": 236,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Speaking · waiting for reply",
       "surface": "android",
@@ -12787,7 +12907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 232,
+      "line": 236,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Speaking…",
       "surface": "android",
@@ -12795,7 +12915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 374,
+      "line": 378,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Voice request failed",
       "surface": "android",
@@ -12803,7 +12923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 384,
+      "line": 388,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Response aborted",
       "surface": "android",
@@ -12811,7 +12931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 398,
+      "line": 402,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Microphone permission required",
       "surface": "android",
@@ -12819,7 +12939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 403,
+      "line": 407,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Mic on · waiting for gateway",
       "surface": "android",
@@ -12827,7 +12947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 428,
+      "line": 432,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Transcription unavailable: $message",
       "surface": "android",
@@ -12835,7 +12955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 467,
+      "line": 471,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Mic off · sending…",
       "surface": "android",
@@ -12843,7 +12963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 520,
+      "line": 524,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Mic off",
       "surface": "android",
@@ -12851,7 +12971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 533,
+      "line": 537,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Sending queued voice",
       "surface": "android",
@@ -12859,7 +12979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 558,
+      "line": 562,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Send failed: Chat failed before the run started; try again.",
       "surface": "android",
@@ -12867,7 +12987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 580,
+      "line": 584,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Send failed: $message",
       "surface": "android",
@@ -12875,7 +12995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 601,
+      "line": 605,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Voice reply timed out; retrying queued turn",
       "surface": "android",
@@ -12883,7 +13003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 621,
+      "line": 625,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "${queuedMessageCount()} queued · waiting for gateway",
       "surface": "android",
@@ -12891,7 +13011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 817,
+      "line": 833,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Transcription failed: $message",
       "surface": "android",
@@ -12899,7 +13019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 824,
+      "line": 840,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Listening · sending queued voice",
       "surface": "android",
@@ -12907,7 +13027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 825,
+      "line": 841,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Listening · ${queuedMessageCount()} queued",
       "surface": "android",
@@ -12915,7 +13035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 826,
+      "line": 842,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Listening",
       "surface": "android",
@@ -12923,7 +13043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 529,
+      "line": 532,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Speech recognizer unavailable",
       "surface": "android",
@@ -12931,7 +13051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 593,
+      "line": 596,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Listening (PTT)",
       "surface": "android",
@@ -12939,7 +13059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 690,
+      "line": 693,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Ready",
       "surface": "android",
@@ -12947,7 +13067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 908,
+      "line": 911,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Start failed: $message",
       "surface": "android",
@@ -12955,7 +13075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 998,
+      "line": 1001,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -12963,7 +13083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1067,
+      "line": 1070,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Off",
       "surface": "android",
@@ -12971,7 +13091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1070,
+      "line": 1073,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Talk failed: Realtime provider closed unexpectedly.",
       "surface": "android",
@@ -12979,7 +13099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1075,
+      "line": 1078,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Talk failed: Realtime provider closed: $reason",
       "surface": "android",
@@ -12987,7 +13107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2201,
+      "line": 2216,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Thinking…",
       "surface": "android",
@@ -12995,7 +13115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2218,
+      "line": 2233,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Gateway not connected",
       "surface": "android",
@@ -13003,7 +13123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2231,
+      "line": 2246,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Aborted",
       "surface": "android",
@@ -13011,7 +13131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2231,
+      "line": 2246,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Chat error",
       "surface": "android",
@@ -13019,7 +13139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2248,
+      "line": 2263,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "No reply",
       "surface": "android",
@@ -13027,7 +13147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2264,
+      "line": 2279,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Talk failed: $message",
       "surface": "android",
@@ -13035,7 +13155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2489,
+      "line": 2504,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Generating voice…",
       "surface": "android",
@@ -13043,7 +13163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2517,
+      "line": 2532,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Speak failed: $message",
       "surface": "android",
@@ -13051,7 +13171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2666,
+      "line": 2681,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Speaking…",
       "surface": "android",
@@ -13059,7 +13179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2983,
+      "line": 2998,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Microphone permission required",
       "surface": "android",
@@ -13067,7 +13187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2989,
+      "line": 3004,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Audio error",
       "surface": "android",
@@ -13075,7 +13195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2990,
+      "line": 3005,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Client error",
       "surface": "android",
@@ -13083,7 +13203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2991,
+      "line": 3006,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Network error",
       "surface": "android",
@@ -13091,7 +13211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2992,
+      "line": 3007,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Network timeout",
       "surface": "android",
@@ -13099,7 +13219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2994,
+      "line": 3009,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Recognizer busy",
       "surface": "android",
@@ -13107,7 +13227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2995,
+      "line": 3010,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Server error",
       "surface": "android",
@@ -13115,7 +13235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2996,
+      "line": 3011,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Listening",
       "surface": "android",
@@ -13123,7 +13243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2997,
+      "line": 3012,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Speech error ($error)",
       "surface": "android",
@@ -17013,9 +17133,9 @@
       "kind": "ui-call",
       "line": 231,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
-      "source": "The session attaches once the gateway is ready.",
+      "source": "The thread attaches once the gateway is ready.",
       "surface": "apple",
-      "id": "native.apple.32179ce0b6d4543f"
+      "id": "native.apple.4da775013ac9b123"
     },
     {
       "kind": "conditional-branch",
@@ -17093,9 +17213,9 @@
       "kind": "ui-localized-call",
       "line": 591,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
-      "source": "Sessions…",
+      "source": "Threads…",
       "surface": "apple",
-      "id": "native.apple.a1b0d289758e2213"
+      "id": "native.apple.003b25ddafeb18e9"
     },
     {
       "kind": "ui-call",
@@ -17357,17 +17477,17 @@
       "kind": "ui-modifier",
       "line": 209,
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
-      "source": "Delete Session?",
+      "source": "Delete Thread?",
       "surface": "apple",
-      "id": "native.apple.f488b9caf6e51ac3"
+      "id": "native.apple.31d5c7287cfb3abe"
     },
     {
       "kind": "ui-call",
       "line": 216,
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
-      "source": "Delete Session",
+      "source": "Delete Thread",
       "surface": "apple",
-      "id": "native.apple.8634b17be9b111bc"
+      "id": "native.apple.d3395564809f1120"
     },
     {
       "kind": "ui-call",
@@ -17381,9 +17501,9 @@
       "kind": "ui-call",
       "line": 224,
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
-      "source": "This permanently deletes the session and its transcript.",
+      "source": "This permanently deletes the thread and its transcript.",
       "surface": "apple",
-      "id": "native.apple.4a9568ac9b18d8d3"
+      "id": "native.apple.092659256d26cb03"
     },
     {
       "kind": "ui-call",
@@ -17429,9 +17549,9 @@
       "kind": "ui-localized-call",
       "line": 269,
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
-      "source": "Rename Session",
+      "source": "Rename Thread",
       "surface": "apple",
-      "id": "native.apple.5bccdc23a1640895"
+      "id": "native.apple.683032464c497bbd"
     },
     {
       "kind": "ui-localized-call",
@@ -17445,9 +17565,9 @@
       "kind": "ui-localized-call",
       "line": 275,
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
-      "source": "Session name",
+      "source": "Thread name",
       "surface": "apple",
-      "id": "native.apple.af789b2d2fda0f67"
+      "id": "native.apple.f887aa956588f237"
     },
     {
       "kind": "ui-call",
@@ -17509,17 +17629,17 @@
       "kind": "ui-named-argument",
       "line": 219,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
-      "source": "Agent session",
+      "source": "Agent thread",
       "surface": "apple",
-      "id": "native.apple.a3bde8045fe9224a"
+      "id": "native.apple.7c8231b7b1ca480f"
     },
     {
       "kind": "ui-named-argument",
       "line": 234,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
-      "source": "Recent sessions",
+      "source": "Recent threads",
       "surface": "apple",
-      "id": "native.apple.27f775de30b37ff8"
+      "id": "native.apple.b3c553614f762a58"
     },
     {
       "kind": "conditional-branch",
@@ -17533,9 +17653,9 @@
       "kind": "conditional-branch",
       "line": 239,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
-      "source": "No recent sessions",
+      "source": "No recent threads",
       "surface": "apple",
-      "id": "native.apple.28c97cf23665ee01"
+      "id": "native.apple.5aa32afda85064ea"
     },
     {
       "kind": "conditional-branch",
@@ -17693,17 +17813,17 @@
       "kind": "ui-call",
       "line": 797,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
-      "source": "Sessions",
+      "source": "Threads",
       "surface": "apple",
-      "id": "native.apple.9f2fd65953013b7c"
+      "id": "native.apple.b6855cf19a50f477"
     },
     {
       "kind": "ui-localized-call",
       "line": 812,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
-      "source": "Archived sessions",
+      "source": "Archived threads",
       "surface": "apple",
-      "id": "native.apple.0422818cc95d5071"
+      "id": "native.apple.9b1d0ef27a1333b0"
     },
     {
       "kind": "ui-call",
@@ -17717,49 +17837,49 @@
       "kind": "ui-named-argument",
       "line": 836,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
-      "source": "Sessions unavailable",
+      "source": "Threads unavailable",
       "surface": "apple",
-      "id": "native.apple.b272115c83f7ef58"
+      "id": "native.apple.98167401c7267735"
     },
     {
       "kind": "ui-localized-call",
       "line": 875,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
-      "source": "Loading archived sessions",
+      "source": "Loading archived threads",
       "surface": "apple",
-      "id": "native.apple.54f8260c9b863087"
+      "id": "native.apple.4d28a7def2337b9f"
     },
     {
       "kind": "ui-localized-call",
       "line": 876,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
-      "source": "Loading recent sessions",
+      "source": "Loading recent threads",
       "surface": "apple",
-      "id": "native.apple.9b305868873dade2"
+      "id": "native.apple.777d7b706933bd7b"
     },
     {
       "kind": "ui-localized-call",
       "line": 883,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
-      "source": "^[\\(count) session](inflect: true)",
+      "source": "^[\\(count) thread](inflect: true)",
       "surface": "apple",
-      "id": "native.apple.207dad20d09f3160"
+      "id": "native.apple.22f81ea94bef8410"
     },
     {
       "kind": "ui-localized-call",
       "line": 913,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
-      "source": "No archived sessions",
+      "source": "No archived threads",
       "surface": "apple",
-      "id": "native.apple.1f4501a6bf2bae4c"
+      "id": "native.apple.1cad51e14db59bf9"
     },
     {
       "kind": "ui-localized-call",
       "line": 919,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
-      "source": "Archived sessions will appear here.",
+      "source": "Archived threads will appear here.",
       "surface": "apple",
-      "id": "native.apple.2a1ba7a5e1979c9e"
+      "id": "native.apple.18ef832d3a7ddcf8"
     },
     {
       "kind": "ui-call",
@@ -17893,9 +18013,9 @@
       "kind": "ui-named-argument",
       "line": 115,
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
-      "source": "Loading sessions",
+      "source": "Loading threads",
       "surface": "apple",
-      "id": "native.apple.2360d25fe6ae9946"
+      "id": "native.apple.21d9208d86a4d1fe"
     },
     {
       "kind": "ui-named-argument",
@@ -17909,25 +18029,25 @@
       "kind": "ui-named-argument",
       "line": 125,
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
-      "source": "Sessions unavailable",
+      "source": "Threads unavailable",
       "surface": "apple",
-      "id": "native.apple.c334f2e86702a7b8"
+      "id": "native.apple.4be1f79aa2b230ff"
     },
     {
       "kind": "conditional-branch",
       "line": 135,
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
-      "source": "No recent sessions",
+      "source": "No recent threads",
       "surface": "apple",
-      "id": "native.apple.6cc6efb7a03960b6"
+      "id": "native.apple.98b348873556bc46"
     },
     {
       "kind": "conditional-branch",
       "line": 135,
       "path": "apps/ios/Sources/Design/IPadActivityScreen.swift",
-      "source": "Session activity offline",
+      "source": "Thread activity offline",
       "surface": "apple",
-      "id": "native.apple.08483af2d043bee6"
+      "id": "native.apple.7396d205574d279f"
     },
     {
       "kind": "conditional-branch",
@@ -18661,9 +18781,9 @@
       "kind": "ui-call",
       "line": 1319,
       "path": "apps/ios/Sources/Design/IPadWorkboardScreen.swift",
-      "source": "Open Session",
+      "source": "Open Thread",
       "surface": "apple",
-      "id": "native.apple.93eeaedb2ff61043"
+      "id": "native.apple.c9ec1b0e18074d8a"
     },
     {
       "kind": "ui-call",
@@ -21045,9 +21165,9 @@
       "kind": "ui-call",
       "line": 1048,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
-      "source": "Used for new Chat and Talk sessions.",
+      "source": "Used for new Chat threads and Talk sessions.",
       "surface": "apple",
-      "id": "native.apple.3de045f17ea3c6d0"
+      "id": "native.apple.f4ae5664c3eda95d"
     },
     {
       "kind": "ui-named-argument",
@@ -23539,7 +23659,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4088,
+      "line": 4087,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval needed",
       "surface": "apple",
@@ -23547,7 +23667,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4089,
+      "line": 4088,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Action required",
       "surface": "apple",
@@ -23555,7 +23675,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4804,
+      "line": 4803,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -23563,7 +23683,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4805,
+      "line": 4804,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting...",
       "surface": "apple",
@@ -23571,7 +23691,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5157,
+      "line": 5156,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connected",
       "surface": "apple",
@@ -23579,7 +23699,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5157,
+      "line": 5156,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Offline",
       "surface": "apple",
@@ -23587,7 +23707,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6327,
+      "line": 6326,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "No chat messages yet",
       "surface": "apple",
@@ -23595,7 +23715,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6526,
+      "line": 6525,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting…",
       "surface": "apple",
@@ -23603,7 +23723,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6526,
+      "line": 6525,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting…",
       "surface": "apple",
@@ -23611,7 +23731,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8935,
+      "line": 8934,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval",
       "surface": "apple",
@@ -23619,7 +23739,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8935,
+      "line": 8934,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "This approval was already",
       "surface": "apple",
@@ -23627,7 +23747,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8941,
+      "line": 8940,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "This approval was already set to Always Allow.",
       "surface": "apple",
@@ -23635,7 +23755,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8942,
+      "line": 8941,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval set to Always Allow.",
       "surface": "apple",
@@ -23643,7 +23763,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 10280,
+      "line": 10278,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "\\(urlText.prefix(500))…",
       "surface": "apple",
@@ -24893,9 +25013,9 @@
       "kind": "ui-localized-call",
       "line": 69,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
-      "source": "Sessions",
+      "source": "Threads",
       "surface": "apple",
-      "id": "native.apple.3579cf2750470a22"
+      "id": "native.apple.11fe8b9941954dfb"
     },
     {
       "kind": "ui-localized-call",
@@ -25779,7 +25899,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4700,
+      "line": 4693,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Realtime unavailable",
       "surface": "apple",
@@ -25787,7 +25907,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4722,
+      "line": 4715,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Listening (PTT)",
       "surface": "apple",
@@ -30189,9 +30309,9 @@
       "kind": "ui-named-argument",
       "line": 109,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
-      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "source": "Global shortcut that opens a floating chat bar for the main thread.",
       "surface": "apple",
-      "id": "native.apple.6ae77665b5f4490f"
+      "id": "native.apple.94dd793cd7d7d555"
     },
     {
       "kind": "ui-call",
@@ -31117,9 +31237,9 @@
       "kind": "ui-call",
       "line": 106,
       "path": "apps/macos/Sources/OpenClaw/MenuBar.swift",
-      "source": "New Session",
+      "source": "New Thread",
       "surface": "apple",
-      "id": "native.apple.75102378a6775180"
+      "id": "native.apple.13f96467014cf344"
     },
     {
       "kind": "ui-call",
@@ -34781,9 +34901,9 @@
       "kind": "ui-call",
       "line": 39,
       "path": "apps/macos/Sources/OpenClaw/SessionsSettings.swift",
-      "source": "Sessions",
+      "source": "Threads",
       "surface": "apple",
-      "id": "native.apple.1ff8aec0044934c3"
+      "id": "native.apple.3ec2afcbc298c673"
     },
     {
       "kind": "ui-call",
@@ -34797,9 +34917,9 @@
       "kind": "ui-call",
       "line": 56,
       "path": "apps/macos/Sources/OpenClaw/SessionsSettings.swift",
-      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
+      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
       "surface": "apple",
-      "id": "native.apple.bab897f3252b134c"
+      "id": "native.apple.14ccb32cd8ed1c81"
     },
     {
       "kind": "ui-call",
@@ -34933,9 +35053,9 @@
       "kind": "conditional-branch",
       "line": 483,
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
-      "source": "Sessions",
+      "source": "Threads",
       "surface": "apple",
-      "id": "native.apple.64a6dc7d49e8fb57"
+      "id": "native.apple.52e37e3a44ae516c"
     },
     {
       "kind": "conditional-branch",
@@ -36541,9 +36661,9 @@
       "kind": "ui-localized-call",
       "line": 849,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
-      "source": "Summarize what happened in my sessions since yesterday.",
+      "source": "Summarize what happened in my threads since yesterday.",
       "surface": "apple",
-      "id": "native.apple.234ec45f4231edc4"
+      "id": "native.apple.fc4ce810900ec0b6"
     },
     {
       "kind": "conditional-branch",
@@ -36757,9 +36877,9 @@
       "kind": "ui-call",
       "line": 575,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
-      "source": "Session",
+      "source": "Thread",
       "surface": "apple",
-      "id": "native.apple.5dfc0700d8dff8de"
+      "id": "native.apple.4edb66657f5aca1f"
     },
     {
       "kind": "ui-modifier",
@@ -37051,11 +37171,83 @@
     },
     {
       "kind": "ui-call",
-      "line": 328,
+      "line": 349,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift",
       "source": "Widget unavailable",
       "surface": "apple",
       "id": "native.apple.2c865ac4a69645d3"
+    },
+    {
+      "kind": "ui-modifier",
+      "line": 368,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift",
+      "source": "Widget export failed",
+      "surface": "apple",
+      "id": "native.apple.d640691fd196f338"
+    },
+    {
+      "kind": "ui-call",
+      "line": 372,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift",
+      "source": "OK",
+      "surface": "apple",
+      "id": "native.apple.533c6e22a11e88de"
+    },
+    {
+      "kind": "ui-call",
+      "line": 413,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift",
+      "source": "Copy image",
+      "surface": "apple",
+      "id": "native.apple.e1fb28a2a9756402"
+    },
+    {
+      "kind": "ui-call",
+      "line": 421,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift",
+      "source": "Save image…",
+      "surface": "apple",
+      "id": "native.apple.ebd7bc92e1b12235"
+    },
+    {
+      "kind": "ui-call",
+      "line": 424,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift",
+      "source": "Save image",
+      "surface": "apple",
+      "id": "native.apple.742c46d4cf2db134"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 439,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift",
+      "source": "The widget image could not be captured.",
+      "surface": "apple",
+      "id": "native.apple.0589cce608418f90"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 469,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift",
+      "source": "The widget image could not be copied.",
+      "surface": "apple",
+      "id": "native.apple.dfe24e827fdbe9c5"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 476,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift",
+      "source": "The widget image could not be encoded as PNG.",
+      "surface": "apple",
+      "id": "native.apple.9e611e3a80e71408"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 488,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatInlineWidgetView.swift",
+      "source": "The widget image could not be saved.",
+      "surface": "apple",
+      "id": "native.apple.9a6e8afbe24a262b"
     },
     {
       "kind": "conditional-branch",
@@ -37285,25 +37477,25 @@
       "kind": "ui-localized-call",
       "line": 30,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionManagementViews.swift",
-      "source": "This session cannot be archived while it is active or running.",
+      "source": "This thread cannot be archived while it is active or running.",
       "surface": "apple",
-      "id": "native.apple.b1cdcb906a43d5d6"
+      "id": "native.apple.9d0cba09d92ee669"
     },
     {
       "kind": "ui-localized-call",
       "line": 32,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionManagementViews.swift",
-      "source": "The main session cannot be deleted.",
+      "source": "The main thread cannot be deleted.",
       "surface": "apple",
-      "id": "native.apple.5817e3f3dab1ee19"
+      "id": "native.apple.8952a111a1075051"
     },
     {
       "kind": "ui-localized-call",
       "line": 34,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionManagementViews.swift",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
       "surface": "apple",
-      "id": "native.apple.a6b8df3f18171c91"
+      "id": "native.apple.90d0ccf80ca28717"
     },
     {
       "kind": "ui-localized-call",
@@ -37525,9 +37717,9 @@
       "kind": "ui-modifier",
       "line": 244,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionManagementViews.swift",
-      "source": "Session Info",
+      "source": "Thread Info",
       "surface": "apple",
-      "id": "native.apple.cd7c3095a22f80a9"
+      "id": "native.apple.bbccb4c8db5cac12"
     },
     {
       "kind": "ui-call",
@@ -37581,9 +37773,9 @@
       "kind": "ui-modifier",
       "line": 412,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionManagementViews.swift",
-      "source": "Session Groups",
+      "source": "Thread Groups",
       "surface": "apple",
-      "id": "native.apple.23d628606fe0734f"
+      "id": "native.apple.7b641fed5bace855"
     },
     {
       "kind": "ui-call",
@@ -37653,9 +37845,9 @@
       "kind": "ui-call",
       "line": 453,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionManagementViews.swift",
-      "source": "Sessions in this group become ungrouped.",
+      "source": "Threads in this group become ungrouped.",
       "surface": "apple",
-      "id": "native.apple.b049c8a4d2805e08"
+      "id": "native.apple.56401c79410a310d"
     },
     {
       "kind": "ui-localized-call",
@@ -37677,9 +37869,9 @@
       "kind": "ui-call",
       "line": 575,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionManagementViews.swift",
-      "source": "New Session Options",
+      "source": "New Thread Options",
       "surface": "apple",
-      "id": "native.apple.6c89f35d53506406"
+      "id": "native.apple.2d96aa7d3d12f85b"
     },
     {
       "kind": "ui-call",
@@ -37725,25 +37917,25 @@
       "kind": "ui-localized-call",
       "line": 623,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionManagementViews.swift",
-      "source": "The session could not be created.",
+      "source": "The thread could not be created.",
       "surface": "apple",
-      "id": "native.apple.795ba37f6782cf28"
+      "id": "native.apple.87ef57319d1ddc85"
     },
     {
       "kind": "ui-localized-call",
       "line": 64,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
-      "source": "Search sessions",
+      "source": "Search threads",
       "surface": "apple",
-      "id": "native.apple.8ec708a3605a2cc3"
+      "id": "native.apple.6bd91c435b69d638"
     },
     {
       "kind": "ui-localized-call",
       "line": 69,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
-      "source": "No Sessions",
+      "source": "No Threads",
       "surface": "apple",
-      "id": "native.apple.23b069b4e7f97039"
+      "id": "native.apple.6fde4bdf9d5b9191"
     },
     {
       "kind": "ui-localized-call",
@@ -37757,41 +37949,41 @@
       "kind": "ui-call",
       "line": 81,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
-      "source": "New Session",
+      "source": "New Thread",
       "surface": "apple",
-      "id": "native.apple.0058923f2ce8a3ec"
+      "id": "native.apple.a02fd99740d29bd3"
     },
     {
       "kind": "ui-localized-call",
       "line": 83,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
-      "source": "New session",
+      "source": "New thread",
       "surface": "apple",
-      "id": "native.apple.66ba42960eb4135b"
+      "id": "native.apple.b625801dd04b09f2"
     },
     {
       "kind": "ui-localized-call",
       "line": 89,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
-      "source": "New session options",
+      "source": "New thread options",
       "surface": "apple",
-      "id": "native.apple.2ef0e34db02ad255"
+      "id": "native.apple.851be81fcc933608"
     },
     {
       "kind": "ui-localized-call",
       "line": 117,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
-      "source": "Rename Session",
+      "source": "Rename Thread",
       "surface": "apple",
-      "id": "native.apple.36753ef2f1ed4264"
+      "id": "native.apple.9ce8a4aba7b444b2"
     },
     {
       "kind": "ui-localized-call",
       "line": 120,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
-      "source": "Session name",
+      "source": "Thread name",
       "surface": "apple",
-      "id": "native.apple.c9de0a1510ef475f"
+      "id": "native.apple.1dd067c44511c7f0"
     },
     {
       "kind": "ui-localized-call",
@@ -37813,17 +38005,17 @@
       "kind": "ui-localized-call",
       "line": 132,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
-      "source": "Delete Session",
+      "source": "Delete Thread",
       "surface": "apple",
-      "id": "native.apple.afb4e6c99c63a28d"
+      "id": "native.apple.618073d6ab3f2721"
     },
     {
       "kind": "ui-localized-call",
       "line": 139,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
-      "source": "The session and its transcript are removed from the gateway.",
+      "source": "The thread and its transcript are removed from the gateway.",
       "surface": "apple",
-      "id": "native.apple.3d4ef32e42f136a4"
+      "id": "native.apple.10a5e72bba3cbccc"
     },
     {
       "kind": "ui-localized-call",
@@ -37837,17 +38029,17 @@
       "kind": "ui-localized-call",
       "line": 215,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
-      "source": "Session running",
+      "source": "Thread running",
       "surface": "apple",
-      "id": "native.apple.9a7dca238fba628d"
+      "id": "native.apple.ac71e3b2aa496a2c"
     },
     {
       "kind": "ui-localized-call",
       "line": 220,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
-      "source": "Session failed",
+      "source": "Thread failed",
       "surface": "apple",
-      "id": "native.apple.fcfbfe5e97a95e9c"
+      "id": "native.apple.c775e87f997278b2"
     },
     {
       "kind": "ui-localized-call",
@@ -37941,9 +38133,9 @@
       "kind": "ui-localized-call",
       "line": 292,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
-      "source": "Delete Session…",
+      "source": "Delete Thread…",
       "surface": "apple",
-      "id": "native.apple.4aeb7c14c26dabac"
+      "id": "native.apple.f4998cfb572f23ff"
     },
     {
       "kind": "ui-localized-call",
@@ -37965,9 +38157,9 @@
       "kind": "ui-localized-call",
       "line": 346,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebar.swift",
-      "source": "Retry session groups",
+      "source": "Retry thread groups",
       "surface": "apple",
-      "id": "native.apple.79f708b3bc1d3a6c"
+      "id": "native.apple.8802e9576ffd0f65"
     },
     {
       "kind": "ui-named-argument",
@@ -38005,33 +38197,33 @@
       "kind": "ui-named-argument",
       "line": 92,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
-      "source": "Search sessions",
+      "source": "Search threads",
       "surface": "apple",
-      "id": "native.apple.2c37581c7b88f741"
+      "id": "native.apple.b313b80def4bda52"
     },
     {
       "kind": "ui-modifier",
       "line": 93,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
-      "source": "Sessions",
+      "source": "Threads",
       "surface": "apple",
-      "id": "native.apple.43be8a2336e42faf"
+      "id": "native.apple.c0cc6acc36f413ce"
     },
     {
       "kind": "ui-modifier",
       "line": 150,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
-      "source": "Rename Session",
+      "source": "Rename Thread",
       "surface": "apple",
-      "id": "native.apple.0b379cdfcbd3247f"
+      "id": "native.apple.854d3928fe5a557c"
     },
     {
       "kind": "ui-call",
       "line": 156,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
-      "source": "Session name",
+      "source": "Thread name",
       "surface": "apple",
-      "id": "native.apple.54b6fbd9e41db009"
+      "id": "native.apple.9d0d3f20096cc4da"
     },
     {
       "kind": "ui-call",
@@ -38045,25 +38237,25 @@
       "kind": "ui-modifier",
       "line": 182,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
-      "source": "Delete selected sessions?",
+      "source": "Delete selected threads?",
       "surface": "apple",
-      "id": "native.apple.751e0f6b81cd374a"
+      "id": "native.apple.dc00eb94f33bae15"
     },
     {
       "kind": "ui-call",
       "line": 187,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
-      "source": "Delete Sessions",
+      "source": "Delete Threads",
       "surface": "apple",
-      "id": "native.apple.aa679276581b0058"
+      "id": "native.apple.2053fc9f74dc3158"
     },
     {
       "kind": "ui-call",
       "line": 191,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
-      "source": "Each selected session and its transcript will be removed from the gateway.",
+      "source": "Each selected thread and its transcript will be removed from the gateway.",
       "surface": "apple",
-      "id": "native.apple.f837129cbee23297"
+      "id": "native.apple.0970247871a834a0"
     },
     {
       "kind": "ui-call",
@@ -38077,9 +38269,9 @@
       "kind": "ui-modifier",
       "line": 226,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
-      "source": "Manage session groups",
+      "source": "Manage thread groups",
       "surface": "apple",
-      "id": "native.apple.64013cfee5e25305"
+      "id": "native.apple.6f8acab2256728b5"
     },
     {
       "kind": "conditional-branch",
@@ -38101,17 +38293,17 @@
       "kind": "conditional-branch",
       "line": 245,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
-      "source": "No archived sessions",
+      "source": "No archived threads",
       "surface": "apple",
-      "id": "native.apple.b67eaecec1b423ac"
+      "id": "native.apple.692972314d04b184"
     },
     {
       "kind": "conditional-branch",
       "line": 245,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
-      "source": "No sessions found",
+      "source": "No threads found",
       "surface": "apple",
-      "id": "native.apple.b2435a79abf0c794"
+      "id": "native.apple.d6a4b5711dcd26e7"
     },
     {
       "kind": "ui-localized-call",
@@ -38307,7 +38499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 513,
+      "line": 515,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Retry Send",
       "surface": "apple",
@@ -38315,7 +38507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 527,
+      "line": 529,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Delete",
       "surface": "apple",
@@ -38323,7 +38515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 561,
+      "line": 565,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Stop Listening",
       "surface": "apple",
@@ -38331,7 +38523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 564,
+      "line": 568,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Listen",
       "surface": "apple",
@@ -38339,7 +38531,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 659,
+      "line": 665,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Jump to latest reply",
       "surface": "apple",
@@ -38347,7 +38539,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 679,
+      "line": 685,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -38355,7 +38547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1074,
+      "line": 1080,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Copy Message",
       "surface": "apple",
@@ -38363,15 +38555,31 @@
     },
     {
       "kind": "ui-call",
-      "line": 1097,
+      "line": 1103,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Open Full Message",
       "surface": "apple",
       "id": "native.apple.90bc8a8045e7017e"
     },
     {
+      "kind": "ui-call",
+      "line": 1122,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
+      "source": "Rewind to Here",
+      "surface": "apple",
+      "id": "native.apple.002bfcede229ad4b"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1142,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
+      "source": "Fork from Here",
+      "surface": "apple",
+      "id": "native.apple.14df2e4997689fb3"
+    },
+    {
       "kind": "ui-localized-call",
-      "line": 1118,
+      "line": 1170,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Reply",
       "surface": "apple",
@@ -38379,7 +38587,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1128,
+      "line": 1180,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "You",
       "surface": "apple",
@@ -38387,7 +38595,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1130,
+      "line": 1182,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Assistant",
       "surface": "apple",
@@ -38395,7 +38603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1196,
+      "line": 1248,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Loading chat",
       "surface": "apple",
@@ -38403,7 +38611,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1276,
+      "line": 1328,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Dismiss",
       "surface": "apple",
@@ -38509,9 +38717,9 @@
       "kind": "ui-localized-call",
       "line": 229,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionActions.swift",
-      "source": "Gateway changed before the session operation started.",
+      "source": "Gateway changed before the thread operation started.",
       "surface": "apple",
-      "id": "native.apple.980f552bb0f96c0f"
+      "id": "native.apple.e0f045151c8d3137"
     },
     {
       "kind": "ui-localized-call",
@@ -38525,9 +38733,9 @@
       "kind": "ui-modifier",
       "line": 78,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Clear this session's history?",
+      "source": "Clear this thread's history?",
       "surface": "apple",
-      "id": "native.apple.87ba543b42696b92"
+      "id": "native.apple.0a5c4e15466c3acc"
     },
     {
       "kind": "ui-call",
@@ -38549,17 +38757,17 @@
       "kind": "ui-localized-call",
       "line": 95,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Rename Session",
+      "source": "Rename Thread",
       "surface": "apple",
-      "id": "native.apple.a92e96bed98bd553"
+      "id": "native.apple.67ac221dbe7179f0"
     },
     {
       "kind": "ui-localized-call",
       "line": 96,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Session name",
+      "source": "Thread name",
       "surface": "apple",
-      "id": "native.apple.848e2388f3466f40"
+      "id": "native.apple.cf0f7e049603f518"
     },
     {
       "kind": "ui-localized-call",
@@ -38589,9 +38797,9 @@
       "kind": "ui-call",
       "line": 152,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Sessions",
+      "source": "Threads",
       "surface": "apple",
-      "id": "native.apple.4af0f566d39d7041"
+      "id": "native.apple.c0ada47504425f23"
     },
     {
       "kind": "ui-localized-call",
@@ -38709,17 +38917,17 @@
       "kind": "ui-call",
       "line": 348,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "New Session",
+      "source": "New Thread",
       "surface": "apple",
-      "id": "native.apple.eb58552e43c8dde2"
+      "id": "native.apple.1a765291943599e5"
     },
     {
       "kind": "ui-call",
       "line": 355,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "New Session Options…",
+      "source": "New Thread Options…",
       "surface": "apple",
-      "id": "native.apple.a7119fbf9d25df5e"
+      "id": "native.apple.c7a3a6d5e43dd98f"
     },
     {
       "kind": "ui-call",
@@ -38733,25 +38941,25 @@
       "kind": "ui-call",
       "line": 369,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Sessions…",
+      "source": "Threads…",
       "surface": "apple",
-      "id": "native.apple.2bcff4a8fa503739"
+      "id": "native.apple.0e710b81808e5dcf"
     },
     {
       "kind": "ui-localized-call",
       "line": 381,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Rename Session…",
+      "source": "Rename Thread…",
       "surface": "apple",
-      "id": "native.apple.c36e008b051adb38"
+      "id": "native.apple.faad8f92b6bef166"
     },
     {
       "kind": "ui-localized-call",
       "line": 389,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Fork Session",
+      "source": "Fork",
       "surface": "apple",
-      "id": "native.apple.ea0ef95a159bffe0"
+      "id": "native.apple.23b61d6cd26ac112"
     },
     {
       "kind": "ui-localized-call",
@@ -38845,33 +39053,33 @@
       "kind": "ui-call",
       "line": 492,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Session",
+      "source": "Thread",
       "surface": "apple",
-      "id": "native.apple.920fe8a7a33f9e92"
+      "id": "native.apple.8b4f1c5107ea8a0e"
     },
     {
       "kind": "ui-modifier",
       "line": 500,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Session actions",
+      "source": "Thread actions",
       "surface": "apple",
-      "id": "native.apple.185a401f78328b0f"
+      "id": "native.apple.4d7750c9bf699469"
     },
     {
       "kind": "ui-localized-call",
       "line": 534,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Session cost %@",
+      "source": "Thread cost %@",
       "surface": "apple",
-      "id": "native.apple.9f9dedf599b2619b"
+      "id": "native.apple.bb2f22cc43c97f8e"
     },
     {
       "kind": "ui-call",
       "line": 540,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
-      "source": "Compact Session",
+      "source": "Compact Thread",
       "surface": "apple",
-      "id": "native.apple.f0a4720df5f5f403"
+      "id": "native.apple.6239ced0b86e86f8"
     },
     {
       "kind": "ui-call",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -939,7 +939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3244,
+      "line": 3246,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect to a Gateway to save wake words",
       "surface": "android",
@@ -947,7 +947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3272,
+      "line": 3274,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Wake words saved",
       "surface": "android",
@@ -955,7 +955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3281,
+      "line": 3283,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not save wake words",
       "surface": "android",
@@ -963,7 +963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3973,
+      "line": 3975,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: no secure gateway endpoint was detected. Enable gateway TLS or Tailscale Serve, or use a trusted private LAN address with Unencrypted selected.",
       "surface": "android",
@@ -971,7 +971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3977,
+      "line": 3979,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -979,7 +979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3981,
+      "line": 3983,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -987,7 +987,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 4025,
+      "line": 4027,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -995,7 +995,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 4208,
+      "line": 4210,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Offline",
       "surface": "android",
@@ -1003,7 +1003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4942,
+      "line": 4944,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load provider catalog.",
       "surface": "android",
@@ -1011,7 +1011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4973,
+      "line": 4975,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Update your Gateway to view provider model config.",
       "surface": "android",
@@ -1019,7 +1019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4975,
+      "line": 4977,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load provider model config.",
       "surface": "android",
@@ -1027,7 +1027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4991,
+      "line": 4993,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Provider models loaded, but readiness is unavailable.",
       "surface": "android",
@@ -1035,7 +1035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5078,
+      "line": 5080,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automations.",
       "surface": "android",
@@ -1043,7 +1043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5164,
+      "line": 5166,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect automations.",
       "surface": "android",
@@ -1051,7 +1051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5174,
+      "line": 5176,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway returned an invalid automation.",
       "surface": "android",
@@ -1059,7 +1059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5178,
+      "line": 5180,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automation.",
       "surface": "android",
@@ -1067,7 +1067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5190,
+      "line": 5192,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect automation run history.",
       "surface": "android",
@@ -1075,7 +1075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5221,
+      "line": 5223,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automation run history.",
       "surface": "android",
@@ -1083,7 +1083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5238,
+      "line": 5240,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron changes require operator.admin access.",
       "surface": "android",
@@ -1091,7 +1091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5247,
+      "line": 5249,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to manage automations.",
       "surface": "android",
@@ -1099,7 +1099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5259,
+      "line": 5261,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Another cron action is still finishing.",
       "surface": "android",
@@ -1107,7 +1107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5306,
+      "line": 5308,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron action failed.",
       "surface": "android",
@@ -1115,7 +1115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5433,
+      "line": 5435,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load usage.",
       "surface": "android",
@@ -1123,7 +1123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5468,
+      "line": 5470,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load skills.",
       "surface": "android",
@@ -1131,7 +1131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5481,
+      "line": 5483,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to update skills.",
       "surface": "android",
@@ -1139,7 +1139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5485,
+      "line": 5487,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This gateway connection needs operator.admin to update skills.",
       "surface": "android",
@@ -1147,7 +1147,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5500,
+      "line": 5502,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not disable skill.",
       "surface": "android",
@@ -1155,7 +1155,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5500,
+      "line": 5502,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not enable skill.",
       "surface": "android",
@@ -1163,7 +1163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5518,
+      "line": 5520,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to search ClawHub skills.",
       "surface": "android",
@@ -1171,7 +1171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5564,
+      "line": 5566,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not search ClawHub skills.",
       "surface": "android",
@@ -1179,7 +1179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5577,
+      "line": 5579,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect ClawHub skills.",
       "surface": "android",
@@ -1187,7 +1187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5610,
+      "line": 5612,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "ClawHub did not return an installable version for ${skill.slug}.",
       "surface": "android",
@@ -1195,7 +1195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5626,
+      "line": 5628,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load ClawHub details for ${skill.slug}.",
       "surface": "android",
@@ -1203,7 +1203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5642,
+      "line": 5644,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to install ClawHub skills.",
       "surface": "android",
@@ -1211,7 +1211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5658,
+      "line": 5660,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This gateway connection needs operator.admin to install ClawHub skills.",
       "surface": "android",
@@ -1219,7 +1219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5748,
+      "line": 5750,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Installed $slug.",
       "surface": "android",
@@ -1227,7 +1227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5755,
+      "line": 5757,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not install ${slug} from ClawHub.",
       "surface": "android",
@@ -1235,7 +1235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5795,
+      "line": 5797,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to load Skill Workshop proposals.",
       "surface": "android",
@@ -1243,7 +1243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5835,
+      "line": 5837,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load Skill Workshop proposals.",
       "surface": "android",
@@ -1251,7 +1251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5855,
+      "line": 5857,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect Skill Workshop proposals.",
       "surface": "android",
@@ -1259,7 +1259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5907,
+      "line": 5909,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not inspect Skill Workshop proposal.",
       "surface": "android",
@@ -1267,7 +1267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5927,
+      "line": 5929,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Skill Workshop proposal actions require operator.admin scope.",
       "surface": "android",
@@ -1275,7 +1275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5932,
+      "line": 5934,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to update Skill Workshop proposals.",
       "surface": "android",
@@ -1283,7 +1283,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 6091,
+      "line": 6093,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected",
       "surface": "android",
@@ -1291,7 +1291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6117,
+      "line": 6119,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load nodes and devices.",
       "surface": "android",
@@ -1299,7 +1299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6775,
+      "line": 6777,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load channels.",
       "surface": "android",
@@ -1307,7 +1307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6805,
+      "line": 6807,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load dreaming.",
       "surface": "android",
@@ -1315,7 +1315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6842,
+      "line": 6844,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load gateway logs.",
       "surface": "android",
@@ -1323,7 +1323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7299,
+      "line": 7301,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "One time",
       "surface": "android",
@@ -1331,7 +1331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7308,
+      "line": 7310,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron",
       "surface": "android",
@@ -1339,7 +1339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7309,
+      "line": 7311,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Scheduled",
       "surface": "android",
@@ -1347,7 +1347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7317,
+      "line": 7319,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${days}d",
       "surface": "android",
@@ -1355,7 +1355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7318,
+      "line": 7320,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${hours}h",
       "surface": "android",
@@ -1363,7 +1363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7319,
+      "line": 7321,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${minutes}m",
       "surface": "android",
@@ -1371,7 +1371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7320,
+      "line": 7322,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Repeating",
       "surface": "android",
@@ -1379,7 +1379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7336,
+      "line": 7338,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "No prompt",
       "surface": "android",
@@ -1387,7 +1387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7353,
+      "line": 7355,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway",
       "surface": "android",
@@ -1395,7 +1395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7361,
+      "line": 7363,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected to $gatewayLabel",
       "surface": "android",
@@ -1403,7 +1403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7362,
+      "line": 7364,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Your agents are ready",
       "surface": "android",
@@ -1411,7 +1411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7364,
+      "line": 7366,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This phone stays dormant until the gateway needs it, then wakes, syncs, and goes back to sleep.",
       "surface": "android",
@@ -1419,7 +1419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7368,
+      "line": 7370,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Selected on this phone",
       "surface": "android",
@@ -1427,7 +1427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7371,
+      "line": 7373,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The overview refreshes on reconnect and when this screen opens.",
       "surface": "android",
@@ -1435,7 +1435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7376,
+      "line": 7378,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Reconnecting",
       "surface": "android",
@@ -1443,7 +1443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7377,
+      "line": 7379,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "OpenClaw is syncing back up",
       "surface": "android",
@@ -1451,7 +1451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7379,
+      "line": 7381,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The gateway session is coming back online. Agent shortcuts should settle automatically in a moment.",
       "surface": "android",
@@ -1459,7 +1459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7383,
+      "line": 7385,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway session in progress",
       "surface": "android",
@@ -1467,7 +1467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7386,
+      "line": 7388,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "If the gateway is reachable, reconnect should complete without intervention.",
       "surface": "android",
@@ -1475,7 +1475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7391,
+      "line": 7393,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Welcome to OpenClaw",
       "surface": "android",
@@ -1483,7 +1483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7392,
+      "line": 7394,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Your phone stays quiet until it is needed",
       "surface": "android",
@@ -1491,7 +1491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7394,
+      "line": 7396,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Pair this device to your gateway to wake it only for real work, keep a live agent overview handy, and avoid battery-draining background loops.",
       "surface": "android",
@@ -1499,7 +1499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7398,
+      "line": 7400,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect to load your agents",
       "surface": "android",
@@ -1507,7 +1507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7401,
+      "line": 7403,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "When connected, the gateway can wake the phone with a silent push instead of holding an always-on session.",
       "surface": "android",
@@ -1515,7 +1515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7433,
+      "line": 7435,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Main",
       "surface": "android",
@@ -1523,7 +1523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7448,
+      "line": 7450,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Active on this phone",
       "surface": "android",
@@ -1531,7 +1531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7449,
+      "line": 7451,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Default agent",
       "surface": "android",
@@ -1539,7 +1539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7450,
+      "line": 7452,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Ready",
       "surface": "android",
@@ -1547,7 +1547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8009,
+      "line": 8011,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Dream",
       "surface": "android",
@@ -1723,7 +1723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1036,
+      "line": 1041,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Wait for the current response to finish before starting a new chat.",
       "surface": "android",
@@ -1731,7 +1731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1169,
+      "line": 1174,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Could not update model.",
       "surface": "android",
@@ -1739,7 +1739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1234,
+      "line": 1239,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Could not update thinking level.",
       "surface": "android",
@@ -1747,7 +1747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1727,
+      "line": 1732,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Chat failed before the run started; try again.",
       "surface": "android",
@@ -1755,7 +1755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3009,
+      "line": 3152,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Could not stage an attachment for sending.",
       "surface": "android",
@@ -1763,7 +1763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3042,
+      "line": 3185,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Offline queue is full ($OUTBOX_MAX_QUEUED messages); delete queued items first.",
       "surface": "android",
@@ -1771,7 +1771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3048,
+      "line": 3191,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Attachments are too large to queue for one message; remove some and try again.",
       "surface": "android",
@@ -1779,7 +1779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3054,
+      "line": 3197,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Offline attachment storage is full; delete queued items first.",
       "surface": "android",
@@ -1787,7 +1787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3059,
+      "line": 3202,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Gateway health not OK; cannot send",
       "surface": "android",
@@ -1795,7 +1795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3066,
+      "line": 3209,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Could not queue message for later delivery.",
       "surface": "android",
@@ -1803,7 +1803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3783,
+      "line": 3926,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Chat failed",
       "surface": "android",
@@ -1811,7 +1811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3921,
+      "line": 4064,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Event stream interrupted; try refreshing.",
       "surface": "android",
@@ -1819,7 +1819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4058,
+      "line": 4201,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Timed out waiting for a reply; try again or refresh.",
       "surface": "android",
@@ -1827,7 +1827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4268,
+      "line": 4411,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Timed out confirming the sent message; refresh to check delivery.",
       "surface": "android",
@@ -11811,7 +11811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 131,
+      "line": 173,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatQuestionCard.kt",
       "source": "Other answer",
       "surface": "android",
@@ -11819,55 +11819,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 160,
+      "line": 203,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatQuestionCard.kt",
-      "source": "Submit",
+      "source": "Skip",
       "surface": "android",
-      "id": "native.android.fa81739f52e7697f"
+      "id": "native.android.de591e6e2e440ecb"
     },
     {
       "kind": "ui-call",
-      "line": 170,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatQuestionCard.kt",
-      "source": "Answered",
-      "surface": "android",
-      "id": "native.android.f68cd7a84be4089e"
-    },
-    {
-      "kind": "ui-call",
-      "line": 171,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatQuestionCard.kt",
-      "source": "Answered elsewhere",
-      "surface": "android",
-      "id": "native.android.a0dc883947c2f980"
-    },
-    {
-      "kind": "ui-call",
-      "line": 172,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatQuestionCard.kt",
-      "source": "Expired",
-      "surface": "android",
-      "id": "native.android.1a0e6b33059a63aa"
-    },
-    {
-      "kind": "ui-call",
-      "line": 173,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatQuestionCard.kt",
-      "source": "Cancelled",
-      "surface": "android",
-      "id": "native.android.d6d8fc83cec68418"
-    },
-    {
-      "kind": "ui-call",
-      "line": 174,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatQuestionCard.kt",
-      "source": "Pending",
-      "surface": "android",
-      "id": "native.android.73f64d0d54b7f9c0"
-    },
-    {
-      "kind": "ui-call",
-      "line": 175,
+      "line": 211,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatQuestionCard.kt",
       "source": "Submitting…",
       "surface": "android",
@@ -11875,19 +11835,51 @@
     },
     {
       "kind": "ui-call",
-      "line": 192,
+      "line": 213,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatQuestionCard.kt",
-      "source": "Expires in ${seconds / 60}m ${seconds % 60}s",
+      "source": "Submit",
       "surface": "android",
-      "id": "native.android.c5e9ee99f9d9c612"
+      "id": "native.android.fa81739f52e7697f"
     },
     {
       "kind": "ui-call",
-      "line": 194,
+      "line": 229,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatQuestionCard.kt",
-      "source": "Expires in ${seconds}s",
+      "source": "Skipped",
       "surface": "android",
-      "id": "native.android.2ca602fbdf96f1e7"
+      "id": "native.android.7da074848cacfe4b"
+    },
+    {
+      "kind": "ui-call",
+      "line": 230,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatQuestionCard.kt",
+      "source": "Expired",
+      "surface": "android",
+      "id": "native.android.1a0e6b33059a63aa"
+    },
+    {
+      "kind": "ui-call",
+      "line": 231,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatQuestionCard.kt",
+      "source": "Unavailable",
+      "surface": "android",
+      "id": "native.android.86c8d6113d07ef82"
+    },
+    {
+      "kind": "ui-call",
+      "line": 235,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatQuestionCard.kt",
+      "source": "Answered",
+      "surface": "android",
+      "id": "native.android.f68cd7a84be4089e"
+    },
+    {
+      "kind": "ui-call",
+      "line": 235,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatQuestionCard.kt",
+      "source": "Answered elsewhere",
+      "surface": "android",
+      "id": "native.android.a0dc883947c2f980"
     },
     {
       "kind": "ui-call",
@@ -11915,7 +11907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 834,
+      "line": 835,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "All",
       "surface": "android",
@@ -11923,7 +11915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 916,
+      "line": 917,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Working",
       "surface": "android",
@@ -11931,7 +11923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 917,
+      "line": 918,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready",
       "surface": "android",
@@ -11939,7 +11931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 918,
+      "line": 919,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Offline",
       "surface": "android",
@@ -11947,7 +11939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 931,
+      "line": 932,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat actions",
       "surface": "android",
@@ -11955,7 +11947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 936,
+      "line": 937,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Refresh chat",
       "surface": "android",
@@ -11963,7 +11955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 944,
+      "line": 945,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Background tasks",
       "surface": "android",
@@ -11971,7 +11963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 965,
+      "line": 966,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -11979,7 +11971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1111,
+      "line": 1113,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Messages to recover",
       "surface": "android",
@@ -11987,7 +11979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1113,
+      "line": 1115,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows.",
       "surface": "android",
@@ -11995,7 +11987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1141,
+      "line": 1143,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Loading session",
       "surface": "android",
@@ -12003,7 +11995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1168,
+      "line": 1170,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Jump to latest",
       "surface": "android",
@@ -12011,7 +12003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1194,
+      "line": 1196,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready when you are",
       "surface": "android",
@@ -12019,7 +12011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1198,
+      "line": 1200,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Start with a prompt, or use voice.",
       "surface": "android",
@@ -12027,7 +12019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1200,
+      "line": 1202,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Use the recovery options below to reconnect.",
       "surface": "android",
@@ -12035,7 +12027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1202,
+      "line": 1204,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat is checking Gateway health.",
       "surface": "android",
@@ -12043,7 +12035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1225,
+      "line": 1227,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Fix connection",
       "surface": "android",
@@ -12051,7 +12043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1226,
+      "line": 1228,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Copy diagnostics",
       "surface": "android",
@@ -12059,7 +12051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1285,
+      "line": 1287,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Catch me up",
       "surface": "android",
@@ -12067,7 +12059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1286,
+      "line": 1288,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Summarize recent sessions and next steps.",
       "surface": "android",
@@ -12075,7 +12067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1287,
+      "line": 1289,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
       "surface": "android",
@@ -12083,7 +12075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1291,
+      "line": 1293,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Plan the work",
       "surface": "android",
@@ -12091,7 +12083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1292,
+      "line": 1294,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Turn a goal into an actionable checklist.",
       "surface": "android",
@@ -12099,7 +12091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1293,
+      "line": 1295,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Help me turn this goal into a practical checklist: ",
       "surface": "android",
@@ -12107,7 +12099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1297,
+      "line": 1299,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Use this phone",
       "surface": "android",
@@ -12115,7 +12107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1298,
+      "line": 1300,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ask OpenClaw to use Android capabilities.",
       "surface": "android",
@@ -12123,7 +12115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1299,
+      "line": 1301,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "What can you help me do from this phone right now?",
       "surface": "android",
@@ -12131,7 +12123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1364,
+      "line": 1366,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw · Live",
       "surface": "android",
@@ -12139,7 +12131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1365,
+      "line": 1367,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "You",
       "surface": "android",
@@ -12147,7 +12139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1366,
+      "line": 1368,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "System",
       "surface": "android",
@@ -12155,7 +12147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1367,
+      "line": 1369,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -12163,7 +12155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1387,
+      "line": 1389,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attachment",
       "surface": "android",
@@ -12171,7 +12163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1440,
+      "line": 1442,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Preparing audio…",
       "surface": "android",
@@ -12179,7 +12171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1440,
+      "line": 1442,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Speaking…",
       "surface": "android",
@@ -12187,7 +12179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1461,
+      "line": 1463,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Tools running",
       "surface": "android",
@@ -12195,7 +12187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1463,
+      "line": 1465,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is working",
       "surface": "android",
@@ -12203,7 +12195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1466,
+      "line": 1468,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "+${toolCalls.size - 4} more",
       "surface": "android",
@@ -12211,7 +12203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1476,
+      "line": 1478,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Thinking",
       "surface": "android",
@@ -12219,7 +12211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1477,
+      "line": 1479,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is preparing a response.",
       "surface": "android",
@@ -12227,7 +12219,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1542,
+      "line": 1544,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$completedCount/${steps.size}",
       "surface": "android",
@@ -12235,7 +12227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1549,
+      "line": 1551,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Collapse plan checklist",
       "surface": "android",
@@ -12243,7 +12235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1549,
+      "line": 1551,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Expand plan checklist",
       "surface": "android",
@@ -12251,7 +12243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1680,
+      "line": 1682,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Dismiss shared-image warning",
       "surface": "android",
@@ -12259,7 +12251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1782,
+      "line": 1784,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Stop",
       "surface": "android",
@@ -12267,7 +12259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1880,
+      "line": 1882,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Default",
       "surface": "android",
@@ -12275,7 +12267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1946,
+      "line": 1948,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Pin model",
       "surface": "android",
@@ -12283,7 +12275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1946,
+      "line": 1948,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Unpin model",
       "surface": "android",
@@ -12291,7 +12283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1963,
+      "line": 1965,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "No commands found",
       "surface": "android",
@@ -12299,7 +12291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2005,
+      "line": 2007,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Command",
       "surface": "android",
@@ -12307,7 +12299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2025,
+      "line": 2027,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway offline",
       "surface": "android",
@@ -12315,7 +12307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2071,
+      "line": 2073,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Close thinking level selector",
       "surface": "android",
@@ -12323,7 +12315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2071,
+      "line": 2073,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Open thinking level selector",
       "surface": "android",
@@ -12331,7 +12323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2135,
+      "line": 2137,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attach image",
       "surface": "android",
@@ -12339,7 +12331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2166,
+      "line": 2168,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Message OpenClaw",
       "surface": "android",
@@ -12347,7 +12339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2195,
+      "line": 2197,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "End Talk",
       "surface": "android",
@@ -12355,7 +12347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2195,
+      "line": 2197,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Start Talk",
       "surface": "android",
@@ -12363,7 +12355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2280,
+      "line": 2282,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Voice note · ${formatVoiceNoteDuration(duration)}",
       "surface": "android",
@@ -12371,7 +12363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2289,
+      "line": 2291,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Remove attachment",
       "surface": "android",
@@ -12379,7 +12371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2301,
+      "line": 2303,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "New chat",
       "surface": "android",
@@ -12387,7 +12379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2310,
+      "line": 2312,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Main",
       "surface": "android",
@@ -12395,7 +12387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2311,
+      "line": 2313,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Current",
       "surface": "android",
@@ -12403,7 +12395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2318,
+      "line": 2320,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$emoji $name",
       "surface": "android",
@@ -12411,7 +12403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2377,
+      "line": 2379,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Send",
       "surface": "android",
@@ -12419,7 +12411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2388,
+      "line": 2390,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat is still checking Gateway health.",
       "surface": "android",
@@ -12427,7 +12419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2389,
+      "line": 2391,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway is offline. Fix the connection below or copy diagnostics.",
       "surface": "android",
@@ -12435,7 +12427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2390,
+      "line": 2392,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway authentication needs attention.",
       "surface": "android",
@@ -12443,7 +12435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2409,
+      "line": 2411,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Context ${(it * 100).roundToInt()}%",
       "surface": "android",
@@ -12451,7 +12443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2410,
+      "line": 2412,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Context --",
       "surface": "android",
@@ -12459,7 +12451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2411,
+      "line": 2413,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$contextLabel · ${contextMeterThinkingLabel(thinkingLevel)}",
       "surface": "android",
@@ -12467,7 +12459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2450,
+      "line": 2452,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Off",
       "surface": "android",
@@ -12475,7 +12467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2451,
+      "line": 2453,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Minimal",
       "surface": "android",
@@ -12483,7 +12475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2452,
+      "line": 2454,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Low",
       "surface": "android",
@@ -12491,7 +12483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2453,
+      "line": 2455,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Medium",
       "surface": "android",
@@ -12499,7 +12491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2454,
+      "line": 2456,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "High",
       "surface": "android",
@@ -12507,7 +12499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2455,
+      "line": 2457,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Xhigh",
       "surface": "android",
@@ -12515,7 +12507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2456,
+      "line": 2458,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Adaptive",
       "surface": "android",
@@ -12523,7 +12515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2457,
+      "line": 2459,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Max",
       "surface": "android",
@@ -13371,7 +13363,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 39,
+      "line": 18,
+      "path": "apps/ios/ActivityWidget/OpenClawLiveActivity.swift",
+      "source": "OPENCLAW",
+      "surface": "apple",
+      "id": "native.apple.093081590556db7f"
+    },
+    {
+      "kind": "ui-call",
+      "line": 55,
       "path": "apps/ios/ActivityWidget/OpenClawLiveActivity.swift",
       "source": "OpenClaw",
       "surface": "apple",
@@ -13379,7 +13379,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 96,
+      "line": 132,
+      "path": "apps/ios/ActivityWidget/OpenClawLiveActivity.swift",
+      "source": "LIVE",
+      "surface": "apple",
+      "id": "native.apple.9fd01bdb5a753f3e"
+    },
+    {
+      "kind": "ui-call",
+      "line": 210,
       "path": "apps/ios/ActivityWidget/OpenClawLiveActivity.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -13387,7 +13395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 97,
+      "line": 211,
       "path": "apps/ios/ActivityWidget/OpenClawLiveActivity.swift",
       "source": "Reconnecting...",
       "surface": "apple",
@@ -13395,7 +13403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 98,
+      "line": 212,
       "path": "apps/ios/ActivityWidget/OpenClawLiveActivity.swift",
       "source": "Approval needed",
       "surface": "apple",
@@ -13403,15 +13411,63 @@
     },
     {
       "kind": "ui-call",
-      "line": 99,
+      "line": 213,
       "path": "apps/ios/ActivityWidget/OpenClawLiveActivity.swift",
       "source": "Action required",
       "surface": "apple",
       "id": "native.apple.c619843217c15317"
     },
     {
+      "kind": "ui-localized-call",
+      "line": 216,
+      "path": "apps/ios/ActivityWidget/OpenClawLiveActivity.swift",
+      "source": "Using %@",
+      "surface": "apple",
+      "id": "native.apple.275026f681242715"
+    },
+    {
       "kind": "ui-call",
-      "line": 100,
+      "line": 218,
+      "path": "apps/ios/ActivityWidget/OpenClawLiveActivity.swift",
+      "source": "Using a tool",
+      "surface": "apple",
+      "id": "native.apple.360d0d0fc0df9eb2"
+    },
+    {
+      "kind": "ui-call",
+      "line": 220,
+      "path": "apps/ios/ActivityWidget/OpenClawLiveActivity.swift",
+      "source": "Listening",
+      "surface": "apple",
+      "id": "native.apple.0d0ee660962ea840"
+    },
+    {
+      "kind": "ui-call",
+      "line": 221,
+      "path": "apps/ios/ActivityWidget/OpenClawLiveActivity.swift",
+      "source": "Speaking",
+      "surface": "apple",
+      "id": "native.apple.095ebf1496feb2ad"
+    },
+    {
+      "kind": "ui-call",
+      "line": 222,
+      "path": "apps/ios/ActivityWidget/OpenClawLiveActivity.swift",
+      "source": "Voice active",
+      "surface": "apple",
+      "id": "native.apple.63c98d2ca6a5b09c"
+    },
+    {
+      "kind": "ui-call",
+      "line": 223,
+      "path": "apps/ios/ActivityWidget/OpenClawLiveActivity.swift",
+      "source": "Paused",
+      "surface": "apple",
+      "id": "native.apple.02470f4b5348f97c"
+    },
+    {
+      "kind": "ui-call",
+      "line": 224,
       "path": "apps/ios/ActivityWidget/OpenClawLiveActivity.swift",
       "source": "Connected",
       "surface": "apple",
@@ -13419,7 +13475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 101,
+      "line": 225,
       "path": "apps/ios/ActivityWidget/OpenClawLiveActivity.swift",
       "source": "Disconnected",
       "surface": "apple",
@@ -16875,7 +16931,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 167,
+      "line": 181,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Unable to Export Transcript",
       "surface": "apple",
@@ -16883,7 +16939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 171,
+      "line": 185,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "OK",
       "surface": "apple",
@@ -16891,7 +16947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 175,
+      "line": 189,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "OpenClaw could not prepare the Markdown file.",
       "surface": "apple",
@@ -16899,7 +16955,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 197,
+      "line": 211,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "What would you like to work on?",
       "surface": "apple",
@@ -16907,23 +16963,63 @@
     },
     {
       "kind": "ui-call",
-      "line": 210,
+      "line": 225,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "The session attaches once the gateway is ready.",
       "surface": "apple",
       "id": "native.apple.32179ce0b6d4543f"
     },
     {
-      "kind": "ui-modifier",
-      "line": 338,
+      "kind": "conditional-branch",
+      "line": 313,
+      "path": "apps/ios/Sources/Design/ChatProTab.swift",
+      "source": "Collapsed",
+      "surface": "apple",
+      "id": "native.apple.02611ddddef7295a"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 313,
+      "path": "apps/ios/Sources/Design/ChatProTab.swift",
+      "source": "Expanded",
+      "surface": "apple",
+      "id": "native.apple.1f4911f4a05230b5"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 383,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Opens Settings / Gateway",
       "surface": "apple",
       "id": "native.apple.d19c9577e0fdfea7"
     },
     {
+      "kind": "ui-localized-call",
+      "line": 386,
+      "path": "apps/ios/Sources/Design/ChatProTab.swift",
+      "source": "Hides the gateway status label",
+      "surface": "apple",
+      "id": "native.apple.b59e690104ae3e24"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 387,
+      "path": "apps/ios/Sources/Design/ChatProTab.swift",
+      "source": "Shows the full gateway status label",
+      "surface": "apple",
+      "id": "native.apple.5fcf9d462463dd27"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 406,
+      "path": "apps/ios/Sources/Design/ChatProTab.swift",
+      "source": "Voice off",
+      "surface": "apple",
+      "id": "native.apple.592b1e673e42df50"
+    },
+    {
       "kind": "ui-call",
-      "line": 363,
+      "line": 547,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "New Chat",
       "surface": "apple",
@@ -16931,7 +17027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 376,
+      "line": 560,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "New Chat in Worktree",
       "surface": "apple",
@@ -16939,7 +17035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 389,
+      "line": 573,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "New Session Options…",
       "surface": "apple",
@@ -16947,7 +17043,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 401,
+      "line": 585,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Sessions…",
       "surface": "apple",
@@ -16955,7 +17051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 419,
+      "line": 603,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Background Tasks",
       "surface": "apple",
@@ -16963,15 +17059,23 @@
     },
     {
       "kind": "ui-call",
-      "line": 431,
+      "line": 615,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Export Transcript",
       "surface": "apple",
       "id": "native.apple.ced228bb4d20a726"
     },
     {
+      "kind": "ui-call",
+      "line": 628,
+      "path": "apps/ios/Sources/Design/ChatProTab.swift",
+      "source": "Gateway Settings",
+      "surface": "apple",
+      "id": "native.apple.d510e012c91b24ed"
+    },
+    {
       "kind": "ui-localized-call",
-      "line": 441,
+      "line": 639,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Show reasoning & tool activity",
       "surface": "apple",
@@ -16979,7 +17083,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 450,
+      "line": 648,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Chat actions",
       "surface": "apple",
@@ -16987,7 +17091,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 519,
+      "line": 742,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Connected",
       "surface": "apple",
@@ -16995,7 +17099,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 519,
+      "line": 742,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Unavailable",
       "surface": "apple",
@@ -17003,7 +17107,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 532,
+      "line": 755,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Message %@...",
       "surface": "apple",
@@ -17011,7 +17115,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 537,
+      "line": 760,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Message %@; sends when connected",
       "surface": "apple",
@@ -17019,7 +17123,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 540,
+      "line": 763,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Connect to a gateway",
       "surface": "apple",
@@ -17027,7 +17131,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 638,
+      "line": 852,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Check OpenClaw status",
       "surface": "apple",
@@ -17035,7 +17139,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 639,
+      "line": 853,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Summarize the current OpenClaw status and tell me what needs attention.",
       "surface": "apple",
@@ -17043,7 +17147,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 642,
+      "line": 856,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "What can I control here?",
       "surface": "apple",
@@ -17051,7 +17155,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 643,
+      "line": 857,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Show me which phone controls and device capabilities are available right now.",
       "surface": "apple",
@@ -17059,7 +17163,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 646,
+      "line": 860,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Help me start voice chat",
       "surface": "apple",
@@ -17067,7 +17171,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 647,
+      "line": 861,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Help me start a realtime voice session from this phone.",
       "surface": "apple",
@@ -18787,7 +18891,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 626,
+      "line": 616,
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "OpenClaw",
       "surface": "apple",
@@ -18795,7 +18899,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 656,
+      "line": 646,
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "Gateway %@",
       "surface": "apple",
@@ -18803,7 +18907,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 663,
+      "line": 653,
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "Online",
       "surface": "apple",
@@ -18811,7 +18915,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 665,
+      "line": 655,
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "Connecting",
       "surface": "apple",
@@ -18819,7 +18923,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 667,
+      "line": 657,
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "Attention",
       "surface": "apple",
@@ -18827,7 +18931,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 669,
+      "line": 659,
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "Offline",
       "surface": "apple",
@@ -18851,7 +18955,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 100,
+      "line": 97,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Agent chat and recent work.",
       "surface": "apple",
@@ -18859,15 +18963,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 103,
-      "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
-      "source": "Realtime voice and controls.",
-      "surface": "apple",
-      "id": "native.apple.a30d0a950d0a77aa"
-    },
-    {
-      "kind": "ui-named-argument",
-      "line": 173,
+      "line": 166,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Overview",
       "surface": "apple",
@@ -18875,7 +18971,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 195,
+      "line": 188,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Instances",
       "surface": "apple",
@@ -18883,7 +18979,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 204,
+      "line": 197,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Files",
       "surface": "apple",
@@ -18891,7 +18987,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 209,
+      "line": 202,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Dreaming",
       "surface": "apple",
@@ -18899,7 +18995,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 214,
+      "line": 207,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Usage",
       "surface": "apple",
@@ -18907,7 +19003,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 219,
+      "line": 212,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Automations",
       "surface": "apple",
@@ -18915,7 +19011,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 284,
+      "line": 277,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Default Agent",
       "surface": "apple",
@@ -18923,7 +19019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 299,
+      "line": 292,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Gateway",
       "surface": "apple",
@@ -18931,7 +19027,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 307,
+      "line": 300,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Gateway %1$@, %2$@, %3$@",
       "surface": "apple",
@@ -18939,7 +19035,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 314,
+      "line": 307,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Gateway %1$@, %2$@",
       "surface": "apple",
@@ -18947,7 +19043,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 323,
+      "line": 316,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Online",
       "surface": "apple",
@@ -18955,7 +19051,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 324,
+      "line": 317,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Connecting",
       "surface": "apple",
@@ -18963,7 +19059,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 325,
+      "line": 318,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Attention",
       "surface": "apple",
@@ -18971,7 +19067,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 326,
+      "line": 319,
       "path": "apps/ios/Sources/Design/RootTabsPhoneControlHub.swift",
       "source": "Offline",
       "surface": "apple",
@@ -19683,7 +19779,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 404,
+      "line": 405,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Opening QR scanner...",
       "surface": "apple",
@@ -19691,7 +19787,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 410,
+      "line": 411,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "QR loaded. Closing scanner...",
       "surface": "apple",
@@ -19699,7 +19795,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 440,
+      "line": 441,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Apple Review demo mode enabled.",
       "surface": "apple",
@@ -19707,7 +19803,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 491,
+      "line": 492,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Failed: host required",
       "surface": "apple",
@@ -19715,7 +19811,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 499,
+      "line": 500,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Failed: invalid port",
       "surface": "apple",
@@ -19723,7 +19819,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 557,
+      "line": 558,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Tailscale is off on this device. Turn it on, then try again.",
       "surface": "apple",
@@ -19731,7 +19827,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 934,
+      "line": 935,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Gateway",
       "surface": "apple",
@@ -19739,7 +19835,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 935,
+      "line": 936,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Apple Watch",
       "surface": "apple",
@@ -19747,7 +19843,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 936,
+      "line": 937,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Approvals",
       "surface": "apple",
@@ -19755,7 +19851,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 937,
+      "line": 938,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Permissions",
       "surface": "apple",
@@ -19763,7 +19859,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 938,
+      "line": 939,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Channels",
       "surface": "apple",
@@ -19771,7 +19867,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 939,
+      "line": 940,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Skills",
       "surface": "apple",
@@ -19779,7 +19875,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 940,
+      "line": 941,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Voice & Talk",
       "surface": "apple",
@@ -19787,7 +19883,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 941,
+      "line": 942,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Diagnostics",
       "surface": "apple",
@@ -19795,7 +19891,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 942,
+      "line": 943,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Privacy",
       "surface": "apple",
@@ -19803,7 +19899,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 944,
+      "line": 945,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Licenses",
       "surface": "apple",
@@ -19811,7 +19907,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 945,
+      "line": 946,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "About",
       "surface": "apple",
@@ -19819,7 +19915,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 952,
+      "line": 953,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Preparing one-time setup…",
       "surface": "apple",
@@ -19827,7 +19923,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 957,
+      "line": 958,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Setup sent. Open OpenClaw on the watch to connect.",
       "surface": "apple",
@@ -19835,7 +19931,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 959,
+      "line": 960,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Setup queued for the watch. Open OpenClaw before the code expires.",
       "surface": "apple",
@@ -19843,7 +19939,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1049,
+      "line": 1050,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "This gateway is on your tailnet. Turn on Tailscale on this device, then tap Connect.",
       "surface": "apple",
@@ -19851,7 +19947,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1056,
+      "line": 1057,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Pairing required. Run /pair approve in your OpenClaw chat, then connect again.",
       "surface": "apple",
@@ -19859,7 +19955,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1059,
+      "line": 1060,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Secure handshake failed. Check Tailscale, then connect again.",
       "surface": "apple",
@@ -19867,7 +19963,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1068,
+      "line": 1069,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Connection timed out. Make sure Tailscale is connected, then try again.",
       "surface": "apple",
@@ -19875,7 +19971,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1072,
+      "line": 1073,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Connected, but some controls are restricted for nodes. This is expected.",
       "surface": "apple",
@@ -19883,7 +19979,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1079,
+      "line": 1080,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Setup code applied. Connecting...",
       "surface": "apple",
@@ -19891,7 +19987,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1080,
+      "line": 1081,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Checking gateway reachability...",
       "surface": "apple",
@@ -19899,7 +19995,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1081,
+      "line": 1082,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "QR loaded. Connecting to %@:%@...",
       "surface": "apple",
@@ -19907,7 +20003,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1144,
+      "line": 1145,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Not loaded",
       "surface": "apple",
@@ -19915,7 +20011,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1147,
+      "line": 1148,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Configured",
       "surface": "apple",
@@ -19923,7 +20019,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1148,
+      "line": 1149,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Not configured",
       "surface": "apple",
@@ -19931,7 +20027,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1155,
+      "line": 1156,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Not active",
       "surface": "apple",
@@ -19939,7 +20035,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1191,
+      "line": 1192,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Apple Review demo mode",
       "surface": "apple",
@@ -19947,7 +20043,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1194,
+      "line": 1195,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Connected",
       "surface": "apple",
@@ -19955,7 +20051,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1200,
+      "line": 1201,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "offline",
       "surface": "apple",
@@ -19963,7 +20059,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1200,
+      "line": 1201,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "online",
       "surface": "apple",
@@ -19971,7 +20067,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1218,
+      "line": 1219,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Live gateway requests are disabled in demo mode.",
       "surface": "apple",
@@ -19979,7 +20075,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1222,
+      "line": 1223,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Foreground approvals still appear while OpenClaw is connected.",
       "surface": "apple",
@@ -19987,7 +20083,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1225,
+      "line": 1226,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Gateway requests will appear here.",
       "surface": "apple",
@@ -19995,7 +20091,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1226,
+      "line": 1227,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Connect to the gateway.",
       "surface": "apple",
@@ -20003,7 +20099,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1230,
+      "line": 1231,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Demo mode only",
       "surface": "apple",
@@ -20011,7 +20107,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1237,
+      "line": 1238,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "loaded",
       "surface": "apple",
@@ -20019,7 +20115,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1238,
+      "line": 1239,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "missing",
       "surface": "apple",
@@ -20027,7 +20123,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1247,
+      "line": 1248,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Waiting for gateway",
       "surface": "apple",
@@ -20035,7 +20131,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1264,
+      "line": 1265,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "1 waiting",
       "surface": "apple",
@@ -20043,7 +20139,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1267,
+      "line": 1268,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "%@ waiting",
       "surface": "apple",
@@ -20051,7 +20147,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1278,
+      "line": 1279,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Review gateway action",
       "surface": "apple",
@@ -20059,7 +20155,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1280,
+      "line": 1281,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Agent: %@",
       "surface": "apple",
@@ -20067,7 +20163,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1289,
+      "line": 1290,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Resolving",
       "surface": "apple",
@@ -20075,7 +20171,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1290,
+      "line": 1291,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "High",
       "surface": "apple",
@@ -20083,7 +20179,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1296,
+      "line": 1297,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Permission can be saved",
       "surface": "apple",
@@ -20091,7 +20187,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1297,
+      "line": 1298,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "One-time approval",
       "surface": "apple",
@@ -20099,7 +20195,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1300,
+      "line": 1301,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Medium",
       "surface": "apple",
@@ -20107,7 +20203,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1301,
+      "line": 1302,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Review",
       "surface": "apple",
@@ -20115,7 +20211,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1307,
+      "line": 1308,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Talk + Wake",
       "surface": "apple",
@@ -20123,7 +20219,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1308,
+      "line": 1309,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Talk on",
       "surface": "apple",
@@ -20131,7 +20227,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1309,
+      "line": 1310,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Wake on",
       "surface": "apple",
@@ -20139,7 +20235,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1310,
+      "line": 1311,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Off",
       "surface": "apple",
@@ -20147,7 +20243,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1314,
+      "line": 1315,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "demo",
       "surface": "apple",
@@ -20155,7 +20251,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1315,
+      "line": 1316,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "ready",
       "surface": "apple",
@@ -20163,7 +20259,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1316,
+      "line": 1317,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "check",
       "surface": "apple",
@@ -20171,7 +20267,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1317,
+      "line": 1318,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "partial",
       "surface": "apple",
@@ -20179,7 +20275,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1321,
+      "line": 1322,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "pending",
       "surface": "apple",
@@ -20187,7 +20283,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1323,
+      "line": 1324,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "pass",
       "surface": "apple",
@@ -20195,7 +20291,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1334,
+      "line": 1335,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Requesting iOS location permission…",
       "surface": "apple",
@@ -20203,7 +20299,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1400,
+      "line": 1401,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "This build uses OpenClaw's hosted push relay at %@ for notification delivery data.",
       "surface": "apple",
@@ -20211,7 +20307,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1404,
+      "line": 1405,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "This build is not configured to use OpenClaw's hosted push relay.",
       "surface": "apple",
@@ -20219,7 +20315,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1409,
+      "line": 1410,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Enabling this sends delivery data through OpenClaw's hosted push relay.",
       "surface": "apple",
@@ -22202,238 +22298,6 @@
       "id": "native.apple.7a5a1b9342f01954"
     },
     {
-      "kind": "ui-modifier",
-      "line": 62,
-      "path": "apps/ios/Sources/Design/TalkProTab.swift",
-      "source": "Enable Talk",
-      "surface": "apple",
-      "id": "native.apple.798c3584ad95f8da"
-    },
-    {
-      "kind": "ui-call",
-      "line": 68,
-      "path": "apps/ios/Sources/Design/TalkProTab.swift",
-      "source": "Not Now",
-      "surface": "apple",
-      "id": "native.apple.c6e171128190d131"
-    },
-    {
-      "kind": "ui-modifier",
-      "line": 107,
-      "path": "apps/ios/Sources/Design/TalkProTab.swift",
-      "source": "Talk",
-      "surface": "apple",
-      "id": "native.apple.e4b15aef3c2e3da7"
-    },
-    {
-      "kind": "ui-call",
-      "line": 161,
-      "path": "apps/ios/Sources/Design/TalkProTab.swift",
-      "source": "Conversation",
-      "surface": "apple",
-      "id": "native.apple.ab3381742bdff650"
-    },
-    {
-      "kind": "ui-call",
-      "line": 162,
-      "path": "apps/ios/Sources/Design/TalkProTab.swift",
-      "source": "Agent",
-      "surface": "apple",
-      "id": "native.apple.7af100f6640c6a69"
-    },
-    {
-      "kind": "ui-call",
-      "line": 163,
-      "path": "apps/ios/Sources/Design/TalkProTab.swift",
-      "source": "Session",
-      "surface": "apple",
-      "id": "native.apple.49c4de60117b1a98"
-    },
-    {
-      "kind": "ui-call",
-      "line": 164,
-      "path": "apps/ios/Sources/Design/TalkProTab.swift",
-      "source": "Runtime",
-      "surface": "apple",
-      "id": "native.apple.37c29d2506b955e9"
-    },
-    {
-      "kind": "ui-call",
-      "line": 169,
-      "path": "apps/ios/Sources/Design/TalkProTab.swift",
-      "source": "Voice Mode",
-      "surface": "apple",
-      "id": "native.apple.13e0ad79b141576e"
-    },
-    {
-      "kind": "ui-call",
-      "line": 170,
-      "path": "apps/ios/Sources/Design/TalkProTab.swift",
-      "source": "Configured",
-      "surface": "apple",
-      "id": "native.apple.e8035b71bab833c7"
-    },
-    {
-      "kind": "ui-call",
-      "line": 173,
-      "path": "apps/ios/Sources/Design/TalkProTab.swift",
-      "source": "Active",
-      "surface": "apple",
-      "id": "native.apple.1b2845ec89d20eef"
-    },
-    {
-      "kind": "ui-call",
-      "line": 174,
-      "path": "apps/ios/Sources/Design/TalkProTab.swift",
-      "source": "Transport",
-      "surface": "apple",
-      "id": "native.apple.a82c07df64d13b23"
-    },
-    {
-      "kind": "ui-call",
-      "line": 176,
-      "path": "apps/ios/Sources/Design/TalkProTab.swift",
-      "source": "Last issue",
-      "surface": "apple",
-      "id": "native.apple.384e097278f76954"
-    },
-    {
-      "kind": "ui-call",
-      "line": 178,
-      "path": "apps/ios/Sources/Design/TalkProTab.swift",
-      "source": "Permission",
-      "surface": "apple",
-      "id": "native.apple.a6d8fc7bfd98836f"
-    },
-    {
-      "kind": "ui-call",
-      "line": 179,
-      "path": "apps/ios/Sources/Design/TalkProTab.swift",
-      "source": "Speech language",
-      "surface": "apple",
-      "id": "native.apple.983bdcd5e3f1baa8"
-    },
-    {
-      "kind": "ui-call",
-      "line": 184,
-      "path": "apps/ios/Sources/Design/TalkProTab.swift",
-      "source": "Controls",
-      "surface": "apple",
-      "id": "native.apple.32e7fa2b1798e9c3"
-    },
-    {
-      "kind": "ui-call",
-      "line": 186,
-      "path": "apps/ios/Sources/Design/TalkProTab.swift",
-      "source": "Speakerphone",
-      "surface": "apple",
-      "id": "native.apple.0eb012a5d3d81b32"
-    },
-    {
-      "kind": "ui-call",
-      "line": 191,
-      "path": "apps/ios/Sources/Design/TalkProTab.swift",
-      "source": "Background listening",
-      "surface": "apple",
-      "id": "native.apple.ef8699e2718346da"
-    },
-    {
-      "kind": "ui-call",
-      "line": 197,
-      "path": "apps/ios/Sources/Design/TalkProTab.swift",
-      "source": "Voice & Talk Settings",
-      "surface": "apple",
-      "id": "native.apple.1e6938a09b4fbe77"
-    },
-    {
-      "kind": "ui-call",
-      "line": 225,
-      "path": "apps/ios/Sources/Design/TalkProTab.swift",
-      "source": "Gateway approval is required before this phone can capture voice.",
-      "surface": "apple",
-      "id": "native.apple.c7a591fd5bb6687e"
-    },
-    {
-      "kind": "ui-call",
-      "line": 228,
-      "path": "apps/ios/Sources/Design/TalkProTab.swift",
-      "source": "Voice is disabled in Apple Review demo mode.",
-      "surface": "apple",
-      "id": "native.apple.9d40e75e55ed39eb"
-    },
-    {
-      "kind": "ui-call",
-      "line": 231,
-      "path": "apps/ios/Sources/Design/TalkProTab.swift",
-      "source": "Connect to your gateway to start a voice conversation.",
-      "surface": "apple",
-      "id": "native.apple.3ef69bf916177799"
-    },
-    {
-      "kind": "ui-call",
-      "line": 234,
-      "path": "apps/ios/Sources/Design/TalkProTab.swift",
-      "source": "Open Voice settings after the gateway loads Talk configuration.",
-      "surface": "apple",
-      "id": "native.apple.ed03af7c68841a5d"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 241,
-      "path": "apps/ios/Sources/Design/TalkProTab.swift",
-      "source": "Routes voice to %@.",
-      "surface": "apple",
-      "id": "native.apple.883a251978601b96"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 254,
-      "path": "apps/ios/Sources/Design/TalkProTab.swift",
-      "source": "Not loaded",
-      "surface": "apple",
-      "id": "native.apple.877fb5c1abfaafa1"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 263,
-      "path": "apps/ios/Sources/Design/TalkProTab.swift",
-      "source": "Not active",
-      "surface": "apple",
-      "id": "native.apple.d3ccb092936551fc"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 441,
-      "path": "apps/ios/Sources/Design/TalkProTab.swift",
-      "source": "Open Gateway Settings",
-      "surface": "apple",
-      "id": "native.apple.1620f7cb3deea133"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 441,
-      "path": "apps/ios/Sources/Design/TalkProTab.swift",
-      "source": "Open Voice Settings",
-      "surface": "apple",
-      "id": "native.apple.3fd2706ef0f14fd2"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 442,
-      "path": "apps/ios/Sources/Design/TalkProTab.swift",
-      "source": "Demo Mode Only",
-      "surface": "apple",
-      "id": "native.apple.3cc9cd23a67db077"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 442,
-      "path": "apps/ios/Sources/Design/TalkProTab.swift",
-      "source": "Waiting for Approval",
-      "surface": "apple",
-      "id": "native.apple.12c9d8231777366c"
-    },
-    {
       "kind": "ui-named-argument",
       "line": 17,
       "path": "apps/ios/Sources/Design/TalkRuntimeIssueBanner.swift",
@@ -22707,7 +22571,7 @@
     },
     {
       "kind": "ui-localized-call-multiline",
-      "line": 1281,
+      "line": 1283,
       "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
       "source": "Can't reach gateway at %1$@:%2$@. Verify Tailscale Serve is enabled and publishes this Gateway.",
       "surface": "apple",
@@ -22715,7 +22579,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1290,
+      "line": 1292,
       "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
       "source": "Can't reach gateway at %1$@:%2$@. Check Tailscale or LAN.",
       "surface": "apple",
@@ -22723,7 +22587,7 @@
     },
     {
       "kind": "ui-localized-call-multiline",
-      "line": 1296,
+      "line": 1298,
       "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
       "source": "TLS fingerprint verification timed out for %1$@:%2$@. Secure endpoint was reached, but TLS did not finish in time.",
       "surface": "apple",
@@ -22731,7 +22595,7 @@
     },
     {
       "kind": "ui-localized-call-multiline",
-      "line": 1304,
+      "line": 1306,
       "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
       "source": "No secure gateway endpoint was detected at %1$@:%2$@. Enable gateway TLS or Tailscale Serve, or use a trusted private LAN address with Unencrypted selected.",
       "surface": "apple",
@@ -22739,7 +22603,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1314,
+      "line": 1316,
       "path": "apps/ios/Sources/Gateway/GatewayConnectionController.swift",
       "source": "Could not read the TLS certificate from %1$@:%2$@.",
       "surface": "apple",
@@ -23307,7 +23171,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 169,
+      "line": 565,
       "path": "apps/ios/Sources/LiveActivity/LiveActivityManager.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -23315,7 +23179,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 172,
+      "line": 568,
       "path": "apps/ios/Sources/LiveActivity/LiveActivityManager.swift",
       "source": "Reconnecting...",
       "surface": "apple",
@@ -23323,7 +23187,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 179,
+      "line": 575,
       "path": "apps/ios/Sources/LiveActivity/LiveActivityManager.swift",
       "source": "Approval needed",
       "surface": "apple",
@@ -23331,11 +23195,67 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 182,
+      "line": 578,
       "path": "apps/ios/Sources/LiveActivity/LiveActivityManager.swift",
       "source": "Action required",
       "surface": "apple",
       "id": "native.apple.8faaac6dab276c0a"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 596,
+      "path": "apps/ios/Sources/LiveActivity/LiveActivityManager.swift",
+      "source": "Listening",
+      "surface": "apple",
+      "id": "native.apple.7205f0822706cb55"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 597,
+      "path": "apps/ios/Sources/LiveActivity/LiveActivityManager.swift",
+      "source": "Listening (PTT)",
+      "surface": "apple",
+      "id": "native.apple.8b10cb1dc21e42af"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 598,
+      "path": "apps/ios/Sources/LiveActivity/LiveActivityManager.swift",
+      "source": "Listening (Realtime)",
+      "surface": "apple",
+      "id": "native.apple.939c7ec55636c67f"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 602,
+      "path": "apps/ios/Sources/LiveActivity/LiveActivityManager.swift",
+      "source": "Speaking…",
+      "surface": "apple",
+      "id": "native.apple.86f203ebb2453d15"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 603,
+      "path": "apps/ios/Sources/LiveActivity/LiveActivityManager.swift",
+      "source": "Speaking (System)…",
+      "surface": "apple",
+      "id": "native.apple.1e3ff6b56ae3828d"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 604,
+      "path": "apps/ios/Sources/LiveActivity/LiveActivityManager.swift",
+      "source": "Generating voice…",
+      "surface": "apple",
+      "id": "native.apple.37a5fedaefb8ebf3"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 607,
+      "path": "apps/ios/Sources/LiveActivity/LiveActivityManager.swift",
+      "source": "Ready",
+      "surface": "apple",
+      "id": "native.apple.47003f094346c660"
     },
     {
       "kind": "conditional-branch",
@@ -23571,7 +23491,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3864,
+      "line": 4065,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval needed",
       "surface": "apple",
@@ -23579,7 +23499,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3865,
+      "line": 4066,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Action required",
       "surface": "apple",
@@ -23587,7 +23507,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4564,
+      "line": 4781,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -23595,7 +23515,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4565,
+      "line": 4782,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting...",
       "surface": "apple",
@@ -23603,7 +23523,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 4909,
+      "line": 5134,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connected",
       "surface": "apple",
@@ -23611,7 +23531,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 4909,
+      "line": 5134,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Offline",
       "surface": "apple",
@@ -23619,7 +23539,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6075,
+      "line": 6304,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "No chat messages yet",
       "surface": "apple",
@@ -23627,7 +23547,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6274,
+      "line": 6503,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting…",
       "surface": "apple",
@@ -23635,7 +23555,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6274,
+      "line": 6503,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting…",
       "surface": "apple",
@@ -23643,7 +23563,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8683,
+      "line": 8912,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval",
       "surface": "apple",
@@ -23651,7 +23571,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8683,
+      "line": 8912,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "This approval was already",
       "surface": "apple",
@@ -23659,7 +23579,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8689,
+      "line": 8918,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "This approval was already set to Always Allow.",
       "surface": "apple",
@@ -23667,7 +23587,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8690,
+      "line": 8919,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval set to Always Allow.",
       "surface": "apple",
@@ -23675,7 +23595,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 10028,
+      "line": 10257,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "\\(urlText.prefix(500))…",
       "surface": "apple",
@@ -24651,39 +24571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 174,
-      "path": "apps/ios/Sources/RootTabs.swift",
-      "source": "Talk",
-      "surface": "apple",
-      "id": "native.apple.f2ea327bfea8b8e3"
-    },
-    {
-      "kind": "ui-call",
-      "line": 187,
-      "path": "apps/ios/Sources/RootTabs.swift",
-      "source": "Control",
-      "surface": "apple",
-      "id": "native.apple.bda6cfa988e49a75"
-    },
-    {
-      "kind": "ui-call",
-      "line": 196,
-      "path": "apps/ios/Sources/RootTabs.swift",
-      "source": "Agent",
-      "surface": "apple",
-      "id": "native.apple.3c80f5351055a5f3"
-    },
-    {
-      "kind": "ui-call",
-      "line": 209,
-      "path": "apps/ios/Sources/RootTabs.swift",
-      "source": "Settings",
-      "surface": "apple",
-      "id": "native.apple.22d107db5b905ef4"
-    },
-    {
-      "kind": "ui-call",
-      "line": 308,
+      "line": 249,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "OpenClaw",
       "surface": "apple",
@@ -24691,7 +24579,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 340,
+      "line": 281,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "OpenClaw %@",
       "surface": "apple",
@@ -24699,7 +24587,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 347,
+      "line": 288,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Online",
       "surface": "apple",
@@ -24707,7 +24595,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 349,
+      "line": 290,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Connecting",
       "surface": "apple",
@@ -24715,7 +24603,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 351,
+      "line": 292,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Needs attention",
       "surface": "apple",
@@ -24723,7 +24611,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 353,
+      "line": 294,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Offline",
       "surface": "apple",
@@ -24731,7 +24619,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 432,
+      "line": 373,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Chat",
       "surface": "apple",
@@ -24739,7 +24627,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 445,
+      "line": 380,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Overview",
       "surface": "apple",
@@ -24747,7 +24635,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 469,
+      "line": 404,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Agents",
       "surface": "apple",
@@ -24755,7 +24643,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 476,
+      "line": 411,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Instances",
       "surface": "apple",
@@ -24763,7 +24651,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 487,
+      "line": 422,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Files",
       "surface": "apple",
@@ -24771,7 +24659,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 494,
+      "line": 429,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Dreaming",
       "surface": "apple",
@@ -24779,7 +24667,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 501,
+      "line": 436,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Usage",
       "surface": "apple",
@@ -24787,7 +24675,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 508,
+      "line": 443,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Automations",
       "surface": "apple",
@@ -24795,7 +24683,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 620,
+      "line": 555,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Show Sidebar",
       "surface": "apple",
@@ -24803,7 +24691,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 631,
+      "line": 566,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Back to %@",
       "surface": "apple",
@@ -24811,7 +24699,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 656,
+      "line": 591,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Hide Sidebar",
       "surface": "apple",
@@ -24819,11 +24707,43 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 774,
+      "line": 709,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Close canvas",
       "surface": "apple",
       "id": "native.apple.8af43f59602ec0d8"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 916,
+      "path": "apps/ios/Sources/RootTabs.swift",
+      "source": "Chat, voice active",
+      "surface": "apple",
+      "id": "native.apple.a1db6ce0aed1d18e"
+    },
+    {
+      "kind": "ui-call",
+      "line": 926,
+      "path": "apps/ios/Sources/RootTabs.swift",
+      "source": "Control",
+      "surface": "apple",
+      "id": "native.apple.bda6cfa988e49a75"
+    },
+    {
+      "kind": "ui-call",
+      "line": 935,
+      "path": "apps/ios/Sources/RootTabs.swift",
+      "source": "Agent",
+      "surface": "apple",
+      "id": "native.apple.3c80f5351055a5f3"
+    },
+    {
+      "kind": "ui-call",
+      "line": 948,
+      "path": "apps/ios/Sources/RootTabs.swift",
+      "source": "Settings",
+      "surface": "apple",
+      "id": "native.apple.22d107db5b905ef4"
     },
     {
       "kind": "conditional-branch",
@@ -24867,7 +24787,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 64,
+      "line": 62,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Chat",
       "surface": "apple",
@@ -24875,15 +24795,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 65,
-      "path": "apps/ios/Sources/RootTabsNavigation.swift",
-      "source": "Talk",
-      "surface": "apple",
-      "id": "native.apple.febca7528af94342"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 66,
+      "line": 63,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Overview",
       "surface": "apple",
@@ -24891,7 +24803,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 67,
+      "line": 64,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Activity",
       "surface": "apple",
@@ -24899,7 +24811,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 68,
+      "line": 65,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Agents",
       "surface": "apple",
@@ -24907,7 +24819,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 69,
+      "line": 66,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Workboard",
       "surface": "apple",
@@ -24915,7 +24827,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 70,
+      "line": 67,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Skill Workshop",
       "surface": "apple",
@@ -24923,7 +24835,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 71,
+      "line": 68,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Instances",
       "surface": "apple",
@@ -24931,7 +24843,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 72,
+      "line": 69,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Sessions",
       "surface": "apple",
@@ -24939,7 +24851,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 73,
+      "line": 70,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Files",
       "surface": "apple",
@@ -24947,7 +24859,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 74,
+      "line": 71,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Dreaming",
       "surface": "apple",
@@ -24955,7 +24867,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 75,
+      "line": 72,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Usage",
       "surface": "apple",
@@ -24963,7 +24875,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 76,
+      "line": 73,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Automations",
       "surface": "apple",
@@ -24971,7 +24883,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 77,
+      "line": 74,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Terminal",
       "surface": "apple",
@@ -24979,7 +24891,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 78,
+      "line": 75,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Docs",
       "surface": "apple",
@@ -24987,7 +24899,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 79,
+      "line": 76,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Settings",
       "surface": "apple",
@@ -24995,7 +24907,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 80,
+      "line": 77,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Settings / Gateway",
       "surface": "apple",
@@ -25003,7 +24915,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 86,
+      "line": 83,
       "path": "apps/ios/Sources/RootTabsNavigation.swift",
       "source": "Connection",
       "surface": "apple",
@@ -25427,7 +25339,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 581,
+      "line": 591,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Gateway relay ready",
       "surface": "apple",
@@ -25435,7 +25347,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 583,
+      "line": 593,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Realtime Voice, Gateway relay ready",
       "surface": "apple",
@@ -25443,7 +25355,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 585,
+      "line": 595,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Listening starts from this phone",
       "surface": "apple",
@@ -25451,7 +25363,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 825,
+      "line": 835,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Off",
       "surface": "apple",
@@ -25459,7 +25371,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 828,
+      "line": 838,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Not active",
       "surface": "apple",
@@ -25467,7 +25379,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1005,
+      "line": 1024,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Requesting permissions…",
       "surface": "apple",
@@ -25475,23 +25387,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1013,
-      "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
-      "source": "Microphone permission denied",
-      "surface": "apple",
-      "id": "native.apple.a1910b5c2e008b6c"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 1022,
-      "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
-      "source": "Speech recognition",
-      "surface": "apple",
-      "id": "native.apple.6a48b93f46ea3b08"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 1058,
+      "line": 1053,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Start failed: %@",
       "surface": "apple",
@@ -25499,7 +25395,23 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1373,
+      "line": 1309,
+      "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
+      "source": "Microphone permission denied",
+      "surface": "apple",
+      "id": "native.apple.a1910b5c2e008b6c"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 1319,
+      "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
+      "source": "Speech recognition",
+      "surface": "apple",
+      "id": "native.apple.6a48b93f46ea3b08"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 1450,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Offline",
       "surface": "apple",
@@ -25507,7 +25419,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1572,
+      "line": 1649,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Speech error: %@",
       "surface": "apple",
@@ -25515,7 +25427,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1881,
+      "line": 1964,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Gateway not connected",
       "surface": "apple",
@@ -25523,7 +25435,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1925,
+      "line": 2008,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Aborted",
       "surface": "apple",
@@ -25531,7 +25443,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1925,
+      "line": 2008,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Chat error",
       "surface": "apple",
@@ -25539,7 +25451,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1953,
+      "line": 2036,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Talk failed: %@",
       "surface": "apple",
@@ -25547,7 +25459,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 2057,
+      "line": 2140,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "No reply",
       "surface": "apple",
@@ -25555,7 +25467,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 2149,
+      "line": 2232,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Paused",
       "surface": "apple",
@@ -25563,7 +25475,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 2559,
+      "line": 2644,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Generating voice…",
       "surface": "apple",
@@ -25571,7 +25483,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 2697,
+      "line": 2782,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Speak failed: %@",
       "surface": "apple",
@@ -25579,7 +25491,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 2796,
+      "line": 2881,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Speaking (System)…",
       "surface": "apple",
@@ -25587,7 +25499,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3669,
+      "line": 3762,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "iOS System Voice",
       "surface": "apple",
@@ -25595,7 +25507,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3671,
+      "line": 3764,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Realtime Voice",
       "surface": "apple",
@@ -25603,7 +25515,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3675,
+      "line": 3768,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Gateway Default",
       "surface": "apple",
@@ -25611,7 +25523,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3734,
+      "line": 3827,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Listening (Realtime)",
       "surface": "apple",
@@ -25619,7 +25531,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3736,
+      "line": 3829,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Thinking",
       "surface": "apple",
@@ -25627,7 +25539,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3738,
+      "line": 3831,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Thinking…",
       "surface": "apple",
@@ -25635,7 +25547,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3740,
+      "line": 3833,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Asking OpenClaw",
       "surface": "apple",
@@ -25643,7 +25555,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3742,
+      "line": 3835,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Still asking OpenClaw",
       "surface": "apple",
@@ -25651,7 +25563,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3744,
+      "line": 3837,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Updating OpenClaw",
       "surface": "apple",
@@ -25659,7 +25571,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3746,
+      "line": 3839,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Speaking",
       "surface": "apple",
@@ -25667,7 +25579,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3748,
+      "line": 3841,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Speaking…",
       "surface": "apple",
@@ -25675,7 +25587,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3750,
+      "line": 3843,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Connecting",
       "surface": "apple",
@@ -25683,7 +25595,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3752,
+      "line": 3845,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Connecting realtime…",
       "surface": "apple",
@@ -25691,7 +25603,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3754,
+      "line": 3847,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Waiting for realtime…",
       "surface": "apple",
@@ -25699,7 +25611,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3756,
+      "line": 3849,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Ready",
       "surface": "apple",
@@ -25707,7 +25619,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3758,
+      "line": 3851,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Reconnecting",
       "surface": "apple",
@@ -25715,7 +25627,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3760,
+      "line": 3853,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Reconnecting…",
       "surface": "apple",
@@ -25723,7 +25635,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3762,
+      "line": 3855,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Realtime failed before connecting",
       "surface": "apple",
@@ -25731,7 +25643,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3764,
+      "line": 3857,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Realtime disconnected",
       "surface": "apple",
@@ -25739,7 +25651,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3766,
+      "line": 3859,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "OpenClaw unavailable",
       "surface": "apple",
@@ -25747,7 +25659,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3806,
+      "line": 3899,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "iOS Speech + TTS",
       "surface": "apple",
@@ -25755,7 +25667,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3808,
+      "line": 3901,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Listening",
       "surface": "apple",
@@ -25763,7 +25675,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3812,
+      "line": 3905,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "iOS Speech fallback",
       "surface": "apple",
@@ -25771,7 +25683,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4073,
+      "line": 4166,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Gateway Relay",
       "surface": "apple",
@@ -25779,7 +25691,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4075,
+      "line": 4168,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Native WebRTC",
       "surface": "apple",
@@ -25787,7 +25699,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4076,
+      "line": 4169,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Native",
       "surface": "apple",
@@ -25795,7 +25707,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4137,
+      "line": 4230,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Gateway permission required",
       "surface": "apple",
@@ -25803,7 +25715,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4159,
+      "line": 4252,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Not loaded",
       "surface": "apple",
@@ -25811,7 +25723,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4177,
+      "line": 4270,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Approval requested",
       "surface": "apple",
@@ -25819,7 +25731,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4603,
+      "line": 4700,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Realtime unavailable",
       "surface": "apple",
@@ -25827,107 +25739,11 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4625,
+      "line": 4722,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Listening (PTT)",
       "surface": "apple",
       "id": "native.apple.2970f0510ac6b396"
-    },
-    {
-      "kind": "ui-call",
-      "line": 65,
-      "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
-      "source": "Request ID",
-      "surface": "apple",
-      "id": "native.apple.0189269b6a863dc2"
-    },
-    {
-      "kind": "ui-call",
-      "line": 76,
-      "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
-      "source": "Sending...",
-      "surface": "apple",
-      "id": "native.apple.f9d69f27f9d7f4de"
-    },
-    {
-      "kind": "ui-call",
-      "line": 92,
-      "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
-      "source": "Retry",
-      "surface": "apple",
-      "id": "native.apple.0c5336129f70faed"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 138,
-      "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
-      "source": "Sending approval request",
-      "surface": "apple",
-      "id": "native.apple.7b23f0a89d3ad411"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 140,
-      "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
-      "source": "Approval sent",
-      "surface": "apple",
-      "id": "native.apple.55db7317a2542e51"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 142,
-      "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
-      "source": "Could not request approval",
-      "surface": "apple",
-      "id": "native.apple.06330f62ab254a0e"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 144,
-      "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
-      "source": "Enable Talk",
-      "surface": "apple",
-      "id": "native.apple.6580d3d1cdda682d"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 151,
-      "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
-      "source": "Sending a new pairing request to your gateway...",
-      "surface": "apple",
-      "id": "native.apple.abbfc1ba85a230b4"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 153,
-      "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
-      "source": "Approve this request on your gateway. Talk will start automatically when approval lands.",
-      "surface": "apple",
-      "id": "native.apple.2880deb53ea2fd86"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 155,
-      "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
-      "source": "This device needs gateway approval before Talk can use realtime voice. Audio will go directly from this device to the voice provider.",
-      "surface": "apple",
-      "id": "native.apple.80faa829f543c03c"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 161,
-      "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
-      "source": "Request Again",
-      "surface": "apple",
-      "id": "native.apple.88b0a2e2986fcebf"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 161,
-      "path": "apps/ios/Sources/Voice/TalkPermissionPromptView.swift",
-      "source": "Send Approval Request",
-      "surface": "apple",
-      "id": "native.apple.5a3faae3472b4b86"
     },
     {
       "kind": "conditional-branch",
@@ -31691,7 +31507,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 385,
+      "line": 389,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Main",
       "surface": "apple",
@@ -31699,7 +31515,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 385,
+      "line": 389,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Other",
       "surface": "apple",
@@ -31707,7 +31523,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 459,
+      "line": 463,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Show pairing requests",
       "surface": "apple",
@@ -31715,7 +31531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 484,
+      "line": 488,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Refreshing microphones…",
       "surface": "apple",
@@ -31723,7 +31539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 491,
+      "line": 495,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Microphone",
       "surface": "apple",
@@ -31731,7 +31547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 516,
+      "line": 520,
       "path": "apps/macos/Sources/OpenClaw/MenuContentView.swift",
       "source": "Disconnected (using System default)",
       "surface": "apple",
@@ -31875,7 +31691,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 435,
+      "line": 436,
       "path": "apps/macos/Sources/OpenClaw/NodePairingApprovalPrompter.swift",
       "source": "Node pairing approved",
       "surface": "apple",
@@ -31883,7 +31699,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 435,
+      "line": 436,
       "path": "apps/macos/Sources/OpenClaw/NodePairingApprovalPrompter.swift",
       "source": "Node pairing rejected",
       "surface": "apple",
@@ -34067,6 +33883,158 @@
     },
     {
       "kind": "ui-localized-call",
+      "line": 616,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatController.swift",
+      "source": "Capture Window…",
+      "surface": "apple",
+      "id": "native.apple.0a4fcdf09c5e7b3f"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 617,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatController.swift",
+      "source": "Capture Area…",
+      "surface": "apple",
+      "id": "native.apple.d7ac1580e29304af"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 203,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
+      "source": "focused app",
+      "surface": "apple",
+      "id": "native.apple.33adb82aa3c53c00"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 208,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
+      "source": "No focused application is available.",
+      "surface": "apple",
+      "id": "native.apple.5d20c8bd1235a43c"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 212,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
+      "source": "Focused app",
+      "surface": "apple",
+      "id": "native.apple.3c1a2f1ac3b50de0"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 216,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
+      "source": "Focus another app before attaching its text.",
+      "surface": "apple",
+      "id": "native.apple.511248f39affffc4"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 227,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
+      "source": "Accessibility access is required to attach text from \\(appName).",
+      "surface": "apple",
+      "id": "native.apple.1c94e8c0010021d9"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 252,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
+      "source": "No focused window is available in \\(appName).",
+      "surface": "apple",
+      "id": "native.apple.a3e3d4b0ab6e94d9"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 264,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
+      "source": "Focused Window",
+      "surface": "apple",
+      "id": "native.apple.a2a454a96a011397"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 299,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
+      "source": "\\(appName) is not responding to Accessibility requests.",
+      "surface": "apple",
+      "id": "native.apple.67d183bf2f9e4c2c"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 302,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
+      "source": "No readable text was found in \\(appName).",
+      "surface": "apple",
+      "id": "native.apple.2f56bc484453a456"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 313,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
+      "source": "Allow OpenClaw to read text from \\(appName)",
+      "surface": "apple",
+      "id": "native.apple.507c2d9c7e94716f"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 314,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
+      "source": "Attaching focused-window text uses macOS Accessibility access.",
+      "surface": "apple",
+      "id": "native.apple.c5313d544a833af0"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 315,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
+      "source": "Grant Access",
+      "surface": "apple",
+      "id": "native.apple.e68aeef0995a7d00"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 316,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatFocusedTextCapture.swift",
+      "source": "Cancel",
+      "surface": "apple",
+      "id": "native.apple.43dd985a6d9ec004"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 154,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatModel.swift",
+      "source": "focused app",
+      "surface": "apple",
+      "id": "native.apple.a8880557335b5a25"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 466,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatModel.swift",
+      "source": "Couldn't capture that image.",
+      "surface": "apple",
+      "id": "native.apple.6af15237e49bd0bd"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 488,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatModel.swift",
+      "source": "Screenshot: \\(label)",
+      "surface": "apple",
+      "id": "native.apple.b31041aa0da3768c"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 549,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatModel.swift",
+      "source": "Context from \\(context.appName) — \\(context.windowTitle)",
+      "surface": "apple",
+      "id": "native.apple.72e5bffb7ee89f19"
+    },
+    {
+      "kind": "ui-localized-call",
       "line": 22,
       "path": "apps/macos/Sources/OpenClaw/QuickChatRecents.swift",
       "source": "New message to \\(agentName)",
@@ -34075,7 +34043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 67,
+      "line": 75,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Reply in \\(override.displayName)",
       "surface": "apple",
@@ -34083,7 +34051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 69,
+      "line": 77,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Message \\(self.model.agentDisplay.name)",
       "surface": "apple",
@@ -34091,23 +34059,31 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 108,
+      "line": 116,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Continue a recent conversation",
       "surface": "apple",
       "id": "native.apple.da0b9bd07a337bda"
     },
     {
-      "kind": "ui-modifier",
-      "line": 121,
+      "kind": "ui-localized-call",
+      "line": 135,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
-      "source": "Send a window screenshot",
+      "source": "Attach text from \\(self.model.frontmostAppName)",
       "surface": "apple",
-      "id": "native.apple.edf12ff583307f43"
+      "id": "native.apple.c76e52d21bef75ba"
     },
     {
       "kind": "ui-modifier",
-      "line": 145,
+      "line": 146,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
+      "source": "Capture a screenshot",
+      "surface": "apple",
+      "id": "native.apple.aedd7e9870c3579a"
+    },
+    {
+      "kind": "ui-modifier",
+      "line": 170,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Send message",
       "surface": "apple",
@@ -34115,7 +34091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 203,
+      "line": 228,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Needs additional permissions",
       "surface": "apple",
@@ -34123,7 +34099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 210,
+      "line": 235,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Grant",
       "surface": "apple",
@@ -34131,11 +34107,75 @@
     },
     {
       "kind": "ui-call",
-      "line": 216,
+      "line": 241,
       "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
       "source": "Not now",
       "surface": "apple",
       "id": "native.apple.a3332fa4db187973"
+    },
+    {
+      "kind": "ui-call",
+      "line": 255,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
+      "source": "\\(context.appName) — \\(context.windowTitle) (\\(context.characterCount) chars)",
+      "surface": "apple",
+      "id": "native.apple.1962232c9bc52e12"
+    },
+    {
+      "kind": "ui-modifier",
+      "line": 264,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatView.swift",
+      "source": "Remove attached text context",
+      "surface": "apple",
+      "id": "native.apple.66ec93e9eefd9bd7"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 221,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatWindowPicker.swift",
+      "source": "Allow OpenClaw to capture windows",
+      "surface": "apple",
+      "id": "native.apple.88d0123c86b06144"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 222,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatWindowPicker.swift",
+      "source": "Allow OpenClaw to capture a screen area",
+      "surface": "apple",
+      "id": "native.apple.677c5733cd132aed"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 223,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatWindowPicker.swift",
+      "source": "Sending a screenshot uses macOS Screen Recording access.",
+      "surface": "apple",
+      "id": "native.apple.529a6fc5aeba03b0"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 224,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatWindowPicker.swift",
+      "source": "Grant Access",
+      "surface": "apple",
+      "id": "native.apple.615245bf05ed3234"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 225,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatWindowPicker.swift",
+      "source": "Cancel",
+      "surface": "apple",
+      "id": "native.apple.2a64131ba32d175d"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 503,
+      "path": "apps/macos/Sources/OpenClaw/QuickChatWindowPicker.swift",
+      "source": "Selected area",
+      "surface": "apple",
+      "id": "native.apple.6521871fc0ddc987"
     },
     {
       "kind": "conditional-branch",
@@ -34323,7 +34363,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 187,
+      "line": 250,
       "path": "apps/macos/Sources/OpenClaw/RemotePortTunnel.swift",
       "source": "ssh tunnel exited before listening",
       "surface": "apple",
@@ -34331,7 +34371,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 203,
+      "line": 264,
       "path": "apps/macos/Sources/OpenClaw/RemotePortTunnel.swift",
       "source": "ssh tunnel did not open local port \\(localPort)",
       "surface": "apple",
@@ -34339,7 +34379,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 203,
+      "line": 264,
       "path": "apps/macos/Sources/OpenClaw/RemotePortTunnel.swift",
       "source": "ssh tunnel failed: \\(stderr)",
       "surface": "apple",
@@ -34347,7 +34387,7 @@
     },
     {
       "kind": "plist-string",
-      "line": 45,
+      "line": 47,
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw needs notification permission to show alerts for agent actions.",
       "surface": "apple",
@@ -34355,7 +34395,7 @@
     },
     {
       "kind": "plist-string",
-      "line": 47,
+      "line": 49,
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw captures the screen when the agent needs screenshots for context.",
       "surface": "apple",
@@ -34363,7 +34403,7 @@
     },
     {
       "kind": "plist-string",
-      "line": 49,
+      "line": 51,
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw can capture photos or short video clips when requested by the agent.",
       "surface": "apple",
@@ -34371,7 +34411,7 @@
     },
     {
       "kind": "plist-string",
-      "line": 55,
+      "line": 57,
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw can share your location when requested by the agent.",
       "surface": "apple",
@@ -34379,7 +34419,7 @@
     },
     {
       "kind": "plist-string",
-      "line": 57,
+      "line": 59,
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw uses the local network to connect to your remote OpenClaw gateway over LAN, Tailnet, or SSH.",
       "surface": "apple",
@@ -34387,7 +34427,7 @@
     },
     {
       "kind": "plist-string",
-      "line": 59,
+      "line": 61,
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw needs the mic for Voice Wake tests and agent audio capture.",
       "surface": "apple",
@@ -34395,7 +34435,7 @@
     },
     {
       "kind": "plist-string",
-      "line": 61,
+      "line": 63,
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw uses speech recognition to detect your Voice Wake trigger phrase.",
       "surface": "apple",
@@ -34403,7 +34443,7 @@
     },
     {
       "kind": "plist-string",
-      "line": 63,
+      "line": 65,
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw needs Automation (AppleScript) permission to drive Terminal and other apps for agent actions.",
       "surface": "apple",
@@ -34411,7 +34451,7 @@
     },
     {
       "kind": "plist-string",
-      "line": 65,
+      "line": 67,
       "path": "apps/macos/Sources/OpenClaw/Resources/Info.plist",
       "source": "OpenClaw can access Reminders when requested by the agent for the apple-reminders skill.",
       "surface": "apple",
@@ -36187,7 +36227,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 816,
+      "line": 826,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Talk mode off",
       "surface": "apple",
@@ -36195,7 +36235,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 817,
+      "line": 827,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Talk mode paused",
       "surface": "apple",
@@ -36203,7 +36243,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 819,
+      "line": 829,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Talk mode ready",
       "surface": "apple",
@@ -36211,7 +36251,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 820,
+      "line": 830,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Listening",
       "surface": "apple",
@@ -36219,7 +36259,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 821,
+      "line": 831,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Thinking",
       "surface": "apple",
@@ -36227,7 +36267,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 822,
+      "line": 832,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Speaking",
       "surface": "apple",
@@ -36235,7 +36275,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 826,
+      "line": 836,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "What would you like to work on?",
       "surface": "apple",
@@ -36243,7 +36283,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 830,
+      "line": 840,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Check OpenClaw status",
       "surface": "apple",
@@ -36251,7 +36291,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 831,
+      "line": 841,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Summarize the current OpenClaw status and tell me what needs attention.",
       "surface": "apple",
@@ -36259,7 +36299,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 834,
+      "line": 844,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "What can you do?",
       "surface": "apple",
@@ -36267,7 +36307,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 835,
+      "line": 845,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Show me what you can help with on this Mac right now.",
       "surface": "apple",
@@ -36275,7 +36315,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 838,
+      "line": 848,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Catch me up",
       "surface": "apple",
@@ -36283,7 +36323,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 839,
+      "line": 849,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Summarize what happened in my sessions since yesterday.",
       "surface": "apple",
@@ -36331,7 +36371,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 455,
+      "line": 460,
       "path": "apps/macos/Sources/OpenClawMacCLI/WizardCommand.swift",
       "source": " [\\(initial)]",
       "surface": "apple",
@@ -36339,7 +36379,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 502,
+      "line": 507,
       "path": "apps/macos/Sources/OpenClawMacCLI/WizardCommand.swift",
       "source": " — \\(option.hint!)",
       "surface": "apple",
@@ -36347,7 +36387,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 509,
+      "line": 514,
       "path": "apps/macos/Sources/OpenClawMacCLI/WizardCommand.swift",
       "source": " [\\(initialIndices.map(String.init).joined(separator: \",\"))]",
       "surface": "apple",
@@ -36371,7 +36411,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 251,
+      "line": 415,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Context %@%% used",
       "surface": "apple",
@@ -36379,7 +36419,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 265,
+      "line": 429,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "%@ (override)",
       "surface": "apple",
@@ -36387,7 +36427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 271,
+      "line": 435,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Thinking",
       "surface": "apple",
@@ -36395,7 +36435,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 291,
+      "line": 455,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Full",
       "surface": "apple",
@@ -36403,7 +36443,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 298,
+      "line": 462,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Verbosity",
       "surface": "apple",
@@ -36411,7 +36451,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 307,
+      "line": 471,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Default (inherited)",
       "surface": "apple",
@@ -36419,7 +36459,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 309,
+      "line": 473,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "On",
       "surface": "apple",
@@ -36427,7 +36467,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 310,
+      "line": 474,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Off",
       "surface": "apple",
@@ -36435,7 +36475,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 312,
+      "line": 476,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Fast",
       "surface": "apple",
@@ -36443,7 +36483,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 317,
+      "line": 481,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Fast responses",
       "surface": "apple",
@@ -36451,7 +36491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 336,
+      "line": 500,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Pinned",
       "surface": "apple",
@@ -36459,7 +36499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 344,
+      "line": 508,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Recent",
       "surface": "apple",
@@ -36467,7 +36507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 363,
+      "line": 527,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Model",
       "surface": "apple",
@@ -36475,7 +36515,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 380,
+      "line": 544,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Default",
       "surface": "apple",
@@ -36483,7 +36523,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 397,
+      "line": 561,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Pin model",
       "surface": "apple",
@@ -36491,7 +36531,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 397,
+      "line": 561,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Unpin model",
       "surface": "apple",
@@ -36499,7 +36539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 411,
+      "line": 575,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Session",
       "surface": "apple",
@@ -36507,7 +36547,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 466,
+      "line": 631,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Add Image",
       "surface": "apple",
@@ -36515,23 +36555,15 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 467,
+      "line": 632,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Attachments",
       "surface": "apple",
       "id": "native.apple.1963dfa3285cb715"
     },
     {
-      "kind": "ui-call",
-      "line": 494,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
-      "source": "Voice note",
-      "surface": "apple",
-      "id": "native.apple.f8dda832ed76441d"
-    },
-    {
       "kind": "conditional-branch",
-      "line": 647,
+      "line": 810,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Talk",
       "surface": "apple",
@@ -36539,7 +36571,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 694,
+      "line": 881,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Start realtime chat",
       "surface": "apple",
@@ -36547,7 +36579,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 694,
+      "line": 881,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop realtime chat",
       "surface": "apple",
@@ -36555,7 +36587,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 728,
+      "line": 915,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Start",
       "surface": "apple",
@@ -36563,7 +36595,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 728,
+      "line": 915,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop",
       "surface": "apple",
@@ -36571,7 +36603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 858,
+      "line": 1045,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Loading commands",
       "surface": "apple",
@@ -36579,7 +36611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 867,
+      "line": 1054,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Commands unavailable",
       "surface": "apple",
@@ -36587,7 +36619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 876,
+      "line": 1063,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Retry",
       "surface": "apple",
@@ -36595,7 +36627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 885,
+      "line": 1072,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "No matching commands",
       "surface": "apple",
@@ -36603,7 +36635,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1117,
+      "line": 1304,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop response",
       "surface": "apple",
@@ -36611,7 +36643,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1142,
+      "line": 1329,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Send message",
       "surface": "apple",
@@ -36619,7 +36651,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1156,
+      "line": 1343,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -36627,7 +36659,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1290,
+      "line": 1468,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -36635,7 +36667,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1290,
+      "line": 1468,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Gateway connected",
       "surface": "apple",
@@ -36643,7 +36675,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1299,
+      "line": 1477,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Message…",
       "surface": "apple",
@@ -36834,16 +36866,8 @@
       "id": "native.apple.fccc8a9ba3da1426"
     },
     {
-      "kind": "ui-named-argument",
-      "line": 357,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
-      "source": "\\(display.emoji) \\(display.title)",
-      "surface": "apple",
-      "id": "native.apple.8509385953c19619"
-    },
-    {
       "kind": "ui-localized-call",
-      "line": 371,
+      "line": 368,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Message usage",
       "surface": "apple",
@@ -36851,31 +36875,15 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 544,
+      "line": 553,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Voice note",
       "surface": "apple",
       "id": "native.apple.3c8c3679fd99c074"
     },
     {
-      "kind": "conditional-branch",
-      "line": 630,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
-      "source": "Show full output",
-      "surface": "apple",
-      "id": "native.apple.aff6385b0a8dd0ac"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 630,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
-      "source": "Show less",
-      "surface": "apple",
-      "id": "native.apple.b9c78020ae8be34a"
-    },
-    {
       "kind": "ui-call",
-      "line": 689,
+      "line": 598,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Writing",
       "surface": "apple",
@@ -36883,7 +36891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 715,
+      "line": 624,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Preparing audio…",
       "surface": "apple",
@@ -36891,7 +36899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 718,
+      "line": 627,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Speaking…",
       "surface": "apple",
@@ -36899,7 +36907,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 726,
+      "line": 635,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Preparing audio, tap to cancel",
       "surface": "apple",
@@ -36907,19 +36915,11 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 727,
+      "line": 636,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Speaking, tap to stop",
       "surface": "apple",
       "id": "native.apple.142c01bf6b97e380"
-    },
-    {
-      "kind": "ui-call",
-      "line": 896,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
-      "source": "Running tools…",
-      "surface": "apple",
-      "id": "native.apple.6b18ea1d85b5d3a2"
     },
     {
       "kind": "ui-localized-call",
@@ -36946,8 +36946,64 @@
       "id": "native.apple.b6b3b9af4c618060"
     },
     {
+      "kind": "ui-localized-call",
+      "line": 258,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatQuestionCard.swift",
+      "source": "Answered",
+      "surface": "apple",
+      "id": "native.apple.ce899320a84d4086"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 261,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatQuestionCard.swift",
+      "source": "Answered elsewhere",
+      "surface": "apple",
+      "id": "native.apple.f019b6a07d5a33d8"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 263,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatQuestionCard.swift",
+      "source": "Skipped",
+      "surface": "apple",
+      "id": "native.apple.ebdedeffad570c43"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 265,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatQuestionCard.swift",
+      "source": "Expired",
+      "surface": "apple",
+      "id": "native.apple.8dde2eaaf6b0dfa9"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 267,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatQuestionCard.swift",
+      "source": "Unavailable",
+      "surface": "apple",
+      "id": "native.apple.6dff9e9194347f3b"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 269,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatQuestionCard.swift",
+      "source": "Pending",
+      "surface": "apple",
+      "id": "native.apple.b34cd890366824f0"
+    },
+    {
+      "kind": "ui-modifier",
+      "line": 367,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatQuestionCard.swift",
+      "source": "Question summary",
+      "surface": "apple",
+      "id": "native.apple.b97da55b7e16e60c"
+    },
+    {
       "kind": "ui-call",
-      "line": 234,
+      "line": 381,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatQuestionCard.swift",
       "source": "Other answer",
       "surface": "apple",
@@ -36955,7 +37011,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 273,
+      "line": 439,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatQuestionCard.swift",
       "source": "Not selected",
       "surface": "apple",
@@ -36963,43 +37019,43 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 273,
+      "line": 439,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatQuestionCard.swift",
       "source": "Selected",
       "surface": "apple",
       "id": "native.apple.bd4335213464d4be"
     },
     {
-      "kind": "conditional-branch",
-      "line": 285,
+      "kind": "ui-call",
+      "line": 456,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatQuestionCard.swift",
-      "source": "Submit",
+      "source": "Skipping…",
       "surface": "apple",
-      "id": "native.apple.e3095b651fc46b52"
+      "id": "native.apple.1bbbbfd1ad3842ce"
     },
     {
-      "kind": "conditional-branch",
-      "line": 285,
+      "kind": "ui-call",
+      "line": 459,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatQuestionCard.swift",
+      "source": "Skip",
+      "surface": "apple",
+      "id": "native.apple.14a4bf7b6b7d40dc"
+    },
+    {
+      "kind": "ui-call",
+      "line": 470,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatQuestionCard.swift",
       "source": "Submitting…",
       "surface": "apple",
       "id": "native.apple.6c1adc16e0a846e5"
     },
     {
-      "kind": "conditional-branch",
-      "line": 306,
+      "kind": "ui-call",
+      "line": 473,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatQuestionCard.swift",
-      "source": "Expires in \\(seconds / 60)m \\(seconds % 60)s",
+      "source": "Submit",
       "surface": "apple",
-      "id": "native.apple.698bdb0d6537edb6"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 306,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatQuestionCard.swift",
-      "source": "Expires in \\(seconds)s",
-      "surface": "apple",
-      "id": "native.apple.30e1c342b3345290"
+      "id": "native.apple.e3095b651fc46b52"
     },
     {
       "kind": "conditional-branch",
@@ -37954,6 +38010,46 @@
       "id": "native.apple.e7beeef6043ffd2a"
     },
     {
+      "kind": "ui-localized-call",
+      "line": 76,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift",
+      "source": "Running",
+      "surface": "apple",
+      "id": "native.apple.f390b84397c0d240"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 109,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift",
+      "source": "Collapse tool result",
+      "surface": "apple",
+      "id": "native.apple.e2e7faa7c9c5c61f"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 109,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift",
+      "source": "Expand tool result",
+      "surface": "apple",
+      "id": "native.apple.4e7850fe95fcd898"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 130,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift",
+      "source": "Show less",
+      "surface": "apple",
+      "id": "native.apple.d65ae0776d6b86ce"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 132,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift",
+      "source": "Show all %lld lines",
+      "surface": "apple",
+      "id": "native.apple.065f4da5ddaf14a1"
+    },
+    {
       "kind": "conditional-branch",
       "line": 1347,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTranscriptCache.swift",
@@ -37995,7 +38091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 489,
+      "line": 513,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Retry Send",
       "surface": "apple",
@@ -38003,7 +38099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 503,
+      "line": 527,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Delete",
       "surface": "apple",
@@ -38011,7 +38107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 537,
+      "line": 561,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Stop Listening",
       "surface": "apple",
@@ -38019,7 +38115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 540,
+      "line": 564,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Listen",
       "surface": "apple",
@@ -38027,7 +38123,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 631,
+      "line": 659,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Jump to latest reply",
       "surface": "apple",
@@ -38035,7 +38131,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 651,
+      "line": 679,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -38043,7 +38139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1038,
+      "line": 1074,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Copy Message",
       "surface": "apple",
@@ -38051,7 +38147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1061,
+      "line": 1097,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Open Full Message",
       "surface": "apple",
@@ -38059,7 +38155,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1082,
+      "line": 1118,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Reply",
       "surface": "apple",
@@ -38067,7 +38163,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1092,
+      "line": 1128,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "You",
       "surface": "apple",
@@ -38075,7 +38171,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1094,
+      "line": 1130,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Assistant",
       "surface": "apple",
@@ -38083,7 +38179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1160,
+      "line": 1196,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Loading chat",
       "surface": "apple",
@@ -38091,7 +38187,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1240,
+      "line": 1276,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Dismiss",
       "surface": "apple",
@@ -38099,7 +38195,15 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 27,
+      "line": 74,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift",
+      "source": "Remove attachments or wait for delivery to resolve before starting a new chat.",
+      "surface": "apple",
+      "id": "native.apple.3892b7f55d9d1f0a"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 112,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift",
       "source": "Could not attach voice note: %@",
       "surface": "apple",
@@ -38107,7 +38211,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 33,
+      "line": 118,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift",
       "source": "Voice note exceeds the 5 MB attachment limit",
       "surface": "apple",
@@ -38115,7 +38219,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 79,
+      "line": 180,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift",
       "source": "Only image attachments are supported right now",
       "surface": "apple",
@@ -38123,7 +38227,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 90,
+      "line": 192,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift",
       "source": "Could not process %1$@: %2$@",
       "surface": "apple",
@@ -38131,7 +38235,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 98,
+      "line": 203,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift",
       "source": "Attachment %@ exceeds 5 MB limit after resizing",
       "surface": "apple",
@@ -38139,7 +38243,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 105,
+      "line": 210,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift",
       "source": "\\(baseName).jpg",
       "surface": "apple",
@@ -38147,7 +38251,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 43,
+      "line": 66,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift",
       "source": "\\(invocation) ",
       "surface": "apple",
@@ -38155,7 +38259,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 295,
+      "line": 324,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift",
       "source": "See attached.",
       "surface": "apple",
@@ -38163,7 +38267,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 700,
+      "line": 735,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift",
       "source": "delivery unconfirmed",
       "surface": "apple",
@@ -38171,7 +38275,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 700,
+      "line": 735,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift",
       "source": "queued after route change",
       "surface": "apple",
@@ -38195,15 +38299,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 773,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
-      "source": "Remove attachments or wait for delivery to resolve before starting a new chat.",
-      "surface": "apple",
-      "id": "native.apple.d93e6fe16ec1b0e5"
-    },
-    {
-      "kind": "ui-localized-call",
-      "line": 1156,
+      "line": 1085,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "Remove attachments or wait for delivery to resolve before switching chats.",
       "surface": "apple",
@@ -38563,6 +38659,94 @@
     },
     {
       "kind": "ui-call",
+      "line": 70,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/CleanChatComposerControls.swift",
+      "source": "Voice note",
+      "surface": "apple",
+      "id": "native.apple.fa10740f9e272e83"
+    },
+    {
+      "kind": "ui-call",
+      "line": 120,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/CleanChatComposerControls.swift",
+      "source": "Photo Library",
+      "surface": "apple",
+      "id": "native.apple.e4de5afc37981d6c"
+    },
+    {
+      "kind": "ui-call",
+      "line": 132,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/CleanChatComposerControls.swift",
+      "source": "Camera",
+      "surface": "apple",
+      "id": "native.apple.37c19a66626b21fa"
+    },
+    {
+      "kind": "ui-call",
+      "line": 145,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/CleanChatComposerControls.swift",
+      "source": "Choose Image File",
+      "surface": "apple",
+      "id": "native.apple.333682684163ba6b"
+    },
+    {
+      "kind": "ui-modifier",
+      "line": 156,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/CleanChatComposerControls.swift",
+      "source": "Add attachment",
+      "surface": "apple",
+      "id": "native.apple.534246792690968d"
+    },
+    {
+      "kind": "ui-call",
+      "line": 282,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/CleanChatComposerControls.swift",
+      "source": "Record Voice Note",
+      "surface": "apple",
+      "id": "native.apple.e33210feaa3da016"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 332,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/CleanChatComposerControls.swift",
+      "source": "Dictate message",
+      "surface": "apple",
+      "id": "native.apple.00f0e15858e38d19"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 333,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/CleanChatComposerControls.swift",
+      "source": "Listening",
+      "surface": "apple",
+      "id": "native.apple.96f20175f61a2b29"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 333,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/CleanChatComposerControls.swift",
+      "source": "Not listening",
+      "surface": "apple",
+      "id": "native.apple.eaa9047db6cfb67e"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 335,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/CleanChatComposerControls.swift",
+      "source": "Finish dictation",
+      "surface": "apple",
+      "id": "native.apple.4185df7a940f09ef"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 335,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/CleanChatComposerControls.swift",
+      "source": "Transcribe speech into the message",
+      "surface": "apple",
+      "id": "native.apple.5a0793d2827b9399"
+    },
+    {
+      "kind": "ui-call",
       "line": 592,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/OpenClawMascotView.swift",
       "source": "z",
@@ -38587,7 +38771,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 63,
+      "line": 64,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteComposerViews.swift",
       "source": "Recording",
       "surface": "apple",
@@ -38595,7 +38779,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 78,
+      "line": 79,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteComposerViews.swift",
       "source": "Cancel voice note",
       "surface": "apple",
@@ -38603,7 +38787,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 87,
+      "line": 88,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteComposerViews.swift",
       "source": "Finish voice note",
       "surface": "apple",

--- a/apps/.i18n/native/ar.json
+++ b/apps/.i18n/native/ar.json
@@ -1429,9 +1429,9 @@
       "translated": "تحدّث أو أملِ باستخدام OpenClaw"
     },
     {
-      "id": "native.android.e2cf5a38587382cb",
-      "source": "Browse Threads",
-      "translated": "تصفح المحادثات"
+      "id": "native.android.5876e15e5e92fd45",
+      "source": "Browse Sessions",
+      "translated": "تصفّح الجلسات"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "لم يتم العثور على إجراءات"
     },
     {
-      "id": "native.android.bc70a4ac965b82ba",
-      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
-      "translated": "جرّب الدردشة أو الصوت أو المحادثات أو موفري الخدمة أو الإعدادات."
+      "id": "native.android.48ad0ae0e930e02b",
+      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
+      "translated": "جرّب الدردشة أو الصوت أو الجلسات أو المزوّدين أو الإعدادات."
     },
     {
-      "id": "native.android.670121e54dbe286f",
-      "source": "Threads",
-      "translated": "المحادثات"
+      "id": "native.android.d4fbd1ee4f55a5db",
+      "source": "Sessions",
+      "translated": "الجلسات"
     },
     {
-      "id": "native.android.d38be650b1bce4a0",
-      "source": "Connect the Gateway to search threads.",
-      "translated": "صِل Gateway للبحث في المحادثات."
+      "id": "native.android.207c2170504e99e6",
+      "source": "Connect the Gateway to search sessions.",
+      "translated": "وصّل Gateway للبحث في الجلسات."
     },
     {
-      "id": "native.android.3d7754721f776ef8",
-      "source": "No matching threads yet.",
-      "translated": "لا توجد محادثات مطابقة حتى الآن."
+      "id": "native.android.25d2c2d792c952fe",
+      "source": "No matching sessions yet.",
+      "translated": "لا توجد جلسات مطابقة بعد."
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "المساعد يعمل"
     },
     {
-      "id": "native.android.9a839f6e3e05a744",
-      "source": "OpenClaw thread",
-      "translated": "محادثة OpenClaw"
+      "id": "native.android.8f8384286317f5c9",
+      "source": "OpenClaw session",
+      "translated": "جلسة OpenClaw"
     },
     {
-      "id": "native.android.d83f82a1e4a5ed99",
-      "source": "Open thread",
-      "translated": "فتح المحادثة"
+      "id": "native.android.15799e57704b20c6",
+      "source": "Open session",
+      "translated": "فتح الجلسة"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "لا يوجد مزوّدون جاهزون"
     },
     {
-      "id": "native.android.8a1c5365c0538908",
-      "source": "Main thread",
-      "translated": "المحادثة الرئيسية"
+      "id": "native.android.73e6ab1a168fd381",
+      "source": "Main session",
+      "translated": "الجلسة الرئيسية"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.a5845742daecb4ba",
-      "source": "Threads",
-      "translated": "المحادثات"
+      "id": "native.android.0e3157c15c56944f",
+      "source": "Sessions",
+      "translated": "الجلسات"
     },
     {
-      "id": "native.android.439b324280869527",
-      "source": "Focus thread search",
-      "translated": "التركيز على البحث في المحادثات"
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "التركيز على بحث الجلسات"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "مؤرشف"
     },
     {
-      "id": "native.android.03981341841b04ac",
-      "source": "Search threads",
-      "translated": "البحث في المحادثات"
+      "id": "native.android.b9cf34c137e4cf03",
+      "source": "Search sessions",
+      "translated": "البحث في الجلسات"
     },
     {
-      "id": "native.android.99570c528a41fa72",
-      "source": "Clear thread search",
-      "translated": "مسح البحث في المحادثات"
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "مسح بحث الجلسات"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "الأقدم أولاً"
     },
     {
-      "id": "native.android.fd67be543e321cc9",
-      "source": "Toggle thread layout",
-      "translated": "تبديل تخطيط المحادثات"
+      "id": "native.android.c6bf8751e2a7f5c7",
+      "source": "Toggle session layout",
+      "translated": "تبديل تخطيط الجلسات"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "التخطيط: مفصّل"
     },
     {
-      "id": "native.android.ebd17565e0ffd8eb",
-      "source": "Searching threads",
-      "translated": "جارٍ البحث في المحادثات"
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "جارٍ البحث في الجلسات"
     },
     {
-      "id": "native.android.472d46ae8669f860",
-      "source": "No matching threads",
-      "translated": "لا توجد محادثات مطابقة"
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "لا توجد جلسات مطابقة"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "بدء الدردشة"
     },
     {
-      "id": "native.android.ff81ad1bee00d384",
-      "source": "Current thread",
-      "translated": "المحادثة الحالية"
+      "id": "native.android.f10d4df7cbc6df4f",
+      "source": "Current session",
+      "translated": "الجلسة الحالية"
     },
     {
-      "id": "native.android.fc145645b9620e57",
-      "source": "OpenClaw thread",
-      "translated": "محادثة OpenClaw"
+      "id": "native.android.8f0482425838ae64",
+      "source": "OpenClaw session",
+      "translated": "جلسة OpenClaw"
     },
     {
-      "id": "native.android.71cbb8dde8bf138b",
-      "source": "Rename thread",
-      "translated": "إعادة تسمية المحادثة"
+      "id": "native.android.786774c8a76e50d7",
+      "source": "Rename session",
+      "translated": "إعادة تسمية الجلسة"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "حذف المجموعة؟"
     },
     {
-      "id": "native.android.691e92cfe5cf106e",
-      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "سيتم الاحتفاظ بالمحادثات في \"$group\" ونقلها مجددًا إلى غير المجمّعة."
+      "id": "native.android.3455fc2f77d564e3",
+      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "يتم الاحتفاظ بالجلسات في \"$group\" ونقلها مرة أخرى إلى غير المجمعة."
     },
     {
-      "id": "native.android.d87a8217ab56999b",
-      "source": "Delete thread?",
-      "translated": "حذف المحادثة؟"
+      "id": "native.android.4805fb9d6623e8c0",
+      "source": "Delete session?",
+      "translated": "حذف الجلسة؟"
     },
     {
-      "id": "native.android.930de97ff47113a8",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "يؤدي هذا إلى حذف سلسلة المحادثة وسجلها نهائيًا."
+      "id": "native.android.0c3283a2b2445eae",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "سيؤدي هذا إلى حذف الجلسة ونصها نهائيًا."
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "غير مصنّف"
     },
     {
-      "id": "native.android.8e21a70428def6e0",
-      "source": "No threads yet",
-      "translated": "لا توجد سلاسل محادثات بعد"
+      "id": "native.android.db243d71d056afa4",
+      "source": "No sessions yet",
+      "translated": "لا توجد جلسات بعد"
     },
     {
-      "id": "native.android.cda4c5ad8b17e394",
-      "source": "No current thread",
-      "translated": "لا توجد سلسلة محادثة حالية"
+      "id": "native.android.5b4eee6a8092925e",
+      "source": "No current session",
+      "translated": "لا توجد جلسة حالية"
     },
     {
-      "id": "native.android.be84f061047aa2da",
-      "source": "No archived threads",
-      "translated": "لا توجد سلاسل محادثات مؤرشفة"
+      "id": "native.android.acbcc9c9ea53d8c0",
+      "source": "No archived sessions",
+      "translated": "لا توجد جلسات مؤرشفة"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "ابدأ محادثة جديدة وستظهر هنا."
     },
     {
-      "id": "native.android.f289d03e1d3eee98",
-      "source": "Open Chat to start or resume the current thread.",
-      "translated": "افتح الدردشة لبدء سلسلة المحادثة الحالية أو استئنافها."
+      "id": "native.android.56fcd605dc7be3c0",
+      "source": "Open Chat to start or resume the current session.",
+      "translated": "افتح الدردشة لبدء الجلسة الحالية أو استئنافها."
     },
     {
-      "id": "native.android.504b71386e76c6ae",
-      "source": "Archived threads will show up here.",
-      "translated": "ستظهر سلاسل المحادثات المؤرشفة هنا."
+      "id": "native.android.085515989f8a2022",
+      "source": "Archived sessions will show up here.",
+      "translated": "ستظهر الجلسات المؤرشفة هنا."
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days} ي"
     },
     {
-      "id": "native.android.ee4c727cdafbe963",
-      "source": "Main thread",
-      "translated": "سلسلة المحادثة الرئيسية"
+      "id": "native.android.3d4fa07acbc015c5",
+      "source": "Main session",
+      "translated": "الجلسة الرئيسية"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway قيد الانتظار"
     },
     {
-      "id": "native.android.da78209effb11cfd",
-      "source": "Thread Activity",
-      "translated": "نشاط سلسلة المحادثة"
+      "id": "native.android.2d8d049afe99f751",
+      "source": "Session Activity",
+      "translated": "نشاط الجلسة"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "ستظهر طلبات الموافقة على Exec هنا أثناء اتصال هذا الهاتف."
     },
     {
-      "id": "native.android.f615712dfb56319a",
-      "source": "Thread activity",
-      "translated": "نشاط سلسلة المحادثة"
+      "id": "native.android.dc3e7ca5a491103a",
+      "source": "Session activity",
+      "translated": "نشاط الجلسة"
     },
     {
-      "id": "native.android.6c93973c13db43ae",
-      "source": "Chat tool calls waiting in the active thread remain visible here.",
-      "translated": "تظل استدعاءات أدوات الدردشة المنتظرة في سلسلة المحادثة النشطة مرئية هنا."
+      "id": "native.android.8551e02b060bd7d8",
+      "source": "Chat tool calls waiting in the active session remain visible here.",
+      "translated": "تظل استدعاءات أدوات الدردشة المنتظرة في الجلسة النشطة مرئية هنا."
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,11 +4294,6 @@
       "translated": "إعداد مزوّد المحادثة"
     },
     {
-      "id": "native.android.23b638094c34b916",
-      "source": "Microphone",
-      "translated": "الميكروفون"
-    },
-    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "اختبار الصوت"
@@ -4342,66 +4337,6 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "تم"
-    },
-    {
-      "id": "native.android.8d9ecdfdd916b780",
-      "source": "Automatic",
-      "translated": "تلقائي"
-    },
-    {
-      "id": "native.android.c1626a6700a570f6",
-      "source": "Preferred microphone unavailable; using automatic routing.",
-      "translated": "الميكروفون المفضل غير متاح؛ جارٍ استخدام التوجيه التلقائي."
-    },
-    {
-      "id": "native.android.820bc5d0ce571d8b",
-      "source": "Prioritizes connected Bluetooth microphones.",
-      "translated": "يعطي الأولوية لميكروفونات Bluetooth المتصلة."
-    },
-    {
-      "id": "native.android.11e48038d5e8bff6",
-      "source": "Preferred microphone",
-      "translated": "الميكروفون المفضل"
-    },
-    {
-      "id": "native.android.eaa4d7563a46d307",
-      "source": "Unavailable",
-      "translated": "غير متاح"
-    },
-    {
-      "id": "native.android.9f5ebf17eb405ba8",
-      "source": "Next session",
-      "translated": "الجلسة التالية"
-    },
-    {
-      "id": "native.android.8c4e91f53928efb2",
-      "source": "Built-in microphone",
-      "translated": "الميكروفون المدمج"
-    },
-    {
-      "id": "native.android.14b613cb6e2446b4",
-      "source": "Bluetooth microphone",
-      "translated": "ميكروفون Bluetooth"
-    },
-    {
-      "id": "native.android.c885247b2d7ce271",
-      "source": "Bluetooth LE microphone",
-      "translated": "ميكروفون Bluetooth LE"
-    },
-    {
-      "id": "native.android.b6a4e674c5fb441a",
-      "source": "Wired headset microphone",
-      "translated": "ميكروفون سماعة الرأس السلكية"
-    },
-    {
-      "id": "native.android.9c8becb3b0fb5a90",
-      "source": "USB microphone",
-      "translated": "ميكروفون USB"
-    },
-    {
-      "id": "native.android.ba46258fadec7a39",
-      "source": "External microphone",
-      "translated": "ميكروفون خارجي"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5139,9 +5074,9 @@
       "translated": "تحقق"
     },
     {
-      "id": "native.android.c971506716c96e91",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
-      "translated": "يحوّل OpenClaw هذا الهاتف إلى واجهة أوامر محمولة ومنظمة لسلاسل المحادثات والصوت ومزوّدي الخدمة وGateway."
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "يحوّل OpenClaw هذا الهاتف إلى واجهة أوامر محمولة ومنظمة للجلسات والصوت ومزوّدي الخدمات وGateway."
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5689,9 +5624,9 @@
       "translated": "إعدادات Talk"
     },
     {
-      "id": "native.android.36f78c8c85dc283f",
-      "source": "Recent Threads",
-      "translated": "سلاسل المحادثات الأخيرة"
+      "id": "native.android.73f07a5d54915259",
+      "source": "Recent Sessions",
+      "translated": "الجلسات الحديثة"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5749,14 +5684,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% متصلة"
     },
     {
-      "id": "native.android.57177017a6a93826",
-      "source": "Threads",
-      "translated": "سلاسل المحادثات"
+      "id": "native.android.16c3425d3a594481",
+      "source": "Sessions",
+      "translated": "الجلسات"
     },
     {
-      "id": "native.android.43320b54a68b00a1",
-      "source": "No recent threads",
-      "translated": "لا توجد سلاسل محادثات حديثة"
+      "id": "native.android.a5c0f8b3112aa58c",
+      "source": "No recent sessions",
+      "translated": "لا توجد جلسات حديثة"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5794,14 +5729,14 @@
       "translated": "جارٍ العمل · $pendingRunCount عمليات تشغيل نشطة"
     },
     {
-      "id": "native.android.e24db059480f1e6a",
-      "source": "Monitoring · 1 thread",
-      "translated": "المراقبة · سلسلة محادثة واحدة"
+      "id": "native.android.2c89da708b12a522",
+      "source": "Monitoring · 1 session",
+      "translated": "جارٍ الرصد · جلسة واحدة"
     },
     {
-      "id": "native.android.5a475f37d80e02bc",
-      "source": "Monitoring · $sessionCount threads",
-      "translated": "المراقبة · $sessionCount من سلاسل المحادثات"
+      "id": "native.android.8b6ee382dcb64e1f",
+      "source": "Monitoring · $sessionCount sessions",
+      "translated": "جارٍ الرصد · $sessionCount جلسات"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5834,9 +5769,9 @@
       "translated": "موفّرو الخدمة"
     },
     {
-      "id": "native.android.358c5e0e838d5423",
-      "source": "Open thread",
-      "translated": "فتح سلسلة المحادثة"
+      "id": "native.android.a65477861c7203aa",
+      "source": "Open session",
+      "translated": "فتح الجلسة"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6259,9 +6194,9 @@
       "translated": "${days}ي"
     },
     {
-      "id": "native.android.28a1a1acc5a0959f",
-      "source": "Main thread",
-      "translated": "سلسلة المحادثة الرئيسية"
+      "id": "native.android.22d755834386db07",
+      "source": "Main session",
+      "translated": "الجلسة الرئيسية"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6942,16 +6877,6 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "إلغاء كتم الصوت"
-    },
-    {
-      "id": "native.android.cb608d82c5b3352a",
-      "source": "Back camera",
-      "translated": "الكاميرا الخلفية"
-    },
-    {
-      "id": "native.android.e89a0e780eed2e1e",
-      "source": "Front camera",
-      "translated": "الكاميرا الأمامية"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7759,9 +7684,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.0c74bc30a994dd33",
-      "source": "Loading thread",
-      "translated": "جارٍ تحميل سلسلة المحادثة"
+      "id": "native.android.882cc14a58e7e105",
+      "source": "Loading session",
+      "translated": "جارٍ تحميل الجلسة"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7804,14 +7729,14 @@
       "translated": "أطلعني على المستجدات"
     },
     {
-      "id": "native.android.cf40df9739f78f27",
-      "source": "Summarize recent threads and next steps.",
-      "translated": "لخّص سلاسل المحادثات الأخيرة والخطوات التالية."
+      "id": "native.android.1e5add56e48c99f9",
+      "source": "Summarize recent sessions and next steps.",
+      "translated": "لخّص الجلسات الأخيرة والخطوات التالية."
     },
     {
-      "id": "native.android.ebe49a8b8df80bd3",
-      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
-      "translated": "أطلعني على أحدث محادثاتي في OpenClaw واقترح الخطوات التالية."
+      "id": "native.android.06d515351bb79576",
+      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
+      "translated": "أطلعني على مستجدات جلساتي الأخيرة في OpenClaw واقترح الخطوات التالية."
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8149,9 +8074,9 @@
       "translated": "متصل"
     },
     {
-      "id": "native.android.6cf5d6fa8a4186d5",
-      "source": "Threads",
-      "translated": "المحادثات"
+      "id": "native.android.81931886b9caf3ab",
+      "source": "Sessions",
+      "translated": "الجلسات"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,6 +10719,61 @@
       "translated": "تفاصيل المهمة"
     },
     {
+      "id": "native.apple.29cacb53ea5e77fc",
+      "source": "Pinned",
+      "translated": "مثبّت"
+    },
+    {
+      "id": "native.apple.940062cfdce9211b",
+      "source": "Recent",
+      "translated": "الأخيرة"
+    },
+    {
+      "id": "native.apple.a0980128426308a9",
+      "source": "Model",
+      "translated": "النموذج"
+    },
+    {
+      "id": "native.apple.9520e60f21535dde",
+      "source": "Thinking",
+      "translated": "التفكير"
+    },
+    {
+      "id": "native.apple.8b321f3ffce97429",
+      "source": "Fast",
+      "translated": "سريع"
+    },
+    {
+      "id": "native.apple.989b70d64e328d55",
+      "source": "Default (inherited)",
+      "translated": "الافتراضي (موروث)"
+    },
+    {
+      "id": "native.apple.f4114e73b07eb9ae",
+      "source": "Off",
+      "translated": "إيقاف"
+    },
+    {
+      "id": "native.apple.7ed231b28d16312f",
+      "source": "On",
+      "translated": "تشغيل"
+    },
+    {
+      "id": "native.apple.412a74802320a037",
+      "source": "Full",
+      "translated": "كامل"
+    },
+    {
+      "id": "native.apple.299f21a2071ff9fc",
+      "source": "Verbosity",
+      "translated": "مستوى التفصيل"
+    },
+    {
+      "id": "native.apple.faf0ef05e1496de7",
+      "source": "Default",
+      "translated": "الافتراضي"
+    },
+    {
       "id": "native.apple.e5524d5756a62744",
       "source": "Unable to Export Transcript",
       "translated": "تعذّر تصدير النص"
@@ -10814,9 +10794,9 @@
       "translated": "ما الذي ترغب في العمل عليه؟"
     },
     {
-      "id": "native.apple.4da775013ac9b123",
-      "source": "The thread attaches once the gateway is ready.",
-      "translated": "سيتم إرفاق المحادثة بمجرد أن يصبح Gateway جاهزًا."
+      "id": "native.apple.32179ce0b6d4543f",
+      "source": "The session attaches once the gateway is ready.",
+      "translated": "يتم إرفاق الجلسة بمجرد أن يصبح Gateway جاهزًا."
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10859,9 +10839,14 @@
       "translated": "دردشة جديدة في Worktree"
     },
     {
-      "id": "native.apple.003b25ddafeb18e9",
-      "source": "Threads…",
-      "translated": "المحادثات…"
+      "id": "native.apple.ce6ebe91fc597015",
+      "source": "New Session Options…",
+      "translated": "خيارات جلسة جديدة…"
+    },
+    {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "الجلسات…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11024,14 +11009,14 @@
       "translated": "إنشاء"
     },
     {
-      "id": "native.apple.31d5c7287cfb3abe",
-      "source": "Delete Thread?",
-      "translated": "حذف المحادثة؟"
+      "id": "native.apple.f488b9caf6e51ac3",
+      "source": "Delete Session?",
+      "translated": "حذف الجلسة؟"
     },
     {
-      "id": "native.apple.d3395564809f1120",
-      "source": "Delete Thread",
-      "translated": "حذف المحادثة"
+      "id": "native.apple.8634b17be9b111bc",
+      "source": "Delete Session",
+      "translated": "حذف الجلسة"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11039,9 +11024,9 @@
       "translated": "إلغاء"
     },
     {
-      "id": "native.apple.092659256d26cb03",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "يؤدي هذا إلى حذف المحادثة ونصها نهائيًا."
+      "id": "native.apple.4a9568ac9b18d8d3",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "سيؤدي هذا إلى حذف الجلسة ونصها بشكل دائم."
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11069,9 +11054,9 @@
       "translated": "مجموعة جديدة"
     },
     {
-      "id": "native.apple.683032464c497bbd",
-      "source": "Rename Thread",
-      "translated": "إعادة تسمية المحادثة"
+      "id": "native.apple.5bccdc23a1640895",
+      "source": "Rename Session",
+      "translated": "إعادة تسمية الجلسة"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11079,9 +11064,9 @@
       "translated": "اسم المجموعة"
     },
     {
-      "id": "native.apple.f887aa956588f237",
-      "source": "Thread name",
-      "translated": "اسم المحادثة"
+      "id": "native.apple.af789b2d2fda0f67",
+      "source": "Session name",
+      "translated": "اسم الجلسة"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11119,14 +11104,14 @@
       "translated": "الوكلاء"
     },
     {
-      "id": "native.apple.7c8231b7b1ca480f",
-      "source": "Agent thread",
-      "translated": "محادثة الوكيل"
+      "id": "native.apple.a3bde8045fe9224a",
+      "source": "Agent session",
+      "translated": "جلسة الوكيل"
     },
     {
-      "id": "native.apple.b3c553614f762a58",
-      "source": "Recent threads",
-      "translated": "المحادثات الأخيرة"
+      "id": "native.apple.27f775de30b37ff8",
+      "source": "Recent sessions",
+      "translated": "الجلسات الأخيرة"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11134,9 +11119,9 @@
       "translated": "Gateway غير متصل"
     },
     {
-      "id": "native.apple.5aa32afda85064ea",
-      "source": "No recent threads",
-      "translated": "لا توجد محادثات حديثة"
+      "id": "native.apple.28c97cf23665ee01",
+      "source": "No recent sessions",
+      "translated": "لا توجد جلسات حديثة"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11234,14 +11219,14 @@
       "translated": "إلغاء"
     },
     {
-      "id": "native.apple.b6855cf19a50f477",
-      "source": "Threads",
-      "translated": "المحادثات"
+      "id": "native.apple.9f2fd65953013b7c",
+      "source": "Sessions",
+      "translated": "الجلسات"
     },
     {
-      "id": "native.apple.9b1d0ef27a1333b0",
-      "source": "Archived threads",
-      "translated": "المحادثات المؤرشفة"
+      "id": "native.apple.0422818cc95d5071",
+      "source": "Archived sessions",
+      "translated": "الجلسات المؤرشفة"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11249,34 +11234,34 @@
       "translated": "إظهار المؤرشفة"
     },
     {
-      "id": "native.apple.98167401c7267735",
-      "source": "Threads unavailable",
-      "translated": "المحادثات غير متاحة"
+      "id": "native.apple.b272115c83f7ef58",
+      "source": "Sessions unavailable",
+      "translated": "الجلسات غير متاحة"
     },
     {
-      "id": "native.apple.4d28a7def2337b9f",
-      "source": "Loading archived threads",
-      "translated": "جارٍ تحميل المحادثات المؤرشفة"
+      "id": "native.apple.54f8260c9b863087",
+      "source": "Loading archived sessions",
+      "translated": "جارٍ تحميل الجلسات المؤرشفة"
     },
     {
-      "id": "native.apple.777d7b706933bd7b",
-      "source": "Loading recent threads",
-      "translated": "جارٍ تحميل المحادثات الأخيرة"
+      "id": "native.apple.9b305868873dade2",
+      "source": "Loading recent sessions",
+      "translated": "جارٍ تحميل الجلسات الأخيرة"
     },
     {
-      "id": "native.apple.22f81ea94bef8410",
-      "source": "^[\\(count) thread](inflect: true)",
-      "translated": "^[\\(count) محادثة](inflect: true)"
+      "id": "native.apple.207dad20d09f3160",
+      "source": "^[\\(count) session](inflect: true)",
+      "translated": "^[\\(count) جلسة](inflect: true)"
     },
     {
-      "id": "native.apple.1cad51e14db59bf9",
-      "source": "No archived threads",
-      "translated": "لا توجد محادثات مؤرشفة"
+      "id": "native.apple.1f4501a6bf2bae4c",
+      "source": "No archived sessions",
+      "translated": "لا توجد جلسات مؤرشفة"
     },
     {
-      "id": "native.apple.18ef832d3a7ddcf8",
-      "source": "Archived threads will appear here.",
-      "translated": "ستظهر المحادثات المؤرشفة هنا."
+      "id": "native.apple.2a1ba7a5e1979c9e",
+      "source": "Archived sessions will appear here.",
+      "translated": "ستظهر الجلسات المؤرشفة هنا."
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11359,9 +11344,9 @@
       "translated": "مشاركة الإدخال"
     },
     {
-      "id": "native.apple.21d9208d86a4d1fe",
-      "source": "Loading threads",
-      "translated": "جارٍ تحميل سلاسل المحادثات"
+      "id": "native.apple.2360d25fe6ae9946",
+      "source": "Loading sessions",
+      "translated": "جارٍ تحميل الجلسات"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11369,19 +11354,19 @@
       "translated": "جارٍ جلب النشاط الأخير من Gateway."
     },
     {
-      "id": "native.apple.4be1f79aa2b230ff",
-      "source": "Threads unavailable",
-      "translated": "سلاسل المحادثات غير متاحة"
+      "id": "native.apple.c334f2e86702a7b8",
+      "source": "Sessions unavailable",
+      "translated": "الجلسات غير متاحة"
     },
     {
-      "id": "native.apple.98b348873556bc46",
-      "source": "No recent threads",
-      "translated": "لا توجد سلاسل محادثات حديثة"
+      "id": "native.apple.6cc6efb7a03960b6",
+      "source": "No recent sessions",
+      "translated": "لا توجد جلسات حديثة"
     },
     {
-      "id": "native.apple.7396d205574d279f",
-      "source": "Thread activity offline",
-      "translated": "نشاط سلاسل المحادثات غير متصل"
+      "id": "native.apple.08483af2d043bee6",
+      "source": "Session activity offline",
+      "translated": "نشاط الجلسة غير متصل"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11839,9 +11824,9 @@
       "translated": "بطاقة"
     },
     {
-      "id": "native.apple.c9ec1b0e18074d8a",
-      "source": "Open Thread",
-      "translated": "فتح سلسلة المحادثة"
+      "id": "native.apple.93eeaedb2ff61043",
+      "source": "Open Session",
+      "translated": "فتح الجلسة"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13329,9 +13314,9 @@
       "translated": "افتراضي"
     },
     {
-      "id": "native.apple.f4ae5664c3eda95d",
-      "source": "Used for new Chat threads and Talk sessions.",
-      "translated": "يُستخدم لسلاسل محادثات الدردشة الجديدة وجلسات التحدث."
+      "id": "native.apple.3de045f17ea3c6d0",
+      "source": "Used for new Chat and Talk sessions.",
+      "translated": "يُستخدم لجلسات الدردشة والتحدث الجديدة."
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15734,9 +15719,9 @@
       "translated": "المثيلات"
     },
     {
-      "id": "native.apple.11fe8b9941954dfb",
-      "source": "Threads",
-      "translated": "سلاسل المحادثات"
+      "id": "native.apple.3579cf2750470a22",
+      "source": "Sessions",
+      "translated": "الجلسات"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19044,9 +19029,9 @@
       "translated": "اختصار الدردشة السريعة"
     },
     {
-      "id": "native.apple.94dd793cd7d7d555",
-      "source": "Global shortcut that opens a floating chat bar for the main thread.",
-      "translated": "اختصار عام يفتح شريط دردشة عائمًا لسلسلة المحادثة الرئيسية."
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "اختصار عام يفتح شريط دردشة عائمًا للجلسة الرئيسية."
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19624,9 +19609,9 @@
       "translated": "حرج"
     },
     {
-      "id": "native.apple.13f96467014cf344",
-      "source": "New Thread",
-      "translated": "سلسلة محادثة جديدة"
+      "id": "native.apple.75102378a6775180",
+      "source": "New Session",
+      "translated": "جلسة جديدة"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21914,9 +21899,9 @@
       "translated": "لا توجد رسائل حديثة"
     },
     {
-      "id": "native.apple.3ec2afcbc298c673",
-      "source": "Threads",
-      "translated": "سلاسل المحادثات"
+      "id": "native.apple.1ff8aec0044934c3",
+      "source": "Sessions",
+      "translated": "الجلسات"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21924,9 +21909,9 @@
       "translated": "ألقِ نظرة على حاويات المحادثات المخزّنة التي تعيد CLI استخدامها للسياق وحدود المعدل."
     },
     {
-      "id": "native.apple.14ccb32cd8ed1c81",
-      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
-      "translated": "لا توجد سلاسل محادثات بعد. ستظهر بعد أول رسالة واردة أو إشارة نبض."
+      "id": "native.apple.bab897f3252b134c",
+      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
+      "translated": "لا توجد جلسات بعد. تظهر بعد أول رسالة واردة أو نبضة."
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -22009,9 +21994,9 @@
       "translated": "موافقات Exec"
     },
     {
-      "id": "native.apple.52e37e3a44ae516c",
-      "source": "Threads",
-      "translated": "سلاسل المحادثات"
+      "id": "native.apple.64a6dc7d49e8fb57",
+      "source": "Sessions",
+      "translated": "الجلسات"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -23014,9 +22999,9 @@
       "translated": "أطلعني على المستجدات"
     },
     {
-      "id": "native.apple.fc4ce810900ec0b6",
-      "source": "Summarize what happened in my threads since yesterday.",
-      "translated": "لخّص ما حدث في سلاسل محادثاتي منذ الأمس."
+      "id": "native.apple.234ec45f4231edc4",
+      "source": "Summarize what happened in my sessions since yesterday.",
+      "translated": "لخّص ما حدث في جلساتي منذ الأمس."
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23194,9 +23179,9 @@
       "translated": "إلغاء تثبيت النموذج"
     },
     {
-      "id": "native.apple.4edb66657f5aca1f",
-      "source": "Thread",
-      "translated": "سلسلة المحادثة"
+      "id": "native.apple.5dfc0700d8dff8de",
+      "source": "Session",
+      "translated": "الجلسة"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23359,51 +23344,6 @@
       "translated": "الأداة غير متاحة"
     },
     {
-      "id": "native.apple.d640691fd196f338",
-      "source": "Widget export failed",
-      "translated": "فشل تصدير الأداة"
-    },
-    {
-      "id": "native.apple.533c6e22a11e88de",
-      "source": "OK",
-      "translated": "موافق"
-    },
-    {
-      "id": "native.apple.e1fb28a2a9756402",
-      "source": "Copy image",
-      "translated": "نسخ الصورة"
-    },
-    {
-      "id": "native.apple.ebd7bc92e1b12235",
-      "source": "Save image…",
-      "translated": "حفظ الصورة…"
-    },
-    {
-      "id": "native.apple.742c46d4cf2db134",
-      "source": "Save image",
-      "translated": "حفظ الصورة"
-    },
-    {
-      "id": "native.apple.0589cce608418f90",
-      "source": "The widget image could not be captured.",
-      "translated": "تعذّر التقاط صورة الأداة."
-    },
-    {
-      "id": "native.apple.dfe24e827fdbe9c5",
-      "source": "The widget image could not be copied.",
-      "translated": "تعذّر نسخ صورة الأداة."
-    },
-    {
-      "id": "native.apple.9e611e3a80e71408",
-      "source": "The widget image could not be encoded as PNG.",
-      "translated": "تعذّر ترميز صورة الأداة بتنسيق PNG."
-    },
-    {
-      "id": "native.apple.9a6e8afbe24a262b",
-      "source": "The widget image could not be saved.",
-      "translated": "تعذّر حفظ صورة الأداة."
-    },
-    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23544,19 +23484,19 @@
       "translated": "المستخدم"
     },
     {
-      "id": "native.apple.9d0cba09d92ee669",
-      "source": "This thread cannot be archived while it is active or running.",
-      "translated": "لا يمكن أرشفة سلسلة المحادثة هذه أثناء نشاطها أو تشغيلها."
+      "id": "native.apple.b1cdcb906a43d5d6",
+      "source": "This session cannot be archived while it is active or running.",
+      "translated": "لا يمكن أرشفة هذه الجلسة أثناء نشاطها أو تشغيلها."
     },
     {
-      "id": "native.apple.8952a111a1075051",
-      "source": "The main thread cannot be deleted.",
-      "translated": "لا يمكن حذف سلسلة المحادثة الرئيسية."
+      "id": "native.apple.5817e3f3dab1ee19",
+      "source": "The main session cannot be deleted.",
+      "translated": "لا يمكن حذف الجلسة الرئيسية."
     },
     {
-      "id": "native.apple.90d0ccf80ca28717",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
-      "translated": "أزل المرفقات أو انتظر تسليمها قبل أرشفة سلسلة المحادثة هذه أو حذفها."
+      "id": "native.apple.a6b8df3f18171c91",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
+      "translated": "أزل المرفقات أو انتظر تسليمها قبل أرشفة هذه الجلسة أو حذفها."
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23694,9 +23634,9 @@
       "translated": "انتهى التشغيل"
     },
     {
-      "id": "native.apple.bbccb4c8db5cac12",
-      "source": "Thread Info",
-      "translated": "معلومات سلسلة المحادثة"
+      "id": "native.apple.cd7c3095a22f80a9",
+      "source": "Session Info",
+      "translated": "معلومات الجلسة"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23729,9 +23669,9 @@
       "translated": "إضافة مجموعة"
     },
     {
-      "id": "native.apple.7b641fed5bace855",
-      "source": "Thread Groups",
-      "translated": "مجموعات سلاسل المحادثات"
+      "id": "native.apple.23d628606fe0734f",
+      "source": "Session Groups",
+      "translated": "مجموعات الجلسة"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23774,9 +23714,9 @@
       "translated": "حذف المجموعة"
     },
     {
-      "id": "native.apple.56401c79410a310d",
-      "source": "Threads in this group become ungrouped.",
-      "translated": "ستصبح سلاسل المحادثات في هذه المجموعة غير مجمّعة."
+      "id": "native.apple.b049c8a4d2805e08",
+      "source": "Sessions in this group become ungrouped.",
+      "translated": "ستصبح الجلسات في هذه المجموعة غير مصنّفة ضمن مجموعة."
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23789,9 +23729,9 @@
       "translated": "لا توجد وكلاء متاحة على هذا Gateway."
     },
     {
-      "id": "native.apple.2d96aa7d3d12f85b",
-      "source": "New Thread Options",
-      "translated": "خيارات المحادثة الجديدة"
+      "id": "native.apple.6c89f35d53506406",
+      "source": "New Session Options",
+      "translated": "خيارات الجلسة الجديدة"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23819,19 +23759,19 @@
       "translated": "إنشاء"
     },
     {
-      "id": "native.apple.87ef57319d1ddc85",
-      "source": "The thread could not be created.",
-      "translated": "تعذّر إنشاء المحادثة."
+      "id": "native.apple.795ba37f6782cf28",
+      "source": "The session could not be created.",
+      "translated": "تعذّر إنشاء الجلسة."
     },
     {
-      "id": "native.apple.6bd91c435b69d638",
-      "source": "Search threads",
-      "translated": "البحث في المحادثات"
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "البحث في الجلسات"
     },
     {
-      "id": "native.apple.6fde4bdf9d5b9191",
-      "source": "No Threads",
-      "translated": "لا توجد محادثات"
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "لا توجد جلسات"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23839,29 +23779,29 @@
       "translated": "لا توجد نتائج"
     },
     {
-      "id": "native.apple.a02fd99740d29bd3",
-      "source": "New Thread",
-      "translated": "محادثة جديدة"
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "جلسة جديدة"
     },
     {
-      "id": "native.apple.b625801dd04b09f2",
-      "source": "New thread",
-      "translated": "محادثة جديدة"
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "جلسة جديدة"
     },
     {
-      "id": "native.apple.851be81fcc933608",
-      "source": "New thread options",
-      "translated": "خيارات المحادثة الجديدة"
+      "id": "native.apple.2ef0e34db02ad255",
+      "source": "New session options",
+      "translated": "خيارات الجلسة الجديدة"
     },
     {
-      "id": "native.apple.9ce8a4aba7b444b2",
-      "source": "Rename Thread",
-      "translated": "إعادة تسمية المحادثة"
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "إعادة تسمية الجلسة"
     },
     {
-      "id": "native.apple.1dd067c44511c7f0",
-      "source": "Thread name",
-      "translated": "اسم المحادثة"
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "اسم الجلسة"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23874,14 +23814,14 @@
       "translated": "إلغاء"
     },
     {
-      "id": "native.apple.618073d6ab3f2721",
-      "source": "Delete Thread",
-      "translated": "حذف المحادثة"
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "حذف الجلسة"
     },
     {
-      "id": "native.apple.10a5e72bba3cbccc",
-      "source": "The thread and its transcript are removed from the gateway.",
-      "translated": "تُزال المحادثة وسجلها من Gateway."
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "تتم إزالة الجلسة ونصها من Gateway."
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23889,14 +23829,14 @@
       "translated": "حذف «%@»؟"
     },
     {
-      "id": "native.apple.ac71e3b2aa496a2c",
-      "source": "Thread running",
-      "translated": "المحادثة قيد التشغيل"
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "الجلسة قيد التشغيل"
     },
     {
-      "id": "native.apple.c775e87f997278b2",
-      "source": "Thread failed",
-      "translated": "فشلت المحادثة"
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "فشلت الجلسة"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23954,9 +23894,9 @@
       "translated": "نسخ مفتاح الجلسة"
     },
     {
-      "id": "native.apple.f4998cfb572f23ff",
-      "source": "Delete Thread…",
-      "translated": "حذف المحادثة…"
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "حذف الجلسة…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23969,9 +23909,9 @@
       "translated": "جارٍ الاتصال…"
     },
     {
-      "id": "native.apple.8802e9576ffd0f65",
-      "source": "Retry thread groups",
-      "translated": "إعادة محاولة مجموعات المحادثات"
+      "id": "native.apple.79f708b3bc1d3a6c",
+      "source": "Retry session groups",
+      "translated": "إعادة محاولة تحميل مجموعات الجلسات"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23994,24 +23934,24 @@
       "translated": "النطاق"
     },
     {
-      "id": "native.apple.b313b80def4bda52",
-      "source": "Search threads",
-      "translated": "البحث في المحادثات"
+      "id": "native.apple.2c37581c7b88f741",
+      "source": "Search sessions",
+      "translated": "البحث في الجلسات"
     },
     {
-      "id": "native.apple.c0cc6acc36f413ce",
-      "source": "Threads",
-      "translated": "المحادثات"
+      "id": "native.apple.43be8a2336e42faf",
+      "source": "Sessions",
+      "translated": "الجلسات"
     },
     {
-      "id": "native.apple.854d3928fe5a557c",
-      "source": "Rename Thread",
-      "translated": "إعادة تسمية المحادثة"
+      "id": "native.apple.0b379cdfcbd3247f",
+      "source": "Rename Session",
+      "translated": "إعادة تسمية الجلسة"
     },
     {
-      "id": "native.apple.9d0d3f20096cc4da",
-      "source": "Thread name",
-      "translated": "اسم المحادثة"
+      "id": "native.apple.54b6fbd9e41db009",
+      "source": "Session name",
+      "translated": "اسم الجلسة"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -24019,19 +23959,19 @@
       "translated": "إلغاء"
     },
     {
-      "id": "native.apple.dc00eb94f33bae15",
-      "source": "Delete selected threads?",
-      "translated": "هل تريد حذف المحادثات المحددة؟"
+      "id": "native.apple.751e0f6b81cd374a",
+      "source": "Delete selected sessions?",
+      "translated": "حذف الجلسات المحددة؟"
     },
     {
-      "id": "native.apple.2053fc9f74dc3158",
-      "source": "Delete Threads",
-      "translated": "حذف المحادثات"
+      "id": "native.apple.aa679276581b0058",
+      "source": "Delete Sessions",
+      "translated": "حذف الجلسات"
     },
     {
-      "id": "native.apple.0970247871a834a0",
-      "source": "Each selected thread and its transcript will be removed from the gateway.",
-      "translated": "ستتم إزالة كل محادثة محددة وسجلها من Gateway."
+      "id": "native.apple.f837129cbee23297",
+      "source": "Each selected session and its transcript will be removed from the gateway.",
+      "translated": "ستُزال كل جلسة محددة ونصها من Gateway."
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -24039,9 +23979,9 @@
       "translated": "المجموعات"
     },
     {
-      "id": "native.apple.6f8acab2256728b5",
-      "source": "Manage thread groups",
-      "translated": "إدارة مجموعات المحادثات"
+      "id": "native.apple.64013cfee5e25305",
+      "source": "Manage session groups",
+      "translated": "إدارة مجموعات الجلسات"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -24054,14 +23994,14 @@
       "translated": "تحديد"
     },
     {
-      "id": "native.apple.692972314d04b184",
-      "source": "No archived threads",
-      "translated": "لا توجد محادثات مؤرشفة"
+      "id": "native.apple.b67eaecec1b423ac",
+      "source": "No archived sessions",
+      "translated": "لا توجد جلسات مؤرشفة"
     },
     {
-      "id": "native.apple.d6a4b5711dcd26e7",
-      "source": "No threads found",
-      "translated": "لم يتم العثور على محادثات"
+      "id": "native.apple.b2435a79abf0c794",
+      "source": "No sessions found",
+      "translated": "لم يتم العثور على جلسات"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24229,16 +24169,6 @@
       "translated": "فتح الرسالة الكاملة"
     },
     {
-      "id": "native.apple.002bfcede229ad4b",
-      "source": "Rewind to Here",
-      "translated": "إرجاع إلى هنا"
-    },
-    {
-      "id": "native.apple.14df2e4997689fb3",
-      "source": "Fork from Here",
-      "translated": "إنشاء تفرّع من هنا"
-    },
-    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "رد"
@@ -24324,9 +24254,9 @@
       "translated": "أزل المرفقات أو انتظر حتى يكتمل التسليم قبل بدء محادثة جديدة."
     },
     {
-      "id": "native.apple.e0f045151c8d3137",
-      "source": "Gateway changed before the thread operation started.",
-      "translated": "تغيّر Gateway قبل بدء عملية المحادثة."
+      "id": "native.apple.980f552bb0f96c0f",
+      "source": "Gateway changed before the session operation started.",
+      "translated": "تغيّر Gateway قبل بدء عملية الجلسة."
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24334,9 +24264,9 @@
       "translated": "أزِل المرفقات أو انتظر اكتمال التسليم قبل تبديل المحادثات."
     },
     {
-      "id": "native.apple.0a5c4e15466c3acc",
-      "source": "Clear this thread's history?",
-      "translated": "هل تريد مسح سجل هذه المحادثة؟"
+      "id": "native.apple.87ba543b42696b92",
+      "source": "Clear this session's history?",
+      "translated": "هل تريد مسح سجل هذه الجلسة؟"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24349,14 +24279,14 @@
       "translated": "سيؤدي هذا إلى إعادة تعيين المحادثة لـ %@. سيبقى مفتاح الجلسة كما هو."
     },
     {
-      "id": "native.apple.67ac221dbe7179f0",
-      "source": "Rename Thread",
-      "translated": "إعادة تسمية المحادثة"
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "إعادة تسمية الجلسة"
     },
     {
-      "id": "native.apple.cf0f7e049603f518",
-      "source": "Thread name",
-      "translated": "اسم المحادثة"
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "اسم الجلسة"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24374,9 +24304,9 @@
       "translated": "تصدير النص"
     },
     {
-      "id": "native.apple.c0ada47504425f23",
-      "source": "Threads",
-      "translated": "المحادثات"
+      "id": "native.apple.4af0f566d39d7041",
+      "source": "Sessions",
+      "translated": "الجلسات"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24449,14 +24379,14 @@
       "translated": "الافتراضي"
     },
     {
-      "id": "native.apple.1a765291943599e5",
-      "source": "New Thread",
-      "translated": "محادثة جديدة"
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "جلسة جديدة"
     },
     {
-      "id": "native.apple.c7a3a6d5e43dd98f",
-      "source": "New Thread Options…",
-      "translated": "خيارات المحادثة الجديدة…"
+      "id": "native.apple.a7119fbf9d25df5e",
+      "source": "New Session Options…",
+      "translated": "خيارات جلسة جديدة…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24464,19 +24394,19 @@
       "translated": "تحديث"
     },
     {
-      "id": "native.apple.0e710b81808e5dcf",
-      "source": "Threads…",
-      "translated": "المحادثات…"
+      "id": "native.apple.2bcff4a8fa503739",
+      "source": "Sessions…",
+      "translated": "الجلسات…"
     },
     {
-      "id": "native.apple.faad8f92b6bef166",
-      "source": "Rename Thread…",
-      "translated": "إعادة تسمية المحادثة…"
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "إعادة تسمية الجلسة…"
     },
     {
-      "id": "native.apple.23b61d6cd26ac112",
-      "source": "Fork",
-      "translated": "إنشاء فرع"
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "تفرّع الجلسة"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24534,24 +24464,24 @@
       "translated": "مسح السجل…"
     },
     {
-      "id": "native.apple.8b4f1c5107ea8a0e",
-      "source": "Thread",
-      "translated": "المحادثة"
+      "id": "native.apple.920fe8a7a33f9e92",
+      "source": "Session",
+      "translated": "الجلسة"
     },
     {
-      "id": "native.apple.4d7750c9bf699469",
-      "source": "Thread actions",
-      "translated": "إجراءات المحادثة"
+      "id": "native.apple.185a401f78328b0f",
+      "source": "Session actions",
+      "translated": "إجراءات الجلسة"
     },
     {
-      "id": "native.apple.bb2f22cc43c97f8e",
-      "source": "Thread cost %@",
-      "translated": "تكلفة المحادثة %@"
+      "id": "native.apple.9f9dedf599b2619b",
+      "source": "Session cost %@",
+      "translated": "تكلفة الجلسة %@"
     },
     {
-      "id": "native.apple.6239ced0b86e86f8",
-      "source": "Compact Thread",
-      "translated": "ضغط المحادثة"
+      "id": "native.apple.f0a4720df5f5f403",
+      "source": "Compact Session",
+      "translated": "ضغط الجلسة"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/ar.json
+++ b/apps/.i18n/native/ar.json
@@ -1429,9 +1429,9 @@
       "translated": "تحدّث أو أملِ باستخدام OpenClaw"
     },
     {
-      "id": "native.android.5876e15e5e92fd45",
-      "source": "Browse Sessions",
-      "translated": "تصفّح الجلسات"
+      "id": "native.android.e2cf5a38587382cb",
+      "source": "Browse Threads",
+      "translated": "تصفّح المحادثات"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "لم يتم العثور على إجراءات"
     },
     {
-      "id": "native.android.48ad0ae0e930e02b",
-      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
-      "translated": "جرّب الدردشة أو الصوت أو الجلسات أو المزوّدين أو الإعدادات."
+      "id": "native.android.bc70a4ac965b82ba",
+      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
+      "translated": "جرّب الدردشة أو الصوت أو المحادثات أو المزوّدين أو الإعدادات."
     },
     {
-      "id": "native.android.d4fbd1ee4f55a5db",
-      "source": "Sessions",
-      "translated": "الجلسات"
+      "id": "native.android.670121e54dbe286f",
+      "source": "Threads",
+      "translated": "المحادثات"
     },
     {
-      "id": "native.android.207c2170504e99e6",
-      "source": "Connect the Gateway to search sessions.",
-      "translated": "وصّل Gateway للبحث في الجلسات."
+      "id": "native.android.d38be650b1bce4a0",
+      "source": "Connect the Gateway to search threads.",
+      "translated": "اتصل بـ Gateway للبحث في المحادثات."
     },
     {
-      "id": "native.android.25d2c2d792c952fe",
-      "source": "No matching sessions yet.",
-      "translated": "لا توجد جلسات مطابقة بعد."
+      "id": "native.android.3d7754721f776ef8",
+      "source": "No matching threads yet.",
+      "translated": "لا توجد محادثات مطابقة حتى الآن."
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "المساعد يعمل"
     },
     {
-      "id": "native.android.8f8384286317f5c9",
-      "source": "OpenClaw session",
-      "translated": "جلسة OpenClaw"
+      "id": "native.android.9a839f6e3e05a744",
+      "source": "OpenClaw thread",
+      "translated": "محادثة OpenClaw"
     },
     {
-      "id": "native.android.15799e57704b20c6",
-      "source": "Open session",
-      "translated": "فتح الجلسة"
+      "id": "native.android.d83f82a1e4a5ed99",
+      "source": "Open thread",
+      "translated": "فتح المحادثة"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "لا يوجد مزوّدون جاهزون"
     },
     {
-      "id": "native.android.73e6ab1a168fd381",
-      "source": "Main session",
-      "translated": "الجلسة الرئيسية"
+      "id": "native.android.8a1c5365c0538908",
+      "source": "Main thread",
+      "translated": "المحادثة الرئيسية"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.0e3157c15c56944f",
-      "source": "Sessions",
-      "translated": "الجلسات"
+      "id": "native.android.a5845742daecb4ba",
+      "source": "Threads",
+      "translated": "المحادثات"
     },
     {
-      "id": "native.android.70f5d0507d34b5c8",
-      "source": "Focus session search",
-      "translated": "التركيز على بحث الجلسات"
+      "id": "native.android.439b324280869527",
+      "source": "Focus thread search",
+      "translated": "التركيز على البحث في المحادثات"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "مؤرشف"
     },
     {
-      "id": "native.android.b9cf34c137e4cf03",
-      "source": "Search sessions",
-      "translated": "البحث في الجلسات"
+      "id": "native.android.03981341841b04ac",
+      "source": "Search threads",
+      "translated": "البحث في المحادثات"
     },
     {
-      "id": "native.android.10cb26723e9990fc",
-      "source": "Clear session search",
-      "translated": "مسح بحث الجلسات"
+      "id": "native.android.99570c528a41fa72",
+      "source": "Clear thread search",
+      "translated": "مسح البحث في المحادثات"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "الأقدم أولاً"
     },
     {
-      "id": "native.android.c6bf8751e2a7f5c7",
-      "source": "Toggle session layout",
-      "translated": "تبديل تخطيط الجلسات"
+      "id": "native.android.fd67be543e321cc9",
+      "source": "Toggle thread layout",
+      "translated": "تبديل تخطيط المحادثات"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "التخطيط: مفصّل"
     },
     {
-      "id": "native.android.69b79a3c2c987cd4",
-      "source": "Searching sessions",
-      "translated": "جارٍ البحث في الجلسات"
+      "id": "native.android.ebd17565e0ffd8eb",
+      "source": "Searching threads",
+      "translated": "جارٍ البحث في المحادثات"
     },
     {
-      "id": "native.android.dd587d341af44212",
-      "source": "No matching sessions",
-      "translated": "لا توجد جلسات مطابقة"
+      "id": "native.android.472d46ae8669f860",
+      "source": "No matching threads",
+      "translated": "لا توجد محادثات مطابقة"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "بدء الدردشة"
     },
     {
-      "id": "native.android.f10d4df7cbc6df4f",
-      "source": "Current session",
-      "translated": "الجلسة الحالية"
+      "id": "native.android.ff81ad1bee00d384",
+      "source": "Current thread",
+      "translated": "المحادثة الحالية"
     },
     {
-      "id": "native.android.8f0482425838ae64",
-      "source": "OpenClaw session",
-      "translated": "جلسة OpenClaw"
+      "id": "native.android.fc145645b9620e57",
+      "source": "OpenClaw thread",
+      "translated": "محادثة OpenClaw"
     },
     {
-      "id": "native.android.786774c8a76e50d7",
-      "source": "Rename session",
-      "translated": "إعادة تسمية الجلسة"
+      "id": "native.android.71cbb8dde8bf138b",
+      "source": "Rename thread",
+      "translated": "إعادة تسمية المحادثة"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "حذف المجموعة؟"
     },
     {
-      "id": "native.android.3455fc2f77d564e3",
-      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "يتم الاحتفاظ بالجلسات في \"$group\" ونقلها مرة أخرى إلى غير المجمعة."
+      "id": "native.android.691e92cfe5cf106e",
+      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "يتم الاحتفاظ بالمحادثات في \"$group\" ونقلها مجددًا إلى غير مجمّعة."
     },
     {
-      "id": "native.android.4805fb9d6623e8c0",
-      "source": "Delete session?",
-      "translated": "حذف الجلسة؟"
+      "id": "native.android.d87a8217ab56999b",
+      "source": "Delete thread?",
+      "translated": "حذف المحادثة؟"
     },
     {
-      "id": "native.android.0c3283a2b2445eae",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "سيؤدي هذا إلى حذف الجلسة ونصها نهائيًا."
+      "id": "native.android.930de97ff47113a8",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "يؤدي هذا إلى حذف المحادثة ونصها نهائيًا."
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "غير مصنّف"
     },
     {
-      "id": "native.android.db243d71d056afa4",
-      "source": "No sessions yet",
-      "translated": "لا توجد جلسات بعد"
+      "id": "native.android.8e21a70428def6e0",
+      "source": "No threads yet",
+      "translated": "لا توجد محادثات بعد"
     },
     {
-      "id": "native.android.5b4eee6a8092925e",
-      "source": "No current session",
-      "translated": "لا توجد جلسة حالية"
+      "id": "native.android.cda4c5ad8b17e394",
+      "source": "No current thread",
+      "translated": "لا توجد محادثة حالية"
     },
     {
-      "id": "native.android.acbcc9c9ea53d8c0",
-      "source": "No archived sessions",
-      "translated": "لا توجد جلسات مؤرشفة"
+      "id": "native.android.be84f061047aa2da",
+      "source": "No archived threads",
+      "translated": "لا توجد محادثات مؤرشفة"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "ابدأ محادثة جديدة وستظهر هنا."
     },
     {
-      "id": "native.android.56fcd605dc7be3c0",
-      "source": "Open Chat to start or resume the current session.",
-      "translated": "افتح الدردشة لبدء الجلسة الحالية أو استئنافها."
+      "id": "native.android.f289d03e1d3eee98",
+      "source": "Open Chat to start or resume the current thread.",
+      "translated": "افتح الدردشة لبدء المحادثة الحالية أو استئنافها."
     },
     {
-      "id": "native.android.085515989f8a2022",
-      "source": "Archived sessions will show up here.",
-      "translated": "ستظهر الجلسات المؤرشفة هنا."
+      "id": "native.android.504b71386e76c6ae",
+      "source": "Archived threads will show up here.",
+      "translated": "ستظهر المحادثات المؤرشفة هنا."
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days} ي"
     },
     {
-      "id": "native.android.3d4fa07acbc015c5",
-      "source": "Main session",
-      "translated": "الجلسة الرئيسية"
+      "id": "native.android.ee4c727cdafbe963",
+      "source": "Main thread",
+      "translated": "المحادثة الرئيسية"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway قيد الانتظار"
     },
     {
-      "id": "native.android.2d8d049afe99f751",
-      "source": "Session Activity",
-      "translated": "نشاط الجلسة"
+      "id": "native.android.da78209effb11cfd",
+      "source": "Thread Activity",
+      "translated": "نشاط المحادثة"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "ستظهر طلبات الموافقة على Exec هنا أثناء اتصال هذا الهاتف."
     },
     {
-      "id": "native.android.dc3e7ca5a491103a",
-      "source": "Session activity",
-      "translated": "نشاط الجلسة"
+      "id": "native.android.f615712dfb56319a",
+      "source": "Thread activity",
+      "translated": "نشاط المحادثة"
     },
     {
-      "id": "native.android.8551e02b060bd7d8",
-      "source": "Chat tool calls waiting in the active session remain visible here.",
-      "translated": "تظل استدعاءات أدوات الدردشة المنتظرة في الجلسة النشطة مرئية هنا."
+      "id": "native.android.6c93973c13db43ae",
+      "source": "Chat tool calls waiting in the active thread remain visible here.",
+      "translated": "تظل استدعاءات أدوات الدردشة المنتظرة في المحادثة النشطة ظاهرة هنا."
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,6 +4294,11 @@
       "translated": "إعداد مزوّد المحادثة"
     },
     {
+      "id": "native.android.23b638094c34b916",
+      "source": "Microphone",
+      "translated": "الميكروفون"
+    },
+    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "اختبار الصوت"
@@ -4337,6 +4342,66 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "تم"
+    },
+    {
+      "id": "native.android.8d9ecdfdd916b780",
+      "source": "Automatic",
+      "translated": "تلقائي"
+    },
+    {
+      "id": "native.android.c1626a6700a570f6",
+      "source": "Preferred microphone unavailable; using automatic routing.",
+      "translated": "الميكروفون المفضل غير متاح؛ جارٍ استخدام التوجيه التلقائي."
+    },
+    {
+      "id": "native.android.820bc5d0ce571d8b",
+      "source": "Prioritizes connected Bluetooth microphones.",
+      "translated": "يعطي الأولوية لميكروفونات Bluetooth المتصلة."
+    },
+    {
+      "id": "native.android.11e48038d5e8bff6",
+      "source": "Preferred microphone",
+      "translated": "الميكروفون المفضل"
+    },
+    {
+      "id": "native.android.eaa4d7563a46d307",
+      "source": "Unavailable",
+      "translated": "غير متاح"
+    },
+    {
+      "id": "native.android.9f5ebf17eb405ba8",
+      "source": "Next session",
+      "translated": "الجلسة التالية"
+    },
+    {
+      "id": "native.android.8c4e91f53928efb2",
+      "source": "Built-in microphone",
+      "translated": "الميكروفون المدمج"
+    },
+    {
+      "id": "native.android.14b613cb6e2446b4",
+      "source": "Bluetooth microphone",
+      "translated": "ميكروفون Bluetooth"
+    },
+    {
+      "id": "native.android.c885247b2d7ce271",
+      "source": "Bluetooth LE microphone",
+      "translated": "ميكروفون Bluetooth LE"
+    },
+    {
+      "id": "native.android.b6a4e674c5fb441a",
+      "source": "Wired headset microphone",
+      "translated": "ميكروفون سماعة الرأس السلكية"
+    },
+    {
+      "id": "native.android.9c8becb3b0fb5a90",
+      "source": "USB microphone",
+      "translated": "ميكروفون USB"
+    },
+    {
+      "id": "native.android.ba46258fadec7a39",
+      "source": "External microphone",
+      "translated": "ميكروفون خارجي"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5074,9 +5139,9 @@
       "translated": "تحقق"
     },
     {
-      "id": "native.android.5a540761383fa474",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
-      "translated": "يحوّل OpenClaw هذا الهاتف إلى واجهة أوامر محمولة ومنظمة للجلسات والصوت ومزوّدي الخدمات وGateway."
+      "id": "native.android.c971506716c96e91",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
+      "translated": "يحوّل OpenClaw هذا الهاتف إلى واجهة أوامر محمولة ومنظّمة لسلاسل المحادثات والصوت ومزوّدي الخدمة وGateway."
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5624,9 +5689,9 @@
       "translated": "إعدادات Talk"
     },
     {
-      "id": "native.android.73f07a5d54915259",
-      "source": "Recent Sessions",
-      "translated": "الجلسات الحديثة"
+      "id": "native.android.36f78c8c85dc283f",
+      "source": "Recent Threads",
+      "translated": "سلاسل المحادثات الأخيرة"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5684,14 +5749,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% متصلة"
     },
     {
-      "id": "native.android.16c3425d3a594481",
-      "source": "Sessions",
-      "translated": "الجلسات"
+      "id": "native.android.57177017a6a93826",
+      "source": "Threads",
+      "translated": "سلاسل المحادثات"
     },
     {
-      "id": "native.android.a5c0f8b3112aa58c",
-      "source": "No recent sessions",
-      "translated": "لا توجد جلسات حديثة"
+      "id": "native.android.43320b54a68b00a1",
+      "source": "No recent threads",
+      "translated": "لا توجد سلاسل محادثات حديثة"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5729,14 +5794,14 @@
       "translated": "جارٍ العمل · $pendingRunCount عمليات تشغيل نشطة"
     },
     {
-      "id": "native.android.2c89da708b12a522",
-      "source": "Monitoring · 1 session",
-      "translated": "جارٍ الرصد · جلسة واحدة"
+      "id": "native.android.e24db059480f1e6a",
+      "source": "Monitoring · 1 thread",
+      "translated": "المراقبة · سلسلة محادثات واحدة"
     },
     {
-      "id": "native.android.8b6ee382dcb64e1f",
-      "source": "Monitoring · $sessionCount sessions",
-      "translated": "جارٍ الرصد · $sessionCount جلسات"
+      "id": "native.android.5a475f37d80e02bc",
+      "source": "Monitoring · $sessionCount threads",
+      "translated": "المراقبة · $sessionCount من سلاسل المحادثات"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5769,9 +5834,9 @@
       "translated": "موفّرو الخدمة"
     },
     {
-      "id": "native.android.a65477861c7203aa",
-      "source": "Open session",
-      "translated": "فتح الجلسة"
+      "id": "native.android.358c5e0e838d5423",
+      "source": "Open thread",
+      "translated": "فتح سلسلة المحادثات"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6194,9 +6259,9 @@
       "translated": "${days}ي"
     },
     {
-      "id": "native.android.22d755834386db07",
-      "source": "Main session",
-      "translated": "الجلسة الرئيسية"
+      "id": "native.android.28a1a1acc5a0959f",
+      "source": "Main thread",
+      "translated": "سلسلة المحادثات الرئيسية"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6877,6 +6942,16 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "إلغاء كتم الصوت"
+    },
+    {
+      "id": "native.android.cb608d82c5b3352a",
+      "source": "Back camera",
+      "translated": "الكاميرا الخلفية"
+    },
+    {
+      "id": "native.android.e89a0e780eed2e1e",
+      "source": "Front camera",
+      "translated": "الكاميرا الأمامية"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7684,9 +7759,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.882cc14a58e7e105",
-      "source": "Loading session",
-      "translated": "جارٍ تحميل الجلسة"
+      "id": "native.android.0c74bc30a994dd33",
+      "source": "Loading thread",
+      "translated": "جارٍ تحميل سلسلة المحادثات"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7729,14 +7804,14 @@
       "translated": "أطلعني على المستجدات"
     },
     {
-      "id": "native.android.1e5add56e48c99f9",
-      "source": "Summarize recent sessions and next steps.",
-      "translated": "لخّص الجلسات الأخيرة والخطوات التالية."
+      "id": "native.android.cf40df9739f78f27",
+      "source": "Summarize recent threads and next steps.",
+      "translated": "لخّص سلاسل المحادثات الأخيرة والخطوات التالية."
     },
     {
-      "id": "native.android.06d515351bb79576",
-      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
-      "translated": "أطلعني على مستجدات جلساتي الأخيرة في OpenClaw واقترح الخطوات التالية."
+      "id": "native.android.ebe49a8b8df80bd3",
+      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
+      "translated": "أطلعني على آخر مستجدات سلاسل محادثاتي الأخيرة في OpenClaw واقترح الخطوات التالية."
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8074,9 +8149,9 @@
       "translated": "متصل"
     },
     {
-      "id": "native.android.81931886b9caf3ab",
-      "source": "Sessions",
-      "translated": "الجلسات"
+      "id": "native.android.6cf5d6fa8a4186d5",
+      "source": "Threads",
+      "translated": "سلاسل المحادثات"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,9 +10869,9 @@
       "translated": "ما الذي ترغب في العمل عليه؟"
     },
     {
-      "id": "native.apple.32179ce0b6d4543f",
-      "source": "The session attaches once the gateway is ready.",
-      "translated": "يتم إرفاق الجلسة بمجرد أن يصبح Gateway جاهزًا."
+      "id": "native.apple.4da775013ac9b123",
+      "source": "The thread attaches once the gateway is ready.",
+      "translated": "سيتم إرفاق سلسلة المحادثات بمجرد أن تصبح البوابة جاهزة."
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10844,9 +10919,9 @@
       "translated": "خيارات جلسة جديدة…"
     },
     {
-      "id": "native.apple.a1b0d289758e2213",
-      "source": "Sessions…",
-      "translated": "الجلسات…"
+      "id": "native.apple.003b25ddafeb18e9",
+      "source": "Threads…",
+      "translated": "سلاسل المحادثات…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11009,14 +11084,14 @@
       "translated": "إنشاء"
     },
     {
-      "id": "native.apple.f488b9caf6e51ac3",
-      "source": "Delete Session?",
-      "translated": "حذف الجلسة؟"
+      "id": "native.apple.31d5c7287cfb3abe",
+      "source": "Delete Thread?",
+      "translated": "حذف سلسلة المحادثات؟"
     },
     {
-      "id": "native.apple.8634b17be9b111bc",
-      "source": "Delete Session",
-      "translated": "حذف الجلسة"
+      "id": "native.apple.d3395564809f1120",
+      "source": "Delete Thread",
+      "translated": "حذف المحادثة"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11024,9 +11099,9 @@
       "translated": "إلغاء"
     },
     {
-      "id": "native.apple.4a9568ac9b18d8d3",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "سيؤدي هذا إلى حذف الجلسة ونصها بشكل دائم."
+      "id": "native.apple.092659256d26cb03",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "يؤدي هذا إلى حذف المحادثة ونصها نهائيًا."
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11054,9 +11129,9 @@
       "translated": "مجموعة جديدة"
     },
     {
-      "id": "native.apple.5bccdc23a1640895",
-      "source": "Rename Session",
-      "translated": "إعادة تسمية الجلسة"
+      "id": "native.apple.683032464c497bbd",
+      "source": "Rename Thread",
+      "translated": "إعادة تسمية المحادثة"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11064,9 +11139,9 @@
       "translated": "اسم المجموعة"
     },
     {
-      "id": "native.apple.af789b2d2fda0f67",
-      "source": "Session name",
-      "translated": "اسم الجلسة"
+      "id": "native.apple.f887aa956588f237",
+      "source": "Thread name",
+      "translated": "اسم المحادثة"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11104,14 +11179,14 @@
       "translated": "الوكلاء"
     },
     {
-      "id": "native.apple.a3bde8045fe9224a",
-      "source": "Agent session",
-      "translated": "جلسة الوكيل"
+      "id": "native.apple.7c8231b7b1ca480f",
+      "source": "Agent thread",
+      "translated": "محادثة الوكيل"
     },
     {
-      "id": "native.apple.27f775de30b37ff8",
-      "source": "Recent sessions",
-      "translated": "الجلسات الأخيرة"
+      "id": "native.apple.b3c553614f762a58",
+      "source": "Recent threads",
+      "translated": "المحادثات الأخيرة"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11119,9 +11194,9 @@
       "translated": "Gateway غير متصل"
     },
     {
-      "id": "native.apple.28c97cf23665ee01",
-      "source": "No recent sessions",
-      "translated": "لا توجد جلسات حديثة"
+      "id": "native.apple.5aa32afda85064ea",
+      "source": "No recent threads",
+      "translated": "لا توجد محادثات أخيرة"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11219,14 +11294,14 @@
       "translated": "إلغاء"
     },
     {
-      "id": "native.apple.9f2fd65953013b7c",
-      "source": "Sessions",
-      "translated": "الجلسات"
+      "id": "native.apple.b6855cf19a50f477",
+      "source": "Threads",
+      "translated": "المحادثات"
     },
     {
-      "id": "native.apple.0422818cc95d5071",
-      "source": "Archived sessions",
-      "translated": "الجلسات المؤرشفة"
+      "id": "native.apple.9b1d0ef27a1333b0",
+      "source": "Archived threads",
+      "translated": "المحادثات المؤرشفة"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11234,34 +11309,34 @@
       "translated": "إظهار المؤرشفة"
     },
     {
-      "id": "native.apple.b272115c83f7ef58",
-      "source": "Sessions unavailable",
-      "translated": "الجلسات غير متاحة"
+      "id": "native.apple.98167401c7267735",
+      "source": "Threads unavailable",
+      "translated": "المحادثات غير متاحة"
     },
     {
-      "id": "native.apple.54f8260c9b863087",
-      "source": "Loading archived sessions",
-      "translated": "جارٍ تحميل الجلسات المؤرشفة"
+      "id": "native.apple.4d28a7def2337b9f",
+      "source": "Loading archived threads",
+      "translated": "جارٍ تحميل المحادثات المؤرشفة"
     },
     {
-      "id": "native.apple.9b305868873dade2",
-      "source": "Loading recent sessions",
-      "translated": "جارٍ تحميل الجلسات الأخيرة"
+      "id": "native.apple.777d7b706933bd7b",
+      "source": "Loading recent threads",
+      "translated": "جارٍ تحميل المحادثات الأخيرة"
     },
     {
-      "id": "native.apple.207dad20d09f3160",
-      "source": "^[\\(count) session](inflect: true)",
-      "translated": "^[\\(count) جلسة](inflect: true)"
+      "id": "native.apple.22f81ea94bef8410",
+      "source": "^[\\(count) thread](inflect: true)",
+      "translated": "^[\\(count) محادثة](inflect: true)"
     },
     {
-      "id": "native.apple.1f4501a6bf2bae4c",
-      "source": "No archived sessions",
-      "translated": "لا توجد جلسات مؤرشفة"
+      "id": "native.apple.1cad51e14db59bf9",
+      "source": "No archived threads",
+      "translated": "لا توجد محادثات مؤرشفة"
     },
     {
-      "id": "native.apple.2a1ba7a5e1979c9e",
-      "source": "Archived sessions will appear here.",
-      "translated": "ستظهر الجلسات المؤرشفة هنا."
+      "id": "native.apple.18ef832d3a7ddcf8",
+      "source": "Archived threads will appear here.",
+      "translated": "ستظهر المحادثات المؤرشفة هنا."
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11344,9 +11419,9 @@
       "translated": "مشاركة الإدخال"
     },
     {
-      "id": "native.apple.2360d25fe6ae9946",
-      "source": "Loading sessions",
-      "translated": "جارٍ تحميل الجلسات"
+      "id": "native.apple.21d9208d86a4d1fe",
+      "source": "Loading threads",
+      "translated": "جارٍ تحميل المحادثات"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11354,19 +11429,19 @@
       "translated": "جارٍ جلب النشاط الأخير من Gateway."
     },
     {
-      "id": "native.apple.c334f2e86702a7b8",
-      "source": "Sessions unavailable",
-      "translated": "الجلسات غير متاحة"
+      "id": "native.apple.4be1f79aa2b230ff",
+      "source": "Threads unavailable",
+      "translated": "المحادثات غير متاحة"
     },
     {
-      "id": "native.apple.6cc6efb7a03960b6",
-      "source": "No recent sessions",
-      "translated": "لا توجد جلسات حديثة"
+      "id": "native.apple.98b348873556bc46",
+      "source": "No recent threads",
+      "translated": "لا توجد محادثات أخيرة"
     },
     {
-      "id": "native.apple.08483af2d043bee6",
-      "source": "Session activity offline",
-      "translated": "نشاط الجلسة غير متصل"
+      "id": "native.apple.7396d205574d279f",
+      "source": "Thread activity offline",
+      "translated": "نشاط المحادثة غير متصل"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11824,9 +11899,9 @@
       "translated": "بطاقة"
     },
     {
-      "id": "native.apple.93eeaedb2ff61043",
-      "source": "Open Session",
-      "translated": "فتح الجلسة"
+      "id": "native.apple.c9ec1b0e18074d8a",
+      "source": "Open Thread",
+      "translated": "فتح المحادثة"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13314,9 +13389,9 @@
       "translated": "افتراضي"
     },
     {
-      "id": "native.apple.3de045f17ea3c6d0",
-      "source": "Used for new Chat and Talk sessions.",
-      "translated": "يُستخدم لجلسات الدردشة والتحدث الجديدة."
+      "id": "native.apple.f4ae5664c3eda95d",
+      "source": "Used for new Chat threads and Talk sessions.",
+      "translated": "تُستخدم لمحادثات الدردشة الجديدة وجلسات التحدث."
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15719,9 +15794,9 @@
       "translated": "المثيلات"
     },
     {
-      "id": "native.apple.3579cf2750470a22",
-      "source": "Sessions",
-      "translated": "الجلسات"
+      "id": "native.apple.11fe8b9941954dfb",
+      "source": "Threads",
+      "translated": "المحادثات"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19029,9 +19104,9 @@
       "translated": "اختصار الدردشة السريعة"
     },
     {
-      "id": "native.apple.6ae77665b5f4490f",
-      "source": "Global shortcut that opens a floating chat bar for the main session.",
-      "translated": "اختصار عام يفتح شريط دردشة عائمًا للجلسة الرئيسية."
+      "id": "native.apple.94dd793cd7d7d555",
+      "source": "Global shortcut that opens a floating chat bar for the main thread.",
+      "translated": "اختصار عام يفتح شريط دردشة عائمًا للمحادثة الرئيسية."
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19609,9 +19684,9 @@
       "translated": "حرج"
     },
     {
-      "id": "native.apple.75102378a6775180",
-      "source": "New Session",
-      "translated": "جلسة جديدة"
+      "id": "native.apple.13f96467014cf344",
+      "source": "New Thread",
+      "translated": "محادثة جديدة"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21899,9 +21974,9 @@
       "translated": "لا توجد رسائل حديثة"
     },
     {
-      "id": "native.apple.1ff8aec0044934c3",
-      "source": "Sessions",
-      "translated": "الجلسات"
+      "id": "native.apple.3ec2afcbc298c673",
+      "source": "Threads",
+      "translated": "المحادثات"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21909,9 +21984,9 @@
       "translated": "ألقِ نظرة على حاويات المحادثات المخزّنة التي تعيد CLI استخدامها للسياق وحدود المعدل."
     },
     {
-      "id": "native.apple.bab897f3252b134c",
-      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
-      "translated": "لا توجد جلسات بعد. تظهر بعد أول رسالة واردة أو نبضة."
+      "id": "native.apple.14ccb32cd8ed1c81",
+      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
+      "translated": "لا توجد محادثات بعد. ستظهر بعد أول رسالة واردة أو إشارة نبض."
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -21994,9 +22069,9 @@
       "translated": "موافقات Exec"
     },
     {
-      "id": "native.apple.64a6dc7d49e8fb57",
-      "source": "Sessions",
-      "translated": "الجلسات"
+      "id": "native.apple.52e37e3a44ae516c",
+      "source": "Threads",
+      "translated": "المحادثات"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -22999,9 +23074,9 @@
       "translated": "أطلعني على المستجدات"
     },
     {
-      "id": "native.apple.234ec45f4231edc4",
-      "source": "Summarize what happened in my sessions since yesterday.",
-      "translated": "لخّص ما حدث في جلساتي منذ الأمس."
+      "id": "native.apple.fc4ce810900ec0b6",
+      "source": "Summarize what happened in my threads since yesterday.",
+      "translated": "لخّص ما حدث في محادثاتي منذ الأمس."
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23179,9 +23254,9 @@
       "translated": "إلغاء تثبيت النموذج"
     },
     {
-      "id": "native.apple.5dfc0700d8dff8de",
-      "source": "Session",
-      "translated": "الجلسة"
+      "id": "native.apple.4edb66657f5aca1f",
+      "source": "Thread",
+      "translated": "المحادثة"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23344,6 +23419,51 @@
       "translated": "الأداة غير متاحة"
     },
     {
+      "id": "native.apple.d640691fd196f338",
+      "source": "Widget export failed",
+      "translated": "فشل تصدير الأداة"
+    },
+    {
+      "id": "native.apple.533c6e22a11e88de",
+      "source": "OK",
+      "translated": "موافق"
+    },
+    {
+      "id": "native.apple.e1fb28a2a9756402",
+      "source": "Copy image",
+      "translated": "نسخ الصورة"
+    },
+    {
+      "id": "native.apple.ebd7bc92e1b12235",
+      "source": "Save image…",
+      "translated": "حفظ الصورة…"
+    },
+    {
+      "id": "native.apple.742c46d4cf2db134",
+      "source": "Save image",
+      "translated": "حفظ الصورة"
+    },
+    {
+      "id": "native.apple.0589cce608418f90",
+      "source": "The widget image could not be captured.",
+      "translated": "تعذر التقاط صورة الأداة."
+    },
+    {
+      "id": "native.apple.dfe24e827fdbe9c5",
+      "source": "The widget image could not be copied.",
+      "translated": "تعذر نسخ صورة الأداة."
+    },
+    {
+      "id": "native.apple.9e611e3a80e71408",
+      "source": "The widget image could not be encoded as PNG.",
+      "translated": "تعذر ترميز صورة الأداة بتنسيق PNG."
+    },
+    {
+      "id": "native.apple.9a6e8afbe24a262b",
+      "source": "The widget image could not be saved.",
+      "translated": "تعذر حفظ صورة الأداة."
+    },
+    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23484,19 +23604,19 @@
       "translated": "المستخدم"
     },
     {
-      "id": "native.apple.b1cdcb906a43d5d6",
-      "source": "This session cannot be archived while it is active or running.",
-      "translated": "لا يمكن أرشفة هذه الجلسة أثناء نشاطها أو تشغيلها."
+      "id": "native.apple.9d0cba09d92ee669",
+      "source": "This thread cannot be archived while it is active or running.",
+      "translated": "لا يمكن أرشفة هذه المحادثة أثناء نشاطها أو تشغيلها."
     },
     {
-      "id": "native.apple.5817e3f3dab1ee19",
-      "source": "The main session cannot be deleted.",
-      "translated": "لا يمكن حذف الجلسة الرئيسية."
+      "id": "native.apple.8952a111a1075051",
+      "source": "The main thread cannot be deleted.",
+      "translated": "لا يمكن حذف المحادثة الرئيسية."
     },
     {
-      "id": "native.apple.a6b8df3f18171c91",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
-      "translated": "أزل المرفقات أو انتظر تسليمها قبل أرشفة هذه الجلسة أو حذفها."
+      "id": "native.apple.90d0ccf80ca28717",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
+      "translated": "أزل المرفقات أو انتظر تسليمها قبل أرشفة سلسلة المحادثة هذه أو حذفها."
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23634,9 +23754,9 @@
       "translated": "انتهى التشغيل"
     },
     {
-      "id": "native.apple.cd7c3095a22f80a9",
-      "source": "Session Info",
-      "translated": "معلومات الجلسة"
+      "id": "native.apple.bbccb4c8db5cac12",
+      "source": "Thread Info",
+      "translated": "معلومات سلسلة المحادثة"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23669,9 +23789,9 @@
       "translated": "إضافة مجموعة"
     },
     {
-      "id": "native.apple.23d628606fe0734f",
-      "source": "Session Groups",
-      "translated": "مجموعات الجلسة"
+      "id": "native.apple.7b641fed5bace855",
+      "source": "Thread Groups",
+      "translated": "مجموعات سلاسل المحادثات"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23714,9 +23834,9 @@
       "translated": "حذف المجموعة"
     },
     {
-      "id": "native.apple.b049c8a4d2805e08",
-      "source": "Sessions in this group become ungrouped.",
-      "translated": "ستصبح الجلسات في هذه المجموعة غير مصنّفة ضمن مجموعة."
+      "id": "native.apple.56401c79410a310d",
+      "source": "Threads in this group become ungrouped.",
+      "translated": "ستصبح سلاسل المحادثات في هذه المجموعة غير مجمّعة."
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23729,9 +23849,9 @@
       "translated": "لا توجد وكلاء متاحة على هذا Gateway."
     },
     {
-      "id": "native.apple.6c89f35d53506406",
-      "source": "New Session Options",
-      "translated": "خيارات الجلسة الجديدة"
+      "id": "native.apple.2d96aa7d3d12f85b",
+      "source": "New Thread Options",
+      "translated": "خيارات سلسلة المحادثة الجديدة"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23759,19 +23879,19 @@
       "translated": "إنشاء"
     },
     {
-      "id": "native.apple.795ba37f6782cf28",
-      "source": "The session could not be created.",
-      "translated": "تعذّر إنشاء الجلسة."
+      "id": "native.apple.87ef57319d1ddc85",
+      "source": "The thread could not be created.",
+      "translated": "تعذّر إنشاء سلسلة المحادثة."
     },
     {
-      "id": "native.apple.8ec708a3605a2cc3",
-      "source": "Search sessions",
-      "translated": "البحث في الجلسات"
+      "id": "native.apple.6bd91c435b69d638",
+      "source": "Search threads",
+      "translated": "البحث في سلاسل المحادثات"
     },
     {
-      "id": "native.apple.23b069b4e7f97039",
-      "source": "No Sessions",
-      "translated": "لا توجد جلسات"
+      "id": "native.apple.6fde4bdf9d5b9191",
+      "source": "No Threads",
+      "translated": "لا توجد سلاسل محادثات"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23779,29 +23899,29 @@
       "translated": "لا توجد نتائج"
     },
     {
-      "id": "native.apple.0058923f2ce8a3ec",
-      "source": "New Session",
-      "translated": "جلسة جديدة"
+      "id": "native.apple.a02fd99740d29bd3",
+      "source": "New Thread",
+      "translated": "سلسلة محادثة جديدة"
     },
     {
-      "id": "native.apple.66ba42960eb4135b",
-      "source": "New session",
-      "translated": "جلسة جديدة"
+      "id": "native.apple.b625801dd04b09f2",
+      "source": "New thread",
+      "translated": "سلسلة محادثة جديدة"
     },
     {
-      "id": "native.apple.2ef0e34db02ad255",
-      "source": "New session options",
-      "translated": "خيارات الجلسة الجديدة"
+      "id": "native.apple.851be81fcc933608",
+      "source": "New thread options",
+      "translated": "خيارات سلسلة المحادثة الجديدة"
     },
     {
-      "id": "native.apple.36753ef2f1ed4264",
-      "source": "Rename Session",
-      "translated": "إعادة تسمية الجلسة"
+      "id": "native.apple.9ce8a4aba7b444b2",
+      "source": "Rename Thread",
+      "translated": "إعادة تسمية سلسلة المحادثة"
     },
     {
-      "id": "native.apple.c9de0a1510ef475f",
-      "source": "Session name",
-      "translated": "اسم الجلسة"
+      "id": "native.apple.1dd067c44511c7f0",
+      "source": "Thread name",
+      "translated": "اسم سلسلة المحادثة"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23814,14 +23934,14 @@
       "translated": "إلغاء"
     },
     {
-      "id": "native.apple.afb4e6c99c63a28d",
-      "source": "Delete Session",
-      "translated": "حذف الجلسة"
+      "id": "native.apple.618073d6ab3f2721",
+      "source": "Delete Thread",
+      "translated": "حذف سلسلة المحادثة"
     },
     {
-      "id": "native.apple.3d4ef32e42f136a4",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "تتم إزالة الجلسة ونصها من Gateway."
+      "id": "native.apple.10a5e72bba3cbccc",
+      "source": "The thread and its transcript are removed from the gateway.",
+      "translated": "تُزال سلسلة المحادثة ونصها من Gateway."
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23829,14 +23949,14 @@
       "translated": "حذف «%@»؟"
     },
     {
-      "id": "native.apple.9a7dca238fba628d",
-      "source": "Session running",
-      "translated": "الجلسة قيد التشغيل"
+      "id": "native.apple.ac71e3b2aa496a2c",
+      "source": "Thread running",
+      "translated": "سلسلة المحادثة قيد التشغيل"
     },
     {
-      "id": "native.apple.fcfbfe5e97a95e9c",
-      "source": "Session failed",
-      "translated": "فشلت الجلسة"
+      "id": "native.apple.c775e87f997278b2",
+      "source": "Thread failed",
+      "translated": "فشلت سلسلة المحادثة"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23894,9 +24014,9 @@
       "translated": "نسخ مفتاح الجلسة"
     },
     {
-      "id": "native.apple.4aeb7c14c26dabac",
-      "source": "Delete Session…",
-      "translated": "حذف الجلسة…"
+      "id": "native.apple.f4998cfb572f23ff",
+      "source": "Delete Thread…",
+      "translated": "حذف سلسلة المحادثة…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23909,9 +24029,9 @@
       "translated": "جارٍ الاتصال…"
     },
     {
-      "id": "native.apple.79f708b3bc1d3a6c",
-      "source": "Retry session groups",
-      "translated": "إعادة محاولة تحميل مجموعات الجلسات"
+      "id": "native.apple.8802e9576ffd0f65",
+      "source": "Retry thread groups",
+      "translated": "إعادة محاولة تحميل مجموعات سلاسل المحادثات"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23934,24 +24054,24 @@
       "translated": "النطاق"
     },
     {
-      "id": "native.apple.2c37581c7b88f741",
-      "source": "Search sessions",
-      "translated": "البحث في الجلسات"
+      "id": "native.apple.b313b80def4bda52",
+      "source": "Search threads",
+      "translated": "البحث في سلاسل المحادثات"
     },
     {
-      "id": "native.apple.43be8a2336e42faf",
-      "source": "Sessions",
-      "translated": "الجلسات"
+      "id": "native.apple.c0cc6acc36f413ce",
+      "source": "Threads",
+      "translated": "المحادثات"
     },
     {
-      "id": "native.apple.0b379cdfcbd3247f",
-      "source": "Rename Session",
-      "translated": "إعادة تسمية الجلسة"
+      "id": "native.apple.854d3928fe5a557c",
+      "source": "Rename Thread",
+      "translated": "إعادة تسمية المحادثة"
     },
     {
-      "id": "native.apple.54b6fbd9e41db009",
-      "source": "Session name",
-      "translated": "اسم الجلسة"
+      "id": "native.apple.9d0d3f20096cc4da",
+      "source": "Thread name",
+      "translated": "اسم المحادثة"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -23959,19 +24079,19 @@
       "translated": "إلغاء"
     },
     {
-      "id": "native.apple.751e0f6b81cd374a",
-      "source": "Delete selected sessions?",
-      "translated": "حذف الجلسات المحددة؟"
+      "id": "native.apple.dc00eb94f33bae15",
+      "source": "Delete selected threads?",
+      "translated": "حذف المحادثات المحددة؟"
     },
     {
-      "id": "native.apple.aa679276581b0058",
-      "source": "Delete Sessions",
-      "translated": "حذف الجلسات"
+      "id": "native.apple.2053fc9f74dc3158",
+      "source": "Delete Threads",
+      "translated": "حذف المحادثات"
     },
     {
-      "id": "native.apple.f837129cbee23297",
-      "source": "Each selected session and its transcript will be removed from the gateway.",
-      "translated": "ستُزال كل جلسة محددة ونصها من Gateway."
+      "id": "native.apple.0970247871a834a0",
+      "source": "Each selected thread and its transcript will be removed from the gateway.",
+      "translated": "ستُزال كل محادثة محددة وسجلها من Gateway."
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -23979,9 +24099,9 @@
       "translated": "المجموعات"
     },
     {
-      "id": "native.apple.64013cfee5e25305",
-      "source": "Manage session groups",
-      "translated": "إدارة مجموعات الجلسات"
+      "id": "native.apple.6f8acab2256728b5",
+      "source": "Manage thread groups",
+      "translated": "إدارة مجموعات المحادثات"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -23994,14 +24114,14 @@
       "translated": "تحديد"
     },
     {
-      "id": "native.apple.b67eaecec1b423ac",
-      "source": "No archived sessions",
-      "translated": "لا توجد جلسات مؤرشفة"
+      "id": "native.apple.692972314d04b184",
+      "source": "No archived threads",
+      "translated": "لا توجد محادثات مؤرشفة"
     },
     {
-      "id": "native.apple.b2435a79abf0c794",
-      "source": "No sessions found",
-      "translated": "لم يتم العثور على جلسات"
+      "id": "native.apple.d6a4b5711dcd26e7",
+      "source": "No threads found",
+      "translated": "لم يتم العثور على محادثات"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24169,6 +24289,16 @@
       "translated": "فتح الرسالة الكاملة"
     },
     {
+      "id": "native.apple.002bfcede229ad4b",
+      "source": "Rewind to Here",
+      "translated": "الرجوع إلى هنا"
+    },
+    {
+      "id": "native.apple.14df2e4997689fb3",
+      "source": "Fork from Here",
+      "translated": "التفرع من هنا"
+    },
+    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "رد"
@@ -24254,9 +24384,9 @@
       "translated": "أزل المرفقات أو انتظر حتى يكتمل التسليم قبل بدء محادثة جديدة."
     },
     {
-      "id": "native.apple.980f552bb0f96c0f",
-      "source": "Gateway changed before the session operation started.",
-      "translated": "تغيّر Gateway قبل بدء عملية الجلسة."
+      "id": "native.apple.e0f045151c8d3137",
+      "source": "Gateway changed before the thread operation started.",
+      "translated": "تغيّر Gateway قبل بدء عملية المحادثة."
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24264,9 +24394,9 @@
       "translated": "أزِل المرفقات أو انتظر اكتمال التسليم قبل تبديل المحادثات."
     },
     {
-      "id": "native.apple.87ba543b42696b92",
-      "source": "Clear this session's history?",
-      "translated": "هل تريد مسح سجل هذه الجلسة؟"
+      "id": "native.apple.0a5c4e15466c3acc",
+      "source": "Clear this thread's history?",
+      "translated": "مسح سجل هذه المحادثة؟"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24279,14 +24409,14 @@
       "translated": "سيؤدي هذا إلى إعادة تعيين المحادثة لـ %@. سيبقى مفتاح الجلسة كما هو."
     },
     {
-      "id": "native.apple.a92e96bed98bd553",
-      "source": "Rename Session",
-      "translated": "إعادة تسمية الجلسة"
+      "id": "native.apple.67ac221dbe7179f0",
+      "source": "Rename Thread",
+      "translated": "إعادة تسمية المحادثة"
     },
     {
-      "id": "native.apple.848e2388f3466f40",
-      "source": "Session name",
-      "translated": "اسم الجلسة"
+      "id": "native.apple.cf0f7e049603f518",
+      "source": "Thread name",
+      "translated": "اسم المحادثة"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24304,9 +24434,9 @@
       "translated": "تصدير النص"
     },
     {
-      "id": "native.apple.4af0f566d39d7041",
-      "source": "Sessions",
-      "translated": "الجلسات"
+      "id": "native.apple.c0ada47504425f23",
+      "source": "Threads",
+      "translated": "المحادثات"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24379,14 +24509,14 @@
       "translated": "الافتراضي"
     },
     {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "جلسة جديدة"
+      "id": "native.apple.1a765291943599e5",
+      "source": "New Thread",
+      "translated": "محادثة جديدة"
     },
     {
-      "id": "native.apple.a7119fbf9d25df5e",
-      "source": "New Session Options…",
-      "translated": "خيارات جلسة جديدة…"
+      "id": "native.apple.c7a3a6d5e43dd98f",
+      "source": "New Thread Options…",
+      "translated": "خيارات المحادثة الجديدة…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24394,19 +24524,19 @@
       "translated": "تحديث"
     },
     {
-      "id": "native.apple.2bcff4a8fa503739",
-      "source": "Sessions…",
-      "translated": "الجلسات…"
+      "id": "native.apple.0e710b81808e5dcf",
+      "source": "Threads…",
+      "translated": "المحادثات…"
     },
     {
-      "id": "native.apple.c36e008b051adb38",
-      "source": "Rename Session…",
-      "translated": "إعادة تسمية الجلسة…"
+      "id": "native.apple.faad8f92b6bef166",
+      "source": "Rename Thread…",
+      "translated": "إعادة تسمية المحادثة…"
     },
     {
-      "id": "native.apple.ea0ef95a159bffe0",
-      "source": "Fork Session",
-      "translated": "تفرّع الجلسة"
+      "id": "native.apple.23b61d6cd26ac112",
+      "source": "Fork",
+      "translated": "تفريع"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24464,24 +24594,24 @@
       "translated": "مسح السجل…"
     },
     {
-      "id": "native.apple.920fe8a7a33f9e92",
-      "source": "Session",
-      "translated": "الجلسة"
+      "id": "native.apple.8b4f1c5107ea8a0e",
+      "source": "Thread",
+      "translated": "المحادثة"
     },
     {
-      "id": "native.apple.185a401f78328b0f",
-      "source": "Session actions",
-      "translated": "إجراءات الجلسة"
+      "id": "native.apple.4d7750c9bf699469",
+      "source": "Thread actions",
+      "translated": "إجراءات المحادثة"
     },
     {
-      "id": "native.apple.9f9dedf599b2619b",
-      "source": "Session cost %@",
-      "translated": "تكلفة الجلسة %@"
+      "id": "native.apple.bb2f22cc43c97f8e",
+      "source": "Thread cost %@",
+      "translated": "تكلفة المحادثة %@"
     },
     {
-      "id": "native.apple.f0a4720df5f5f403",
-      "source": "Compact Session",
-      "translated": "ضغط الجلسة"
+      "id": "native.apple.6239ced0b86e86f8",
+      "source": "Compact Thread",
+      "translated": "ضغط المحادثة"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/de.json
+++ b/apps/.i18n/native/de.json
@@ -1429,9 +1429,9 @@
       "translated": "Mit OpenClaw sprechen oder diktieren"
     },
     {
-      "id": "native.android.5876e15e5e92fd45",
-      "source": "Browse Sessions",
-      "translated": "Sitzungen durchsuchen"
+      "id": "native.android.e2cf5a38587382cb",
+      "source": "Browse Threads",
+      "translated": "Threads durchsuchen"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "Keine Aktionen gefunden"
     },
     {
-      "id": "native.android.48ad0ae0e930e02b",
-      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
-      "translated": "Probieren Sie Chat, Voice, Sessions, Providers oder Settings aus."
+      "id": "native.android.bc70a4ac965b82ba",
+      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
+      "translated": "Probiere Chat, Sprache, Threads, Anbieter oder Einstellungen aus."
     },
     {
-      "id": "native.android.d4fbd1ee4f55a5db",
-      "source": "Sessions",
-      "translated": "Sitzungen"
+      "id": "native.android.670121e54dbe286f",
+      "source": "Threads",
+      "translated": "Threads"
     },
     {
-      "id": "native.android.207c2170504e99e6",
-      "source": "Connect the Gateway to search sessions.",
-      "translated": "Verbinde die Gateway, um Sitzungen zu suchen."
+      "id": "native.android.d38be650b1bce4a0",
+      "source": "Connect the Gateway to search threads.",
+      "translated": "Verbinde das Gateway, um Threads zu durchsuchen."
     },
     {
-      "id": "native.android.25d2c2d792c952fe",
-      "source": "No matching sessions yet.",
-      "translated": "Noch keine passenden Sitzungen."
+      "id": "native.android.3d7754721f776ef8",
+      "source": "No matching threads yet.",
+      "translated": "Noch keine passenden Threads."
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "Assistent arbeitet"
     },
     {
-      "id": "native.android.8f8384286317f5c9",
-      "source": "OpenClaw session",
-      "translated": "OpenClaw-Sitzung"
+      "id": "native.android.9a839f6e3e05a744",
+      "source": "OpenClaw thread",
+      "translated": "OpenClaw-Thread"
     },
     {
-      "id": "native.android.15799e57704b20c6",
-      "source": "Open session",
-      "translated": "Sitzung öffnen"
+      "id": "native.android.d83f82a1e4a5ed99",
+      "source": "Open thread",
+      "translated": "Thread öffnen"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "Keine Anbieter bereit"
     },
     {
-      "id": "native.android.73e6ab1a168fd381",
-      "source": "Main session",
-      "translated": "Hauptsitzung"
+      "id": "native.android.8a1c5365c0538908",
+      "source": "Main thread",
+      "translated": "Haupt-Thread"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.0e3157c15c56944f",
-      "source": "Sessions",
-      "translated": "Sitzungen"
+      "id": "native.android.a5845742daecb4ba",
+      "source": "Threads",
+      "translated": "Threads"
     },
     {
-      "id": "native.android.70f5d0507d34b5c8",
-      "source": "Focus session search",
-      "translated": "Sitzungssuche fokussieren"
+      "id": "native.android.439b324280869527",
+      "source": "Focus thread search",
+      "translated": "Thread-Suche fokussieren"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "Archiviert"
     },
     {
-      "id": "native.android.b9cf34c137e4cf03",
-      "source": "Search sessions",
-      "translated": "Sitzungen suchen"
+      "id": "native.android.03981341841b04ac",
+      "source": "Search threads",
+      "translated": "Threads durchsuchen"
     },
     {
-      "id": "native.android.10cb26723e9990fc",
-      "source": "Clear session search",
-      "translated": "Sitzungssuche löschen"
+      "id": "native.android.99570c528a41fa72",
+      "source": "Clear thread search",
+      "translated": "Thread-Suche löschen"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "Älteste zuerst"
     },
     {
-      "id": "native.android.c6bf8751e2a7f5c7",
-      "source": "Toggle session layout",
-      "translated": "Sitzungslayout umschalten"
+      "id": "native.android.fd67be543e321cc9",
+      "source": "Toggle thread layout",
+      "translated": "Thread-Layout umschalten"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "Layout: Detailliert"
     },
     {
-      "id": "native.android.69b79a3c2c987cd4",
-      "source": "Searching sessions",
-      "translated": "Sitzungen werden durchsucht"
+      "id": "native.android.ebd17565e0ffd8eb",
+      "source": "Searching threads",
+      "translated": "Threads werden durchsucht"
     },
     {
-      "id": "native.android.dd587d341af44212",
-      "source": "No matching sessions",
-      "translated": "Keine passenden Sitzungen"
+      "id": "native.android.472d46ae8669f860",
+      "source": "No matching threads",
+      "translated": "Keine passenden Threads"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "Chat starten"
     },
     {
-      "id": "native.android.f10d4df7cbc6df4f",
-      "source": "Current session",
-      "translated": "Aktuelle Sitzung"
+      "id": "native.android.ff81ad1bee00d384",
+      "source": "Current thread",
+      "translated": "Aktueller Thread"
     },
     {
-      "id": "native.android.8f0482425838ae64",
-      "source": "OpenClaw session",
-      "translated": "OpenClaw-Sitzung"
+      "id": "native.android.fc145645b9620e57",
+      "source": "OpenClaw thread",
+      "translated": "OpenClaw-Thread"
     },
     {
-      "id": "native.android.786774c8a76e50d7",
-      "source": "Rename session",
-      "translated": "Sitzung umbenennen"
+      "id": "native.android.71cbb8dde8bf138b",
+      "source": "Rename thread",
+      "translated": "Thread umbenennen"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "Gruppe löschen?"
     },
     {
-      "id": "native.android.3455fc2f77d564e3",
-      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "Sitzungen in \"$group\" bleiben erhalten und werden zurück in „Nicht gruppiert“ verschoben."
+      "id": "native.android.691e92cfe5cf106e",
+      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "Threads in \"$group\" bleiben erhalten und werden zurück nach „Nicht gruppiert“ verschoben."
     },
     {
-      "id": "native.android.4805fb9d6623e8c0",
-      "source": "Delete session?",
-      "translated": "Sitzung löschen?"
+      "id": "native.android.d87a8217ab56999b",
+      "source": "Delete thread?",
+      "translated": "Thread löschen?"
     },
     {
-      "id": "native.android.0c3283a2b2445eae",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "Dadurch werden die Sitzung und ihr Transkript dauerhaft gelöscht."
+      "id": "native.android.930de97ff47113a8",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "Dadurch werden der Thread und sein Transkript dauerhaft gelöscht."
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "Nicht gruppiert"
     },
     {
-      "id": "native.android.db243d71d056afa4",
-      "source": "No sessions yet",
-      "translated": "Noch keine Sitzungen"
+      "id": "native.android.8e21a70428def6e0",
+      "source": "No threads yet",
+      "translated": "Noch keine Threads"
     },
     {
-      "id": "native.android.5b4eee6a8092925e",
-      "source": "No current session",
-      "translated": "Keine aktuelle Sitzung"
+      "id": "native.android.cda4c5ad8b17e394",
+      "source": "No current thread",
+      "translated": "Kein aktueller Thread"
     },
     {
-      "id": "native.android.acbcc9c9ea53d8c0",
-      "source": "No archived sessions",
-      "translated": "Keine archivierten Sitzungen"
+      "id": "native.android.be84f061047aa2da",
+      "source": "No archived threads",
+      "translated": "Keine archivierten Threads"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "Starten Sie eine neue Unterhaltung; sie wird dann hier angezeigt."
     },
     {
-      "id": "native.android.56fcd605dc7be3c0",
-      "source": "Open Chat to start or resume the current session.",
-      "translated": "Öffnen Sie den Chat, um die aktuelle Sitzung zu starten oder fortzusetzen."
+      "id": "native.android.f289d03e1d3eee98",
+      "source": "Open Chat to start or resume the current thread.",
+      "translated": "Öffne den Chat, um den aktuellen Thread zu starten oder fortzusetzen."
     },
     {
-      "id": "native.android.085515989f8a2022",
-      "source": "Archived sessions will show up here.",
-      "translated": "Archivierte Sitzungen werden hier angezeigt."
+      "id": "native.android.504b71386e76c6ae",
+      "source": "Archived threads will show up here.",
+      "translated": "Archivierte Threads werden hier angezeigt."
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days} T."
     },
     {
-      "id": "native.android.3d4fa07acbc015c5",
-      "source": "Main session",
-      "translated": "Hauptsitzung"
+      "id": "native.android.ee4c727cdafbe963",
+      "source": "Main thread",
+      "translated": "Haupt-Thread"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway ausstehend"
     },
     {
-      "id": "native.android.2d8d049afe99f751",
-      "source": "Session Activity",
-      "translated": "Sitzungsaktivität"
+      "id": "native.android.da78209effb11cfd",
+      "source": "Thread Activity",
+      "translated": "Thread-Aktivität"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "Exec-Genehmigungsanfragen werden hier angezeigt, während dieses Telefon verbunden ist."
     },
     {
-      "id": "native.android.dc3e7ca5a491103a",
-      "source": "Session activity",
-      "translated": "Sitzungsaktivität"
+      "id": "native.android.f615712dfb56319a",
+      "source": "Thread activity",
+      "translated": "Thread-Aktivität"
     },
     {
-      "id": "native.android.8551e02b060bd7d8",
-      "source": "Chat tool calls waiting in the active session remain visible here.",
-      "translated": "Chat-Tool-Aufrufe, die in der aktiven Sitzung warten, bleiben hier sichtbar."
+      "id": "native.android.6c93973c13db43ae",
+      "source": "Chat tool calls waiting in the active thread remain visible here.",
+      "translated": "Aufrufe von Chat-Tools, die im aktiven Thread warten, bleiben hier sichtbar."
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,6 +4294,11 @@
       "translated": "Einrichtung des Sprachanbieters"
     },
     {
+      "id": "native.android.23b638094c34b916",
+      "source": "Microphone",
+      "translated": "Mikrofon"
+    },
+    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "Audiotest"
@@ -4337,6 +4342,66 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "Fertig"
+    },
+    {
+      "id": "native.android.8d9ecdfdd916b780",
+      "source": "Automatic",
+      "translated": "Automatisch"
+    },
+    {
+      "id": "native.android.c1626a6700a570f6",
+      "source": "Preferred microphone unavailable; using automatic routing.",
+      "translated": "Das bevorzugte Mikrofon ist nicht verfügbar; die automatische Auswahl wird verwendet."
+    },
+    {
+      "id": "native.android.820bc5d0ce571d8b",
+      "source": "Prioritizes connected Bluetooth microphones.",
+      "translated": "Priorisiert verbundene Bluetooth-Mikrofone."
+    },
+    {
+      "id": "native.android.11e48038d5e8bff6",
+      "source": "Preferred microphone",
+      "translated": "Bevorzugtes Mikrofon"
+    },
+    {
+      "id": "native.android.eaa4d7563a46d307",
+      "source": "Unavailable",
+      "translated": "Nicht verfügbar"
+    },
+    {
+      "id": "native.android.9f5ebf17eb405ba8",
+      "source": "Next session",
+      "translated": "Nächste Sitzung"
+    },
+    {
+      "id": "native.android.8c4e91f53928efb2",
+      "source": "Built-in microphone",
+      "translated": "Integriertes Mikrofon"
+    },
+    {
+      "id": "native.android.14b613cb6e2446b4",
+      "source": "Bluetooth microphone",
+      "translated": "Bluetooth-Mikrofon"
+    },
+    {
+      "id": "native.android.c885247b2d7ce271",
+      "source": "Bluetooth LE microphone",
+      "translated": "Bluetooth-LE-Mikrofon"
+    },
+    {
+      "id": "native.android.b6a4e674c5fb441a",
+      "source": "Wired headset microphone",
+      "translated": "Mikrofon des kabelgebundenen Headsets"
+    },
+    {
+      "id": "native.android.9c8becb3b0fb5a90",
+      "source": "USB microphone",
+      "translated": "USB-Mikrofon"
+    },
+    {
+      "id": "native.android.ba46258fadec7a39",
+      "source": "External microphone",
+      "translated": "Externes Mikrofon"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5074,9 +5139,9 @@
       "translated": "Prüfen"
     },
     {
-      "id": "native.android.5a540761383fa474",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
-      "translated": "OpenClaw macht dieses Smartphone zu einer übersichtlichen mobilen Steuerungsoberfläche für Sitzungen, Sprache, Anbieter und Gateway."
+      "id": "native.android.c971506716c96e91",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
+      "translated": "OpenClaw verwandelt dieses Smartphone in eine übersichtliche mobile Bedienoberfläche für Threads, Sprache, Anbieter und Gateway."
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5624,9 +5689,9 @@
       "translated": "Talk-Einstellungen"
     },
     {
-      "id": "native.android.73f07a5d54915259",
-      "source": "Recent Sessions",
-      "translated": "Aktuelle Sitzungen"
+      "id": "native.android.36f78c8c85dc283f",
+      "source": "Recent Threads",
+      "translated": "Letzte Threads"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5684,14 +5749,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)} % online"
     },
     {
-      "id": "native.android.16c3425d3a594481",
-      "source": "Sessions",
-      "translated": "Sitzungen"
+      "id": "native.android.57177017a6a93826",
+      "source": "Threads",
+      "translated": "Threads"
     },
     {
-      "id": "native.android.a5c0f8b3112aa58c",
-      "source": "No recent sessions",
-      "translated": "Keine aktuellen Sitzungen"
+      "id": "native.android.43320b54a68b00a1",
+      "source": "No recent threads",
+      "translated": "Keine aktuellen Threads"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5729,14 +5794,14 @@
       "translated": "In Bearbeitung · $pendingRunCount aktive Läufe"
     },
     {
-      "id": "native.android.2c89da708b12a522",
-      "source": "Monitoring · 1 session",
-      "translated": "Überwachung · 1 Sitzung"
+      "id": "native.android.e24db059480f1e6a",
+      "source": "Monitoring · 1 thread",
+      "translated": "Überwachung · 1 Thread"
     },
     {
-      "id": "native.android.8b6ee382dcb64e1f",
-      "source": "Monitoring · $sessionCount sessions",
-      "translated": "Überwachung · $sessionCount Sitzungen"
+      "id": "native.android.5a475f37d80e02bc",
+      "source": "Monitoring · $sessionCount threads",
+      "translated": "Überwachung · $sessionCount Threads"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5769,9 +5834,9 @@
       "translated": "Anbieter"
     },
     {
-      "id": "native.android.a65477861c7203aa",
-      "source": "Open session",
-      "translated": "Sitzung öffnen"
+      "id": "native.android.358c5e0e838d5423",
+      "source": "Open thread",
+      "translated": "Thread öffnen"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6194,9 +6259,9 @@
       "translated": "${days} T."
     },
     {
-      "id": "native.android.22d755834386db07",
-      "source": "Main session",
-      "translated": "Hauptsitzung"
+      "id": "native.android.28a1a1acc5a0959f",
+      "source": "Main thread",
+      "translated": "Haupt-Thread"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6877,6 +6942,16 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "Stummschaltung aufheben"
+    },
+    {
+      "id": "native.android.cb608d82c5b3352a",
+      "source": "Back camera",
+      "translated": "Rückkamera"
+    },
+    {
+      "id": "native.android.e89a0e780eed2e1e",
+      "source": "Front camera",
+      "translated": "Frontkamera"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7684,9 +7759,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.882cc14a58e7e105",
-      "source": "Loading session",
-      "translated": "Sitzung wird geladen"
+      "id": "native.android.0c74bc30a994dd33",
+      "source": "Loading thread",
+      "translated": "Thread wird geladen"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7729,14 +7804,14 @@
       "translated": "Auf den neuesten Stand bringen"
     },
     {
-      "id": "native.android.1e5add56e48c99f9",
-      "source": "Summarize recent sessions and next steps.",
-      "translated": "Fasse die letzten Sitzungen und nächsten Schritte zusammen."
+      "id": "native.android.cf40df9739f78f27",
+      "source": "Summarize recent threads and next steps.",
+      "translated": "Fasse die letzten Threads und die nächsten Schritte zusammen."
     },
     {
-      "id": "native.android.06d515351bb79576",
-      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
-      "translated": "Bringe mich über meine letzten OpenClaw-Sitzungen auf den neuesten Stand und schlage nächste Schritte vor."
+      "id": "native.android.ebe49a8b8df80bd3",
+      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
+      "translated": "Bring mich bei meinen letzten OpenClaw-Threads auf den neuesten Stand und schlage nächste Schritte vor."
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8074,9 +8149,9 @@
       "translated": "Verbunden"
     },
     {
-      "id": "native.android.81931886b9caf3ab",
-      "source": "Sessions",
-      "translated": "Sitzungen"
+      "id": "native.android.6cf5d6fa8a4186d5",
+      "source": "Threads",
+      "translated": "Threads"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,9 +10869,9 @@
       "translated": "Woran möchten Sie arbeiten?"
     },
     {
-      "id": "native.apple.32179ce0b6d4543f",
-      "source": "The session attaches once the gateway is ready.",
-      "translated": "Die Sitzung wird angehängt, sobald die Gateway bereit ist."
+      "id": "native.apple.4da775013ac9b123",
+      "source": "The thread attaches once the gateway is ready.",
+      "translated": "Der Thread wird angehängt, sobald das Gateway bereit ist."
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10844,9 +10919,9 @@
       "translated": "Optionen für neue Sitzung…"
     },
     {
-      "id": "native.apple.a1b0d289758e2213",
-      "source": "Sessions…",
-      "translated": "Sitzungen…"
+      "id": "native.apple.003b25ddafeb18e9",
+      "source": "Threads…",
+      "translated": "Threads…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11009,14 +11084,14 @@
       "translated": "Erstellen"
     },
     {
-      "id": "native.apple.f488b9caf6e51ac3",
-      "source": "Delete Session?",
-      "translated": "Sitzung löschen?"
+      "id": "native.apple.31d5c7287cfb3abe",
+      "source": "Delete Thread?",
+      "translated": "Thread löschen?"
     },
     {
-      "id": "native.apple.8634b17be9b111bc",
-      "source": "Delete Session",
-      "translated": "Sitzung löschen"
+      "id": "native.apple.d3395564809f1120",
+      "source": "Delete Thread",
+      "translated": "Thread löschen"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11024,9 +11099,9 @@
       "translated": "Abbrechen"
     },
     {
-      "id": "native.apple.4a9568ac9b18d8d3",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "Dadurch werden die Sitzung und ihr Transkript dauerhaft gelöscht."
+      "id": "native.apple.092659256d26cb03",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "Dadurch werden der Thread und sein Transkript dauerhaft gelöscht."
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11054,9 +11129,9 @@
       "translated": "Neue Gruppe"
     },
     {
-      "id": "native.apple.5bccdc23a1640895",
-      "source": "Rename Session",
-      "translated": "Sitzung umbenennen"
+      "id": "native.apple.683032464c497bbd",
+      "source": "Rename Thread",
+      "translated": "Thread umbenennen"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11064,9 +11139,9 @@
       "translated": "Gruppenname"
     },
     {
-      "id": "native.apple.af789b2d2fda0f67",
-      "source": "Session name",
-      "translated": "Sitzungsname"
+      "id": "native.apple.f887aa956588f237",
+      "source": "Thread name",
+      "translated": "Thread-Name"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11104,14 +11179,14 @@
       "translated": "Agents"
     },
     {
-      "id": "native.apple.a3bde8045fe9224a",
-      "source": "Agent session",
-      "translated": "Agent-Sitzung"
+      "id": "native.apple.7c8231b7b1ca480f",
+      "source": "Agent thread",
+      "translated": "Agenten-Thread"
     },
     {
-      "id": "native.apple.27f775de30b37ff8",
-      "source": "Recent sessions",
-      "translated": "Letzte Sitzungen"
+      "id": "native.apple.b3c553614f762a58",
+      "source": "Recent threads",
+      "translated": "Kürzlich verwendete Threads"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11119,9 +11194,9 @@
       "translated": "Gateway offline"
     },
     {
-      "id": "native.apple.28c97cf23665ee01",
-      "source": "No recent sessions",
-      "translated": "Keine letzten Sitzungen"
+      "id": "native.apple.5aa32afda85064ea",
+      "source": "No recent threads",
+      "translated": "Keine kürzlich verwendeten Threads"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11219,14 +11294,14 @@
       "translated": "Abbrechen"
     },
     {
-      "id": "native.apple.9f2fd65953013b7c",
-      "source": "Sessions",
-      "translated": "Sitzungen"
+      "id": "native.apple.b6855cf19a50f477",
+      "source": "Threads",
+      "translated": "Threads"
     },
     {
-      "id": "native.apple.0422818cc95d5071",
-      "source": "Archived sessions",
-      "translated": "Archivierte Sitzungen"
+      "id": "native.apple.9b1d0ef27a1333b0",
+      "source": "Archived threads",
+      "translated": "Archivierte Threads"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11234,34 +11309,34 @@
       "translated": "Archivierte anzeigen"
     },
     {
-      "id": "native.apple.b272115c83f7ef58",
-      "source": "Sessions unavailable",
-      "translated": "Sitzungen nicht verfügbar"
+      "id": "native.apple.98167401c7267735",
+      "source": "Threads unavailable",
+      "translated": "Threads nicht verfügbar"
     },
     {
-      "id": "native.apple.54f8260c9b863087",
-      "source": "Loading archived sessions",
-      "translated": "Archivierte Sitzungen werden geladen"
+      "id": "native.apple.4d28a7def2337b9f",
+      "source": "Loading archived threads",
+      "translated": "Archivierte Threads werden geladen"
     },
     {
-      "id": "native.apple.9b305868873dade2",
-      "source": "Loading recent sessions",
-      "translated": "Letzte Sitzungen werden geladen"
+      "id": "native.apple.777d7b706933bd7b",
+      "source": "Loading recent threads",
+      "translated": "Kürzlich verwendete Threads werden geladen"
     },
     {
-      "id": "native.apple.207dad20d09f3160",
-      "source": "^[\\(count) session](inflect: true)",
-      "translated": "^[\\(count) Sitzung](inflect: true)"
+      "id": "native.apple.22f81ea94bef8410",
+      "source": "^[\\(count) thread](inflect: true)",
+      "translated": "^[\\(count) Thread](inflect: true)"
     },
     {
-      "id": "native.apple.1f4501a6bf2bae4c",
-      "source": "No archived sessions",
-      "translated": "Keine archivierten Sitzungen"
+      "id": "native.apple.1cad51e14db59bf9",
+      "source": "No archived threads",
+      "translated": "Keine archivierten Threads"
     },
     {
-      "id": "native.apple.2a1ba7a5e1979c9e",
-      "source": "Archived sessions will appear here.",
-      "translated": "Archivierte Sitzungen werden hier angezeigt."
+      "id": "native.apple.18ef832d3a7ddcf8",
+      "source": "Archived threads will appear here.",
+      "translated": "Archivierte Threads werden hier angezeigt."
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11344,9 +11419,9 @@
       "translated": "Eingang teilen"
     },
     {
-      "id": "native.apple.2360d25fe6ae9946",
-      "source": "Loading sessions",
-      "translated": "Sitzungen werden geladen"
+      "id": "native.apple.21d9208d86a4d1fe",
+      "source": "Loading threads",
+      "translated": "Threads werden geladen"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11354,19 +11429,19 @@
       "translated": "Letzte Aktivität wird vom Gateway abgerufen."
     },
     {
-      "id": "native.apple.c334f2e86702a7b8",
-      "source": "Sessions unavailable",
-      "translated": "Sitzungen nicht verfügbar"
+      "id": "native.apple.4be1f79aa2b230ff",
+      "source": "Threads unavailable",
+      "translated": "Threads nicht verfügbar"
     },
     {
-      "id": "native.apple.6cc6efb7a03960b6",
-      "source": "No recent sessions",
-      "translated": "Keine aktuellen Sitzungen"
+      "id": "native.apple.98b348873556bc46",
+      "source": "No recent threads",
+      "translated": "Keine kürzlich verwendeten Threads"
     },
     {
-      "id": "native.apple.08483af2d043bee6",
-      "source": "Session activity offline",
-      "translated": "Sitzungsaktivität offline"
+      "id": "native.apple.7396d205574d279f",
+      "source": "Thread activity offline",
+      "translated": "Thread-Aktivität offline"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11824,9 +11899,9 @@
       "translated": "Karte"
     },
     {
-      "id": "native.apple.93eeaedb2ff61043",
-      "source": "Open Session",
-      "translated": "Sitzung öffnen"
+      "id": "native.apple.c9ec1b0e18074d8a",
+      "source": "Open Thread",
+      "translated": "Thread öffnen"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13314,9 +13389,9 @@
       "translated": "Standard"
     },
     {
-      "id": "native.apple.3de045f17ea3c6d0",
-      "source": "Used for new Chat and Talk sessions.",
-      "translated": "Wird für neue Chat- und Talk-Sitzungen verwendet."
+      "id": "native.apple.f4ae5664c3eda95d",
+      "source": "Used for new Chat threads and Talk sessions.",
+      "translated": "Wird für neue Chat-Threads und Sprachsitzungen verwendet."
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15719,9 +15794,9 @@
       "translated": "Instanzen"
     },
     {
-      "id": "native.apple.3579cf2750470a22",
-      "source": "Sessions",
-      "translated": "Sitzungen"
+      "id": "native.apple.11fe8b9941954dfb",
+      "source": "Threads",
+      "translated": "Threads"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19029,9 +19104,9 @@
       "translated": "Tastenkürzel für Quick Chat"
     },
     {
-      "id": "native.apple.6ae77665b5f4490f",
-      "source": "Global shortcut that opens a floating chat bar for the main session.",
-      "translated": "Globales Tastenkürzel, das eine schwebende Chatleiste für die Hauptsitzung öffnet."
+      "id": "native.apple.94dd793cd7d7d555",
+      "source": "Global shortcut that opens a floating chat bar for the main thread.",
+      "translated": "Globales Tastenkürzel, das eine schwebende Chatleiste für den Haupt-Thread öffnet."
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19609,9 +19684,9 @@
       "translated": "Kritisch"
     },
     {
-      "id": "native.apple.75102378a6775180",
-      "source": "New Session",
-      "translated": "Neue Sitzung"
+      "id": "native.apple.13f96467014cf344",
+      "source": "New Thread",
+      "translated": "Neuer Thread"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21899,9 +21974,9 @@
       "translated": "Keine aktuellen Nachrichten"
     },
     {
-      "id": "native.apple.1ff8aec0044934c3",
-      "source": "Sessions",
-      "translated": "Sitzungen"
+      "id": "native.apple.3ec2afcbc298c673",
+      "source": "Threads",
+      "translated": "Threads"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21909,9 +21984,9 @@
       "translated": "Einblick in die gespeicherten Konversations-Buckets, die die CLI für Kontext und Ratenbegrenzungen wiederverwendet."
     },
     {
-      "id": "native.apple.bab897f3252b134c",
-      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
-      "translated": "Noch keine Sitzungen. Sie erscheinen nach der ersten eingehenden Nachricht oder dem ersten Heartbeat."
+      "id": "native.apple.14ccb32cd8ed1c81",
+      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
+      "translated": "Noch keine Threads. Sie werden nach der ersten eingehenden Nachricht oder dem ersten Heartbeat angezeigt."
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -21994,9 +22069,9 @@
       "translated": "Ausführungsgenehmigungen"
     },
     {
-      "id": "native.apple.64a6dc7d49e8fb57",
-      "source": "Sessions",
-      "translated": "Sitzungen"
+      "id": "native.apple.52e37e3a44ae516c",
+      "source": "Threads",
+      "translated": "Threads"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -22999,9 +23074,9 @@
       "translated": "Bring mich auf den neuesten Stand"
     },
     {
-      "id": "native.apple.234ec45f4231edc4",
-      "source": "Summarize what happened in my sessions since yesterday.",
-      "translated": "Fasse zusammen, was seit gestern in meinen Sitzungen passiert ist."
+      "id": "native.apple.fc4ce810900ec0b6",
+      "source": "Summarize what happened in my threads since yesterday.",
+      "translated": "Fasse zusammen, was seit gestern in meinen Threads passiert ist."
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23179,9 +23254,9 @@
       "translated": "Modell lösen"
     },
     {
-      "id": "native.apple.5dfc0700d8dff8de",
-      "source": "Session",
-      "translated": "Sitzung"
+      "id": "native.apple.4edb66657f5aca1f",
+      "source": "Thread",
+      "translated": "Thread"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23344,6 +23419,51 @@
       "translated": "Widget nicht verfügbar"
     },
     {
+      "id": "native.apple.d640691fd196f338",
+      "source": "Widget export failed",
+      "translated": "Widget-Export fehlgeschlagen"
+    },
+    {
+      "id": "native.apple.533c6e22a11e88de",
+      "source": "OK",
+      "translated": "OK"
+    },
+    {
+      "id": "native.apple.e1fb28a2a9756402",
+      "source": "Copy image",
+      "translated": "Bild kopieren"
+    },
+    {
+      "id": "native.apple.ebd7bc92e1b12235",
+      "source": "Save image…",
+      "translated": "Bild speichern…"
+    },
+    {
+      "id": "native.apple.742c46d4cf2db134",
+      "source": "Save image",
+      "translated": "Bild speichern"
+    },
+    {
+      "id": "native.apple.0589cce608418f90",
+      "source": "The widget image could not be captured.",
+      "translated": "Das Widget-Bild konnte nicht erfasst werden."
+    },
+    {
+      "id": "native.apple.dfe24e827fdbe9c5",
+      "source": "The widget image could not be copied.",
+      "translated": "Das Widget-Bild konnte nicht kopiert werden."
+    },
+    {
+      "id": "native.apple.9e611e3a80e71408",
+      "source": "The widget image could not be encoded as PNG.",
+      "translated": "Das Widget-Bild konnte nicht als PNG codiert werden."
+    },
+    {
+      "id": "native.apple.9a6e8afbe24a262b",
+      "source": "The widget image could not be saved.",
+      "translated": "Das Widget-Bild konnte nicht gespeichert werden."
+    },
+    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23484,19 +23604,19 @@
       "translated": "Benutzer"
     },
     {
-      "id": "native.apple.b1cdcb906a43d5d6",
-      "source": "This session cannot be archived while it is active or running.",
-      "translated": "Diese Sitzung kann nicht archiviert werden, solange sie aktiv ist oder ausgeführt wird."
+      "id": "native.apple.9d0cba09d92ee669",
+      "source": "This thread cannot be archived while it is active or running.",
+      "translated": "Dieser Thread kann nicht archiviert werden, solange er aktiv ist oder ausgeführt wird."
     },
     {
-      "id": "native.apple.5817e3f3dab1ee19",
-      "source": "The main session cannot be deleted.",
-      "translated": "Die Hauptsitzung kann nicht gelöscht werden."
+      "id": "native.apple.8952a111a1075051",
+      "source": "The main thread cannot be deleted.",
+      "translated": "Der Haupt-Thread kann nicht gelöscht werden."
     },
     {
-      "id": "native.apple.a6b8df3f18171c91",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
-      "translated": "Entfernen Sie Anhänge oder warten Sie auf deren Zustellung, bevor Sie diese Sitzung archivieren oder löschen."
+      "id": "native.apple.90d0ccf80ca28717",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
+      "translated": "Entfernen Sie Anhänge oder warten Sie auf die Zustellung, bevor Sie diesen Thread archivieren oder löschen."
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23634,9 +23754,9 @@
       "translated": "Ausführung beendet"
     },
     {
-      "id": "native.apple.cd7c3095a22f80a9",
-      "source": "Session Info",
-      "translated": "Sitzungsinformationen"
+      "id": "native.apple.bbccb4c8db5cac12",
+      "source": "Thread Info",
+      "translated": "Thread-Informationen"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23669,9 +23789,9 @@
       "translated": "Gruppe hinzufügen"
     },
     {
-      "id": "native.apple.23d628606fe0734f",
-      "source": "Session Groups",
-      "translated": "Sitzungsgruppen"
+      "id": "native.apple.7b641fed5bace855",
+      "source": "Thread Groups",
+      "translated": "Thread-Gruppen"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23714,9 +23834,9 @@
       "translated": "Gruppe löschen"
     },
     {
-      "id": "native.apple.b049c8a4d2805e08",
-      "source": "Sessions in this group become ungrouped.",
-      "translated": "Sitzungen in dieser Gruppe werden aus der Gruppe entfernt."
+      "id": "native.apple.56401c79410a310d",
+      "source": "Threads in this group become ungrouped.",
+      "translated": "Die Threads in dieser Gruppe werden aus der Gruppe entfernt."
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23729,9 +23849,9 @@
       "translated": "Auf diesem Gateway sind keine Agenten verfügbar."
     },
     {
-      "id": "native.apple.6c89f35d53506406",
-      "source": "New Session Options",
-      "translated": "Optionen für neue Sitzungen"
+      "id": "native.apple.2d96aa7d3d12f85b",
+      "source": "New Thread Options",
+      "translated": "Optionen für neuen Thread"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23759,19 +23879,19 @@
       "translated": "Erstellen"
     },
     {
-      "id": "native.apple.795ba37f6782cf28",
-      "source": "The session could not be created.",
-      "translated": "Die Sitzung konnte nicht erstellt werden."
+      "id": "native.apple.87ef57319d1ddc85",
+      "source": "The thread could not be created.",
+      "translated": "Der Thread konnte nicht erstellt werden."
     },
     {
-      "id": "native.apple.8ec708a3605a2cc3",
-      "source": "Search sessions",
-      "translated": "Sitzungen durchsuchen"
+      "id": "native.apple.6bd91c435b69d638",
+      "source": "Search threads",
+      "translated": "Threads durchsuchen"
     },
     {
-      "id": "native.apple.23b069b4e7f97039",
-      "source": "No Sessions",
-      "translated": "Keine Sitzungen"
+      "id": "native.apple.6fde4bdf9d5b9191",
+      "source": "No Threads",
+      "translated": "Keine Threads"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23779,29 +23899,29 @@
       "translated": "Keine Ergebnisse"
     },
     {
-      "id": "native.apple.0058923f2ce8a3ec",
-      "source": "New Session",
-      "translated": "Neue Sitzung"
+      "id": "native.apple.a02fd99740d29bd3",
+      "source": "New Thread",
+      "translated": "Neuer Thread"
     },
     {
-      "id": "native.apple.66ba42960eb4135b",
-      "source": "New session",
-      "translated": "Neue Sitzung"
+      "id": "native.apple.b625801dd04b09f2",
+      "source": "New thread",
+      "translated": "Neuer Thread"
     },
     {
-      "id": "native.apple.2ef0e34db02ad255",
-      "source": "New session options",
-      "translated": "Optionen für neue Sitzungen"
+      "id": "native.apple.851be81fcc933608",
+      "source": "New thread options",
+      "translated": "Optionen für neuen Thread"
     },
     {
-      "id": "native.apple.36753ef2f1ed4264",
-      "source": "Rename Session",
-      "translated": "Sitzung umbenennen"
+      "id": "native.apple.9ce8a4aba7b444b2",
+      "source": "Rename Thread",
+      "translated": "Thread umbenennen"
     },
     {
-      "id": "native.apple.c9de0a1510ef475f",
-      "source": "Session name",
-      "translated": "Sitzungsname"
+      "id": "native.apple.1dd067c44511c7f0",
+      "source": "Thread name",
+      "translated": "Thread-Name"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23814,14 +23934,14 @@
       "translated": "Abbrechen"
     },
     {
-      "id": "native.apple.afb4e6c99c63a28d",
-      "source": "Delete Session",
-      "translated": "Sitzung löschen"
+      "id": "native.apple.618073d6ab3f2721",
+      "source": "Delete Thread",
+      "translated": "Thread löschen"
     },
     {
-      "id": "native.apple.3d4ef32e42f136a4",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "Die Sitzung und ihr Transkript werden vom Gateway entfernt."
+      "id": "native.apple.10a5e72bba3cbccc",
+      "source": "The thread and its transcript are removed from the gateway.",
+      "translated": "Der Thread und sein Transkript werden aus dem Gateway entfernt."
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23829,14 +23949,14 @@
       "translated": "„%@“ löschen?"
     },
     {
-      "id": "native.apple.9a7dca238fba628d",
-      "source": "Session running",
-      "translated": "Sitzung wird ausgeführt"
+      "id": "native.apple.ac71e3b2aa496a2c",
+      "source": "Thread running",
+      "translated": "Thread wird ausgeführt"
     },
     {
-      "id": "native.apple.fcfbfe5e97a95e9c",
-      "source": "Session failed",
-      "translated": "Sitzung fehlgeschlagen"
+      "id": "native.apple.c775e87f997278b2",
+      "source": "Thread failed",
+      "translated": "Thread fehlgeschlagen"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23894,9 +24014,9 @@
       "translated": "Sitzungsschlüssel kopieren"
     },
     {
-      "id": "native.apple.4aeb7c14c26dabac",
-      "source": "Delete Session…",
-      "translated": "Sitzung löschen…"
+      "id": "native.apple.f4998cfb572f23ff",
+      "source": "Delete Thread…",
+      "translated": "Thread löschen…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23909,9 +24029,9 @@
       "translated": "Verbindung wird hergestellt…"
     },
     {
-      "id": "native.apple.79f708b3bc1d3a6c",
-      "source": "Retry session groups",
-      "translated": "Sitzungsgruppen erneut laden"
+      "id": "native.apple.8802e9576ffd0f65",
+      "source": "Retry thread groups",
+      "translated": "Thread-Gruppen erneut laden"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23934,24 +24054,24 @@
       "translated": "Umfang"
     },
     {
-      "id": "native.apple.2c37581c7b88f741",
-      "source": "Search sessions",
-      "translated": "Sitzungen suchen"
+      "id": "native.apple.b313b80def4bda52",
+      "source": "Search threads",
+      "translated": "Threads durchsuchen"
     },
     {
-      "id": "native.apple.43be8a2336e42faf",
-      "source": "Sessions",
-      "translated": "Sitzungen"
+      "id": "native.apple.c0cc6acc36f413ce",
+      "source": "Threads",
+      "translated": "Threads"
     },
     {
-      "id": "native.apple.0b379cdfcbd3247f",
-      "source": "Rename Session",
-      "translated": "Sitzung umbenennen"
+      "id": "native.apple.854d3928fe5a557c",
+      "source": "Rename Thread",
+      "translated": "Thread umbenennen"
     },
     {
-      "id": "native.apple.54b6fbd9e41db009",
-      "source": "Session name",
-      "translated": "Sitzungsname"
+      "id": "native.apple.9d0d3f20096cc4da",
+      "source": "Thread name",
+      "translated": "Thread-Name"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -23959,19 +24079,19 @@
       "translated": "Abbrechen"
     },
     {
-      "id": "native.apple.751e0f6b81cd374a",
-      "source": "Delete selected sessions?",
-      "translated": "Ausgewählte Sitzungen löschen?"
+      "id": "native.apple.dc00eb94f33bae15",
+      "source": "Delete selected threads?",
+      "translated": "Ausgewählte Threads löschen?"
     },
     {
-      "id": "native.apple.aa679276581b0058",
-      "source": "Delete Sessions",
-      "translated": "Sitzungen löschen"
+      "id": "native.apple.2053fc9f74dc3158",
+      "source": "Delete Threads",
+      "translated": "Threads löschen"
     },
     {
-      "id": "native.apple.f837129cbee23297",
-      "source": "Each selected session and its transcript will be removed from the gateway.",
-      "translated": "Alle ausgewählten Sitzungen und ihre Transkripte werden aus dem Gateway entfernt."
+      "id": "native.apple.0970247871a834a0",
+      "source": "Each selected thread and its transcript will be removed from the gateway.",
+      "translated": "Jeder ausgewählte Thread und sein Transkript werden aus dem Gateway entfernt."
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -23979,9 +24099,9 @@
       "translated": "Gruppen"
     },
     {
-      "id": "native.apple.64013cfee5e25305",
-      "source": "Manage session groups",
-      "translated": "Sitzungsgruppen verwalten"
+      "id": "native.apple.6f8acab2256728b5",
+      "source": "Manage thread groups",
+      "translated": "Thread-Gruppen verwalten"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -23994,14 +24114,14 @@
       "translated": "Auswählen"
     },
     {
-      "id": "native.apple.b67eaecec1b423ac",
-      "source": "No archived sessions",
-      "translated": "Keine archivierten Sitzungen"
+      "id": "native.apple.692972314d04b184",
+      "source": "No archived threads",
+      "translated": "Keine archivierten Threads"
     },
     {
-      "id": "native.apple.b2435a79abf0c794",
-      "source": "No sessions found",
-      "translated": "Keine Sitzungen gefunden"
+      "id": "native.apple.d6a4b5711dcd26e7",
+      "source": "No threads found",
+      "translated": "Keine Threads gefunden"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24169,6 +24289,16 @@
       "translated": "Vollständige Nachricht öffnen"
     },
     {
+      "id": "native.apple.002bfcede229ad4b",
+      "source": "Rewind to Here",
+      "translated": "Bis hierher zurücksetzen"
+    },
+    {
+      "id": "native.apple.14df2e4997689fb3",
+      "source": "Fork from Here",
+      "translated": "Ab hier verzweigen"
+    },
+    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "Antwort"
@@ -24254,9 +24384,9 @@
       "translated": "Entferne Anhänge oder warte, bis die Zustellung abgeschlossen ist, bevor du einen neuen Chat startest."
     },
     {
-      "id": "native.apple.980f552bb0f96c0f",
-      "source": "Gateway changed before the session operation started.",
-      "translated": "Das Gateway wurde geändert, bevor der Sitzungsvorgang gestartet wurde."
+      "id": "native.apple.e0f045151c8d3137",
+      "source": "Gateway changed before the thread operation started.",
+      "translated": "Das Gateway wurde geändert, bevor der Thread-Vorgang gestartet wurde."
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24264,9 +24394,9 @@
       "translated": "Entfernen Sie Anhänge oder warten Sie auf die Zustellung, bevor Sie den Chat wechseln."
     },
     {
-      "id": "native.apple.87ba543b42696b92",
-      "source": "Clear this session's history?",
-      "translated": "Verlauf dieser Sitzung löschen?"
+      "id": "native.apple.0a5c4e15466c3acc",
+      "source": "Clear this thread's history?",
+      "translated": "Verlauf dieses Threads löschen?"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24279,14 +24409,14 @@
       "translated": "Dadurch wird die Unterhaltung für %@ zurückgesetzt. Der Sitzungsschlüssel bleibt unverändert."
     },
     {
-      "id": "native.apple.a92e96bed98bd553",
-      "source": "Rename Session",
-      "translated": "Sitzung umbenennen"
+      "id": "native.apple.67ac221dbe7179f0",
+      "source": "Rename Thread",
+      "translated": "Thread umbenennen"
     },
     {
-      "id": "native.apple.848e2388f3466f40",
-      "source": "Session name",
-      "translated": "Sitzungsname"
+      "id": "native.apple.cf0f7e049603f518",
+      "source": "Thread name",
+      "translated": "Thread-Name"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24304,9 +24434,9 @@
       "translated": "Transkript exportieren"
     },
     {
-      "id": "native.apple.4af0f566d39d7041",
-      "source": "Sessions",
-      "translated": "Sitzungen"
+      "id": "native.apple.c0ada47504425f23",
+      "source": "Threads",
+      "translated": "Threads"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24379,14 +24509,14 @@
       "translated": "Standard"
     },
     {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "Neue Sitzung"
+      "id": "native.apple.1a765291943599e5",
+      "source": "New Thread",
+      "translated": "Neuer Thread"
     },
     {
-      "id": "native.apple.a7119fbf9d25df5e",
-      "source": "New Session Options…",
-      "translated": "Optionen für neue Sitzung…"
+      "id": "native.apple.c7a3a6d5e43dd98f",
+      "source": "New Thread Options…",
+      "translated": "Optionen für neuen Thread…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24394,19 +24524,19 @@
       "translated": "Aktualisieren"
     },
     {
-      "id": "native.apple.2bcff4a8fa503739",
-      "source": "Sessions…",
-      "translated": "Sitzungen…"
+      "id": "native.apple.0e710b81808e5dcf",
+      "source": "Threads…",
+      "translated": "Threads…"
     },
     {
-      "id": "native.apple.c36e008b051adb38",
-      "source": "Rename Session…",
-      "translated": "Sitzung umbenennen…"
+      "id": "native.apple.faad8f92b6bef166",
+      "source": "Rename Thread…",
+      "translated": "Thread umbenennen…"
     },
     {
-      "id": "native.apple.ea0ef95a159bffe0",
-      "source": "Fork Session",
-      "translated": "Sitzung abzweigen"
+      "id": "native.apple.23b61d6cd26ac112",
+      "source": "Fork",
+      "translated": "Abzweigen"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24464,24 +24594,24 @@
       "translated": "Verlauf löschen…"
     },
     {
-      "id": "native.apple.920fe8a7a33f9e92",
-      "source": "Session",
-      "translated": "Sitzung"
+      "id": "native.apple.8b4f1c5107ea8a0e",
+      "source": "Thread",
+      "translated": "Thread"
     },
     {
-      "id": "native.apple.185a401f78328b0f",
-      "source": "Session actions",
-      "translated": "Sitzungsaktionen"
+      "id": "native.apple.4d7750c9bf699469",
+      "source": "Thread actions",
+      "translated": "Thread-Aktionen"
     },
     {
-      "id": "native.apple.9f9dedf599b2619b",
-      "source": "Session cost %@",
-      "translated": "Sitzungskosten: %@"
+      "id": "native.apple.bb2f22cc43c97f8e",
+      "source": "Thread cost %@",
+      "translated": "Thread-Kosten %@"
     },
     {
-      "id": "native.apple.f0a4720df5f5f403",
-      "source": "Compact Session",
-      "translated": "Sitzung komprimieren"
+      "id": "native.apple.6239ced0b86e86f8",
+      "source": "Compact Thread",
+      "translated": "Thread komprimieren"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/de.json
+++ b/apps/.i18n/native/de.json
@@ -1429,9 +1429,9 @@
       "translated": "Mit OpenClaw sprechen oder diktieren"
     },
     {
-      "id": "native.android.e2cf5a38587382cb",
-      "source": "Browse Threads",
-      "translated": "Threads durchsuchen"
+      "id": "native.android.5876e15e5e92fd45",
+      "source": "Browse Sessions",
+      "translated": "Sitzungen durchsuchen"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "Keine Aktionen gefunden"
     },
     {
-      "id": "native.android.bc70a4ac965b82ba",
-      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
-      "translated": "Probiere Chat, Sprache, Threads, Anbieter oder Einstellungen aus."
+      "id": "native.android.48ad0ae0e930e02b",
+      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
+      "translated": "Probieren Sie Chat, Voice, Sessions, Providers oder Settings aus."
     },
     {
-      "id": "native.android.670121e54dbe286f",
-      "source": "Threads",
-      "translated": "Threads"
+      "id": "native.android.d4fbd1ee4f55a5db",
+      "source": "Sessions",
+      "translated": "Sitzungen"
     },
     {
-      "id": "native.android.d38be650b1bce4a0",
-      "source": "Connect the Gateway to search threads.",
-      "translated": "Verbinde das Gateway, um Threads zu durchsuchen."
+      "id": "native.android.207c2170504e99e6",
+      "source": "Connect the Gateway to search sessions.",
+      "translated": "Verbinde die Gateway, um Sitzungen zu suchen."
     },
     {
-      "id": "native.android.3d7754721f776ef8",
-      "source": "No matching threads yet.",
-      "translated": "Noch keine passenden Threads."
+      "id": "native.android.25d2c2d792c952fe",
+      "source": "No matching sessions yet.",
+      "translated": "Noch keine passenden Sitzungen."
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "Assistent arbeitet"
     },
     {
-      "id": "native.android.9a839f6e3e05a744",
-      "source": "OpenClaw thread",
-      "translated": "OpenClaw-Thread"
+      "id": "native.android.8f8384286317f5c9",
+      "source": "OpenClaw session",
+      "translated": "OpenClaw-Sitzung"
     },
     {
-      "id": "native.android.d83f82a1e4a5ed99",
-      "source": "Open thread",
-      "translated": "Thread öffnen"
+      "id": "native.android.15799e57704b20c6",
+      "source": "Open session",
+      "translated": "Sitzung öffnen"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "Keine Anbieter bereit"
     },
     {
-      "id": "native.android.8a1c5365c0538908",
-      "source": "Main thread",
-      "translated": "Haupt-Thread"
+      "id": "native.android.73e6ab1a168fd381",
+      "source": "Main session",
+      "translated": "Hauptsitzung"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.a5845742daecb4ba",
-      "source": "Threads",
-      "translated": "Threads"
+      "id": "native.android.0e3157c15c56944f",
+      "source": "Sessions",
+      "translated": "Sitzungen"
     },
     {
-      "id": "native.android.439b324280869527",
-      "source": "Focus thread search",
-      "translated": "Thread-Suche fokussieren"
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "Sitzungssuche fokussieren"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "Archiviert"
     },
     {
-      "id": "native.android.03981341841b04ac",
-      "source": "Search threads",
-      "translated": "Threads durchsuchen"
+      "id": "native.android.b9cf34c137e4cf03",
+      "source": "Search sessions",
+      "translated": "Sitzungen suchen"
     },
     {
-      "id": "native.android.99570c528a41fa72",
-      "source": "Clear thread search",
-      "translated": "Thread-Suche löschen"
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "Sitzungssuche löschen"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "Älteste zuerst"
     },
     {
-      "id": "native.android.fd67be543e321cc9",
-      "source": "Toggle thread layout",
-      "translated": "Thread-Layout umschalten"
+      "id": "native.android.c6bf8751e2a7f5c7",
+      "source": "Toggle session layout",
+      "translated": "Sitzungslayout umschalten"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "Layout: Detailliert"
     },
     {
-      "id": "native.android.ebd17565e0ffd8eb",
-      "source": "Searching threads",
-      "translated": "Threads werden durchsucht"
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "Sitzungen werden durchsucht"
     },
     {
-      "id": "native.android.472d46ae8669f860",
-      "source": "No matching threads",
-      "translated": "Keine passenden Threads"
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "Keine passenden Sitzungen"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "Chat starten"
     },
     {
-      "id": "native.android.ff81ad1bee00d384",
-      "source": "Current thread",
-      "translated": "Aktueller Thread"
+      "id": "native.android.f10d4df7cbc6df4f",
+      "source": "Current session",
+      "translated": "Aktuelle Sitzung"
     },
     {
-      "id": "native.android.fc145645b9620e57",
-      "source": "OpenClaw thread",
-      "translated": "OpenClaw-Thread"
+      "id": "native.android.8f0482425838ae64",
+      "source": "OpenClaw session",
+      "translated": "OpenClaw-Sitzung"
     },
     {
-      "id": "native.android.71cbb8dde8bf138b",
-      "source": "Rename thread",
-      "translated": "Thread umbenennen"
+      "id": "native.android.786774c8a76e50d7",
+      "source": "Rename session",
+      "translated": "Sitzung umbenennen"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "Gruppe löschen?"
     },
     {
-      "id": "native.android.691e92cfe5cf106e",
-      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "Threads in \"$group\" bleiben erhalten und werden zurück nach „Nicht gruppiert“ verschoben."
+      "id": "native.android.3455fc2f77d564e3",
+      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "Sitzungen in \"$group\" bleiben erhalten und werden zurück in „Nicht gruppiert“ verschoben."
     },
     {
-      "id": "native.android.d87a8217ab56999b",
-      "source": "Delete thread?",
-      "translated": "Thread löschen?"
+      "id": "native.android.4805fb9d6623e8c0",
+      "source": "Delete session?",
+      "translated": "Sitzung löschen?"
     },
     {
-      "id": "native.android.930de97ff47113a8",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "Dadurch werden der Thread und sein Transkript dauerhaft gelöscht."
+      "id": "native.android.0c3283a2b2445eae",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "Dadurch werden die Sitzung und ihr Transkript dauerhaft gelöscht."
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "Nicht gruppiert"
     },
     {
-      "id": "native.android.8e21a70428def6e0",
-      "source": "No threads yet",
-      "translated": "Noch keine Threads"
+      "id": "native.android.db243d71d056afa4",
+      "source": "No sessions yet",
+      "translated": "Noch keine Sitzungen"
     },
     {
-      "id": "native.android.cda4c5ad8b17e394",
-      "source": "No current thread",
-      "translated": "Kein aktueller Thread"
+      "id": "native.android.5b4eee6a8092925e",
+      "source": "No current session",
+      "translated": "Keine aktuelle Sitzung"
     },
     {
-      "id": "native.android.be84f061047aa2da",
-      "source": "No archived threads",
-      "translated": "Keine archivierten Threads"
+      "id": "native.android.acbcc9c9ea53d8c0",
+      "source": "No archived sessions",
+      "translated": "Keine archivierten Sitzungen"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "Starten Sie eine neue Unterhaltung; sie wird dann hier angezeigt."
     },
     {
-      "id": "native.android.f289d03e1d3eee98",
-      "source": "Open Chat to start or resume the current thread.",
-      "translated": "Öffne den Chat, um den aktuellen Thread zu starten oder fortzusetzen."
+      "id": "native.android.56fcd605dc7be3c0",
+      "source": "Open Chat to start or resume the current session.",
+      "translated": "Öffnen Sie den Chat, um die aktuelle Sitzung zu starten oder fortzusetzen."
     },
     {
-      "id": "native.android.504b71386e76c6ae",
-      "source": "Archived threads will show up here.",
-      "translated": "Archivierte Threads werden hier angezeigt."
+      "id": "native.android.085515989f8a2022",
+      "source": "Archived sessions will show up here.",
+      "translated": "Archivierte Sitzungen werden hier angezeigt."
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days} T."
     },
     {
-      "id": "native.android.ee4c727cdafbe963",
-      "source": "Main thread",
-      "translated": "Haupt-Thread"
+      "id": "native.android.3d4fa07acbc015c5",
+      "source": "Main session",
+      "translated": "Hauptsitzung"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway ausstehend"
     },
     {
-      "id": "native.android.da78209effb11cfd",
-      "source": "Thread Activity",
-      "translated": "Thread-Aktivität"
+      "id": "native.android.2d8d049afe99f751",
+      "source": "Session Activity",
+      "translated": "Sitzungsaktivität"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "Exec-Genehmigungsanfragen werden hier angezeigt, während dieses Telefon verbunden ist."
     },
     {
-      "id": "native.android.f615712dfb56319a",
-      "source": "Thread activity",
-      "translated": "Thread-Aktivität"
+      "id": "native.android.dc3e7ca5a491103a",
+      "source": "Session activity",
+      "translated": "Sitzungsaktivität"
     },
     {
-      "id": "native.android.6c93973c13db43ae",
-      "source": "Chat tool calls waiting in the active thread remain visible here.",
-      "translated": "Aufrufe von Chat-Tools, die im aktiven Thread ausstehen, bleiben hier sichtbar."
+      "id": "native.android.8551e02b060bd7d8",
+      "source": "Chat tool calls waiting in the active session remain visible here.",
+      "translated": "Chat-Tool-Aufrufe, die in der aktiven Sitzung warten, bleiben hier sichtbar."
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,11 +4294,6 @@
       "translated": "Einrichtung des Sprachanbieters"
     },
     {
-      "id": "native.android.23b638094c34b916",
-      "source": "Microphone",
-      "translated": "Mikrofon"
-    },
-    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "Audiotest"
@@ -4342,66 +4337,6 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "Fertig"
-    },
-    {
-      "id": "native.android.8d9ecdfdd916b780",
-      "source": "Automatic",
-      "translated": "Automatisch"
-    },
-    {
-      "id": "native.android.c1626a6700a570f6",
-      "source": "Preferred microphone unavailable; using automatic routing.",
-      "translated": "Bevorzugtes Mikrofon nicht verfügbar; automatische Audioausgabe wird verwendet."
-    },
-    {
-      "id": "native.android.820bc5d0ce571d8b",
-      "source": "Prioritizes connected Bluetooth microphones.",
-      "translated": "Priorisiert verbundene Bluetooth-Mikrofone."
-    },
-    {
-      "id": "native.android.11e48038d5e8bff6",
-      "source": "Preferred microphone",
-      "translated": "Bevorzugtes Mikrofon"
-    },
-    {
-      "id": "native.android.eaa4d7563a46d307",
-      "source": "Unavailable",
-      "translated": "Nicht verfügbar"
-    },
-    {
-      "id": "native.android.9f5ebf17eb405ba8",
-      "source": "Next session",
-      "translated": "Nächste Sitzung"
-    },
-    {
-      "id": "native.android.8c4e91f53928efb2",
-      "source": "Built-in microphone",
-      "translated": "Integriertes Mikrofon"
-    },
-    {
-      "id": "native.android.14b613cb6e2446b4",
-      "source": "Bluetooth microphone",
-      "translated": "Bluetooth-Mikrofon"
-    },
-    {
-      "id": "native.android.c885247b2d7ce271",
-      "source": "Bluetooth LE microphone",
-      "translated": "Bluetooth-LE-Mikrofon"
-    },
-    {
-      "id": "native.android.b6a4e674c5fb441a",
-      "source": "Wired headset microphone",
-      "translated": "Mikrofon des kabelgebundenen Headsets"
-    },
-    {
-      "id": "native.android.9c8becb3b0fb5a90",
-      "source": "USB microphone",
-      "translated": "USB-Mikrofon"
-    },
-    {
-      "id": "native.android.ba46258fadec7a39",
-      "source": "External microphone",
-      "translated": "Externes Mikrofon"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5139,9 +5074,9 @@
       "translated": "Prüfen"
     },
     {
-      "id": "native.android.c971506716c96e91",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
-      "translated": "OpenClaw macht dieses Smartphone zu einer übersichtlichen mobilen Steuerungsoberfläche für Threads, Sprache, Anbieter und Gateway."
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw macht dieses Smartphone zu einer übersichtlichen mobilen Steuerungsoberfläche für Sitzungen, Sprache, Anbieter und Gateway."
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5689,9 +5624,9 @@
       "translated": "Talk-Einstellungen"
     },
     {
-      "id": "native.android.36f78c8c85dc283f",
-      "source": "Recent Threads",
-      "translated": "Kürzlich verwendete Threads"
+      "id": "native.android.73f07a5d54915259",
+      "source": "Recent Sessions",
+      "translated": "Aktuelle Sitzungen"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5749,14 +5684,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)} % online"
     },
     {
-      "id": "native.android.57177017a6a93826",
-      "source": "Threads",
-      "translated": "Threads"
+      "id": "native.android.16c3425d3a594481",
+      "source": "Sessions",
+      "translated": "Sitzungen"
     },
     {
-      "id": "native.android.43320b54a68b00a1",
-      "source": "No recent threads",
-      "translated": "Keine kürzlich verwendeten Threads"
+      "id": "native.android.a5c0f8b3112aa58c",
+      "source": "No recent sessions",
+      "translated": "Keine aktuellen Sitzungen"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5794,14 +5729,14 @@
       "translated": "In Bearbeitung · $pendingRunCount aktive Läufe"
     },
     {
-      "id": "native.android.e24db059480f1e6a",
-      "source": "Monitoring · 1 thread",
-      "translated": "Überwachung · 1 Thread"
+      "id": "native.android.2c89da708b12a522",
+      "source": "Monitoring · 1 session",
+      "translated": "Überwachung · 1 Sitzung"
     },
     {
-      "id": "native.android.5a475f37d80e02bc",
-      "source": "Monitoring · $sessionCount threads",
-      "translated": "Überwachung · $sessionCount Threads"
+      "id": "native.android.8b6ee382dcb64e1f",
+      "source": "Monitoring · $sessionCount sessions",
+      "translated": "Überwachung · $sessionCount Sitzungen"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5834,9 +5769,9 @@
       "translated": "Anbieter"
     },
     {
-      "id": "native.android.358c5e0e838d5423",
-      "source": "Open thread",
-      "translated": "Thread öffnen"
+      "id": "native.android.a65477861c7203aa",
+      "source": "Open session",
+      "translated": "Sitzung öffnen"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6259,9 +6194,9 @@
       "translated": "${days} T."
     },
     {
-      "id": "native.android.28a1a1acc5a0959f",
-      "source": "Main thread",
-      "translated": "Haupt-Thread"
+      "id": "native.android.22d755834386db07",
+      "source": "Main session",
+      "translated": "Hauptsitzung"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6942,16 +6877,6 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "Stummschaltung aufheben"
-    },
-    {
-      "id": "native.android.cb608d82c5b3352a",
-      "source": "Back camera",
-      "translated": "Rückkamera"
-    },
-    {
-      "id": "native.android.e89a0e780eed2e1e",
-      "source": "Front camera",
-      "translated": "Frontkamera"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7759,9 +7684,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.0c74bc30a994dd33",
-      "source": "Loading thread",
-      "translated": "Thread wird geladen"
+      "id": "native.android.882cc14a58e7e105",
+      "source": "Loading session",
+      "translated": "Sitzung wird geladen"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7804,14 +7729,14 @@
       "translated": "Auf den neuesten Stand bringen"
     },
     {
-      "id": "native.android.cf40df9739f78f27",
-      "source": "Summarize recent threads and next steps.",
-      "translated": "Fasse die letzten Threads und die nächsten Schritte zusammen."
+      "id": "native.android.1e5add56e48c99f9",
+      "source": "Summarize recent sessions and next steps.",
+      "translated": "Fasse die letzten Sitzungen und nächsten Schritte zusammen."
     },
     {
-      "id": "native.android.ebe49a8b8df80bd3",
-      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
-      "translated": "Bring mich bei meinen neuesten OpenClaw-Threads auf den aktuellen Stand und schlage nächste Schritte vor."
+      "id": "native.android.06d515351bb79576",
+      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
+      "translated": "Bringe mich über meine letzten OpenClaw-Sitzungen auf den neuesten Stand und schlage nächste Schritte vor."
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8149,9 +8074,9 @@
       "translated": "Verbunden"
     },
     {
-      "id": "native.android.6cf5d6fa8a4186d5",
-      "source": "Threads",
-      "translated": "Threads"
+      "id": "native.android.81931886b9caf3ab",
+      "source": "Sessions",
+      "translated": "Sitzungen"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,6 +10719,61 @@
       "translated": "Aufgabendetails"
     },
     {
+      "id": "native.apple.29cacb53ea5e77fc",
+      "source": "Pinned",
+      "translated": "Angeheftet"
+    },
+    {
+      "id": "native.apple.940062cfdce9211b",
+      "source": "Recent",
+      "translated": "Zuletzt verwendet"
+    },
+    {
+      "id": "native.apple.a0980128426308a9",
+      "source": "Model",
+      "translated": "Modell"
+    },
+    {
+      "id": "native.apple.9520e60f21535dde",
+      "source": "Thinking",
+      "translated": "Denkmodus"
+    },
+    {
+      "id": "native.apple.8b321f3ffce97429",
+      "source": "Fast",
+      "translated": "Schnell"
+    },
+    {
+      "id": "native.apple.989b70d64e328d55",
+      "source": "Default (inherited)",
+      "translated": "Standard (übernommen)"
+    },
+    {
+      "id": "native.apple.f4114e73b07eb9ae",
+      "source": "Off",
+      "translated": "Aus"
+    },
+    {
+      "id": "native.apple.7ed231b28d16312f",
+      "source": "On",
+      "translated": "Ein"
+    },
+    {
+      "id": "native.apple.412a74802320a037",
+      "source": "Full",
+      "translated": "Vollständig"
+    },
+    {
+      "id": "native.apple.299f21a2071ff9fc",
+      "source": "Verbosity",
+      "translated": "Ausführlichkeit"
+    },
+    {
+      "id": "native.apple.faf0ef05e1496de7",
+      "source": "Default",
+      "translated": "Standard"
+    },
+    {
       "id": "native.apple.e5524d5756a62744",
       "source": "Unable to Export Transcript",
       "translated": "Transkript kann nicht exportiert werden"
@@ -10814,9 +10794,9 @@
       "translated": "Woran möchten Sie arbeiten?"
     },
     {
-      "id": "native.apple.4da775013ac9b123",
-      "source": "The thread attaches once the gateway is ready.",
-      "translated": "Der Thread wird angehängt, sobald das Gateway bereit ist."
+      "id": "native.apple.32179ce0b6d4543f",
+      "source": "The session attaches once the gateway is ready.",
+      "translated": "Die Sitzung wird angehängt, sobald die Gateway bereit ist."
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10859,9 +10839,14 @@
       "translated": "Neuer Chat im Worktree"
     },
     {
-      "id": "native.apple.003b25ddafeb18e9",
-      "source": "Threads…",
-      "translated": "Threads…"
+      "id": "native.apple.ce6ebe91fc597015",
+      "source": "New Session Options…",
+      "translated": "Optionen für neue Sitzung…"
+    },
+    {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "Sitzungen…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11024,14 +11009,14 @@
       "translated": "Erstellen"
     },
     {
-      "id": "native.apple.31d5c7287cfb3abe",
-      "source": "Delete Thread?",
-      "translated": "Thread löschen?"
+      "id": "native.apple.f488b9caf6e51ac3",
+      "source": "Delete Session?",
+      "translated": "Sitzung löschen?"
     },
     {
-      "id": "native.apple.d3395564809f1120",
-      "source": "Delete Thread",
-      "translated": "Thread löschen"
+      "id": "native.apple.8634b17be9b111bc",
+      "source": "Delete Session",
+      "translated": "Sitzung löschen"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11039,9 +11024,9 @@
       "translated": "Abbrechen"
     },
     {
-      "id": "native.apple.092659256d26cb03",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "Dadurch werden der Thread und sein Transkript dauerhaft gelöscht."
+      "id": "native.apple.4a9568ac9b18d8d3",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "Dadurch werden die Sitzung und ihr Transkript dauerhaft gelöscht."
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11069,9 +11054,9 @@
       "translated": "Neue Gruppe"
     },
     {
-      "id": "native.apple.683032464c497bbd",
-      "source": "Rename Thread",
-      "translated": "Thread umbenennen"
+      "id": "native.apple.5bccdc23a1640895",
+      "source": "Rename Session",
+      "translated": "Sitzung umbenennen"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11079,9 +11064,9 @@
       "translated": "Gruppenname"
     },
     {
-      "id": "native.apple.f887aa956588f237",
-      "source": "Thread name",
-      "translated": "Threadname"
+      "id": "native.apple.af789b2d2fda0f67",
+      "source": "Session name",
+      "translated": "Sitzungsname"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11119,14 +11104,14 @@
       "translated": "Agents"
     },
     {
-      "id": "native.apple.7c8231b7b1ca480f",
-      "source": "Agent thread",
-      "translated": "Agenten-Thread"
+      "id": "native.apple.a3bde8045fe9224a",
+      "source": "Agent session",
+      "translated": "Agent-Sitzung"
     },
     {
-      "id": "native.apple.b3c553614f762a58",
-      "source": "Recent threads",
-      "translated": "Neueste Threads"
+      "id": "native.apple.27f775de30b37ff8",
+      "source": "Recent sessions",
+      "translated": "Letzte Sitzungen"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11134,9 +11119,9 @@
       "translated": "Gateway offline"
     },
     {
-      "id": "native.apple.5aa32afda85064ea",
-      "source": "No recent threads",
-      "translated": "Keine neuen Threads"
+      "id": "native.apple.28c97cf23665ee01",
+      "source": "No recent sessions",
+      "translated": "Keine letzten Sitzungen"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11234,14 +11219,14 @@
       "translated": "Abbrechen"
     },
     {
-      "id": "native.apple.b6855cf19a50f477",
-      "source": "Threads",
-      "translated": "Threads"
+      "id": "native.apple.9f2fd65953013b7c",
+      "source": "Sessions",
+      "translated": "Sitzungen"
     },
     {
-      "id": "native.apple.9b1d0ef27a1333b0",
-      "source": "Archived threads",
-      "translated": "Archivierte Threads"
+      "id": "native.apple.0422818cc95d5071",
+      "source": "Archived sessions",
+      "translated": "Archivierte Sitzungen"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11249,34 +11234,34 @@
       "translated": "Archivierte anzeigen"
     },
     {
-      "id": "native.apple.98167401c7267735",
-      "source": "Threads unavailable",
-      "translated": "Threads nicht verfügbar"
+      "id": "native.apple.b272115c83f7ef58",
+      "source": "Sessions unavailable",
+      "translated": "Sitzungen nicht verfügbar"
     },
     {
-      "id": "native.apple.4d28a7def2337b9f",
-      "source": "Loading archived threads",
-      "translated": "Archivierte Threads werden geladen"
+      "id": "native.apple.54f8260c9b863087",
+      "source": "Loading archived sessions",
+      "translated": "Archivierte Sitzungen werden geladen"
     },
     {
-      "id": "native.apple.777d7b706933bd7b",
-      "source": "Loading recent threads",
-      "translated": "Neueste Threads werden geladen"
+      "id": "native.apple.9b305868873dade2",
+      "source": "Loading recent sessions",
+      "translated": "Letzte Sitzungen werden geladen"
     },
     {
-      "id": "native.apple.22f81ea94bef8410",
-      "source": "^[\\(count) thread](inflect: true)",
-      "translated": "^[\\(count) Thread](inflect: true)"
+      "id": "native.apple.207dad20d09f3160",
+      "source": "^[\\(count) session](inflect: true)",
+      "translated": "^[\\(count) Sitzung](inflect: true)"
     },
     {
-      "id": "native.apple.1cad51e14db59bf9",
-      "source": "No archived threads",
-      "translated": "Keine archivierten Threads"
+      "id": "native.apple.1f4501a6bf2bae4c",
+      "source": "No archived sessions",
+      "translated": "Keine archivierten Sitzungen"
     },
     {
-      "id": "native.apple.18ef832d3a7ddcf8",
-      "source": "Archived threads will appear here.",
-      "translated": "Archivierte Threads werden hier angezeigt."
+      "id": "native.apple.2a1ba7a5e1979c9e",
+      "source": "Archived sessions will appear here.",
+      "translated": "Archivierte Sitzungen werden hier angezeigt."
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11359,9 +11344,9 @@
       "translated": "Eingang teilen"
     },
     {
-      "id": "native.apple.21d9208d86a4d1fe",
-      "source": "Loading threads",
-      "translated": "Threads werden geladen"
+      "id": "native.apple.2360d25fe6ae9946",
+      "source": "Loading sessions",
+      "translated": "Sitzungen werden geladen"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11369,19 +11354,19 @@
       "translated": "Letzte Aktivität wird vom Gateway abgerufen."
     },
     {
-      "id": "native.apple.4be1f79aa2b230ff",
-      "source": "Threads unavailable",
-      "translated": "Threads nicht verfügbar"
+      "id": "native.apple.c334f2e86702a7b8",
+      "source": "Sessions unavailable",
+      "translated": "Sitzungen nicht verfügbar"
     },
     {
-      "id": "native.apple.98b348873556bc46",
-      "source": "No recent threads",
-      "translated": "Keine aktuellen Threads"
+      "id": "native.apple.6cc6efb7a03960b6",
+      "source": "No recent sessions",
+      "translated": "Keine aktuellen Sitzungen"
     },
     {
-      "id": "native.apple.7396d205574d279f",
-      "source": "Thread activity offline",
-      "translated": "Thread-Aktivität offline"
+      "id": "native.apple.08483af2d043bee6",
+      "source": "Session activity offline",
+      "translated": "Sitzungsaktivität offline"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11839,9 +11824,9 @@
       "translated": "Karte"
     },
     {
-      "id": "native.apple.c9ec1b0e18074d8a",
-      "source": "Open Thread",
-      "translated": "Thread öffnen"
+      "id": "native.apple.93eeaedb2ff61043",
+      "source": "Open Session",
+      "translated": "Sitzung öffnen"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13329,9 +13314,9 @@
       "translated": "Standard"
     },
     {
-      "id": "native.apple.f4ae5664c3eda95d",
-      "source": "Used for new Chat threads and Talk sessions.",
-      "translated": "Wird für neue Chat-Threads und Gesprächssitzungen verwendet."
+      "id": "native.apple.3de045f17ea3c6d0",
+      "source": "Used for new Chat and Talk sessions.",
+      "translated": "Wird für neue Chat- und Talk-Sitzungen verwendet."
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15734,9 +15719,9 @@
       "translated": "Instanzen"
     },
     {
-      "id": "native.apple.11fe8b9941954dfb",
-      "source": "Threads",
-      "translated": "Threads"
+      "id": "native.apple.3579cf2750470a22",
+      "source": "Sessions",
+      "translated": "Sitzungen"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19044,9 +19029,9 @@
       "translated": "Tastenkürzel für Quick Chat"
     },
     {
-      "id": "native.apple.94dd793cd7d7d555",
-      "source": "Global shortcut that opens a floating chat bar for the main thread.",
-      "translated": "Globales Tastenkürzel, das eine schwebende Chatleiste für den Haupt-Thread öffnet."
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "Globales Tastenkürzel, das eine schwebende Chatleiste für die Hauptsitzung öffnet."
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19624,9 +19609,9 @@
       "translated": "Kritisch"
     },
     {
-      "id": "native.apple.13f96467014cf344",
-      "source": "New Thread",
-      "translated": "Neuer Thread"
+      "id": "native.apple.75102378a6775180",
+      "source": "New Session",
+      "translated": "Neue Sitzung"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21914,9 +21899,9 @@
       "translated": "Keine aktuellen Nachrichten"
     },
     {
-      "id": "native.apple.3ec2afcbc298c673",
-      "source": "Threads",
-      "translated": "Threads"
+      "id": "native.apple.1ff8aec0044934c3",
+      "source": "Sessions",
+      "translated": "Sitzungen"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21924,9 +21909,9 @@
       "translated": "Einblick in die gespeicherten Konversations-Buckets, die die CLI für Kontext und Ratenbegrenzungen wiederverwendet."
     },
     {
-      "id": "native.apple.14ccb32cd8ed1c81",
-      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
-      "translated": "Noch keine Threads. Sie werden nach der ersten eingehenden Nachricht oder dem ersten Heartbeat angezeigt."
+      "id": "native.apple.bab897f3252b134c",
+      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
+      "translated": "Noch keine Sitzungen. Sie erscheinen nach der ersten eingehenden Nachricht oder dem ersten Heartbeat."
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -22009,9 +21994,9 @@
       "translated": "Ausführungsgenehmigungen"
     },
     {
-      "id": "native.apple.52e37e3a44ae516c",
-      "source": "Threads",
-      "translated": "Threads"
+      "id": "native.apple.64a6dc7d49e8fb57",
+      "source": "Sessions",
+      "translated": "Sitzungen"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -23014,9 +22999,9 @@
       "translated": "Bring mich auf den neuesten Stand"
     },
     {
-      "id": "native.apple.fc4ce810900ec0b6",
-      "source": "Summarize what happened in my threads since yesterday.",
-      "translated": "Fasse zusammen, was seit gestern in meinen Threads passiert ist."
+      "id": "native.apple.234ec45f4231edc4",
+      "source": "Summarize what happened in my sessions since yesterday.",
+      "translated": "Fasse zusammen, was seit gestern in meinen Sitzungen passiert ist."
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23194,9 +23179,9 @@
       "translated": "Modell lösen"
     },
     {
-      "id": "native.apple.4edb66657f5aca1f",
-      "source": "Thread",
-      "translated": "Thread"
+      "id": "native.apple.5dfc0700d8dff8de",
+      "source": "Session",
+      "translated": "Sitzung"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23359,51 +23344,6 @@
       "translated": "Widget nicht verfügbar"
     },
     {
-      "id": "native.apple.d640691fd196f338",
-      "source": "Widget export failed",
-      "translated": "Widget-Export fehlgeschlagen"
-    },
-    {
-      "id": "native.apple.533c6e22a11e88de",
-      "source": "OK",
-      "translated": "OK"
-    },
-    {
-      "id": "native.apple.e1fb28a2a9756402",
-      "source": "Copy image",
-      "translated": "Bild kopieren"
-    },
-    {
-      "id": "native.apple.ebd7bc92e1b12235",
-      "source": "Save image…",
-      "translated": "Bild speichern…"
-    },
-    {
-      "id": "native.apple.742c46d4cf2db134",
-      "source": "Save image",
-      "translated": "Bild speichern"
-    },
-    {
-      "id": "native.apple.0589cce608418f90",
-      "source": "The widget image could not be captured.",
-      "translated": "Das Widget-Bild konnte nicht erfasst werden."
-    },
-    {
-      "id": "native.apple.dfe24e827fdbe9c5",
-      "source": "The widget image could not be copied.",
-      "translated": "Das Widget-Bild konnte nicht kopiert werden."
-    },
-    {
-      "id": "native.apple.9e611e3a80e71408",
-      "source": "The widget image could not be encoded as PNG.",
-      "translated": "Das Widget-Bild konnte nicht als PNG codiert werden."
-    },
-    {
-      "id": "native.apple.9a6e8afbe24a262b",
-      "source": "The widget image could not be saved.",
-      "translated": "Das Widget-Bild konnte nicht gespeichert werden."
-    },
-    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23544,19 +23484,19 @@
       "translated": "Benutzer"
     },
     {
-      "id": "native.apple.9d0cba09d92ee669",
-      "source": "This thread cannot be archived while it is active or running.",
-      "translated": "Dieser Thread kann nicht archiviert werden, solange er aktiv ist oder ausgeführt wird."
+      "id": "native.apple.b1cdcb906a43d5d6",
+      "source": "This session cannot be archived while it is active or running.",
+      "translated": "Diese Sitzung kann nicht archiviert werden, solange sie aktiv ist oder ausgeführt wird."
     },
     {
-      "id": "native.apple.8952a111a1075051",
-      "source": "The main thread cannot be deleted.",
-      "translated": "Der Haupt-Thread kann nicht gelöscht werden."
+      "id": "native.apple.5817e3f3dab1ee19",
+      "source": "The main session cannot be deleted.",
+      "translated": "Die Hauptsitzung kann nicht gelöscht werden."
     },
     {
-      "id": "native.apple.90d0ccf80ca28717",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
-      "translated": "Entferne Anhänge oder warte auf die Zustellung, bevor du diesen Thread archivierst oder löschst."
+      "id": "native.apple.a6b8df3f18171c91",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
+      "translated": "Entfernen Sie Anhänge oder warten Sie auf deren Zustellung, bevor Sie diese Sitzung archivieren oder löschen."
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23694,9 +23634,9 @@
       "translated": "Ausführung beendet"
     },
     {
-      "id": "native.apple.bbccb4c8db5cac12",
-      "source": "Thread Info",
-      "translated": "Thread-Informationen"
+      "id": "native.apple.cd7c3095a22f80a9",
+      "source": "Session Info",
+      "translated": "Sitzungsinformationen"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23729,9 +23669,9 @@
       "translated": "Gruppe hinzufügen"
     },
     {
-      "id": "native.apple.7b641fed5bace855",
-      "source": "Thread Groups",
-      "translated": "Thread-Gruppen"
+      "id": "native.apple.23d628606fe0734f",
+      "source": "Session Groups",
+      "translated": "Sitzungsgruppen"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23774,9 +23714,9 @@
       "translated": "Gruppe löschen"
     },
     {
-      "id": "native.apple.56401c79410a310d",
-      "source": "Threads in this group become ungrouped.",
-      "translated": "Threads in dieser Gruppe werden aus der Gruppe entfernt."
+      "id": "native.apple.b049c8a4d2805e08",
+      "source": "Sessions in this group become ungrouped.",
+      "translated": "Sitzungen in dieser Gruppe werden aus der Gruppe entfernt."
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23789,9 +23729,9 @@
       "translated": "Auf diesem Gateway sind keine Agenten verfügbar."
     },
     {
-      "id": "native.apple.2d96aa7d3d12f85b",
-      "source": "New Thread Options",
-      "translated": "Optionen für neuen Thread"
+      "id": "native.apple.6c89f35d53506406",
+      "source": "New Session Options",
+      "translated": "Optionen für neue Sitzungen"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23819,19 +23759,19 @@
       "translated": "Erstellen"
     },
     {
-      "id": "native.apple.87ef57319d1ddc85",
-      "source": "The thread could not be created.",
-      "translated": "Der Thread konnte nicht erstellt werden."
+      "id": "native.apple.795ba37f6782cf28",
+      "source": "The session could not be created.",
+      "translated": "Die Sitzung konnte nicht erstellt werden."
     },
     {
-      "id": "native.apple.6bd91c435b69d638",
-      "source": "Search threads",
-      "translated": "Threads durchsuchen"
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "Sitzungen durchsuchen"
     },
     {
-      "id": "native.apple.6fde4bdf9d5b9191",
-      "source": "No Threads",
-      "translated": "Keine Threads"
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "Keine Sitzungen"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23839,29 +23779,29 @@
       "translated": "Keine Ergebnisse"
     },
     {
-      "id": "native.apple.a02fd99740d29bd3",
-      "source": "New Thread",
-      "translated": "Neuer Thread"
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "Neue Sitzung"
     },
     {
-      "id": "native.apple.b625801dd04b09f2",
-      "source": "New thread",
-      "translated": "Neuer Thread"
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "Neue Sitzung"
     },
     {
-      "id": "native.apple.851be81fcc933608",
-      "source": "New thread options",
-      "translated": "Optionen für neuen Thread"
+      "id": "native.apple.2ef0e34db02ad255",
+      "source": "New session options",
+      "translated": "Optionen für neue Sitzungen"
     },
     {
-      "id": "native.apple.9ce8a4aba7b444b2",
-      "source": "Rename Thread",
-      "translated": "Thread umbenennen"
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "Sitzung umbenennen"
     },
     {
-      "id": "native.apple.1dd067c44511c7f0",
-      "source": "Thread name",
-      "translated": "Thread-Name"
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "Sitzungsname"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23874,14 +23814,14 @@
       "translated": "Abbrechen"
     },
     {
-      "id": "native.apple.618073d6ab3f2721",
-      "source": "Delete Thread",
-      "translated": "Thread löschen"
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "Sitzung löschen"
     },
     {
-      "id": "native.apple.10a5e72bba3cbccc",
-      "source": "The thread and its transcript are removed from the gateway.",
-      "translated": "Der Thread und sein Transkript werden vom Gateway entfernt."
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "Die Sitzung und ihr Transkript werden vom Gateway entfernt."
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23889,14 +23829,14 @@
       "translated": "„%@“ löschen?"
     },
     {
-      "id": "native.apple.ac71e3b2aa496a2c",
-      "source": "Thread running",
-      "translated": "Thread wird ausgeführt"
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "Sitzung wird ausgeführt"
     },
     {
-      "id": "native.apple.c775e87f997278b2",
-      "source": "Thread failed",
-      "translated": "Thread fehlgeschlagen"
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "Sitzung fehlgeschlagen"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23954,9 +23894,9 @@
       "translated": "Sitzungsschlüssel kopieren"
     },
     {
-      "id": "native.apple.f4998cfb572f23ff",
-      "source": "Delete Thread…",
-      "translated": "Thread löschen…"
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "Sitzung löschen…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23969,9 +23909,9 @@
       "translated": "Verbindung wird hergestellt…"
     },
     {
-      "id": "native.apple.8802e9576ffd0f65",
-      "source": "Retry thread groups",
-      "translated": "Thread-Gruppen erneut laden"
+      "id": "native.apple.79f708b3bc1d3a6c",
+      "source": "Retry session groups",
+      "translated": "Sitzungsgruppen erneut laden"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23994,24 +23934,24 @@
       "translated": "Umfang"
     },
     {
-      "id": "native.apple.b313b80def4bda52",
-      "source": "Search threads",
-      "translated": "Threads durchsuchen"
+      "id": "native.apple.2c37581c7b88f741",
+      "source": "Search sessions",
+      "translated": "Sitzungen suchen"
     },
     {
-      "id": "native.apple.c0cc6acc36f413ce",
-      "source": "Threads",
-      "translated": "Threads"
+      "id": "native.apple.43be8a2336e42faf",
+      "source": "Sessions",
+      "translated": "Sitzungen"
     },
     {
-      "id": "native.apple.854d3928fe5a557c",
-      "source": "Rename Thread",
-      "translated": "Thread umbenennen"
+      "id": "native.apple.0b379cdfcbd3247f",
+      "source": "Rename Session",
+      "translated": "Sitzung umbenennen"
     },
     {
-      "id": "native.apple.9d0d3f20096cc4da",
-      "source": "Thread name",
-      "translated": "Thread-Name"
+      "id": "native.apple.54b6fbd9e41db009",
+      "source": "Session name",
+      "translated": "Sitzungsname"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -24019,19 +23959,19 @@
       "translated": "Abbrechen"
     },
     {
-      "id": "native.apple.dc00eb94f33bae15",
-      "source": "Delete selected threads?",
-      "translated": "Ausgewählte Threads löschen?"
+      "id": "native.apple.751e0f6b81cd374a",
+      "source": "Delete selected sessions?",
+      "translated": "Ausgewählte Sitzungen löschen?"
     },
     {
-      "id": "native.apple.2053fc9f74dc3158",
-      "source": "Delete Threads",
-      "translated": "Threads löschen"
+      "id": "native.apple.aa679276581b0058",
+      "source": "Delete Sessions",
+      "translated": "Sitzungen löschen"
     },
     {
-      "id": "native.apple.0970247871a834a0",
-      "source": "Each selected thread and its transcript will be removed from the gateway.",
-      "translated": "Jeder ausgewählte Thread und sein Transkript werden vom Gateway entfernt."
+      "id": "native.apple.f837129cbee23297",
+      "source": "Each selected session and its transcript will be removed from the gateway.",
+      "translated": "Alle ausgewählten Sitzungen und ihre Transkripte werden aus dem Gateway entfernt."
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -24039,9 +23979,9 @@
       "translated": "Gruppen"
     },
     {
-      "id": "native.apple.6f8acab2256728b5",
-      "source": "Manage thread groups",
-      "translated": "Thread-Gruppen verwalten"
+      "id": "native.apple.64013cfee5e25305",
+      "source": "Manage session groups",
+      "translated": "Sitzungsgruppen verwalten"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -24054,14 +23994,14 @@
       "translated": "Auswählen"
     },
     {
-      "id": "native.apple.692972314d04b184",
-      "source": "No archived threads",
-      "translated": "Keine archivierten Threads"
+      "id": "native.apple.b67eaecec1b423ac",
+      "source": "No archived sessions",
+      "translated": "Keine archivierten Sitzungen"
     },
     {
-      "id": "native.apple.d6a4b5711dcd26e7",
-      "source": "No threads found",
-      "translated": "Keine Threads gefunden"
+      "id": "native.apple.b2435a79abf0c794",
+      "source": "No sessions found",
+      "translated": "Keine Sitzungen gefunden"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24229,16 +24169,6 @@
       "translated": "Vollständige Nachricht öffnen"
     },
     {
-      "id": "native.apple.002bfcede229ad4b",
-      "source": "Rewind to Here",
-      "translated": "Bis hierhin zurückspulen"
-    },
-    {
-      "id": "native.apple.14df2e4997689fb3",
-      "source": "Fork from Here",
-      "translated": "Ab hier abzweigen"
-    },
-    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "Antwort"
@@ -24324,9 +24254,9 @@
       "translated": "Entferne Anhänge oder warte, bis die Zustellung abgeschlossen ist, bevor du einen neuen Chat startest."
     },
     {
-      "id": "native.apple.e0f045151c8d3137",
-      "source": "Gateway changed before the thread operation started.",
-      "translated": "Das Gateway wurde geändert, bevor der Thread-Vorgang gestartet wurde."
+      "id": "native.apple.980f552bb0f96c0f",
+      "source": "Gateway changed before the session operation started.",
+      "translated": "Das Gateway wurde geändert, bevor der Sitzungsvorgang gestartet wurde."
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24334,9 +24264,9 @@
       "translated": "Entfernen Sie Anhänge oder warten Sie auf die Zustellung, bevor Sie den Chat wechseln."
     },
     {
-      "id": "native.apple.0a5c4e15466c3acc",
-      "source": "Clear this thread's history?",
-      "translated": "Verlauf dieses Threads löschen?"
+      "id": "native.apple.87ba543b42696b92",
+      "source": "Clear this session's history?",
+      "translated": "Verlauf dieser Sitzung löschen?"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24349,14 +24279,14 @@
       "translated": "Dadurch wird die Unterhaltung für %@ zurückgesetzt. Der Sitzungsschlüssel bleibt unverändert."
     },
     {
-      "id": "native.apple.67ac221dbe7179f0",
-      "source": "Rename Thread",
-      "translated": "Thread umbenennen"
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "Sitzung umbenennen"
     },
     {
-      "id": "native.apple.cf0f7e049603f518",
-      "source": "Thread name",
-      "translated": "Thread-Name"
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "Sitzungsname"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24374,9 +24304,9 @@
       "translated": "Transkript exportieren"
     },
     {
-      "id": "native.apple.c0ada47504425f23",
-      "source": "Threads",
-      "translated": "Threads"
+      "id": "native.apple.4af0f566d39d7041",
+      "source": "Sessions",
+      "translated": "Sitzungen"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24449,14 +24379,14 @@
       "translated": "Standard"
     },
     {
-      "id": "native.apple.1a765291943599e5",
-      "source": "New Thread",
-      "translated": "Neuer Thread"
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "Neue Sitzung"
     },
     {
-      "id": "native.apple.c7a3a6d5e43dd98f",
-      "source": "New Thread Options…",
-      "translated": "Optionen für neuen Thread…"
+      "id": "native.apple.a7119fbf9d25df5e",
+      "source": "New Session Options…",
+      "translated": "Optionen für neue Sitzung…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24464,19 +24394,19 @@
       "translated": "Aktualisieren"
     },
     {
-      "id": "native.apple.0e710b81808e5dcf",
-      "source": "Threads…",
-      "translated": "Threads…"
+      "id": "native.apple.2bcff4a8fa503739",
+      "source": "Sessions…",
+      "translated": "Sitzungen…"
     },
     {
-      "id": "native.apple.faad8f92b6bef166",
-      "source": "Rename Thread…",
-      "translated": "Thread umbenennen…"
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "Sitzung umbenennen…"
     },
     {
-      "id": "native.apple.23b61d6cd26ac112",
-      "source": "Fork",
-      "translated": "Abzweigen"
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "Sitzung abzweigen"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24534,24 +24464,24 @@
       "translated": "Verlauf löschen…"
     },
     {
-      "id": "native.apple.8b4f1c5107ea8a0e",
-      "source": "Thread",
-      "translated": "Thread"
+      "id": "native.apple.920fe8a7a33f9e92",
+      "source": "Session",
+      "translated": "Sitzung"
     },
     {
-      "id": "native.apple.4d7750c9bf699469",
-      "source": "Thread actions",
-      "translated": "Thread-Aktionen"
+      "id": "native.apple.185a401f78328b0f",
+      "source": "Session actions",
+      "translated": "Sitzungsaktionen"
     },
     {
-      "id": "native.apple.bb2f22cc43c97f8e",
-      "source": "Thread cost %@",
-      "translated": "Thread-Kosten %@"
+      "id": "native.apple.9f9dedf599b2619b",
+      "source": "Session cost %@",
+      "translated": "Sitzungskosten: %@"
     },
     {
-      "id": "native.apple.6239ced0b86e86f8",
-      "source": "Compact Thread",
-      "translated": "Thread komprimieren"
+      "id": "native.apple.f0a4720df5f5f403",
+      "source": "Compact Session",
+      "translated": "Sitzung komprimieren"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/es.json
+++ b/apps/.i18n/native/es.json
@@ -1429,9 +1429,9 @@
       "translated": "Hable o dicte con OpenClaw"
     },
     {
-      "id": "native.android.e2cf5a38587382cb",
-      "source": "Browse Threads",
-      "translated": "Explorar hilos"
+      "id": "native.android.5876e15e5e92fd45",
+      "source": "Browse Sessions",
+      "translated": "Explorar sesiones"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "No se encontraron acciones"
     },
     {
-      "id": "native.android.bc70a4ac965b82ba",
-      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
-      "translated": "Prueba Chat, Voz, Hilos, Proveedores o Ajustes."
+      "id": "native.android.48ad0ae0e930e02b",
+      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
+      "translated": "Prueba Chat, Voice, Sessions, Providers o Settings."
     },
     {
-      "id": "native.android.670121e54dbe286f",
-      "source": "Threads",
-      "translated": "Hilos"
+      "id": "native.android.d4fbd1ee4f55a5db",
+      "source": "Sessions",
+      "translated": "Sesiones"
     },
     {
-      "id": "native.android.d38be650b1bce4a0",
-      "source": "Connect the Gateway to search threads.",
-      "translated": "Conecta el Gateway para buscar hilos."
+      "id": "native.android.207c2170504e99e6",
+      "source": "Connect the Gateway to search sessions.",
+      "translated": "Conecta el Gateway para buscar sesiones."
     },
     {
-      "id": "native.android.3d7754721f776ef8",
-      "source": "No matching threads yet.",
-      "translated": "Aún no hay hilos coincidentes."
+      "id": "native.android.25d2c2d792c952fe",
+      "source": "No matching sessions yet.",
+      "translated": "Aún no hay sesiones coincidentes."
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "Asistente trabajando"
     },
     {
-      "id": "native.android.9a839f6e3e05a744",
-      "source": "OpenClaw thread",
-      "translated": "Hilo de OpenClaw"
+      "id": "native.android.8f8384286317f5c9",
+      "source": "OpenClaw session",
+      "translated": "Sesión de OpenClaw"
     },
     {
-      "id": "native.android.d83f82a1e4a5ed99",
-      "source": "Open thread",
-      "translated": "Abrir hilo"
+      "id": "native.android.15799e57704b20c6",
+      "source": "Open session",
+      "translated": "Abrir sesión"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "No hay proveedores listos"
     },
     {
-      "id": "native.android.8a1c5365c0538908",
-      "source": "Main thread",
-      "translated": "Hilo principal"
+      "id": "native.android.73e6ab1a168fd381",
+      "source": "Main session",
+      "translated": "Sesión principal"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.a5845742daecb4ba",
-      "source": "Threads",
-      "translated": "Hilos"
+      "id": "native.android.0e3157c15c56944f",
+      "source": "Sessions",
+      "translated": "Sesiones"
     },
     {
-      "id": "native.android.439b324280869527",
-      "source": "Focus thread search",
-      "translated": "Enfocar la búsqueda de hilos"
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "Enfocar la búsqueda de sesiones"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "Archivado"
     },
     {
-      "id": "native.android.03981341841b04ac",
-      "source": "Search threads",
-      "translated": "Buscar hilos"
+      "id": "native.android.b9cf34c137e4cf03",
+      "source": "Search sessions",
+      "translated": "Buscar sesiones"
     },
     {
-      "id": "native.android.99570c528a41fa72",
-      "source": "Clear thread search",
-      "translated": "Borrar la búsqueda de hilos"
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "Borrar la búsqueda de sesiones"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "Más antiguos primero"
     },
     {
-      "id": "native.android.fd67be543e321cc9",
-      "source": "Toggle thread layout",
-      "translated": "Cambiar el diseño de los hilos"
+      "id": "native.android.c6bf8751e2a7f5c7",
+      "source": "Toggle session layout",
+      "translated": "Cambiar diseño de sesiones"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "Diseño: Detallado"
     },
     {
-      "id": "native.android.ebd17565e0ffd8eb",
-      "source": "Searching threads",
-      "translated": "Buscando hilos"
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "Buscando sesiones"
     },
     {
-      "id": "native.android.472d46ae8669f860",
-      "source": "No matching threads",
-      "translated": "No hay hilos coincidentes"
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "No hay sesiones coincidentes"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "Iniciar chat"
     },
     {
-      "id": "native.android.ff81ad1bee00d384",
-      "source": "Current thread",
-      "translated": "Hilo actual"
+      "id": "native.android.f10d4df7cbc6df4f",
+      "source": "Current session",
+      "translated": "Sesión actual"
     },
     {
-      "id": "native.android.fc145645b9620e57",
-      "source": "OpenClaw thread",
-      "translated": "Hilo de OpenClaw"
+      "id": "native.android.8f0482425838ae64",
+      "source": "OpenClaw session",
+      "translated": "Sesión de OpenClaw"
     },
     {
-      "id": "native.android.71cbb8dde8bf138b",
-      "source": "Rename thread",
-      "translated": "Cambiar el nombre del hilo"
+      "id": "native.android.786774c8a76e50d7",
+      "source": "Rename session",
+      "translated": "Renombrar sesión"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "¿Eliminar grupo?"
     },
     {
-      "id": "native.android.691e92cfe5cf106e",
-      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "Los hilos de \"$group\" se conservan y vuelven a Sin agrupar."
+      "id": "native.android.3455fc2f77d564e3",
+      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "Las sesiones en \"$group\" se conservan y vuelven a Sin agrupar."
     },
     {
-      "id": "native.android.d87a8217ab56999b",
-      "source": "Delete thread?",
-      "translated": "¿Eliminar el hilo?"
+      "id": "native.android.4805fb9d6623e8c0",
+      "source": "Delete session?",
+      "translated": "¿Eliminar sesión?"
     },
     {
-      "id": "native.android.930de97ff47113a8",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "Esto elimina permanentemente el hilo y su transcripción."
+      "id": "native.android.0c3283a2b2445eae",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "Esto elimina permanentemente la sesión y su transcripción."
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "Sin agrupar"
     },
     {
-      "id": "native.android.8e21a70428def6e0",
-      "source": "No threads yet",
-      "translated": "Aún no hay hilos"
+      "id": "native.android.db243d71d056afa4",
+      "source": "No sessions yet",
+      "translated": "Aún no hay sesiones"
     },
     {
-      "id": "native.android.cda4c5ad8b17e394",
-      "source": "No current thread",
-      "translated": "No hay ningún hilo actual"
+      "id": "native.android.5b4eee6a8092925e",
+      "source": "No current session",
+      "translated": "No hay ninguna sesión actual"
     },
     {
-      "id": "native.android.be84f061047aa2da",
-      "source": "No archived threads",
-      "translated": "No hay hilos archivados"
+      "id": "native.android.acbcc9c9ea53d8c0",
+      "source": "No archived sessions",
+      "translated": "No hay sesiones archivadas"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "Inicia una nueva conversación y aparecerá aquí."
     },
     {
-      "id": "native.android.f289d03e1d3eee98",
-      "source": "Open Chat to start or resume the current thread.",
-      "translated": "Abre el chat para iniciar o reanudar el hilo actual."
+      "id": "native.android.56fcd605dc7be3c0",
+      "source": "Open Chat to start or resume the current session.",
+      "translated": "Abre Chat para iniciar o reanudar la sesión actual."
     },
     {
-      "id": "native.android.504b71386e76c6ae",
-      "source": "Archived threads will show up here.",
-      "translated": "Los hilos archivados aparecerán aquí."
+      "id": "native.android.085515989f8a2022",
+      "source": "Archived sessions will show up here.",
+      "translated": "Las sesiones archivadas aparecerán aquí."
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days} d"
     },
     {
-      "id": "native.android.ee4c727cdafbe963",
-      "source": "Main thread",
-      "translated": "Hilo principal"
+      "id": "native.android.3d4fa07acbc015c5",
+      "source": "Main session",
+      "translated": "Sesión principal"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway pendiente"
     },
     {
-      "id": "native.android.da78209effb11cfd",
-      "source": "Thread Activity",
-      "translated": "Actividad del hilo"
+      "id": "native.android.2d8d049afe99f751",
+      "source": "Session Activity",
+      "translated": "Actividad de la sesión"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "Las solicitudes de aprobación de ejecución aparecerán aquí mientras este teléfono esté conectado."
     },
     {
-      "id": "native.android.f615712dfb56319a",
-      "source": "Thread activity",
-      "translated": "Actividad del hilo"
+      "id": "native.android.dc3e7ca5a491103a",
+      "source": "Session activity",
+      "translated": "Actividad de la sesión"
     },
     {
-      "id": "native.android.6c93973c13db43ae",
-      "source": "Chat tool calls waiting in the active thread remain visible here.",
-      "translated": "Las llamadas a herramientas del chat que estén en espera en el hilo activo seguirán visibles aquí."
+      "id": "native.android.8551e02b060bd7d8",
+      "source": "Chat tool calls waiting in the active session remain visible here.",
+      "translated": "Las llamadas a herramientas del chat en espera en la sesión activa permanecen visibles aquí."
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,11 +4294,6 @@
       "translated": "Configuración del proveedor de conversación"
     },
     {
-      "id": "native.android.23b638094c34b916",
-      "source": "Microphone",
-      "translated": "Micrófono"
-    },
-    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "Prueba de audio"
@@ -4342,66 +4337,6 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "Listo"
-    },
-    {
-      "id": "native.android.8d9ecdfdd916b780",
-      "source": "Automatic",
-      "translated": "Automático"
-    },
-    {
-      "id": "native.android.c1626a6700a570f6",
-      "source": "Preferred microphone unavailable; using automatic routing.",
-      "translated": "El micrófono preferido no está disponible; se usará el enrutamiento automático."
-    },
-    {
-      "id": "native.android.820bc5d0ce571d8b",
-      "source": "Prioritizes connected Bluetooth microphones.",
-      "translated": "Prioriza los micrófonos Bluetooth conectados."
-    },
-    {
-      "id": "native.android.11e48038d5e8bff6",
-      "source": "Preferred microphone",
-      "translated": "Micrófono preferido"
-    },
-    {
-      "id": "native.android.eaa4d7563a46d307",
-      "source": "Unavailable",
-      "translated": "No disponible"
-    },
-    {
-      "id": "native.android.9f5ebf17eb405ba8",
-      "source": "Next session",
-      "translated": "Próxima sesión"
-    },
-    {
-      "id": "native.android.8c4e91f53928efb2",
-      "source": "Built-in microphone",
-      "translated": "Micrófono integrado"
-    },
-    {
-      "id": "native.android.14b613cb6e2446b4",
-      "source": "Bluetooth microphone",
-      "translated": "Micrófono Bluetooth"
-    },
-    {
-      "id": "native.android.c885247b2d7ce271",
-      "source": "Bluetooth LE microphone",
-      "translated": "Micrófono Bluetooth LE"
-    },
-    {
-      "id": "native.android.b6a4e674c5fb441a",
-      "source": "Wired headset microphone",
-      "translated": "Micrófono de auriculares con cable"
-    },
-    {
-      "id": "native.android.9c8becb3b0fb5a90",
-      "source": "USB microphone",
-      "translated": "Micrófono USB"
-    },
-    {
-      "id": "native.android.ba46258fadec7a39",
-      "source": "External microphone",
-      "translated": "Micrófono externo"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5139,9 +5074,9 @@
       "translated": "Comprobar"
     },
     {
-      "id": "native.android.c971506716c96e91",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
-      "translated": "OpenClaw convierte este teléfono en una interfaz móvil despejada para gestionar hilos, voz, proveedores y Gateway."
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw convierte este teléfono en una interfaz móvil sencilla para sesiones, voz, proveedores y Gateway."
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5689,9 +5624,9 @@
       "translated": "Configuración de Talk"
     },
     {
-      "id": "native.android.36f78c8c85dc283f",
-      "source": "Recent Threads",
-      "translated": "Hilos recientes"
+      "id": "native.android.73f07a5d54915259",
+      "source": "Recent Sessions",
+      "translated": "Sesiones recientes"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5749,14 +5684,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% en línea"
     },
     {
-      "id": "native.android.57177017a6a93826",
-      "source": "Threads",
-      "translated": "Hilos"
+      "id": "native.android.16c3425d3a594481",
+      "source": "Sessions",
+      "translated": "Sesiones"
     },
     {
-      "id": "native.android.43320b54a68b00a1",
-      "source": "No recent threads",
-      "translated": "No hay hilos recientes"
+      "id": "native.android.a5c0f8b3112aa58c",
+      "source": "No recent sessions",
+      "translated": "No hay sesiones recientes"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5794,14 +5729,14 @@
       "translated": "Trabajando · $pendingRunCount ejecuciones activas"
     },
     {
-      "id": "native.android.e24db059480f1e6a",
-      "source": "Monitoring · 1 thread",
-      "translated": "Supervisión · 1 hilo"
+      "id": "native.android.2c89da708b12a522",
+      "source": "Monitoring · 1 session",
+      "translated": "Supervisando · 1 sesión"
     },
     {
-      "id": "native.android.5a475f37d80e02bc",
-      "source": "Monitoring · $sessionCount threads",
-      "translated": "Supervisión · $sessionCount hilos"
+      "id": "native.android.8b6ee382dcb64e1f",
+      "source": "Monitoring · $sessionCount sessions",
+      "translated": "Supervisando · $sessionCount sesiones"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5834,9 +5769,9 @@
       "translated": "Proveedores"
     },
     {
-      "id": "native.android.358c5e0e838d5423",
-      "source": "Open thread",
-      "translated": "Abrir hilo"
+      "id": "native.android.a65477861c7203aa",
+      "source": "Open session",
+      "translated": "Abrir sesión"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6259,9 +6194,9 @@
       "translated": "${days} d"
     },
     {
-      "id": "native.android.28a1a1acc5a0959f",
-      "source": "Main thread",
-      "translated": "Hilo principal"
+      "id": "native.android.22d755834386db07",
+      "source": "Main session",
+      "translated": "Sesión principal"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6942,16 +6877,6 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "Activar sonido"
-    },
-    {
-      "id": "native.android.cb608d82c5b3352a",
-      "source": "Back camera",
-      "translated": "Cámara trasera"
-    },
-    {
-      "id": "native.android.e89a0e780eed2e1e",
-      "source": "Front camera",
-      "translated": "Cámara frontal"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7759,9 +7684,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.0c74bc30a994dd33",
-      "source": "Loading thread",
-      "translated": "Cargando hilo"
+      "id": "native.android.882cc14a58e7e105",
+      "source": "Loading session",
+      "translated": "Cargando sesión"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7804,14 +7729,14 @@
       "translated": "Ponme al día"
     },
     {
-      "id": "native.android.cf40df9739f78f27",
-      "source": "Summarize recent threads and next steps.",
-      "translated": "Resume los hilos recientes y los próximos pasos."
+      "id": "native.android.1e5add56e48c99f9",
+      "source": "Summarize recent sessions and next steps.",
+      "translated": "Resume las sesiones recientes y los próximos pasos."
     },
     {
-      "id": "native.android.ebe49a8b8df80bd3",
-      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
-      "translated": "Ponme al día sobre mis hilos recientes de OpenClaw y sugiere los próximos pasos."
+      "id": "native.android.06d515351bb79576",
+      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
+      "translated": "Ponme al día sobre mis sesiones recientes de OpenClaw y sugiere los próximos pasos."
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8149,9 +8074,9 @@
       "translated": "Conectado"
     },
     {
-      "id": "native.android.6cf5d6fa8a4186d5",
-      "source": "Threads",
-      "translated": "Hilos"
+      "id": "native.android.81931886b9caf3ab",
+      "source": "Sessions",
+      "translated": "Sesiones"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,6 +10719,61 @@
       "translated": "Detalles de la tarea"
     },
     {
+      "id": "native.apple.29cacb53ea5e77fc",
+      "source": "Pinned",
+      "translated": "Fijado"
+    },
+    {
+      "id": "native.apple.940062cfdce9211b",
+      "source": "Recent",
+      "translated": "Reciente"
+    },
+    {
+      "id": "native.apple.a0980128426308a9",
+      "source": "Model",
+      "translated": "Modelo"
+    },
+    {
+      "id": "native.apple.9520e60f21535dde",
+      "source": "Thinking",
+      "translated": "Razonamiento"
+    },
+    {
+      "id": "native.apple.8b321f3ffce97429",
+      "source": "Fast",
+      "translated": "Rápido"
+    },
+    {
+      "id": "native.apple.989b70d64e328d55",
+      "source": "Default (inherited)",
+      "translated": "Predeterminado (heredado)"
+    },
+    {
+      "id": "native.apple.f4114e73b07eb9ae",
+      "source": "Off",
+      "translated": "Desactivado"
+    },
+    {
+      "id": "native.apple.7ed231b28d16312f",
+      "source": "On",
+      "translated": "Activado"
+    },
+    {
+      "id": "native.apple.412a74802320a037",
+      "source": "Full",
+      "translated": "Completo"
+    },
+    {
+      "id": "native.apple.299f21a2071ff9fc",
+      "source": "Verbosity",
+      "translated": "Nivel de detalle"
+    },
+    {
+      "id": "native.apple.faf0ef05e1496de7",
+      "source": "Default",
+      "translated": "Predeterminado"
+    },
+    {
       "id": "native.apple.e5524d5756a62744",
       "source": "Unable to Export Transcript",
       "translated": "No se puede exportar la transcripción"
@@ -10814,9 +10794,9 @@
       "translated": "¿En qué te gustaría trabajar?"
     },
     {
-      "id": "native.apple.4da775013ac9b123",
-      "source": "The thread attaches once the gateway is ready.",
-      "translated": "El hilo se adjuntará cuando el Gateway esté listo."
+      "id": "native.apple.32179ce0b6d4543f",
+      "source": "The session attaches once the gateway is ready.",
+      "translated": "La sesión se adjunta una vez que el gateway esté listo."
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10859,9 +10839,14 @@
       "translated": "Nuevo chat en worktree"
     },
     {
-      "id": "native.apple.003b25ddafeb18e9",
-      "source": "Threads…",
-      "translated": "Hilos…"
+      "id": "native.apple.ce6ebe91fc597015",
+      "source": "New Session Options…",
+      "translated": "Opciones de nueva sesión…"
+    },
+    {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "Sesiones…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11024,14 +11009,14 @@
       "translated": "Crear"
     },
     {
-      "id": "native.apple.31d5c7287cfb3abe",
-      "source": "Delete Thread?",
-      "translated": "¿Eliminar hilo?"
+      "id": "native.apple.f488b9caf6e51ac3",
+      "source": "Delete Session?",
+      "translated": "¿Eliminar sesión?"
     },
     {
-      "id": "native.apple.d3395564809f1120",
-      "source": "Delete Thread",
-      "translated": "Eliminar hilo"
+      "id": "native.apple.8634b17be9b111bc",
+      "source": "Delete Session",
+      "translated": "Eliminar sesión"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11039,9 +11024,9 @@
       "translated": "Cancelar"
     },
     {
-      "id": "native.apple.092659256d26cb03",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "Esto elimina permanentemente el hilo y su transcripción."
+      "id": "native.apple.4a9568ac9b18d8d3",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "Esto elimina permanentemente la sesión y su transcripción."
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11069,9 +11054,9 @@
       "translated": "Nuevo grupo"
     },
     {
-      "id": "native.apple.683032464c497bbd",
-      "source": "Rename Thread",
-      "translated": "Cambiar el nombre del hilo"
+      "id": "native.apple.5bccdc23a1640895",
+      "source": "Rename Session",
+      "translated": "Renombrar sesión"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11079,9 +11064,9 @@
       "translated": "Nombre del grupo"
     },
     {
-      "id": "native.apple.f887aa956588f237",
-      "source": "Thread name",
-      "translated": "Nombre del hilo"
+      "id": "native.apple.af789b2d2fda0f67",
+      "source": "Session name",
+      "translated": "Nombre de la sesión"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11119,14 +11104,14 @@
       "translated": "Agentes"
     },
     {
-      "id": "native.apple.7c8231b7b1ca480f",
-      "source": "Agent thread",
-      "translated": "Hilo del agente"
+      "id": "native.apple.a3bde8045fe9224a",
+      "source": "Agent session",
+      "translated": "Sesión de agente"
     },
     {
-      "id": "native.apple.b3c553614f762a58",
-      "source": "Recent threads",
-      "translated": "Hilos recientes"
+      "id": "native.apple.27f775de30b37ff8",
+      "source": "Recent sessions",
+      "translated": "Sesiones recientes"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11134,9 +11119,9 @@
       "translated": "Gateway sin conexión"
     },
     {
-      "id": "native.apple.5aa32afda85064ea",
-      "source": "No recent threads",
-      "translated": "No hay hilos recientes"
+      "id": "native.apple.28c97cf23665ee01",
+      "source": "No recent sessions",
+      "translated": "No hay sesiones recientes"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11234,14 +11219,14 @@
       "translated": "Cancelar"
     },
     {
-      "id": "native.apple.b6855cf19a50f477",
-      "source": "Threads",
-      "translated": "Hilos"
+      "id": "native.apple.9f2fd65953013b7c",
+      "source": "Sessions",
+      "translated": "Sesiones"
     },
     {
-      "id": "native.apple.9b1d0ef27a1333b0",
-      "source": "Archived threads",
-      "translated": "Hilos archivados"
+      "id": "native.apple.0422818cc95d5071",
+      "source": "Archived sessions",
+      "translated": "Sesiones archivadas"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11249,34 +11234,34 @@
       "translated": "Mostrar archivadas"
     },
     {
-      "id": "native.apple.98167401c7267735",
-      "source": "Threads unavailable",
-      "translated": "Hilos no disponibles"
+      "id": "native.apple.b272115c83f7ef58",
+      "source": "Sessions unavailable",
+      "translated": "Sesiones no disponibles"
     },
     {
-      "id": "native.apple.4d28a7def2337b9f",
-      "source": "Loading archived threads",
-      "translated": "Cargando hilos archivados"
+      "id": "native.apple.54f8260c9b863087",
+      "source": "Loading archived sessions",
+      "translated": "Cargando sesiones archivadas"
     },
     {
-      "id": "native.apple.777d7b706933bd7b",
-      "source": "Loading recent threads",
-      "translated": "Cargando hilos recientes"
+      "id": "native.apple.9b305868873dade2",
+      "source": "Loading recent sessions",
+      "translated": "Cargando sesiones recientes"
     },
     {
-      "id": "native.apple.22f81ea94bef8410",
-      "source": "^[\\(count) thread](inflect: true)",
-      "translated": "^[\\(count) hilo](inflect: true)"
+      "id": "native.apple.207dad20d09f3160",
+      "source": "^[\\(count) session](inflect: true)",
+      "translated": "^[\\(count) sesión](inflect: true)"
     },
     {
-      "id": "native.apple.1cad51e14db59bf9",
-      "source": "No archived threads",
-      "translated": "No hay hilos archivados"
+      "id": "native.apple.1f4501a6bf2bae4c",
+      "source": "No archived sessions",
+      "translated": "No hay sesiones archivadas"
     },
     {
-      "id": "native.apple.18ef832d3a7ddcf8",
-      "source": "Archived threads will appear here.",
-      "translated": "Los hilos archivados aparecerán aquí."
+      "id": "native.apple.2a1ba7a5e1979c9e",
+      "source": "Archived sessions will appear here.",
+      "translated": "Las sesiones archivadas aparecerán aquí."
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11359,9 +11344,9 @@
       "translated": "Compartir entrada"
     },
     {
-      "id": "native.apple.21d9208d86a4d1fe",
-      "source": "Loading threads",
-      "translated": "Cargando hilos"
+      "id": "native.apple.2360d25fe6ae9946",
+      "source": "Loading sessions",
+      "translated": "Cargando sesiones"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11369,19 +11354,19 @@
       "translated": "Obteniendo actividad reciente del gateway."
     },
     {
-      "id": "native.apple.4be1f79aa2b230ff",
-      "source": "Threads unavailable",
-      "translated": "Hilos no disponibles"
+      "id": "native.apple.c334f2e86702a7b8",
+      "source": "Sessions unavailable",
+      "translated": "Sesiones no disponibles"
     },
     {
-      "id": "native.apple.98b348873556bc46",
-      "source": "No recent threads",
-      "translated": "No hay hilos recientes"
+      "id": "native.apple.6cc6efb7a03960b6",
+      "source": "No recent sessions",
+      "translated": "No hay sesiones recientes"
     },
     {
-      "id": "native.apple.7396d205574d279f",
-      "source": "Thread activity offline",
-      "translated": "Actividad de los hilos sin conexión"
+      "id": "native.apple.08483af2d043bee6",
+      "source": "Session activity offline",
+      "translated": "Actividad de sesión sin conexión"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11839,9 +11824,9 @@
       "translated": "Tarjeta"
     },
     {
-      "id": "native.apple.c9ec1b0e18074d8a",
-      "source": "Open Thread",
-      "translated": "Abrir hilo"
+      "id": "native.apple.93eeaedb2ff61043",
+      "source": "Open Session",
+      "translated": "Abrir sesión"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13329,9 +13314,9 @@
       "translated": "Predeterminado"
     },
     {
-      "id": "native.apple.f4ae5664c3eda95d",
-      "source": "Used for new Chat threads and Talk sessions.",
-      "translated": "Se usa para nuevos hilos de Chat y sesiones de Talk."
+      "id": "native.apple.3de045f17ea3c6d0",
+      "source": "Used for new Chat and Talk sessions.",
+      "translated": "Se usa para nuevas sesiones de Chat y Talk."
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15734,9 +15719,9 @@
       "translated": "Instancias"
     },
     {
-      "id": "native.apple.11fe8b9941954dfb",
-      "source": "Threads",
-      "translated": "Hilos"
+      "id": "native.apple.3579cf2750470a22",
+      "source": "Sessions",
+      "translated": "Sesiones"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19044,9 +19029,9 @@
       "translated": "Atajo de Chat rápido"
     },
     {
-      "id": "native.apple.94dd793cd7d7d555",
-      "source": "Global shortcut that opens a floating chat bar for the main thread.",
-      "translated": "Atajo global que abre una barra de chat flotante para el hilo principal."
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "Atajo global que abre una barra de chat flotante para la sesión principal."
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19624,9 +19609,9 @@
       "translated": "Crítico"
     },
     {
-      "id": "native.apple.13f96467014cf344",
-      "source": "New Thread",
-      "translated": "Nuevo hilo"
+      "id": "native.apple.75102378a6775180",
+      "source": "New Session",
+      "translated": "Nueva sesión"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21914,9 +21899,9 @@
       "translated": "No hay mensajes recientes"
     },
     {
-      "id": "native.apple.3ec2afcbc298c673",
-      "source": "Threads",
-      "translated": "Hilos"
+      "id": "native.apple.1ff8aec0044934c3",
+      "source": "Sessions",
+      "translated": "Sesiones"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21924,9 +21909,9 @@
       "translated": "Echa un vistazo a los grupos de conversaciones almacenados que la CLI reutiliza para el contexto y los límites de frecuencia."
     },
     {
-      "id": "native.apple.14ccb32cd8ed1c81",
-      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
-      "translated": "Aún no hay hilos. Aparecerán después del primer mensaje entrante o señal de actividad."
+      "id": "native.apple.bab897f3252b134c",
+      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
+      "translated": "Aún no hay sesiones. Aparecen después del primer mensaje entrante o latido."
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -22009,9 +21994,9 @@
       "translated": "Aprobaciones de ejecución"
     },
     {
-      "id": "native.apple.52e37e3a44ae516c",
-      "source": "Threads",
-      "translated": "Hilos"
+      "id": "native.apple.64a6dc7d49e8fb57",
+      "source": "Sessions",
+      "translated": "Sesiones"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -23014,9 +22999,9 @@
       "translated": "Ponme al día"
     },
     {
-      "id": "native.apple.fc4ce810900ec0b6",
-      "source": "Summarize what happened in my threads since yesterday.",
-      "translated": "Resume lo que ha ocurrido en mis hilos desde ayer."
+      "id": "native.apple.234ec45f4231edc4",
+      "source": "Summarize what happened in my sessions since yesterday.",
+      "translated": "Resume lo que ha ocurrido en mis sesiones desde ayer."
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23194,9 +23179,9 @@
       "translated": "Desfijar modelo"
     },
     {
-      "id": "native.apple.4edb66657f5aca1f",
-      "source": "Thread",
-      "translated": "Hilo"
+      "id": "native.apple.5dfc0700d8dff8de",
+      "source": "Session",
+      "translated": "Sesión"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23359,51 +23344,6 @@
       "translated": "Widget no disponible"
     },
     {
-      "id": "native.apple.d640691fd196f338",
-      "source": "Widget export failed",
-      "translated": "Error al exportar el widget"
-    },
-    {
-      "id": "native.apple.533c6e22a11e88de",
-      "source": "OK",
-      "translated": "Aceptar"
-    },
-    {
-      "id": "native.apple.e1fb28a2a9756402",
-      "source": "Copy image",
-      "translated": "Copiar imagen"
-    },
-    {
-      "id": "native.apple.ebd7bc92e1b12235",
-      "source": "Save image…",
-      "translated": "Guardar imagen…"
-    },
-    {
-      "id": "native.apple.742c46d4cf2db134",
-      "source": "Save image",
-      "translated": "Guardar imagen"
-    },
-    {
-      "id": "native.apple.0589cce608418f90",
-      "source": "The widget image could not be captured.",
-      "translated": "No se pudo capturar la imagen del widget."
-    },
-    {
-      "id": "native.apple.dfe24e827fdbe9c5",
-      "source": "The widget image could not be copied.",
-      "translated": "No se pudo copiar la imagen del widget."
-    },
-    {
-      "id": "native.apple.9e611e3a80e71408",
-      "source": "The widget image could not be encoded as PNG.",
-      "translated": "No se pudo codificar la imagen del widget como PNG."
-    },
-    {
-      "id": "native.apple.9a6e8afbe24a262b",
-      "source": "The widget image could not be saved.",
-      "translated": "No se pudo guardar la imagen del widget."
-    },
-    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23544,19 +23484,19 @@
       "translated": "Usuario"
     },
     {
-      "id": "native.apple.9d0cba09d92ee669",
-      "source": "This thread cannot be archived while it is active or running.",
-      "translated": "Este hilo no se puede archivar mientras esté activo o en ejecución."
+      "id": "native.apple.b1cdcb906a43d5d6",
+      "source": "This session cannot be archived while it is active or running.",
+      "translated": "Esta sesión no se puede archivar mientras esté activa o en ejecución."
     },
     {
-      "id": "native.apple.8952a111a1075051",
-      "source": "The main thread cannot be deleted.",
-      "translated": "El hilo principal no se puede eliminar."
+      "id": "native.apple.5817e3f3dab1ee19",
+      "source": "The main session cannot be deleted.",
+      "translated": "La sesión principal no se puede eliminar."
     },
     {
-      "id": "native.apple.90d0ccf80ca28717",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
-      "translated": "Elimina los archivos adjuntos o espera a que se entreguen antes de archivar o eliminar este hilo."
+      "id": "native.apple.a6b8df3f18171c91",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
+      "translated": "Elimina los archivos adjuntos o espera a que se entreguen antes de archivar o eliminar esta sesión."
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23694,9 +23634,9 @@
       "translated": "Ejecución finalizada"
     },
     {
-      "id": "native.apple.bbccb4c8db5cac12",
-      "source": "Thread Info",
-      "translated": "Información del hilo"
+      "id": "native.apple.cd7c3095a22f80a9",
+      "source": "Session Info",
+      "translated": "Información de la sesión"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23729,9 +23669,9 @@
       "translated": "Añadir grupo"
     },
     {
-      "id": "native.apple.7b641fed5bace855",
-      "source": "Thread Groups",
-      "translated": "Grupos de hilos"
+      "id": "native.apple.23d628606fe0734f",
+      "source": "Session Groups",
+      "translated": "Grupos de sesiones"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23774,9 +23714,9 @@
       "translated": "Eliminar grupo"
     },
     {
-      "id": "native.apple.56401c79410a310d",
-      "source": "Threads in this group become ungrouped.",
-      "translated": "Los hilos de este grupo dejarán de estar agrupados."
+      "id": "native.apple.b049c8a4d2805e08",
+      "source": "Sessions in this group become ungrouped.",
+      "translated": "Las sesiones de este grupo quedarán sin agrupar."
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23789,9 +23729,9 @@
       "translated": "No hay agentes disponibles en este Gateway."
     },
     {
-      "id": "native.apple.2d96aa7d3d12f85b",
-      "source": "New Thread Options",
-      "translated": "Opciones del nuevo hilo"
+      "id": "native.apple.6c89f35d53506406",
+      "source": "New Session Options",
+      "translated": "Opciones de nueva sesión"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23819,19 +23759,19 @@
       "translated": "Crear"
     },
     {
-      "id": "native.apple.87ef57319d1ddc85",
-      "source": "The thread could not be created.",
-      "translated": "No se pudo crear el hilo."
+      "id": "native.apple.795ba37f6782cf28",
+      "source": "The session could not be created.",
+      "translated": "No se pudo crear la sesión."
     },
     {
-      "id": "native.apple.6bd91c435b69d638",
-      "source": "Search threads",
-      "translated": "Buscar hilos"
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "Buscar sesiones"
     },
     {
-      "id": "native.apple.6fde4bdf9d5b9191",
-      "source": "No Threads",
-      "translated": "No hay hilos"
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "No hay sesiones"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23839,29 +23779,29 @@
       "translated": "No hay resultados"
     },
     {
-      "id": "native.apple.a02fd99740d29bd3",
-      "source": "New Thread",
-      "translated": "Nuevo hilo"
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "Nueva sesión"
     },
     {
-      "id": "native.apple.b625801dd04b09f2",
-      "source": "New thread",
-      "translated": "Nuevo hilo"
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "Nueva sesión"
     },
     {
-      "id": "native.apple.851be81fcc933608",
-      "source": "New thread options",
-      "translated": "Opciones del nuevo hilo"
+      "id": "native.apple.2ef0e34db02ad255",
+      "source": "New session options",
+      "translated": "Opciones de nueva sesión"
     },
     {
-      "id": "native.apple.9ce8a4aba7b444b2",
-      "source": "Rename Thread",
-      "translated": "Renombrar hilo"
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "Cambiar nombre de la sesión"
     },
     {
-      "id": "native.apple.1dd067c44511c7f0",
-      "source": "Thread name",
-      "translated": "Nombre del hilo"
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "Nombre de la sesión"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23874,14 +23814,14 @@
       "translated": "Cancelar"
     },
     {
-      "id": "native.apple.618073d6ab3f2721",
-      "source": "Delete Thread",
-      "translated": "Eliminar hilo"
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "Eliminar sesión"
     },
     {
-      "id": "native.apple.10a5e72bba3cbccc",
-      "source": "The thread and its transcript are removed from the gateway.",
-      "translated": "El hilo y su transcripción se eliminarán del Gateway."
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "La sesión y su transcripción se eliminan del Gateway."
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23889,14 +23829,14 @@
       "translated": "¿Eliminar “%@”?"
     },
     {
-      "id": "native.apple.ac71e3b2aa496a2c",
-      "source": "Thread running",
-      "translated": "Hilo en ejecución"
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "Sesión en curso"
     },
     {
-      "id": "native.apple.c775e87f997278b2",
-      "source": "Thread failed",
-      "translated": "Error en el hilo"
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "Error en la sesión"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23954,9 +23894,9 @@
       "translated": "Copiar clave de sesión"
     },
     {
-      "id": "native.apple.f4998cfb572f23ff",
-      "source": "Delete Thread…",
-      "translated": "Eliminar hilo…"
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "Eliminar sesión…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23969,9 +23909,9 @@
       "translated": "Conectando…"
     },
     {
-      "id": "native.apple.8802e9576ffd0f65",
-      "source": "Retry thread groups",
-      "translated": "Reintentar grupos de hilos"
+      "id": "native.apple.79f708b3bc1d3a6c",
+      "source": "Retry session groups",
+      "translated": "Reintentar grupos de sesiones"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23994,24 +23934,24 @@
       "translated": "Alcance"
     },
     {
-      "id": "native.apple.b313b80def4bda52",
-      "source": "Search threads",
-      "translated": "Buscar hilos"
+      "id": "native.apple.2c37581c7b88f741",
+      "source": "Search sessions",
+      "translated": "Buscar sesiones"
     },
     {
-      "id": "native.apple.c0cc6acc36f413ce",
-      "source": "Threads",
-      "translated": "Hilos"
+      "id": "native.apple.43be8a2336e42faf",
+      "source": "Sessions",
+      "translated": "Sesiones"
     },
     {
-      "id": "native.apple.854d3928fe5a557c",
-      "source": "Rename Thread",
-      "translated": "Renombrar hilo"
+      "id": "native.apple.0b379cdfcbd3247f",
+      "source": "Rename Session",
+      "translated": "Cambiar nombre de sesión"
     },
     {
-      "id": "native.apple.9d0d3f20096cc4da",
-      "source": "Thread name",
-      "translated": "Nombre del hilo"
+      "id": "native.apple.54b6fbd9e41db009",
+      "source": "Session name",
+      "translated": "Nombre de sesión"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -24019,19 +23959,19 @@
       "translated": "Cancelar"
     },
     {
-      "id": "native.apple.dc00eb94f33bae15",
-      "source": "Delete selected threads?",
-      "translated": "¿Eliminar los hilos seleccionados?"
+      "id": "native.apple.751e0f6b81cd374a",
+      "source": "Delete selected sessions?",
+      "translated": "¿Eliminar las sesiones seleccionadas?"
     },
     {
-      "id": "native.apple.2053fc9f74dc3158",
-      "source": "Delete Threads",
-      "translated": "Eliminar hilos"
+      "id": "native.apple.aa679276581b0058",
+      "source": "Delete Sessions",
+      "translated": "Eliminar sesiones"
     },
     {
-      "id": "native.apple.0970247871a834a0",
-      "source": "Each selected thread and its transcript will be removed from the gateway.",
-      "translated": "Cada hilo seleccionado y su transcripción se eliminarán del Gateway."
+      "id": "native.apple.f837129cbee23297",
+      "source": "Each selected session and its transcript will be removed from the gateway.",
+      "translated": "Cada sesión seleccionada y su transcripción se eliminarán del Gateway."
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -24039,9 +23979,9 @@
       "translated": "Grupos"
     },
     {
-      "id": "native.apple.6f8acab2256728b5",
-      "source": "Manage thread groups",
-      "translated": "Gestionar grupos de hilos"
+      "id": "native.apple.64013cfee5e25305",
+      "source": "Manage session groups",
+      "translated": "Gestionar grupos de sesiones"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -24054,14 +23994,14 @@
       "translated": "Seleccionar"
     },
     {
-      "id": "native.apple.692972314d04b184",
-      "source": "No archived threads",
-      "translated": "No hay hilos archivados"
+      "id": "native.apple.b67eaecec1b423ac",
+      "source": "No archived sessions",
+      "translated": "No hay sesiones archivadas"
     },
     {
-      "id": "native.apple.d6a4b5711dcd26e7",
-      "source": "No threads found",
-      "translated": "No se encontraron hilos"
+      "id": "native.apple.b2435a79abf0c794",
+      "source": "No sessions found",
+      "translated": "No se encontraron sesiones"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24229,16 +24169,6 @@
       "translated": "Abrir mensaje completo"
     },
     {
-      "id": "native.apple.002bfcede229ad4b",
-      "source": "Rewind to Here",
-      "translated": "Retroceder hasta aquí"
-    },
-    {
-      "id": "native.apple.14df2e4997689fb3",
-      "source": "Fork from Here",
-      "translated": "Bifurcar desde aquí"
-    },
-    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "Responder"
@@ -24324,9 +24254,9 @@
       "translated": "Elimina los archivos adjuntos o espera a que se complete la entrega antes de iniciar un nuevo chat."
     },
     {
-      "id": "native.apple.e0f045151c8d3137",
-      "source": "Gateway changed before the thread operation started.",
-      "translated": "El Gateway cambió antes de que comenzara la operación del hilo."
+      "id": "native.apple.980f552bb0f96c0f",
+      "source": "Gateway changed before the session operation started.",
+      "translated": "El Gateway cambió antes de que se iniciara la operación de sesión."
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24334,9 +24264,9 @@
       "translated": "Elimina los adjuntos o espera a que se complete la entrega antes de cambiar de chat."
     },
     {
-      "id": "native.apple.0a5c4e15466c3acc",
-      "source": "Clear this thread's history?",
-      "translated": "¿Borrar el historial de este hilo?"
+      "id": "native.apple.87ba543b42696b92",
+      "source": "Clear this session's history?",
+      "translated": "¿Borrar el historial de esta sesión?"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24349,14 +24279,14 @@
       "translated": "Esto reinicia la conversación para %@. La clave de sesión permanece igual."
     },
     {
-      "id": "native.apple.67ac221dbe7179f0",
-      "source": "Rename Thread",
-      "translated": "Renombrar hilo"
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "Renombrar sesión"
     },
     {
-      "id": "native.apple.cf0f7e049603f518",
-      "source": "Thread name",
-      "translated": "Nombre del hilo"
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "Nombre de la sesión"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24374,9 +24304,9 @@
       "translated": "Exportar transcripción"
     },
     {
-      "id": "native.apple.c0ada47504425f23",
-      "source": "Threads",
-      "translated": "Hilos"
+      "id": "native.apple.4af0f566d39d7041",
+      "source": "Sessions",
+      "translated": "Sesiones"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24449,14 +24379,14 @@
       "translated": "Predeterminado"
     },
     {
-      "id": "native.apple.1a765291943599e5",
-      "source": "New Thread",
-      "translated": "Nuevo hilo"
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "Nueva sesión"
     },
     {
-      "id": "native.apple.c7a3a6d5e43dd98f",
-      "source": "New Thread Options…",
-      "translated": "Opciones de nuevo hilo…"
+      "id": "native.apple.a7119fbf9d25df5e",
+      "source": "New Session Options…",
+      "translated": "Opciones de nueva sesión…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24464,19 +24394,19 @@
       "translated": "Actualizar"
     },
     {
-      "id": "native.apple.0e710b81808e5dcf",
-      "source": "Threads…",
-      "translated": "Hilos…"
+      "id": "native.apple.2bcff4a8fa503739",
+      "source": "Sessions…",
+      "translated": "Sesiones…"
     },
     {
-      "id": "native.apple.faad8f92b6bef166",
-      "source": "Rename Thread…",
-      "translated": "Renombrar hilo…"
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "Renombrar sesión…"
     },
     {
-      "id": "native.apple.23b61d6cd26ac112",
-      "source": "Fork",
-      "translated": "Bifurcar"
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "Bifurcar sesión"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24534,24 +24464,24 @@
       "translated": "Borrar historial…"
     },
     {
-      "id": "native.apple.8b4f1c5107ea8a0e",
-      "source": "Thread",
-      "translated": "Hilo"
+      "id": "native.apple.920fe8a7a33f9e92",
+      "source": "Session",
+      "translated": "Sesión"
     },
     {
-      "id": "native.apple.4d7750c9bf699469",
-      "source": "Thread actions",
-      "translated": "Acciones del hilo"
+      "id": "native.apple.185a401f78328b0f",
+      "source": "Session actions",
+      "translated": "Acciones de sesión"
     },
     {
-      "id": "native.apple.bb2f22cc43c97f8e",
-      "source": "Thread cost %@",
-      "translated": "Coste del hilo %@"
+      "id": "native.apple.9f9dedf599b2619b",
+      "source": "Session cost %@",
+      "translated": "Costo de la sesión: %@"
     },
     {
-      "id": "native.apple.6239ced0b86e86f8",
-      "source": "Compact Thread",
-      "translated": "Compactar hilo"
+      "id": "native.apple.f0a4720df5f5f403",
+      "source": "Compact Session",
+      "translated": "Compactar sesión"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/es.json
+++ b/apps/.i18n/native/es.json
@@ -1429,9 +1429,9 @@
       "translated": "Hable o dicte con OpenClaw"
     },
     {
-      "id": "native.android.5876e15e5e92fd45",
-      "source": "Browse Sessions",
-      "translated": "Explorar sesiones"
+      "id": "native.android.e2cf5a38587382cb",
+      "source": "Browse Threads",
+      "translated": "Explorar hilos"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "No se encontraron acciones"
     },
     {
-      "id": "native.android.48ad0ae0e930e02b",
-      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
-      "translated": "Prueba Chat, Voice, Sessions, Providers o Settings."
+      "id": "native.android.bc70a4ac965b82ba",
+      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
+      "translated": "Prueba Chat, Voz, Hilos, Proveedores o Configuración."
     },
     {
-      "id": "native.android.d4fbd1ee4f55a5db",
-      "source": "Sessions",
-      "translated": "Sesiones"
+      "id": "native.android.670121e54dbe286f",
+      "source": "Threads",
+      "translated": "Hilos"
     },
     {
-      "id": "native.android.207c2170504e99e6",
-      "source": "Connect the Gateway to search sessions.",
-      "translated": "Conecta el Gateway para buscar sesiones."
+      "id": "native.android.d38be650b1bce4a0",
+      "source": "Connect the Gateway to search threads.",
+      "translated": "Conecta el Gateway para buscar hilos."
     },
     {
-      "id": "native.android.25d2c2d792c952fe",
-      "source": "No matching sessions yet.",
-      "translated": "Aún no hay sesiones coincidentes."
+      "id": "native.android.3d7754721f776ef8",
+      "source": "No matching threads yet.",
+      "translated": "Aún no hay hilos coincidentes."
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "Asistente trabajando"
     },
     {
-      "id": "native.android.8f8384286317f5c9",
-      "source": "OpenClaw session",
-      "translated": "Sesión de OpenClaw"
+      "id": "native.android.9a839f6e3e05a744",
+      "source": "OpenClaw thread",
+      "translated": "Hilo de OpenClaw"
     },
     {
-      "id": "native.android.15799e57704b20c6",
-      "source": "Open session",
-      "translated": "Abrir sesión"
+      "id": "native.android.d83f82a1e4a5ed99",
+      "source": "Open thread",
+      "translated": "Abrir hilo"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "No hay proveedores listos"
     },
     {
-      "id": "native.android.73e6ab1a168fd381",
-      "source": "Main session",
-      "translated": "Sesión principal"
+      "id": "native.android.8a1c5365c0538908",
+      "source": "Main thread",
+      "translated": "Hilo principal"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.0e3157c15c56944f",
-      "source": "Sessions",
-      "translated": "Sesiones"
+      "id": "native.android.a5845742daecb4ba",
+      "source": "Threads",
+      "translated": "Hilos"
     },
     {
-      "id": "native.android.70f5d0507d34b5c8",
-      "source": "Focus session search",
-      "translated": "Enfocar la búsqueda de sesiones"
+      "id": "native.android.439b324280869527",
+      "source": "Focus thread search",
+      "translated": "Enfocar la búsqueda de hilos"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "Archivado"
     },
     {
-      "id": "native.android.b9cf34c137e4cf03",
-      "source": "Search sessions",
-      "translated": "Buscar sesiones"
+      "id": "native.android.03981341841b04ac",
+      "source": "Search threads",
+      "translated": "Buscar hilos"
     },
     {
-      "id": "native.android.10cb26723e9990fc",
-      "source": "Clear session search",
-      "translated": "Borrar la búsqueda de sesiones"
+      "id": "native.android.99570c528a41fa72",
+      "source": "Clear thread search",
+      "translated": "Borrar la búsqueda de hilos"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "Más antiguos primero"
     },
     {
-      "id": "native.android.c6bf8751e2a7f5c7",
-      "source": "Toggle session layout",
-      "translated": "Cambiar diseño de sesiones"
+      "id": "native.android.fd67be543e321cc9",
+      "source": "Toggle thread layout",
+      "translated": "Cambiar el diseño de los hilos"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "Diseño: Detallado"
     },
     {
-      "id": "native.android.69b79a3c2c987cd4",
-      "source": "Searching sessions",
-      "translated": "Buscando sesiones"
+      "id": "native.android.ebd17565e0ffd8eb",
+      "source": "Searching threads",
+      "translated": "Buscando hilos"
     },
     {
-      "id": "native.android.dd587d341af44212",
-      "source": "No matching sessions",
-      "translated": "No hay sesiones coincidentes"
+      "id": "native.android.472d46ae8669f860",
+      "source": "No matching threads",
+      "translated": "No hay hilos coincidentes"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "Iniciar chat"
     },
     {
-      "id": "native.android.f10d4df7cbc6df4f",
-      "source": "Current session",
-      "translated": "Sesión actual"
+      "id": "native.android.ff81ad1bee00d384",
+      "source": "Current thread",
+      "translated": "Hilo actual"
     },
     {
-      "id": "native.android.8f0482425838ae64",
-      "source": "OpenClaw session",
-      "translated": "Sesión de OpenClaw"
+      "id": "native.android.fc145645b9620e57",
+      "source": "OpenClaw thread",
+      "translated": "Hilo de OpenClaw"
     },
     {
-      "id": "native.android.786774c8a76e50d7",
-      "source": "Rename session",
-      "translated": "Renombrar sesión"
+      "id": "native.android.71cbb8dde8bf138b",
+      "source": "Rename thread",
+      "translated": "Cambiar el nombre del hilo"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "¿Eliminar grupo?"
     },
     {
-      "id": "native.android.3455fc2f77d564e3",
-      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "Las sesiones en \"$group\" se conservan y vuelven a Sin agrupar."
+      "id": "native.android.691e92cfe5cf106e",
+      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "Los hilos de \"$group\" se conservan y vuelven a Sin agrupar."
     },
     {
-      "id": "native.android.4805fb9d6623e8c0",
-      "source": "Delete session?",
-      "translated": "¿Eliminar sesión?"
+      "id": "native.android.d87a8217ab56999b",
+      "source": "Delete thread?",
+      "translated": "¿Eliminar el hilo?"
     },
     {
-      "id": "native.android.0c3283a2b2445eae",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "Esto elimina permanentemente la sesión y su transcripción."
+      "id": "native.android.930de97ff47113a8",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "Esto elimina permanentemente el hilo y su transcripción."
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "Sin agrupar"
     },
     {
-      "id": "native.android.db243d71d056afa4",
-      "source": "No sessions yet",
-      "translated": "Aún no hay sesiones"
+      "id": "native.android.8e21a70428def6e0",
+      "source": "No threads yet",
+      "translated": "Aún no hay hilos"
     },
     {
-      "id": "native.android.5b4eee6a8092925e",
-      "source": "No current session",
-      "translated": "No hay ninguna sesión actual"
+      "id": "native.android.cda4c5ad8b17e394",
+      "source": "No current thread",
+      "translated": "No hay ningún hilo actual"
     },
     {
-      "id": "native.android.acbcc9c9ea53d8c0",
-      "source": "No archived sessions",
-      "translated": "No hay sesiones archivadas"
+      "id": "native.android.be84f061047aa2da",
+      "source": "No archived threads",
+      "translated": "No hay hilos archivados"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "Inicia una nueva conversación y aparecerá aquí."
     },
     {
-      "id": "native.android.56fcd605dc7be3c0",
-      "source": "Open Chat to start or resume the current session.",
-      "translated": "Abre Chat para iniciar o reanudar la sesión actual."
+      "id": "native.android.f289d03e1d3eee98",
+      "source": "Open Chat to start or resume the current thread.",
+      "translated": "Abre el chat para iniciar o reanudar el hilo actual."
     },
     {
-      "id": "native.android.085515989f8a2022",
-      "source": "Archived sessions will show up here.",
-      "translated": "Las sesiones archivadas aparecerán aquí."
+      "id": "native.android.504b71386e76c6ae",
+      "source": "Archived threads will show up here.",
+      "translated": "Los hilos archivados aparecerán aquí."
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days} d"
     },
     {
-      "id": "native.android.3d4fa07acbc015c5",
-      "source": "Main session",
-      "translated": "Sesión principal"
+      "id": "native.android.ee4c727cdafbe963",
+      "source": "Main thread",
+      "translated": "Hilo principal"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway pendiente"
     },
     {
-      "id": "native.android.2d8d049afe99f751",
-      "source": "Session Activity",
-      "translated": "Actividad de la sesión"
+      "id": "native.android.da78209effb11cfd",
+      "source": "Thread Activity",
+      "translated": "Actividad del hilo"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "Las solicitudes de aprobación de ejecución aparecerán aquí mientras este teléfono esté conectado."
     },
     {
-      "id": "native.android.dc3e7ca5a491103a",
-      "source": "Session activity",
-      "translated": "Actividad de la sesión"
+      "id": "native.android.f615712dfb56319a",
+      "source": "Thread activity",
+      "translated": "Actividad del hilo"
     },
     {
-      "id": "native.android.8551e02b060bd7d8",
-      "source": "Chat tool calls waiting in the active session remain visible here.",
-      "translated": "Las llamadas a herramientas del chat en espera en la sesión activa permanecen visibles aquí."
+      "id": "native.android.6c93973c13db43ae",
+      "source": "Chat tool calls waiting in the active thread remain visible here.",
+      "translated": "Las llamadas a herramientas del chat que esperan en el hilo activo siguen visibles aquí."
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,6 +4294,11 @@
       "translated": "Configuración del proveedor de conversación"
     },
     {
+      "id": "native.android.23b638094c34b916",
+      "source": "Microphone",
+      "translated": "Micrófono"
+    },
+    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "Prueba de audio"
@@ -4337,6 +4342,66 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "Listo"
+    },
+    {
+      "id": "native.android.8d9ecdfdd916b780",
+      "source": "Automatic",
+      "translated": "Automático"
+    },
+    {
+      "id": "native.android.c1626a6700a570f6",
+      "source": "Preferred microphone unavailable; using automatic routing.",
+      "translated": "El micrófono preferido no está disponible; se usará el enrutamiento automático."
+    },
+    {
+      "id": "native.android.820bc5d0ce571d8b",
+      "source": "Prioritizes connected Bluetooth microphones.",
+      "translated": "Prioriza los micrófonos Bluetooth conectados."
+    },
+    {
+      "id": "native.android.11e48038d5e8bff6",
+      "source": "Preferred microphone",
+      "translated": "Micrófono preferido"
+    },
+    {
+      "id": "native.android.eaa4d7563a46d307",
+      "source": "Unavailable",
+      "translated": "No disponible"
+    },
+    {
+      "id": "native.android.9f5ebf17eb405ba8",
+      "source": "Next session",
+      "translated": "Próxima sesión"
+    },
+    {
+      "id": "native.android.8c4e91f53928efb2",
+      "source": "Built-in microphone",
+      "translated": "Micrófono integrado"
+    },
+    {
+      "id": "native.android.14b613cb6e2446b4",
+      "source": "Bluetooth microphone",
+      "translated": "Micrófono Bluetooth"
+    },
+    {
+      "id": "native.android.c885247b2d7ce271",
+      "source": "Bluetooth LE microphone",
+      "translated": "Micrófono Bluetooth LE"
+    },
+    {
+      "id": "native.android.b6a4e674c5fb441a",
+      "source": "Wired headset microphone",
+      "translated": "Micrófono de auriculares con cable"
+    },
+    {
+      "id": "native.android.9c8becb3b0fb5a90",
+      "source": "USB microphone",
+      "translated": "Micrófono USB"
+    },
+    {
+      "id": "native.android.ba46258fadec7a39",
+      "source": "External microphone",
+      "translated": "Micrófono externo"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5074,9 +5139,9 @@
       "translated": "Comprobar"
     },
     {
-      "id": "native.android.5a540761383fa474",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
-      "translated": "OpenClaw convierte este teléfono en una interfaz móvil sencilla para sesiones, voz, proveedores y Gateway."
+      "id": "native.android.c971506716c96e91",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
+      "translated": "OpenClaw convierte este teléfono en una interfaz móvil sencilla para hilos, voz, proveedores y Gateway."
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5624,9 +5689,9 @@
       "translated": "Configuración de Talk"
     },
     {
-      "id": "native.android.73f07a5d54915259",
-      "source": "Recent Sessions",
-      "translated": "Sesiones recientes"
+      "id": "native.android.36f78c8c85dc283f",
+      "source": "Recent Threads",
+      "translated": "Hilos recientes"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5684,14 +5749,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% en línea"
     },
     {
-      "id": "native.android.16c3425d3a594481",
-      "source": "Sessions",
-      "translated": "Sesiones"
+      "id": "native.android.57177017a6a93826",
+      "source": "Threads",
+      "translated": "Hilos"
     },
     {
-      "id": "native.android.a5c0f8b3112aa58c",
-      "source": "No recent sessions",
-      "translated": "No hay sesiones recientes"
+      "id": "native.android.43320b54a68b00a1",
+      "source": "No recent threads",
+      "translated": "No hay hilos recientes"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5729,14 +5794,14 @@
       "translated": "Trabajando · $pendingRunCount ejecuciones activas"
     },
     {
-      "id": "native.android.2c89da708b12a522",
-      "source": "Monitoring · 1 session",
-      "translated": "Supervisando · 1 sesión"
+      "id": "native.android.e24db059480f1e6a",
+      "source": "Monitoring · 1 thread",
+      "translated": "Supervisión · 1 hilo"
     },
     {
-      "id": "native.android.8b6ee382dcb64e1f",
-      "source": "Monitoring · $sessionCount sessions",
-      "translated": "Supervisando · $sessionCount sesiones"
+      "id": "native.android.5a475f37d80e02bc",
+      "source": "Monitoring · $sessionCount threads",
+      "translated": "Supervisión · $sessionCount hilos"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5769,9 +5834,9 @@
       "translated": "Proveedores"
     },
     {
-      "id": "native.android.a65477861c7203aa",
-      "source": "Open session",
-      "translated": "Abrir sesión"
+      "id": "native.android.358c5e0e838d5423",
+      "source": "Open thread",
+      "translated": "Abrir hilo"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6194,9 +6259,9 @@
       "translated": "${days} d"
     },
     {
-      "id": "native.android.22d755834386db07",
-      "source": "Main session",
-      "translated": "Sesión principal"
+      "id": "native.android.28a1a1acc5a0959f",
+      "source": "Main thread",
+      "translated": "Hilo principal"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6877,6 +6942,16 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "Activar sonido"
+    },
+    {
+      "id": "native.android.cb608d82c5b3352a",
+      "source": "Back camera",
+      "translated": "Cámara trasera"
+    },
+    {
+      "id": "native.android.e89a0e780eed2e1e",
+      "source": "Front camera",
+      "translated": "Cámara frontal"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7684,9 +7759,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.882cc14a58e7e105",
-      "source": "Loading session",
-      "translated": "Cargando sesión"
+      "id": "native.android.0c74bc30a994dd33",
+      "source": "Loading thread",
+      "translated": "Cargando hilo"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7729,14 +7804,14 @@
       "translated": "Ponme al día"
     },
     {
-      "id": "native.android.1e5add56e48c99f9",
-      "source": "Summarize recent sessions and next steps.",
-      "translated": "Resume las sesiones recientes y los próximos pasos."
+      "id": "native.android.cf40df9739f78f27",
+      "source": "Summarize recent threads and next steps.",
+      "translated": "Resume los hilos recientes y los próximos pasos."
     },
     {
-      "id": "native.android.06d515351bb79576",
-      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
-      "translated": "Ponme al día sobre mis sesiones recientes de OpenClaw y sugiere los próximos pasos."
+      "id": "native.android.ebe49a8b8df80bd3",
+      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
+      "translated": "Ponme al día sobre mis hilos recientes de OpenClaw y sugiere los próximos pasos."
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8074,9 +8149,9 @@
       "translated": "Conectado"
     },
     {
-      "id": "native.android.81931886b9caf3ab",
-      "source": "Sessions",
-      "translated": "Sesiones"
+      "id": "native.android.6cf5d6fa8a4186d5",
+      "source": "Threads",
+      "translated": "Hilos"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,9 +10869,9 @@
       "translated": "¿En qué te gustaría trabajar?"
     },
     {
-      "id": "native.apple.32179ce0b6d4543f",
-      "source": "The session attaches once the gateway is ready.",
-      "translated": "La sesión se adjunta una vez que el gateway esté listo."
+      "id": "native.apple.4da775013ac9b123",
+      "source": "The thread attaches once the gateway is ready.",
+      "translated": "El hilo se conecta cuando el Gateway está listo."
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10844,9 +10919,9 @@
       "translated": "Opciones de nueva sesión…"
     },
     {
-      "id": "native.apple.a1b0d289758e2213",
-      "source": "Sessions…",
-      "translated": "Sesiones…"
+      "id": "native.apple.003b25ddafeb18e9",
+      "source": "Threads…",
+      "translated": "Hilos…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11009,14 +11084,14 @@
       "translated": "Crear"
     },
     {
-      "id": "native.apple.f488b9caf6e51ac3",
-      "source": "Delete Session?",
-      "translated": "¿Eliminar sesión?"
+      "id": "native.apple.31d5c7287cfb3abe",
+      "source": "Delete Thread?",
+      "translated": "¿Eliminar el hilo?"
     },
     {
-      "id": "native.apple.8634b17be9b111bc",
-      "source": "Delete Session",
-      "translated": "Eliminar sesión"
+      "id": "native.apple.d3395564809f1120",
+      "source": "Delete Thread",
+      "translated": "Eliminar hilo"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11024,9 +11099,9 @@
       "translated": "Cancelar"
     },
     {
-      "id": "native.apple.4a9568ac9b18d8d3",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "Esto elimina permanentemente la sesión y su transcripción."
+      "id": "native.apple.092659256d26cb03",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "Esto elimina permanentemente el hilo y su transcripción."
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11054,9 +11129,9 @@
       "translated": "Nuevo grupo"
     },
     {
-      "id": "native.apple.5bccdc23a1640895",
-      "source": "Rename Session",
-      "translated": "Renombrar sesión"
+      "id": "native.apple.683032464c497bbd",
+      "source": "Rename Thread",
+      "translated": "Renombrar hilo"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11064,9 +11139,9 @@
       "translated": "Nombre del grupo"
     },
     {
-      "id": "native.apple.af789b2d2fda0f67",
-      "source": "Session name",
-      "translated": "Nombre de la sesión"
+      "id": "native.apple.f887aa956588f237",
+      "source": "Thread name",
+      "translated": "Nombre del hilo"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11104,14 +11179,14 @@
       "translated": "Agentes"
     },
     {
-      "id": "native.apple.a3bde8045fe9224a",
-      "source": "Agent session",
-      "translated": "Sesión de agente"
+      "id": "native.apple.7c8231b7b1ca480f",
+      "source": "Agent thread",
+      "translated": "Hilo del agente"
     },
     {
-      "id": "native.apple.27f775de30b37ff8",
-      "source": "Recent sessions",
-      "translated": "Sesiones recientes"
+      "id": "native.apple.b3c553614f762a58",
+      "source": "Recent threads",
+      "translated": "Hilos recientes"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11119,9 +11194,9 @@
       "translated": "Gateway sin conexión"
     },
     {
-      "id": "native.apple.28c97cf23665ee01",
-      "source": "No recent sessions",
-      "translated": "No hay sesiones recientes"
+      "id": "native.apple.5aa32afda85064ea",
+      "source": "No recent threads",
+      "translated": "No hay hilos recientes"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11219,14 +11294,14 @@
       "translated": "Cancelar"
     },
     {
-      "id": "native.apple.9f2fd65953013b7c",
-      "source": "Sessions",
-      "translated": "Sesiones"
+      "id": "native.apple.b6855cf19a50f477",
+      "source": "Threads",
+      "translated": "Hilos"
     },
     {
-      "id": "native.apple.0422818cc95d5071",
-      "source": "Archived sessions",
-      "translated": "Sesiones archivadas"
+      "id": "native.apple.9b1d0ef27a1333b0",
+      "source": "Archived threads",
+      "translated": "Hilos archivados"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11234,34 +11309,34 @@
       "translated": "Mostrar archivadas"
     },
     {
-      "id": "native.apple.b272115c83f7ef58",
-      "source": "Sessions unavailable",
-      "translated": "Sesiones no disponibles"
+      "id": "native.apple.98167401c7267735",
+      "source": "Threads unavailable",
+      "translated": "Hilos no disponibles"
     },
     {
-      "id": "native.apple.54f8260c9b863087",
-      "source": "Loading archived sessions",
-      "translated": "Cargando sesiones archivadas"
+      "id": "native.apple.4d28a7def2337b9f",
+      "source": "Loading archived threads",
+      "translated": "Cargando hilos archivados"
     },
     {
-      "id": "native.apple.9b305868873dade2",
-      "source": "Loading recent sessions",
-      "translated": "Cargando sesiones recientes"
+      "id": "native.apple.777d7b706933bd7b",
+      "source": "Loading recent threads",
+      "translated": "Cargando hilos recientes"
     },
     {
-      "id": "native.apple.207dad20d09f3160",
-      "source": "^[\\(count) session](inflect: true)",
-      "translated": "^[\\(count) sesión](inflect: true)"
+      "id": "native.apple.22f81ea94bef8410",
+      "source": "^[\\(count) thread](inflect: true)",
+      "translated": "^[\\(count) hilo](inflect: true)"
     },
     {
-      "id": "native.apple.1f4501a6bf2bae4c",
-      "source": "No archived sessions",
-      "translated": "No hay sesiones archivadas"
+      "id": "native.apple.1cad51e14db59bf9",
+      "source": "No archived threads",
+      "translated": "No hay hilos archivados"
     },
     {
-      "id": "native.apple.2a1ba7a5e1979c9e",
-      "source": "Archived sessions will appear here.",
-      "translated": "Las sesiones archivadas aparecerán aquí."
+      "id": "native.apple.18ef832d3a7ddcf8",
+      "source": "Archived threads will appear here.",
+      "translated": "Los hilos archivados aparecerán aquí."
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11344,9 +11419,9 @@
       "translated": "Compartir entrada"
     },
     {
-      "id": "native.apple.2360d25fe6ae9946",
-      "source": "Loading sessions",
-      "translated": "Cargando sesiones"
+      "id": "native.apple.21d9208d86a4d1fe",
+      "source": "Loading threads",
+      "translated": "Cargando hilos"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11354,19 +11429,19 @@
       "translated": "Obteniendo actividad reciente del gateway."
     },
     {
-      "id": "native.apple.c334f2e86702a7b8",
-      "source": "Sessions unavailable",
-      "translated": "Sesiones no disponibles"
+      "id": "native.apple.4be1f79aa2b230ff",
+      "source": "Threads unavailable",
+      "translated": "Hilos no disponibles"
     },
     {
-      "id": "native.apple.6cc6efb7a03960b6",
-      "source": "No recent sessions",
-      "translated": "No hay sesiones recientes"
+      "id": "native.apple.98b348873556bc46",
+      "source": "No recent threads",
+      "translated": "No hay hilos recientes"
     },
     {
-      "id": "native.apple.08483af2d043bee6",
-      "source": "Session activity offline",
-      "translated": "Actividad de sesión sin conexión"
+      "id": "native.apple.7396d205574d279f",
+      "source": "Thread activity offline",
+      "translated": "La actividad de los hilos está sin conexión"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11824,9 +11899,9 @@
       "translated": "Tarjeta"
     },
     {
-      "id": "native.apple.93eeaedb2ff61043",
-      "source": "Open Session",
-      "translated": "Abrir sesión"
+      "id": "native.apple.c9ec1b0e18074d8a",
+      "source": "Open Thread",
+      "translated": "Abrir hilo"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13314,9 +13389,9 @@
       "translated": "Predeterminado"
     },
     {
-      "id": "native.apple.3de045f17ea3c6d0",
-      "source": "Used for new Chat and Talk sessions.",
-      "translated": "Se usa para nuevas sesiones de Chat y Talk."
+      "id": "native.apple.f4ae5664c3eda95d",
+      "source": "Used for new Chat threads and Talk sessions.",
+      "translated": "Se usa para nuevos hilos de Chat y sesiones de Talk."
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15719,9 +15794,9 @@
       "translated": "Instancias"
     },
     {
-      "id": "native.apple.3579cf2750470a22",
-      "source": "Sessions",
-      "translated": "Sesiones"
+      "id": "native.apple.11fe8b9941954dfb",
+      "source": "Threads",
+      "translated": "Hilos"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19029,9 +19104,9 @@
       "translated": "Atajo de Chat rápido"
     },
     {
-      "id": "native.apple.6ae77665b5f4490f",
-      "source": "Global shortcut that opens a floating chat bar for the main session.",
-      "translated": "Atajo global que abre una barra de chat flotante para la sesión principal."
+      "id": "native.apple.94dd793cd7d7d555",
+      "source": "Global shortcut that opens a floating chat bar for the main thread.",
+      "translated": "Atajo global que abre una barra de chat flotante para el hilo principal."
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19609,9 +19684,9 @@
       "translated": "Crítico"
     },
     {
-      "id": "native.apple.75102378a6775180",
-      "source": "New Session",
-      "translated": "Nueva sesión"
+      "id": "native.apple.13f96467014cf344",
+      "source": "New Thread",
+      "translated": "Nuevo hilo"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21899,9 +21974,9 @@
       "translated": "No hay mensajes recientes"
     },
     {
-      "id": "native.apple.1ff8aec0044934c3",
-      "source": "Sessions",
-      "translated": "Sesiones"
+      "id": "native.apple.3ec2afcbc298c673",
+      "source": "Threads",
+      "translated": "Hilos"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21909,9 +21984,9 @@
       "translated": "Echa un vistazo a los grupos de conversaciones almacenados que la CLI reutiliza para el contexto y los límites de frecuencia."
     },
     {
-      "id": "native.apple.bab897f3252b134c",
-      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
-      "translated": "Aún no hay sesiones. Aparecen después del primer mensaje entrante o latido."
+      "id": "native.apple.14ccb32cd8ed1c81",
+      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
+      "translated": "Aún no hay hilos. Aparecen después del primer mensaje entrante o heartbeat."
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -21994,9 +22069,9 @@
       "translated": "Aprobaciones de ejecución"
     },
     {
-      "id": "native.apple.64a6dc7d49e8fb57",
-      "source": "Sessions",
-      "translated": "Sesiones"
+      "id": "native.apple.52e37e3a44ae516c",
+      "source": "Threads",
+      "translated": "Hilos"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -22999,9 +23074,9 @@
       "translated": "Ponme al día"
     },
     {
-      "id": "native.apple.234ec45f4231edc4",
-      "source": "Summarize what happened in my sessions since yesterday.",
-      "translated": "Resume lo que ha ocurrido en mis sesiones desde ayer."
+      "id": "native.apple.fc4ce810900ec0b6",
+      "source": "Summarize what happened in my threads since yesterday.",
+      "translated": "Resume lo que ocurrió en mis hilos desde ayer."
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23179,9 +23254,9 @@
       "translated": "Desfijar modelo"
     },
     {
-      "id": "native.apple.5dfc0700d8dff8de",
-      "source": "Session",
-      "translated": "Sesión"
+      "id": "native.apple.4edb66657f5aca1f",
+      "source": "Thread",
+      "translated": "Hilo"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23344,6 +23419,51 @@
       "translated": "Widget no disponible"
     },
     {
+      "id": "native.apple.d640691fd196f338",
+      "source": "Widget export failed",
+      "translated": "Error al exportar el widget"
+    },
+    {
+      "id": "native.apple.533c6e22a11e88de",
+      "source": "OK",
+      "translated": "Aceptar"
+    },
+    {
+      "id": "native.apple.e1fb28a2a9756402",
+      "source": "Copy image",
+      "translated": "Copiar imagen"
+    },
+    {
+      "id": "native.apple.ebd7bc92e1b12235",
+      "source": "Save image…",
+      "translated": "Guardar imagen…"
+    },
+    {
+      "id": "native.apple.742c46d4cf2db134",
+      "source": "Save image",
+      "translated": "Guardar imagen"
+    },
+    {
+      "id": "native.apple.0589cce608418f90",
+      "source": "The widget image could not be captured.",
+      "translated": "No se pudo capturar la imagen del widget."
+    },
+    {
+      "id": "native.apple.dfe24e827fdbe9c5",
+      "source": "The widget image could not be copied.",
+      "translated": "No se pudo copiar la imagen del widget."
+    },
+    {
+      "id": "native.apple.9e611e3a80e71408",
+      "source": "The widget image could not be encoded as PNG.",
+      "translated": "No se pudo codificar la imagen del widget como PNG."
+    },
+    {
+      "id": "native.apple.9a6e8afbe24a262b",
+      "source": "The widget image could not be saved.",
+      "translated": "No se pudo guardar la imagen del widget."
+    },
+    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23484,19 +23604,19 @@
       "translated": "Usuario"
     },
     {
-      "id": "native.apple.b1cdcb906a43d5d6",
-      "source": "This session cannot be archived while it is active or running.",
-      "translated": "Esta sesión no se puede archivar mientras esté activa o en ejecución."
+      "id": "native.apple.9d0cba09d92ee669",
+      "source": "This thread cannot be archived while it is active or running.",
+      "translated": "Este hilo no se puede archivar mientras esté activo o en ejecución."
     },
     {
-      "id": "native.apple.5817e3f3dab1ee19",
-      "source": "The main session cannot be deleted.",
-      "translated": "La sesión principal no se puede eliminar."
+      "id": "native.apple.8952a111a1075051",
+      "source": "The main thread cannot be deleted.",
+      "translated": "El hilo principal no se puede eliminar."
     },
     {
-      "id": "native.apple.a6b8df3f18171c91",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
-      "translated": "Elimina los archivos adjuntos o espera a que se entreguen antes de archivar o eliminar esta sesión."
+      "id": "native.apple.90d0ccf80ca28717",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
+      "translated": "Elimina los archivos adjuntos o espera a que se entreguen antes de archivar o eliminar este hilo."
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23634,9 +23754,9 @@
       "translated": "Ejecución finalizada"
     },
     {
-      "id": "native.apple.cd7c3095a22f80a9",
-      "source": "Session Info",
-      "translated": "Información de la sesión"
+      "id": "native.apple.bbccb4c8db5cac12",
+      "source": "Thread Info",
+      "translated": "Información del hilo"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23669,9 +23789,9 @@
       "translated": "Añadir grupo"
     },
     {
-      "id": "native.apple.23d628606fe0734f",
-      "source": "Session Groups",
-      "translated": "Grupos de sesiones"
+      "id": "native.apple.7b641fed5bace855",
+      "source": "Thread Groups",
+      "translated": "Grupos de hilos"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23714,9 +23834,9 @@
       "translated": "Eliminar grupo"
     },
     {
-      "id": "native.apple.b049c8a4d2805e08",
-      "source": "Sessions in this group become ungrouped.",
-      "translated": "Las sesiones de este grupo quedarán sin agrupar."
+      "id": "native.apple.56401c79410a310d",
+      "source": "Threads in this group become ungrouped.",
+      "translated": "Los hilos de este grupo dejarán de estar agrupados."
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23729,9 +23849,9 @@
       "translated": "No hay agentes disponibles en este Gateway."
     },
     {
-      "id": "native.apple.6c89f35d53506406",
-      "source": "New Session Options",
-      "translated": "Opciones de nueva sesión"
+      "id": "native.apple.2d96aa7d3d12f85b",
+      "source": "New Thread Options",
+      "translated": "Opciones de hilo nuevo"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23759,19 +23879,19 @@
       "translated": "Crear"
     },
     {
-      "id": "native.apple.795ba37f6782cf28",
-      "source": "The session could not be created.",
-      "translated": "No se pudo crear la sesión."
+      "id": "native.apple.87ef57319d1ddc85",
+      "source": "The thread could not be created.",
+      "translated": "No se pudo crear el hilo."
     },
     {
-      "id": "native.apple.8ec708a3605a2cc3",
-      "source": "Search sessions",
-      "translated": "Buscar sesiones"
+      "id": "native.apple.6bd91c435b69d638",
+      "source": "Search threads",
+      "translated": "Buscar hilos"
     },
     {
-      "id": "native.apple.23b069b4e7f97039",
-      "source": "No Sessions",
-      "translated": "No hay sesiones"
+      "id": "native.apple.6fde4bdf9d5b9191",
+      "source": "No Threads",
+      "translated": "No hay hilos"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23779,29 +23899,29 @@
       "translated": "No hay resultados"
     },
     {
-      "id": "native.apple.0058923f2ce8a3ec",
-      "source": "New Session",
-      "translated": "Nueva sesión"
+      "id": "native.apple.a02fd99740d29bd3",
+      "source": "New Thread",
+      "translated": "Nuevo hilo"
     },
     {
-      "id": "native.apple.66ba42960eb4135b",
-      "source": "New session",
-      "translated": "Nueva sesión"
+      "id": "native.apple.b625801dd04b09f2",
+      "source": "New thread",
+      "translated": "Nuevo hilo"
     },
     {
-      "id": "native.apple.2ef0e34db02ad255",
-      "source": "New session options",
-      "translated": "Opciones de nueva sesión"
+      "id": "native.apple.851be81fcc933608",
+      "source": "New thread options",
+      "translated": "Opciones de hilo nuevo"
     },
     {
-      "id": "native.apple.36753ef2f1ed4264",
-      "source": "Rename Session",
-      "translated": "Cambiar nombre de la sesión"
+      "id": "native.apple.9ce8a4aba7b444b2",
+      "source": "Rename Thread",
+      "translated": "Cambiar el nombre del hilo"
     },
     {
-      "id": "native.apple.c9de0a1510ef475f",
-      "source": "Session name",
-      "translated": "Nombre de la sesión"
+      "id": "native.apple.1dd067c44511c7f0",
+      "source": "Thread name",
+      "translated": "Nombre del hilo"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23814,14 +23934,14 @@
       "translated": "Cancelar"
     },
     {
-      "id": "native.apple.afb4e6c99c63a28d",
-      "source": "Delete Session",
-      "translated": "Eliminar sesión"
+      "id": "native.apple.618073d6ab3f2721",
+      "source": "Delete Thread",
+      "translated": "Eliminar hilo"
     },
     {
-      "id": "native.apple.3d4ef32e42f136a4",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "La sesión y su transcripción se eliminan del Gateway."
+      "id": "native.apple.10a5e72bba3cbccc",
+      "source": "The thread and its transcript are removed from the gateway.",
+      "translated": "El hilo y su transcripción se eliminan del Gateway."
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23829,14 +23949,14 @@
       "translated": "¿Eliminar “%@”?"
     },
     {
-      "id": "native.apple.9a7dca238fba628d",
-      "source": "Session running",
-      "translated": "Sesión en curso"
+      "id": "native.apple.ac71e3b2aa496a2c",
+      "source": "Thread running",
+      "translated": "Hilo en ejecución"
     },
     {
-      "id": "native.apple.fcfbfe5e97a95e9c",
-      "source": "Session failed",
-      "translated": "Error en la sesión"
+      "id": "native.apple.c775e87f997278b2",
+      "source": "Thread failed",
+      "translated": "Error en el hilo"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23894,9 +24014,9 @@
       "translated": "Copiar clave de sesión"
     },
     {
-      "id": "native.apple.4aeb7c14c26dabac",
-      "source": "Delete Session…",
-      "translated": "Eliminar sesión…"
+      "id": "native.apple.f4998cfb572f23ff",
+      "source": "Delete Thread…",
+      "translated": "Eliminar hilo…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23909,9 +24029,9 @@
       "translated": "Conectando…"
     },
     {
-      "id": "native.apple.79f708b3bc1d3a6c",
-      "source": "Retry session groups",
-      "translated": "Reintentar grupos de sesiones"
+      "id": "native.apple.8802e9576ffd0f65",
+      "source": "Retry thread groups",
+      "translated": "Volver a intentar cargar los grupos de hilos"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23934,24 +24054,24 @@
       "translated": "Alcance"
     },
     {
-      "id": "native.apple.2c37581c7b88f741",
-      "source": "Search sessions",
-      "translated": "Buscar sesiones"
+      "id": "native.apple.b313b80def4bda52",
+      "source": "Search threads",
+      "translated": "Buscar hilos"
     },
     {
-      "id": "native.apple.43be8a2336e42faf",
-      "source": "Sessions",
-      "translated": "Sesiones"
+      "id": "native.apple.c0cc6acc36f413ce",
+      "source": "Threads",
+      "translated": "Hilos"
     },
     {
-      "id": "native.apple.0b379cdfcbd3247f",
-      "source": "Rename Session",
-      "translated": "Cambiar nombre de sesión"
+      "id": "native.apple.854d3928fe5a557c",
+      "source": "Rename Thread",
+      "translated": "Renombrar hilo"
     },
     {
-      "id": "native.apple.54b6fbd9e41db009",
-      "source": "Session name",
-      "translated": "Nombre de sesión"
+      "id": "native.apple.9d0d3f20096cc4da",
+      "source": "Thread name",
+      "translated": "Nombre del hilo"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -23959,19 +24079,19 @@
       "translated": "Cancelar"
     },
     {
-      "id": "native.apple.751e0f6b81cd374a",
-      "source": "Delete selected sessions?",
-      "translated": "¿Eliminar las sesiones seleccionadas?"
+      "id": "native.apple.dc00eb94f33bae15",
+      "source": "Delete selected threads?",
+      "translated": "¿Eliminar los hilos seleccionados?"
     },
     {
-      "id": "native.apple.aa679276581b0058",
-      "source": "Delete Sessions",
-      "translated": "Eliminar sesiones"
+      "id": "native.apple.2053fc9f74dc3158",
+      "source": "Delete Threads",
+      "translated": "Eliminar hilos"
     },
     {
-      "id": "native.apple.f837129cbee23297",
-      "source": "Each selected session and its transcript will be removed from the gateway.",
-      "translated": "Cada sesión seleccionada y su transcripción se eliminarán del Gateway."
+      "id": "native.apple.0970247871a834a0",
+      "source": "Each selected thread and its transcript will be removed from the gateway.",
+      "translated": "Cada hilo seleccionado y su transcripción se eliminarán del Gateway."
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -23979,9 +24099,9 @@
       "translated": "Grupos"
     },
     {
-      "id": "native.apple.64013cfee5e25305",
-      "source": "Manage session groups",
-      "translated": "Gestionar grupos de sesiones"
+      "id": "native.apple.6f8acab2256728b5",
+      "source": "Manage thread groups",
+      "translated": "Gestionar grupos de hilos"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -23994,14 +24114,14 @@
       "translated": "Seleccionar"
     },
     {
-      "id": "native.apple.b67eaecec1b423ac",
-      "source": "No archived sessions",
-      "translated": "No hay sesiones archivadas"
+      "id": "native.apple.692972314d04b184",
+      "source": "No archived threads",
+      "translated": "No hay hilos archivados"
     },
     {
-      "id": "native.apple.b2435a79abf0c794",
-      "source": "No sessions found",
-      "translated": "No se encontraron sesiones"
+      "id": "native.apple.d6a4b5711dcd26e7",
+      "source": "No threads found",
+      "translated": "No se encontraron hilos"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24169,6 +24289,16 @@
       "translated": "Abrir mensaje completo"
     },
     {
+      "id": "native.apple.002bfcede229ad4b",
+      "source": "Rewind to Here",
+      "translated": "Retroceder hasta aquí"
+    },
+    {
+      "id": "native.apple.14df2e4997689fb3",
+      "source": "Fork from Here",
+      "translated": "Bifurcar desde aquí"
+    },
+    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "Responder"
@@ -24254,9 +24384,9 @@
       "translated": "Elimina los archivos adjuntos o espera a que se complete la entrega antes de iniciar un nuevo chat."
     },
     {
-      "id": "native.apple.980f552bb0f96c0f",
-      "source": "Gateway changed before the session operation started.",
-      "translated": "El Gateway cambió antes de que se iniciara la operación de sesión."
+      "id": "native.apple.e0f045151c8d3137",
+      "source": "Gateway changed before the thread operation started.",
+      "translated": "El Gateway cambió antes de que comenzara la operación del hilo."
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24264,9 +24394,9 @@
       "translated": "Elimina los adjuntos o espera a que se complete la entrega antes de cambiar de chat."
     },
     {
-      "id": "native.apple.87ba543b42696b92",
-      "source": "Clear this session's history?",
-      "translated": "¿Borrar el historial de esta sesión?"
+      "id": "native.apple.0a5c4e15466c3acc",
+      "source": "Clear this thread's history?",
+      "translated": "¿Borrar el historial de este hilo?"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24279,14 +24409,14 @@
       "translated": "Esto reinicia la conversación para %@. La clave de sesión permanece igual."
     },
     {
-      "id": "native.apple.a92e96bed98bd553",
-      "source": "Rename Session",
-      "translated": "Renombrar sesión"
+      "id": "native.apple.67ac221dbe7179f0",
+      "source": "Rename Thread",
+      "translated": "Renombrar hilo"
     },
     {
-      "id": "native.apple.848e2388f3466f40",
-      "source": "Session name",
-      "translated": "Nombre de la sesión"
+      "id": "native.apple.cf0f7e049603f518",
+      "source": "Thread name",
+      "translated": "Nombre del hilo"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24304,9 +24434,9 @@
       "translated": "Exportar transcripción"
     },
     {
-      "id": "native.apple.4af0f566d39d7041",
-      "source": "Sessions",
-      "translated": "Sesiones"
+      "id": "native.apple.c0ada47504425f23",
+      "source": "Threads",
+      "translated": "Hilos"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24379,14 +24509,14 @@
       "translated": "Predeterminado"
     },
     {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "Nueva sesión"
+      "id": "native.apple.1a765291943599e5",
+      "source": "New Thread",
+      "translated": "Nuevo hilo"
     },
     {
-      "id": "native.apple.a7119fbf9d25df5e",
-      "source": "New Session Options…",
-      "translated": "Opciones de nueva sesión…"
+      "id": "native.apple.c7a3a6d5e43dd98f",
+      "source": "New Thread Options…",
+      "translated": "Opciones del nuevo hilo…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24394,19 +24524,19 @@
       "translated": "Actualizar"
     },
     {
-      "id": "native.apple.2bcff4a8fa503739",
-      "source": "Sessions…",
-      "translated": "Sesiones…"
+      "id": "native.apple.0e710b81808e5dcf",
+      "source": "Threads…",
+      "translated": "Hilos…"
     },
     {
-      "id": "native.apple.c36e008b051adb38",
-      "source": "Rename Session…",
-      "translated": "Renombrar sesión…"
+      "id": "native.apple.faad8f92b6bef166",
+      "source": "Rename Thread…",
+      "translated": "Renombrar hilo…"
     },
     {
-      "id": "native.apple.ea0ef95a159bffe0",
-      "source": "Fork Session",
-      "translated": "Bifurcar sesión"
+      "id": "native.apple.23b61d6cd26ac112",
+      "source": "Fork",
+      "translated": "Bifurcar"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24464,24 +24594,24 @@
       "translated": "Borrar historial…"
     },
     {
-      "id": "native.apple.920fe8a7a33f9e92",
-      "source": "Session",
-      "translated": "Sesión"
+      "id": "native.apple.8b4f1c5107ea8a0e",
+      "source": "Thread",
+      "translated": "Hilo"
     },
     {
-      "id": "native.apple.185a401f78328b0f",
-      "source": "Session actions",
-      "translated": "Acciones de sesión"
+      "id": "native.apple.4d7750c9bf699469",
+      "source": "Thread actions",
+      "translated": "Acciones del hilo"
     },
     {
-      "id": "native.apple.9f9dedf599b2619b",
-      "source": "Session cost %@",
-      "translated": "Costo de la sesión: %@"
+      "id": "native.apple.bb2f22cc43c97f8e",
+      "source": "Thread cost %@",
+      "translated": "Coste del hilo %@"
     },
     {
-      "id": "native.apple.f0a4720df5f5f403",
-      "source": "Compact Session",
-      "translated": "Compactar sesión"
+      "id": "native.apple.6239ced0b86e86f8",
+      "source": "Compact Thread",
+      "translated": "Compactar hilo"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/fa.json
+++ b/apps/.i18n/native/fa.json
@@ -1429,9 +1429,9 @@
       "translated": "با OpenClaw صحبت یا دیکته کنید"
     },
     {
-      "id": "native.android.5876e15e5e92fd45",
-      "source": "Browse Sessions",
-      "translated": "مرور نشست‌ها"
+      "id": "native.android.e2cf5a38587382cb",
+      "source": "Browse Threads",
+      "translated": "مرور گفتگوها"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "اقدامی پیدا نشد"
     },
     {
-      "id": "native.android.48ad0ae0e930e02b",
-      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
-      "translated": "Chat، Voice، Sessions، Providers یا Settings را امتحان کنید."
+      "id": "native.android.bc70a4ac965b82ba",
+      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
+      "translated": "گفتگو، صدا، گفتگوها، ارائه‌دهندگان یا تنظیمات را امتحان کنید."
     },
     {
-      "id": "native.android.d4fbd1ee4f55a5db",
-      "source": "Sessions",
-      "translated": "جلسه‌ها"
+      "id": "native.android.670121e54dbe286f",
+      "source": "Threads",
+      "translated": "گفتگوها"
     },
     {
-      "id": "native.android.207c2170504e99e6",
-      "source": "Connect the Gateway to search sessions.",
-      "translated": "برای جستجوی جلسه‌ها، Gateway را متصل کنید."
+      "id": "native.android.d38be650b1bce4a0",
+      "source": "Connect the Gateway to search threads.",
+      "translated": "برای جستجوی گفتگوها، به Gateway متصل شوید."
     },
     {
-      "id": "native.android.25d2c2d792c952fe",
-      "source": "No matching sessions yet.",
-      "translated": "هنوز جلسهٔ مطابقی وجود ندارد."
+      "id": "native.android.3d7754721f776ef8",
+      "source": "No matching threads yet.",
+      "translated": "هنوز گفتگوی منطبقی وجود ندارد."
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "دستیار در حال کار است"
     },
     {
-      "id": "native.android.8f8384286317f5c9",
-      "source": "OpenClaw session",
-      "translated": "جلسه OpenClaw"
+      "id": "native.android.9a839f6e3e05a744",
+      "source": "OpenClaw thread",
+      "translated": "گفتگوی OpenClaw"
     },
     {
-      "id": "native.android.15799e57704b20c6",
-      "source": "Open session",
-      "translated": "باز کردن جلسه"
+      "id": "native.android.d83f82a1e4a5ed99",
+      "source": "Open thread",
+      "translated": "باز کردن گفتگو"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "هیچ ارائه‌دهنده آماده‌ای وجود ندارد"
     },
     {
-      "id": "native.android.73e6ab1a168fd381",
-      "source": "Main session",
-      "translated": "نشست اصلی"
+      "id": "native.android.8a1c5365c0538908",
+      "source": "Main thread",
+      "translated": "گفتگوی اصلی"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.0e3157c15c56944f",
-      "source": "Sessions",
-      "translated": "نشست‌ها"
+      "id": "native.android.a5845742daecb4ba",
+      "source": "Threads",
+      "translated": "گفتگوها"
     },
     {
-      "id": "native.android.70f5d0507d34b5c8",
-      "source": "Focus session search",
-      "translated": "تمرکز روی جست‌وجوی نشست"
+      "id": "native.android.439b324280869527",
+      "source": "Focus thread search",
+      "translated": "تمرکز روی جستجوی گفتگو"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "بایگانی‌شده"
     },
     {
-      "id": "native.android.b9cf34c137e4cf03",
-      "source": "Search sessions",
-      "translated": "جستجوی نشست‌ها"
+      "id": "native.android.03981341841b04ac",
+      "source": "Search threads",
+      "translated": "جستجوی گفتگوها"
     },
     {
-      "id": "native.android.10cb26723e9990fc",
-      "source": "Clear session search",
-      "translated": "پاک‌کردن جست‌وجوی نشست"
+      "id": "native.android.99570c528a41fa72",
+      "source": "Clear thread search",
+      "translated": "پاک کردن جستجوی گفتگو"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "ابتدا قدیمی‌ترین"
     },
     {
-      "id": "native.android.c6bf8751e2a7f5c7",
-      "source": "Toggle session layout",
-      "translated": "تغییر چیدمان نشست‌ها"
+      "id": "native.android.fd67be543e321cc9",
+      "source": "Toggle thread layout",
+      "translated": "تغییر چیدمان گفتگوها"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "چیدمان: با جزئیات"
     },
     {
-      "id": "native.android.69b79a3c2c987cd4",
-      "source": "Searching sessions",
-      "translated": "در حال جست‌وجوی نشست‌ها"
+      "id": "native.android.ebd17565e0ffd8eb",
+      "source": "Searching threads",
+      "translated": "در حال جستجوی گفتگوها"
     },
     {
-      "id": "native.android.dd587d341af44212",
-      "source": "No matching sessions",
-      "translated": "هیچ نشست منطبقی یافت نشد"
+      "id": "native.android.472d46ae8669f860",
+      "source": "No matching threads",
+      "translated": "هیچ گفتگوی منطبقی وجود ندارد"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "شروع گفتگو"
     },
     {
-      "id": "native.android.f10d4df7cbc6df4f",
-      "source": "Current session",
-      "translated": "نشست فعلی"
+      "id": "native.android.ff81ad1bee00d384",
+      "source": "Current thread",
+      "translated": "گفتگوی فعلی"
     },
     {
-      "id": "native.android.8f0482425838ae64",
-      "source": "OpenClaw session",
-      "translated": "نشست OpenClaw"
+      "id": "native.android.fc145645b9620e57",
+      "source": "OpenClaw thread",
+      "translated": "گفتگوی OpenClaw"
     },
     {
-      "id": "native.android.786774c8a76e50d7",
-      "source": "Rename session",
-      "translated": "تغییر نام جلسه"
+      "id": "native.android.71cbb8dde8bf138b",
+      "source": "Rename thread",
+      "translated": "تغییر نام گفتگو"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "گروه حذف شود؟"
     },
     {
-      "id": "native.android.3455fc2f77d564e3",
-      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "نشست‌های موجود در «$group» نگه داشته شده و به گروه‌بندی‌نشده منتقل می‌شوند."
+      "id": "native.android.691e92cfe5cf106e",
+      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "گفتگوهای موجود در «$group» حفظ می‌شوند و به بخش بدون گروه بازمی‌گردند."
     },
     {
-      "id": "native.android.4805fb9d6623e8c0",
-      "source": "Delete session?",
-      "translated": "جلسه حذف شود؟"
+      "id": "native.android.d87a8217ab56999b",
+      "source": "Delete thread?",
+      "translated": "گفتگو حذف شود؟"
     },
     {
-      "id": "native.android.0c3283a2b2445eae",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "این کار جلسه و رونوشت آن را برای همیشه حذف می‌کند."
+      "id": "native.android.930de97ff47113a8",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "این کار رشته و رونوشت آن را برای همیشه حذف می‌کند."
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "گروه‌بندی‌نشده"
     },
     {
-      "id": "native.android.db243d71d056afa4",
-      "source": "No sessions yet",
-      "translated": "هنوز نشستی وجود ندارد"
+      "id": "native.android.8e21a70428def6e0",
+      "source": "No threads yet",
+      "translated": "هنوز رشته‌ای وجود ندارد"
     },
     {
-      "id": "native.android.5b4eee6a8092925e",
-      "source": "No current session",
-      "translated": "نشست فعلی وجود ندارد"
+      "id": "native.android.cda4c5ad8b17e394",
+      "source": "No current thread",
+      "translated": "رشته فعالی وجود ندارد"
     },
     {
-      "id": "native.android.acbcc9c9ea53d8c0",
-      "source": "No archived sessions",
-      "translated": "هیچ جلسه بایگانی‌شده‌ای وجود ندارد"
+      "id": "native.android.be84f061047aa2da",
+      "source": "No archived threads",
+      "translated": "رشته بایگانی‌شده‌ای وجود ندارد"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "یک گفتگوی جدید را شروع کنید تا اینجا نمایش داده شود."
     },
     {
-      "id": "native.android.56fcd605dc7be3c0",
-      "source": "Open Chat to start or resume the current session.",
-      "translated": "برای شروع یا ازسرگیری نشست فعلی، گفتگو را باز کنید."
+      "id": "native.android.f289d03e1d3eee98",
+      "source": "Open Chat to start or resume the current thread.",
+      "translated": "برای شروع یا ازسرگیری رشته فعلی، Chat را باز کنید."
     },
     {
-      "id": "native.android.085515989f8a2022",
-      "source": "Archived sessions will show up here.",
-      "translated": "جلسه‌های بایگانی‌شده اینجا نمایش داده می‌شوند."
+      "id": "native.android.504b71386e76c6ae",
+      "source": "Archived threads will show up here.",
+      "translated": "رشته‌های بایگانی‌شده اینجا نمایش داده می‌شوند."
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days} روز"
     },
     {
-      "id": "native.android.3d4fa07acbc015c5",
-      "source": "Main session",
-      "translated": "نشست اصلی"
+      "id": "native.android.ee4c727cdafbe963",
+      "source": "Main thread",
+      "translated": "رشته اصلی"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway در انتظار"
     },
     {
-      "id": "native.android.2d8d049afe99f751",
-      "source": "Session Activity",
-      "translated": "فعالیت نشست"
+      "id": "native.android.da78209effb11cfd",
+      "source": "Thread Activity",
+      "translated": "فعالیت رشته"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "درخواست‌های تأیید اجرا تا زمانی که این تلفن متصل است اینجا نمایش داده می‌شوند."
     },
     {
-      "id": "native.android.dc3e7ca5a491103a",
-      "source": "Session activity",
-      "translated": "فعالیت جلسه"
+      "id": "native.android.f615712dfb56319a",
+      "source": "Thread activity",
+      "translated": "فعالیت رشته"
     },
     {
-      "id": "native.android.8551e02b060bd7d8",
-      "source": "Chat tool calls waiting in the active session remain visible here.",
-      "translated": "فراخوانی‌های ابزار چت که در جلسه فعال در انتظار هستند، اینجا قابل مشاهده می‌مانند."
+      "id": "native.android.6c93973c13db43ae",
+      "source": "Chat tool calls waiting in the active thread remain visible here.",
+      "translated": "فراخوانی‌های ابزار Chat که در رشته فعال منتظر هستند، اینجا قابل مشاهده می‌مانند."
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,6 +4294,11 @@
       "translated": "راه‌اندازی ارائه‌دهنده گفتار"
     },
     {
+      "id": "native.android.23b638094c34b916",
+      "source": "Microphone",
+      "translated": "میکروفون"
+    },
+    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "آزمایش صدا"
@@ -4337,6 +4342,66 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "انجام شد"
+    },
+    {
+      "id": "native.android.8d9ecdfdd916b780",
+      "source": "Automatic",
+      "translated": "خودکار"
+    },
+    {
+      "id": "native.android.c1626a6700a570f6",
+      "source": "Preferred microphone unavailable; using automatic routing.",
+      "translated": "میکروفون ترجیحی در دسترس نیست؛ از مسیریابی خودکار استفاده می‌شود."
+    },
+    {
+      "id": "native.android.820bc5d0ce571d8b",
+      "source": "Prioritizes connected Bluetooth microphones.",
+      "translated": "میکروفون‌های Bluetooth متصل را در اولویت قرار می‌دهد."
+    },
+    {
+      "id": "native.android.11e48038d5e8bff6",
+      "source": "Preferred microphone",
+      "translated": "میکروفون ترجیحی"
+    },
+    {
+      "id": "native.android.eaa4d7563a46d307",
+      "source": "Unavailable",
+      "translated": "در دسترس نیست"
+    },
+    {
+      "id": "native.android.9f5ebf17eb405ba8",
+      "source": "Next session",
+      "translated": "جلسه بعدی"
+    },
+    {
+      "id": "native.android.8c4e91f53928efb2",
+      "source": "Built-in microphone",
+      "translated": "میکروفون داخلی"
+    },
+    {
+      "id": "native.android.14b613cb6e2446b4",
+      "source": "Bluetooth microphone",
+      "translated": "میکروفون Bluetooth"
+    },
+    {
+      "id": "native.android.c885247b2d7ce271",
+      "source": "Bluetooth LE microphone",
+      "translated": "میکروفون Bluetooth LE"
+    },
+    {
+      "id": "native.android.b6a4e674c5fb441a",
+      "source": "Wired headset microphone",
+      "translated": "میکروفون هدست سیمی"
+    },
+    {
+      "id": "native.android.9c8becb3b0fb5a90",
+      "source": "USB microphone",
+      "translated": "میکروفون USB"
+    },
+    {
+      "id": "native.android.ba46258fadec7a39",
+      "source": "External microphone",
+      "translated": "میکروفون خارجی"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5074,9 +5139,9 @@
       "translated": "بررسی"
     },
     {
-      "id": "native.android.5a540761383fa474",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
-      "translated": "OpenClaw این تلفن را به یک رابط فرمان موبایل ساده برای نشست‌ها، صدا، ارائه‌دهندگان و Gateway تبدیل می‌کند."
+      "id": "native.android.c971506716c96e91",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
+      "translated": "OpenClaw این تلفن را به یک رابط فرمان موبایل ساده برای رشته‌ها، صدا، ارائه‌دهندگان و Gateway تبدیل می‌کند."
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5624,9 +5689,9 @@
       "translated": "تنظیمات Talk"
     },
     {
-      "id": "native.android.73f07a5d54915259",
-      "source": "Recent Sessions",
-      "translated": "نشست‌های اخیر"
+      "id": "native.android.36f78c8c85dc283f",
+      "source": "Recent Threads",
+      "translated": "رشته‌های اخیر"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5684,14 +5749,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}٪ آنلاین"
     },
     {
-      "id": "native.android.16c3425d3a594481",
-      "source": "Sessions",
-      "translated": "نشست‌ها"
+      "id": "native.android.57177017a6a93826",
+      "source": "Threads",
+      "translated": "رشته‌ها"
     },
     {
-      "id": "native.android.a5c0f8b3112aa58c",
-      "source": "No recent sessions",
-      "translated": "نشست اخیری وجود ندارد"
+      "id": "native.android.43320b54a68b00a1",
+      "source": "No recent threads",
+      "translated": "رشته اخیری وجود ندارد"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5729,14 +5794,14 @@
       "translated": "در حال کار · $pendingRunCount اجرای فعال"
     },
     {
-      "id": "native.android.2c89da708b12a522",
-      "source": "Monitoring · 1 session",
-      "translated": "در حال پایش · ۱ نشست"
+      "id": "native.android.e24db059480f1e6a",
+      "source": "Monitoring · 1 thread",
+      "translated": "در حال نظارت · ۱ رشته"
     },
     {
-      "id": "native.android.8b6ee382dcb64e1f",
-      "source": "Monitoring · $sessionCount sessions",
-      "translated": "در حال پایش · $sessionCount نشست"
+      "id": "native.android.5a475f37d80e02bc",
+      "source": "Monitoring · $sessionCount threads",
+      "translated": "در حال نظارت · $sessionCount رشته"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5769,9 +5834,9 @@
       "translated": "ارائه‌دهندگان"
     },
     {
-      "id": "native.android.a65477861c7203aa",
-      "source": "Open session",
-      "translated": "باز کردن جلسه"
+      "id": "native.android.358c5e0e838d5423",
+      "source": "Open thread",
+      "translated": "باز کردن رشته"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6194,9 +6259,9 @@
       "translated": "${days} روز"
     },
     {
-      "id": "native.android.22d755834386db07",
-      "source": "Main session",
-      "translated": "نشست اصلی"
+      "id": "native.android.28a1a1acc5a0959f",
+      "source": "Main thread",
+      "translated": "رشته اصلی"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6877,6 +6942,16 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "خارج کردن از حالت بی‌صدا"
+    },
+    {
+      "id": "native.android.cb608d82c5b3352a",
+      "source": "Back camera",
+      "translated": "دوربین پشت"
+    },
+    {
+      "id": "native.android.e89a0e780eed2e1e",
+      "source": "Front camera",
+      "translated": "دوربین جلو"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7684,9 +7759,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.882cc14a58e7e105",
-      "source": "Loading session",
-      "translated": "در حال بارگذاری نشست"
+      "id": "native.android.0c74bc30a994dd33",
+      "source": "Loading thread",
+      "translated": "در حال بارگذاری رشته"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7729,14 +7804,14 @@
       "translated": "من را در جریان بگذار"
     },
     {
-      "id": "native.android.1e5add56e48c99f9",
-      "source": "Summarize recent sessions and next steps.",
-      "translated": "جلسات اخیر و گام‌های بعدی را خلاصه کن."
+      "id": "native.android.cf40df9739f78f27",
+      "source": "Summarize recent threads and next steps.",
+      "translated": "رشته‌های اخیر و گام‌های بعدی را خلاصه کن."
     },
     {
-      "id": "native.android.06d515351bb79576",
-      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
-      "translated": "من را در جریان جلسات اخیر OpenClaw بگذار و گام‌های بعدی را پیشنهاد کن."
+      "id": "native.android.ebe49a8b8df80bd3",
+      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
+      "translated": "من را در جریان رشته‌های اخیر OpenClaw بگذار و گام‌های بعدی را پیشنهاد کن."
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8074,9 +8149,9 @@
       "translated": "متصل"
     },
     {
-      "id": "native.android.81931886b9caf3ab",
-      "source": "Sessions",
-      "translated": "جلسات"
+      "id": "native.android.6cf5d6fa8a4186d5",
+      "source": "Threads",
+      "translated": "رشته‌ها"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,9 +10869,9 @@
       "translated": "دوست دارید روی چه چیزی کار کنید؟"
     },
     {
-      "id": "native.apple.32179ce0b6d4543f",
-      "source": "The session attaches once the gateway is ready.",
-      "translated": "پس از آماده شدن Gateway، نشست متصل می‌شود."
+      "id": "native.apple.4da775013ac9b123",
+      "source": "The thread attaches once the gateway is ready.",
+      "translated": "پس از آماده شدن Gateway، رشته متصل می‌شود."
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10844,9 +10919,9 @@
       "translated": "گزینه‌های نشست جدید…"
     },
     {
-      "id": "native.apple.a1b0d289758e2213",
-      "source": "Sessions…",
-      "translated": "نشست‌ها…"
+      "id": "native.apple.003b25ddafeb18e9",
+      "source": "Threads…",
+      "translated": "رشته‌ها…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11009,14 +11084,14 @@
       "translated": "ایجاد"
     },
     {
-      "id": "native.apple.f488b9caf6e51ac3",
-      "source": "Delete Session?",
-      "translated": "جلسه حذف شود؟"
+      "id": "native.apple.31d5c7287cfb3abe",
+      "source": "Delete Thread?",
+      "translated": "رشته حذف شود؟"
     },
     {
-      "id": "native.apple.8634b17be9b111bc",
-      "source": "Delete Session",
-      "translated": "حذف جلسه"
+      "id": "native.apple.d3395564809f1120",
+      "source": "Delete Thread",
+      "translated": "حذف رشته"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11024,9 +11099,9 @@
       "translated": "لغو"
     },
     {
-      "id": "native.apple.4a9568ac9b18d8d3",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "این کار جلسه و رونوشت آن را برای همیشه حذف می‌کند."
+      "id": "native.apple.092659256d26cb03",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "این کار رشته و رونوشت آن را برای همیشه حذف می‌کند."
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11054,9 +11129,9 @@
       "translated": "گروه جدید"
     },
     {
-      "id": "native.apple.5bccdc23a1640895",
-      "source": "Rename Session",
-      "translated": "تغییر نام جلسه"
+      "id": "native.apple.683032464c497bbd",
+      "source": "Rename Thread",
+      "translated": "تغییر نام رشته"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11064,9 +11139,9 @@
       "translated": "نام گروه"
     },
     {
-      "id": "native.apple.af789b2d2fda0f67",
-      "source": "Session name",
-      "translated": "نام جلسه"
+      "id": "native.apple.f887aa956588f237",
+      "source": "Thread name",
+      "translated": "نام رشته"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11104,14 +11179,14 @@
       "translated": "عامل‌ها"
     },
     {
-      "id": "native.apple.a3bde8045fe9224a",
-      "source": "Agent session",
-      "translated": "جلسه عامل"
+      "id": "native.apple.7c8231b7b1ca480f",
+      "source": "Agent thread",
+      "translated": "رشته عامل"
     },
     {
-      "id": "native.apple.27f775de30b37ff8",
-      "source": "Recent sessions",
-      "translated": "جلسه‌های اخیر"
+      "id": "native.apple.b3c553614f762a58",
+      "source": "Recent threads",
+      "translated": "رشته‌های اخیر"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11119,9 +11194,9 @@
       "translated": "Gateway آفلاین است"
     },
     {
-      "id": "native.apple.28c97cf23665ee01",
-      "source": "No recent sessions",
-      "translated": "جلسه اخیر وجود ندارد"
+      "id": "native.apple.5aa32afda85064ea",
+      "source": "No recent threads",
+      "translated": "هیچ رشته اخیری وجود ندارد"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11219,14 +11294,14 @@
       "translated": "لغو"
     },
     {
-      "id": "native.apple.9f2fd65953013b7c",
-      "source": "Sessions",
-      "translated": "جلسه‌ها"
+      "id": "native.apple.b6855cf19a50f477",
+      "source": "Threads",
+      "translated": "رشته‌ها"
     },
     {
-      "id": "native.apple.0422818cc95d5071",
-      "source": "Archived sessions",
-      "translated": "جلسه‌های بایگانی‌شده"
+      "id": "native.apple.9b1d0ef27a1333b0",
+      "source": "Archived threads",
+      "translated": "رشته‌های بایگانی‌شده"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11234,34 +11309,34 @@
       "translated": "نمایش بایگانی‌شده‌ها"
     },
     {
-      "id": "native.apple.b272115c83f7ef58",
-      "source": "Sessions unavailable",
-      "translated": "جلسه‌ها در دسترس نیستند"
+      "id": "native.apple.98167401c7267735",
+      "source": "Threads unavailable",
+      "translated": "رشته‌ها در دسترس نیستند"
     },
     {
-      "id": "native.apple.54f8260c9b863087",
-      "source": "Loading archived sessions",
-      "translated": "در حال بارگیری جلسه‌های بایگانی‌شده"
+      "id": "native.apple.4d28a7def2337b9f",
+      "source": "Loading archived threads",
+      "translated": "در حال بارگذاری رشته‌های بایگانی‌شده"
     },
     {
-      "id": "native.apple.9b305868873dade2",
-      "source": "Loading recent sessions",
-      "translated": "در حال بارگیری جلسه‌های اخیر"
+      "id": "native.apple.777d7b706933bd7b",
+      "source": "Loading recent threads",
+      "translated": "در حال بارگذاری رشته‌های اخیر"
     },
     {
-      "id": "native.apple.207dad20d09f3160",
-      "source": "^[\\(count) session](inflect: true)",
-      "translated": "^[\\(count) نشست](inflect: true)"
+      "id": "native.apple.22f81ea94bef8410",
+      "source": "^[\\(count) thread](inflect: true)",
+      "translated": "^[\\(count) رشته](inflect: true)"
     },
     {
-      "id": "native.apple.1f4501a6bf2bae4c",
-      "source": "No archived sessions",
-      "translated": "جلسه بایگانی‌شده‌ای وجود ندارد"
+      "id": "native.apple.1cad51e14db59bf9",
+      "source": "No archived threads",
+      "translated": "هیچ رشته بایگانی‌شده‌ای وجود ندارد"
     },
     {
-      "id": "native.apple.2a1ba7a5e1979c9e",
-      "source": "Archived sessions will appear here.",
-      "translated": "جلسات بایگانی‌شده اینجا نمایش داده می‌شوند."
+      "id": "native.apple.18ef832d3a7ddcf8",
+      "source": "Archived threads will appear here.",
+      "translated": "رشته‌های بایگانی‌شده اینجا نمایش داده می‌شوند."
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11344,9 +11419,9 @@
       "translated": "اشتراک‌گذاری ورودی"
     },
     {
-      "id": "native.apple.2360d25fe6ae9946",
-      "source": "Loading sessions",
-      "translated": "در حال بارگذاری نشست‌ها"
+      "id": "native.apple.21d9208d86a4d1fe",
+      "source": "Loading threads",
+      "translated": "در حال بارگذاری رشته‌ها"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11354,19 +11429,19 @@
       "translated": "در حال دریافت فعالیت اخیر از Gateway."
     },
     {
-      "id": "native.apple.c334f2e86702a7b8",
-      "source": "Sessions unavailable",
-      "translated": "نشست‌ها در دسترس نیستند"
+      "id": "native.apple.4be1f79aa2b230ff",
+      "source": "Threads unavailable",
+      "translated": "رشته‌ها در دسترس نیستند"
     },
     {
-      "id": "native.apple.6cc6efb7a03960b6",
-      "source": "No recent sessions",
-      "translated": "نشست اخیر وجود ندارد"
+      "id": "native.apple.98b348873556bc46",
+      "source": "No recent threads",
+      "translated": "هیچ رشته اخیری وجود ندارد"
     },
     {
-      "id": "native.apple.08483af2d043bee6",
-      "source": "Session activity offline",
-      "translated": "فعالیت نشست آفلاین است"
+      "id": "native.apple.7396d205574d279f",
+      "source": "Thread activity offline",
+      "translated": "فعالیت رشته آفلاین است"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11824,9 +11899,9 @@
       "translated": "کارت"
     },
     {
-      "id": "native.apple.93eeaedb2ff61043",
-      "source": "Open Session",
-      "translated": "باز کردن نشست"
+      "id": "native.apple.c9ec1b0e18074d8a",
+      "source": "Open Thread",
+      "translated": "باز کردن رشته"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13314,9 +13389,9 @@
       "translated": "پیش‌فرض"
     },
     {
-      "id": "native.apple.3de045f17ea3c6d0",
-      "source": "Used for new Chat and Talk sessions.",
-      "translated": "برای جلسه‌های جدید Chat و Talk استفاده می‌شود."
+      "id": "native.apple.f4ae5664c3eda95d",
+      "source": "Used for new Chat threads and Talk sessions.",
+      "translated": "برای رشته‌های گفت‌وگوی جدید و نشست‌های مکالمه استفاده می‌شود."
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15719,9 +15794,9 @@
       "translated": "نمونه‌ها"
     },
     {
-      "id": "native.apple.3579cf2750470a22",
-      "source": "Sessions",
-      "translated": "نشست‌ها"
+      "id": "native.apple.11fe8b9941954dfb",
+      "source": "Threads",
+      "translated": "رشته‌ها"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19029,9 +19104,9 @@
       "translated": "میان‌بر گفت‌وگوی سریع"
     },
     {
-      "id": "native.apple.6ae77665b5f4490f",
-      "source": "Global shortcut that opens a floating chat bar for the main session.",
-      "translated": "میان‌بر سراسری که نوار گفت‌وگوی شناور را برای نشست اصلی باز می‌کند."
+      "id": "native.apple.94dd793cd7d7d555",
+      "source": "Global shortcut that opens a floating chat bar for the main thread.",
+      "translated": "میان‌بر سراسری که یک نوار گفت‌وگوی شناور برای رشته اصلی باز می‌کند."
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19609,9 +19684,9 @@
       "translated": "بحرانی"
     },
     {
-      "id": "native.apple.75102378a6775180",
-      "source": "New Session",
-      "translated": "جلسه جدید"
+      "id": "native.apple.13f96467014cf344",
+      "source": "New Thread",
+      "translated": "رشته جدید"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21899,9 +21974,9 @@
       "translated": "پیام جدیدی نیست"
     },
     {
-      "id": "native.apple.1ff8aec0044934c3",
-      "source": "Sessions",
-      "translated": "جلسه‌ها"
+      "id": "native.apple.3ec2afcbc298c673",
+      "source": "Threads",
+      "translated": "رشته‌ها"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21909,9 +21984,9 @@
       "translated": "نگاهی به سطل‌های مکالمهٔ ذخیره‌شده بیندازید که CLI برای زمینه و محدودیت‌های نرخ دوباره استفاده می‌کند."
     },
     {
-      "id": "native.apple.bab897f3252b134c",
-      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
-      "translated": "هنوز جلسه‌ای وجود ندارد. پس از نخستین پیام ورودی یا heartbeat ظاهر می‌شوند."
+      "id": "native.apple.14ccb32cd8ed1c81",
+      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
+      "translated": "هنوز رشته‌ای وجود ندارد. رشته‌ها پس از نخستین پیام ورودی یا سیگنال ضربان قلب نمایش داده می‌شوند."
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -21994,9 +22069,9 @@
       "translated": "تأییدیه‌های اجرا"
     },
     {
-      "id": "native.apple.64a6dc7d49e8fb57",
-      "source": "Sessions",
-      "translated": "جلسه‌ها"
+      "id": "native.apple.52e37e3a44ae516c",
+      "source": "Threads",
+      "translated": "رشته‌ها"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -22999,9 +23074,9 @@
       "translated": "من را در جریان بگذار"
     },
     {
-      "id": "native.apple.234ec45f4231edc4",
-      "source": "Summarize what happened in my sessions since yesterday.",
-      "translated": "اتفاقات جلسه‌هایم از دیروز تاکنون را خلاصه کن."
+      "id": "native.apple.fc4ce810900ec0b6",
+      "source": "Summarize what happened in my threads since yesterday.",
+      "translated": "آنچه از دیروز در رشته‌هایم رخ داده است را خلاصه کن."
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23179,9 +23254,9 @@
       "translated": "برداشتن سنجاق مدل"
     },
     {
-      "id": "native.apple.5dfc0700d8dff8de",
-      "source": "Session",
-      "translated": "جلسه"
+      "id": "native.apple.4edb66657f5aca1f",
+      "source": "Thread",
+      "translated": "رشته"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23344,6 +23419,51 @@
       "translated": "ویجت در دسترس نیست"
     },
     {
+      "id": "native.apple.d640691fd196f338",
+      "source": "Widget export failed",
+      "translated": "برون‌بری ویجت ناموفق بود"
+    },
+    {
+      "id": "native.apple.533c6e22a11e88de",
+      "source": "OK",
+      "translated": "تأیید"
+    },
+    {
+      "id": "native.apple.e1fb28a2a9756402",
+      "source": "Copy image",
+      "translated": "کپی تصویر"
+    },
+    {
+      "id": "native.apple.ebd7bc92e1b12235",
+      "source": "Save image…",
+      "translated": "ذخیره تصویر…"
+    },
+    {
+      "id": "native.apple.742c46d4cf2db134",
+      "source": "Save image",
+      "translated": "ذخیره تصویر"
+    },
+    {
+      "id": "native.apple.0589cce608418f90",
+      "source": "The widget image could not be captured.",
+      "translated": "ثبت تصویر ویجت ممکن نبود."
+    },
+    {
+      "id": "native.apple.dfe24e827fdbe9c5",
+      "source": "The widget image could not be copied.",
+      "translated": "کپی تصویر ویجت ممکن نبود."
+    },
+    {
+      "id": "native.apple.9e611e3a80e71408",
+      "source": "The widget image could not be encoded as PNG.",
+      "translated": "رمزگذاری تصویر ویجت با قالب PNG ممکن نبود."
+    },
+    {
+      "id": "native.apple.9a6e8afbe24a262b",
+      "source": "The widget image could not be saved.",
+      "translated": "ذخیره تصویر ویجت ممکن نبود."
+    },
+    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23484,19 +23604,19 @@
       "translated": "کاربر"
     },
     {
-      "id": "native.apple.b1cdcb906a43d5d6",
-      "source": "This session cannot be archived while it is active or running.",
-      "translated": "این نشست تا زمانی که فعال یا در حال اجرا است، قابل بایگانی نیست."
+      "id": "native.apple.9d0cba09d92ee669",
+      "source": "This thread cannot be archived while it is active or running.",
+      "translated": "تا زمانی که این رشته فعال یا در حال اجرا است، نمی‌توان آن را بایگانی کرد."
     },
     {
-      "id": "native.apple.5817e3f3dab1ee19",
-      "source": "The main session cannot be deleted.",
-      "translated": "نشست اصلی قابل حذف نیست."
+      "id": "native.apple.8952a111a1075051",
+      "source": "The main thread cannot be deleted.",
+      "translated": "رشته اصلی را نمی‌توان حذف کرد."
     },
     {
-      "id": "native.apple.a6b8df3f18171c91",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
-      "translated": "پیش از بایگانی یا حذف این نشست، پیوست‌ها را حذف کنید یا منتظر تحویل آن‌ها بمانید."
+      "id": "native.apple.90d0ccf80ca28717",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
+      "translated": "پیش از بایگانی یا حذف این رشته، پیوست‌ها را حذف کنید یا منتظر تحویل آن‌ها بمانید."
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23634,9 +23754,9 @@
       "translated": "اجرا پایان یافت"
     },
     {
-      "id": "native.apple.cd7c3095a22f80a9",
-      "source": "Session Info",
-      "translated": "اطلاعات نشست"
+      "id": "native.apple.bbccb4c8db5cac12",
+      "source": "Thread Info",
+      "translated": "اطلاعات رشته"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23669,9 +23789,9 @@
       "translated": "افزودن گروه"
     },
     {
-      "id": "native.apple.23d628606fe0734f",
-      "source": "Session Groups",
-      "translated": "گروه‌های نشست"
+      "id": "native.apple.7b641fed5bace855",
+      "source": "Thread Groups",
+      "translated": "گروه‌های رشته"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23714,9 +23834,9 @@
       "translated": "حذف گروه"
     },
     {
-      "id": "native.apple.b049c8a4d2805e08",
-      "source": "Sessions in this group become ungrouped.",
-      "translated": "نشست‌های این گروه از گروه خارج می‌شوند."
+      "id": "native.apple.56401c79410a310d",
+      "source": "Threads in this group become ungrouped.",
+      "translated": "رشته‌های این گروه از حالت گروه‌بندی خارج می‌شوند."
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23729,9 +23849,9 @@
       "translated": "هیچ عاملی در این Gateway در دسترس نیست."
     },
     {
-      "id": "native.apple.6c89f35d53506406",
-      "source": "New Session Options",
-      "translated": "گزینه‌های نشست جدید"
+      "id": "native.apple.2d96aa7d3d12f85b",
+      "source": "New Thread Options",
+      "translated": "گزینه‌های رشته جدید"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23759,19 +23879,19 @@
       "translated": "ایجاد"
     },
     {
-      "id": "native.apple.795ba37f6782cf28",
-      "source": "The session could not be created.",
-      "translated": "جلسه ایجاد نشد."
+      "id": "native.apple.87ef57319d1ddc85",
+      "source": "The thread could not be created.",
+      "translated": "رشته ایجاد نشد."
     },
     {
-      "id": "native.apple.8ec708a3605a2cc3",
-      "source": "Search sessions",
-      "translated": "جستجوی نشست‌ها"
+      "id": "native.apple.6bd91c435b69d638",
+      "source": "Search threads",
+      "translated": "جستجوی رشته‌ها"
     },
     {
-      "id": "native.apple.23b069b4e7f97039",
-      "source": "No Sessions",
-      "translated": "هیچ نشستی وجود ندارد"
+      "id": "native.apple.6fde4bdf9d5b9191",
+      "source": "No Threads",
+      "translated": "رشته‌ای وجود ندارد"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23779,29 +23899,29 @@
       "translated": "نتیجه‌ای یافت نشد"
     },
     {
-      "id": "native.apple.0058923f2ce8a3ec",
-      "source": "New Session",
-      "translated": "نشست جدید"
+      "id": "native.apple.a02fd99740d29bd3",
+      "source": "New Thread",
+      "translated": "رشته جدید"
     },
     {
-      "id": "native.apple.66ba42960eb4135b",
-      "source": "New session",
-      "translated": "نشست جدید"
+      "id": "native.apple.b625801dd04b09f2",
+      "source": "New thread",
+      "translated": "رشته جدید"
     },
     {
-      "id": "native.apple.2ef0e34db02ad255",
-      "source": "New session options",
-      "translated": "گزینه‌های نشست جدید"
+      "id": "native.apple.851be81fcc933608",
+      "source": "New thread options",
+      "translated": "گزینه‌های رشته جدید"
     },
     {
-      "id": "native.apple.36753ef2f1ed4264",
-      "source": "Rename Session",
-      "translated": "تغییر نام نشست"
+      "id": "native.apple.9ce8a4aba7b444b2",
+      "source": "Rename Thread",
+      "translated": "تغییر نام رشته"
     },
     {
-      "id": "native.apple.c9de0a1510ef475f",
-      "source": "Session name",
-      "translated": "نام نشست"
+      "id": "native.apple.1dd067c44511c7f0",
+      "source": "Thread name",
+      "translated": "نام رشته"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23814,14 +23934,14 @@
       "translated": "لغو"
     },
     {
-      "id": "native.apple.afb4e6c99c63a28d",
-      "source": "Delete Session",
-      "translated": "حذف نشست"
+      "id": "native.apple.618073d6ab3f2721",
+      "source": "Delete Thread",
+      "translated": "حذف رشته"
     },
     {
-      "id": "native.apple.3d4ef32e42f136a4",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "نشست و رونوشت آن از Gateway حذف می‌شوند."
+      "id": "native.apple.10a5e72bba3cbccc",
+      "source": "The thread and its transcript are removed from the gateway.",
+      "translated": "رشته و رونوشت آن از Gateway حذف می‌شوند."
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23829,14 +23949,14 @@
       "translated": "«%@» حذف شود؟"
     },
     {
-      "id": "native.apple.9a7dca238fba628d",
-      "source": "Session running",
-      "translated": "نشست در حال اجرا است"
+      "id": "native.apple.ac71e3b2aa496a2c",
+      "source": "Thread running",
+      "translated": "رشته در حال اجراست"
     },
     {
-      "id": "native.apple.fcfbfe5e97a95e9c",
-      "source": "Session failed",
-      "translated": "نشست ناموفق بود"
+      "id": "native.apple.c775e87f997278b2",
+      "source": "Thread failed",
+      "translated": "رشته ناموفق بود"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23894,9 +24014,9 @@
       "translated": "کپی کلید نشست"
     },
     {
-      "id": "native.apple.4aeb7c14c26dabac",
-      "source": "Delete Session…",
-      "translated": "حذف نشست…"
+      "id": "native.apple.f4998cfb572f23ff",
+      "source": "Delete Thread…",
+      "translated": "حذف رشته…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23909,9 +24029,9 @@
       "translated": "در حال اتصال…"
     },
     {
-      "id": "native.apple.79f708b3bc1d3a6c",
-      "source": "Retry session groups",
-      "translated": "تلاش مجدد برای گروه‌های نشست"
+      "id": "native.apple.8802e9576ffd0f65",
+      "source": "Retry thread groups",
+      "translated": "تلاش مجدد برای بارگیری گروه‌های رشته"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23934,24 +24054,24 @@
       "translated": "دامنه"
     },
     {
-      "id": "native.apple.2c37581c7b88f741",
-      "source": "Search sessions",
-      "translated": "جستجوی نشست‌ها"
+      "id": "native.apple.b313b80def4bda52",
+      "source": "Search threads",
+      "translated": "جستجوی رشته‌ها"
     },
     {
-      "id": "native.apple.43be8a2336e42faf",
-      "source": "Sessions",
-      "translated": "جلسه‌ها"
+      "id": "native.apple.c0cc6acc36f413ce",
+      "source": "Threads",
+      "translated": "رشته‌ها"
     },
     {
-      "id": "native.apple.0b379cdfcbd3247f",
-      "source": "Rename Session",
-      "translated": "تغییر نام نشست"
+      "id": "native.apple.854d3928fe5a557c",
+      "source": "Rename Thread",
+      "translated": "تغییر نام رشته"
     },
     {
-      "id": "native.apple.54b6fbd9e41db009",
-      "source": "Session name",
-      "translated": "نام نشست"
+      "id": "native.apple.9d0d3f20096cc4da",
+      "source": "Thread name",
+      "translated": "نام رشته"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -23959,19 +24079,19 @@
       "translated": "لغو"
     },
     {
-      "id": "native.apple.751e0f6b81cd374a",
-      "source": "Delete selected sessions?",
-      "translated": "نشست‌های انتخاب‌شده حذف شوند؟"
+      "id": "native.apple.dc00eb94f33bae15",
+      "source": "Delete selected threads?",
+      "translated": "رشته‌های انتخاب‌شده حذف شوند؟"
     },
     {
-      "id": "native.apple.aa679276581b0058",
-      "source": "Delete Sessions",
-      "translated": "حذف نشست‌ها"
+      "id": "native.apple.2053fc9f74dc3158",
+      "source": "Delete Threads",
+      "translated": "حذف رشته‌ها"
     },
     {
-      "id": "native.apple.f837129cbee23297",
-      "source": "Each selected session and its transcript will be removed from the gateway.",
-      "translated": "هر نشست انتخاب‌شده و رونوشت آن از Gateway حذف خواهد شد."
+      "id": "native.apple.0970247871a834a0",
+      "source": "Each selected thread and its transcript will be removed from the gateway.",
+      "translated": "هر رشته انتخاب‌شده و رونوشت آن از Gateway حذف خواهد شد."
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -23979,9 +24099,9 @@
       "translated": "گروه‌ها"
     },
     {
-      "id": "native.apple.64013cfee5e25305",
-      "source": "Manage session groups",
-      "translated": "مدیریت گروه‌های نشست"
+      "id": "native.apple.6f8acab2256728b5",
+      "source": "Manage thread groups",
+      "translated": "مدیریت گروه‌های رشته"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -23994,14 +24114,14 @@
       "translated": "انتخاب"
     },
     {
-      "id": "native.apple.b67eaecec1b423ac",
-      "source": "No archived sessions",
-      "translated": "نشست بایگانی‌شده‌ای وجود ندارد"
+      "id": "native.apple.692972314d04b184",
+      "source": "No archived threads",
+      "translated": "هیچ رشته بایگانی‌شده‌ای وجود ندارد"
     },
     {
-      "id": "native.apple.b2435a79abf0c794",
-      "source": "No sessions found",
-      "translated": "نشستی یافت نشد"
+      "id": "native.apple.d6a4b5711dcd26e7",
+      "source": "No threads found",
+      "translated": "هیچ رشته‌ای یافت نشد"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24169,6 +24289,16 @@
       "translated": "باز کردن پیام کامل"
     },
     {
+      "id": "native.apple.002bfcede229ad4b",
+      "source": "Rewind to Here",
+      "translated": "بازگشت به اینجا"
+    },
+    {
+      "id": "native.apple.14df2e4997689fb3",
+      "source": "Fork from Here",
+      "translated": "انشعاب از اینجا"
+    },
+    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "پاسخ"
@@ -24254,9 +24384,9 @@
       "translated": "پیش از شروع گفت‌وگوی جدید، پیوست‌ها را حذف کنید یا منتظر بمانید تا ارسال آن‌ها تکمیل شود."
     },
     {
-      "id": "native.apple.980f552bb0f96c0f",
-      "source": "Gateway changed before the session operation started.",
-      "translated": "Gateway پیش از شروع عملیات نشست تغییر کرد."
+      "id": "native.apple.e0f045151c8d3137",
+      "source": "Gateway changed before the thread operation started.",
+      "translated": "Gateway پیش از شروع عملیات رشته تغییر کرد."
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24264,9 +24394,9 @@
       "translated": "پیش از تغییر گفتگو، پیوست‌ها را حذف کنید یا منتظر تکمیل ارسال بمانید."
     },
     {
-      "id": "native.apple.87ba543b42696b92",
-      "source": "Clear this session's history?",
-      "translated": "تاریخچه این نشست پاک شود؟"
+      "id": "native.apple.0a5c4e15466c3acc",
+      "source": "Clear this thread's history?",
+      "translated": "تاریخچه این رشته پاک شود؟"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24279,14 +24409,14 @@
       "translated": "با این کار مکالمه برای %@ بازنشانی می‌شود. کلید نشست بدون تغییر باقی می‌ماند."
     },
     {
-      "id": "native.apple.a92e96bed98bd553",
-      "source": "Rename Session",
-      "translated": "تغییر نام نشست"
+      "id": "native.apple.67ac221dbe7179f0",
+      "source": "Rename Thread",
+      "translated": "تغییر نام رشته"
     },
     {
-      "id": "native.apple.848e2388f3466f40",
-      "source": "Session name",
-      "translated": "نام نشست"
+      "id": "native.apple.cf0f7e049603f518",
+      "source": "Thread name",
+      "translated": "نام رشته"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24304,9 +24434,9 @@
       "translated": "خروجی گرفتن رونوشت"
     },
     {
-      "id": "native.apple.4af0f566d39d7041",
-      "source": "Sessions",
-      "translated": "جلسه‌ها"
+      "id": "native.apple.c0ada47504425f23",
+      "source": "Threads",
+      "translated": "رشته‌ها"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24379,14 +24509,14 @@
       "translated": "پیش‌فرض"
     },
     {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "نشست جدید"
+      "id": "native.apple.1a765291943599e5",
+      "source": "New Thread",
+      "translated": "رشته جدید"
     },
     {
-      "id": "native.apple.a7119fbf9d25df5e",
-      "source": "New Session Options…",
-      "translated": "گزینه‌های نشست جدید…"
+      "id": "native.apple.c7a3a6d5e43dd98f",
+      "source": "New Thread Options…",
+      "translated": "گزینه‌های رشته جدید…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24394,19 +24524,19 @@
       "translated": "بازخوانی"
     },
     {
-      "id": "native.apple.2bcff4a8fa503739",
-      "source": "Sessions…",
-      "translated": "جلسه‌ها…"
+      "id": "native.apple.0e710b81808e5dcf",
+      "source": "Threads…",
+      "translated": "رشته‌ها…"
     },
     {
-      "id": "native.apple.c36e008b051adb38",
-      "source": "Rename Session…",
-      "translated": "تغییر نام نشست…"
+      "id": "native.apple.faad8f92b6bef166",
+      "source": "Rename Thread…",
+      "translated": "تغییر نام رشته…"
     },
     {
-      "id": "native.apple.ea0ef95a159bffe0",
-      "source": "Fork Session",
-      "translated": "انشعاب نشست"
+      "id": "native.apple.23b61d6cd26ac112",
+      "source": "Fork",
+      "translated": "انشعاب"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24464,24 +24594,24 @@
       "translated": "پاک کردن تاریخچه…"
     },
     {
-      "id": "native.apple.920fe8a7a33f9e92",
-      "source": "Session",
-      "translated": "نشست"
+      "id": "native.apple.8b4f1c5107ea8a0e",
+      "source": "Thread",
+      "translated": "رشته"
     },
     {
-      "id": "native.apple.185a401f78328b0f",
-      "source": "Session actions",
-      "translated": "کنش‌های نشست"
+      "id": "native.apple.4d7750c9bf699469",
+      "source": "Thread actions",
+      "translated": "اقدامات رشته"
     },
     {
-      "id": "native.apple.9f9dedf599b2619b",
-      "source": "Session cost %@",
-      "translated": "هزینه نشست %@"
+      "id": "native.apple.bb2f22cc43c97f8e",
+      "source": "Thread cost %@",
+      "translated": "هزینه رشته %@"
     },
     {
-      "id": "native.apple.f0a4720df5f5f403",
-      "source": "Compact Session",
-      "translated": "فشرده‌سازی نشست"
+      "id": "native.apple.6239ced0b86e86f8",
+      "source": "Compact Thread",
+      "translated": "فشرده‌سازی رشته"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/fa.json
+++ b/apps/.i18n/native/fa.json
@@ -1429,9 +1429,9 @@
       "translated": "با OpenClaw صحبت یا دیکته کنید"
     },
     {
-      "id": "native.android.e2cf5a38587382cb",
-      "source": "Browse Threads",
-      "translated": "مرور رشته‌ها"
+      "id": "native.android.5876e15e5e92fd45",
+      "source": "Browse Sessions",
+      "translated": "مرور نشست‌ها"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "اقدامی پیدا نشد"
     },
     {
-      "id": "native.android.bc70a4ac965b82ba",
-      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
-      "translated": "گفت‌وگو، صدا، رشته‌ها، ارائه‌دهندگان یا تنظیمات را امتحان کنید."
+      "id": "native.android.48ad0ae0e930e02b",
+      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
+      "translated": "Chat، Voice، Sessions، Providers یا Settings را امتحان کنید."
     },
     {
-      "id": "native.android.670121e54dbe286f",
-      "source": "Threads",
-      "translated": "رشته‌ها"
+      "id": "native.android.d4fbd1ee4f55a5db",
+      "source": "Sessions",
+      "translated": "جلسه‌ها"
     },
     {
-      "id": "native.android.d38be650b1bce4a0",
-      "source": "Connect the Gateway to search threads.",
-      "translated": "برای جست‌وجوی رشته‌ها، به Gateway متصل شوید."
+      "id": "native.android.207c2170504e99e6",
+      "source": "Connect the Gateway to search sessions.",
+      "translated": "برای جستجوی جلسه‌ها، Gateway را متصل کنید."
     },
     {
-      "id": "native.android.3d7754721f776ef8",
-      "source": "No matching threads yet.",
-      "translated": "هنوز رشته منطبقی وجود ندارد."
+      "id": "native.android.25d2c2d792c952fe",
+      "source": "No matching sessions yet.",
+      "translated": "هنوز جلسهٔ مطابقی وجود ندارد."
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "دستیار در حال کار است"
     },
     {
-      "id": "native.android.9a839f6e3e05a744",
-      "source": "OpenClaw thread",
-      "translated": "رشته OpenClaw"
+      "id": "native.android.8f8384286317f5c9",
+      "source": "OpenClaw session",
+      "translated": "جلسه OpenClaw"
     },
     {
-      "id": "native.android.d83f82a1e4a5ed99",
-      "source": "Open thread",
-      "translated": "باز کردن رشته"
+      "id": "native.android.15799e57704b20c6",
+      "source": "Open session",
+      "translated": "باز کردن جلسه"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "هیچ ارائه‌دهنده آماده‌ای وجود ندارد"
     },
     {
-      "id": "native.android.8a1c5365c0538908",
-      "source": "Main thread",
-      "translated": "رشته اصلی"
+      "id": "native.android.73e6ab1a168fd381",
+      "source": "Main session",
+      "translated": "نشست اصلی"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.a5845742daecb4ba",
-      "source": "Threads",
-      "translated": "رشته‌ها"
+      "id": "native.android.0e3157c15c56944f",
+      "source": "Sessions",
+      "translated": "نشست‌ها"
     },
     {
-      "id": "native.android.439b324280869527",
-      "source": "Focus thread search",
-      "translated": "تمرکز روی جست‌وجوی رشته‌ها"
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "تمرکز روی جست‌وجوی نشست"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "بایگانی‌شده"
     },
     {
-      "id": "native.android.03981341841b04ac",
-      "source": "Search threads",
-      "translated": "جست‌وجوی رشته‌ها"
+      "id": "native.android.b9cf34c137e4cf03",
+      "source": "Search sessions",
+      "translated": "جستجوی نشست‌ها"
     },
     {
-      "id": "native.android.99570c528a41fa72",
-      "source": "Clear thread search",
-      "translated": "پاک کردن جست‌وجوی رشته‌ها"
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "پاک‌کردن جست‌وجوی نشست"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "ابتدا قدیمی‌ترین"
     },
     {
-      "id": "native.android.fd67be543e321cc9",
-      "source": "Toggle thread layout",
-      "translated": "تغییر چیدمان رشته‌ها"
+      "id": "native.android.c6bf8751e2a7f5c7",
+      "source": "Toggle session layout",
+      "translated": "تغییر چیدمان نشست‌ها"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "چیدمان: با جزئیات"
     },
     {
-      "id": "native.android.ebd17565e0ffd8eb",
-      "source": "Searching threads",
-      "translated": "در حال جست‌وجوی رشته‌ها"
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "در حال جست‌وجوی نشست‌ها"
     },
     {
-      "id": "native.android.472d46ae8669f860",
-      "source": "No matching threads",
-      "translated": "هیچ رشته منطبقی وجود ندارد"
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "هیچ نشست منطبقی یافت نشد"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "شروع گفتگو"
     },
     {
-      "id": "native.android.ff81ad1bee00d384",
-      "source": "Current thread",
-      "translated": "رشته فعلی"
+      "id": "native.android.f10d4df7cbc6df4f",
+      "source": "Current session",
+      "translated": "نشست فعلی"
     },
     {
-      "id": "native.android.fc145645b9620e57",
-      "source": "OpenClaw thread",
-      "translated": "رشته OpenClaw"
+      "id": "native.android.8f0482425838ae64",
+      "source": "OpenClaw session",
+      "translated": "نشست OpenClaw"
     },
     {
-      "id": "native.android.71cbb8dde8bf138b",
-      "source": "Rename thread",
-      "translated": "تغییر نام رشته"
+      "id": "native.android.786774c8a76e50d7",
+      "source": "Rename session",
+      "translated": "تغییر نام جلسه"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "گروه حذف شود؟"
     },
     {
-      "id": "native.android.691e92cfe5cf106e",
-      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "رشته‌های موجود در \"$group\" حفظ می‌شوند و به «بدون گروه» بازمی‌گردند."
+      "id": "native.android.3455fc2f77d564e3",
+      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "نشست‌های موجود در «$group» نگه داشته شده و به گروه‌بندی‌نشده منتقل می‌شوند."
     },
     {
-      "id": "native.android.d87a8217ab56999b",
-      "source": "Delete thread?",
-      "translated": "رشته حذف شود؟"
+      "id": "native.android.4805fb9d6623e8c0",
+      "source": "Delete session?",
+      "translated": "جلسه حذف شود؟"
     },
     {
-      "id": "native.android.930de97ff47113a8",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "این کار رشته و رونوشت آن را برای همیشه حذف می‌کند."
+      "id": "native.android.0c3283a2b2445eae",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "این کار جلسه و رونوشت آن را برای همیشه حذف می‌کند."
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "گروه‌بندی‌نشده"
     },
     {
-      "id": "native.android.8e21a70428def6e0",
-      "source": "No threads yet",
-      "translated": "هنوز رشته‌ای وجود ندارد"
+      "id": "native.android.db243d71d056afa4",
+      "source": "No sessions yet",
+      "translated": "هنوز نشستی وجود ندارد"
     },
     {
-      "id": "native.android.cda4c5ad8b17e394",
-      "source": "No current thread",
-      "translated": "رشته فعالی وجود ندارد"
+      "id": "native.android.5b4eee6a8092925e",
+      "source": "No current session",
+      "translated": "نشست فعلی وجود ندارد"
     },
     {
-      "id": "native.android.be84f061047aa2da",
-      "source": "No archived threads",
-      "translated": "رشته بایگانی‌شده‌ای وجود ندارد"
+      "id": "native.android.acbcc9c9ea53d8c0",
+      "source": "No archived sessions",
+      "translated": "هیچ جلسه بایگانی‌شده‌ای وجود ندارد"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "یک گفتگوی جدید را شروع کنید تا اینجا نمایش داده شود."
     },
     {
-      "id": "native.android.f289d03e1d3eee98",
-      "source": "Open Chat to start or resume the current thread.",
-      "translated": "برای شروع یا ازسرگیری رشته فعلی، گپ را باز کنید."
+      "id": "native.android.56fcd605dc7be3c0",
+      "source": "Open Chat to start or resume the current session.",
+      "translated": "برای شروع یا ازسرگیری نشست فعلی، گفتگو را باز کنید."
     },
     {
-      "id": "native.android.504b71386e76c6ae",
-      "source": "Archived threads will show up here.",
-      "translated": "رشته‌های بایگانی‌شده اینجا نمایش داده می‌شوند."
+      "id": "native.android.085515989f8a2022",
+      "source": "Archived sessions will show up here.",
+      "translated": "جلسه‌های بایگانی‌شده اینجا نمایش داده می‌شوند."
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days} روز"
     },
     {
-      "id": "native.android.ee4c727cdafbe963",
-      "source": "Main thread",
-      "translated": "رشته اصلی"
+      "id": "native.android.3d4fa07acbc015c5",
+      "source": "Main session",
+      "translated": "نشست اصلی"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway در انتظار"
     },
     {
-      "id": "native.android.da78209effb11cfd",
-      "source": "Thread Activity",
-      "translated": "فعالیت رشته"
+      "id": "native.android.2d8d049afe99f751",
+      "source": "Session Activity",
+      "translated": "فعالیت نشست"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "درخواست‌های تأیید اجرا تا زمانی که این تلفن متصل است اینجا نمایش داده می‌شوند."
     },
     {
-      "id": "native.android.f615712dfb56319a",
-      "source": "Thread activity",
-      "translated": "فعالیت رشته"
+      "id": "native.android.dc3e7ca5a491103a",
+      "source": "Session activity",
+      "translated": "فعالیت جلسه"
     },
     {
-      "id": "native.android.6c93973c13db43ae",
-      "source": "Chat tool calls waiting in the active thread remain visible here.",
-      "translated": "فراخوانی‌های ابزار گپ که در رشته فعال منتظر هستند، اینجا قابل مشاهده می‌مانند."
+      "id": "native.android.8551e02b060bd7d8",
+      "source": "Chat tool calls waiting in the active session remain visible here.",
+      "translated": "فراخوانی‌های ابزار چت که در جلسه فعال در انتظار هستند، اینجا قابل مشاهده می‌مانند."
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,11 +4294,6 @@
       "translated": "راه‌اندازی ارائه‌دهنده گفتار"
     },
     {
-      "id": "native.android.23b638094c34b916",
-      "source": "Microphone",
-      "translated": "میکروفون"
-    },
-    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "آزمایش صدا"
@@ -4342,66 +4337,6 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "انجام شد"
-    },
-    {
-      "id": "native.android.8d9ecdfdd916b780",
-      "source": "Automatic",
-      "translated": "خودکار"
-    },
-    {
-      "id": "native.android.c1626a6700a570f6",
-      "source": "Preferred microphone unavailable; using automatic routing.",
-      "translated": "میکروفون ترجیحی در دسترس نیست؛ از مسیریابی خودکار استفاده می‌شود."
-    },
-    {
-      "id": "native.android.820bc5d0ce571d8b",
-      "source": "Prioritizes connected Bluetooth microphones.",
-      "translated": "میکروفون‌های Bluetooth متصل را در اولویت قرار می‌دهد."
-    },
-    {
-      "id": "native.android.11e48038d5e8bff6",
-      "source": "Preferred microphone",
-      "translated": "میکروفون ترجیحی"
-    },
-    {
-      "id": "native.android.eaa4d7563a46d307",
-      "source": "Unavailable",
-      "translated": "در دسترس نیست"
-    },
-    {
-      "id": "native.android.9f5ebf17eb405ba8",
-      "source": "Next session",
-      "translated": "جلسه بعدی"
-    },
-    {
-      "id": "native.android.8c4e91f53928efb2",
-      "source": "Built-in microphone",
-      "translated": "میکروفون داخلی"
-    },
-    {
-      "id": "native.android.14b613cb6e2446b4",
-      "source": "Bluetooth microphone",
-      "translated": "میکروفون Bluetooth"
-    },
-    {
-      "id": "native.android.c885247b2d7ce271",
-      "source": "Bluetooth LE microphone",
-      "translated": "میکروفون Bluetooth LE"
-    },
-    {
-      "id": "native.android.b6a4e674c5fb441a",
-      "source": "Wired headset microphone",
-      "translated": "میکروفون هدست سیمی"
-    },
-    {
-      "id": "native.android.9c8becb3b0fb5a90",
-      "source": "USB microphone",
-      "translated": "میکروفون USB"
-    },
-    {
-      "id": "native.android.ba46258fadec7a39",
-      "source": "External microphone",
-      "translated": "میکروفون خارجی"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5139,9 +5074,9 @@
       "translated": "بررسی"
     },
     {
-      "id": "native.android.c971506716c96e91",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
-      "translated": "OpenClaw این تلفن را به یک رابط فرمان همراه و ساده برای رشته‌ها، صدا، ارائه‌دهندگان و Gateway تبدیل می‌کند."
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw این تلفن را به یک رابط فرمان موبایل ساده برای نشست‌ها، صدا، ارائه‌دهندگان و Gateway تبدیل می‌کند."
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5689,9 +5624,9 @@
       "translated": "تنظیمات Talk"
     },
     {
-      "id": "native.android.36f78c8c85dc283f",
-      "source": "Recent Threads",
-      "translated": "رشته‌های اخیر"
+      "id": "native.android.73f07a5d54915259",
+      "source": "Recent Sessions",
+      "translated": "نشست‌های اخیر"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5749,14 +5684,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}٪ آنلاین"
     },
     {
-      "id": "native.android.57177017a6a93826",
-      "source": "Threads",
-      "translated": "رشته‌ها"
+      "id": "native.android.16c3425d3a594481",
+      "source": "Sessions",
+      "translated": "نشست‌ها"
     },
     {
-      "id": "native.android.43320b54a68b00a1",
-      "source": "No recent threads",
-      "translated": "رشته اخیری وجود ندارد"
+      "id": "native.android.a5c0f8b3112aa58c",
+      "source": "No recent sessions",
+      "translated": "نشست اخیری وجود ندارد"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5794,14 +5729,14 @@
       "translated": "در حال کار · $pendingRunCount اجرای فعال"
     },
     {
-      "id": "native.android.e24db059480f1e6a",
-      "source": "Monitoring · 1 thread",
-      "translated": "در حال پایش · ۱ رشته"
+      "id": "native.android.2c89da708b12a522",
+      "source": "Monitoring · 1 session",
+      "translated": "در حال پایش · ۱ نشست"
     },
     {
-      "id": "native.android.5a475f37d80e02bc",
-      "source": "Monitoring · $sessionCount threads",
-      "translated": "در حال پایش · $sessionCount رشته"
+      "id": "native.android.8b6ee382dcb64e1f",
+      "source": "Monitoring · $sessionCount sessions",
+      "translated": "در حال پایش · $sessionCount نشست"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5834,9 +5769,9 @@
       "translated": "ارائه‌دهندگان"
     },
     {
-      "id": "native.android.358c5e0e838d5423",
-      "source": "Open thread",
-      "translated": "باز کردن رشته"
+      "id": "native.android.a65477861c7203aa",
+      "source": "Open session",
+      "translated": "باز کردن جلسه"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6259,9 +6194,9 @@
       "translated": "${days} روز"
     },
     {
-      "id": "native.android.28a1a1acc5a0959f",
-      "source": "Main thread",
-      "translated": "رشته اصلی"
+      "id": "native.android.22d755834386db07",
+      "source": "Main session",
+      "translated": "نشست اصلی"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6942,16 +6877,6 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "خارج کردن از حالت بی‌صدا"
-    },
-    {
-      "id": "native.android.cb608d82c5b3352a",
-      "source": "Back camera",
-      "translated": "دوربین پشت"
-    },
-    {
-      "id": "native.android.e89a0e780eed2e1e",
-      "source": "Front camera",
-      "translated": "دوربین جلو"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7759,9 +7684,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.0c74bc30a994dd33",
-      "source": "Loading thread",
-      "translated": "در حال بارگیری رشته"
+      "id": "native.android.882cc14a58e7e105",
+      "source": "Loading session",
+      "translated": "در حال بارگذاری نشست"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7804,14 +7729,14 @@
       "translated": "من را در جریان بگذار"
     },
     {
-      "id": "native.android.cf40df9739f78f27",
-      "source": "Summarize recent threads and next steps.",
-      "translated": "رشته‌های اخیر و گام‌های بعدی را خلاصه کنید."
+      "id": "native.android.1e5add56e48c99f9",
+      "source": "Summarize recent sessions and next steps.",
+      "translated": "جلسات اخیر و گام‌های بعدی را خلاصه کن."
     },
     {
-      "id": "native.android.ebe49a8b8df80bd3",
-      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
-      "translated": "خلاصه‌ای از رشته‌های اخیر OpenClaw من ارائه کن و گام‌های بعدی را پیشنهاد بده."
+      "id": "native.android.06d515351bb79576",
+      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
+      "translated": "من را در جریان جلسات اخیر OpenClaw بگذار و گام‌های بعدی را پیشنهاد کن."
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8149,9 +8074,9 @@
       "translated": "متصل"
     },
     {
-      "id": "native.android.6cf5d6fa8a4186d5",
-      "source": "Threads",
-      "translated": "رشته‌ها"
+      "id": "native.android.81931886b9caf3ab",
+      "source": "Sessions",
+      "translated": "جلسات"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,6 +10719,61 @@
       "translated": "جزئیات وظیفه"
     },
     {
+      "id": "native.apple.29cacb53ea5e77fc",
+      "source": "Pinned",
+      "translated": "سنجاق‌شده"
+    },
+    {
+      "id": "native.apple.940062cfdce9211b",
+      "source": "Recent",
+      "translated": "اخیر"
+    },
+    {
+      "id": "native.apple.a0980128426308a9",
+      "source": "Model",
+      "translated": "مدل"
+    },
+    {
+      "id": "native.apple.9520e60f21535dde",
+      "source": "Thinking",
+      "translated": "تفکر"
+    },
+    {
+      "id": "native.apple.8b321f3ffce97429",
+      "source": "Fast",
+      "translated": "سریع"
+    },
+    {
+      "id": "native.apple.989b70d64e328d55",
+      "source": "Default (inherited)",
+      "translated": "پیش‌فرض (به‌ارث‌رسیده)"
+    },
+    {
+      "id": "native.apple.f4114e73b07eb9ae",
+      "source": "Off",
+      "translated": "خاموش"
+    },
+    {
+      "id": "native.apple.7ed231b28d16312f",
+      "source": "On",
+      "translated": "روشن"
+    },
+    {
+      "id": "native.apple.412a74802320a037",
+      "source": "Full",
+      "translated": "کامل"
+    },
+    {
+      "id": "native.apple.299f21a2071ff9fc",
+      "source": "Verbosity",
+      "translated": "میزان جزئیات"
+    },
+    {
+      "id": "native.apple.faf0ef05e1496de7",
+      "source": "Default",
+      "translated": "پیش‌فرض"
+    },
+    {
       "id": "native.apple.e5524d5756a62744",
       "source": "Unable to Export Transcript",
       "translated": "امکان خروجی گرفتن از رونوشت وجود ندارد"
@@ -10814,9 +10794,9 @@
       "translated": "دوست دارید روی چه چیزی کار کنید؟"
     },
     {
-      "id": "native.apple.4da775013ac9b123",
-      "source": "The thread attaches once the gateway is ready.",
-      "translated": "پس از آماده‌شدن Gateway، رشته پیوست می‌شود."
+      "id": "native.apple.32179ce0b6d4543f",
+      "source": "The session attaches once the gateway is ready.",
+      "translated": "پس از آماده شدن Gateway، نشست متصل می‌شود."
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10859,9 +10839,14 @@
       "translated": "چت جدید در Worktree"
     },
     {
-      "id": "native.apple.003b25ddafeb18e9",
-      "source": "Threads…",
-      "translated": "رشته‌ها…"
+      "id": "native.apple.ce6ebe91fc597015",
+      "source": "New Session Options…",
+      "translated": "گزینه‌های نشست جدید…"
+    },
+    {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "نشست‌ها…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11024,14 +11009,14 @@
       "translated": "ایجاد"
     },
     {
-      "id": "native.apple.31d5c7287cfb3abe",
-      "source": "Delete Thread?",
-      "translated": "رشته حذف شود؟"
+      "id": "native.apple.f488b9caf6e51ac3",
+      "source": "Delete Session?",
+      "translated": "جلسه حذف شود؟"
     },
     {
-      "id": "native.apple.d3395564809f1120",
-      "source": "Delete Thread",
-      "translated": "حذف رشته"
+      "id": "native.apple.8634b17be9b111bc",
+      "source": "Delete Session",
+      "translated": "حذف جلسه"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11039,9 +11024,9 @@
       "translated": "لغو"
     },
     {
-      "id": "native.apple.092659256d26cb03",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "این کار رشته و رونوشت آن را برای همیشه حذف می‌کند."
+      "id": "native.apple.4a9568ac9b18d8d3",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "این کار جلسه و رونوشت آن را برای همیشه حذف می‌کند."
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11069,9 +11054,9 @@
       "translated": "گروه جدید"
     },
     {
-      "id": "native.apple.683032464c497bbd",
-      "source": "Rename Thread",
-      "translated": "تغییر نام رشته"
+      "id": "native.apple.5bccdc23a1640895",
+      "source": "Rename Session",
+      "translated": "تغییر نام جلسه"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11079,9 +11064,9 @@
       "translated": "نام گروه"
     },
     {
-      "id": "native.apple.f887aa956588f237",
-      "source": "Thread name",
-      "translated": "نام رشته"
+      "id": "native.apple.af789b2d2fda0f67",
+      "source": "Session name",
+      "translated": "نام جلسه"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11119,14 +11104,14 @@
       "translated": "عامل‌ها"
     },
     {
-      "id": "native.apple.7c8231b7b1ca480f",
-      "source": "Agent thread",
-      "translated": "رشته عامل"
+      "id": "native.apple.a3bde8045fe9224a",
+      "source": "Agent session",
+      "translated": "جلسه عامل"
     },
     {
-      "id": "native.apple.b3c553614f762a58",
-      "source": "Recent threads",
-      "translated": "رشته‌های اخیر"
+      "id": "native.apple.27f775de30b37ff8",
+      "source": "Recent sessions",
+      "translated": "جلسه‌های اخیر"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11134,9 +11119,9 @@
       "translated": "Gateway آفلاین است"
     },
     {
-      "id": "native.apple.5aa32afda85064ea",
-      "source": "No recent threads",
-      "translated": "رشته اخیری وجود ندارد"
+      "id": "native.apple.28c97cf23665ee01",
+      "source": "No recent sessions",
+      "translated": "جلسه اخیر وجود ندارد"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11234,14 +11219,14 @@
       "translated": "لغو"
     },
     {
-      "id": "native.apple.b6855cf19a50f477",
-      "source": "Threads",
-      "translated": "رشته‌ها"
+      "id": "native.apple.9f2fd65953013b7c",
+      "source": "Sessions",
+      "translated": "جلسه‌ها"
     },
     {
-      "id": "native.apple.9b1d0ef27a1333b0",
-      "source": "Archived threads",
-      "translated": "رشته‌های بایگانی‌شده"
+      "id": "native.apple.0422818cc95d5071",
+      "source": "Archived sessions",
+      "translated": "جلسه‌های بایگانی‌شده"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11249,34 +11234,34 @@
       "translated": "نمایش بایگانی‌شده‌ها"
     },
     {
-      "id": "native.apple.98167401c7267735",
-      "source": "Threads unavailable",
-      "translated": "رشته‌ها در دسترس نیستند"
+      "id": "native.apple.b272115c83f7ef58",
+      "source": "Sessions unavailable",
+      "translated": "جلسه‌ها در دسترس نیستند"
     },
     {
-      "id": "native.apple.4d28a7def2337b9f",
-      "source": "Loading archived threads",
-      "translated": "در حال بارگذاری رشته‌های بایگانی‌شده"
+      "id": "native.apple.54f8260c9b863087",
+      "source": "Loading archived sessions",
+      "translated": "در حال بارگیری جلسه‌های بایگانی‌شده"
     },
     {
-      "id": "native.apple.777d7b706933bd7b",
-      "source": "Loading recent threads",
-      "translated": "در حال بارگذاری رشته‌های اخیر"
+      "id": "native.apple.9b305868873dade2",
+      "source": "Loading recent sessions",
+      "translated": "در حال بارگیری جلسه‌های اخیر"
     },
     {
-      "id": "native.apple.22f81ea94bef8410",
-      "source": "^[\\(count) thread](inflect: true)",
-      "translated": "^[\\(count) رشته](inflect: true)"
+      "id": "native.apple.207dad20d09f3160",
+      "source": "^[\\(count) session](inflect: true)",
+      "translated": "^[\\(count) نشست](inflect: true)"
     },
     {
-      "id": "native.apple.1cad51e14db59bf9",
-      "source": "No archived threads",
-      "translated": "رشته بایگانی‌شده‌ای وجود ندارد"
+      "id": "native.apple.1f4501a6bf2bae4c",
+      "source": "No archived sessions",
+      "translated": "جلسه بایگانی‌شده‌ای وجود ندارد"
     },
     {
-      "id": "native.apple.18ef832d3a7ddcf8",
-      "source": "Archived threads will appear here.",
-      "translated": "رشته‌های بایگانی‌شده اینجا نمایش داده می‌شوند."
+      "id": "native.apple.2a1ba7a5e1979c9e",
+      "source": "Archived sessions will appear here.",
+      "translated": "جلسات بایگانی‌شده اینجا نمایش داده می‌شوند."
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11359,9 +11344,9 @@
       "translated": "اشتراک‌گذاری ورودی"
     },
     {
-      "id": "native.apple.21d9208d86a4d1fe",
-      "source": "Loading threads",
-      "translated": "در حال بارگیری رشته‌ها"
+      "id": "native.apple.2360d25fe6ae9946",
+      "source": "Loading sessions",
+      "translated": "در حال بارگذاری نشست‌ها"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11369,19 +11354,19 @@
       "translated": "در حال دریافت فعالیت اخیر از Gateway."
     },
     {
-      "id": "native.apple.4be1f79aa2b230ff",
-      "source": "Threads unavailable",
-      "translated": "رشته‌ها در دسترس نیستند"
+      "id": "native.apple.c334f2e86702a7b8",
+      "source": "Sessions unavailable",
+      "translated": "نشست‌ها در دسترس نیستند"
     },
     {
-      "id": "native.apple.98b348873556bc46",
-      "source": "No recent threads",
-      "translated": "هیچ رشتهٔ اخیری وجود ندارد"
+      "id": "native.apple.6cc6efb7a03960b6",
+      "source": "No recent sessions",
+      "translated": "نشست اخیر وجود ندارد"
     },
     {
-      "id": "native.apple.7396d205574d279f",
-      "source": "Thread activity offline",
-      "translated": "فعالیت رشته آفلاین است"
+      "id": "native.apple.08483af2d043bee6",
+      "source": "Session activity offline",
+      "translated": "فعالیت نشست آفلاین است"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11839,9 +11824,9 @@
       "translated": "کارت"
     },
     {
-      "id": "native.apple.c9ec1b0e18074d8a",
-      "source": "Open Thread",
-      "translated": "باز کردن رشته"
+      "id": "native.apple.93eeaedb2ff61043",
+      "source": "Open Session",
+      "translated": "باز کردن نشست"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13329,9 +13314,9 @@
       "translated": "پیش‌فرض"
     },
     {
-      "id": "native.apple.f4ae5664c3eda95d",
-      "source": "Used for new Chat threads and Talk sessions.",
-      "translated": "برای رشته‌های جدید گفت‌وگو و جلسه‌های مکالمه استفاده می‌شود."
+      "id": "native.apple.3de045f17ea3c6d0",
+      "source": "Used for new Chat and Talk sessions.",
+      "translated": "برای جلسه‌های جدید Chat و Talk استفاده می‌شود."
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15734,9 +15719,9 @@
       "translated": "نمونه‌ها"
     },
     {
-      "id": "native.apple.11fe8b9941954dfb",
-      "source": "Threads",
-      "translated": "رشته‌ها"
+      "id": "native.apple.3579cf2750470a22",
+      "source": "Sessions",
+      "translated": "نشست‌ها"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19044,9 +19029,9 @@
       "translated": "میان‌بر گفت‌وگوی سریع"
     },
     {
-      "id": "native.apple.94dd793cd7d7d555",
-      "source": "Global shortcut that opens a floating chat bar for the main thread.",
-      "translated": "میان‌بر سراسری که یک نوار گفت‌وگوی شناور را برای رشتهٔ اصلی باز می‌کند."
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "میان‌بر سراسری که نوار گفت‌وگوی شناور را برای نشست اصلی باز می‌کند."
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19624,9 +19609,9 @@
       "translated": "بحرانی"
     },
     {
-      "id": "native.apple.13f96467014cf344",
-      "source": "New Thread",
-      "translated": "رشتهٔ جدید"
+      "id": "native.apple.75102378a6775180",
+      "source": "New Session",
+      "translated": "جلسه جدید"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21914,9 +21899,9 @@
       "translated": "پیام جدیدی نیست"
     },
     {
-      "id": "native.apple.3ec2afcbc298c673",
-      "source": "Threads",
-      "translated": "رشته‌ها"
+      "id": "native.apple.1ff8aec0044934c3",
+      "source": "Sessions",
+      "translated": "جلسه‌ها"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21924,9 +21909,9 @@
       "translated": "نگاهی به سطل‌های مکالمهٔ ذخیره‌شده بیندازید که CLI برای زمینه و محدودیت‌های نرخ دوباره استفاده می‌کند."
     },
     {
-      "id": "native.apple.14ccb32cd8ed1c81",
-      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
-      "translated": "هنوز رشته‌ای وجود ندارد. رشته‌ها پس از نخستین پیام ورودی یا ضربان قلب ظاهر می‌شوند."
+      "id": "native.apple.bab897f3252b134c",
+      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
+      "translated": "هنوز جلسه‌ای وجود ندارد. پس از نخستین پیام ورودی یا heartbeat ظاهر می‌شوند."
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -22009,9 +21994,9 @@
       "translated": "تأییدیه‌های اجرا"
     },
     {
-      "id": "native.apple.52e37e3a44ae516c",
-      "source": "Threads",
-      "translated": "رشته‌ها"
+      "id": "native.apple.64a6dc7d49e8fb57",
+      "source": "Sessions",
+      "translated": "جلسه‌ها"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -23014,9 +22999,9 @@
       "translated": "من را در جریان بگذار"
     },
     {
-      "id": "native.apple.fc4ce810900ec0b6",
-      "source": "Summarize what happened in my threads since yesterday.",
-      "translated": "آنچه را از دیروز تاکنون در رشته‌هایم رخ داده است خلاصه کن."
+      "id": "native.apple.234ec45f4231edc4",
+      "source": "Summarize what happened in my sessions since yesterday.",
+      "translated": "اتفاقات جلسه‌هایم از دیروز تاکنون را خلاصه کن."
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23194,9 +23179,9 @@
       "translated": "برداشتن سنجاق مدل"
     },
     {
-      "id": "native.apple.4edb66657f5aca1f",
-      "source": "Thread",
-      "translated": "رشته"
+      "id": "native.apple.5dfc0700d8dff8de",
+      "source": "Session",
+      "translated": "جلسه"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23359,51 +23344,6 @@
       "translated": "ویجت در دسترس نیست"
     },
     {
-      "id": "native.apple.d640691fd196f338",
-      "source": "Widget export failed",
-      "translated": "برون‌بری ویجت ناموفق بود"
-    },
-    {
-      "id": "native.apple.533c6e22a11e88de",
-      "source": "OK",
-      "translated": "تأیید"
-    },
-    {
-      "id": "native.apple.e1fb28a2a9756402",
-      "source": "Copy image",
-      "translated": "کپی تصویر"
-    },
-    {
-      "id": "native.apple.ebd7bc92e1b12235",
-      "source": "Save image…",
-      "translated": "ذخیره تصویر…"
-    },
-    {
-      "id": "native.apple.742c46d4cf2db134",
-      "source": "Save image",
-      "translated": "ذخیره تصویر"
-    },
-    {
-      "id": "native.apple.0589cce608418f90",
-      "source": "The widget image could not be captured.",
-      "translated": "تصویر ویجت ثبت نشد."
-    },
-    {
-      "id": "native.apple.dfe24e827fdbe9c5",
-      "source": "The widget image could not be copied.",
-      "translated": "تصویر ویجت کپی نشد."
-    },
-    {
-      "id": "native.apple.9e611e3a80e71408",
-      "source": "The widget image could not be encoded as PNG.",
-      "translated": "تصویر ویجت با فرمت PNG کدگذاری نشد."
-    },
-    {
-      "id": "native.apple.9a6e8afbe24a262b",
-      "source": "The widget image could not be saved.",
-      "translated": "تصویر ویجت ذخیره نشد."
-    },
-    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23544,19 +23484,19 @@
       "translated": "کاربر"
     },
     {
-      "id": "native.apple.9d0cba09d92ee669",
-      "source": "This thread cannot be archived while it is active or running.",
-      "translated": "تا زمانی که این رشته فعال یا در حال اجرا است، نمی‌توان آن را بایگانی کرد."
+      "id": "native.apple.b1cdcb906a43d5d6",
+      "source": "This session cannot be archived while it is active or running.",
+      "translated": "این نشست تا زمانی که فعال یا در حال اجرا است، قابل بایگانی نیست."
     },
     {
-      "id": "native.apple.8952a111a1075051",
-      "source": "The main thread cannot be deleted.",
-      "translated": "رشتهٔ اصلی را نمی‌توان حذف کرد."
+      "id": "native.apple.5817e3f3dab1ee19",
+      "source": "The main session cannot be deleted.",
+      "translated": "نشست اصلی قابل حذف نیست."
     },
     {
-      "id": "native.apple.90d0ccf80ca28717",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
-      "translated": "پیش از بایگانی یا حذف این رشته، پیوست‌ها را حذف کنید یا منتظر تحویل آن‌ها بمانید."
+      "id": "native.apple.a6b8df3f18171c91",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
+      "translated": "پیش از بایگانی یا حذف این نشست، پیوست‌ها را حذف کنید یا منتظر تحویل آن‌ها بمانید."
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23694,9 +23634,9 @@
       "translated": "اجرا پایان یافت"
     },
     {
-      "id": "native.apple.bbccb4c8db5cac12",
-      "source": "Thread Info",
-      "translated": "اطلاعات رشته"
+      "id": "native.apple.cd7c3095a22f80a9",
+      "source": "Session Info",
+      "translated": "اطلاعات نشست"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23729,9 +23669,9 @@
       "translated": "افزودن گروه"
     },
     {
-      "id": "native.apple.7b641fed5bace855",
-      "source": "Thread Groups",
-      "translated": "گروه‌های رشته"
+      "id": "native.apple.23d628606fe0734f",
+      "source": "Session Groups",
+      "translated": "گروه‌های نشست"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23774,9 +23714,9 @@
       "translated": "حذف گروه"
     },
     {
-      "id": "native.apple.56401c79410a310d",
-      "source": "Threads in this group become ungrouped.",
-      "translated": "رشته‌های این گروه از گروه خارج می‌شوند."
+      "id": "native.apple.b049c8a4d2805e08",
+      "source": "Sessions in this group become ungrouped.",
+      "translated": "نشست‌های این گروه از گروه خارج می‌شوند."
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23789,9 +23729,9 @@
       "translated": "هیچ عاملی در این Gateway در دسترس نیست."
     },
     {
-      "id": "native.apple.2d96aa7d3d12f85b",
-      "source": "New Thread Options",
-      "translated": "گزینه‌های گفت‌وگوی جدید"
+      "id": "native.apple.6c89f35d53506406",
+      "source": "New Session Options",
+      "translated": "گزینه‌های نشست جدید"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23819,19 +23759,19 @@
       "translated": "ایجاد"
     },
     {
-      "id": "native.apple.87ef57319d1ddc85",
-      "source": "The thread could not be created.",
-      "translated": "گفت‌وگو ایجاد نشد."
+      "id": "native.apple.795ba37f6782cf28",
+      "source": "The session could not be created.",
+      "translated": "جلسه ایجاد نشد."
     },
     {
-      "id": "native.apple.6bd91c435b69d638",
-      "source": "Search threads",
-      "translated": "جست‌وجوی گفت‌وگوها"
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "جستجوی نشست‌ها"
     },
     {
-      "id": "native.apple.6fde4bdf9d5b9191",
-      "source": "No Threads",
-      "translated": "گفت‌وگویی وجود ندارد"
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "هیچ نشستی وجود ندارد"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23839,29 +23779,29 @@
       "translated": "نتیجه‌ای یافت نشد"
     },
     {
-      "id": "native.apple.a02fd99740d29bd3",
-      "source": "New Thread",
-      "translated": "گفت‌وگوی جدید"
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "نشست جدید"
     },
     {
-      "id": "native.apple.b625801dd04b09f2",
-      "source": "New thread",
-      "translated": "گفت‌وگوی جدید"
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "نشست جدید"
     },
     {
-      "id": "native.apple.851be81fcc933608",
-      "source": "New thread options",
-      "translated": "گزینه‌های گفت‌وگوی جدید"
+      "id": "native.apple.2ef0e34db02ad255",
+      "source": "New session options",
+      "translated": "گزینه‌های نشست جدید"
     },
     {
-      "id": "native.apple.9ce8a4aba7b444b2",
-      "source": "Rename Thread",
-      "translated": "تغییر نام گفت‌وگو"
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "تغییر نام نشست"
     },
     {
-      "id": "native.apple.1dd067c44511c7f0",
-      "source": "Thread name",
-      "translated": "نام گفت‌وگو"
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "نام نشست"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23874,14 +23814,14 @@
       "translated": "لغو"
     },
     {
-      "id": "native.apple.618073d6ab3f2721",
-      "source": "Delete Thread",
-      "translated": "حذف گفت‌وگو"
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "حذف نشست"
     },
     {
-      "id": "native.apple.10a5e72bba3cbccc",
-      "source": "The thread and its transcript are removed from the gateway.",
-      "translated": "گفت‌وگو و رونوشت آن از Gateway حذف می‌شوند."
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "نشست و رونوشت آن از Gateway حذف می‌شوند."
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23889,14 +23829,14 @@
       "translated": "«%@» حذف شود؟"
     },
     {
-      "id": "native.apple.ac71e3b2aa496a2c",
-      "source": "Thread running",
-      "translated": "گفت‌وگو در حال اجراست"
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "نشست در حال اجرا است"
     },
     {
-      "id": "native.apple.c775e87f997278b2",
-      "source": "Thread failed",
-      "translated": "گفت‌وگو ناموفق بود"
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "نشست ناموفق بود"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23954,9 +23894,9 @@
       "translated": "کپی کلید نشست"
     },
     {
-      "id": "native.apple.f4998cfb572f23ff",
-      "source": "Delete Thread…",
-      "translated": "حذف گفت‌وگو…"
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "حذف نشست…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23969,9 +23909,9 @@
       "translated": "در حال اتصال…"
     },
     {
-      "id": "native.apple.8802e9576ffd0f65",
-      "source": "Retry thread groups",
-      "translated": "تلاش مجدد برای گروه‌های گفت‌وگو"
+      "id": "native.apple.79f708b3bc1d3a6c",
+      "source": "Retry session groups",
+      "translated": "تلاش مجدد برای گروه‌های نشست"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23994,24 +23934,24 @@
       "translated": "دامنه"
     },
     {
-      "id": "native.apple.b313b80def4bda52",
-      "source": "Search threads",
-      "translated": "جست‌وجوی گفت‌وگوها"
+      "id": "native.apple.2c37581c7b88f741",
+      "source": "Search sessions",
+      "translated": "جستجوی نشست‌ها"
     },
     {
-      "id": "native.apple.c0cc6acc36f413ce",
-      "source": "Threads",
-      "translated": "گفت‌وگوها"
+      "id": "native.apple.43be8a2336e42faf",
+      "source": "Sessions",
+      "translated": "جلسه‌ها"
     },
     {
-      "id": "native.apple.854d3928fe5a557c",
-      "source": "Rename Thread",
-      "translated": "تغییر نام گفت‌وگو"
+      "id": "native.apple.0b379cdfcbd3247f",
+      "source": "Rename Session",
+      "translated": "تغییر نام نشست"
     },
     {
-      "id": "native.apple.9d0d3f20096cc4da",
-      "source": "Thread name",
-      "translated": "نام گفت‌وگو"
+      "id": "native.apple.54b6fbd9e41db009",
+      "source": "Session name",
+      "translated": "نام نشست"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -24019,19 +23959,19 @@
       "translated": "لغو"
     },
     {
-      "id": "native.apple.dc00eb94f33bae15",
-      "source": "Delete selected threads?",
-      "translated": "گفت‌وگوهای انتخاب‌شده حذف شوند؟"
+      "id": "native.apple.751e0f6b81cd374a",
+      "source": "Delete selected sessions?",
+      "translated": "نشست‌های انتخاب‌شده حذف شوند؟"
     },
     {
-      "id": "native.apple.2053fc9f74dc3158",
-      "source": "Delete Threads",
-      "translated": "حذف رشته‌ها"
+      "id": "native.apple.aa679276581b0058",
+      "source": "Delete Sessions",
+      "translated": "حذف نشست‌ها"
     },
     {
-      "id": "native.apple.0970247871a834a0",
-      "source": "Each selected thread and its transcript will be removed from the gateway.",
-      "translated": "هر رشته انتخاب‌شده و رونوشت آن از Gateway حذف خواهد شد."
+      "id": "native.apple.f837129cbee23297",
+      "source": "Each selected session and its transcript will be removed from the gateway.",
+      "translated": "هر نشست انتخاب‌شده و رونوشت آن از Gateway حذف خواهد شد."
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -24039,9 +23979,9 @@
       "translated": "گروه‌ها"
     },
     {
-      "id": "native.apple.6f8acab2256728b5",
-      "source": "Manage thread groups",
-      "translated": "مدیریت گروه‌های رشته"
+      "id": "native.apple.64013cfee5e25305",
+      "source": "Manage session groups",
+      "translated": "مدیریت گروه‌های نشست"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -24054,14 +23994,14 @@
       "translated": "انتخاب"
     },
     {
-      "id": "native.apple.692972314d04b184",
-      "source": "No archived threads",
-      "translated": "هیچ رشته بایگانی‌شده‌ای وجود ندارد"
+      "id": "native.apple.b67eaecec1b423ac",
+      "source": "No archived sessions",
+      "translated": "نشست بایگانی‌شده‌ای وجود ندارد"
     },
     {
-      "id": "native.apple.d6a4b5711dcd26e7",
-      "source": "No threads found",
-      "translated": "هیچ رشته‌ای یافت نشد"
+      "id": "native.apple.b2435a79abf0c794",
+      "source": "No sessions found",
+      "translated": "نشستی یافت نشد"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24229,16 +24169,6 @@
       "translated": "باز کردن پیام کامل"
     },
     {
-      "id": "native.apple.002bfcede229ad4b",
-      "source": "Rewind to Here",
-      "translated": "بازگشت به اینجا"
-    },
-    {
-      "id": "native.apple.14df2e4997689fb3",
-      "source": "Fork from Here",
-      "translated": "از اینجا منشعب شوید"
-    },
-    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "پاسخ"
@@ -24324,9 +24254,9 @@
       "translated": "پیش از شروع گفت‌وگوی جدید، پیوست‌ها را حذف کنید یا منتظر بمانید تا ارسال آن‌ها تکمیل شود."
     },
     {
-      "id": "native.apple.e0f045151c8d3137",
-      "source": "Gateway changed before the thread operation started.",
-      "translated": "Gateway پیش از شروع عملیات رشته تغییر کرد."
+      "id": "native.apple.980f552bb0f96c0f",
+      "source": "Gateway changed before the session operation started.",
+      "translated": "Gateway پیش از شروع عملیات نشست تغییر کرد."
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24334,9 +24264,9 @@
       "translated": "پیش از تغییر گفتگو، پیوست‌ها را حذف کنید یا منتظر تکمیل ارسال بمانید."
     },
     {
-      "id": "native.apple.0a5c4e15466c3acc",
-      "source": "Clear this thread's history?",
-      "translated": "تاریخچه این رشته پاک شود؟"
+      "id": "native.apple.87ba543b42696b92",
+      "source": "Clear this session's history?",
+      "translated": "تاریخچه این نشست پاک شود؟"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24349,14 +24279,14 @@
       "translated": "با این کار مکالمه برای %@ بازنشانی می‌شود. کلید نشست بدون تغییر باقی می‌ماند."
     },
     {
-      "id": "native.apple.67ac221dbe7179f0",
-      "source": "Rename Thread",
-      "translated": "تغییر نام رشته"
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "تغییر نام نشست"
     },
     {
-      "id": "native.apple.cf0f7e049603f518",
-      "source": "Thread name",
-      "translated": "نام رشته"
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "نام نشست"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24374,9 +24304,9 @@
       "translated": "خروجی گرفتن رونوشت"
     },
     {
-      "id": "native.apple.c0ada47504425f23",
-      "source": "Threads",
-      "translated": "رشته‌ها"
+      "id": "native.apple.4af0f566d39d7041",
+      "source": "Sessions",
+      "translated": "جلسه‌ها"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24449,14 +24379,14 @@
       "translated": "پیش‌فرض"
     },
     {
-      "id": "native.apple.1a765291943599e5",
-      "source": "New Thread",
-      "translated": "رشته جدید"
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "نشست جدید"
     },
     {
-      "id": "native.apple.c7a3a6d5e43dd98f",
-      "source": "New Thread Options…",
-      "translated": "گزینه‌های رشته جدید…"
+      "id": "native.apple.a7119fbf9d25df5e",
+      "source": "New Session Options…",
+      "translated": "گزینه‌های نشست جدید…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24464,19 +24394,19 @@
       "translated": "بازخوانی"
     },
     {
-      "id": "native.apple.0e710b81808e5dcf",
-      "source": "Threads…",
-      "translated": "رشته‌ها…"
+      "id": "native.apple.2bcff4a8fa503739",
+      "source": "Sessions…",
+      "translated": "جلسه‌ها…"
     },
     {
-      "id": "native.apple.faad8f92b6bef166",
-      "source": "Rename Thread…",
-      "translated": "تغییر نام رشته…"
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "تغییر نام نشست…"
     },
     {
-      "id": "native.apple.23b61d6cd26ac112",
-      "source": "Fork",
-      "translated": "انشعاب"
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "انشعاب نشست"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24534,24 +24464,24 @@
       "translated": "پاک کردن تاریخچه…"
     },
     {
-      "id": "native.apple.8b4f1c5107ea8a0e",
-      "source": "Thread",
-      "translated": "رشته"
+      "id": "native.apple.920fe8a7a33f9e92",
+      "source": "Session",
+      "translated": "نشست"
     },
     {
-      "id": "native.apple.4d7750c9bf699469",
-      "source": "Thread actions",
-      "translated": "اقدامات رشته"
+      "id": "native.apple.185a401f78328b0f",
+      "source": "Session actions",
+      "translated": "کنش‌های نشست"
     },
     {
-      "id": "native.apple.bb2f22cc43c97f8e",
-      "source": "Thread cost %@",
-      "translated": "هزینه رشته %@"
+      "id": "native.apple.9f9dedf599b2619b",
+      "source": "Session cost %@",
+      "translated": "هزینه نشست %@"
     },
     {
-      "id": "native.apple.6239ced0b86e86f8",
-      "source": "Compact Thread",
-      "translated": "فشرده‌سازی رشته"
+      "id": "native.apple.f0a4720df5f5f403",
+      "source": "Compact Session",
+      "translated": "فشرده‌سازی نشست"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/fr.json
+++ b/apps/.i18n/native/fr.json
@@ -1429,9 +1429,9 @@
       "translated": "Parler ou dicter avec OpenClaw"
     },
     {
-      "id": "native.android.5876e15e5e92fd45",
-      "source": "Browse Sessions",
-      "translated": "Parcourir les sessions"
+      "id": "native.android.e2cf5a38587382cb",
+      "source": "Browse Threads",
+      "translated": "Parcourir les fils"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "Aucune action trouvée"
     },
     {
-      "id": "native.android.48ad0ae0e930e02b",
-      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
-      "translated": "Essayez Chat, Voice, Sessions, Providers ou Settings."
+      "id": "native.android.bc70a4ac965b82ba",
+      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
+      "translated": "Essayez Chat, Voix, Fils, Fournisseurs ou Paramètres."
     },
     {
-      "id": "native.android.d4fbd1ee4f55a5db",
-      "source": "Sessions",
-      "translated": "Sessions"
+      "id": "native.android.670121e54dbe286f",
+      "source": "Threads",
+      "translated": "Fils"
     },
     {
-      "id": "native.android.207c2170504e99e6",
-      "source": "Connect the Gateway to search sessions.",
-      "translated": "Connectez le Gateway pour rechercher des sessions."
+      "id": "native.android.d38be650b1bce4a0",
+      "source": "Connect the Gateway to search threads.",
+      "translated": "Connectez le Gateway pour rechercher des fils."
     },
     {
-      "id": "native.android.25d2c2d792c952fe",
-      "source": "No matching sessions yet.",
-      "translated": "Aucune session correspondante pour le moment."
+      "id": "native.android.3d7754721f776ef8",
+      "source": "No matching threads yet.",
+      "translated": "Aucun fil correspondant pour le moment."
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "Assistant en cours de travail"
     },
     {
-      "id": "native.android.8f8384286317f5c9",
-      "source": "OpenClaw session",
-      "translated": "Session OpenClaw"
+      "id": "native.android.9a839f6e3e05a744",
+      "source": "OpenClaw thread",
+      "translated": "Fil OpenClaw"
     },
     {
-      "id": "native.android.15799e57704b20c6",
-      "source": "Open session",
-      "translated": "Ouvrir la session"
+      "id": "native.android.d83f82a1e4a5ed99",
+      "source": "Open thread",
+      "translated": "Ouvrir le fil"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "Aucun fournisseur prêt"
     },
     {
-      "id": "native.android.73e6ab1a168fd381",
-      "source": "Main session",
-      "translated": "Session principale"
+      "id": "native.android.8a1c5365c0538908",
+      "source": "Main thread",
+      "translated": "Fil principal"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.0e3157c15c56944f",
-      "source": "Sessions",
-      "translated": "Sessions"
+      "id": "native.android.a5845742daecb4ba",
+      "source": "Threads",
+      "translated": "Fils"
     },
     {
-      "id": "native.android.70f5d0507d34b5c8",
-      "source": "Focus session search",
-      "translated": "Rechercher dans les sessions"
+      "id": "native.android.439b324280869527",
+      "source": "Focus thread search",
+      "translated": "Activer la recherche de fils"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "Archivé"
     },
     {
-      "id": "native.android.b9cf34c137e4cf03",
-      "source": "Search sessions",
-      "translated": "Rechercher des sessions"
+      "id": "native.android.03981341841b04ac",
+      "source": "Search threads",
+      "translated": "Rechercher des fils"
     },
     {
-      "id": "native.android.10cb26723e9990fc",
-      "source": "Clear session search",
-      "translated": "Effacer la recherche de sessions"
+      "id": "native.android.99570c528a41fa72",
+      "source": "Clear thread search",
+      "translated": "Effacer la recherche de fils"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "Plus anciens d'abord"
     },
     {
-      "id": "native.android.c6bf8751e2a7f5c7",
-      "source": "Toggle session layout",
-      "translated": "Changer la disposition des sessions"
+      "id": "native.android.fd67be543e321cc9",
+      "source": "Toggle thread layout",
+      "translated": "Changer la disposition des fils"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "Disposition : détaillée"
     },
     {
-      "id": "native.android.69b79a3c2c987cd4",
-      "source": "Searching sessions",
-      "translated": "Recherche de sessions"
+      "id": "native.android.ebd17565e0ffd8eb",
+      "source": "Searching threads",
+      "translated": "Recherche de fils"
     },
     {
-      "id": "native.android.dd587d341af44212",
-      "source": "No matching sessions",
-      "translated": "Aucune session correspondante"
+      "id": "native.android.472d46ae8669f860",
+      "source": "No matching threads",
+      "translated": "Aucun fil correspondant"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "Démarrer le chat"
     },
     {
-      "id": "native.android.f10d4df7cbc6df4f",
-      "source": "Current session",
-      "translated": "Session actuelle"
+      "id": "native.android.ff81ad1bee00d384",
+      "source": "Current thread",
+      "translated": "Fil actuel"
     },
     {
-      "id": "native.android.8f0482425838ae64",
-      "source": "OpenClaw session",
-      "translated": "Session OpenClaw"
+      "id": "native.android.fc145645b9620e57",
+      "source": "OpenClaw thread",
+      "translated": "Fil OpenClaw"
     },
     {
-      "id": "native.android.786774c8a76e50d7",
-      "source": "Rename session",
-      "translated": "Renommer la session"
+      "id": "native.android.71cbb8dde8bf138b",
+      "source": "Rename thread",
+      "translated": "Renommer le fil"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "Supprimer le groupe ?"
     },
     {
-      "id": "native.android.3455fc2f77d564e3",
-      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "Les sessions de « $group » sont conservées et reviennent dans Non groupées."
+      "id": "native.android.691e92cfe5cf106e",
+      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "Les fils de \"$group\" sont conservés et replacés dans Non groupés."
     },
     {
-      "id": "native.android.4805fb9d6623e8c0",
-      "source": "Delete session?",
-      "translated": "Supprimer la session ?"
+      "id": "native.android.d87a8217ab56999b",
+      "source": "Delete thread?",
+      "translated": "Supprimer le fil ?"
     },
     {
-      "id": "native.android.0c3283a2b2445eae",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "Cette action supprime définitivement la session et sa transcription."
+      "id": "native.android.930de97ff47113a8",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "Cette action supprime définitivement le fil et sa transcription."
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "Non regroupé"
     },
     {
-      "id": "native.android.db243d71d056afa4",
-      "source": "No sessions yet",
-      "translated": "Aucune session pour le moment"
+      "id": "native.android.8e21a70428def6e0",
+      "source": "No threads yet",
+      "translated": "Aucun fil pour le moment"
     },
     {
-      "id": "native.android.5b4eee6a8092925e",
-      "source": "No current session",
-      "translated": "Aucune session actuelle"
+      "id": "native.android.cda4c5ad8b17e394",
+      "source": "No current thread",
+      "translated": "Aucun fil actuel"
     },
     {
-      "id": "native.android.acbcc9c9ea53d8c0",
-      "source": "No archived sessions",
-      "translated": "Aucune session archivée"
+      "id": "native.android.be84f061047aa2da",
+      "source": "No archived threads",
+      "translated": "Aucun fil archivé"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "Démarrez une nouvelle conversation et elle s’affichera ici."
     },
     {
-      "id": "native.android.56fcd605dc7be3c0",
-      "source": "Open Chat to start or resume the current session.",
-      "translated": "Ouvrez le chat pour démarrer ou reprendre la session actuelle."
+      "id": "native.android.f289d03e1d3eee98",
+      "source": "Open Chat to start or resume the current thread.",
+      "translated": "Ouvrez le chat pour démarrer ou reprendre le fil actuel."
     },
     {
-      "id": "native.android.085515989f8a2022",
-      "source": "Archived sessions will show up here.",
-      "translated": "Les sessions archivées s’afficheront ici."
+      "id": "native.android.504b71386e76c6ae",
+      "source": "Archived threads will show up here.",
+      "translated": "Les fils archivés apparaîtront ici."
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days} j"
     },
     {
-      "id": "native.android.3d4fa07acbc015c5",
-      "source": "Main session",
-      "translated": "Session principale"
+      "id": "native.android.ee4c727cdafbe963",
+      "source": "Main thread",
+      "translated": "Fil principal"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway en attente"
     },
     {
-      "id": "native.android.2d8d049afe99f751",
-      "source": "Session Activity",
-      "translated": "Activité de la session"
+      "id": "native.android.da78209effb11cfd",
+      "source": "Thread Activity",
+      "translated": "Activité du fil"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "Les demandes d’approbation d’exécution apparaîtront ici tant que ce téléphone sera connecté."
     },
     {
-      "id": "native.android.dc3e7ca5a491103a",
-      "source": "Session activity",
-      "translated": "Activité de la session"
+      "id": "native.android.f615712dfb56319a",
+      "source": "Thread activity",
+      "translated": "Activité du fil"
     },
     {
-      "id": "native.android.8551e02b060bd7d8",
-      "source": "Chat tool calls waiting in the active session remain visible here.",
-      "translated": "Les appels d’outils de chat en attente dans la session active restent visibles ici."
+      "id": "native.android.6c93973c13db43ae",
+      "source": "Chat tool calls waiting in the active thread remain visible here.",
+      "translated": "Les appels d’outils du chat en attente dans le fil actif restent visibles ici."
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,6 +4294,11 @@
       "translated": "Configuration du fournisseur de conversation"
     },
     {
+      "id": "native.android.23b638094c34b916",
+      "source": "Microphone",
+      "translated": "Microphone"
+    },
+    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "Test audio"
@@ -4337,6 +4342,66 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "Terminé"
+    },
+    {
+      "id": "native.android.8d9ecdfdd916b780",
+      "source": "Automatic",
+      "translated": "Automatique"
+    },
+    {
+      "id": "native.android.c1626a6700a570f6",
+      "source": "Preferred microphone unavailable; using automatic routing.",
+      "translated": "Le microphone préféré n’est pas disponible ; utilisation du routage automatique."
+    },
+    {
+      "id": "native.android.820bc5d0ce571d8b",
+      "source": "Prioritizes connected Bluetooth microphones.",
+      "translated": "Donne la priorité aux microphones Bluetooth connectés."
+    },
+    {
+      "id": "native.android.11e48038d5e8bff6",
+      "source": "Preferred microphone",
+      "translated": "Microphone préféré"
+    },
+    {
+      "id": "native.android.eaa4d7563a46d307",
+      "source": "Unavailable",
+      "translated": "Indisponible"
+    },
+    {
+      "id": "native.android.9f5ebf17eb405ba8",
+      "source": "Next session",
+      "translated": "Prochaine session"
+    },
+    {
+      "id": "native.android.8c4e91f53928efb2",
+      "source": "Built-in microphone",
+      "translated": "Microphone intégré"
+    },
+    {
+      "id": "native.android.14b613cb6e2446b4",
+      "source": "Bluetooth microphone",
+      "translated": "Microphone Bluetooth"
+    },
+    {
+      "id": "native.android.c885247b2d7ce271",
+      "source": "Bluetooth LE microphone",
+      "translated": "Microphone Bluetooth LE"
+    },
+    {
+      "id": "native.android.b6a4e674c5fb441a",
+      "source": "Wired headset microphone",
+      "translated": "Microphone du casque filaire"
+    },
+    {
+      "id": "native.android.9c8becb3b0fb5a90",
+      "source": "USB microphone",
+      "translated": "Microphone USB"
+    },
+    {
+      "id": "native.android.ba46258fadec7a39",
+      "source": "External microphone",
+      "translated": "Microphone externe"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5074,9 +5139,9 @@
       "translated": "Vérifier"
     },
     {
-      "id": "native.android.5a540761383fa474",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
-      "translated": "OpenClaw transforme ce téléphone en une interface de commande mobile épurée pour les sessions, la voix, les fournisseurs et Gateway."
+      "id": "native.android.c971506716c96e91",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
+      "translated": "OpenClaw transforme ce téléphone en une interface de commande mobile épurée pour les fils de discussion, la voix, les fournisseurs et Gateway."
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5624,9 +5689,9 @@
       "translated": "Paramètres de Talk"
     },
     {
-      "id": "native.android.73f07a5d54915259",
-      "source": "Recent Sessions",
-      "translated": "Sessions récentes"
+      "id": "native.android.36f78c8c85dc283f",
+      "source": "Recent Threads",
+      "translated": "Fils de discussion récents"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5684,14 +5749,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% en ligne"
     },
     {
-      "id": "native.android.16c3425d3a594481",
-      "source": "Sessions",
-      "translated": "Sessions"
+      "id": "native.android.57177017a6a93826",
+      "source": "Threads",
+      "translated": "Fils de discussion"
     },
     {
-      "id": "native.android.a5c0f8b3112aa58c",
-      "source": "No recent sessions",
-      "translated": "Aucune session récente"
+      "id": "native.android.43320b54a68b00a1",
+      "source": "No recent threads",
+      "translated": "Aucun fil de discussion récent"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5729,14 +5794,14 @@
       "translated": "En cours · $pendingRunCount exécutions actives"
     },
     {
-      "id": "native.android.2c89da708b12a522",
-      "source": "Monitoring · 1 session",
-      "translated": "Surveillance · 1 session"
+      "id": "native.android.e24db059480f1e6a",
+      "source": "Monitoring · 1 thread",
+      "translated": "Surveillance · 1 fil de discussion"
     },
     {
-      "id": "native.android.8b6ee382dcb64e1f",
-      "source": "Monitoring · $sessionCount sessions",
-      "translated": "Surveillance · $sessionCount sessions"
+      "id": "native.android.5a475f37d80e02bc",
+      "source": "Monitoring · $sessionCount threads",
+      "translated": "Surveillance · $sessionCount fils de discussion"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5769,9 +5834,9 @@
       "translated": "Fournisseurs"
     },
     {
-      "id": "native.android.a65477861c7203aa",
-      "source": "Open session",
-      "translated": "Ouvrir la session"
+      "id": "native.android.358c5e0e838d5423",
+      "source": "Open thread",
+      "translated": "Ouvrir le fil de discussion"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6194,9 +6259,9 @@
       "translated": "${days} j"
     },
     {
-      "id": "native.android.22d755834386db07",
-      "source": "Main session",
-      "translated": "Session principale"
+      "id": "native.android.28a1a1acc5a0959f",
+      "source": "Main thread",
+      "translated": "Fil de discussion principal"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6877,6 +6942,16 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "Réactiver le micro"
+    },
+    {
+      "id": "native.android.cb608d82c5b3352a",
+      "source": "Back camera",
+      "translated": "Caméra arrière"
+    },
+    {
+      "id": "native.android.e89a0e780eed2e1e",
+      "source": "Front camera",
+      "translated": "Caméra avant"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7684,9 +7759,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.882cc14a58e7e105",
-      "source": "Loading session",
-      "translated": "Chargement de la session"
+      "id": "native.android.0c74bc30a994dd33",
+      "source": "Loading thread",
+      "translated": "Chargement du fil de discussion"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7729,14 +7804,14 @@
       "translated": "Mettre à jour"
     },
     {
-      "id": "native.android.1e5add56e48c99f9",
-      "source": "Summarize recent sessions and next steps.",
-      "translated": "Résumez les sessions récentes et les prochaines étapes."
+      "id": "native.android.cf40df9739f78f27",
+      "source": "Summarize recent threads and next steps.",
+      "translated": "Résumer les fils de discussion récents et les prochaines étapes."
     },
     {
-      "id": "native.android.06d515351bb79576",
-      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
-      "translated": "Résume mes sessions OpenClaw récentes et suggère les prochaines étapes."
+      "id": "native.android.ebe49a8b8df80bd3",
+      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
+      "translated": "Fais-moi un récapitulatif de mes fils de discussion OpenClaw récents et suggère les prochaines étapes."
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8074,9 +8149,9 @@
       "translated": "Connecté"
     },
     {
-      "id": "native.android.81931886b9caf3ab",
-      "source": "Sessions",
-      "translated": "Sessions"
+      "id": "native.android.6cf5d6fa8a4186d5",
+      "source": "Threads",
+      "translated": "Fils de discussion"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,9 +10869,9 @@
       "translated": "Sur quoi souhaitez-vous travailler ?"
     },
     {
-      "id": "native.apple.32179ce0b6d4543f",
-      "source": "The session attaches once the gateway is ready.",
-      "translated": "La session se connecte une fois que le gateway est prêt."
+      "id": "native.apple.4da775013ac9b123",
+      "source": "The thread attaches once the gateway is ready.",
+      "translated": "Le fil de discussion est joint une fois que le Gateway est prêt."
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10844,9 +10919,9 @@
       "translated": "Options de la nouvelle session…"
     },
     {
-      "id": "native.apple.a1b0d289758e2213",
-      "source": "Sessions…",
-      "translated": "Sessions…"
+      "id": "native.apple.003b25ddafeb18e9",
+      "source": "Threads…",
+      "translated": "Fils de discussion…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11009,14 +11084,14 @@
       "translated": "Créer"
     },
     {
-      "id": "native.apple.f488b9caf6e51ac3",
-      "source": "Delete Session?",
-      "translated": "Supprimer la session ?"
+      "id": "native.apple.31d5c7287cfb3abe",
+      "source": "Delete Thread?",
+      "translated": "Supprimer le fil de discussion ?"
     },
     {
-      "id": "native.apple.8634b17be9b111bc",
-      "source": "Delete Session",
-      "translated": "Supprimer la session"
+      "id": "native.apple.d3395564809f1120",
+      "source": "Delete Thread",
+      "translated": "Supprimer le fil"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11024,9 +11099,9 @@
       "translated": "Annuler"
     },
     {
-      "id": "native.apple.4a9568ac9b18d8d3",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "Cette action supprime définitivement la session et sa transcription."
+      "id": "native.apple.092659256d26cb03",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "Cette action supprime définitivement le fil et sa transcription."
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11054,9 +11129,9 @@
       "translated": "Nouveau groupe"
     },
     {
-      "id": "native.apple.5bccdc23a1640895",
-      "source": "Rename Session",
-      "translated": "Renommer la session"
+      "id": "native.apple.683032464c497bbd",
+      "source": "Rename Thread",
+      "translated": "Renommer le fil"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11064,9 +11139,9 @@
       "translated": "Nom du groupe"
     },
     {
-      "id": "native.apple.af789b2d2fda0f67",
-      "source": "Session name",
-      "translated": "Nom de la session"
+      "id": "native.apple.f887aa956588f237",
+      "source": "Thread name",
+      "translated": "Nom du fil"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11104,14 +11179,14 @@
       "translated": "Agents"
     },
     {
-      "id": "native.apple.a3bde8045fe9224a",
-      "source": "Agent session",
-      "translated": "Session d’agent"
+      "id": "native.apple.7c8231b7b1ca480f",
+      "source": "Agent thread",
+      "translated": "Fil de l’agent"
     },
     {
-      "id": "native.apple.27f775de30b37ff8",
-      "source": "Recent sessions",
-      "translated": "Sessions récentes"
+      "id": "native.apple.b3c553614f762a58",
+      "source": "Recent threads",
+      "translated": "Fils récents"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11119,9 +11194,9 @@
       "translated": "Gateway hors ligne"
     },
     {
-      "id": "native.apple.28c97cf23665ee01",
-      "source": "No recent sessions",
-      "translated": "Aucune session récente"
+      "id": "native.apple.5aa32afda85064ea",
+      "source": "No recent threads",
+      "translated": "Aucun fil récent"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11219,14 +11294,14 @@
       "translated": "Annuler"
     },
     {
-      "id": "native.apple.9f2fd65953013b7c",
-      "source": "Sessions",
-      "translated": "Sessions"
+      "id": "native.apple.b6855cf19a50f477",
+      "source": "Threads",
+      "translated": "Fils"
     },
     {
-      "id": "native.apple.0422818cc95d5071",
-      "source": "Archived sessions",
-      "translated": "Sessions archivées"
+      "id": "native.apple.9b1d0ef27a1333b0",
+      "source": "Archived threads",
+      "translated": "Fils archivés"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11234,34 +11309,34 @@
       "translated": "Afficher les éléments archivés"
     },
     {
-      "id": "native.apple.b272115c83f7ef58",
-      "source": "Sessions unavailable",
-      "translated": "Sessions indisponibles"
+      "id": "native.apple.98167401c7267735",
+      "source": "Threads unavailable",
+      "translated": "Fils indisponibles"
     },
     {
-      "id": "native.apple.54f8260c9b863087",
-      "source": "Loading archived sessions",
-      "translated": "Chargement des sessions archivées"
+      "id": "native.apple.4d28a7def2337b9f",
+      "source": "Loading archived threads",
+      "translated": "Chargement des fils archivés"
     },
     {
-      "id": "native.apple.9b305868873dade2",
-      "source": "Loading recent sessions",
-      "translated": "Chargement des sessions récentes"
+      "id": "native.apple.777d7b706933bd7b",
+      "source": "Loading recent threads",
+      "translated": "Chargement des fils récents"
     },
     {
-      "id": "native.apple.207dad20d09f3160",
-      "source": "^[\\(count) session](inflect: true)",
-      "translated": "^[\\(count) session](inflect: true)"
+      "id": "native.apple.22f81ea94bef8410",
+      "source": "^[\\(count) thread](inflect: true)",
+      "translated": "^[\\(count) fil](inflect: true)"
     },
     {
-      "id": "native.apple.1f4501a6bf2bae4c",
-      "source": "No archived sessions",
-      "translated": "Aucune session archivée"
+      "id": "native.apple.1cad51e14db59bf9",
+      "source": "No archived threads",
+      "translated": "Aucun fil archivé"
     },
     {
-      "id": "native.apple.2a1ba7a5e1979c9e",
-      "source": "Archived sessions will appear here.",
-      "translated": "Les sessions archivées apparaîtront ici."
+      "id": "native.apple.18ef832d3a7ddcf8",
+      "source": "Archived threads will appear here.",
+      "translated": "Les fils archivés apparaîtront ici."
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11344,9 +11419,9 @@
       "translated": "Partager la réception"
     },
     {
-      "id": "native.apple.2360d25fe6ae9946",
-      "source": "Loading sessions",
-      "translated": "Chargement des sessions"
+      "id": "native.apple.21d9208d86a4d1fe",
+      "source": "Loading threads",
+      "translated": "Chargement des fils"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11354,19 +11429,19 @@
       "translated": "Récupération de l’activité récente depuis le Gateway."
     },
     {
-      "id": "native.apple.c334f2e86702a7b8",
-      "source": "Sessions unavailable",
-      "translated": "Sessions indisponibles"
+      "id": "native.apple.4be1f79aa2b230ff",
+      "source": "Threads unavailable",
+      "translated": "Fils indisponibles"
     },
     {
-      "id": "native.apple.6cc6efb7a03960b6",
-      "source": "No recent sessions",
-      "translated": "Aucune session récente"
+      "id": "native.apple.98b348873556bc46",
+      "source": "No recent threads",
+      "translated": "Aucun fil récent"
     },
     {
-      "id": "native.apple.08483af2d043bee6",
-      "source": "Session activity offline",
-      "translated": "Activité de session hors ligne"
+      "id": "native.apple.7396d205574d279f",
+      "source": "Thread activity offline",
+      "translated": "Activité du fil hors ligne"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11824,9 +11899,9 @@
       "translated": "Carte"
     },
     {
-      "id": "native.apple.93eeaedb2ff61043",
-      "source": "Open Session",
-      "translated": "Ouvrir la session"
+      "id": "native.apple.c9ec1b0e18074d8a",
+      "source": "Open Thread",
+      "translated": "Ouvrir le fil"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13314,9 +13389,9 @@
       "translated": "Par défaut"
     },
     {
-      "id": "native.apple.3de045f17ea3c6d0",
-      "source": "Used for new Chat and Talk sessions.",
-      "translated": "Utilisé pour les nouvelles sessions Chat et Talk."
+      "id": "native.apple.f4ae5664c3eda95d",
+      "source": "Used for new Chat threads and Talk sessions.",
+      "translated": "Utilisé pour les nouveaux fils de discussion Chat et les sessions Talk."
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15719,9 +15794,9 @@
       "translated": "Instances"
     },
     {
-      "id": "native.apple.3579cf2750470a22",
-      "source": "Sessions",
-      "translated": "Sessions"
+      "id": "native.apple.11fe8b9941954dfb",
+      "source": "Threads",
+      "translated": "Fils de discussion"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19029,9 +19104,9 @@
       "translated": "Raccourci de discussion rapide"
     },
     {
-      "id": "native.apple.6ae77665b5f4490f",
-      "source": "Global shortcut that opens a floating chat bar for the main session.",
-      "translated": "Raccourci global qui ouvre une barre de discussion flottante pour la session principale."
+      "id": "native.apple.94dd793cd7d7d555",
+      "source": "Global shortcut that opens a floating chat bar for the main thread.",
+      "translated": "Raccourci global qui ouvre une barre de chat flottante pour le fil de discussion principal."
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19609,9 +19684,9 @@
       "translated": "Critique"
     },
     {
-      "id": "native.apple.75102378a6775180",
-      "source": "New Session",
-      "translated": "Nouvelle session"
+      "id": "native.apple.13f96467014cf344",
+      "source": "New Thread",
+      "translated": "Nouveau fil de discussion"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21899,9 +21974,9 @@
       "translated": "Aucun message récent"
     },
     {
-      "id": "native.apple.1ff8aec0044934c3",
-      "source": "Sessions",
-      "translated": "Sessions"
+      "id": "native.apple.3ec2afcbc298c673",
+      "source": "Threads",
+      "translated": "Fils de discussion"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21909,9 +21984,9 @@
       "translated": "Consultez les compartiments de conversations stockés que la CLI réutilise pour le contexte et les limites de débit."
     },
     {
-      "id": "native.apple.bab897f3252b134c",
-      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
-      "translated": "Aucune session pour le moment. Elles apparaissent après le premier message entrant ou signal de présence."
+      "id": "native.apple.14ccb32cd8ed1c81",
+      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
+      "translated": "Aucun fil de discussion pour le moment. Ils apparaissent après le premier message entrant ou signal périodique."
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -21994,9 +22069,9 @@
       "translated": "Approbations d’exécution"
     },
     {
-      "id": "native.apple.64a6dc7d49e8fb57",
-      "source": "Sessions",
-      "translated": "Sessions"
+      "id": "native.apple.52e37e3a44ae516c",
+      "source": "Threads",
+      "translated": "Fils de discussion"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -22999,9 +23074,9 @@
       "translated": "Mets-moi au courant"
     },
     {
-      "id": "native.apple.234ec45f4231edc4",
-      "source": "Summarize what happened in my sessions since yesterday.",
-      "translated": "Résume ce qui s’est passé dans mes sessions depuis hier."
+      "id": "native.apple.fc4ce810900ec0b6",
+      "source": "Summarize what happened in my threads since yesterday.",
+      "translated": "Résumez ce qui s’est passé dans mes fils de discussion depuis hier."
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23179,9 +23254,9 @@
       "translated": "Désépingler le modèle"
     },
     {
-      "id": "native.apple.5dfc0700d8dff8de",
-      "source": "Session",
-      "translated": "Session"
+      "id": "native.apple.4edb66657f5aca1f",
+      "source": "Thread",
+      "translated": "Fil de discussion"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23344,6 +23419,51 @@
       "translated": "Widget indisponible"
     },
     {
+      "id": "native.apple.d640691fd196f338",
+      "source": "Widget export failed",
+      "translated": "Échec de l’exportation du widget"
+    },
+    {
+      "id": "native.apple.533c6e22a11e88de",
+      "source": "OK",
+      "translated": "OK"
+    },
+    {
+      "id": "native.apple.e1fb28a2a9756402",
+      "source": "Copy image",
+      "translated": "Copier l’image"
+    },
+    {
+      "id": "native.apple.ebd7bc92e1b12235",
+      "source": "Save image…",
+      "translated": "Enregistrer l’image…"
+    },
+    {
+      "id": "native.apple.742c46d4cf2db134",
+      "source": "Save image",
+      "translated": "Enregistrer l’image"
+    },
+    {
+      "id": "native.apple.0589cce608418f90",
+      "source": "The widget image could not be captured.",
+      "translated": "L’image du widget n’a pas pu être capturée."
+    },
+    {
+      "id": "native.apple.dfe24e827fdbe9c5",
+      "source": "The widget image could not be copied.",
+      "translated": "L’image du widget n’a pas pu être copiée."
+    },
+    {
+      "id": "native.apple.9e611e3a80e71408",
+      "source": "The widget image could not be encoded as PNG.",
+      "translated": "L’image du widget n’a pas pu être encodée au format PNG."
+    },
+    {
+      "id": "native.apple.9a6e8afbe24a262b",
+      "source": "The widget image could not be saved.",
+      "translated": "L’image du widget n’a pas pu être enregistrée."
+    },
+    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23484,19 +23604,19 @@
       "translated": "Utilisateur"
     },
     {
-      "id": "native.apple.b1cdcb906a43d5d6",
-      "source": "This session cannot be archived while it is active or running.",
-      "translated": "Cette session ne peut pas être archivée tant qu’elle est active ou en cours d’exécution."
+      "id": "native.apple.9d0cba09d92ee669",
+      "source": "This thread cannot be archived while it is active or running.",
+      "translated": "Ce fil de discussion ne peut pas être archivé tant qu’il est actif ou en cours d’exécution."
     },
     {
-      "id": "native.apple.5817e3f3dab1ee19",
-      "source": "The main session cannot be deleted.",
-      "translated": "La session principale ne peut pas être supprimée."
+      "id": "native.apple.8952a111a1075051",
+      "source": "The main thread cannot be deleted.",
+      "translated": "Le fil de discussion principal ne peut pas être supprimé."
     },
     {
-      "id": "native.apple.a6b8df3f18171c91",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
-      "translated": "Supprimez les pièces jointes ou attendez leur envoi avant d’archiver ou de supprimer cette session."
+      "id": "native.apple.90d0ccf80ca28717",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
+      "translated": "Supprimez les pièces jointes ou attendez leur livraison avant d’archiver ou de supprimer ce fil."
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23634,9 +23754,9 @@
       "translated": "Fin de l’exécution"
     },
     {
-      "id": "native.apple.cd7c3095a22f80a9",
-      "source": "Session Info",
-      "translated": "Informations sur la session"
+      "id": "native.apple.bbccb4c8db5cac12",
+      "source": "Thread Info",
+      "translated": "Informations sur le fil"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23669,9 +23789,9 @@
       "translated": "Ajouter un groupe"
     },
     {
-      "id": "native.apple.23d628606fe0734f",
-      "source": "Session Groups",
-      "translated": "Groupes de sessions"
+      "id": "native.apple.7b641fed5bace855",
+      "source": "Thread Groups",
+      "translated": "Groupes de fils"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23714,9 +23834,9 @@
       "translated": "Supprimer le groupe"
     },
     {
-      "id": "native.apple.b049c8a4d2805e08",
-      "source": "Sessions in this group become ungrouped.",
-      "translated": "Les sessions de ce groupe ne seront plus regroupées."
+      "id": "native.apple.56401c79410a310d",
+      "source": "Threads in this group become ungrouped.",
+      "translated": "Les fils de ce groupe ne seront plus groupés."
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23729,9 +23849,9 @@
       "translated": "Aucun agent n’est disponible sur ce Gateway."
     },
     {
-      "id": "native.apple.6c89f35d53506406",
-      "source": "New Session Options",
-      "translated": "Options de la nouvelle session"
+      "id": "native.apple.2d96aa7d3d12f85b",
+      "source": "New Thread Options",
+      "translated": "Options du nouveau fil"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23759,19 +23879,19 @@
       "translated": "Créer"
     },
     {
-      "id": "native.apple.795ba37f6782cf28",
-      "source": "The session could not be created.",
-      "translated": "La session n’a pas pu être créée."
+      "id": "native.apple.87ef57319d1ddc85",
+      "source": "The thread could not be created.",
+      "translated": "Le fil n’a pas pu être créé."
     },
     {
-      "id": "native.apple.8ec708a3605a2cc3",
-      "source": "Search sessions",
-      "translated": "Rechercher des sessions"
+      "id": "native.apple.6bd91c435b69d638",
+      "source": "Search threads",
+      "translated": "Rechercher des fils"
     },
     {
-      "id": "native.apple.23b069b4e7f97039",
-      "source": "No Sessions",
-      "translated": "Aucune session"
+      "id": "native.apple.6fde4bdf9d5b9191",
+      "source": "No Threads",
+      "translated": "Aucun fil"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23779,29 +23899,29 @@
       "translated": "Aucun résultat"
     },
     {
-      "id": "native.apple.0058923f2ce8a3ec",
-      "source": "New Session",
-      "translated": "Nouvelle session"
+      "id": "native.apple.a02fd99740d29bd3",
+      "source": "New Thread",
+      "translated": "Nouveau fil"
     },
     {
-      "id": "native.apple.66ba42960eb4135b",
-      "source": "New session",
-      "translated": "Nouvelle session"
+      "id": "native.apple.b625801dd04b09f2",
+      "source": "New thread",
+      "translated": "Nouveau fil"
     },
     {
-      "id": "native.apple.2ef0e34db02ad255",
-      "source": "New session options",
-      "translated": "Options de la nouvelle session"
+      "id": "native.apple.851be81fcc933608",
+      "source": "New thread options",
+      "translated": "Options du nouveau fil"
     },
     {
-      "id": "native.apple.36753ef2f1ed4264",
-      "source": "Rename Session",
-      "translated": "Renommer la session"
+      "id": "native.apple.9ce8a4aba7b444b2",
+      "source": "Rename Thread",
+      "translated": "Renommer le fil"
     },
     {
-      "id": "native.apple.c9de0a1510ef475f",
-      "source": "Session name",
-      "translated": "Nom de la session"
+      "id": "native.apple.1dd067c44511c7f0",
+      "source": "Thread name",
+      "translated": "Nom du fil"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23814,14 +23934,14 @@
       "translated": "Annuler"
     },
     {
-      "id": "native.apple.afb4e6c99c63a28d",
-      "source": "Delete Session",
-      "translated": "Supprimer la session"
+      "id": "native.apple.618073d6ab3f2721",
+      "source": "Delete Thread",
+      "translated": "Supprimer le fil"
     },
     {
-      "id": "native.apple.3d4ef32e42f136a4",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "La session et sa transcription sont supprimées du Gateway."
+      "id": "native.apple.10a5e72bba3cbccc",
+      "source": "The thread and its transcript are removed from the gateway.",
+      "translated": "Le fil et sa transcription sont supprimés du Gateway."
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23829,14 +23949,14 @@
       "translated": "Supprimer « %@ » ?"
     },
     {
-      "id": "native.apple.9a7dca238fba628d",
-      "source": "Session running",
-      "translated": "Session en cours"
+      "id": "native.apple.ac71e3b2aa496a2c",
+      "source": "Thread running",
+      "translated": "Fil en cours d’exécution"
     },
     {
-      "id": "native.apple.fcfbfe5e97a95e9c",
-      "source": "Session failed",
-      "translated": "Échec de la session"
+      "id": "native.apple.c775e87f997278b2",
+      "source": "Thread failed",
+      "translated": "Échec du fil"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23894,9 +24014,9 @@
       "translated": "Copier la clé de session"
     },
     {
-      "id": "native.apple.4aeb7c14c26dabac",
-      "source": "Delete Session…",
-      "translated": "Supprimer la session…"
+      "id": "native.apple.f4998cfb572f23ff",
+      "source": "Delete Thread…",
+      "translated": "Supprimer le fil…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23909,9 +24029,9 @@
       "translated": "Connexion…"
     },
     {
-      "id": "native.apple.79f708b3bc1d3a6c",
-      "source": "Retry session groups",
-      "translated": "Réessayer de charger les groupes de sessions"
+      "id": "native.apple.8802e9576ffd0f65",
+      "source": "Retry thread groups",
+      "translated": "Réessayer de charger les groupes de fils"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23934,24 +24054,24 @@
       "translated": "Portée"
     },
     {
-      "id": "native.apple.2c37581c7b88f741",
-      "source": "Search sessions",
-      "translated": "Rechercher des sessions"
+      "id": "native.apple.b313b80def4bda52",
+      "source": "Search threads",
+      "translated": "Rechercher des fils"
     },
     {
-      "id": "native.apple.43be8a2336e42faf",
-      "source": "Sessions",
-      "translated": "Sessions"
+      "id": "native.apple.c0cc6acc36f413ce",
+      "source": "Threads",
+      "translated": "Fils de discussion"
     },
     {
-      "id": "native.apple.0b379cdfcbd3247f",
-      "source": "Rename Session",
-      "translated": "Renommer la session"
+      "id": "native.apple.854d3928fe5a557c",
+      "source": "Rename Thread",
+      "translated": "Renommer le fil de discussion"
     },
     {
-      "id": "native.apple.54b6fbd9e41db009",
-      "source": "Session name",
-      "translated": "Nom de la session"
+      "id": "native.apple.9d0d3f20096cc4da",
+      "source": "Thread name",
+      "translated": "Nom du fil de discussion"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -23959,19 +24079,19 @@
       "translated": "Annuler"
     },
     {
-      "id": "native.apple.751e0f6b81cd374a",
-      "source": "Delete selected sessions?",
-      "translated": "Supprimer les sessions sélectionnées ?"
+      "id": "native.apple.dc00eb94f33bae15",
+      "source": "Delete selected threads?",
+      "translated": "Supprimer les fils de discussion sélectionnés ?"
     },
     {
-      "id": "native.apple.aa679276581b0058",
-      "source": "Delete Sessions",
-      "translated": "Supprimer les sessions"
+      "id": "native.apple.2053fc9f74dc3158",
+      "source": "Delete Threads",
+      "translated": "Supprimer les fils de discussion"
     },
     {
-      "id": "native.apple.f837129cbee23297",
-      "source": "Each selected session and its transcript will be removed from the gateway.",
-      "translated": "Chaque session sélectionnée et sa transcription seront supprimées du Gateway."
+      "id": "native.apple.0970247871a834a0",
+      "source": "Each selected thread and its transcript will be removed from the gateway.",
+      "translated": "Chaque fil de discussion sélectionné et sa transcription seront supprimés du Gateway."
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -23979,9 +24099,9 @@
       "translated": "Groupes"
     },
     {
-      "id": "native.apple.64013cfee5e25305",
-      "source": "Manage session groups",
-      "translated": "Gérer les groupes de sessions"
+      "id": "native.apple.6f8acab2256728b5",
+      "source": "Manage thread groups",
+      "translated": "Gérer les groupes de fils de discussion"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -23994,14 +24114,14 @@
       "translated": "Sélectionner"
     },
     {
-      "id": "native.apple.b67eaecec1b423ac",
-      "source": "No archived sessions",
-      "translated": "Aucune session archivée"
+      "id": "native.apple.692972314d04b184",
+      "source": "No archived threads",
+      "translated": "Aucun fil de discussion archivé"
     },
     {
-      "id": "native.apple.b2435a79abf0c794",
-      "source": "No sessions found",
-      "translated": "Aucune session trouvée"
+      "id": "native.apple.d6a4b5711dcd26e7",
+      "source": "No threads found",
+      "translated": "Aucun fil de discussion trouvé"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24169,6 +24289,16 @@
       "translated": "Ouvrir le message complet"
     },
     {
+      "id": "native.apple.002bfcede229ad4b",
+      "source": "Rewind to Here",
+      "translated": "Revenir ici"
+    },
+    {
+      "id": "native.apple.14df2e4997689fb3",
+      "source": "Fork from Here",
+      "translated": "Créer une branche à partir d’ici"
+    },
+    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "Répondre"
@@ -24254,9 +24384,9 @@
       "translated": "Supprimez les pièces jointes ou attendez la fin de leur envoi avant de démarrer une nouvelle discussion."
     },
     {
-      "id": "native.apple.980f552bb0f96c0f",
-      "source": "Gateway changed before the session operation started.",
-      "translated": "Le Gateway a changé avant le début de l’opération sur la session."
+      "id": "native.apple.e0f045151c8d3137",
+      "source": "Gateway changed before the thread operation started.",
+      "translated": "Le Gateway a changé avant le début de l’opération sur le fil de discussion."
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24264,9 +24394,9 @@
       "translated": "Supprimez les pièces jointes ou attendez la livraison avant de changer de conversation."
     },
     {
-      "id": "native.apple.87ba543b42696b92",
-      "source": "Clear this session's history?",
-      "translated": "Effacer l'historique de cette session ?"
+      "id": "native.apple.0a5c4e15466c3acc",
+      "source": "Clear this thread's history?",
+      "translated": "Effacer l’historique de ce fil de discussion ?"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24279,14 +24409,14 @@
       "translated": "Cette opération réinitialise la conversation pour %@. La clé de session reste la même."
     },
     {
-      "id": "native.apple.a92e96bed98bd553",
-      "source": "Rename Session",
-      "translated": "Renommer la session"
+      "id": "native.apple.67ac221dbe7179f0",
+      "source": "Rename Thread",
+      "translated": "Renommer le fil de discussion"
     },
     {
-      "id": "native.apple.848e2388f3466f40",
-      "source": "Session name",
-      "translated": "Nom de la session"
+      "id": "native.apple.cf0f7e049603f518",
+      "source": "Thread name",
+      "translated": "Nom du fil de discussion"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24304,9 +24434,9 @@
       "translated": "Exporter la transcription"
     },
     {
-      "id": "native.apple.4af0f566d39d7041",
-      "source": "Sessions",
-      "translated": "Sessions"
+      "id": "native.apple.c0ada47504425f23",
+      "source": "Threads",
+      "translated": "Fils de discussion"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24379,14 +24509,14 @@
       "translated": "Par défaut"
     },
     {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "Nouvelle session"
+      "id": "native.apple.1a765291943599e5",
+      "source": "New Thread",
+      "translated": "Nouveau fil de discussion"
     },
     {
-      "id": "native.apple.a7119fbf9d25df5e",
-      "source": "New Session Options…",
-      "translated": "Options de la nouvelle session…"
+      "id": "native.apple.c7a3a6d5e43dd98f",
+      "source": "New Thread Options…",
+      "translated": "Options du nouveau fil de discussion…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24394,19 +24524,19 @@
       "translated": "Actualiser"
     },
     {
-      "id": "native.apple.2bcff4a8fa503739",
-      "source": "Sessions…",
-      "translated": "Sessions…"
+      "id": "native.apple.0e710b81808e5dcf",
+      "source": "Threads…",
+      "translated": "Fils de discussion…"
     },
     {
-      "id": "native.apple.c36e008b051adb38",
-      "source": "Rename Session…",
-      "translated": "Renommer la session…"
+      "id": "native.apple.faad8f92b6bef166",
+      "source": "Rename Thread…",
+      "translated": "Renommer le fil de discussion…"
     },
     {
-      "id": "native.apple.ea0ef95a159bffe0",
-      "source": "Fork Session",
-      "translated": "Dupliquer la session"
+      "id": "native.apple.23b61d6cd26ac112",
+      "source": "Fork",
+      "translated": "Bifurquer"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24464,24 +24594,24 @@
       "translated": "Effacer l'historique…"
     },
     {
-      "id": "native.apple.920fe8a7a33f9e92",
-      "source": "Session",
-      "translated": "Session"
+      "id": "native.apple.8b4f1c5107ea8a0e",
+      "source": "Thread",
+      "translated": "Fil"
     },
     {
-      "id": "native.apple.185a401f78328b0f",
-      "source": "Session actions",
-      "translated": "Actions de session"
+      "id": "native.apple.4d7750c9bf699469",
+      "source": "Thread actions",
+      "translated": "Actions du fil"
     },
     {
-      "id": "native.apple.9f9dedf599b2619b",
-      "source": "Session cost %@",
-      "translated": "Coût de la session : %@"
+      "id": "native.apple.bb2f22cc43c97f8e",
+      "source": "Thread cost %@",
+      "translated": "Coût du fil %@"
     },
     {
-      "id": "native.apple.f0a4720df5f5f403",
-      "source": "Compact Session",
-      "translated": "Compacter la session"
+      "id": "native.apple.6239ced0b86e86f8",
+      "source": "Compact Thread",
+      "translated": "Compacter le fil"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/fr.json
+++ b/apps/.i18n/native/fr.json
@@ -1429,9 +1429,9 @@
       "translated": "Parler ou dicter avec OpenClaw"
     },
     {
-      "id": "native.android.e2cf5a38587382cb",
-      "source": "Browse Threads",
-      "translated": "Parcourir les fils"
+      "id": "native.android.5876e15e5e92fd45",
+      "source": "Browse Sessions",
+      "translated": "Parcourir les sessions"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "Aucune action trouvée"
     },
     {
-      "id": "native.android.bc70a4ac965b82ba",
-      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
-      "translated": "Essayez Chat, Voix, Fils, Fournisseurs ou Paramètres."
+      "id": "native.android.48ad0ae0e930e02b",
+      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
+      "translated": "Essayez Chat, Voice, Sessions, Providers ou Settings."
     },
     {
-      "id": "native.android.670121e54dbe286f",
-      "source": "Threads",
-      "translated": "Fils"
+      "id": "native.android.d4fbd1ee4f55a5db",
+      "source": "Sessions",
+      "translated": "Sessions"
     },
     {
-      "id": "native.android.d38be650b1bce4a0",
-      "source": "Connect the Gateway to search threads.",
-      "translated": "Connectez le Gateway pour rechercher des fils."
+      "id": "native.android.207c2170504e99e6",
+      "source": "Connect the Gateway to search sessions.",
+      "translated": "Connectez le Gateway pour rechercher des sessions."
     },
     {
-      "id": "native.android.3d7754721f776ef8",
-      "source": "No matching threads yet.",
-      "translated": "Aucun fil correspondant pour le moment."
+      "id": "native.android.25d2c2d792c952fe",
+      "source": "No matching sessions yet.",
+      "translated": "Aucune session correspondante pour le moment."
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "Assistant en cours de travail"
     },
     {
-      "id": "native.android.9a839f6e3e05a744",
-      "source": "OpenClaw thread",
-      "translated": "Fil OpenClaw"
+      "id": "native.android.8f8384286317f5c9",
+      "source": "OpenClaw session",
+      "translated": "Session OpenClaw"
     },
     {
-      "id": "native.android.d83f82a1e4a5ed99",
-      "source": "Open thread",
-      "translated": "Ouvrir le fil"
+      "id": "native.android.15799e57704b20c6",
+      "source": "Open session",
+      "translated": "Ouvrir la session"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "Aucun fournisseur prêt"
     },
     {
-      "id": "native.android.8a1c5365c0538908",
-      "source": "Main thread",
-      "translated": "Fil principal"
+      "id": "native.android.73e6ab1a168fd381",
+      "source": "Main session",
+      "translated": "Session principale"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.a5845742daecb4ba",
-      "source": "Threads",
-      "translated": "Fils"
+      "id": "native.android.0e3157c15c56944f",
+      "source": "Sessions",
+      "translated": "Sessions"
     },
     {
-      "id": "native.android.439b324280869527",
-      "source": "Focus thread search",
-      "translated": "Activer la recherche de fils"
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "Rechercher dans les sessions"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "Archivé"
     },
     {
-      "id": "native.android.03981341841b04ac",
-      "source": "Search threads",
-      "translated": "Rechercher des fils"
+      "id": "native.android.b9cf34c137e4cf03",
+      "source": "Search sessions",
+      "translated": "Rechercher des sessions"
     },
     {
-      "id": "native.android.99570c528a41fa72",
-      "source": "Clear thread search",
-      "translated": "Effacer la recherche de fils"
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "Effacer la recherche de sessions"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "Plus anciens d'abord"
     },
     {
-      "id": "native.android.fd67be543e321cc9",
-      "source": "Toggle thread layout",
-      "translated": "Changer la disposition des fils"
+      "id": "native.android.c6bf8751e2a7f5c7",
+      "source": "Toggle session layout",
+      "translated": "Changer la disposition des sessions"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "Disposition : détaillée"
     },
     {
-      "id": "native.android.ebd17565e0ffd8eb",
-      "source": "Searching threads",
-      "translated": "Recherche de fils"
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "Recherche de sessions"
     },
     {
-      "id": "native.android.472d46ae8669f860",
-      "source": "No matching threads",
-      "translated": "Aucun fil correspondant"
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "Aucune session correspondante"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "Démarrer le chat"
     },
     {
-      "id": "native.android.ff81ad1bee00d384",
-      "source": "Current thread",
-      "translated": "Fil actuel"
+      "id": "native.android.f10d4df7cbc6df4f",
+      "source": "Current session",
+      "translated": "Session actuelle"
     },
     {
-      "id": "native.android.fc145645b9620e57",
-      "source": "OpenClaw thread",
-      "translated": "Fil OpenClaw"
+      "id": "native.android.8f0482425838ae64",
+      "source": "OpenClaw session",
+      "translated": "Session OpenClaw"
     },
     {
-      "id": "native.android.71cbb8dde8bf138b",
-      "source": "Rename thread",
-      "translated": "Renommer le fil"
+      "id": "native.android.786774c8a76e50d7",
+      "source": "Rename session",
+      "translated": "Renommer la session"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "Supprimer le groupe ?"
     },
     {
-      "id": "native.android.691e92cfe5cf106e",
-      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "Les fils de \"$group\" sont conservés et replacés dans Non groupés."
+      "id": "native.android.3455fc2f77d564e3",
+      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "Les sessions de « $group » sont conservées et reviennent dans Non groupées."
     },
     {
-      "id": "native.android.d87a8217ab56999b",
-      "source": "Delete thread?",
-      "translated": "Supprimer le fil ?"
+      "id": "native.android.4805fb9d6623e8c0",
+      "source": "Delete session?",
+      "translated": "Supprimer la session ?"
     },
     {
-      "id": "native.android.930de97ff47113a8",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "Cette action supprime définitivement le fil et sa transcription."
+      "id": "native.android.0c3283a2b2445eae",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "Cette action supprime définitivement la session et sa transcription."
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "Non regroupé"
     },
     {
-      "id": "native.android.8e21a70428def6e0",
-      "source": "No threads yet",
-      "translated": "Aucun fil pour le moment"
+      "id": "native.android.db243d71d056afa4",
+      "source": "No sessions yet",
+      "translated": "Aucune session pour le moment"
     },
     {
-      "id": "native.android.cda4c5ad8b17e394",
-      "source": "No current thread",
-      "translated": "Aucun fil actuel"
+      "id": "native.android.5b4eee6a8092925e",
+      "source": "No current session",
+      "translated": "Aucune session actuelle"
     },
     {
-      "id": "native.android.be84f061047aa2da",
-      "source": "No archived threads",
-      "translated": "Aucun fil archivé"
+      "id": "native.android.acbcc9c9ea53d8c0",
+      "source": "No archived sessions",
+      "translated": "Aucune session archivée"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "Démarrez une nouvelle conversation et elle s’affichera ici."
     },
     {
-      "id": "native.android.f289d03e1d3eee98",
-      "source": "Open Chat to start or resume the current thread.",
-      "translated": "Ouvrez le chat pour démarrer ou reprendre le fil actuel."
+      "id": "native.android.56fcd605dc7be3c0",
+      "source": "Open Chat to start or resume the current session.",
+      "translated": "Ouvrez le chat pour démarrer ou reprendre la session actuelle."
     },
     {
-      "id": "native.android.504b71386e76c6ae",
-      "source": "Archived threads will show up here.",
-      "translated": "Les fils archivés apparaîtront ici."
+      "id": "native.android.085515989f8a2022",
+      "source": "Archived sessions will show up here.",
+      "translated": "Les sessions archivées s’afficheront ici."
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days} j"
     },
     {
-      "id": "native.android.ee4c727cdafbe963",
-      "source": "Main thread",
-      "translated": "Fil principal"
+      "id": "native.android.3d4fa07acbc015c5",
+      "source": "Main session",
+      "translated": "Session principale"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway en attente"
     },
     {
-      "id": "native.android.da78209effb11cfd",
-      "source": "Thread Activity",
-      "translated": "Activité du fil"
+      "id": "native.android.2d8d049afe99f751",
+      "source": "Session Activity",
+      "translated": "Activité de la session"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "Les demandes d’approbation d’exécution apparaîtront ici tant que ce téléphone sera connecté."
     },
     {
-      "id": "native.android.f615712dfb56319a",
-      "source": "Thread activity",
-      "translated": "Activité du fil"
+      "id": "native.android.dc3e7ca5a491103a",
+      "source": "Session activity",
+      "translated": "Activité de la session"
     },
     {
-      "id": "native.android.6c93973c13db43ae",
-      "source": "Chat tool calls waiting in the active thread remain visible here.",
-      "translated": "Les appels d’outils du chat en attente dans le fil actif restent visibles ici."
+      "id": "native.android.8551e02b060bd7d8",
+      "source": "Chat tool calls waiting in the active session remain visible here.",
+      "translated": "Les appels d’outils de chat en attente dans la session active restent visibles ici."
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,11 +4294,6 @@
       "translated": "Configuration du fournisseur de conversation"
     },
     {
-      "id": "native.android.23b638094c34b916",
-      "source": "Microphone",
-      "translated": "Microphone"
-    },
-    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "Test audio"
@@ -4342,66 +4337,6 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "Terminé"
-    },
-    {
-      "id": "native.android.8d9ecdfdd916b780",
-      "source": "Automatic",
-      "translated": "Automatique"
-    },
-    {
-      "id": "native.android.c1626a6700a570f6",
-      "source": "Preferred microphone unavailable; using automatic routing.",
-      "translated": "Le microphone préféré n’est pas disponible ; utilisation du routage automatique."
-    },
-    {
-      "id": "native.android.820bc5d0ce571d8b",
-      "source": "Prioritizes connected Bluetooth microphones.",
-      "translated": "Donne la priorité aux microphones Bluetooth connectés."
-    },
-    {
-      "id": "native.android.11e48038d5e8bff6",
-      "source": "Preferred microphone",
-      "translated": "Microphone préféré"
-    },
-    {
-      "id": "native.android.eaa4d7563a46d307",
-      "source": "Unavailable",
-      "translated": "Indisponible"
-    },
-    {
-      "id": "native.android.9f5ebf17eb405ba8",
-      "source": "Next session",
-      "translated": "Session suivante"
-    },
-    {
-      "id": "native.android.8c4e91f53928efb2",
-      "source": "Built-in microphone",
-      "translated": "Microphone intégré"
-    },
-    {
-      "id": "native.android.14b613cb6e2446b4",
-      "source": "Bluetooth microphone",
-      "translated": "Microphone Bluetooth"
-    },
-    {
-      "id": "native.android.c885247b2d7ce271",
-      "source": "Bluetooth LE microphone",
-      "translated": "Microphone Bluetooth LE"
-    },
-    {
-      "id": "native.android.b6a4e674c5fb441a",
-      "source": "Wired headset microphone",
-      "translated": "Microphone de casque filaire"
-    },
-    {
-      "id": "native.android.9c8becb3b0fb5a90",
-      "source": "USB microphone",
-      "translated": "Microphone USB"
-    },
-    {
-      "id": "native.android.ba46258fadec7a39",
-      "source": "External microphone",
-      "translated": "Microphone externe"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5139,9 +5074,9 @@
       "translated": "Vérifier"
     },
     {
-      "id": "native.android.c971506716c96e91",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
-      "translated": "OpenClaw transforme ce téléphone en une interface de commande mobile épurée pour les fils, la voix, les fournisseurs et Gateway."
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw transforme ce téléphone en une interface de commande mobile épurée pour les sessions, la voix, les fournisseurs et Gateway."
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5689,9 +5624,9 @@
       "translated": "Paramètres de Talk"
     },
     {
-      "id": "native.android.36f78c8c85dc283f",
-      "source": "Recent Threads",
-      "translated": "Fils récents"
+      "id": "native.android.73f07a5d54915259",
+      "source": "Recent Sessions",
+      "translated": "Sessions récentes"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5749,14 +5684,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% en ligne"
     },
     {
-      "id": "native.android.57177017a6a93826",
-      "source": "Threads",
-      "translated": "Fils"
+      "id": "native.android.16c3425d3a594481",
+      "source": "Sessions",
+      "translated": "Sessions"
     },
     {
-      "id": "native.android.43320b54a68b00a1",
-      "source": "No recent threads",
-      "translated": "Aucun fil récent"
+      "id": "native.android.a5c0f8b3112aa58c",
+      "source": "No recent sessions",
+      "translated": "Aucune session récente"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5794,14 +5729,14 @@
       "translated": "En cours · $pendingRunCount exécutions actives"
     },
     {
-      "id": "native.android.e24db059480f1e6a",
-      "source": "Monitoring · 1 thread",
-      "translated": "Surveillance · 1 fil"
+      "id": "native.android.2c89da708b12a522",
+      "source": "Monitoring · 1 session",
+      "translated": "Surveillance · 1 session"
     },
     {
-      "id": "native.android.5a475f37d80e02bc",
-      "source": "Monitoring · $sessionCount threads",
-      "translated": "Surveillance · $sessionCount fils"
+      "id": "native.android.8b6ee382dcb64e1f",
+      "source": "Monitoring · $sessionCount sessions",
+      "translated": "Surveillance · $sessionCount sessions"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5834,9 +5769,9 @@
       "translated": "Fournisseurs"
     },
     {
-      "id": "native.android.358c5e0e838d5423",
-      "source": "Open thread",
-      "translated": "Ouvrir le fil"
+      "id": "native.android.a65477861c7203aa",
+      "source": "Open session",
+      "translated": "Ouvrir la session"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6259,9 +6194,9 @@
       "translated": "${days} j"
     },
     {
-      "id": "native.android.28a1a1acc5a0959f",
-      "source": "Main thread",
-      "translated": "Fil principal"
+      "id": "native.android.22d755834386db07",
+      "source": "Main session",
+      "translated": "Session principale"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6942,16 +6877,6 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "Réactiver le micro"
-    },
-    {
-      "id": "native.android.cb608d82c5b3352a",
-      "source": "Back camera",
-      "translated": "Caméra arrière"
-    },
-    {
-      "id": "native.android.e89a0e780eed2e1e",
-      "source": "Front camera",
-      "translated": "Caméra avant"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7759,9 +7684,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.0c74bc30a994dd33",
-      "source": "Loading thread",
-      "translated": "Chargement du fil"
+      "id": "native.android.882cc14a58e7e105",
+      "source": "Loading session",
+      "translated": "Chargement de la session"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7804,14 +7729,14 @@
       "translated": "Mettre à jour"
     },
     {
-      "id": "native.android.cf40df9739f78f27",
-      "source": "Summarize recent threads and next steps.",
-      "translated": "Résumez les fils récents et les prochaines étapes."
+      "id": "native.android.1e5add56e48c99f9",
+      "source": "Summarize recent sessions and next steps.",
+      "translated": "Résumez les sessions récentes et les prochaines étapes."
     },
     {
-      "id": "native.android.ebe49a8b8df80bd3",
-      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
-      "translated": "Résume mes discussions OpenClaw récentes et suggère les prochaines étapes."
+      "id": "native.android.06d515351bb79576",
+      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
+      "translated": "Résume mes sessions OpenClaw récentes et suggère les prochaines étapes."
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8149,9 +8074,9 @@
       "translated": "Connecté"
     },
     {
-      "id": "native.android.6cf5d6fa8a4186d5",
-      "source": "Threads",
-      "translated": "Discussions"
+      "id": "native.android.81931886b9caf3ab",
+      "source": "Sessions",
+      "translated": "Sessions"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,6 +10719,61 @@
       "translated": "Détails de la tâche"
     },
     {
+      "id": "native.apple.29cacb53ea5e77fc",
+      "source": "Pinned",
+      "translated": "Épinglé"
+    },
+    {
+      "id": "native.apple.940062cfdce9211b",
+      "source": "Recent",
+      "translated": "Récent"
+    },
+    {
+      "id": "native.apple.a0980128426308a9",
+      "source": "Model",
+      "translated": "Modèle"
+    },
+    {
+      "id": "native.apple.9520e60f21535dde",
+      "source": "Thinking",
+      "translated": "Réflexion"
+    },
+    {
+      "id": "native.apple.8b321f3ffce97429",
+      "source": "Fast",
+      "translated": "Rapide"
+    },
+    {
+      "id": "native.apple.989b70d64e328d55",
+      "source": "Default (inherited)",
+      "translated": "Par défaut (hérité)"
+    },
+    {
+      "id": "native.apple.f4114e73b07eb9ae",
+      "source": "Off",
+      "translated": "Désactivé"
+    },
+    {
+      "id": "native.apple.7ed231b28d16312f",
+      "source": "On",
+      "translated": "Activé"
+    },
+    {
+      "id": "native.apple.412a74802320a037",
+      "source": "Full",
+      "translated": "Complet"
+    },
+    {
+      "id": "native.apple.299f21a2071ff9fc",
+      "source": "Verbosity",
+      "translated": "Verbosité"
+    },
+    {
+      "id": "native.apple.faf0ef05e1496de7",
+      "source": "Default",
+      "translated": "Par défaut"
+    },
+    {
       "id": "native.apple.e5524d5756a62744",
       "source": "Unable to Export Transcript",
       "translated": "Impossible d’exporter la transcription"
@@ -10814,9 +10794,9 @@
       "translated": "Sur quoi souhaitez-vous travailler ?"
     },
     {
-      "id": "native.apple.4da775013ac9b123",
-      "source": "The thread attaches once the gateway is ready.",
-      "translated": "La discussion sera jointe une fois le Gateway prêt."
+      "id": "native.apple.32179ce0b6d4543f",
+      "source": "The session attaches once the gateway is ready.",
+      "translated": "La session se connecte une fois que le gateway est prêt."
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10859,9 +10839,14 @@
       "translated": "Nouveau chat dans le worktree"
     },
     {
-      "id": "native.apple.003b25ddafeb18e9",
-      "source": "Threads…",
-      "translated": "Discussions…"
+      "id": "native.apple.ce6ebe91fc597015",
+      "source": "New Session Options…",
+      "translated": "Options de la nouvelle session…"
+    },
+    {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "Sessions…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11024,14 +11009,14 @@
       "translated": "Créer"
     },
     {
-      "id": "native.apple.31d5c7287cfb3abe",
-      "source": "Delete Thread?",
-      "translated": "Supprimer la discussion ?"
+      "id": "native.apple.f488b9caf6e51ac3",
+      "source": "Delete Session?",
+      "translated": "Supprimer la session ?"
     },
     {
-      "id": "native.apple.d3395564809f1120",
-      "source": "Delete Thread",
-      "translated": "Supprimer la discussion"
+      "id": "native.apple.8634b17be9b111bc",
+      "source": "Delete Session",
+      "translated": "Supprimer la session"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11039,9 +11024,9 @@
       "translated": "Annuler"
     },
     {
-      "id": "native.apple.092659256d26cb03",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "Cette action supprime définitivement la discussion et sa transcription."
+      "id": "native.apple.4a9568ac9b18d8d3",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "Cette action supprime définitivement la session et sa transcription."
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11069,9 +11054,9 @@
       "translated": "Nouveau groupe"
     },
     {
-      "id": "native.apple.683032464c497bbd",
-      "source": "Rename Thread",
-      "translated": "Renommer la discussion"
+      "id": "native.apple.5bccdc23a1640895",
+      "source": "Rename Session",
+      "translated": "Renommer la session"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11079,9 +11064,9 @@
       "translated": "Nom du groupe"
     },
     {
-      "id": "native.apple.f887aa956588f237",
-      "source": "Thread name",
-      "translated": "Nom de la discussion"
+      "id": "native.apple.af789b2d2fda0f67",
+      "source": "Session name",
+      "translated": "Nom de la session"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11119,14 +11104,14 @@
       "translated": "Agents"
     },
     {
-      "id": "native.apple.7c8231b7b1ca480f",
-      "source": "Agent thread",
-      "translated": "Discussion de l’agent"
+      "id": "native.apple.a3bde8045fe9224a",
+      "source": "Agent session",
+      "translated": "Session d’agent"
     },
     {
-      "id": "native.apple.b3c553614f762a58",
-      "source": "Recent threads",
-      "translated": "Discussions récentes"
+      "id": "native.apple.27f775de30b37ff8",
+      "source": "Recent sessions",
+      "translated": "Sessions récentes"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11134,9 +11119,9 @@
       "translated": "Gateway hors ligne"
     },
     {
-      "id": "native.apple.5aa32afda85064ea",
-      "source": "No recent threads",
-      "translated": "Aucune discussion récente"
+      "id": "native.apple.28c97cf23665ee01",
+      "source": "No recent sessions",
+      "translated": "Aucune session récente"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11234,14 +11219,14 @@
       "translated": "Annuler"
     },
     {
-      "id": "native.apple.b6855cf19a50f477",
-      "source": "Threads",
-      "translated": "Discussions"
+      "id": "native.apple.9f2fd65953013b7c",
+      "source": "Sessions",
+      "translated": "Sessions"
     },
     {
-      "id": "native.apple.9b1d0ef27a1333b0",
-      "source": "Archived threads",
-      "translated": "Discussions archivées"
+      "id": "native.apple.0422818cc95d5071",
+      "source": "Archived sessions",
+      "translated": "Sessions archivées"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11249,34 +11234,34 @@
       "translated": "Afficher les éléments archivés"
     },
     {
-      "id": "native.apple.98167401c7267735",
-      "source": "Threads unavailable",
-      "translated": "Discussions indisponibles"
+      "id": "native.apple.b272115c83f7ef58",
+      "source": "Sessions unavailable",
+      "translated": "Sessions indisponibles"
     },
     {
-      "id": "native.apple.4d28a7def2337b9f",
-      "source": "Loading archived threads",
-      "translated": "Chargement des discussions archivées"
+      "id": "native.apple.54f8260c9b863087",
+      "source": "Loading archived sessions",
+      "translated": "Chargement des sessions archivées"
     },
     {
-      "id": "native.apple.777d7b706933bd7b",
-      "source": "Loading recent threads",
-      "translated": "Chargement des discussions récentes"
+      "id": "native.apple.9b305868873dade2",
+      "source": "Loading recent sessions",
+      "translated": "Chargement des sessions récentes"
     },
     {
-      "id": "native.apple.22f81ea94bef8410",
-      "source": "^[\\(count) thread](inflect: true)",
-      "translated": "^[\\(count) discussion](inflect: true)"
+      "id": "native.apple.207dad20d09f3160",
+      "source": "^[\\(count) session](inflect: true)",
+      "translated": "^[\\(count) session](inflect: true)"
     },
     {
-      "id": "native.apple.1cad51e14db59bf9",
-      "source": "No archived threads",
-      "translated": "Aucune discussion archivée"
+      "id": "native.apple.1f4501a6bf2bae4c",
+      "source": "No archived sessions",
+      "translated": "Aucune session archivée"
     },
     {
-      "id": "native.apple.18ef832d3a7ddcf8",
-      "source": "Archived threads will appear here.",
-      "translated": "Les discussions archivées apparaîtront ici."
+      "id": "native.apple.2a1ba7a5e1979c9e",
+      "source": "Archived sessions will appear here.",
+      "translated": "Les sessions archivées apparaîtront ici."
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11359,9 +11344,9 @@
       "translated": "Partager la réception"
     },
     {
-      "id": "native.apple.21d9208d86a4d1fe",
-      "source": "Loading threads",
-      "translated": "Chargement des fils de discussion"
+      "id": "native.apple.2360d25fe6ae9946",
+      "source": "Loading sessions",
+      "translated": "Chargement des sessions"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11369,19 +11354,19 @@
       "translated": "Récupération de l’activité récente depuis le Gateway."
     },
     {
-      "id": "native.apple.4be1f79aa2b230ff",
-      "source": "Threads unavailable",
-      "translated": "Fils de discussion indisponibles"
+      "id": "native.apple.c334f2e86702a7b8",
+      "source": "Sessions unavailable",
+      "translated": "Sessions indisponibles"
     },
     {
-      "id": "native.apple.98b348873556bc46",
-      "source": "No recent threads",
-      "translated": "Aucun fil de discussion récent"
+      "id": "native.apple.6cc6efb7a03960b6",
+      "source": "No recent sessions",
+      "translated": "Aucune session récente"
     },
     {
-      "id": "native.apple.7396d205574d279f",
-      "source": "Thread activity offline",
-      "translated": "Activité des fils de discussion hors ligne"
+      "id": "native.apple.08483af2d043bee6",
+      "source": "Session activity offline",
+      "translated": "Activité de session hors ligne"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11839,9 +11824,9 @@
       "translated": "Carte"
     },
     {
-      "id": "native.apple.c9ec1b0e18074d8a",
-      "source": "Open Thread",
-      "translated": "Ouvrir le fil de discussion"
+      "id": "native.apple.93eeaedb2ff61043",
+      "source": "Open Session",
+      "translated": "Ouvrir la session"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13329,9 +13314,9 @@
       "translated": "Par défaut"
     },
     {
-      "id": "native.apple.f4ae5664c3eda95d",
-      "source": "Used for new Chat threads and Talk sessions.",
-      "translated": "Utilisé pour les nouveaux fils de discussion et les sessions Talk."
+      "id": "native.apple.3de045f17ea3c6d0",
+      "source": "Used for new Chat and Talk sessions.",
+      "translated": "Utilisé pour les nouvelles sessions Chat et Talk."
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15734,9 +15719,9 @@
       "translated": "Instances"
     },
     {
-      "id": "native.apple.11fe8b9941954dfb",
-      "source": "Threads",
-      "translated": "Fils de discussion"
+      "id": "native.apple.3579cf2750470a22",
+      "source": "Sessions",
+      "translated": "Sessions"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19044,9 +19029,9 @@
       "translated": "Raccourci de discussion rapide"
     },
     {
-      "id": "native.apple.94dd793cd7d7d555",
-      "source": "Global shortcut that opens a floating chat bar for the main thread.",
-      "translated": "Raccourci global qui ouvre une barre de discussion flottante pour le fil principal."
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "Raccourci global qui ouvre une barre de discussion flottante pour la session principale."
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19624,9 +19609,9 @@
       "translated": "Critique"
     },
     {
-      "id": "native.apple.13f96467014cf344",
-      "source": "New Thread",
-      "translated": "Nouveau fil de discussion"
+      "id": "native.apple.75102378a6775180",
+      "source": "New Session",
+      "translated": "Nouvelle session"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21914,9 +21899,9 @@
       "translated": "Aucun message récent"
     },
     {
-      "id": "native.apple.3ec2afcbc298c673",
-      "source": "Threads",
-      "translated": "Fils de discussion"
+      "id": "native.apple.1ff8aec0044934c3",
+      "source": "Sessions",
+      "translated": "Sessions"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21924,9 +21909,9 @@
       "translated": "Consultez les compartiments de conversations stockés que la CLI réutilise pour le contexte et les limites de débit."
     },
     {
-      "id": "native.apple.14ccb32cd8ed1c81",
-      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
-      "translated": "Aucun fil de discussion pour le moment. Ils apparaissent après le premier message entrant ou signal de présence."
+      "id": "native.apple.bab897f3252b134c",
+      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
+      "translated": "Aucune session pour le moment. Elles apparaissent après le premier message entrant ou signal de présence."
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -22009,9 +21994,9 @@
       "translated": "Approbations d’exécution"
     },
     {
-      "id": "native.apple.52e37e3a44ae516c",
-      "source": "Threads",
-      "translated": "Fils de discussion"
+      "id": "native.apple.64a6dc7d49e8fb57",
+      "source": "Sessions",
+      "translated": "Sessions"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -23014,9 +22999,9 @@
       "translated": "Mets-moi au courant"
     },
     {
-      "id": "native.apple.fc4ce810900ec0b6",
-      "source": "Summarize what happened in my threads since yesterday.",
-      "translated": "Résume ce qui s’est passé dans mes fils de discussion depuis hier."
+      "id": "native.apple.234ec45f4231edc4",
+      "source": "Summarize what happened in my sessions since yesterday.",
+      "translated": "Résume ce qui s’est passé dans mes sessions depuis hier."
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23194,9 +23179,9 @@
       "translated": "Désépingler le modèle"
     },
     {
-      "id": "native.apple.4edb66657f5aca1f",
-      "source": "Thread",
-      "translated": "Fil de discussion"
+      "id": "native.apple.5dfc0700d8dff8de",
+      "source": "Session",
+      "translated": "Session"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23359,51 +23344,6 @@
       "translated": "Widget indisponible"
     },
     {
-      "id": "native.apple.d640691fd196f338",
-      "source": "Widget export failed",
-      "translated": "Échec de l’exportation du widget"
-    },
-    {
-      "id": "native.apple.533c6e22a11e88de",
-      "source": "OK",
-      "translated": "OK"
-    },
-    {
-      "id": "native.apple.e1fb28a2a9756402",
-      "source": "Copy image",
-      "translated": "Copier l’image"
-    },
-    {
-      "id": "native.apple.ebd7bc92e1b12235",
-      "source": "Save image…",
-      "translated": "Enregistrer l’image…"
-    },
-    {
-      "id": "native.apple.742c46d4cf2db134",
-      "source": "Save image",
-      "translated": "Enregistrer l’image"
-    },
-    {
-      "id": "native.apple.0589cce608418f90",
-      "source": "The widget image could not be captured.",
-      "translated": "L’image du widget n’a pas pu être capturée."
-    },
-    {
-      "id": "native.apple.dfe24e827fdbe9c5",
-      "source": "The widget image could not be copied.",
-      "translated": "L’image du widget n’a pas pu être copiée."
-    },
-    {
-      "id": "native.apple.9e611e3a80e71408",
-      "source": "The widget image could not be encoded as PNG.",
-      "translated": "L’image du widget n’a pas pu être encodée au format PNG."
-    },
-    {
-      "id": "native.apple.9a6e8afbe24a262b",
-      "source": "The widget image could not be saved.",
-      "translated": "L’image du widget n’a pas pu être enregistrée."
-    },
-    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23544,19 +23484,19 @@
       "translated": "Utilisateur"
     },
     {
-      "id": "native.apple.9d0cba09d92ee669",
-      "source": "This thread cannot be archived while it is active or running.",
-      "translated": "Ce fil de discussion ne peut pas être archivé tant qu’il est actif ou en cours d’exécution."
+      "id": "native.apple.b1cdcb906a43d5d6",
+      "source": "This session cannot be archived while it is active or running.",
+      "translated": "Cette session ne peut pas être archivée tant qu’elle est active ou en cours d’exécution."
     },
     {
-      "id": "native.apple.8952a111a1075051",
-      "source": "The main thread cannot be deleted.",
-      "translated": "Le fil de discussion principal ne peut pas être supprimé."
+      "id": "native.apple.5817e3f3dab1ee19",
+      "source": "The main session cannot be deleted.",
+      "translated": "La session principale ne peut pas être supprimée."
     },
     {
-      "id": "native.apple.90d0ccf80ca28717",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
-      "translated": "Supprimez les pièces jointes ou attendez leur livraison avant d’archiver ou de supprimer ce fil de discussion."
+      "id": "native.apple.a6b8df3f18171c91",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
+      "translated": "Supprimez les pièces jointes ou attendez leur envoi avant d’archiver ou de supprimer cette session."
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23694,9 +23634,9 @@
       "translated": "Fin de l’exécution"
     },
     {
-      "id": "native.apple.bbccb4c8db5cac12",
-      "source": "Thread Info",
-      "translated": "Informations sur le fil de discussion"
+      "id": "native.apple.cd7c3095a22f80a9",
+      "source": "Session Info",
+      "translated": "Informations sur la session"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23729,9 +23669,9 @@
       "translated": "Ajouter un groupe"
     },
     {
-      "id": "native.apple.7b641fed5bace855",
-      "source": "Thread Groups",
-      "translated": "Groupes de fils de discussion"
+      "id": "native.apple.23d628606fe0734f",
+      "source": "Session Groups",
+      "translated": "Groupes de sessions"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23774,9 +23714,9 @@
       "translated": "Supprimer le groupe"
     },
     {
-      "id": "native.apple.56401c79410a310d",
-      "source": "Threads in this group become ungrouped.",
-      "translated": "Les fils de discussion de ce groupe ne seront plus regroupés."
+      "id": "native.apple.b049c8a4d2805e08",
+      "source": "Sessions in this group become ungrouped.",
+      "translated": "Les sessions de ce groupe ne seront plus regroupées."
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23789,9 +23729,9 @@
       "translated": "Aucun agent n’est disponible sur ce Gateway."
     },
     {
-      "id": "native.apple.2d96aa7d3d12f85b",
-      "source": "New Thread Options",
-      "translated": "Options du nouveau fil"
+      "id": "native.apple.6c89f35d53506406",
+      "source": "New Session Options",
+      "translated": "Options de la nouvelle session"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23819,19 +23759,19 @@
       "translated": "Créer"
     },
     {
-      "id": "native.apple.87ef57319d1ddc85",
-      "source": "The thread could not be created.",
-      "translated": "Le fil n’a pas pu être créé."
+      "id": "native.apple.795ba37f6782cf28",
+      "source": "The session could not be created.",
+      "translated": "La session n’a pas pu être créée."
     },
     {
-      "id": "native.apple.6bd91c435b69d638",
-      "source": "Search threads",
-      "translated": "Rechercher des fils"
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "Rechercher des sessions"
     },
     {
-      "id": "native.apple.6fde4bdf9d5b9191",
-      "source": "No Threads",
-      "translated": "Aucun fil"
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "Aucune session"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23839,29 +23779,29 @@
       "translated": "Aucun résultat"
     },
     {
-      "id": "native.apple.a02fd99740d29bd3",
-      "source": "New Thread",
-      "translated": "Nouveau fil"
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "Nouvelle session"
     },
     {
-      "id": "native.apple.b625801dd04b09f2",
-      "source": "New thread",
-      "translated": "Nouveau fil"
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "Nouvelle session"
     },
     {
-      "id": "native.apple.851be81fcc933608",
-      "source": "New thread options",
-      "translated": "Options du nouveau fil"
+      "id": "native.apple.2ef0e34db02ad255",
+      "source": "New session options",
+      "translated": "Options de la nouvelle session"
     },
     {
-      "id": "native.apple.9ce8a4aba7b444b2",
-      "source": "Rename Thread",
-      "translated": "Renommer le fil"
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "Renommer la session"
     },
     {
-      "id": "native.apple.1dd067c44511c7f0",
-      "source": "Thread name",
-      "translated": "Nom du fil"
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "Nom de la session"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23874,14 +23814,14 @@
       "translated": "Annuler"
     },
     {
-      "id": "native.apple.618073d6ab3f2721",
-      "source": "Delete Thread",
-      "translated": "Supprimer le fil"
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "Supprimer la session"
     },
     {
-      "id": "native.apple.10a5e72bba3cbccc",
-      "source": "The thread and its transcript are removed from the gateway.",
-      "translated": "Le fil et sa transcription sont supprimés du Gateway."
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "La session et sa transcription sont supprimées du Gateway."
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23889,14 +23829,14 @@
       "translated": "Supprimer « %@ » ?"
     },
     {
-      "id": "native.apple.ac71e3b2aa496a2c",
-      "source": "Thread running",
-      "translated": "Fil en cours d’exécution"
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "Session en cours"
     },
     {
-      "id": "native.apple.c775e87f997278b2",
-      "source": "Thread failed",
-      "translated": "Échec du fil"
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "Échec de la session"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23954,9 +23894,9 @@
       "translated": "Copier la clé de session"
     },
     {
-      "id": "native.apple.f4998cfb572f23ff",
-      "source": "Delete Thread…",
-      "translated": "Supprimer le fil…"
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "Supprimer la session…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23969,9 +23909,9 @@
       "translated": "Connexion…"
     },
     {
-      "id": "native.apple.8802e9576ffd0f65",
-      "source": "Retry thread groups",
-      "translated": "Réessayer les groupes de fils"
+      "id": "native.apple.79f708b3bc1d3a6c",
+      "source": "Retry session groups",
+      "translated": "Réessayer de charger les groupes de sessions"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23994,24 +23934,24 @@
       "translated": "Portée"
     },
     {
-      "id": "native.apple.b313b80def4bda52",
-      "source": "Search threads",
-      "translated": "Rechercher des fils"
+      "id": "native.apple.2c37581c7b88f741",
+      "source": "Search sessions",
+      "translated": "Rechercher des sessions"
     },
     {
-      "id": "native.apple.c0cc6acc36f413ce",
-      "source": "Threads",
-      "translated": "Fils"
+      "id": "native.apple.43be8a2336e42faf",
+      "source": "Sessions",
+      "translated": "Sessions"
     },
     {
-      "id": "native.apple.854d3928fe5a557c",
-      "source": "Rename Thread",
-      "translated": "Renommer le fil"
+      "id": "native.apple.0b379cdfcbd3247f",
+      "source": "Rename Session",
+      "translated": "Renommer la session"
     },
     {
-      "id": "native.apple.9d0d3f20096cc4da",
-      "source": "Thread name",
-      "translated": "Nom du fil"
+      "id": "native.apple.54b6fbd9e41db009",
+      "source": "Session name",
+      "translated": "Nom de la session"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -24019,19 +23959,19 @@
       "translated": "Annuler"
     },
     {
-      "id": "native.apple.dc00eb94f33bae15",
-      "source": "Delete selected threads?",
-      "translated": "Supprimer les fils sélectionnés ?"
+      "id": "native.apple.751e0f6b81cd374a",
+      "source": "Delete selected sessions?",
+      "translated": "Supprimer les sessions sélectionnées ?"
     },
     {
-      "id": "native.apple.2053fc9f74dc3158",
-      "source": "Delete Threads",
-      "translated": "Supprimer les conversations"
+      "id": "native.apple.aa679276581b0058",
+      "source": "Delete Sessions",
+      "translated": "Supprimer les sessions"
     },
     {
-      "id": "native.apple.0970247871a834a0",
-      "source": "Each selected thread and its transcript will be removed from the gateway.",
-      "translated": "Chaque conversation sélectionnée et sa transcription seront supprimées du Gateway."
+      "id": "native.apple.f837129cbee23297",
+      "source": "Each selected session and its transcript will be removed from the gateway.",
+      "translated": "Chaque session sélectionnée et sa transcription seront supprimées du Gateway."
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -24039,9 +23979,9 @@
       "translated": "Groupes"
     },
     {
-      "id": "native.apple.6f8acab2256728b5",
-      "source": "Manage thread groups",
-      "translated": "Gérer les groupes de conversations"
+      "id": "native.apple.64013cfee5e25305",
+      "source": "Manage session groups",
+      "translated": "Gérer les groupes de sessions"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -24054,14 +23994,14 @@
       "translated": "Sélectionner"
     },
     {
-      "id": "native.apple.692972314d04b184",
-      "source": "No archived threads",
-      "translated": "Aucune conversation archivée"
+      "id": "native.apple.b67eaecec1b423ac",
+      "source": "No archived sessions",
+      "translated": "Aucune session archivée"
     },
     {
-      "id": "native.apple.d6a4b5711dcd26e7",
-      "source": "No threads found",
-      "translated": "Aucune conversation trouvée"
+      "id": "native.apple.b2435a79abf0c794",
+      "source": "No sessions found",
+      "translated": "Aucune session trouvée"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24229,16 +24169,6 @@
       "translated": "Ouvrir le message complet"
     },
     {
-      "id": "native.apple.002bfcede229ad4b",
-      "source": "Rewind to Here",
-      "translated": "Revenir ici"
-    },
-    {
-      "id": "native.apple.14df2e4997689fb3",
-      "source": "Fork from Here",
-      "translated": "Créer une branche à partir d’ici"
-    },
-    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "Répondre"
@@ -24324,9 +24254,9 @@
       "translated": "Supprimez les pièces jointes ou attendez la fin de leur envoi avant de démarrer une nouvelle discussion."
     },
     {
-      "id": "native.apple.e0f045151c8d3137",
-      "source": "Gateway changed before the thread operation started.",
-      "translated": "Le Gateway a changé avant le début de l’opération sur la conversation."
+      "id": "native.apple.980f552bb0f96c0f",
+      "source": "Gateway changed before the session operation started.",
+      "translated": "Le Gateway a changé avant le début de l’opération sur la session."
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24334,9 +24264,9 @@
       "translated": "Supprimez les pièces jointes ou attendez la livraison avant de changer de conversation."
     },
     {
-      "id": "native.apple.0a5c4e15466c3acc",
-      "source": "Clear this thread's history?",
-      "translated": "Effacer l’historique de cette conversation ?"
+      "id": "native.apple.87ba543b42696b92",
+      "source": "Clear this session's history?",
+      "translated": "Effacer l'historique de cette session ?"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24349,14 +24279,14 @@
       "translated": "Cette opération réinitialise la conversation pour %@. La clé de session reste la même."
     },
     {
-      "id": "native.apple.67ac221dbe7179f0",
-      "source": "Rename Thread",
-      "translated": "Renommer la conversation"
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "Renommer la session"
     },
     {
-      "id": "native.apple.cf0f7e049603f518",
-      "source": "Thread name",
-      "translated": "Nom de la conversation"
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "Nom de la session"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24374,9 +24304,9 @@
       "translated": "Exporter la transcription"
     },
     {
-      "id": "native.apple.c0ada47504425f23",
-      "source": "Threads",
-      "translated": "Conversations"
+      "id": "native.apple.4af0f566d39d7041",
+      "source": "Sessions",
+      "translated": "Sessions"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24449,14 +24379,14 @@
       "translated": "Par défaut"
     },
     {
-      "id": "native.apple.1a765291943599e5",
-      "source": "New Thread",
-      "translated": "Nouvelle conversation"
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "Nouvelle session"
     },
     {
-      "id": "native.apple.c7a3a6d5e43dd98f",
-      "source": "New Thread Options…",
-      "translated": "Options de la nouvelle conversation…"
+      "id": "native.apple.a7119fbf9d25df5e",
+      "source": "New Session Options…",
+      "translated": "Options de la nouvelle session…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24464,19 +24394,19 @@
       "translated": "Actualiser"
     },
     {
-      "id": "native.apple.0e710b81808e5dcf",
-      "source": "Threads…",
-      "translated": "Conversations…"
+      "id": "native.apple.2bcff4a8fa503739",
+      "source": "Sessions…",
+      "translated": "Sessions…"
     },
     {
-      "id": "native.apple.faad8f92b6bef166",
-      "source": "Rename Thread…",
-      "translated": "Renommer la conversation…"
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "Renommer la session…"
     },
     {
-      "id": "native.apple.23b61d6cd26ac112",
-      "source": "Fork",
-      "translated": "Bifurquer"
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "Dupliquer la session"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24534,24 +24464,24 @@
       "translated": "Effacer l'historique…"
     },
     {
-      "id": "native.apple.8b4f1c5107ea8a0e",
-      "source": "Thread",
-      "translated": "Conversation"
+      "id": "native.apple.920fe8a7a33f9e92",
+      "source": "Session",
+      "translated": "Session"
     },
     {
-      "id": "native.apple.4d7750c9bf699469",
-      "source": "Thread actions",
-      "translated": "Actions de la conversation"
+      "id": "native.apple.185a401f78328b0f",
+      "source": "Session actions",
+      "translated": "Actions de session"
     },
     {
-      "id": "native.apple.bb2f22cc43c97f8e",
-      "source": "Thread cost %@",
-      "translated": "Coût de la conversation %@"
+      "id": "native.apple.9f9dedf599b2619b",
+      "source": "Session cost %@",
+      "translated": "Coût de la session : %@"
     },
     {
-      "id": "native.apple.6239ced0b86e86f8",
-      "source": "Compact Thread",
-      "translated": "Compacter la conversation"
+      "id": "native.apple.f0a4720df5f5f403",
+      "source": "Compact Session",
+      "translated": "Compacter la session"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/hi.json
+++ b/apps/.i18n/native/hi.json
@@ -1429,9 +1429,9 @@
       "translated": "OpenClaw के साथ बोलें या डिक्टेट करें"
     },
     {
-      "id": "native.android.e2cf5a38587382cb",
-      "source": "Browse Threads",
-      "translated": "थ्रेड ब्राउज़ करें"
+      "id": "native.android.5876e15e5e92fd45",
+      "source": "Browse Sessions",
+      "translated": "सत्र ब्राउज़ करें"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "कोई कार्रवाई नहीं मिली"
     },
     {
-      "id": "native.android.bc70a4ac965b82ba",
-      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
-      "translated": "चैट, वॉइस, थ्रेड, प्रोवाइडर या सेटिंग्स आज़माएँ।"
+      "id": "native.android.48ad0ae0e930e02b",
+      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
+      "translated": "Chat, Voice, Sessions, Providers, या Settings आज़माएँ।"
     },
     {
-      "id": "native.android.670121e54dbe286f",
-      "source": "Threads",
-      "translated": "थ्रेड"
+      "id": "native.android.d4fbd1ee4f55a5db",
+      "source": "Sessions",
+      "translated": "सेशन"
     },
     {
-      "id": "native.android.d38be650b1bce4a0",
-      "source": "Connect the Gateway to search threads.",
-      "translated": "थ्रेड खोजने के लिए Gateway कनेक्ट करें।"
+      "id": "native.android.207c2170504e99e6",
+      "source": "Connect the Gateway to search sessions.",
+      "translated": "सेशन खोजने के लिए Gateway कनेक्ट करें।"
     },
     {
-      "id": "native.android.3d7754721f776ef8",
-      "source": "No matching threads yet.",
-      "translated": "अभी तक कोई मेल खाता थ्रेड नहीं है।"
+      "id": "native.android.25d2c2d792c952fe",
+      "source": "No matching sessions yet.",
+      "translated": "अभी तक कोई मेल खाता सेशन नहीं है।"
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "असिस्टेंट काम कर रहा है"
     },
     {
-      "id": "native.android.9a839f6e3e05a744",
-      "source": "OpenClaw thread",
-      "translated": "OpenClaw थ्रेड"
+      "id": "native.android.8f8384286317f5c9",
+      "source": "OpenClaw session",
+      "translated": "OpenClaw सेशन"
     },
     {
-      "id": "native.android.d83f82a1e4a5ed99",
-      "source": "Open thread",
-      "translated": "थ्रेड खोलें"
+      "id": "native.android.15799e57704b20c6",
+      "source": "Open session",
+      "translated": "सेशन खोलें"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "कोई तैयार प्रोवाइडर नहीं"
     },
     {
-      "id": "native.android.8a1c5365c0538908",
-      "source": "Main thread",
-      "translated": "मुख्य थ्रेड"
+      "id": "native.android.73e6ab1a168fd381",
+      "source": "Main session",
+      "translated": "मुख्य सत्र"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.a5845742daecb4ba",
-      "source": "Threads",
-      "translated": "थ्रेड"
+      "id": "native.android.0e3157c15c56944f",
+      "source": "Sessions",
+      "translated": "सत्र"
     },
     {
-      "id": "native.android.439b324280869527",
-      "source": "Focus thread search",
-      "translated": "थ्रेड खोज पर फ़ोकस करें"
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "सेशन खोज पर फ़ोकस करें"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "संग्रहीत"
     },
     {
-      "id": "native.android.03981341841b04ac",
-      "source": "Search threads",
-      "translated": "थ्रेड खोजें"
+      "id": "native.android.b9cf34c137e4cf03",
+      "source": "Search sessions",
+      "translated": "सत्र खोजें"
     },
     {
-      "id": "native.android.99570c528a41fa72",
-      "source": "Clear thread search",
-      "translated": "थ्रेड खोज साफ़ करें"
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "सेशन खोज साफ़ करें"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "सबसे पुराने पहले"
     },
     {
-      "id": "native.android.fd67be543e321cc9",
-      "source": "Toggle thread layout",
-      "translated": "थ्रेड लेआउट टॉगल करें"
+      "id": "native.android.c6bf8751e2a7f5c7",
+      "source": "Toggle session layout",
+      "translated": "सत्र लेआउट टॉगल करें"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "लेआउट: विस्तृत"
     },
     {
-      "id": "native.android.ebd17565e0ffd8eb",
-      "source": "Searching threads",
-      "translated": "थ्रेड खोजे जा रहे हैं"
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "सेशन खोजे जा रहे हैं"
     },
     {
-      "id": "native.android.472d46ae8669f860",
-      "source": "No matching threads",
-      "translated": "कोई मेल खाता थ्रेड नहीं"
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "कोई मेल खाता सेशन नहीं मिला"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "चैट शुरू करें"
     },
     {
-      "id": "native.android.ff81ad1bee00d384",
-      "source": "Current thread",
-      "translated": "वर्तमान थ्रेड"
+      "id": "native.android.f10d4df7cbc6df4f",
+      "source": "Current session",
+      "translated": "वर्तमान सत्र"
     },
     {
-      "id": "native.android.fc145645b9620e57",
-      "source": "OpenClaw thread",
-      "translated": "OpenClaw थ्रेड"
+      "id": "native.android.8f0482425838ae64",
+      "source": "OpenClaw session",
+      "translated": "OpenClaw सत्र"
     },
     {
-      "id": "native.android.71cbb8dde8bf138b",
-      "source": "Rename thread",
-      "translated": "थ्रेड का नाम बदलें"
+      "id": "native.android.786774c8a76e50d7",
+      "source": "Rename session",
+      "translated": "सेशन का नाम बदलें"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "समूह हटाएं?"
     },
     {
-      "id": "native.android.691e92cfe5cf106e",
-      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "\"$group\" के थ्रेड रखे जाते हैं और वापस असमूहीकृत में चले जाते हैं।"
+      "id": "native.android.3455fc2f77d564e3",
+      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "\"$group\" में सत्र रखे जाते हैं और वापस Ungrouped में चले जाते हैं।"
     },
     {
-      "id": "native.android.d87a8217ab56999b",
-      "source": "Delete thread?",
-      "translated": "थ्रेड हटाएँ?"
+      "id": "native.android.4805fb9d6623e8c0",
+      "source": "Delete session?",
+      "translated": "सत्र हटाएँ?"
     },
     {
-      "id": "native.android.930de97ff47113a8",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "यह थ्रेड और इसकी ट्रांसक्रिप्ट को स्थायी रूप से हटा देता है।"
+      "id": "native.android.0c3283a2b2445eae",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "यह सत्र और इसकी ट्रांसक्रिप्ट को स्थायी रूप से हटा देता है।"
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "असमूहीकृत"
     },
     {
-      "id": "native.android.8e21a70428def6e0",
-      "source": "No threads yet",
-      "translated": "अभी तक कोई थ्रेड नहीं"
+      "id": "native.android.db243d71d056afa4",
+      "source": "No sessions yet",
+      "translated": "अभी तक कोई सत्र नहीं"
     },
     {
-      "id": "native.android.cda4c5ad8b17e394",
-      "source": "No current thread",
-      "translated": "कोई मौजूदा थ्रेड नहीं"
+      "id": "native.android.5b4eee6a8092925e",
+      "source": "No current session",
+      "translated": "कोई वर्तमान सत्र नहीं"
     },
     {
-      "id": "native.android.be84f061047aa2da",
-      "source": "No archived threads",
-      "translated": "कोई आर्काइव किया गया थ्रेड नहीं"
+      "id": "native.android.acbcc9c9ea53d8c0",
+      "source": "No archived sessions",
+      "translated": "कोई संग्रहीत सत्र नहीं"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "नई बातचीत शुरू करें और वह यहाँ दिखाई देगी।"
     },
     {
-      "id": "native.android.f289d03e1d3eee98",
-      "source": "Open Chat to start or resume the current thread.",
-      "translated": "मौजूदा थ्रेड शुरू करने या फिर से जारी रखने के लिए Chat खोलें।"
+      "id": "native.android.56fcd605dc7be3c0",
+      "source": "Open Chat to start or resume the current session.",
+      "translated": "वर्तमान सत्र शुरू या फिर से शुरू करने के लिए चैट खोलें।"
     },
     {
-      "id": "native.android.504b71386e76c6ae",
-      "source": "Archived threads will show up here.",
-      "translated": "आर्काइव किए गए थ्रेड यहाँ दिखाई देंगे।"
+      "id": "native.android.085515989f8a2022",
+      "source": "Archived sessions will show up here.",
+      "translated": "संग्रहीत सत्र यहाँ दिखाई देंगे।"
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days}दि"
     },
     {
-      "id": "native.android.ee4c727cdafbe963",
-      "source": "Main thread",
-      "translated": "मुख्य थ्रेड"
+      "id": "native.android.3d4fa07acbc015c5",
+      "source": "Main session",
+      "translated": "मुख्य सत्र"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway लंबित"
     },
     {
-      "id": "native.android.da78209effb11cfd",
-      "source": "Thread Activity",
-      "translated": "थ्रेड गतिविधि"
+      "id": "native.android.2d8d049afe99f751",
+      "source": "Session Activity",
+      "translated": "सत्र गतिविधि"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "इस फ़ोन के कनेक्ट रहने के दौरान Exec अनुमोदन अनुरोध यहाँ दिखाई देंगे।"
     },
     {
-      "id": "native.android.f615712dfb56319a",
-      "source": "Thread activity",
-      "translated": "थ्रेड गतिविधि"
+      "id": "native.android.dc3e7ca5a491103a",
+      "source": "Session activity",
+      "translated": "सेशन गतिविधि"
     },
     {
-      "id": "native.android.6c93973c13db43ae",
-      "source": "Chat tool calls waiting in the active thread remain visible here.",
-      "translated": "सक्रिय थ्रेड में प्रतीक्षारत Chat टूल कॉल यहाँ दिखाई देते रहेंगे।"
+      "id": "native.android.8551e02b060bd7d8",
+      "source": "Chat tool calls waiting in the active session remain visible here.",
+      "translated": "सक्रिय सेशन में प्रतीक्षा कर रही चैट टूल कॉल यहाँ दिखाई देती रहेंगी।"
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,11 +4294,6 @@
       "translated": "Talk Provider सेटअप"
     },
     {
-      "id": "native.android.23b638094c34b916",
-      "source": "Microphone",
-      "translated": "माइक्रोफ़ोन"
-    },
-    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "ऑडियो टेस्ट"
@@ -4342,66 +4337,6 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "हो गया"
-    },
-    {
-      "id": "native.android.8d9ecdfdd916b780",
-      "source": "Automatic",
-      "translated": "स्वचालित"
-    },
-    {
-      "id": "native.android.c1626a6700a570f6",
-      "source": "Preferred microphone unavailable; using automatic routing.",
-      "translated": "पसंदीदा माइक्रोफ़ोन उपलब्ध नहीं है; स्वचालित रूटिंग का उपयोग किया जा रहा है।"
-    },
-    {
-      "id": "native.android.820bc5d0ce571d8b",
-      "source": "Prioritizes connected Bluetooth microphones.",
-      "translated": "कनेक्ट किए गए Bluetooth माइक्रोफ़ोन को प्राथमिकता देता है।"
-    },
-    {
-      "id": "native.android.11e48038d5e8bff6",
-      "source": "Preferred microphone",
-      "translated": "पसंदीदा माइक्रोफ़ोन"
-    },
-    {
-      "id": "native.android.eaa4d7563a46d307",
-      "source": "Unavailable",
-      "translated": "अनुपलब्ध"
-    },
-    {
-      "id": "native.android.9f5ebf17eb405ba8",
-      "source": "Next session",
-      "translated": "अगला सत्र"
-    },
-    {
-      "id": "native.android.8c4e91f53928efb2",
-      "source": "Built-in microphone",
-      "translated": "बिल्ट-इन माइक्रोफ़ोन"
-    },
-    {
-      "id": "native.android.14b613cb6e2446b4",
-      "source": "Bluetooth microphone",
-      "translated": "Bluetooth माइक्रोफ़ोन"
-    },
-    {
-      "id": "native.android.c885247b2d7ce271",
-      "source": "Bluetooth LE microphone",
-      "translated": "Bluetooth LE माइक्रोफ़ोन"
-    },
-    {
-      "id": "native.android.b6a4e674c5fb441a",
-      "source": "Wired headset microphone",
-      "translated": "वायर्ड हेडसेट माइक्रोफ़ोन"
-    },
-    {
-      "id": "native.android.9c8becb3b0fb5a90",
-      "source": "USB microphone",
-      "translated": "USB माइक्रोफ़ोन"
-    },
-    {
-      "id": "native.android.ba46258fadec7a39",
-      "source": "External microphone",
-      "translated": "बाहरी माइक्रोफ़ोन"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5139,9 +5074,9 @@
       "translated": "जाँचें"
     },
     {
-      "id": "native.android.c971506716c96e91",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
-      "translated": "OpenClaw इस फ़ोन को थ्रेड, वॉइस, प्रोवाइडर और Gateway के लिए एक सुव्यवस्थित मोबाइल कमांड इंटरफ़ेस में बदल देता है।"
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw इस फ़ोन को सत्रों, वॉइस, प्रदाताओं और Gateway के लिए एक सुव्यवस्थित मोबाइल कमांड इंटरफ़ेस में बदल देता है।"
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5689,9 +5624,9 @@
       "translated": "बातचीत सेटिंग्स"
     },
     {
-      "id": "native.android.36f78c8c85dc283f",
-      "source": "Recent Threads",
-      "translated": "हाल के थ्रेड"
+      "id": "native.android.73f07a5d54915259",
+      "source": "Recent Sessions",
+      "translated": "हाल के सेशन"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5749,14 +5684,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% ऑनलाइन"
     },
     {
-      "id": "native.android.57177017a6a93826",
-      "source": "Threads",
-      "translated": "थ्रेड"
+      "id": "native.android.16c3425d3a594481",
+      "source": "Sessions",
+      "translated": "सेशन"
     },
     {
-      "id": "native.android.43320b54a68b00a1",
-      "source": "No recent threads",
-      "translated": "कोई हाल का थ्रेड नहीं"
+      "id": "native.android.a5c0f8b3112aa58c",
+      "source": "No recent sessions",
+      "translated": "हाल की कोई सत्र नहीं"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5794,14 +5729,14 @@
       "translated": "कार्यरत · $pendingRunCount सक्रिय रन"
     },
     {
-      "id": "native.android.e24db059480f1e6a",
-      "source": "Monitoring · 1 thread",
-      "translated": "निगरानी · 1 थ्रेड"
+      "id": "native.android.2c89da708b12a522",
+      "source": "Monitoring · 1 session",
+      "translated": "निगरानी जारी · 1 सत्र"
     },
     {
-      "id": "native.android.5a475f37d80e02bc",
-      "source": "Monitoring · $sessionCount threads",
-      "translated": "निगरानी · $sessionCount थ्रेड"
+      "id": "native.android.8b6ee382dcb64e1f",
+      "source": "Monitoring · $sessionCount sessions",
+      "translated": "निगरानी जारी · $sessionCount सत्र"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5834,9 +5769,9 @@
       "translated": "प्रदाता"
     },
     {
-      "id": "native.android.358c5e0e838d5423",
-      "source": "Open thread",
-      "translated": "थ्रेड खोलें"
+      "id": "native.android.a65477861c7203aa",
+      "source": "Open session",
+      "translated": "सत्र खोलें"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6259,9 +6194,9 @@
       "translated": "${days}दि"
     },
     {
-      "id": "native.android.28a1a1acc5a0959f",
-      "source": "Main thread",
-      "translated": "मुख्य थ्रेड"
+      "id": "native.android.22d755834386db07",
+      "source": "Main session",
+      "translated": "मुख्य सत्र"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6942,16 +6877,6 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "अनम्यूट करें"
-    },
-    {
-      "id": "native.android.cb608d82c5b3352a",
-      "source": "Back camera",
-      "translated": "पिछला कैमरा"
-    },
-    {
-      "id": "native.android.e89a0e780eed2e1e",
-      "source": "Front camera",
-      "translated": "सामने का कैमरा"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7759,9 +7684,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.0c74bc30a994dd33",
-      "source": "Loading thread",
-      "translated": "थ्रेड लोड हो रहा है"
+      "id": "native.android.882cc14a58e7e105",
+      "source": "Loading session",
+      "translated": "सेशन लोड हो रहा है"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7804,14 +7729,14 @@
       "translated": "मुझे ताज़ा जानकारी दें"
     },
     {
-      "id": "native.android.cf40df9739f78f27",
-      "source": "Summarize recent threads and next steps.",
-      "translated": "हाल के थ्रेड और अगले चरणों का सारांश दें।"
+      "id": "native.android.1e5add56e48c99f9",
+      "source": "Summarize recent sessions and next steps.",
+      "translated": "हाल के सेशन और अगले चरणों का सारांश दें।"
     },
     {
-      "id": "native.android.ebe49a8b8df80bd3",
-      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
-      "translated": "मेरे हाल के OpenClaw थ्रेड की जानकारी दें और अगले चरण सुझाएँ।"
+      "id": "native.android.06d515351bb79576",
+      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
+      "translated": "मेरे हाल के OpenClaw सेशन की जानकारी दें और अगले चरण सुझाएँ।"
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8149,9 +8074,9 @@
       "translated": "कनेक्टेड"
     },
     {
-      "id": "native.android.6cf5d6fa8a4186d5",
-      "source": "Threads",
-      "translated": "थ्रेड"
+      "id": "native.android.81931886b9caf3ab",
+      "source": "Sessions",
+      "translated": "सेशन"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,6 +10719,61 @@
       "translated": "कार्य का विवरण"
     },
     {
+      "id": "native.apple.29cacb53ea5e77fc",
+      "source": "Pinned",
+      "translated": "पिन किया गया"
+    },
+    {
+      "id": "native.apple.940062cfdce9211b",
+      "source": "Recent",
+      "translated": "हाल के"
+    },
+    {
+      "id": "native.apple.a0980128426308a9",
+      "source": "Model",
+      "translated": "मॉडल"
+    },
+    {
+      "id": "native.apple.9520e60f21535dde",
+      "source": "Thinking",
+      "translated": "सोच-विचार"
+    },
+    {
+      "id": "native.apple.8b321f3ffce97429",
+      "source": "Fast",
+      "translated": "तेज़"
+    },
+    {
+      "id": "native.apple.989b70d64e328d55",
+      "source": "Default (inherited)",
+      "translated": "डिफ़ॉल्ट (इनहेरिट किया गया)"
+    },
+    {
+      "id": "native.apple.f4114e73b07eb9ae",
+      "source": "Off",
+      "translated": "बंद"
+    },
+    {
+      "id": "native.apple.7ed231b28d16312f",
+      "source": "On",
+      "translated": "चालू"
+    },
+    {
+      "id": "native.apple.412a74802320a037",
+      "source": "Full",
+      "translated": "पूर्ण"
+    },
+    {
+      "id": "native.apple.299f21a2071ff9fc",
+      "source": "Verbosity",
+      "translated": "विस्तार का स्तर"
+    },
+    {
+      "id": "native.apple.faf0ef05e1496de7",
+      "source": "Default",
+      "translated": "डिफ़ॉल्ट"
+    },
+    {
       "id": "native.apple.e5524d5756a62744",
       "source": "Unable to Export Transcript",
       "translated": "प्रतिलेख निर्यात नहीं किया जा सका"
@@ -10814,9 +10794,9 @@
       "translated": "आप किस पर काम करना चाहेंगे?"
     },
     {
-      "id": "native.apple.4da775013ac9b123",
-      "source": "The thread attaches once the gateway is ready.",
-      "translated": "Gateway तैयार होने पर थ्रेड संलग्न हो जाता है।"
+      "id": "native.apple.32179ce0b6d4543f",
+      "source": "The session attaches once the gateway is ready.",
+      "translated": "Gateway तैयार होने के बाद सेशन अटैच हो जाता है।"
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10859,9 +10839,14 @@
       "translated": "Worktree में नया चैट"
     },
     {
-      "id": "native.apple.003b25ddafeb18e9",
-      "source": "Threads…",
-      "translated": "थ्रेड…"
+      "id": "native.apple.ce6ebe91fc597015",
+      "source": "New Session Options…",
+      "translated": "नए सत्र के विकल्प…"
+    },
+    {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "सत्र…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11024,14 +11009,14 @@
       "translated": "बनाएँ"
     },
     {
-      "id": "native.apple.31d5c7287cfb3abe",
-      "source": "Delete Thread?",
-      "translated": "थ्रेड हटाएँ?"
+      "id": "native.apple.f488b9caf6e51ac3",
+      "source": "Delete Session?",
+      "translated": "सेशन हटाएँ?"
     },
     {
-      "id": "native.apple.d3395564809f1120",
-      "source": "Delete Thread",
-      "translated": "थ्रेड हटाएँ"
+      "id": "native.apple.8634b17be9b111bc",
+      "source": "Delete Session",
+      "translated": "सेशन हटाएँ"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11039,9 +11024,9 @@
       "translated": "रद्द करें"
     },
     {
-      "id": "native.apple.092659256d26cb03",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "इससे थ्रेड और उसका ट्रांसक्रिप्ट स्थायी रूप से हट जाएगा।"
+      "id": "native.apple.4a9568ac9b18d8d3",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "इससे सेशन और उसका ट्रांसक्रिप्ट स्थायी रूप से हट जाएगा।"
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11069,9 +11054,9 @@
       "translated": "नया समूह"
     },
     {
-      "id": "native.apple.683032464c497bbd",
-      "source": "Rename Thread",
-      "translated": "थ्रेड का नाम बदलें"
+      "id": "native.apple.5bccdc23a1640895",
+      "source": "Rename Session",
+      "translated": "सेशन का नाम बदलें"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11079,9 +11064,9 @@
       "translated": "समूह का नाम"
     },
     {
-      "id": "native.apple.f887aa956588f237",
-      "source": "Thread name",
-      "translated": "थ्रेड का नाम"
+      "id": "native.apple.af789b2d2fda0f67",
+      "source": "Session name",
+      "translated": "सेशन का नाम"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11119,14 +11104,14 @@
       "translated": "एजेंट"
     },
     {
-      "id": "native.apple.7c8231b7b1ca480f",
-      "source": "Agent thread",
-      "translated": "एजेंट थ्रेड"
+      "id": "native.apple.a3bde8045fe9224a",
+      "source": "Agent session",
+      "translated": "एजेंट सत्र"
     },
     {
-      "id": "native.apple.b3c553614f762a58",
-      "source": "Recent threads",
-      "translated": "हाल के थ्रेड"
+      "id": "native.apple.27f775de30b37ff8",
+      "source": "Recent sessions",
+      "translated": "हाल के सत्र"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11134,9 +11119,9 @@
       "translated": "Gateway ऑफ़लाइन है"
     },
     {
-      "id": "native.apple.5aa32afda85064ea",
-      "source": "No recent threads",
-      "translated": "कोई हाल का थ्रेड नहीं"
+      "id": "native.apple.28c97cf23665ee01",
+      "source": "No recent sessions",
+      "translated": "हाल के कोई सत्र नहीं"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11234,14 +11219,14 @@
       "translated": "रद्द करें"
     },
     {
-      "id": "native.apple.b6855cf19a50f477",
-      "source": "Threads",
-      "translated": "थ्रेड"
+      "id": "native.apple.9f2fd65953013b7c",
+      "source": "Sessions",
+      "translated": "सत्र"
     },
     {
-      "id": "native.apple.9b1d0ef27a1333b0",
-      "source": "Archived threads",
-      "translated": "संग्रहीत थ्रेड"
+      "id": "native.apple.0422818cc95d5071",
+      "source": "Archived sessions",
+      "translated": "आर्काइव किए गए सेशन"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11249,34 +11234,34 @@
       "translated": "आर्काइव किए गए दिखाएँ"
     },
     {
-      "id": "native.apple.98167401c7267735",
-      "source": "Threads unavailable",
-      "translated": "थ्रेड उपलब्ध नहीं हैं"
+      "id": "native.apple.b272115c83f7ef58",
+      "source": "Sessions unavailable",
+      "translated": "सत्र उपलब्ध नहीं हैं"
     },
     {
-      "id": "native.apple.4d28a7def2337b9f",
-      "source": "Loading archived threads",
-      "translated": "संग्रहीत थ्रेड लोड किए जा रहे हैं"
+      "id": "native.apple.54f8260c9b863087",
+      "source": "Loading archived sessions",
+      "translated": "आर्काइव किए गए सेशन लोड हो रहे हैं"
     },
     {
-      "id": "native.apple.777d7b706933bd7b",
-      "source": "Loading recent threads",
-      "translated": "हाल के थ्रेड लोड किए जा रहे हैं"
+      "id": "native.apple.9b305868873dade2",
+      "source": "Loading recent sessions",
+      "translated": "हाल के सेशन लोड हो रहे हैं"
     },
     {
-      "id": "native.apple.22f81ea94bef8410",
-      "source": "^[\\(count) thread](inflect: true)",
-      "translated": "^[\\(count) थ्रेड](inflect: true)"
+      "id": "native.apple.207dad20d09f3160",
+      "source": "^[\\(count) session](inflect: true)",
+      "translated": "^[\\(count) सत्र](inflect: true)"
     },
     {
-      "id": "native.apple.1cad51e14db59bf9",
-      "source": "No archived threads",
-      "translated": "कोई संग्रहीत थ्रेड नहीं"
+      "id": "native.apple.1f4501a6bf2bae4c",
+      "source": "No archived sessions",
+      "translated": "कोई आर्काइव किया गया सेशन नहीं"
     },
     {
-      "id": "native.apple.18ef832d3a7ddcf8",
-      "source": "Archived threads will appear here.",
-      "translated": "संग्रहीत थ्रेड यहाँ दिखाई देंगे।"
+      "id": "native.apple.2a1ba7a5e1979c9e",
+      "source": "Archived sessions will appear here.",
+      "translated": "संग्रहीत सत्र यहाँ दिखाई देंगे।"
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11359,9 +11344,9 @@
       "translated": "इनटेक साझा करें"
     },
     {
-      "id": "native.apple.21d9208d86a4d1fe",
-      "source": "Loading threads",
-      "translated": "थ्रेड लोड हो रहे हैं"
+      "id": "native.apple.2360d25fe6ae9946",
+      "source": "Loading sessions",
+      "translated": "सत्र लोड हो रहे हैं"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11369,19 +11354,19 @@
       "translated": "Gateway से हाल की गतिविधि प्राप्त की जा रही है।"
     },
     {
-      "id": "native.apple.4be1f79aa2b230ff",
-      "source": "Threads unavailable",
-      "translated": "थ्रेड उपलब्ध नहीं हैं"
+      "id": "native.apple.c334f2e86702a7b8",
+      "source": "Sessions unavailable",
+      "translated": "सत्र उपलब्ध नहीं हैं"
     },
     {
-      "id": "native.apple.98b348873556bc46",
-      "source": "No recent threads",
-      "translated": "कोई हालिया थ्रेड नहीं"
+      "id": "native.apple.6cc6efb7a03960b6",
+      "source": "No recent sessions",
+      "translated": "कोई हाल के सत्र नहीं"
     },
     {
-      "id": "native.apple.7396d205574d279f",
-      "source": "Thread activity offline",
-      "translated": "थ्रेड गतिविधि ऑफ़लाइन है"
+      "id": "native.apple.08483af2d043bee6",
+      "source": "Session activity offline",
+      "translated": "सत्र गतिविधि ऑफ़लाइन है"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11839,9 +11824,9 @@
       "translated": "कार्ड"
     },
     {
-      "id": "native.apple.c9ec1b0e18074d8a",
-      "source": "Open Thread",
-      "translated": "थ्रेड खोलें"
+      "id": "native.apple.93eeaedb2ff61043",
+      "source": "Open Session",
+      "translated": "सेशन खोलें"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13329,9 +13314,9 @@
       "translated": "डिफ़ॉल्ट"
     },
     {
-      "id": "native.apple.f4ae5664c3eda95d",
-      "source": "Used for new Chat threads and Talk sessions.",
-      "translated": "नए Chat थ्रेड और Talk सत्रों के लिए उपयोग किया जाता है।"
+      "id": "native.apple.3de045f17ea3c6d0",
+      "source": "Used for new Chat and Talk sessions.",
+      "translated": "नए Chat और Talk सत्रों के लिए उपयोग किया जाता है।"
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15734,9 +15719,9 @@
       "translated": "इंस्टेंस"
     },
     {
-      "id": "native.apple.11fe8b9941954dfb",
-      "source": "Threads",
-      "translated": "थ्रेड"
+      "id": "native.apple.3579cf2750470a22",
+      "source": "Sessions",
+      "translated": "सत्र"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19044,9 +19029,9 @@
       "translated": "क्विक चैट शॉर्टकट"
     },
     {
-      "id": "native.apple.94dd793cd7d7d555",
-      "source": "Global shortcut that opens a floating chat bar for the main thread.",
-      "translated": "मुख्य थ्रेड के लिए फ़्लोटिंग चैट बार खोलने वाला ग्लोबल शॉर्टकट।"
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "मुख्य सत्र के लिए फ़्लोटिंग चैट बार खोलने वाला ग्लोबल शॉर्टकट।"
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19624,9 +19609,9 @@
       "translated": "गंभीर"
     },
     {
-      "id": "native.apple.13f96467014cf344",
-      "source": "New Thread",
-      "translated": "नया थ्रेड"
+      "id": "native.apple.75102378a6775180",
+      "source": "New Session",
+      "translated": "नया सत्र"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21914,9 +21899,9 @@
       "translated": "हाल के कोई संदेश नहीं"
     },
     {
-      "id": "native.apple.3ec2afcbc298c673",
-      "source": "Threads",
-      "translated": "थ्रेड"
+      "id": "native.apple.1ff8aec0044934c3",
+      "source": "Sessions",
+      "translated": "सत्र"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21924,9 +21909,9 @@
       "translated": "संदर्भ और रेट सीमाओं के लिए CLI द्वारा फिर से उपयोग की जाने वाली संग्रहीत बातचीत बकेट्स पर एक नज़र डालें।"
     },
     {
-      "id": "native.apple.14ccb32cd8ed1c81",
-      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
-      "translated": "अभी तक कोई थ्रेड नहीं है। वे पहला इनबाउंड संदेश या हार्टबीट मिलने के बाद दिखाई देते हैं।"
+      "id": "native.apple.bab897f3252b134c",
+      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
+      "translated": "अभी कोई सत्र नहीं हैं। वे पहले इनबाउंड संदेश या हार्टबीट के बाद दिखाई देते हैं।"
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -22009,9 +21994,9 @@
       "translated": "Exec अनुमोदन"
     },
     {
-      "id": "native.apple.52e37e3a44ae516c",
-      "source": "Threads",
-      "translated": "थ्रेड"
+      "id": "native.apple.64a6dc7d49e8fb57",
+      "source": "Sessions",
+      "translated": "सत्र"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -23014,9 +22999,9 @@
       "translated": "मुझे अब तक की जानकारी दें"
     },
     {
-      "id": "native.apple.fc4ce810900ec0b6",
-      "source": "Summarize what happened in my threads since yesterday.",
-      "translated": "कल से अब तक मेरे थ्रेड में क्या हुआ, उसका सारांश दें।"
+      "id": "native.apple.234ec45f4231edc4",
+      "source": "Summarize what happened in my sessions since yesterday.",
+      "translated": "कल से अब तक मेरे सत्रों में जो हुआ उसका सारांश दें।"
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23194,9 +23179,9 @@
       "translated": "मॉडल अनपिन करें"
     },
     {
-      "id": "native.apple.4edb66657f5aca1f",
-      "source": "Thread",
-      "translated": "थ्रेड"
+      "id": "native.apple.5dfc0700d8dff8de",
+      "source": "Session",
+      "translated": "सत्र"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23359,51 +23344,6 @@
       "translated": "विजेट उपलब्ध नहीं है"
     },
     {
-      "id": "native.apple.d640691fd196f338",
-      "source": "Widget export failed",
-      "translated": "विजेट एक्सपोर्ट विफल रहा"
-    },
-    {
-      "id": "native.apple.533c6e22a11e88de",
-      "source": "OK",
-      "translated": "ठीक है"
-    },
-    {
-      "id": "native.apple.e1fb28a2a9756402",
-      "source": "Copy image",
-      "translated": "इमेज कॉपी करें"
-    },
-    {
-      "id": "native.apple.ebd7bc92e1b12235",
-      "source": "Save image…",
-      "translated": "इमेज सेव करें…"
-    },
-    {
-      "id": "native.apple.742c46d4cf2db134",
-      "source": "Save image",
-      "translated": "इमेज सेव करें"
-    },
-    {
-      "id": "native.apple.0589cce608418f90",
-      "source": "The widget image could not be captured.",
-      "translated": "विजेट की छवि कैप्चर नहीं की जा सकी।"
-    },
-    {
-      "id": "native.apple.dfe24e827fdbe9c5",
-      "source": "The widget image could not be copied.",
-      "translated": "विजेट की छवि कॉपी नहीं की जा सकी।"
-    },
-    {
-      "id": "native.apple.9e611e3a80e71408",
-      "source": "The widget image could not be encoded as PNG.",
-      "translated": "विजेट की छवि को PNG के रूप में एन्कोड नहीं किया जा सका।"
-    },
-    {
-      "id": "native.apple.9a6e8afbe24a262b",
-      "source": "The widget image could not be saved.",
-      "translated": "विजेट की छवि सहेजी नहीं जा सकी।"
-    },
-    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23544,19 +23484,19 @@
       "translated": "उपयोगकर्ता"
     },
     {
-      "id": "native.apple.9d0cba09d92ee669",
-      "source": "This thread cannot be archived while it is active or running.",
-      "translated": "सक्रिय या चल रहे इस थ्रेड को आर्काइव नहीं किया जा सकता।"
+      "id": "native.apple.b1cdcb906a43d5d6",
+      "source": "This session cannot be archived while it is active or running.",
+      "translated": "यह सत्र सक्रिय या चल रहा होने के दौरान संग्रहीत नहीं किया जा सकता।"
     },
     {
-      "id": "native.apple.8952a111a1075051",
-      "source": "The main thread cannot be deleted.",
-      "translated": "मुख्य थ्रेड को हटाया नहीं जा सकता।"
+      "id": "native.apple.5817e3f3dab1ee19",
+      "source": "The main session cannot be deleted.",
+      "translated": "मुख्य सत्र को हटाया नहीं जा सकता।"
     },
     {
-      "id": "native.apple.90d0ccf80ca28717",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
-      "translated": "इस थ्रेड को आर्काइव करने या हटाने से पहले अटैचमेंट हटाएँ या डिलीवरी की प्रतीक्षा करें।"
+      "id": "native.apple.a6b8df3f18171c91",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
+      "translated": "इस सत्र को संग्रहीत करने या हटाने से पहले अटैचमेंट हटाएँ या डिलीवरी की प्रतीक्षा करें।"
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23694,9 +23634,9 @@
       "translated": "रन समाप्त हुआ"
     },
     {
-      "id": "native.apple.bbccb4c8db5cac12",
-      "source": "Thread Info",
-      "translated": "थ्रेड की जानकारी"
+      "id": "native.apple.cd7c3095a22f80a9",
+      "source": "Session Info",
+      "translated": "सेशन की जानकारी"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23729,9 +23669,9 @@
       "translated": "समूह जोड़ें"
     },
     {
-      "id": "native.apple.7b641fed5bace855",
-      "source": "Thread Groups",
-      "translated": "थ्रेड समूह"
+      "id": "native.apple.23d628606fe0734f",
+      "source": "Session Groups",
+      "translated": "सेशन समूह"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23774,9 +23714,9 @@
       "translated": "समूह हटाएँ"
     },
     {
-      "id": "native.apple.56401c79410a310d",
-      "source": "Threads in this group become ungrouped.",
-      "translated": "इस समूह के थ्रेड असमूहीकृत हो जाएँगे।"
+      "id": "native.apple.b049c8a4d2805e08",
+      "source": "Sessions in this group become ungrouped.",
+      "translated": "इस समूह के सत्र असमूहीकृत हो जाएँगे।"
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23789,9 +23729,9 @@
       "translated": "इस Gateway पर कोई एजेंट उपलब्ध नहीं है।"
     },
     {
-      "id": "native.apple.2d96aa7d3d12f85b",
-      "source": "New Thread Options",
-      "translated": "नए थ्रेड के विकल्प"
+      "id": "native.apple.6c89f35d53506406",
+      "source": "New Session Options",
+      "translated": "नए सत्र के विकल्प"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23819,19 +23759,19 @@
       "translated": "बनाएँ"
     },
     {
-      "id": "native.apple.87ef57319d1ddc85",
-      "source": "The thread could not be created.",
-      "translated": "थ्रेड बनाया नहीं जा सका।"
+      "id": "native.apple.795ba37f6782cf28",
+      "source": "The session could not be created.",
+      "translated": "सत्र बनाया नहीं जा सका।"
     },
     {
-      "id": "native.apple.6bd91c435b69d638",
-      "source": "Search threads",
-      "translated": "थ्रेड खोजें"
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "सत्र खोजें"
     },
     {
-      "id": "native.apple.6fde4bdf9d5b9191",
-      "source": "No Threads",
-      "translated": "कोई थ्रेड नहीं"
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "कोई सत्र नहीं"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23839,29 +23779,29 @@
       "translated": "कोई परिणाम नहीं"
     },
     {
-      "id": "native.apple.a02fd99740d29bd3",
-      "source": "New Thread",
-      "translated": "नया थ्रेड"
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "नया सत्र"
     },
     {
-      "id": "native.apple.b625801dd04b09f2",
-      "source": "New thread",
-      "translated": "नया थ्रेड"
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "नया सत्र"
     },
     {
-      "id": "native.apple.851be81fcc933608",
-      "source": "New thread options",
-      "translated": "नए थ्रेड के विकल्प"
+      "id": "native.apple.2ef0e34db02ad255",
+      "source": "New session options",
+      "translated": "नए सत्र के विकल्प"
     },
     {
-      "id": "native.apple.9ce8a4aba7b444b2",
-      "source": "Rename Thread",
-      "translated": "थ्रेड का नाम बदलें"
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "सत्र का नाम बदलें"
     },
     {
-      "id": "native.apple.1dd067c44511c7f0",
-      "source": "Thread name",
-      "translated": "थ्रेड का नाम"
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "सत्र का नाम"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23874,14 +23814,14 @@
       "translated": "रद्द करें"
     },
     {
-      "id": "native.apple.618073d6ab3f2721",
-      "source": "Delete Thread",
-      "translated": "थ्रेड हटाएँ"
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "सत्र हटाएँ"
     },
     {
-      "id": "native.apple.10a5e72bba3cbccc",
-      "source": "The thread and its transcript are removed from the gateway.",
-      "translated": "थ्रेड और उसकी ट्रांसक्रिप्ट Gateway से हटा दिए जाते हैं।"
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "सत्र और उसकी ट्रांसक्रिप्ट Gateway से हटा दिए जाते हैं।"
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23889,14 +23829,14 @@
       "translated": "“%@” को हटाएँ?"
     },
     {
-      "id": "native.apple.ac71e3b2aa496a2c",
-      "source": "Thread running",
-      "translated": "थ्रेड चल रहा है"
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "सत्र चल रहा है"
     },
     {
-      "id": "native.apple.c775e87f997278b2",
-      "source": "Thread failed",
-      "translated": "थ्रेड विफल रहा"
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "सत्र विफल रहा"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23954,9 +23894,9 @@
       "translated": "सत्र कुंजी कॉपी करें"
     },
     {
-      "id": "native.apple.f4998cfb572f23ff",
-      "source": "Delete Thread…",
-      "translated": "थ्रेड हटाएँ…"
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "सत्र हटाएँ…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23969,9 +23909,9 @@
       "translated": "कनेक्ट हो रहा है…"
     },
     {
-      "id": "native.apple.8802e9576ffd0f65",
-      "source": "Retry thread groups",
-      "translated": "थ्रेड समूहों के लिए फिर से प्रयास करें"
+      "id": "native.apple.79f708b3bc1d3a6c",
+      "source": "Retry session groups",
+      "translated": "सत्र समूहों के लिए फिर से प्रयास करें"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23994,24 +23934,24 @@
       "translated": "स्कोप"
     },
     {
-      "id": "native.apple.b313b80def4bda52",
-      "source": "Search threads",
-      "translated": "थ्रेड खोजें"
+      "id": "native.apple.2c37581c7b88f741",
+      "source": "Search sessions",
+      "translated": "सत्र खोजें"
     },
     {
-      "id": "native.apple.c0cc6acc36f413ce",
-      "source": "Threads",
-      "translated": "थ्रेड"
+      "id": "native.apple.43be8a2336e42faf",
+      "source": "Sessions",
+      "translated": "सत्र"
     },
     {
-      "id": "native.apple.854d3928fe5a557c",
-      "source": "Rename Thread",
-      "translated": "थ्रेड का नाम बदलें"
+      "id": "native.apple.0b379cdfcbd3247f",
+      "source": "Rename Session",
+      "translated": "सत्र का नाम बदलें"
     },
     {
-      "id": "native.apple.9d0d3f20096cc4da",
-      "source": "Thread name",
-      "translated": "थ्रेड का नाम"
+      "id": "native.apple.54b6fbd9e41db009",
+      "source": "Session name",
+      "translated": "सत्र का नाम"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -24019,19 +23959,19 @@
       "translated": "रद्द करें"
     },
     {
-      "id": "native.apple.dc00eb94f33bae15",
-      "source": "Delete selected threads?",
-      "translated": "चुने गए थ्रेड हटाएँ?"
+      "id": "native.apple.751e0f6b81cd374a",
+      "source": "Delete selected sessions?",
+      "translated": "चुने गए सत्र हटाएँ?"
     },
     {
-      "id": "native.apple.2053fc9f74dc3158",
-      "source": "Delete Threads",
-      "translated": "थ्रेड हटाएँ"
+      "id": "native.apple.aa679276581b0058",
+      "source": "Delete Sessions",
+      "translated": "सत्र हटाएँ"
     },
     {
-      "id": "native.apple.0970247871a834a0",
-      "source": "Each selected thread and its transcript will be removed from the gateway.",
-      "translated": "प्रत्येक चयनित थ्रेड और उसकी ट्रांसक्रिप्ट Gateway से हटा दी जाएगी।"
+      "id": "native.apple.f837129cbee23297",
+      "source": "Each selected session and its transcript will be removed from the gateway.",
+      "translated": "हर चुना गया सत्र और उसकी प्रतिलिपि Gateway से हटा दी जाएगी।"
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -24039,9 +23979,9 @@
       "translated": "समूह"
     },
     {
-      "id": "native.apple.6f8acab2256728b5",
-      "source": "Manage thread groups",
-      "translated": "थ्रेड समूह प्रबंधित करें"
+      "id": "native.apple.64013cfee5e25305",
+      "source": "Manage session groups",
+      "translated": "सत्र समूह प्रबंधित करें"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -24054,14 +23994,14 @@
       "translated": "चुनें"
     },
     {
-      "id": "native.apple.692972314d04b184",
-      "source": "No archived threads",
-      "translated": "कोई संग्रहीत थ्रेड नहीं"
+      "id": "native.apple.b67eaecec1b423ac",
+      "source": "No archived sessions",
+      "translated": "कोई संग्रहीत सत्र नहीं"
     },
     {
-      "id": "native.apple.d6a4b5711dcd26e7",
-      "source": "No threads found",
-      "translated": "कोई थ्रेड नहीं मिला"
+      "id": "native.apple.b2435a79abf0c794",
+      "source": "No sessions found",
+      "translated": "कोई सत्र नहीं मिला"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24229,16 +24169,6 @@
       "translated": "पूरा संदेश खोलें"
     },
     {
-      "id": "native.apple.002bfcede229ad4b",
-      "source": "Rewind to Here",
-      "translated": "यहाँ तक रिवाइंड करें"
-    },
-    {
-      "id": "native.apple.14df2e4997689fb3",
-      "source": "Fork from Here",
-      "translated": "यहाँ से फ़ोर्क करें"
-    },
-    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "जवाब दें"
@@ -24324,9 +24254,9 @@
       "translated": "नई चैट शुरू करने से पहले अटैचमेंट हटाएँ या डिलीवरी पूरी होने की प्रतीक्षा करें।"
     },
     {
-      "id": "native.apple.e0f045151c8d3137",
-      "source": "Gateway changed before the thread operation started.",
-      "translated": "थ्रेड कार्रवाई शुरू होने से पहले Gateway बदल गया।"
+      "id": "native.apple.980f552bb0f96c0f",
+      "source": "Gateway changed before the session operation started.",
+      "translated": "सत्र संचालन शुरू होने से पहले Gateway बदल गया।"
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24334,9 +24264,9 @@
       "translated": "चैट बदलने से पहले अटैचमेंट हटाएं या डिलीवरी पूरी होने की प्रतीक्षा करें।"
     },
     {
-      "id": "native.apple.0a5c4e15466c3acc",
-      "source": "Clear this thread's history?",
-      "translated": "इस थ्रेड का इतिहास साफ़ करें?"
+      "id": "native.apple.87ba543b42696b92",
+      "source": "Clear this session's history?",
+      "translated": "इस सत्र का इतिहास साफ़ करें?"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24349,14 +24279,14 @@
       "translated": "यह %@ के लिए बातचीत रीसेट करता है। सेशन कुंजी वही रहती है।"
     },
     {
-      "id": "native.apple.67ac221dbe7179f0",
-      "source": "Rename Thread",
-      "translated": "थ्रेड का नाम बदलें"
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "सत्र का नाम बदलें"
     },
     {
-      "id": "native.apple.cf0f7e049603f518",
-      "source": "Thread name",
-      "translated": "थ्रेड का नाम"
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "सत्र का नाम"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24374,9 +24304,9 @@
       "translated": "ट्रांसक्रिप्ट निर्यात करें"
     },
     {
-      "id": "native.apple.c0ada47504425f23",
-      "source": "Threads",
-      "translated": "थ्रेड"
+      "id": "native.apple.4af0f566d39d7041",
+      "source": "Sessions",
+      "translated": "सत्र"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24449,14 +24379,14 @@
       "translated": "डिफ़ॉल्ट"
     },
     {
-      "id": "native.apple.1a765291943599e5",
-      "source": "New Thread",
-      "translated": "नया थ्रेड"
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "नया सेशन"
     },
     {
-      "id": "native.apple.c7a3a6d5e43dd98f",
-      "source": "New Thread Options…",
-      "translated": "नए थ्रेड के विकल्प…"
+      "id": "native.apple.a7119fbf9d25df5e",
+      "source": "New Session Options…",
+      "translated": "नए सत्र के विकल्प…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24464,19 +24394,19 @@
       "translated": "रीफ़्रेश करें"
     },
     {
-      "id": "native.apple.0e710b81808e5dcf",
-      "source": "Threads…",
-      "translated": "थ्रेड…"
+      "id": "native.apple.2bcff4a8fa503739",
+      "source": "Sessions…",
+      "translated": "सत्र…"
     },
     {
-      "id": "native.apple.faad8f92b6bef166",
-      "source": "Rename Thread…",
-      "translated": "थ्रेड का नाम बदलें…"
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "सत्र का नाम बदलें…"
     },
     {
-      "id": "native.apple.23b61d6cd26ac112",
-      "source": "Fork",
-      "translated": "फोर्क"
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "सत्र को फ़ोर्क करें"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24534,24 +24464,24 @@
       "translated": "इतिहास साफ़ करें…"
     },
     {
-      "id": "native.apple.8b4f1c5107ea8a0e",
-      "source": "Thread",
-      "translated": "थ्रेड"
+      "id": "native.apple.920fe8a7a33f9e92",
+      "source": "Session",
+      "translated": "सेशन"
     },
     {
-      "id": "native.apple.4d7750c9bf699469",
-      "source": "Thread actions",
-      "translated": "थ्रेड की कार्रवाइयाँ"
+      "id": "native.apple.185a401f78328b0f",
+      "source": "Session actions",
+      "translated": "सेशन क्रियाएँ"
     },
     {
-      "id": "native.apple.bb2f22cc43c97f8e",
-      "source": "Thread cost %@",
-      "translated": "थ्रेड की लागत %@"
+      "id": "native.apple.9f9dedf599b2619b",
+      "source": "Session cost %@",
+      "translated": "सेशन की लागत %@"
     },
     {
-      "id": "native.apple.6239ced0b86e86f8",
-      "source": "Compact Thread",
-      "translated": "थ्रेड संक्षिप्त करें"
+      "id": "native.apple.f0a4720df5f5f403",
+      "source": "Compact Session",
+      "translated": "सेशन कॉम्पैक्ट करें"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/hi.json
+++ b/apps/.i18n/native/hi.json
@@ -1429,9 +1429,9 @@
       "translated": "OpenClaw के साथ बोलें या डिक्टेट करें"
     },
     {
-      "id": "native.android.5876e15e5e92fd45",
-      "source": "Browse Sessions",
-      "translated": "सत्र ब्राउज़ करें"
+      "id": "native.android.e2cf5a38587382cb",
+      "source": "Browse Threads",
+      "translated": "थ्रेड ब्राउज़ करें"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "कोई कार्रवाई नहीं मिली"
     },
     {
-      "id": "native.android.48ad0ae0e930e02b",
-      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
-      "translated": "Chat, Voice, Sessions, Providers, या Settings आज़माएँ।"
+      "id": "native.android.bc70a4ac965b82ba",
+      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
+      "translated": "चैट, वॉइस, थ्रेड, प्रोवाइडर या सेटिंग्स आज़माएँ।"
     },
     {
-      "id": "native.android.d4fbd1ee4f55a5db",
-      "source": "Sessions",
-      "translated": "सेशन"
+      "id": "native.android.670121e54dbe286f",
+      "source": "Threads",
+      "translated": "थ्रेड"
     },
     {
-      "id": "native.android.207c2170504e99e6",
-      "source": "Connect the Gateway to search sessions.",
-      "translated": "सेशन खोजने के लिए Gateway कनेक्ट करें।"
+      "id": "native.android.d38be650b1bce4a0",
+      "source": "Connect the Gateway to search threads.",
+      "translated": "थ्रेड खोजने के लिए Gateway कनेक्ट करें।"
     },
     {
-      "id": "native.android.25d2c2d792c952fe",
-      "source": "No matching sessions yet.",
-      "translated": "अभी तक कोई मेल खाता सेशन नहीं है।"
+      "id": "native.android.3d7754721f776ef8",
+      "source": "No matching threads yet.",
+      "translated": "अभी तक कोई मेल खाता थ्रेड नहीं है।"
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "असिस्टेंट काम कर रहा है"
     },
     {
-      "id": "native.android.8f8384286317f5c9",
-      "source": "OpenClaw session",
-      "translated": "OpenClaw सेशन"
+      "id": "native.android.9a839f6e3e05a744",
+      "source": "OpenClaw thread",
+      "translated": "OpenClaw थ्रेड"
     },
     {
-      "id": "native.android.15799e57704b20c6",
-      "source": "Open session",
-      "translated": "सेशन खोलें"
+      "id": "native.android.d83f82a1e4a5ed99",
+      "source": "Open thread",
+      "translated": "थ्रेड खोलें"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "कोई तैयार प्रोवाइडर नहीं"
     },
     {
-      "id": "native.android.73e6ab1a168fd381",
-      "source": "Main session",
-      "translated": "मुख्य सत्र"
+      "id": "native.android.8a1c5365c0538908",
+      "source": "Main thread",
+      "translated": "मुख्य थ्रेड"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.0e3157c15c56944f",
-      "source": "Sessions",
-      "translated": "सत्र"
+      "id": "native.android.a5845742daecb4ba",
+      "source": "Threads",
+      "translated": "थ्रेड"
     },
     {
-      "id": "native.android.70f5d0507d34b5c8",
-      "source": "Focus session search",
-      "translated": "सेशन खोज पर फ़ोकस करें"
+      "id": "native.android.439b324280869527",
+      "source": "Focus thread search",
+      "translated": "थ्रेड खोज पर फ़ोकस करें"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "संग्रहीत"
     },
     {
-      "id": "native.android.b9cf34c137e4cf03",
-      "source": "Search sessions",
-      "translated": "सत्र खोजें"
+      "id": "native.android.03981341841b04ac",
+      "source": "Search threads",
+      "translated": "थ्रेड खोजें"
     },
     {
-      "id": "native.android.10cb26723e9990fc",
-      "source": "Clear session search",
-      "translated": "सेशन खोज साफ़ करें"
+      "id": "native.android.99570c528a41fa72",
+      "source": "Clear thread search",
+      "translated": "थ्रेड खोज साफ़ करें"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "सबसे पुराने पहले"
     },
     {
-      "id": "native.android.c6bf8751e2a7f5c7",
-      "source": "Toggle session layout",
-      "translated": "सत्र लेआउट टॉगल करें"
+      "id": "native.android.fd67be543e321cc9",
+      "source": "Toggle thread layout",
+      "translated": "थ्रेड लेआउट बदलें"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "लेआउट: विस्तृत"
     },
     {
-      "id": "native.android.69b79a3c2c987cd4",
-      "source": "Searching sessions",
-      "translated": "सेशन खोजे जा रहे हैं"
+      "id": "native.android.ebd17565e0ffd8eb",
+      "source": "Searching threads",
+      "translated": "थ्रेड खोजे जा रहे हैं"
     },
     {
-      "id": "native.android.dd587d341af44212",
-      "source": "No matching sessions",
-      "translated": "कोई मेल खाता सेशन नहीं मिला"
+      "id": "native.android.472d46ae8669f860",
+      "source": "No matching threads",
+      "translated": "कोई मेल खाता थ्रेड नहीं"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "चैट शुरू करें"
     },
     {
-      "id": "native.android.f10d4df7cbc6df4f",
-      "source": "Current session",
-      "translated": "वर्तमान सत्र"
+      "id": "native.android.ff81ad1bee00d384",
+      "source": "Current thread",
+      "translated": "वर्तमान थ्रेड"
     },
     {
-      "id": "native.android.8f0482425838ae64",
-      "source": "OpenClaw session",
-      "translated": "OpenClaw सत्र"
+      "id": "native.android.fc145645b9620e57",
+      "source": "OpenClaw thread",
+      "translated": "OpenClaw थ्रेड"
     },
     {
-      "id": "native.android.786774c8a76e50d7",
-      "source": "Rename session",
-      "translated": "सेशन का नाम बदलें"
+      "id": "native.android.71cbb8dde8bf138b",
+      "source": "Rename thread",
+      "translated": "थ्रेड का नाम बदलें"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "समूह हटाएं?"
     },
     {
-      "id": "native.android.3455fc2f77d564e3",
-      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "\"$group\" में सत्र रखे जाते हैं और वापस Ungrouped में चले जाते हैं।"
+      "id": "native.android.691e92cfe5cf106e",
+      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "\"$group\" के थ्रेड रखे जाते हैं और वापस अवर्गीकृत में चले जाते हैं।"
     },
     {
-      "id": "native.android.4805fb9d6623e8c0",
-      "source": "Delete session?",
-      "translated": "सत्र हटाएँ?"
+      "id": "native.android.d87a8217ab56999b",
+      "source": "Delete thread?",
+      "translated": "थ्रेड हटाएँ?"
     },
     {
-      "id": "native.android.0c3283a2b2445eae",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "यह सत्र और इसकी ट्रांसक्रिप्ट को स्थायी रूप से हटा देता है।"
+      "id": "native.android.930de97ff47113a8",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "यह थ्रेड और इसकी प्रतिलिपि को स्थायी रूप से हटा देता है।"
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "असमूहीकृत"
     },
     {
-      "id": "native.android.db243d71d056afa4",
-      "source": "No sessions yet",
-      "translated": "अभी तक कोई सत्र नहीं"
+      "id": "native.android.8e21a70428def6e0",
+      "source": "No threads yet",
+      "translated": "अभी कोई थ्रेड नहीं है"
     },
     {
-      "id": "native.android.5b4eee6a8092925e",
-      "source": "No current session",
-      "translated": "कोई वर्तमान सत्र नहीं"
+      "id": "native.android.cda4c5ad8b17e394",
+      "source": "No current thread",
+      "translated": "कोई मौजूदा थ्रेड नहीं है"
     },
     {
-      "id": "native.android.acbcc9c9ea53d8c0",
-      "source": "No archived sessions",
-      "translated": "कोई संग्रहीत सत्र नहीं"
+      "id": "native.android.be84f061047aa2da",
+      "source": "No archived threads",
+      "translated": "कोई संग्रहीत थ्रेड नहीं है"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "नई बातचीत शुरू करें और वह यहाँ दिखाई देगी।"
     },
     {
-      "id": "native.android.56fcd605dc7be3c0",
-      "source": "Open Chat to start or resume the current session.",
-      "translated": "वर्तमान सत्र शुरू या फिर से शुरू करने के लिए चैट खोलें।"
+      "id": "native.android.f289d03e1d3eee98",
+      "source": "Open Chat to start or resume the current thread.",
+      "translated": "मौजूदा थ्रेड शुरू करने या फिर से जारी रखने के लिए चैट खोलें।"
     },
     {
-      "id": "native.android.085515989f8a2022",
-      "source": "Archived sessions will show up here.",
-      "translated": "संग्रहीत सत्र यहाँ दिखाई देंगे।"
+      "id": "native.android.504b71386e76c6ae",
+      "source": "Archived threads will show up here.",
+      "translated": "संग्रहीत थ्रेड यहाँ दिखाई देंगे।"
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days}दि"
     },
     {
-      "id": "native.android.3d4fa07acbc015c5",
-      "source": "Main session",
-      "translated": "मुख्य सत्र"
+      "id": "native.android.ee4c727cdafbe963",
+      "source": "Main thread",
+      "translated": "मुख्य थ्रेड"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway लंबित"
     },
     {
-      "id": "native.android.2d8d049afe99f751",
-      "source": "Session Activity",
-      "translated": "सत्र गतिविधि"
+      "id": "native.android.da78209effb11cfd",
+      "source": "Thread Activity",
+      "translated": "थ्रेड गतिविधि"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "इस फ़ोन के कनेक्ट रहने के दौरान Exec अनुमोदन अनुरोध यहाँ दिखाई देंगे।"
     },
     {
-      "id": "native.android.dc3e7ca5a491103a",
-      "source": "Session activity",
-      "translated": "सेशन गतिविधि"
+      "id": "native.android.f615712dfb56319a",
+      "source": "Thread activity",
+      "translated": "थ्रेड गतिविधि"
     },
     {
-      "id": "native.android.8551e02b060bd7d8",
-      "source": "Chat tool calls waiting in the active session remain visible here.",
-      "translated": "सक्रिय सेशन में प्रतीक्षा कर रही चैट टूल कॉल यहाँ दिखाई देती रहेंगी।"
+      "id": "native.android.6c93973c13db43ae",
+      "source": "Chat tool calls waiting in the active thread remain visible here.",
+      "translated": "सक्रिय थ्रेड में प्रतीक्षारत चैट टूल कॉल यहाँ दिखाई देते रहेंगे।"
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,6 +4294,11 @@
       "translated": "Talk Provider सेटअप"
     },
     {
+      "id": "native.android.23b638094c34b916",
+      "source": "Microphone",
+      "translated": "माइक्रोफ़ोन"
+    },
+    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "ऑडियो टेस्ट"
@@ -4337,6 +4342,66 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "हो गया"
+    },
+    {
+      "id": "native.android.8d9ecdfdd916b780",
+      "source": "Automatic",
+      "translated": "स्वचालित"
+    },
+    {
+      "id": "native.android.c1626a6700a570f6",
+      "source": "Preferred microphone unavailable; using automatic routing.",
+      "translated": "पसंदीदा माइक्रोफ़ोन उपलब्ध नहीं है; स्वचालित रूटिंग का उपयोग किया जा रहा है।"
+    },
+    {
+      "id": "native.android.820bc5d0ce571d8b",
+      "source": "Prioritizes connected Bluetooth microphones.",
+      "translated": "कनेक्ट किए गए Bluetooth माइक्रोफ़ोन को प्राथमिकता देता है।"
+    },
+    {
+      "id": "native.android.11e48038d5e8bff6",
+      "source": "Preferred microphone",
+      "translated": "पसंदीदा माइक्रोफ़ोन"
+    },
+    {
+      "id": "native.android.eaa4d7563a46d307",
+      "source": "Unavailable",
+      "translated": "अनुपलब्ध"
+    },
+    {
+      "id": "native.android.9f5ebf17eb405ba8",
+      "source": "Next session",
+      "translated": "अगला सत्र"
+    },
+    {
+      "id": "native.android.8c4e91f53928efb2",
+      "source": "Built-in microphone",
+      "translated": "अंतर्निहित माइक्रोफ़ोन"
+    },
+    {
+      "id": "native.android.14b613cb6e2446b4",
+      "source": "Bluetooth microphone",
+      "translated": "Bluetooth माइक्रोफ़ोन"
+    },
+    {
+      "id": "native.android.c885247b2d7ce271",
+      "source": "Bluetooth LE microphone",
+      "translated": "Bluetooth LE माइक्रोफ़ोन"
+    },
+    {
+      "id": "native.android.b6a4e674c5fb441a",
+      "source": "Wired headset microphone",
+      "translated": "वायर्ड हेडसेट माइक्रोफ़ोन"
+    },
+    {
+      "id": "native.android.9c8becb3b0fb5a90",
+      "source": "USB microphone",
+      "translated": "USB माइक्रोफ़ोन"
+    },
+    {
+      "id": "native.android.ba46258fadec7a39",
+      "source": "External microphone",
+      "translated": "बाहरी माइक्रोफ़ोन"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5074,9 +5139,9 @@
       "translated": "जाँचें"
     },
     {
-      "id": "native.android.5a540761383fa474",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
-      "translated": "OpenClaw इस फ़ोन को सत्रों, वॉइस, प्रदाताओं और Gateway के लिए एक सुव्यवस्थित मोबाइल कमांड इंटरफ़ेस में बदल देता है।"
+      "id": "native.android.c971506716c96e91",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
+      "translated": "OpenClaw इस फ़ोन को थ्रेड, वॉइस, प्रोवाइडर और Gateway के लिए एक सुव्यवस्थित मोबाइल कमांड इंटरफ़ेस में बदल देता है।"
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5624,9 +5689,9 @@
       "translated": "बातचीत सेटिंग्स"
     },
     {
-      "id": "native.android.73f07a5d54915259",
-      "source": "Recent Sessions",
-      "translated": "हाल के सेशन"
+      "id": "native.android.36f78c8c85dc283f",
+      "source": "Recent Threads",
+      "translated": "हाल के थ्रेड"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5684,14 +5749,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% ऑनलाइन"
     },
     {
-      "id": "native.android.16c3425d3a594481",
-      "source": "Sessions",
-      "translated": "सेशन"
+      "id": "native.android.57177017a6a93826",
+      "source": "Threads",
+      "translated": "थ्रेड"
     },
     {
-      "id": "native.android.a5c0f8b3112aa58c",
-      "source": "No recent sessions",
-      "translated": "हाल की कोई सत्र नहीं"
+      "id": "native.android.43320b54a68b00a1",
+      "source": "No recent threads",
+      "translated": "कोई हालिया थ्रेड नहीं"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5729,14 +5794,14 @@
       "translated": "कार्यरत · $pendingRunCount सक्रिय रन"
     },
     {
-      "id": "native.android.2c89da708b12a522",
-      "source": "Monitoring · 1 session",
-      "translated": "निगरानी जारी · 1 सत्र"
+      "id": "native.android.e24db059480f1e6a",
+      "source": "Monitoring · 1 thread",
+      "translated": "निगरानी · 1 थ्रेड"
     },
     {
-      "id": "native.android.8b6ee382dcb64e1f",
-      "source": "Monitoring · $sessionCount sessions",
-      "translated": "निगरानी जारी · $sessionCount सत्र"
+      "id": "native.android.5a475f37d80e02bc",
+      "source": "Monitoring · $sessionCount threads",
+      "translated": "निगरानी · $sessionCount थ्रेड"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5769,9 +5834,9 @@
       "translated": "प्रदाता"
     },
     {
-      "id": "native.android.a65477861c7203aa",
-      "source": "Open session",
-      "translated": "सत्र खोलें"
+      "id": "native.android.358c5e0e838d5423",
+      "source": "Open thread",
+      "translated": "थ्रेड खोलें"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6194,9 +6259,9 @@
       "translated": "${days}दि"
     },
     {
-      "id": "native.android.22d755834386db07",
-      "source": "Main session",
-      "translated": "मुख्य सत्र"
+      "id": "native.android.28a1a1acc5a0959f",
+      "source": "Main thread",
+      "translated": "मुख्य थ्रेड"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6877,6 +6942,16 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "अनम्यूट करें"
+    },
+    {
+      "id": "native.android.cb608d82c5b3352a",
+      "source": "Back camera",
+      "translated": "पिछला कैमरा"
+    },
+    {
+      "id": "native.android.e89a0e780eed2e1e",
+      "source": "Front camera",
+      "translated": "सामने का कैमरा"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7684,9 +7759,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.882cc14a58e7e105",
-      "source": "Loading session",
-      "translated": "सेशन लोड हो रहा है"
+      "id": "native.android.0c74bc30a994dd33",
+      "source": "Loading thread",
+      "translated": "थ्रेड लोड हो रहा है"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7729,14 +7804,14 @@
       "translated": "मुझे ताज़ा जानकारी दें"
     },
     {
-      "id": "native.android.1e5add56e48c99f9",
-      "source": "Summarize recent sessions and next steps.",
-      "translated": "हाल के सेशन और अगले चरणों का सारांश दें।"
+      "id": "native.android.cf40df9739f78f27",
+      "source": "Summarize recent threads and next steps.",
+      "translated": "हाल के थ्रेड और अगले चरणों का सारांश दें।"
     },
     {
-      "id": "native.android.06d515351bb79576",
-      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
-      "translated": "मेरे हाल के OpenClaw सेशन की जानकारी दें और अगले चरण सुझाएँ।"
+      "id": "native.android.ebe49a8b8df80bd3",
+      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
+      "translated": "मेरे हाल के OpenClaw थ्रेड की जानकारी दें और अगले चरण सुझाएँ।"
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8074,9 +8149,9 @@
       "translated": "कनेक्टेड"
     },
     {
-      "id": "native.android.81931886b9caf3ab",
-      "source": "Sessions",
-      "translated": "सेशन"
+      "id": "native.android.6cf5d6fa8a4186d5",
+      "source": "Threads",
+      "translated": "थ्रेड"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,9 +10869,9 @@
       "translated": "आप किस पर काम करना चाहेंगे?"
     },
     {
-      "id": "native.apple.32179ce0b6d4543f",
-      "source": "The session attaches once the gateway is ready.",
-      "translated": "Gateway तैयार होने के बाद सेशन अटैच हो जाता है।"
+      "id": "native.apple.4da775013ac9b123",
+      "source": "The thread attaches once the gateway is ready.",
+      "translated": "Gateway तैयार होते ही थ्रेड संलग्न हो जाएगा।"
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10844,9 +10919,9 @@
       "translated": "नए सत्र के विकल्प…"
     },
     {
-      "id": "native.apple.a1b0d289758e2213",
-      "source": "Sessions…",
-      "translated": "सत्र…"
+      "id": "native.apple.003b25ddafeb18e9",
+      "source": "Threads…",
+      "translated": "थ्रेड…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11009,14 +11084,14 @@
       "translated": "बनाएँ"
     },
     {
-      "id": "native.apple.f488b9caf6e51ac3",
-      "source": "Delete Session?",
-      "translated": "सेशन हटाएँ?"
+      "id": "native.apple.31d5c7287cfb3abe",
+      "source": "Delete Thread?",
+      "translated": "थ्रेड हटाएँ?"
     },
     {
-      "id": "native.apple.8634b17be9b111bc",
-      "source": "Delete Session",
-      "translated": "सेशन हटाएँ"
+      "id": "native.apple.d3395564809f1120",
+      "source": "Delete Thread",
+      "translated": "थ्रेड हटाएँ"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11024,9 +11099,9 @@
       "translated": "रद्द करें"
     },
     {
-      "id": "native.apple.4a9568ac9b18d8d3",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "इससे सेशन और उसका ट्रांसक्रिप्ट स्थायी रूप से हट जाएगा।"
+      "id": "native.apple.092659256d26cb03",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "यह थ्रेड और इसकी ट्रांसक्रिप्ट को स्थायी रूप से हटा देता है।"
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11054,9 +11129,9 @@
       "translated": "नया समूह"
     },
     {
-      "id": "native.apple.5bccdc23a1640895",
-      "source": "Rename Session",
-      "translated": "सेशन का नाम बदलें"
+      "id": "native.apple.683032464c497bbd",
+      "source": "Rename Thread",
+      "translated": "थ्रेड का नाम बदलें"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11064,9 +11139,9 @@
       "translated": "समूह का नाम"
     },
     {
-      "id": "native.apple.af789b2d2fda0f67",
-      "source": "Session name",
-      "translated": "सेशन का नाम"
+      "id": "native.apple.f887aa956588f237",
+      "source": "Thread name",
+      "translated": "थ्रेड का नाम"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11104,14 +11179,14 @@
       "translated": "एजेंट"
     },
     {
-      "id": "native.apple.a3bde8045fe9224a",
-      "source": "Agent session",
-      "translated": "एजेंट सत्र"
+      "id": "native.apple.7c8231b7b1ca480f",
+      "source": "Agent thread",
+      "translated": "एजेंट थ्रेड"
     },
     {
-      "id": "native.apple.27f775de30b37ff8",
-      "source": "Recent sessions",
-      "translated": "हाल के सत्र"
+      "id": "native.apple.b3c553614f762a58",
+      "source": "Recent threads",
+      "translated": "हाल के थ्रेड"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11119,9 +11194,9 @@
       "translated": "Gateway ऑफ़लाइन है"
     },
     {
-      "id": "native.apple.28c97cf23665ee01",
-      "source": "No recent sessions",
-      "translated": "हाल के कोई सत्र नहीं"
+      "id": "native.apple.5aa32afda85064ea",
+      "source": "No recent threads",
+      "translated": "कोई हालिया थ्रेड नहीं"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11219,14 +11294,14 @@
       "translated": "रद्द करें"
     },
     {
-      "id": "native.apple.9f2fd65953013b7c",
-      "source": "Sessions",
-      "translated": "सत्र"
+      "id": "native.apple.b6855cf19a50f477",
+      "source": "Threads",
+      "translated": "थ्रेड"
     },
     {
-      "id": "native.apple.0422818cc95d5071",
-      "source": "Archived sessions",
-      "translated": "आर्काइव किए गए सेशन"
+      "id": "native.apple.9b1d0ef27a1333b0",
+      "source": "Archived threads",
+      "translated": "संग्रहीत थ्रेड"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11234,34 +11309,34 @@
       "translated": "आर्काइव किए गए दिखाएँ"
     },
     {
-      "id": "native.apple.b272115c83f7ef58",
-      "source": "Sessions unavailable",
-      "translated": "सत्र उपलब्ध नहीं हैं"
+      "id": "native.apple.98167401c7267735",
+      "source": "Threads unavailable",
+      "translated": "थ्रेड उपलब्ध नहीं हैं"
     },
     {
-      "id": "native.apple.54f8260c9b863087",
-      "source": "Loading archived sessions",
-      "translated": "आर्काइव किए गए सेशन लोड हो रहे हैं"
+      "id": "native.apple.4d28a7def2337b9f",
+      "source": "Loading archived threads",
+      "translated": "संग्रहीत थ्रेड लोड हो रहे हैं"
     },
     {
-      "id": "native.apple.9b305868873dade2",
-      "source": "Loading recent sessions",
-      "translated": "हाल के सेशन लोड हो रहे हैं"
+      "id": "native.apple.777d7b706933bd7b",
+      "source": "Loading recent threads",
+      "translated": "हाल के थ्रेड लोड हो रहे हैं"
     },
     {
-      "id": "native.apple.207dad20d09f3160",
-      "source": "^[\\(count) session](inflect: true)",
-      "translated": "^[\\(count) सत्र](inflect: true)"
+      "id": "native.apple.22f81ea94bef8410",
+      "source": "^[\\(count) thread](inflect: true)",
+      "translated": "^[\\(count) थ्रेड](inflect: true)"
     },
     {
-      "id": "native.apple.1f4501a6bf2bae4c",
-      "source": "No archived sessions",
-      "translated": "कोई आर्काइव किया गया सेशन नहीं"
+      "id": "native.apple.1cad51e14db59bf9",
+      "source": "No archived threads",
+      "translated": "कोई संग्रहीत थ्रेड नहीं"
     },
     {
-      "id": "native.apple.2a1ba7a5e1979c9e",
-      "source": "Archived sessions will appear here.",
-      "translated": "संग्रहीत सत्र यहाँ दिखाई देंगे।"
+      "id": "native.apple.18ef832d3a7ddcf8",
+      "source": "Archived threads will appear here.",
+      "translated": "संग्रहीत थ्रेड यहाँ दिखाई देंगे।"
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11344,9 +11419,9 @@
       "translated": "इनटेक साझा करें"
     },
     {
-      "id": "native.apple.2360d25fe6ae9946",
-      "source": "Loading sessions",
-      "translated": "सत्र लोड हो रहे हैं"
+      "id": "native.apple.21d9208d86a4d1fe",
+      "source": "Loading threads",
+      "translated": "थ्रेड लोड हो रहे हैं"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11354,19 +11429,19 @@
       "translated": "Gateway से हाल की गतिविधि प्राप्त की जा रही है।"
     },
     {
-      "id": "native.apple.c334f2e86702a7b8",
-      "source": "Sessions unavailable",
-      "translated": "सत्र उपलब्ध नहीं हैं"
+      "id": "native.apple.4be1f79aa2b230ff",
+      "source": "Threads unavailable",
+      "translated": "थ्रेड उपलब्ध नहीं हैं"
     },
     {
-      "id": "native.apple.6cc6efb7a03960b6",
-      "source": "No recent sessions",
-      "translated": "कोई हाल के सत्र नहीं"
+      "id": "native.apple.98b348873556bc46",
+      "source": "No recent threads",
+      "translated": "कोई हालिया थ्रेड नहीं"
     },
     {
-      "id": "native.apple.08483af2d043bee6",
-      "source": "Session activity offline",
-      "translated": "सत्र गतिविधि ऑफ़लाइन है"
+      "id": "native.apple.7396d205574d279f",
+      "source": "Thread activity offline",
+      "translated": "थ्रेड गतिविधि ऑफ़लाइन है"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11824,9 +11899,9 @@
       "translated": "कार्ड"
     },
     {
-      "id": "native.apple.93eeaedb2ff61043",
-      "source": "Open Session",
-      "translated": "सेशन खोलें"
+      "id": "native.apple.c9ec1b0e18074d8a",
+      "source": "Open Thread",
+      "translated": "थ्रेड खोलें"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13314,9 +13389,9 @@
       "translated": "डिफ़ॉल्ट"
     },
     {
-      "id": "native.apple.3de045f17ea3c6d0",
-      "source": "Used for new Chat and Talk sessions.",
-      "translated": "नए Chat और Talk सत्रों के लिए उपयोग किया जाता है।"
+      "id": "native.apple.f4ae5664c3eda95d",
+      "source": "Used for new Chat threads and Talk sessions.",
+      "translated": "नई चैट थ्रेड और बातचीत सत्रों के लिए उपयोग किया जाता है।"
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15719,9 +15794,9 @@
       "translated": "इंस्टेंस"
     },
     {
-      "id": "native.apple.3579cf2750470a22",
-      "source": "Sessions",
-      "translated": "सत्र"
+      "id": "native.apple.11fe8b9941954dfb",
+      "source": "Threads",
+      "translated": "थ्रेड"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19029,9 +19104,9 @@
       "translated": "क्विक चैट शॉर्टकट"
     },
     {
-      "id": "native.apple.6ae77665b5f4490f",
-      "source": "Global shortcut that opens a floating chat bar for the main session.",
-      "translated": "मुख्य सत्र के लिए फ़्लोटिंग चैट बार खोलने वाला ग्लोबल शॉर्टकट।"
+      "id": "native.apple.94dd793cd7d7d555",
+      "source": "Global shortcut that opens a floating chat bar for the main thread.",
+      "translated": "मुख्य थ्रेड के लिए फ़्लोटिंग चैट बार खोलने वाला ग्लोबल शॉर्टकट।"
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19609,9 +19684,9 @@
       "translated": "गंभीर"
     },
     {
-      "id": "native.apple.75102378a6775180",
-      "source": "New Session",
-      "translated": "नया सत्र"
+      "id": "native.apple.13f96467014cf344",
+      "source": "New Thread",
+      "translated": "नई थ्रेड"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21899,9 +21974,9 @@
       "translated": "हाल के कोई संदेश नहीं"
     },
     {
-      "id": "native.apple.1ff8aec0044934c3",
-      "source": "Sessions",
-      "translated": "सत्र"
+      "id": "native.apple.3ec2afcbc298c673",
+      "source": "Threads",
+      "translated": "थ्रेड"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21909,9 +21984,9 @@
       "translated": "संदर्भ और रेट सीमाओं के लिए CLI द्वारा फिर से उपयोग की जाने वाली संग्रहीत बातचीत बकेट्स पर एक नज़र डालें।"
     },
     {
-      "id": "native.apple.bab897f3252b134c",
-      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
-      "translated": "अभी कोई सत्र नहीं हैं। वे पहले इनबाउंड संदेश या हार्टबीट के बाद दिखाई देते हैं।"
+      "id": "native.apple.14ccb32cd8ed1c81",
+      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
+      "translated": "अभी तक कोई थ्रेड नहीं है। वे पहला इनबाउंड संदेश या हार्टबीट मिलने के बाद दिखाई देती हैं।"
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -21994,9 +22069,9 @@
       "translated": "Exec अनुमोदन"
     },
     {
-      "id": "native.apple.64a6dc7d49e8fb57",
-      "source": "Sessions",
-      "translated": "सत्र"
+      "id": "native.apple.52e37e3a44ae516c",
+      "source": "Threads",
+      "translated": "थ्रेड"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -22999,9 +23074,9 @@
       "translated": "मुझे अब तक की जानकारी दें"
     },
     {
-      "id": "native.apple.234ec45f4231edc4",
-      "source": "Summarize what happened in my sessions since yesterday.",
-      "translated": "कल से अब तक मेरे सत्रों में जो हुआ उसका सारांश दें।"
+      "id": "native.apple.fc4ce810900ec0b6",
+      "source": "Summarize what happened in my threads since yesterday.",
+      "translated": "कल से अब तक मेरी थ्रेड में जो हुआ, उसका सारांश दें।"
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23179,9 +23254,9 @@
       "translated": "मॉडल अनपिन करें"
     },
     {
-      "id": "native.apple.5dfc0700d8dff8de",
-      "source": "Session",
-      "translated": "सत्र"
+      "id": "native.apple.4edb66657f5aca1f",
+      "source": "Thread",
+      "translated": "थ्रेड"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23344,6 +23419,51 @@
       "translated": "विजेट उपलब्ध नहीं है"
     },
     {
+      "id": "native.apple.d640691fd196f338",
+      "source": "Widget export failed",
+      "translated": "विजेट एक्सपोर्ट विफल रहा"
+    },
+    {
+      "id": "native.apple.533c6e22a11e88de",
+      "source": "OK",
+      "translated": "ठीक है"
+    },
+    {
+      "id": "native.apple.e1fb28a2a9756402",
+      "source": "Copy image",
+      "translated": "इमेज कॉपी करें"
+    },
+    {
+      "id": "native.apple.ebd7bc92e1b12235",
+      "source": "Save image…",
+      "translated": "इमेज सेव करें…"
+    },
+    {
+      "id": "native.apple.742c46d4cf2db134",
+      "source": "Save image",
+      "translated": "इमेज सेव करें"
+    },
+    {
+      "id": "native.apple.0589cce608418f90",
+      "source": "The widget image could not be captured.",
+      "translated": "विजेट की इमेज कैप्चर नहीं की जा सकी।"
+    },
+    {
+      "id": "native.apple.dfe24e827fdbe9c5",
+      "source": "The widget image could not be copied.",
+      "translated": "विजेट की इमेज कॉपी नहीं की जा सकी।"
+    },
+    {
+      "id": "native.apple.9e611e3a80e71408",
+      "source": "The widget image could not be encoded as PNG.",
+      "translated": "विजेट की इमेज को PNG के रूप में एन्कोड नहीं किया जा सका।"
+    },
+    {
+      "id": "native.apple.9a6e8afbe24a262b",
+      "source": "The widget image could not be saved.",
+      "translated": "विजेट की इमेज सेव नहीं की जा सकी।"
+    },
+    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23484,19 +23604,19 @@
       "translated": "उपयोगकर्ता"
     },
     {
-      "id": "native.apple.b1cdcb906a43d5d6",
-      "source": "This session cannot be archived while it is active or running.",
-      "translated": "यह सत्र सक्रिय या चल रहा होने के दौरान संग्रहीत नहीं किया जा सकता।"
+      "id": "native.apple.9d0cba09d92ee669",
+      "source": "This thread cannot be archived while it is active or running.",
+      "translated": "सक्रिय या चालू होने के दौरान इस थ्रेड को आर्काइव नहीं किया जा सकता।"
     },
     {
-      "id": "native.apple.5817e3f3dab1ee19",
-      "source": "The main session cannot be deleted.",
-      "translated": "मुख्य सत्र को हटाया नहीं जा सकता।"
+      "id": "native.apple.8952a111a1075051",
+      "source": "The main thread cannot be deleted.",
+      "translated": "मुख्य थ्रेड को डिलीट नहीं किया जा सकता।"
     },
     {
-      "id": "native.apple.a6b8df3f18171c91",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
-      "translated": "इस सत्र को संग्रहीत करने या हटाने से पहले अटैचमेंट हटाएँ या डिलीवरी की प्रतीक्षा करें।"
+      "id": "native.apple.90d0ccf80ca28717",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
+      "translated": "इस थ्रेड को संग्रहित करने या हटाने से पहले अटैचमेंट हटाएँ या उनके डिलीवर होने की प्रतीक्षा करें।"
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23634,9 +23754,9 @@
       "translated": "रन समाप्त हुआ"
     },
     {
-      "id": "native.apple.cd7c3095a22f80a9",
-      "source": "Session Info",
-      "translated": "सेशन की जानकारी"
+      "id": "native.apple.bbccb4c8db5cac12",
+      "source": "Thread Info",
+      "translated": "थ्रेड की जानकारी"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23669,9 +23789,9 @@
       "translated": "समूह जोड़ें"
     },
     {
-      "id": "native.apple.23d628606fe0734f",
-      "source": "Session Groups",
-      "translated": "सेशन समूह"
+      "id": "native.apple.7b641fed5bace855",
+      "source": "Thread Groups",
+      "translated": "थ्रेड समूह"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23714,9 +23834,9 @@
       "translated": "समूह हटाएँ"
     },
     {
-      "id": "native.apple.b049c8a4d2805e08",
-      "source": "Sessions in this group become ungrouped.",
-      "translated": "इस समूह के सत्र असमूहीकृत हो जाएँगे।"
+      "id": "native.apple.56401c79410a310d",
+      "source": "Threads in this group become ungrouped.",
+      "translated": "इस समूह के थ्रेड असमूहीकृत हो जाएँगे।"
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23729,9 +23849,9 @@
       "translated": "इस Gateway पर कोई एजेंट उपलब्ध नहीं है।"
     },
     {
-      "id": "native.apple.6c89f35d53506406",
-      "source": "New Session Options",
-      "translated": "नए सत्र के विकल्प"
+      "id": "native.apple.2d96aa7d3d12f85b",
+      "source": "New Thread Options",
+      "translated": "नए थ्रेड के विकल्प"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23759,19 +23879,19 @@
       "translated": "बनाएँ"
     },
     {
-      "id": "native.apple.795ba37f6782cf28",
-      "source": "The session could not be created.",
-      "translated": "सत्र बनाया नहीं जा सका।"
+      "id": "native.apple.87ef57319d1ddc85",
+      "source": "The thread could not be created.",
+      "translated": "थ्रेड नहीं बनाया जा सका।"
     },
     {
-      "id": "native.apple.8ec708a3605a2cc3",
-      "source": "Search sessions",
-      "translated": "सत्र खोजें"
+      "id": "native.apple.6bd91c435b69d638",
+      "source": "Search threads",
+      "translated": "थ्रेड खोजें"
     },
     {
-      "id": "native.apple.23b069b4e7f97039",
-      "source": "No Sessions",
-      "translated": "कोई सत्र नहीं"
+      "id": "native.apple.6fde4bdf9d5b9191",
+      "source": "No Threads",
+      "translated": "कोई थ्रेड नहीं"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23779,29 +23899,29 @@
       "translated": "कोई परिणाम नहीं"
     },
     {
-      "id": "native.apple.0058923f2ce8a3ec",
-      "source": "New Session",
-      "translated": "नया सत्र"
+      "id": "native.apple.a02fd99740d29bd3",
+      "source": "New Thread",
+      "translated": "नया थ्रेड"
     },
     {
-      "id": "native.apple.66ba42960eb4135b",
-      "source": "New session",
-      "translated": "नया सत्र"
+      "id": "native.apple.b625801dd04b09f2",
+      "source": "New thread",
+      "translated": "नया थ्रेड"
     },
     {
-      "id": "native.apple.2ef0e34db02ad255",
-      "source": "New session options",
-      "translated": "नए सत्र के विकल्प"
+      "id": "native.apple.851be81fcc933608",
+      "source": "New thread options",
+      "translated": "नए थ्रेड के विकल्प"
     },
     {
-      "id": "native.apple.36753ef2f1ed4264",
-      "source": "Rename Session",
-      "translated": "सत्र का नाम बदलें"
+      "id": "native.apple.9ce8a4aba7b444b2",
+      "source": "Rename Thread",
+      "translated": "थ्रेड का नाम बदलें"
     },
     {
-      "id": "native.apple.c9de0a1510ef475f",
-      "source": "Session name",
-      "translated": "सत्र का नाम"
+      "id": "native.apple.1dd067c44511c7f0",
+      "source": "Thread name",
+      "translated": "थ्रेड का नाम"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23814,14 +23934,14 @@
       "translated": "रद्द करें"
     },
     {
-      "id": "native.apple.afb4e6c99c63a28d",
-      "source": "Delete Session",
-      "translated": "सत्र हटाएँ"
+      "id": "native.apple.618073d6ab3f2721",
+      "source": "Delete Thread",
+      "translated": "थ्रेड हटाएँ"
     },
     {
-      "id": "native.apple.3d4ef32e42f136a4",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "सत्र और उसकी ट्रांसक्रिप्ट Gateway से हटा दिए जाते हैं।"
+      "id": "native.apple.10a5e72bba3cbccc",
+      "source": "The thread and its transcript are removed from the gateway.",
+      "translated": "थ्रेड और उसकी ट्रांसक्रिप्ट Gateway से हटा दिए जाते हैं।"
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23829,14 +23949,14 @@
       "translated": "“%@” को हटाएँ?"
     },
     {
-      "id": "native.apple.9a7dca238fba628d",
-      "source": "Session running",
-      "translated": "सत्र चल रहा है"
+      "id": "native.apple.ac71e3b2aa496a2c",
+      "source": "Thread running",
+      "translated": "थ्रेड चल रहा है"
     },
     {
-      "id": "native.apple.fcfbfe5e97a95e9c",
-      "source": "Session failed",
-      "translated": "सत्र विफल रहा"
+      "id": "native.apple.c775e87f997278b2",
+      "source": "Thread failed",
+      "translated": "थ्रेड विफल रहा"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23894,9 +24014,9 @@
       "translated": "सत्र कुंजी कॉपी करें"
     },
     {
-      "id": "native.apple.4aeb7c14c26dabac",
-      "source": "Delete Session…",
-      "translated": "सत्र हटाएँ…"
+      "id": "native.apple.f4998cfb572f23ff",
+      "source": "Delete Thread…",
+      "translated": "थ्रेड हटाएँ…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23909,9 +24029,9 @@
       "translated": "कनेक्ट हो रहा है…"
     },
     {
-      "id": "native.apple.79f708b3bc1d3a6c",
-      "source": "Retry session groups",
-      "translated": "सत्र समूहों के लिए फिर से प्रयास करें"
+      "id": "native.apple.8802e9576ffd0f65",
+      "source": "Retry thread groups",
+      "translated": "थ्रेड समूहों के लिए फिर से प्रयास करें"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23934,24 +24054,24 @@
       "translated": "स्कोप"
     },
     {
-      "id": "native.apple.2c37581c7b88f741",
-      "source": "Search sessions",
-      "translated": "सत्र खोजें"
+      "id": "native.apple.b313b80def4bda52",
+      "source": "Search threads",
+      "translated": "थ्रेड खोजें"
     },
     {
-      "id": "native.apple.43be8a2336e42faf",
-      "source": "Sessions",
-      "translated": "सत्र"
+      "id": "native.apple.c0cc6acc36f413ce",
+      "source": "Threads",
+      "translated": "थ्रेड"
     },
     {
-      "id": "native.apple.0b379cdfcbd3247f",
-      "source": "Rename Session",
-      "translated": "सत्र का नाम बदलें"
+      "id": "native.apple.854d3928fe5a557c",
+      "source": "Rename Thread",
+      "translated": "थ्रेड का नाम बदलें"
     },
     {
-      "id": "native.apple.54b6fbd9e41db009",
-      "source": "Session name",
-      "translated": "सत्र का नाम"
+      "id": "native.apple.9d0d3f20096cc4da",
+      "source": "Thread name",
+      "translated": "थ्रेड का नाम"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -23959,19 +24079,19 @@
       "translated": "रद्द करें"
     },
     {
-      "id": "native.apple.751e0f6b81cd374a",
-      "source": "Delete selected sessions?",
-      "translated": "चुने गए सत्र हटाएँ?"
+      "id": "native.apple.dc00eb94f33bae15",
+      "source": "Delete selected threads?",
+      "translated": "चुने गए थ्रेड हटाएँ?"
     },
     {
-      "id": "native.apple.aa679276581b0058",
-      "source": "Delete Sessions",
-      "translated": "सत्र हटाएँ"
+      "id": "native.apple.2053fc9f74dc3158",
+      "source": "Delete Threads",
+      "translated": "थ्रेड हटाएँ"
     },
     {
-      "id": "native.apple.f837129cbee23297",
-      "source": "Each selected session and its transcript will be removed from the gateway.",
-      "translated": "हर चुना गया सत्र और उसकी प्रतिलिपि Gateway से हटा दी जाएगी।"
+      "id": "native.apple.0970247871a834a0",
+      "source": "Each selected thread and its transcript will be removed from the gateway.",
+      "translated": "हर चुना गया थ्रेड और उसका ट्रांसक्रिप्ट Gateway से हटा दिया जाएगा।"
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -23979,9 +24099,9 @@
       "translated": "समूह"
     },
     {
-      "id": "native.apple.64013cfee5e25305",
-      "source": "Manage session groups",
-      "translated": "सत्र समूह प्रबंधित करें"
+      "id": "native.apple.6f8acab2256728b5",
+      "source": "Manage thread groups",
+      "translated": "थ्रेड समूह प्रबंधित करें"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -23994,14 +24114,14 @@
       "translated": "चुनें"
     },
     {
-      "id": "native.apple.b67eaecec1b423ac",
-      "source": "No archived sessions",
-      "translated": "कोई संग्रहीत सत्र नहीं"
+      "id": "native.apple.692972314d04b184",
+      "source": "No archived threads",
+      "translated": "कोई संग्रहीत थ्रेड नहीं"
     },
     {
-      "id": "native.apple.b2435a79abf0c794",
-      "source": "No sessions found",
-      "translated": "कोई सत्र नहीं मिला"
+      "id": "native.apple.d6a4b5711dcd26e7",
+      "source": "No threads found",
+      "translated": "कोई थ्रेड नहीं मिला"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24169,6 +24289,16 @@
       "translated": "पूरा संदेश खोलें"
     },
     {
+      "id": "native.apple.002bfcede229ad4b",
+      "source": "Rewind to Here",
+      "translated": "यहाँ तक वापस जाएँ"
+    },
+    {
+      "id": "native.apple.14df2e4997689fb3",
+      "source": "Fork from Here",
+      "translated": "यहाँ से फ़ोर्क करें"
+    },
+    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "जवाब दें"
@@ -24254,9 +24384,9 @@
       "translated": "नई चैट शुरू करने से पहले अटैचमेंट हटाएँ या डिलीवरी पूरी होने की प्रतीक्षा करें।"
     },
     {
-      "id": "native.apple.980f552bb0f96c0f",
-      "source": "Gateway changed before the session operation started.",
-      "translated": "सत्र संचालन शुरू होने से पहले Gateway बदल गया।"
+      "id": "native.apple.e0f045151c8d3137",
+      "source": "Gateway changed before the thread operation started.",
+      "translated": "थ्रेड की कार्रवाई शुरू होने से पहले Gateway बदल गया।"
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24264,9 +24394,9 @@
       "translated": "चैट बदलने से पहले अटैचमेंट हटाएं या डिलीवरी पूरी होने की प्रतीक्षा करें।"
     },
     {
-      "id": "native.apple.87ba543b42696b92",
-      "source": "Clear this session's history?",
-      "translated": "इस सत्र का इतिहास साफ़ करें?"
+      "id": "native.apple.0a5c4e15466c3acc",
+      "source": "Clear this thread's history?",
+      "translated": "इस थ्रेड का इतिहास साफ़ करें?"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24279,14 +24409,14 @@
       "translated": "यह %@ के लिए बातचीत रीसेट करता है। सेशन कुंजी वही रहती है।"
     },
     {
-      "id": "native.apple.a92e96bed98bd553",
-      "source": "Rename Session",
-      "translated": "सत्र का नाम बदलें"
+      "id": "native.apple.67ac221dbe7179f0",
+      "source": "Rename Thread",
+      "translated": "थ्रेड का नाम बदलें"
     },
     {
-      "id": "native.apple.848e2388f3466f40",
-      "source": "Session name",
-      "translated": "सत्र का नाम"
+      "id": "native.apple.cf0f7e049603f518",
+      "source": "Thread name",
+      "translated": "थ्रेड का नाम"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24304,9 +24434,9 @@
       "translated": "ट्रांसक्रिप्ट निर्यात करें"
     },
     {
-      "id": "native.apple.4af0f566d39d7041",
-      "source": "Sessions",
-      "translated": "सत्र"
+      "id": "native.apple.c0ada47504425f23",
+      "source": "Threads",
+      "translated": "थ्रेड"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24379,14 +24509,14 @@
       "translated": "डिफ़ॉल्ट"
     },
     {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "नया सेशन"
+      "id": "native.apple.1a765291943599e5",
+      "source": "New Thread",
+      "translated": "नया थ्रेड"
     },
     {
-      "id": "native.apple.a7119fbf9d25df5e",
-      "source": "New Session Options…",
-      "translated": "नए सत्र के विकल्प…"
+      "id": "native.apple.c7a3a6d5e43dd98f",
+      "source": "New Thread Options…",
+      "translated": "नए थ्रेड के विकल्प…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24394,19 +24524,19 @@
       "translated": "रीफ़्रेश करें"
     },
     {
-      "id": "native.apple.2bcff4a8fa503739",
-      "source": "Sessions…",
-      "translated": "सत्र…"
+      "id": "native.apple.0e710b81808e5dcf",
+      "source": "Threads…",
+      "translated": "थ्रेड…"
     },
     {
-      "id": "native.apple.c36e008b051adb38",
-      "source": "Rename Session…",
-      "translated": "सत्र का नाम बदलें…"
+      "id": "native.apple.faad8f92b6bef166",
+      "source": "Rename Thread…",
+      "translated": "थ्रेड का नाम बदलें…"
     },
     {
-      "id": "native.apple.ea0ef95a159bffe0",
-      "source": "Fork Session",
-      "translated": "सत्र को फ़ोर्क करें"
+      "id": "native.apple.23b61d6cd26ac112",
+      "source": "Fork",
+      "translated": "फोर्क"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24464,24 +24594,24 @@
       "translated": "इतिहास साफ़ करें…"
     },
     {
-      "id": "native.apple.920fe8a7a33f9e92",
-      "source": "Session",
-      "translated": "सेशन"
+      "id": "native.apple.8b4f1c5107ea8a0e",
+      "source": "Thread",
+      "translated": "थ्रेड"
     },
     {
-      "id": "native.apple.185a401f78328b0f",
-      "source": "Session actions",
-      "translated": "सेशन क्रियाएँ"
+      "id": "native.apple.4d7750c9bf699469",
+      "source": "Thread actions",
+      "translated": "थ्रेड की कार्रवाइयाँ"
     },
     {
-      "id": "native.apple.9f9dedf599b2619b",
-      "source": "Session cost %@",
-      "translated": "सेशन की लागत %@"
+      "id": "native.apple.bb2f22cc43c97f8e",
+      "source": "Thread cost %@",
+      "translated": "थ्रेड की लागत %@"
     },
     {
-      "id": "native.apple.f0a4720df5f5f403",
-      "source": "Compact Session",
-      "translated": "सेशन कॉम्पैक्ट करें"
+      "id": "native.apple.6239ced0b86e86f8",
+      "source": "Compact Thread",
+      "translated": "थ्रेड को संक्षिप्त करें"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/id.json
+++ b/apps/.i18n/native/id.json
@@ -1429,9 +1429,9 @@
       "translated": "Bicara atau dikte dengan OpenClaw"
     },
     {
-      "id": "native.android.5876e15e5e92fd45",
-      "source": "Browse Sessions",
-      "translated": "Telusuri Sesi"
+      "id": "native.android.e2cf5a38587382cb",
+      "source": "Browse Threads",
+      "translated": "Jelajahi Utas"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "Tidak ada tindakan yang ditemukan"
     },
     {
-      "id": "native.android.48ad0ae0e930e02b",
-      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
-      "translated": "Coba Chat, Voice, Sessions, Providers, atau Settings."
+      "id": "native.android.bc70a4ac965b82ba",
+      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
+      "translated": "Coba Chat, Suara, Utas, Penyedia, atau Pengaturan."
     },
     {
-      "id": "native.android.d4fbd1ee4f55a5db",
-      "source": "Sessions",
-      "translated": "Sesi"
+      "id": "native.android.670121e54dbe286f",
+      "source": "Threads",
+      "translated": "Utas"
     },
     {
-      "id": "native.android.207c2170504e99e6",
-      "source": "Connect the Gateway to search sessions.",
-      "translated": "Hubungkan Gateway untuk mencari sesi."
+      "id": "native.android.d38be650b1bce4a0",
+      "source": "Connect the Gateway to search threads.",
+      "translated": "Hubungkan Gateway untuk mencari utas."
     },
     {
-      "id": "native.android.25d2c2d792c952fe",
-      "source": "No matching sessions yet.",
-      "translated": "Belum ada sesi yang cocok."
+      "id": "native.android.3d7754721f776ef8",
+      "source": "No matching threads yet.",
+      "translated": "Belum ada utas yang cocok."
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "Asisten sedang bekerja"
     },
     {
-      "id": "native.android.8f8384286317f5c9",
-      "source": "OpenClaw session",
-      "translated": "Sesi OpenClaw"
+      "id": "native.android.9a839f6e3e05a744",
+      "source": "OpenClaw thread",
+      "translated": "Utas OpenClaw"
     },
     {
-      "id": "native.android.15799e57704b20c6",
-      "source": "Open session",
-      "translated": "Buka sesi"
+      "id": "native.android.d83f82a1e4a5ed99",
+      "source": "Open thread",
+      "translated": "Buka utas"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "Tidak ada penyedia yang siap"
     },
     {
-      "id": "native.android.73e6ab1a168fd381",
-      "source": "Main session",
-      "translated": "Sesi utama"
+      "id": "native.android.8a1c5365c0538908",
+      "source": "Main thread",
+      "translated": "Utas utama"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.0e3157c15c56944f",
-      "source": "Sessions",
-      "translated": "Sesi"
+      "id": "native.android.a5845742daecb4ba",
+      "source": "Threads",
+      "translated": "Utas"
     },
     {
-      "id": "native.android.70f5d0507d34b5c8",
-      "source": "Focus session search",
-      "translated": "Fokuskan pencarian sesi"
+      "id": "native.android.439b324280869527",
+      "source": "Focus thread search",
+      "translated": "Fokuskan pencarian utas"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "Diarsipkan"
     },
     {
-      "id": "native.android.b9cf34c137e4cf03",
-      "source": "Search sessions",
-      "translated": "Cari sesi"
+      "id": "native.android.03981341841b04ac",
+      "source": "Search threads",
+      "translated": "Cari utas"
     },
     {
-      "id": "native.android.10cb26723e9990fc",
-      "source": "Clear session search",
-      "translated": "Hapus pencarian sesi"
+      "id": "native.android.99570c528a41fa72",
+      "source": "Clear thread search",
+      "translated": "Hapus pencarian utas"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "Terlama dahulu"
     },
     {
-      "id": "native.android.c6bf8751e2a7f5c7",
-      "source": "Toggle session layout",
-      "translated": "Alihkan tata letak sesi"
+      "id": "native.android.fd67be543e321cc9",
+      "source": "Toggle thread layout",
+      "translated": "Ubah tata letak utas"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "Tata letak: Terperinci"
     },
     {
-      "id": "native.android.69b79a3c2c987cd4",
-      "source": "Searching sessions",
-      "translated": "Mencari sesi"
+      "id": "native.android.ebd17565e0ffd8eb",
+      "source": "Searching threads",
+      "translated": "Mencari utas"
     },
     {
-      "id": "native.android.dd587d341af44212",
-      "source": "No matching sessions",
-      "translated": "Tidak ada sesi yang cocok"
+      "id": "native.android.472d46ae8669f860",
+      "source": "No matching threads",
+      "translated": "Tidak ada utas yang cocok"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "Mulai Chat"
     },
     {
-      "id": "native.android.f10d4df7cbc6df4f",
-      "source": "Current session",
-      "translated": "Sesi saat ini"
+      "id": "native.android.ff81ad1bee00d384",
+      "source": "Current thread",
+      "translated": "Utas saat ini"
     },
     {
-      "id": "native.android.8f0482425838ae64",
-      "source": "OpenClaw session",
-      "translated": "Sesi OpenClaw"
+      "id": "native.android.fc145645b9620e57",
+      "source": "OpenClaw thread",
+      "translated": "Utas OpenClaw"
     },
     {
-      "id": "native.android.786774c8a76e50d7",
-      "source": "Rename session",
-      "translated": "Ganti nama sesi"
+      "id": "native.android.71cbb8dde8bf138b",
+      "source": "Rename thread",
+      "translated": "Ganti nama utas"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "Hapus grup?"
     },
     {
-      "id": "native.android.3455fc2f77d564e3",
-      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "Sesi dalam \"$group\" disimpan dan dipindahkan kembali ke Ungrouped."
+      "id": "native.android.691e92cfe5cf106e",
+      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "Utas di \"$group\" tetap dipertahankan dan dipindahkan kembali ke Tidak dikelompokkan."
     },
     {
-      "id": "native.android.4805fb9d6623e8c0",
-      "source": "Delete session?",
-      "translated": "Hapus sesi?"
+      "id": "native.android.d87a8217ab56999b",
+      "source": "Delete thread?",
+      "translated": "Hapus utas?"
     },
     {
-      "id": "native.android.0c3283a2b2445eae",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "Ini akan menghapus sesi dan transkripnya secara permanen."
+      "id": "native.android.930de97ff47113a8",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "Tindakan ini akan menghapus utas dan transkripnya secara permanen."
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "Tidak dikelompokkan"
     },
     {
-      "id": "native.android.db243d71d056afa4",
-      "source": "No sessions yet",
-      "translated": "Belum ada sesi"
+      "id": "native.android.8e21a70428def6e0",
+      "source": "No threads yet",
+      "translated": "Belum ada utas"
     },
     {
-      "id": "native.android.5b4eee6a8092925e",
-      "source": "No current session",
-      "translated": "Tidak ada sesi saat ini"
+      "id": "native.android.cda4c5ad8b17e394",
+      "source": "No current thread",
+      "translated": "Tidak ada utas saat ini"
     },
     {
-      "id": "native.android.acbcc9c9ea53d8c0",
-      "source": "No archived sessions",
-      "translated": "Tidak ada sesi yang diarsipkan"
+      "id": "native.android.be84f061047aa2da",
+      "source": "No archived threads",
+      "translated": "Tidak ada utas yang diarsipkan"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "Mulai percakapan baru dan percakapan itu akan muncul di sini."
     },
     {
-      "id": "native.android.56fcd605dc7be3c0",
-      "source": "Open Chat to start or resume the current session.",
-      "translated": "Buka Chat untuk memulai atau melanjutkan sesi saat ini."
+      "id": "native.android.f289d03e1d3eee98",
+      "source": "Open Chat to start or resume the current thread.",
+      "translated": "Buka Chat untuk memulai atau melanjutkan utas saat ini."
     },
     {
-      "id": "native.android.085515989f8a2022",
-      "source": "Archived sessions will show up here.",
-      "translated": "Sesi yang diarsipkan akan muncul di sini."
+      "id": "native.android.504b71386e76c6ae",
+      "source": "Archived threads will show up here.",
+      "translated": "Utas yang diarsipkan akan muncul di sini."
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days}h"
     },
     {
-      "id": "native.android.3d4fa07acbc015c5",
-      "source": "Main session",
-      "translated": "Sesi utama"
+      "id": "native.android.ee4c727cdafbe963",
+      "source": "Main thread",
+      "translated": "Utas utama"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway Tertunda"
     },
     {
-      "id": "native.android.2d8d049afe99f751",
-      "source": "Session Activity",
-      "translated": "Aktivitas Sesi"
+      "id": "native.android.da78209effb11cfd",
+      "source": "Thread Activity",
+      "translated": "Aktivitas Utas"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "Permintaan persetujuan exec akan muncul di sini saat ponsel ini terhubung."
     },
     {
-      "id": "native.android.dc3e7ca5a491103a",
-      "source": "Session activity",
-      "translated": "Aktivitas sesi"
+      "id": "native.android.f615712dfb56319a",
+      "source": "Thread activity",
+      "translated": "Aktivitas utas"
     },
     {
-      "id": "native.android.8551e02b060bd7d8",
-      "source": "Chat tool calls waiting in the active session remain visible here.",
-      "translated": "Panggilan alat chat yang menunggu dalam sesi aktif tetap terlihat di sini."
+      "id": "native.android.6c93973c13db43ae",
+      "source": "Chat tool calls waiting in the active thread remain visible here.",
+      "translated": "Panggilan alat Chat yang menunggu di utas aktif tetap terlihat di sini."
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,6 +4294,11 @@
       "translated": "Penyiapan Penyedia Talk"
     },
     {
+      "id": "native.android.23b638094c34b916",
+      "source": "Microphone",
+      "translated": "Mikrofon"
+    },
+    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "Tes Audio"
@@ -4337,6 +4342,66 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "Selesai"
+    },
+    {
+      "id": "native.android.8d9ecdfdd916b780",
+      "source": "Automatic",
+      "translated": "Otomatis"
+    },
+    {
+      "id": "native.android.c1626a6700a570f6",
+      "source": "Preferred microphone unavailable; using automatic routing.",
+      "translated": "Mikrofon pilihan tidak tersedia; menggunakan perutean otomatis."
+    },
+    {
+      "id": "native.android.820bc5d0ce571d8b",
+      "source": "Prioritizes connected Bluetooth microphones.",
+      "translated": "Memprioritaskan mikrofon Bluetooth yang terhubung."
+    },
+    {
+      "id": "native.android.11e48038d5e8bff6",
+      "source": "Preferred microphone",
+      "translated": "Mikrofon pilihan"
+    },
+    {
+      "id": "native.android.eaa4d7563a46d307",
+      "source": "Unavailable",
+      "translated": "Tidak tersedia"
+    },
+    {
+      "id": "native.android.9f5ebf17eb405ba8",
+      "source": "Next session",
+      "translated": "Sesi berikutnya"
+    },
+    {
+      "id": "native.android.8c4e91f53928efb2",
+      "source": "Built-in microphone",
+      "translated": "Mikrofon bawaan"
+    },
+    {
+      "id": "native.android.14b613cb6e2446b4",
+      "source": "Bluetooth microphone",
+      "translated": "Mikrofon Bluetooth"
+    },
+    {
+      "id": "native.android.c885247b2d7ce271",
+      "source": "Bluetooth LE microphone",
+      "translated": "Mikrofon Bluetooth LE"
+    },
+    {
+      "id": "native.android.b6a4e674c5fb441a",
+      "source": "Wired headset microphone",
+      "translated": "Mikrofon headset berkabel"
+    },
+    {
+      "id": "native.android.9c8becb3b0fb5a90",
+      "source": "USB microphone",
+      "translated": "Mikrofon USB"
+    },
+    {
+      "id": "native.android.ba46258fadec7a39",
+      "source": "External microphone",
+      "translated": "Mikrofon eksternal"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5074,9 +5139,9 @@
       "translated": "Periksa"
     },
     {
-      "id": "native.android.5a540761383fa474",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
-      "translated": "OpenClaw mengubah ponsel ini menjadi antarmuka perintah seluler yang ringkas untuk sesi, suara, penyedia, dan Gateway."
+      "id": "native.android.c971506716c96e91",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
+      "translated": "OpenClaw mengubah ponsel ini menjadi antarmuka perintah seluler yang rapi untuk utas, suara, penyedia, dan Gateway."
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5624,9 +5689,9 @@
       "translated": "Pengaturan Bicara"
     },
     {
-      "id": "native.android.73f07a5d54915259",
-      "source": "Recent Sessions",
-      "translated": "Sesi Terbaru"
+      "id": "native.android.36f78c8c85dc283f",
+      "source": "Recent Threads",
+      "translated": "Utas Terbaru"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5684,14 +5749,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online"
     },
     {
-      "id": "native.android.16c3425d3a594481",
-      "source": "Sessions",
-      "translated": "Sesi"
+      "id": "native.android.57177017a6a93826",
+      "source": "Threads",
+      "translated": "Utas"
     },
     {
-      "id": "native.android.a5c0f8b3112aa58c",
-      "source": "No recent sessions",
-      "translated": "Tidak ada sesi terbaru"
+      "id": "native.android.43320b54a68b00a1",
+      "source": "No recent threads",
+      "translated": "Tidak ada utas terbaru"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5729,14 +5794,14 @@
       "translated": "Bekerja · $pendingRunCount proses aktif"
     },
     {
-      "id": "native.android.2c89da708b12a522",
-      "source": "Monitoring · 1 session",
-      "translated": "Memantau · 1 sesi"
+      "id": "native.android.e24db059480f1e6a",
+      "source": "Monitoring · 1 thread",
+      "translated": "Memantau · 1 utas"
     },
     {
-      "id": "native.android.8b6ee382dcb64e1f",
-      "source": "Monitoring · $sessionCount sessions",
-      "translated": "Memantau · $sessionCount sesi"
+      "id": "native.android.5a475f37d80e02bc",
+      "source": "Monitoring · $sessionCount threads",
+      "translated": "Memantau · $sessionCount utas"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5769,9 +5834,9 @@
       "translated": "Penyedia"
     },
     {
-      "id": "native.android.a65477861c7203aa",
-      "source": "Open session",
-      "translated": "Buka sesi"
+      "id": "native.android.358c5e0e838d5423",
+      "source": "Open thread",
+      "translated": "Buka utas"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6194,9 +6259,9 @@
       "translated": "${days}h"
     },
     {
-      "id": "native.android.22d755834386db07",
-      "source": "Main session",
-      "translated": "Sesi utama"
+      "id": "native.android.28a1a1acc5a0959f",
+      "source": "Main thread",
+      "translated": "Utas utama"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6877,6 +6942,16 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "Suarakan"
+    },
+    {
+      "id": "native.android.cb608d82c5b3352a",
+      "source": "Back camera",
+      "translated": "Kamera belakang"
+    },
+    {
+      "id": "native.android.e89a0e780eed2e1e",
+      "source": "Front camera",
+      "translated": "Kamera depan"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7684,9 +7759,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.882cc14a58e7e105",
-      "source": "Loading session",
-      "translated": "Memuat sesi"
+      "id": "native.android.0c74bc30a994dd33",
+      "source": "Loading thread",
+      "translated": "Memuat utas"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7729,14 +7804,14 @@
       "translated": "Beri saya rangkuman"
     },
     {
-      "id": "native.android.1e5add56e48c99f9",
-      "source": "Summarize recent sessions and next steps.",
-      "translated": "Ringkas sesi terbaru dan langkah berikutnya."
+      "id": "native.android.cf40df9739f78f27",
+      "source": "Summarize recent threads and next steps.",
+      "translated": "Rangkum utas terbaru dan langkah berikutnya."
     },
     {
-      "id": "native.android.06d515351bb79576",
-      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
-      "translated": "Beri saya ringkasan sesi OpenClaw terbaru dan sarankan langkah berikutnya."
+      "id": "native.android.ebe49a8b8df80bd3",
+      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
+      "translated": "Beri saya ringkasan utas OpenClaw terbaru saya dan sarankan langkah berikutnya."
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8074,9 +8149,9 @@
       "translated": "Terhubung"
     },
     {
-      "id": "native.android.81931886b9caf3ab",
-      "source": "Sessions",
-      "translated": "Sesi"
+      "id": "native.android.6cf5d6fa8a4186d5",
+      "source": "Threads",
+      "translated": "Utas"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,9 +10869,9 @@
       "translated": "Apa yang ingin Anda kerjakan?"
     },
     {
-      "id": "native.apple.32179ce0b6d4543f",
-      "source": "The session attaches once the gateway is ready.",
-      "translated": "Sesi terhubung setelah gateway siap."
+      "id": "native.apple.4da775013ac9b123",
+      "source": "The thread attaches once the gateway is ready.",
+      "translated": "Utas akan terhubung setelah Gateway siap."
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10844,9 +10919,9 @@
       "translated": "Opsi Sesi Baru…"
     },
     {
-      "id": "native.apple.a1b0d289758e2213",
-      "source": "Sessions…",
-      "translated": "Sesi…"
+      "id": "native.apple.003b25ddafeb18e9",
+      "source": "Threads…",
+      "translated": "Utas…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11009,14 +11084,14 @@
       "translated": "Buat"
     },
     {
-      "id": "native.apple.f488b9caf6e51ac3",
-      "source": "Delete Session?",
-      "translated": "Hapus Sesi?"
+      "id": "native.apple.31d5c7287cfb3abe",
+      "source": "Delete Thread?",
+      "translated": "Hapus Utas?"
     },
     {
-      "id": "native.apple.8634b17be9b111bc",
-      "source": "Delete Session",
-      "translated": "Hapus Sesi"
+      "id": "native.apple.d3395564809f1120",
+      "source": "Delete Thread",
+      "translated": "Hapus Utas"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11024,9 +11099,9 @@
       "translated": "Batal"
     },
     {
-      "id": "native.apple.4a9568ac9b18d8d3",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "Tindakan ini akan menghapus sesi dan transkripnya secara permanen."
+      "id": "native.apple.092659256d26cb03",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "Tindakan ini akan menghapus utas dan transkripnya secara permanen."
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11054,9 +11129,9 @@
       "translated": "Grup Baru"
     },
     {
-      "id": "native.apple.5bccdc23a1640895",
-      "source": "Rename Session",
-      "translated": "Ganti Nama Sesi"
+      "id": "native.apple.683032464c497bbd",
+      "source": "Rename Thread",
+      "translated": "Ganti Nama Utas"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11064,9 +11139,9 @@
       "translated": "Nama grup"
     },
     {
-      "id": "native.apple.af789b2d2fda0f67",
-      "source": "Session name",
-      "translated": "Nama sesi"
+      "id": "native.apple.f887aa956588f237",
+      "source": "Thread name",
+      "translated": "Nama utas"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11104,14 +11179,14 @@
       "translated": "Agen"
     },
     {
-      "id": "native.apple.a3bde8045fe9224a",
-      "source": "Agent session",
-      "translated": "Sesi agen"
+      "id": "native.apple.7c8231b7b1ca480f",
+      "source": "Agent thread",
+      "translated": "Utas agen"
     },
     {
-      "id": "native.apple.27f775de30b37ff8",
-      "source": "Recent sessions",
-      "translated": "Sesi terbaru"
+      "id": "native.apple.b3c553614f762a58",
+      "source": "Recent threads",
+      "translated": "Utas terbaru"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11119,9 +11194,9 @@
       "translated": "Gateway offline"
     },
     {
-      "id": "native.apple.28c97cf23665ee01",
-      "source": "No recent sessions",
-      "translated": "Tidak ada sesi terbaru"
+      "id": "native.apple.5aa32afda85064ea",
+      "source": "No recent threads",
+      "translated": "Tidak ada utas terbaru"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11219,14 +11294,14 @@
       "translated": "Batal"
     },
     {
-      "id": "native.apple.9f2fd65953013b7c",
-      "source": "Sessions",
-      "translated": "Sesi"
+      "id": "native.apple.b6855cf19a50f477",
+      "source": "Threads",
+      "translated": "Utas"
     },
     {
-      "id": "native.apple.0422818cc95d5071",
-      "source": "Archived sessions",
-      "translated": "Sesi yang diarsipkan"
+      "id": "native.apple.9b1d0ef27a1333b0",
+      "source": "Archived threads",
+      "translated": "Utas yang diarsipkan"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11234,34 +11309,34 @@
       "translated": "Tampilkan yang Diarsipkan"
     },
     {
-      "id": "native.apple.b272115c83f7ef58",
-      "source": "Sessions unavailable",
-      "translated": "Sesi tidak tersedia"
+      "id": "native.apple.98167401c7267735",
+      "source": "Threads unavailable",
+      "translated": "Utas tidak tersedia"
     },
     {
-      "id": "native.apple.54f8260c9b863087",
-      "source": "Loading archived sessions",
-      "translated": "Memuat sesi yang diarsipkan"
+      "id": "native.apple.4d28a7def2337b9f",
+      "source": "Loading archived threads",
+      "translated": "Memuat utas yang diarsipkan"
     },
     {
-      "id": "native.apple.9b305868873dade2",
-      "source": "Loading recent sessions",
-      "translated": "Memuat sesi terbaru"
+      "id": "native.apple.777d7b706933bd7b",
+      "source": "Loading recent threads",
+      "translated": "Memuat utas terbaru"
     },
     {
-      "id": "native.apple.207dad20d09f3160",
-      "source": "^[\\(count) session](inflect: true)",
-      "translated": "^[\\(count) sesi](inflect: true)"
+      "id": "native.apple.22f81ea94bef8410",
+      "source": "^[\\(count) thread](inflect: true)",
+      "translated": "^[\\(count) utas](inflect: true)"
     },
     {
-      "id": "native.apple.1f4501a6bf2bae4c",
-      "source": "No archived sessions",
-      "translated": "Tidak ada sesi yang diarsipkan"
+      "id": "native.apple.1cad51e14db59bf9",
+      "source": "No archived threads",
+      "translated": "Tidak ada utas yang diarsipkan"
     },
     {
-      "id": "native.apple.2a1ba7a5e1979c9e",
-      "source": "Archived sessions will appear here.",
-      "translated": "Sesi yang diarsipkan akan muncul di sini."
+      "id": "native.apple.18ef832d3a7ddcf8",
+      "source": "Archived threads will appear here.",
+      "translated": "Utas yang diarsipkan akan muncul di sini."
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11344,9 +11419,9 @@
       "translated": "Bagikan masukan"
     },
     {
-      "id": "native.apple.2360d25fe6ae9946",
-      "source": "Loading sessions",
-      "translated": "Memuat sesi"
+      "id": "native.apple.21d9208d86a4d1fe",
+      "source": "Loading threads",
+      "translated": "Memuat utas"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11354,19 +11429,19 @@
       "translated": "Mengambil aktivitas terbaru dari gateway."
     },
     {
-      "id": "native.apple.c334f2e86702a7b8",
-      "source": "Sessions unavailable",
-      "translated": "Sesi tidak tersedia"
+      "id": "native.apple.4be1f79aa2b230ff",
+      "source": "Threads unavailable",
+      "translated": "Utas tidak tersedia"
     },
     {
-      "id": "native.apple.6cc6efb7a03960b6",
-      "source": "No recent sessions",
-      "translated": "Tidak ada sesi terbaru"
+      "id": "native.apple.98b348873556bc46",
+      "source": "No recent threads",
+      "translated": "Tidak ada utas terbaru"
     },
     {
-      "id": "native.apple.08483af2d043bee6",
-      "source": "Session activity offline",
-      "translated": "Aktivitas sesi offline"
+      "id": "native.apple.7396d205574d279f",
+      "source": "Thread activity offline",
+      "translated": "Aktivitas utas offline"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11824,9 +11899,9 @@
       "translated": "Kartu"
     },
     {
-      "id": "native.apple.93eeaedb2ff61043",
-      "source": "Open Session",
-      "translated": "Buka Sesi"
+      "id": "native.apple.c9ec1b0e18074d8a",
+      "source": "Open Thread",
+      "translated": "Buka Utas"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13314,9 +13389,9 @@
       "translated": "Default"
     },
     {
-      "id": "native.apple.3de045f17ea3c6d0",
-      "source": "Used for new Chat and Talk sessions.",
-      "translated": "Digunakan untuk sesi Chat dan Talk baru."
+      "id": "native.apple.f4ae5664c3eda95d",
+      "source": "Used for new Chat threads and Talk sessions.",
+      "translated": "Digunakan untuk utas Chat baru dan sesi Talk."
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15719,9 +15794,9 @@
       "translated": "Instans"
     },
     {
-      "id": "native.apple.3579cf2750470a22",
-      "source": "Sessions",
-      "translated": "Sesi"
+      "id": "native.apple.11fe8b9941954dfb",
+      "source": "Threads",
+      "translated": "Utas"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19029,9 +19104,9 @@
       "translated": "Pintasan Obrolan Cepat"
     },
     {
-      "id": "native.apple.6ae77665b5f4490f",
-      "source": "Global shortcut that opens a floating chat bar for the main session.",
-      "translated": "Pintasan global yang membuka bilah obrolan mengambang untuk sesi utama."
+      "id": "native.apple.94dd793cd7d7d555",
+      "source": "Global shortcut that opens a floating chat bar for the main thread.",
+      "translated": "Pintasan global yang membuka bilah chat mengambang untuk utas utama."
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19609,9 +19684,9 @@
       "translated": "Kritis"
     },
     {
-      "id": "native.apple.75102378a6775180",
-      "source": "New Session",
-      "translated": "Sesi Baru"
+      "id": "native.apple.13f96467014cf344",
+      "source": "New Thread",
+      "translated": "Utas Baru"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21899,9 +21974,9 @@
       "translated": "Tidak ada pesan terbaru"
     },
     {
-      "id": "native.apple.1ff8aec0044934c3",
-      "source": "Sessions",
-      "translated": "Sesi"
+      "id": "native.apple.3ec2afcbc298c673",
+      "source": "Threads",
+      "translated": "Utas"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21909,9 +21984,9 @@
       "translated": "Intip bucket percakapan tersimpan yang digunakan kembali oleh CLI untuk konteks dan batas laju."
     },
     {
-      "id": "native.apple.bab897f3252b134c",
-      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
-      "translated": "Belum ada sesi. Sesi muncul setelah pesan masuk atau heartbeat pertama."
+      "id": "native.apple.14ccb32cd8ed1c81",
+      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
+      "translated": "Belum ada utas. Utas akan muncul setelah pesan masuk atau heartbeat pertama."
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -21994,9 +22069,9 @@
       "translated": "Persetujuan Exec"
     },
     {
-      "id": "native.apple.64a6dc7d49e8fb57",
-      "source": "Sessions",
-      "translated": "Sesi"
+      "id": "native.apple.52e37e3a44ae516c",
+      "source": "Threads",
+      "translated": "Utas"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -22999,9 +23074,9 @@
       "translated": "Beri saya kabar terbaru"
     },
     {
-      "id": "native.apple.234ec45f4231edc4",
-      "source": "Summarize what happened in my sessions since yesterday.",
-      "translated": "Rangkum apa yang terjadi dalam sesi saya sejak kemarin."
+      "id": "native.apple.fc4ce810900ec0b6",
+      "source": "Summarize what happened in my threads since yesterday.",
+      "translated": "Rangkum apa yang terjadi di utas saya sejak kemarin."
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23179,9 +23254,9 @@
       "translated": "Lepas sematan model"
     },
     {
-      "id": "native.apple.5dfc0700d8dff8de",
-      "source": "Session",
-      "translated": "Sesi"
+      "id": "native.apple.4edb66657f5aca1f",
+      "source": "Thread",
+      "translated": "Utas"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23344,6 +23419,51 @@
       "translated": "Widget tidak tersedia"
     },
     {
+      "id": "native.apple.d640691fd196f338",
+      "source": "Widget export failed",
+      "translated": "Ekspor widget gagal"
+    },
+    {
+      "id": "native.apple.533c6e22a11e88de",
+      "source": "OK",
+      "translated": "OK"
+    },
+    {
+      "id": "native.apple.e1fb28a2a9756402",
+      "source": "Copy image",
+      "translated": "Salin gambar"
+    },
+    {
+      "id": "native.apple.ebd7bc92e1b12235",
+      "source": "Save image…",
+      "translated": "Simpan gambar…"
+    },
+    {
+      "id": "native.apple.742c46d4cf2db134",
+      "source": "Save image",
+      "translated": "Simpan gambar"
+    },
+    {
+      "id": "native.apple.0589cce608418f90",
+      "source": "The widget image could not be captured.",
+      "translated": "Gambar widget tidak dapat diambil."
+    },
+    {
+      "id": "native.apple.dfe24e827fdbe9c5",
+      "source": "The widget image could not be copied.",
+      "translated": "Gambar widget tidak dapat disalin."
+    },
+    {
+      "id": "native.apple.9e611e3a80e71408",
+      "source": "The widget image could not be encoded as PNG.",
+      "translated": "Gambar widget tidak dapat dikodekan sebagai PNG."
+    },
+    {
+      "id": "native.apple.9a6e8afbe24a262b",
+      "source": "The widget image could not be saved.",
+      "translated": "Gambar widget tidak dapat disimpan."
+    },
+    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23484,19 +23604,19 @@
       "translated": "Pengguna"
     },
     {
-      "id": "native.apple.b1cdcb906a43d5d6",
-      "source": "This session cannot be archived while it is active or running.",
-      "translated": "Sesi ini tidak dapat diarsipkan saat masih aktif atau berjalan."
+      "id": "native.apple.9d0cba09d92ee669",
+      "source": "This thread cannot be archived while it is active or running.",
+      "translated": "Utas ini tidak dapat diarsipkan saat aktif atau sedang berjalan."
     },
     {
-      "id": "native.apple.5817e3f3dab1ee19",
-      "source": "The main session cannot be deleted.",
-      "translated": "Sesi utama tidak dapat dihapus."
+      "id": "native.apple.8952a111a1075051",
+      "source": "The main thread cannot be deleted.",
+      "translated": "Utas utama tidak dapat dihapus."
     },
     {
-      "id": "native.apple.a6b8df3f18171c91",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
-      "translated": "Hapus lampiran atau tunggu hingga pengiriman selesai sebelum mengarsipkan atau menghapus sesi ini."
+      "id": "native.apple.90d0ccf80ca28717",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
+      "translated": "Hapus lampiran atau tunggu hingga pengiriman selesai sebelum mengarsipkan atau menghapus utas ini."
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23634,9 +23754,9 @@
       "translated": "Proses berakhir"
     },
     {
-      "id": "native.apple.cd7c3095a22f80a9",
-      "source": "Session Info",
-      "translated": "Info Sesi"
+      "id": "native.apple.bbccb4c8db5cac12",
+      "source": "Thread Info",
+      "translated": "Info Utas"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23669,9 +23789,9 @@
       "translated": "Tambahkan Grup"
     },
     {
-      "id": "native.apple.23d628606fe0734f",
-      "source": "Session Groups",
-      "translated": "Grup Sesi"
+      "id": "native.apple.7b641fed5bace855",
+      "source": "Thread Groups",
+      "translated": "Grup Utas"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23714,9 +23834,9 @@
       "translated": "Hapus Grup"
     },
     {
-      "id": "native.apple.b049c8a4d2805e08",
-      "source": "Sessions in this group become ungrouped.",
-      "translated": "Sesi dalam grup ini tidak akan lagi dikelompokkan."
+      "id": "native.apple.56401c79410a310d",
+      "source": "Threads in this group become ungrouped.",
+      "translated": "Utas dalam grup ini tidak lagi dikelompokkan."
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23729,9 +23849,9 @@
       "translated": "Tidak ada agen yang tersedia di gateway ini."
     },
     {
-      "id": "native.apple.6c89f35d53506406",
-      "source": "New Session Options",
-      "translated": "Opsi Sesi Baru"
+      "id": "native.apple.2d96aa7d3d12f85b",
+      "source": "New Thread Options",
+      "translated": "Opsi Utas Baru"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23759,19 +23879,19 @@
       "translated": "Buat"
     },
     {
-      "id": "native.apple.795ba37f6782cf28",
-      "source": "The session could not be created.",
-      "translated": "Sesi tidak dapat dibuat."
+      "id": "native.apple.87ef57319d1ddc85",
+      "source": "The thread could not be created.",
+      "translated": "Utas tidak dapat dibuat."
     },
     {
-      "id": "native.apple.8ec708a3605a2cc3",
-      "source": "Search sessions",
-      "translated": "Cari sesi"
+      "id": "native.apple.6bd91c435b69d638",
+      "source": "Search threads",
+      "translated": "Cari utas"
     },
     {
-      "id": "native.apple.23b069b4e7f97039",
-      "source": "No Sessions",
-      "translated": "Tidak Ada Sesi"
+      "id": "native.apple.6fde4bdf9d5b9191",
+      "source": "No Threads",
+      "translated": "Tidak Ada Utas"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23779,29 +23899,29 @@
       "translated": "Tidak Ada Hasil"
     },
     {
-      "id": "native.apple.0058923f2ce8a3ec",
-      "source": "New Session",
-      "translated": "Sesi Baru"
+      "id": "native.apple.a02fd99740d29bd3",
+      "source": "New Thread",
+      "translated": "Utas Baru"
     },
     {
-      "id": "native.apple.66ba42960eb4135b",
-      "source": "New session",
-      "translated": "Sesi baru"
+      "id": "native.apple.b625801dd04b09f2",
+      "source": "New thread",
+      "translated": "Utas baru"
     },
     {
-      "id": "native.apple.2ef0e34db02ad255",
-      "source": "New session options",
-      "translated": "Opsi sesi baru"
+      "id": "native.apple.851be81fcc933608",
+      "source": "New thread options",
+      "translated": "Opsi utas baru"
     },
     {
-      "id": "native.apple.36753ef2f1ed4264",
-      "source": "Rename Session",
-      "translated": "Ubah Nama Sesi"
+      "id": "native.apple.9ce8a4aba7b444b2",
+      "source": "Rename Thread",
+      "translated": "Ganti Nama Utas"
     },
     {
-      "id": "native.apple.c9de0a1510ef475f",
-      "source": "Session name",
-      "translated": "Nama sesi"
+      "id": "native.apple.1dd067c44511c7f0",
+      "source": "Thread name",
+      "translated": "Nama utas"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23814,14 +23934,14 @@
       "translated": "Batal"
     },
     {
-      "id": "native.apple.afb4e6c99c63a28d",
-      "source": "Delete Session",
-      "translated": "Hapus Sesi"
+      "id": "native.apple.618073d6ab3f2721",
+      "source": "Delete Thread",
+      "translated": "Hapus Utas"
     },
     {
-      "id": "native.apple.3d4ef32e42f136a4",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "Sesi dan transkripnya dihapus dari gateway."
+      "id": "native.apple.10a5e72bba3cbccc",
+      "source": "The thread and its transcript are removed from the gateway.",
+      "translated": "Utas dan transkripnya dihapus dari gateway."
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23829,14 +23949,14 @@
       "translated": "Hapus “%@”?"
     },
     {
-      "id": "native.apple.9a7dca238fba628d",
-      "source": "Session running",
-      "translated": "Sesi sedang berjalan"
+      "id": "native.apple.ac71e3b2aa496a2c",
+      "source": "Thread running",
+      "translated": "Utas sedang berjalan"
     },
     {
-      "id": "native.apple.fcfbfe5e97a95e9c",
-      "source": "Session failed",
-      "translated": "Sesi gagal"
+      "id": "native.apple.c775e87f997278b2",
+      "source": "Thread failed",
+      "translated": "Utas gagal"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23894,9 +24014,9 @@
       "translated": "Salin Kunci Sesi"
     },
     {
-      "id": "native.apple.4aeb7c14c26dabac",
-      "source": "Delete Session…",
-      "translated": "Hapus Sesi…"
+      "id": "native.apple.f4998cfb572f23ff",
+      "source": "Delete Thread…",
+      "translated": "Hapus Utas…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23909,9 +24029,9 @@
       "translated": "Menghubungkan…"
     },
     {
-      "id": "native.apple.79f708b3bc1d3a6c",
-      "source": "Retry session groups",
-      "translated": "Coba lagi grup sesi"
+      "id": "native.apple.8802e9576ffd0f65",
+      "source": "Retry thread groups",
+      "translated": "Coba lagi grup utas"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23934,24 +24054,24 @@
       "translated": "Cakupan"
     },
     {
-      "id": "native.apple.2c37581c7b88f741",
-      "source": "Search sessions",
-      "translated": "Cari sesi"
+      "id": "native.apple.b313b80def4bda52",
+      "source": "Search threads",
+      "translated": "Cari utas"
     },
     {
-      "id": "native.apple.43be8a2336e42faf",
-      "source": "Sessions",
-      "translated": "Sesi"
+      "id": "native.apple.c0cc6acc36f413ce",
+      "source": "Threads",
+      "translated": "Utas"
     },
     {
-      "id": "native.apple.0b379cdfcbd3247f",
-      "source": "Rename Session",
-      "translated": "Ganti Nama Sesi"
+      "id": "native.apple.854d3928fe5a557c",
+      "source": "Rename Thread",
+      "translated": "Ganti Nama Utas"
     },
     {
-      "id": "native.apple.54b6fbd9e41db009",
-      "source": "Session name",
-      "translated": "Nama sesi"
+      "id": "native.apple.9d0d3f20096cc4da",
+      "source": "Thread name",
+      "translated": "Nama utas"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -23959,19 +24079,19 @@
       "translated": "Batal"
     },
     {
-      "id": "native.apple.751e0f6b81cd374a",
-      "source": "Delete selected sessions?",
-      "translated": "Hapus sesi yang dipilih?"
+      "id": "native.apple.dc00eb94f33bae15",
+      "source": "Delete selected threads?",
+      "translated": "Hapus utas yang dipilih?"
     },
     {
-      "id": "native.apple.aa679276581b0058",
-      "source": "Delete Sessions",
-      "translated": "Hapus Sesi"
+      "id": "native.apple.2053fc9f74dc3158",
+      "source": "Delete Threads",
+      "translated": "Hapus Utas"
     },
     {
-      "id": "native.apple.f837129cbee23297",
-      "source": "Each selected session and its transcript will be removed from the gateway.",
-      "translated": "Setiap sesi yang dipilih beserta transkripnya akan dihapus dari Gateway."
+      "id": "native.apple.0970247871a834a0",
+      "source": "Each selected thread and its transcript will be removed from the gateway.",
+      "translated": "Setiap utas yang dipilih beserta transkripnya akan dihapus dari Gateway."
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -23979,9 +24099,9 @@
       "translated": "Grup"
     },
     {
-      "id": "native.apple.64013cfee5e25305",
-      "source": "Manage session groups",
-      "translated": "Kelola grup sesi"
+      "id": "native.apple.6f8acab2256728b5",
+      "source": "Manage thread groups",
+      "translated": "Kelola grup utas"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -23994,14 +24114,14 @@
       "translated": "Pilih"
     },
     {
-      "id": "native.apple.b67eaecec1b423ac",
-      "source": "No archived sessions",
-      "translated": "Tidak ada sesi yang diarsipkan"
+      "id": "native.apple.692972314d04b184",
+      "source": "No archived threads",
+      "translated": "Tidak ada utas yang diarsipkan"
     },
     {
-      "id": "native.apple.b2435a79abf0c794",
-      "source": "No sessions found",
-      "translated": "Tidak ada sesi ditemukan"
+      "id": "native.apple.d6a4b5711dcd26e7",
+      "source": "No threads found",
+      "translated": "Tidak ada utas yang ditemukan"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24169,6 +24289,16 @@
       "translated": "Buka Pesan Lengkap"
     },
     {
+      "id": "native.apple.002bfcede229ad4b",
+      "source": "Rewind to Here",
+      "translated": "Mundur ke Sini"
+    },
+    {
+      "id": "native.apple.14df2e4997689fb3",
+      "source": "Fork from Here",
+      "translated": "Buat Cabang dari Sini"
+    },
+    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "Balas"
@@ -24254,9 +24384,9 @@
       "translated": "Hapus lampiran atau tunggu hingga pengiriman selesai sebelum memulai obrolan baru."
     },
     {
-      "id": "native.apple.980f552bb0f96c0f",
-      "source": "Gateway changed before the session operation started.",
-      "translated": "Gateway berubah sebelum operasi sesi dimulai."
+      "id": "native.apple.e0f045151c8d3137",
+      "source": "Gateway changed before the thread operation started.",
+      "translated": "Gateway berubah sebelum operasi utas dimulai."
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24264,9 +24394,9 @@
       "translated": "Hapus lampiran atau tunggu pengiriman selesai sebelum beralih obrolan."
     },
     {
-      "id": "native.apple.87ba543b42696b92",
-      "source": "Clear this session's history?",
-      "translated": "Hapus riwayat sesi ini?"
+      "id": "native.apple.0a5c4e15466c3acc",
+      "source": "Clear this thread's history?",
+      "translated": "Hapus riwayat utas ini?"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24279,14 +24409,14 @@
       "translated": "Tindakan ini mengatur ulang percakapan untuk %@. Kunci sesi tetap sama."
     },
     {
-      "id": "native.apple.a92e96bed98bd553",
-      "source": "Rename Session",
-      "translated": "Ubah Nama Sesi"
+      "id": "native.apple.67ac221dbe7179f0",
+      "source": "Rename Thread",
+      "translated": "Ganti Nama Utas"
     },
     {
-      "id": "native.apple.848e2388f3466f40",
-      "source": "Session name",
-      "translated": "Nama sesi"
+      "id": "native.apple.cf0f7e049603f518",
+      "source": "Thread name",
+      "translated": "Nama utas"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24304,9 +24434,9 @@
       "translated": "Ekspor Transkrip"
     },
     {
-      "id": "native.apple.4af0f566d39d7041",
-      "source": "Sessions",
-      "translated": "Sesi"
+      "id": "native.apple.c0ada47504425f23",
+      "source": "Threads",
+      "translated": "Utas"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24379,14 +24509,14 @@
       "translated": "Default"
     },
     {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "Sesi Baru"
+      "id": "native.apple.1a765291943599e5",
+      "source": "New Thread",
+      "translated": "Utas Baru"
     },
     {
-      "id": "native.apple.a7119fbf9d25df5e",
-      "source": "New Session Options…",
-      "translated": "Opsi Sesi Baru…"
+      "id": "native.apple.c7a3a6d5e43dd98f",
+      "source": "New Thread Options…",
+      "translated": "Opsi Utas Baru…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24394,19 +24524,19 @@
       "translated": "Segarkan"
     },
     {
-      "id": "native.apple.2bcff4a8fa503739",
-      "source": "Sessions…",
-      "translated": "Sesi…"
+      "id": "native.apple.0e710b81808e5dcf",
+      "source": "Threads…",
+      "translated": "Utas…"
     },
     {
-      "id": "native.apple.c36e008b051adb38",
-      "source": "Rename Session…",
-      "translated": "Ubah Nama Sesi…"
+      "id": "native.apple.faad8f92b6bef166",
+      "source": "Rename Thread…",
+      "translated": "Ganti Nama Utas…"
     },
     {
-      "id": "native.apple.ea0ef95a159bffe0",
-      "source": "Fork Session",
-      "translated": "Fork Sesi"
+      "id": "native.apple.23b61d6cd26ac112",
+      "source": "Fork",
+      "translated": "Cabangkan"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24464,24 +24594,24 @@
       "translated": "Hapus Riwayat…"
     },
     {
-      "id": "native.apple.920fe8a7a33f9e92",
-      "source": "Session",
-      "translated": "Sesi"
+      "id": "native.apple.8b4f1c5107ea8a0e",
+      "source": "Thread",
+      "translated": "Utas"
     },
     {
-      "id": "native.apple.185a401f78328b0f",
-      "source": "Session actions",
-      "translated": "Tindakan sesi"
+      "id": "native.apple.4d7750c9bf699469",
+      "source": "Thread actions",
+      "translated": "Tindakan utas"
     },
     {
-      "id": "native.apple.9f9dedf599b2619b",
-      "source": "Session cost %@",
-      "translated": "Biaya sesi %@"
+      "id": "native.apple.bb2f22cc43c97f8e",
+      "source": "Thread cost %@",
+      "translated": "Biaya utas %@"
     },
     {
-      "id": "native.apple.f0a4720df5f5f403",
-      "source": "Compact Session",
-      "translated": "Ringkas Sesi"
+      "id": "native.apple.6239ced0b86e86f8",
+      "source": "Compact Thread",
+      "translated": "Ringkas Utas"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/id.json
+++ b/apps/.i18n/native/id.json
@@ -1429,9 +1429,9 @@
       "translated": "Bicara atau dikte dengan OpenClaw"
     },
     {
-      "id": "native.android.e2cf5a38587382cb",
-      "source": "Browse Threads",
-      "translated": "Jelajahi Utas"
+      "id": "native.android.5876e15e5e92fd45",
+      "source": "Browse Sessions",
+      "translated": "Telusuri Sesi"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "Tidak ada tindakan yang ditemukan"
     },
     {
-      "id": "native.android.bc70a4ac965b82ba",
-      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
-      "translated": "Coba Chat, Suara, Utas, Penyedia, atau Pengaturan."
+      "id": "native.android.48ad0ae0e930e02b",
+      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
+      "translated": "Coba Chat, Voice, Sessions, Providers, atau Settings."
     },
     {
-      "id": "native.android.670121e54dbe286f",
-      "source": "Threads",
-      "translated": "Utas"
+      "id": "native.android.d4fbd1ee4f55a5db",
+      "source": "Sessions",
+      "translated": "Sesi"
     },
     {
-      "id": "native.android.d38be650b1bce4a0",
-      "source": "Connect the Gateway to search threads.",
-      "translated": "Hubungkan Gateway untuk mencari utas."
+      "id": "native.android.207c2170504e99e6",
+      "source": "Connect the Gateway to search sessions.",
+      "translated": "Hubungkan Gateway untuk mencari sesi."
     },
     {
-      "id": "native.android.3d7754721f776ef8",
-      "source": "No matching threads yet.",
-      "translated": "Belum ada utas yang cocok."
+      "id": "native.android.25d2c2d792c952fe",
+      "source": "No matching sessions yet.",
+      "translated": "Belum ada sesi yang cocok."
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "Asisten sedang bekerja"
     },
     {
-      "id": "native.android.9a839f6e3e05a744",
-      "source": "OpenClaw thread",
-      "translated": "Utas OpenClaw"
+      "id": "native.android.8f8384286317f5c9",
+      "source": "OpenClaw session",
+      "translated": "Sesi OpenClaw"
     },
     {
-      "id": "native.android.d83f82a1e4a5ed99",
-      "source": "Open thread",
-      "translated": "Buka utas"
+      "id": "native.android.15799e57704b20c6",
+      "source": "Open session",
+      "translated": "Buka sesi"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "Tidak ada penyedia yang siap"
     },
     {
-      "id": "native.android.8a1c5365c0538908",
-      "source": "Main thread",
-      "translated": "Utas utama"
+      "id": "native.android.73e6ab1a168fd381",
+      "source": "Main session",
+      "translated": "Sesi utama"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.a5845742daecb4ba",
-      "source": "Threads",
-      "translated": "Utas"
+      "id": "native.android.0e3157c15c56944f",
+      "source": "Sessions",
+      "translated": "Sesi"
     },
     {
-      "id": "native.android.439b324280869527",
-      "source": "Focus thread search",
-      "translated": "Fokuskan pencarian utas"
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "Fokuskan pencarian sesi"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "Diarsipkan"
     },
     {
-      "id": "native.android.03981341841b04ac",
-      "source": "Search threads",
-      "translated": "Cari utas"
+      "id": "native.android.b9cf34c137e4cf03",
+      "source": "Search sessions",
+      "translated": "Cari sesi"
     },
     {
-      "id": "native.android.99570c528a41fa72",
-      "source": "Clear thread search",
-      "translated": "Hapus pencarian utas"
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "Hapus pencarian sesi"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "Terlama dahulu"
     },
     {
-      "id": "native.android.fd67be543e321cc9",
-      "source": "Toggle thread layout",
-      "translated": "Alihkan tata letak utas"
+      "id": "native.android.c6bf8751e2a7f5c7",
+      "source": "Toggle session layout",
+      "translated": "Alihkan tata letak sesi"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "Tata letak: Terperinci"
     },
     {
-      "id": "native.android.ebd17565e0ffd8eb",
-      "source": "Searching threads",
-      "translated": "Mencari utas"
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "Mencari sesi"
     },
     {
-      "id": "native.android.472d46ae8669f860",
-      "source": "No matching threads",
-      "translated": "Tidak ada utas yang cocok"
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "Tidak ada sesi yang cocok"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "Mulai Chat"
     },
     {
-      "id": "native.android.ff81ad1bee00d384",
-      "source": "Current thread",
-      "translated": "Utas saat ini"
+      "id": "native.android.f10d4df7cbc6df4f",
+      "source": "Current session",
+      "translated": "Sesi saat ini"
     },
     {
-      "id": "native.android.fc145645b9620e57",
-      "source": "OpenClaw thread",
-      "translated": "Utas OpenClaw"
+      "id": "native.android.8f0482425838ae64",
+      "source": "OpenClaw session",
+      "translated": "Sesi OpenClaw"
     },
     {
-      "id": "native.android.71cbb8dde8bf138b",
-      "source": "Rename thread",
-      "translated": "Ganti nama utas"
+      "id": "native.android.786774c8a76e50d7",
+      "source": "Rename session",
+      "translated": "Ganti nama sesi"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "Hapus grup?"
     },
     {
-      "id": "native.android.691e92cfe5cf106e",
-      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "Utas di \"$group\" tetap disimpan dan dipindahkan kembali ke Tanpa Grup."
+      "id": "native.android.3455fc2f77d564e3",
+      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "Sesi dalam \"$group\" disimpan dan dipindahkan kembali ke Ungrouped."
     },
     {
-      "id": "native.android.d87a8217ab56999b",
-      "source": "Delete thread?",
-      "translated": "Hapus utas?"
+      "id": "native.android.4805fb9d6623e8c0",
+      "source": "Delete session?",
+      "translated": "Hapus sesi?"
     },
     {
-      "id": "native.android.930de97ff47113a8",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "Tindakan ini akan menghapus utas dan transkripnya secara permanen."
+      "id": "native.android.0c3283a2b2445eae",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "Ini akan menghapus sesi dan transkripnya secara permanen."
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "Tidak dikelompokkan"
     },
     {
-      "id": "native.android.8e21a70428def6e0",
-      "source": "No threads yet",
-      "translated": "Belum ada utas"
+      "id": "native.android.db243d71d056afa4",
+      "source": "No sessions yet",
+      "translated": "Belum ada sesi"
     },
     {
-      "id": "native.android.cda4c5ad8b17e394",
-      "source": "No current thread",
-      "translated": "Tidak ada utas saat ini"
+      "id": "native.android.5b4eee6a8092925e",
+      "source": "No current session",
+      "translated": "Tidak ada sesi saat ini"
     },
     {
-      "id": "native.android.be84f061047aa2da",
-      "source": "No archived threads",
-      "translated": "Tidak ada utas yang diarsipkan"
+      "id": "native.android.acbcc9c9ea53d8c0",
+      "source": "No archived sessions",
+      "translated": "Tidak ada sesi yang diarsipkan"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "Mulai percakapan baru dan percakapan itu akan muncul di sini."
     },
     {
-      "id": "native.android.f289d03e1d3eee98",
-      "source": "Open Chat to start or resume the current thread.",
-      "translated": "Buka Chat untuk memulai atau melanjutkan utas saat ini."
+      "id": "native.android.56fcd605dc7be3c0",
+      "source": "Open Chat to start or resume the current session.",
+      "translated": "Buka Chat untuk memulai atau melanjutkan sesi saat ini."
     },
     {
-      "id": "native.android.504b71386e76c6ae",
-      "source": "Archived threads will show up here.",
-      "translated": "Utas yang diarsipkan akan muncul di sini."
+      "id": "native.android.085515989f8a2022",
+      "source": "Archived sessions will show up here.",
+      "translated": "Sesi yang diarsipkan akan muncul di sini."
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days}h"
     },
     {
-      "id": "native.android.ee4c727cdafbe963",
-      "source": "Main thread",
-      "translated": "Utas utama"
+      "id": "native.android.3d4fa07acbc015c5",
+      "source": "Main session",
+      "translated": "Sesi utama"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway Tertunda"
     },
     {
-      "id": "native.android.da78209effb11cfd",
-      "source": "Thread Activity",
-      "translated": "Aktivitas Utas"
+      "id": "native.android.2d8d049afe99f751",
+      "source": "Session Activity",
+      "translated": "Aktivitas Sesi"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "Permintaan persetujuan exec akan muncul di sini saat ponsel ini terhubung."
     },
     {
-      "id": "native.android.f615712dfb56319a",
-      "source": "Thread activity",
-      "translated": "Aktivitas utas"
+      "id": "native.android.dc3e7ca5a491103a",
+      "source": "Session activity",
+      "translated": "Aktivitas sesi"
     },
     {
-      "id": "native.android.6c93973c13db43ae",
-      "source": "Chat tool calls waiting in the active thread remain visible here.",
-      "translated": "Panggilan alat Chat yang menunggu di utas aktif tetap terlihat di sini."
+      "id": "native.android.8551e02b060bd7d8",
+      "source": "Chat tool calls waiting in the active session remain visible here.",
+      "translated": "Panggilan alat chat yang menunggu dalam sesi aktif tetap terlihat di sini."
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,11 +4294,6 @@
       "translated": "Penyiapan Penyedia Talk"
     },
     {
-      "id": "native.android.23b638094c34b916",
-      "source": "Microphone",
-      "translated": "Mikrofon"
-    },
-    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "Tes Audio"
@@ -4342,66 +4337,6 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "Selesai"
-    },
-    {
-      "id": "native.android.8d9ecdfdd916b780",
-      "source": "Automatic",
-      "translated": "Otomatis"
-    },
-    {
-      "id": "native.android.c1626a6700a570f6",
-      "source": "Preferred microphone unavailable; using automatic routing.",
-      "translated": "Mikrofon pilihan tidak tersedia; menggunakan perutean otomatis."
-    },
-    {
-      "id": "native.android.820bc5d0ce571d8b",
-      "source": "Prioritizes connected Bluetooth microphones.",
-      "translated": "Memprioritaskan mikrofon Bluetooth yang terhubung."
-    },
-    {
-      "id": "native.android.11e48038d5e8bff6",
-      "source": "Preferred microphone",
-      "translated": "Mikrofon pilihan"
-    },
-    {
-      "id": "native.android.eaa4d7563a46d307",
-      "source": "Unavailable",
-      "translated": "Tidak tersedia"
-    },
-    {
-      "id": "native.android.9f5ebf17eb405ba8",
-      "source": "Next session",
-      "translated": "Sesi berikutnya"
-    },
-    {
-      "id": "native.android.8c4e91f53928efb2",
-      "source": "Built-in microphone",
-      "translated": "Mikrofon bawaan"
-    },
-    {
-      "id": "native.android.14b613cb6e2446b4",
-      "source": "Bluetooth microphone",
-      "translated": "Mikrofon Bluetooth"
-    },
-    {
-      "id": "native.android.c885247b2d7ce271",
-      "source": "Bluetooth LE microphone",
-      "translated": "Mikrofon Bluetooth LE"
-    },
-    {
-      "id": "native.android.b6a4e674c5fb441a",
-      "source": "Wired headset microphone",
-      "translated": "Mikrofon headset berkabel"
-    },
-    {
-      "id": "native.android.9c8becb3b0fb5a90",
-      "source": "USB microphone",
-      "translated": "Mikrofon USB"
-    },
-    {
-      "id": "native.android.ba46258fadec7a39",
-      "source": "External microphone",
-      "translated": "Mikrofon eksternal"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5139,9 +5074,9 @@
       "translated": "Periksa"
     },
     {
-      "id": "native.android.c971506716c96e91",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
-      "translated": "OpenClaw mengubah ponsel ini menjadi antarmuka perintah seluler yang ringkas untuk utas, suara, penyedia, dan Gateway."
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw mengubah ponsel ini menjadi antarmuka perintah seluler yang ringkas untuk sesi, suara, penyedia, dan Gateway."
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5689,9 +5624,9 @@
       "translated": "Pengaturan Bicara"
     },
     {
-      "id": "native.android.36f78c8c85dc283f",
-      "source": "Recent Threads",
-      "translated": "Utas Terbaru"
+      "id": "native.android.73f07a5d54915259",
+      "source": "Recent Sessions",
+      "translated": "Sesi Terbaru"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5749,14 +5684,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online"
     },
     {
-      "id": "native.android.57177017a6a93826",
-      "source": "Threads",
-      "translated": "Utas"
+      "id": "native.android.16c3425d3a594481",
+      "source": "Sessions",
+      "translated": "Sesi"
     },
     {
-      "id": "native.android.43320b54a68b00a1",
-      "source": "No recent threads",
-      "translated": "Tidak ada utas terbaru"
+      "id": "native.android.a5c0f8b3112aa58c",
+      "source": "No recent sessions",
+      "translated": "Tidak ada sesi terbaru"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5794,14 +5729,14 @@
       "translated": "Bekerja · $pendingRunCount proses aktif"
     },
     {
-      "id": "native.android.e24db059480f1e6a",
-      "source": "Monitoring · 1 thread",
-      "translated": "Memantau · 1 utas"
+      "id": "native.android.2c89da708b12a522",
+      "source": "Monitoring · 1 session",
+      "translated": "Memantau · 1 sesi"
     },
     {
-      "id": "native.android.5a475f37d80e02bc",
-      "source": "Monitoring · $sessionCount threads",
-      "translated": "Memantau · $sessionCount utas"
+      "id": "native.android.8b6ee382dcb64e1f",
+      "source": "Monitoring · $sessionCount sessions",
+      "translated": "Memantau · $sessionCount sesi"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5834,9 +5769,9 @@
       "translated": "Penyedia"
     },
     {
-      "id": "native.android.358c5e0e838d5423",
-      "source": "Open thread",
-      "translated": "Buka utas"
+      "id": "native.android.a65477861c7203aa",
+      "source": "Open session",
+      "translated": "Buka sesi"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6259,9 +6194,9 @@
       "translated": "${days}h"
     },
     {
-      "id": "native.android.28a1a1acc5a0959f",
-      "source": "Main thread",
-      "translated": "Utas utama"
+      "id": "native.android.22d755834386db07",
+      "source": "Main session",
+      "translated": "Sesi utama"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6942,16 +6877,6 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "Suarakan"
-    },
-    {
-      "id": "native.android.cb608d82c5b3352a",
-      "source": "Back camera",
-      "translated": "Kamera belakang"
-    },
-    {
-      "id": "native.android.e89a0e780eed2e1e",
-      "source": "Front camera",
-      "translated": "Kamera depan"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7759,9 +7684,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.0c74bc30a994dd33",
-      "source": "Loading thread",
-      "translated": "Memuat utas"
+      "id": "native.android.882cc14a58e7e105",
+      "source": "Loading session",
+      "translated": "Memuat sesi"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7804,14 +7729,14 @@
       "translated": "Beri saya rangkuman"
     },
     {
-      "id": "native.android.cf40df9739f78f27",
-      "source": "Summarize recent threads and next steps.",
-      "translated": "Rangkum utas terbaru dan langkah selanjutnya."
+      "id": "native.android.1e5add56e48c99f9",
+      "source": "Summarize recent sessions and next steps.",
+      "translated": "Ringkas sesi terbaru dan langkah berikutnya."
     },
     {
-      "id": "native.android.ebe49a8b8df80bd3",
-      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
-      "translated": "Berikan ringkasan tentang utas OpenClaw terbaru saya dan sarankan langkah berikutnya."
+      "id": "native.android.06d515351bb79576",
+      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
+      "translated": "Beri saya ringkasan sesi OpenClaw terbaru dan sarankan langkah berikutnya."
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8149,9 +8074,9 @@
       "translated": "Terhubung"
     },
     {
-      "id": "native.android.6cf5d6fa8a4186d5",
-      "source": "Threads",
-      "translated": "Utas"
+      "id": "native.android.81931886b9caf3ab",
+      "source": "Sessions",
+      "translated": "Sesi"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,6 +10719,61 @@
       "translated": "Detail Tugas"
     },
     {
+      "id": "native.apple.29cacb53ea5e77fc",
+      "source": "Pinned",
+      "translated": "Disematkan"
+    },
+    {
+      "id": "native.apple.940062cfdce9211b",
+      "source": "Recent",
+      "translated": "Terbaru"
+    },
+    {
+      "id": "native.apple.a0980128426308a9",
+      "source": "Model",
+      "translated": "Model"
+    },
+    {
+      "id": "native.apple.9520e60f21535dde",
+      "source": "Thinking",
+      "translated": "Penalaran"
+    },
+    {
+      "id": "native.apple.8b321f3ffce97429",
+      "source": "Fast",
+      "translated": "Cepat"
+    },
+    {
+      "id": "native.apple.989b70d64e328d55",
+      "source": "Default (inherited)",
+      "translated": "Default (diwarisi)"
+    },
+    {
+      "id": "native.apple.f4114e73b07eb9ae",
+      "source": "Off",
+      "translated": "Nonaktif"
+    },
+    {
+      "id": "native.apple.7ed231b28d16312f",
+      "source": "On",
+      "translated": "Aktif"
+    },
+    {
+      "id": "native.apple.412a74802320a037",
+      "source": "Full",
+      "translated": "Penuh"
+    },
+    {
+      "id": "native.apple.299f21a2071ff9fc",
+      "source": "Verbosity",
+      "translated": "Tingkat detail"
+    },
+    {
+      "id": "native.apple.faf0ef05e1496de7",
+      "source": "Default",
+      "translated": "Default"
+    },
+    {
       "id": "native.apple.e5524d5756a62744",
       "source": "Unable to Export Transcript",
       "translated": "Tidak Dapat Mengekspor Transkrip"
@@ -10814,9 +10794,9 @@
       "translated": "Apa yang ingin Anda kerjakan?"
     },
     {
-      "id": "native.apple.4da775013ac9b123",
-      "source": "The thread attaches once the gateway is ready.",
-      "translated": "Utas akan terhubung setelah Gateway siap."
+      "id": "native.apple.32179ce0b6d4543f",
+      "source": "The session attaches once the gateway is ready.",
+      "translated": "Sesi terhubung setelah gateway siap."
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10859,9 +10839,14 @@
       "translated": "Chat Baru di Worktree"
     },
     {
-      "id": "native.apple.003b25ddafeb18e9",
-      "source": "Threads…",
-      "translated": "Utas…"
+      "id": "native.apple.ce6ebe91fc597015",
+      "source": "New Session Options…",
+      "translated": "Opsi Sesi Baru…"
+    },
+    {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "Sesi…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11024,14 +11009,14 @@
       "translated": "Buat"
     },
     {
-      "id": "native.apple.31d5c7287cfb3abe",
-      "source": "Delete Thread?",
-      "translated": "Hapus Utas?"
+      "id": "native.apple.f488b9caf6e51ac3",
+      "source": "Delete Session?",
+      "translated": "Hapus Sesi?"
     },
     {
-      "id": "native.apple.d3395564809f1120",
-      "source": "Delete Thread",
-      "translated": "Hapus Utas"
+      "id": "native.apple.8634b17be9b111bc",
+      "source": "Delete Session",
+      "translated": "Hapus Sesi"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11039,9 +11024,9 @@
       "translated": "Batal"
     },
     {
-      "id": "native.apple.092659256d26cb03",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "Tindakan ini akan menghapus utas dan transkripnya secara permanen."
+      "id": "native.apple.4a9568ac9b18d8d3",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "Tindakan ini akan menghapus sesi dan transkripnya secara permanen."
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11069,9 +11054,9 @@
       "translated": "Grup Baru"
     },
     {
-      "id": "native.apple.683032464c497bbd",
-      "source": "Rename Thread",
-      "translated": "Ubah Nama Utas"
+      "id": "native.apple.5bccdc23a1640895",
+      "source": "Rename Session",
+      "translated": "Ganti Nama Sesi"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11079,9 +11064,9 @@
       "translated": "Nama grup"
     },
     {
-      "id": "native.apple.f887aa956588f237",
-      "source": "Thread name",
-      "translated": "Nama utas"
+      "id": "native.apple.af789b2d2fda0f67",
+      "source": "Session name",
+      "translated": "Nama sesi"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11119,14 +11104,14 @@
       "translated": "Agen"
     },
     {
-      "id": "native.apple.7c8231b7b1ca480f",
-      "source": "Agent thread",
-      "translated": "Utas agen"
+      "id": "native.apple.a3bde8045fe9224a",
+      "source": "Agent session",
+      "translated": "Sesi agen"
     },
     {
-      "id": "native.apple.b3c553614f762a58",
-      "source": "Recent threads",
-      "translated": "Utas terbaru"
+      "id": "native.apple.27f775de30b37ff8",
+      "source": "Recent sessions",
+      "translated": "Sesi terbaru"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11134,9 +11119,9 @@
       "translated": "Gateway offline"
     },
     {
-      "id": "native.apple.5aa32afda85064ea",
-      "source": "No recent threads",
-      "translated": "Tidak ada utas terbaru"
+      "id": "native.apple.28c97cf23665ee01",
+      "source": "No recent sessions",
+      "translated": "Tidak ada sesi terbaru"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11234,14 +11219,14 @@
       "translated": "Batal"
     },
     {
-      "id": "native.apple.b6855cf19a50f477",
-      "source": "Threads",
-      "translated": "Utas"
+      "id": "native.apple.9f2fd65953013b7c",
+      "source": "Sessions",
+      "translated": "Sesi"
     },
     {
-      "id": "native.apple.9b1d0ef27a1333b0",
-      "source": "Archived threads",
-      "translated": "Utas yang diarsipkan"
+      "id": "native.apple.0422818cc95d5071",
+      "source": "Archived sessions",
+      "translated": "Sesi yang diarsipkan"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11249,34 +11234,34 @@
       "translated": "Tampilkan yang Diarsipkan"
     },
     {
-      "id": "native.apple.98167401c7267735",
-      "source": "Threads unavailable",
-      "translated": "Utas tidak tersedia"
+      "id": "native.apple.b272115c83f7ef58",
+      "source": "Sessions unavailable",
+      "translated": "Sesi tidak tersedia"
     },
     {
-      "id": "native.apple.4d28a7def2337b9f",
-      "source": "Loading archived threads",
-      "translated": "Memuat utas yang diarsipkan"
+      "id": "native.apple.54f8260c9b863087",
+      "source": "Loading archived sessions",
+      "translated": "Memuat sesi yang diarsipkan"
     },
     {
-      "id": "native.apple.777d7b706933bd7b",
-      "source": "Loading recent threads",
-      "translated": "Memuat utas terbaru"
+      "id": "native.apple.9b305868873dade2",
+      "source": "Loading recent sessions",
+      "translated": "Memuat sesi terbaru"
     },
     {
-      "id": "native.apple.22f81ea94bef8410",
-      "source": "^[\\(count) thread](inflect: true)",
-      "translated": "^[\\(count) utas](inflect: true)"
+      "id": "native.apple.207dad20d09f3160",
+      "source": "^[\\(count) session](inflect: true)",
+      "translated": "^[\\(count) sesi](inflect: true)"
     },
     {
-      "id": "native.apple.1cad51e14db59bf9",
-      "source": "No archived threads",
-      "translated": "Tidak ada utas yang diarsipkan"
+      "id": "native.apple.1f4501a6bf2bae4c",
+      "source": "No archived sessions",
+      "translated": "Tidak ada sesi yang diarsipkan"
     },
     {
-      "id": "native.apple.18ef832d3a7ddcf8",
-      "source": "Archived threads will appear here.",
-      "translated": "Utas yang diarsipkan akan muncul di sini."
+      "id": "native.apple.2a1ba7a5e1979c9e",
+      "source": "Archived sessions will appear here.",
+      "translated": "Sesi yang diarsipkan akan muncul di sini."
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11359,9 +11344,9 @@
       "translated": "Bagikan masukan"
     },
     {
-      "id": "native.apple.21d9208d86a4d1fe",
-      "source": "Loading threads",
-      "translated": "Memuat utas"
+      "id": "native.apple.2360d25fe6ae9946",
+      "source": "Loading sessions",
+      "translated": "Memuat sesi"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11369,19 +11354,19 @@
       "translated": "Mengambil aktivitas terbaru dari gateway."
     },
     {
-      "id": "native.apple.4be1f79aa2b230ff",
-      "source": "Threads unavailable",
-      "translated": "Utas tidak tersedia"
+      "id": "native.apple.c334f2e86702a7b8",
+      "source": "Sessions unavailable",
+      "translated": "Sesi tidak tersedia"
     },
     {
-      "id": "native.apple.98b348873556bc46",
-      "source": "No recent threads",
-      "translated": "Tidak ada utas terbaru"
+      "id": "native.apple.6cc6efb7a03960b6",
+      "source": "No recent sessions",
+      "translated": "Tidak ada sesi terbaru"
     },
     {
-      "id": "native.apple.7396d205574d279f",
-      "source": "Thread activity offline",
-      "translated": "Aktivitas utas offline"
+      "id": "native.apple.08483af2d043bee6",
+      "source": "Session activity offline",
+      "translated": "Aktivitas sesi offline"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11839,9 +11824,9 @@
       "translated": "Kartu"
     },
     {
-      "id": "native.apple.c9ec1b0e18074d8a",
-      "source": "Open Thread",
-      "translated": "Buka Utas"
+      "id": "native.apple.93eeaedb2ff61043",
+      "source": "Open Session",
+      "translated": "Buka Sesi"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13329,9 +13314,9 @@
       "translated": "Default"
     },
     {
-      "id": "native.apple.f4ae5664c3eda95d",
-      "source": "Used for new Chat threads and Talk sessions.",
-      "translated": "Digunakan untuk utas Obrolan baru dan sesi Bicara."
+      "id": "native.apple.3de045f17ea3c6d0",
+      "source": "Used for new Chat and Talk sessions.",
+      "translated": "Digunakan untuk sesi Chat dan Talk baru."
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15734,9 +15719,9 @@
       "translated": "Instans"
     },
     {
-      "id": "native.apple.11fe8b9941954dfb",
-      "source": "Threads",
-      "translated": "Utas"
+      "id": "native.apple.3579cf2750470a22",
+      "source": "Sessions",
+      "translated": "Sesi"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19044,9 +19029,9 @@
       "translated": "Pintasan Obrolan Cepat"
     },
     {
-      "id": "native.apple.94dd793cd7d7d555",
-      "source": "Global shortcut that opens a floating chat bar for the main thread.",
-      "translated": "Pintasan global yang membuka bilah obrolan mengambang untuk utas utama."
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "Pintasan global yang membuka bilah obrolan mengambang untuk sesi utama."
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19624,9 +19609,9 @@
       "translated": "Kritis"
     },
     {
-      "id": "native.apple.13f96467014cf344",
-      "source": "New Thread",
-      "translated": "Utas Baru"
+      "id": "native.apple.75102378a6775180",
+      "source": "New Session",
+      "translated": "Sesi Baru"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21914,9 +21899,9 @@
       "translated": "Tidak ada pesan terbaru"
     },
     {
-      "id": "native.apple.3ec2afcbc298c673",
-      "source": "Threads",
-      "translated": "Utas"
+      "id": "native.apple.1ff8aec0044934c3",
+      "source": "Sessions",
+      "translated": "Sesi"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21924,9 +21909,9 @@
       "translated": "Intip bucket percakapan tersimpan yang digunakan kembali oleh CLI untuk konteks dan batas laju."
     },
     {
-      "id": "native.apple.14ccb32cd8ed1c81",
-      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
-      "translated": "Belum ada utas. Utas akan muncul setelah pesan masuk atau heartbeat pertama."
+      "id": "native.apple.bab897f3252b134c",
+      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
+      "translated": "Belum ada sesi. Sesi muncul setelah pesan masuk atau heartbeat pertama."
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -22009,9 +21994,9 @@
       "translated": "Persetujuan Exec"
     },
     {
-      "id": "native.apple.52e37e3a44ae516c",
-      "source": "Threads",
-      "translated": "Utas"
+      "id": "native.apple.64a6dc7d49e8fb57",
+      "source": "Sessions",
+      "translated": "Sesi"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -23014,9 +22999,9 @@
       "translated": "Beri saya kabar terbaru"
     },
     {
-      "id": "native.apple.fc4ce810900ec0b6",
-      "source": "Summarize what happened in my threads since yesterday.",
-      "translated": "Ringkas apa yang terjadi di utas saya sejak kemarin."
+      "id": "native.apple.234ec45f4231edc4",
+      "source": "Summarize what happened in my sessions since yesterday.",
+      "translated": "Rangkum apa yang terjadi dalam sesi saya sejak kemarin."
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23194,9 +23179,9 @@
       "translated": "Lepas sematan model"
     },
     {
-      "id": "native.apple.4edb66657f5aca1f",
-      "source": "Thread",
-      "translated": "Utas"
+      "id": "native.apple.5dfc0700d8dff8de",
+      "source": "Session",
+      "translated": "Sesi"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23359,51 +23344,6 @@
       "translated": "Widget tidak tersedia"
     },
     {
-      "id": "native.apple.d640691fd196f338",
-      "source": "Widget export failed",
-      "translated": "Ekspor widget gagal"
-    },
-    {
-      "id": "native.apple.533c6e22a11e88de",
-      "source": "OK",
-      "translated": "OK"
-    },
-    {
-      "id": "native.apple.e1fb28a2a9756402",
-      "source": "Copy image",
-      "translated": "Salin gambar"
-    },
-    {
-      "id": "native.apple.ebd7bc92e1b12235",
-      "source": "Save image…",
-      "translated": "Simpan gambar…"
-    },
-    {
-      "id": "native.apple.742c46d4cf2db134",
-      "source": "Save image",
-      "translated": "Simpan gambar"
-    },
-    {
-      "id": "native.apple.0589cce608418f90",
-      "source": "The widget image could not be captured.",
-      "translated": "Gambar widget tidak dapat diambil."
-    },
-    {
-      "id": "native.apple.dfe24e827fdbe9c5",
-      "source": "The widget image could not be copied.",
-      "translated": "Gambar widget tidak dapat disalin."
-    },
-    {
-      "id": "native.apple.9e611e3a80e71408",
-      "source": "The widget image could not be encoded as PNG.",
-      "translated": "Gambar widget tidak dapat dikodekan sebagai PNG."
-    },
-    {
-      "id": "native.apple.9a6e8afbe24a262b",
-      "source": "The widget image could not be saved.",
-      "translated": "Gambar widget tidak dapat disimpan."
-    },
-    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23544,19 +23484,19 @@
       "translated": "Pengguna"
     },
     {
-      "id": "native.apple.9d0cba09d92ee669",
-      "source": "This thread cannot be archived while it is active or running.",
-      "translated": "Utas ini tidak dapat diarsipkan saat masih aktif atau berjalan."
+      "id": "native.apple.b1cdcb906a43d5d6",
+      "source": "This session cannot be archived while it is active or running.",
+      "translated": "Sesi ini tidak dapat diarsipkan saat masih aktif atau berjalan."
     },
     {
-      "id": "native.apple.8952a111a1075051",
-      "source": "The main thread cannot be deleted.",
-      "translated": "Utas utama tidak dapat dihapus."
+      "id": "native.apple.5817e3f3dab1ee19",
+      "source": "The main session cannot be deleted.",
+      "translated": "Sesi utama tidak dapat dihapus."
     },
     {
-      "id": "native.apple.90d0ccf80ca28717",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
-      "translated": "Hapus lampiran atau tunggu hingga pengiriman selesai sebelum mengarsipkan atau menghapus utas ini."
+      "id": "native.apple.a6b8df3f18171c91",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
+      "translated": "Hapus lampiran atau tunggu hingga pengiriman selesai sebelum mengarsipkan atau menghapus sesi ini."
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23694,9 +23634,9 @@
       "translated": "Proses berakhir"
     },
     {
-      "id": "native.apple.bbccb4c8db5cac12",
-      "source": "Thread Info",
-      "translated": "Info Utas"
+      "id": "native.apple.cd7c3095a22f80a9",
+      "source": "Session Info",
+      "translated": "Info Sesi"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23729,9 +23669,9 @@
       "translated": "Tambahkan Grup"
     },
     {
-      "id": "native.apple.7b641fed5bace855",
-      "source": "Thread Groups",
-      "translated": "Grup Utas"
+      "id": "native.apple.23d628606fe0734f",
+      "source": "Session Groups",
+      "translated": "Grup Sesi"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23774,9 +23714,9 @@
       "translated": "Hapus Grup"
     },
     {
-      "id": "native.apple.56401c79410a310d",
-      "source": "Threads in this group become ungrouped.",
-      "translated": "Utas dalam grup ini tidak lagi dikelompokkan."
+      "id": "native.apple.b049c8a4d2805e08",
+      "source": "Sessions in this group become ungrouped.",
+      "translated": "Sesi dalam grup ini tidak akan lagi dikelompokkan."
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23789,9 +23729,9 @@
       "translated": "Tidak ada agen yang tersedia di gateway ini."
     },
     {
-      "id": "native.apple.2d96aa7d3d12f85b",
-      "source": "New Thread Options",
-      "translated": "Opsi Utas Baru"
+      "id": "native.apple.6c89f35d53506406",
+      "source": "New Session Options",
+      "translated": "Opsi Sesi Baru"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23819,19 +23759,19 @@
       "translated": "Buat"
     },
     {
-      "id": "native.apple.87ef57319d1ddc85",
-      "source": "The thread could not be created.",
-      "translated": "Utas tidak dapat dibuat."
+      "id": "native.apple.795ba37f6782cf28",
+      "source": "The session could not be created.",
+      "translated": "Sesi tidak dapat dibuat."
     },
     {
-      "id": "native.apple.6bd91c435b69d638",
-      "source": "Search threads",
-      "translated": "Cari utas"
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "Cari sesi"
     },
     {
-      "id": "native.apple.6fde4bdf9d5b9191",
-      "source": "No Threads",
-      "translated": "Tidak Ada Utas"
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "Tidak Ada Sesi"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23839,29 +23779,29 @@
       "translated": "Tidak Ada Hasil"
     },
     {
-      "id": "native.apple.a02fd99740d29bd3",
-      "source": "New Thread",
-      "translated": "Utas Baru"
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "Sesi Baru"
     },
     {
-      "id": "native.apple.b625801dd04b09f2",
-      "source": "New thread",
-      "translated": "Utas baru"
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "Sesi baru"
     },
     {
-      "id": "native.apple.851be81fcc933608",
-      "source": "New thread options",
-      "translated": "Opsi utas baru"
+      "id": "native.apple.2ef0e34db02ad255",
+      "source": "New session options",
+      "translated": "Opsi sesi baru"
     },
     {
-      "id": "native.apple.9ce8a4aba7b444b2",
-      "source": "Rename Thread",
-      "translated": "Ubah Nama Utas"
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "Ubah Nama Sesi"
     },
     {
-      "id": "native.apple.1dd067c44511c7f0",
-      "source": "Thread name",
-      "translated": "Nama utas"
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "Nama sesi"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23874,14 +23814,14 @@
       "translated": "Batal"
     },
     {
-      "id": "native.apple.618073d6ab3f2721",
-      "source": "Delete Thread",
-      "translated": "Hapus Utas"
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "Hapus Sesi"
     },
     {
-      "id": "native.apple.10a5e72bba3cbccc",
-      "source": "The thread and its transcript are removed from the gateway.",
-      "translated": "Utas dan transkripnya dihapus dari gateway."
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "Sesi dan transkripnya dihapus dari gateway."
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23889,14 +23829,14 @@
       "translated": "Hapus “%@”?"
     },
     {
-      "id": "native.apple.ac71e3b2aa496a2c",
-      "source": "Thread running",
-      "translated": "Utas sedang berjalan"
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "Sesi sedang berjalan"
     },
     {
-      "id": "native.apple.c775e87f997278b2",
-      "source": "Thread failed",
-      "translated": "Utas gagal"
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "Sesi gagal"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23954,9 +23894,9 @@
       "translated": "Salin Kunci Sesi"
     },
     {
-      "id": "native.apple.f4998cfb572f23ff",
-      "source": "Delete Thread…",
-      "translated": "Hapus Utas…"
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "Hapus Sesi…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23969,9 +23909,9 @@
       "translated": "Menghubungkan…"
     },
     {
-      "id": "native.apple.8802e9576ffd0f65",
-      "source": "Retry thread groups",
-      "translated": "Coba lagi grup utas"
+      "id": "native.apple.79f708b3bc1d3a6c",
+      "source": "Retry session groups",
+      "translated": "Coba lagi grup sesi"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23994,24 +23934,24 @@
       "translated": "Cakupan"
     },
     {
-      "id": "native.apple.b313b80def4bda52",
-      "source": "Search threads",
-      "translated": "Cari utas"
+      "id": "native.apple.2c37581c7b88f741",
+      "source": "Search sessions",
+      "translated": "Cari sesi"
     },
     {
-      "id": "native.apple.c0cc6acc36f413ce",
-      "source": "Threads",
-      "translated": "Utas"
+      "id": "native.apple.43be8a2336e42faf",
+      "source": "Sessions",
+      "translated": "Sesi"
     },
     {
-      "id": "native.apple.854d3928fe5a557c",
-      "source": "Rename Thread",
-      "translated": "Ubah Nama Utas"
+      "id": "native.apple.0b379cdfcbd3247f",
+      "source": "Rename Session",
+      "translated": "Ganti Nama Sesi"
     },
     {
-      "id": "native.apple.9d0d3f20096cc4da",
-      "source": "Thread name",
-      "translated": "Nama utas"
+      "id": "native.apple.54b6fbd9e41db009",
+      "source": "Session name",
+      "translated": "Nama sesi"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -24019,19 +23959,19 @@
       "translated": "Batal"
     },
     {
-      "id": "native.apple.dc00eb94f33bae15",
-      "source": "Delete selected threads?",
-      "translated": "Hapus utas yang dipilih?"
+      "id": "native.apple.751e0f6b81cd374a",
+      "source": "Delete selected sessions?",
+      "translated": "Hapus sesi yang dipilih?"
     },
     {
-      "id": "native.apple.2053fc9f74dc3158",
-      "source": "Delete Threads",
-      "translated": "Hapus Utas"
+      "id": "native.apple.aa679276581b0058",
+      "source": "Delete Sessions",
+      "translated": "Hapus Sesi"
     },
     {
-      "id": "native.apple.0970247871a834a0",
-      "source": "Each selected thread and its transcript will be removed from the gateway.",
-      "translated": "Setiap utas yang dipilih beserta transkripnya akan dihapus dari Gateway."
+      "id": "native.apple.f837129cbee23297",
+      "source": "Each selected session and its transcript will be removed from the gateway.",
+      "translated": "Setiap sesi yang dipilih beserta transkripnya akan dihapus dari Gateway."
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -24039,9 +23979,9 @@
       "translated": "Grup"
     },
     {
-      "id": "native.apple.6f8acab2256728b5",
-      "source": "Manage thread groups",
-      "translated": "Kelola grup utas"
+      "id": "native.apple.64013cfee5e25305",
+      "source": "Manage session groups",
+      "translated": "Kelola grup sesi"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -24054,14 +23994,14 @@
       "translated": "Pilih"
     },
     {
-      "id": "native.apple.692972314d04b184",
-      "source": "No archived threads",
-      "translated": "Tidak ada utas yang diarsipkan"
+      "id": "native.apple.b67eaecec1b423ac",
+      "source": "No archived sessions",
+      "translated": "Tidak ada sesi yang diarsipkan"
     },
     {
-      "id": "native.apple.d6a4b5711dcd26e7",
-      "source": "No threads found",
-      "translated": "Tidak ada utas yang ditemukan"
+      "id": "native.apple.b2435a79abf0c794",
+      "source": "No sessions found",
+      "translated": "Tidak ada sesi ditemukan"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24229,16 +24169,6 @@
       "translated": "Buka Pesan Lengkap"
     },
     {
-      "id": "native.apple.002bfcede229ad4b",
-      "source": "Rewind to Here",
-      "translated": "Putar Balik ke Sini"
-    },
-    {
-      "id": "native.apple.14df2e4997689fb3",
-      "source": "Fork from Here",
-      "translated": "Buat Cabang dari Sini"
-    },
-    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "Balas"
@@ -24324,9 +24254,9 @@
       "translated": "Hapus lampiran atau tunggu hingga pengiriman selesai sebelum memulai obrolan baru."
     },
     {
-      "id": "native.apple.e0f045151c8d3137",
-      "source": "Gateway changed before the thread operation started.",
-      "translated": "Gateway berubah sebelum operasi utas dimulai."
+      "id": "native.apple.980f552bb0f96c0f",
+      "source": "Gateway changed before the session operation started.",
+      "translated": "Gateway berubah sebelum operasi sesi dimulai."
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24334,9 +24264,9 @@
       "translated": "Hapus lampiran atau tunggu pengiriman selesai sebelum beralih obrolan."
     },
     {
-      "id": "native.apple.0a5c4e15466c3acc",
-      "source": "Clear this thread's history?",
-      "translated": "Hapus riwayat utas ini?"
+      "id": "native.apple.87ba543b42696b92",
+      "source": "Clear this session's history?",
+      "translated": "Hapus riwayat sesi ini?"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24349,14 +24279,14 @@
       "translated": "Tindakan ini mengatur ulang percakapan untuk %@. Kunci sesi tetap sama."
     },
     {
-      "id": "native.apple.67ac221dbe7179f0",
-      "source": "Rename Thread",
-      "translated": "Ganti Nama Utas"
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "Ubah Nama Sesi"
     },
     {
-      "id": "native.apple.cf0f7e049603f518",
-      "source": "Thread name",
-      "translated": "Nama utas"
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "Nama sesi"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24374,9 +24304,9 @@
       "translated": "Ekspor Transkrip"
     },
     {
-      "id": "native.apple.c0ada47504425f23",
-      "source": "Threads",
-      "translated": "Utas"
+      "id": "native.apple.4af0f566d39d7041",
+      "source": "Sessions",
+      "translated": "Sesi"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24449,14 +24379,14 @@
       "translated": "Default"
     },
     {
-      "id": "native.apple.1a765291943599e5",
-      "source": "New Thread",
-      "translated": "Utas Baru"
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "Sesi Baru"
     },
     {
-      "id": "native.apple.c7a3a6d5e43dd98f",
-      "source": "New Thread Options…",
-      "translated": "Opsi Utas Baru…"
+      "id": "native.apple.a7119fbf9d25df5e",
+      "source": "New Session Options…",
+      "translated": "Opsi Sesi Baru…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24464,19 +24394,19 @@
       "translated": "Segarkan"
     },
     {
-      "id": "native.apple.0e710b81808e5dcf",
-      "source": "Threads…",
-      "translated": "Utas…"
+      "id": "native.apple.2bcff4a8fa503739",
+      "source": "Sessions…",
+      "translated": "Sesi…"
     },
     {
-      "id": "native.apple.faad8f92b6bef166",
-      "source": "Rename Thread…",
-      "translated": "Ganti Nama Utas…"
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "Ubah Nama Sesi…"
     },
     {
-      "id": "native.apple.23b61d6cd26ac112",
-      "source": "Fork",
-      "translated": "Buat Cabang"
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "Fork Sesi"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24534,24 +24464,24 @@
       "translated": "Hapus Riwayat…"
     },
     {
-      "id": "native.apple.8b4f1c5107ea8a0e",
-      "source": "Thread",
-      "translated": "Utas"
+      "id": "native.apple.920fe8a7a33f9e92",
+      "source": "Session",
+      "translated": "Sesi"
     },
     {
-      "id": "native.apple.4d7750c9bf699469",
-      "source": "Thread actions",
-      "translated": "Tindakan utas"
+      "id": "native.apple.185a401f78328b0f",
+      "source": "Session actions",
+      "translated": "Tindakan sesi"
     },
     {
-      "id": "native.apple.bb2f22cc43c97f8e",
-      "source": "Thread cost %@",
-      "translated": "Biaya utas %@"
+      "id": "native.apple.9f9dedf599b2619b",
+      "source": "Session cost %@",
+      "translated": "Biaya sesi %@"
     },
     {
-      "id": "native.apple.6239ced0b86e86f8",
-      "source": "Compact Thread",
-      "translated": "Ringkas Utas"
+      "id": "native.apple.f0a4720df5f5f403",
+      "source": "Compact Session",
+      "translated": "Ringkas Sesi"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/it.json
+++ b/apps/.i18n/native/it.json
@@ -1429,9 +1429,9 @@
       "translated": "Parla o detta con OpenClaw"
     },
     {
-      "id": "native.android.e2cf5a38587382cb",
-      "source": "Browse Threads",
-      "translated": "Sfoglia i thread"
+      "id": "native.android.5876e15e5e92fd45",
+      "source": "Browse Sessions",
+      "translated": "Sfoglia sessioni"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "Nessuna azione trovata"
     },
     {
-      "id": "native.android.bc70a4ac965b82ba",
-      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
-      "translated": "Prova Chat, Voce, Thread, Provider o Impostazioni."
+      "id": "native.android.48ad0ae0e930e02b",
+      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
+      "translated": "Prova Chat, Voce, Sessioni, Provider o Impostazioni."
     },
     {
-      "id": "native.android.670121e54dbe286f",
-      "source": "Threads",
-      "translated": "Thread"
+      "id": "native.android.d4fbd1ee4f55a5db",
+      "source": "Sessions",
+      "translated": "Sessioni"
     },
     {
-      "id": "native.android.d38be650b1bce4a0",
-      "source": "Connect the Gateway to search threads.",
-      "translated": "Connetti il Gateway per cercare i thread."
+      "id": "native.android.207c2170504e99e6",
+      "source": "Connect the Gateway to search sessions.",
+      "translated": "Connetti il Gateway per cercare sessioni."
     },
     {
-      "id": "native.android.3d7754721f776ef8",
-      "source": "No matching threads yet.",
-      "translated": "Nessun thread corrispondente per ora."
+      "id": "native.android.25d2c2d792c952fe",
+      "source": "No matching sessions yet.",
+      "translated": "Ancora nessuna sessione corrispondente."
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "Assistente al lavoro"
     },
     {
-      "id": "native.android.9a839f6e3e05a744",
-      "source": "OpenClaw thread",
-      "translated": "Thread OpenClaw"
+      "id": "native.android.8f8384286317f5c9",
+      "source": "OpenClaw session",
+      "translated": "Sessione OpenClaw"
     },
     {
-      "id": "native.android.d83f82a1e4a5ed99",
-      "source": "Open thread",
-      "translated": "Apri thread"
+      "id": "native.android.15799e57704b20c6",
+      "source": "Open session",
+      "translated": "Apri sessione"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "Nessun provider pronto"
     },
     {
-      "id": "native.android.8a1c5365c0538908",
-      "source": "Main thread",
-      "translated": "Thread principale"
+      "id": "native.android.73e6ab1a168fd381",
+      "source": "Main session",
+      "translated": "Sessione principale"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.a5845742daecb4ba",
-      "source": "Threads",
-      "translated": "Thread"
+      "id": "native.android.0e3157c15c56944f",
+      "source": "Sessions",
+      "translated": "Sessioni"
     },
     {
-      "id": "native.android.439b324280869527",
-      "source": "Focus thread search",
-      "translated": "Porta il cursore sulla ricerca dei thread"
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "Vai alla ricerca delle sessioni"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "Archiviato"
     },
     {
-      "id": "native.android.03981341841b04ac",
-      "source": "Search threads",
-      "translated": "Cerca thread"
+      "id": "native.android.b9cf34c137e4cf03",
+      "source": "Search sessions",
+      "translated": "Cerca sessioni"
     },
     {
-      "id": "native.android.99570c528a41fa72",
-      "source": "Clear thread search",
-      "translated": "Cancella la ricerca dei thread"
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "Cancella la ricerca delle sessioni"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "Prima i più vecchi"
     },
     {
-      "id": "native.android.fd67be543e321cc9",
-      "source": "Toggle thread layout",
-      "translated": "Cambia layout dei thread"
+      "id": "native.android.c6bf8751e2a7f5c7",
+      "source": "Toggle session layout",
+      "translated": "Cambia layout delle sessioni"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "Layout: dettagliato"
     },
     {
-      "id": "native.android.ebd17565e0ffd8eb",
-      "source": "Searching threads",
-      "translated": "Ricerca dei thread"
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "Ricerca delle sessioni"
     },
     {
-      "id": "native.android.472d46ae8669f860",
-      "source": "No matching threads",
-      "translated": "Nessun thread corrispondente"
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "Nessuna sessione corrispondente"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "Avvia chat"
     },
     {
-      "id": "native.android.ff81ad1bee00d384",
-      "source": "Current thread",
-      "translated": "Thread corrente"
+      "id": "native.android.f10d4df7cbc6df4f",
+      "source": "Current session",
+      "translated": "Sessione attuale"
     },
     {
-      "id": "native.android.fc145645b9620e57",
-      "source": "OpenClaw thread",
-      "translated": "Thread OpenClaw"
+      "id": "native.android.8f0482425838ae64",
+      "source": "OpenClaw session",
+      "translated": "Sessione OpenClaw"
     },
     {
-      "id": "native.android.71cbb8dde8bf138b",
-      "source": "Rename thread",
-      "translated": "Rinomina thread"
+      "id": "native.android.786774c8a76e50d7",
+      "source": "Rename session",
+      "translated": "Rinomina sessione"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "Eliminare il gruppo?"
     },
     {
-      "id": "native.android.691e92cfe5cf106e",
-      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "I thread in \"$group\" vengono mantenuti e spostati di nuovo in Non raggruppati."
+      "id": "native.android.3455fc2f77d564e3",
+      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "Le sessioni in \"$group\" vengono mantenute e tornano in Non raggruppate."
     },
     {
-      "id": "native.android.d87a8217ab56999b",
-      "source": "Delete thread?",
-      "translated": "Eliminare il thread?"
+      "id": "native.android.4805fb9d6623e8c0",
+      "source": "Delete session?",
+      "translated": "Eliminare la sessione?"
     },
     {
-      "id": "native.android.930de97ff47113a8",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "Questa operazione elimina definitivamente il thread e la relativa trascrizione."
+      "id": "native.android.0c3283a2b2445eae",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "Questa azione elimina definitivamente la sessione e la sua trascrizione."
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "Non raggruppati"
     },
     {
-      "id": "native.android.8e21a70428def6e0",
-      "source": "No threads yet",
-      "translated": "Nessun thread"
+      "id": "native.android.db243d71d056afa4",
+      "source": "No sessions yet",
+      "translated": "Ancora nessuna sessione"
     },
     {
-      "id": "native.android.cda4c5ad8b17e394",
-      "source": "No current thread",
-      "translated": "Nessun thread corrente"
+      "id": "native.android.5b4eee6a8092925e",
+      "source": "No current session",
+      "translated": "Nessuna sessione attuale"
     },
     {
-      "id": "native.android.be84f061047aa2da",
-      "source": "No archived threads",
-      "translated": "Nessun thread archiviato"
+      "id": "native.android.acbcc9c9ea53d8c0",
+      "source": "No archived sessions",
+      "translated": "Nessuna sessione archiviata"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "Avvia una nuova conversazione e verrà visualizzata qui."
     },
     {
-      "id": "native.android.f289d03e1d3eee98",
-      "source": "Open Chat to start or resume the current thread.",
-      "translated": "Apri la chat per avviare o riprendere il thread corrente."
+      "id": "native.android.56fcd605dc7be3c0",
+      "source": "Open Chat to start or resume the current session.",
+      "translated": "Apri Chat per avviare o riprendere la sessione attuale."
     },
     {
-      "id": "native.android.504b71386e76c6ae",
-      "source": "Archived threads will show up here.",
-      "translated": "I thread archiviati verranno visualizzati qui."
+      "id": "native.android.085515989f8a2022",
+      "source": "Archived sessions will show up here.",
+      "translated": "Le sessioni archiviate verranno visualizzate qui."
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days} g"
     },
     {
-      "id": "native.android.ee4c727cdafbe963",
-      "source": "Main thread",
-      "translated": "Thread principale"
+      "id": "native.android.3d4fa07acbc015c5",
+      "source": "Main session",
+      "translated": "Sessione principale"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway in attesa"
     },
     {
-      "id": "native.android.da78209effb11cfd",
-      "source": "Thread Activity",
-      "translated": "Attività del thread"
+      "id": "native.android.2d8d049afe99f751",
+      "source": "Session Activity",
+      "translated": "Attività della sessione"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "Le richieste di approvazione dell'esecuzione verranno visualizzate qui mentre questo telefono è connesso."
     },
     {
-      "id": "native.android.f615712dfb56319a",
-      "source": "Thread activity",
-      "translated": "Attività del thread"
+      "id": "native.android.dc3e7ca5a491103a",
+      "source": "Session activity",
+      "translated": "Attività della sessione"
     },
     {
-      "id": "native.android.6c93973c13db43ae",
-      "source": "Chat tool calls waiting in the active thread remain visible here.",
-      "translated": "Le chiamate agli strumenti della chat in attesa nel thread attivo rimangono visibili qui."
+      "id": "native.android.8551e02b060bd7d8",
+      "source": "Chat tool calls waiting in the active session remain visible here.",
+      "translated": "Le chiamate agli strumenti della chat in attesa nella sessione attiva rimangono visibili qui."
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,11 +4294,6 @@
       "translated": "Configurazione del provider Talk"
     },
     {
-      "id": "native.android.23b638094c34b916",
-      "source": "Microphone",
-      "translated": "Microfono"
-    },
-    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "Test audio"
@@ -4342,66 +4337,6 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "Fine"
-    },
-    {
-      "id": "native.android.8d9ecdfdd916b780",
-      "source": "Automatic",
-      "translated": "Automatico"
-    },
-    {
-      "id": "native.android.c1626a6700a570f6",
-      "source": "Preferred microphone unavailable; using automatic routing.",
-      "translated": "Il microfono preferito non è disponibile; verrà usato l'instradamento automatico."
-    },
-    {
-      "id": "native.android.820bc5d0ce571d8b",
-      "source": "Prioritizes connected Bluetooth microphones.",
-      "translated": "Dà priorità ai microfoni Bluetooth connessi."
-    },
-    {
-      "id": "native.android.11e48038d5e8bff6",
-      "source": "Preferred microphone",
-      "translated": "Microfono preferito"
-    },
-    {
-      "id": "native.android.eaa4d7563a46d307",
-      "source": "Unavailable",
-      "translated": "Non disponibile"
-    },
-    {
-      "id": "native.android.9f5ebf17eb405ba8",
-      "source": "Next session",
-      "translated": "Prossima sessione"
-    },
-    {
-      "id": "native.android.8c4e91f53928efb2",
-      "source": "Built-in microphone",
-      "translated": "Microfono integrato"
-    },
-    {
-      "id": "native.android.14b613cb6e2446b4",
-      "source": "Bluetooth microphone",
-      "translated": "Microfono Bluetooth"
-    },
-    {
-      "id": "native.android.c885247b2d7ce271",
-      "source": "Bluetooth LE microphone",
-      "translated": "Microfono Bluetooth LE"
-    },
-    {
-      "id": "native.android.b6a4e674c5fb441a",
-      "source": "Wired headset microphone",
-      "translated": "Microfono delle cuffie cablate"
-    },
-    {
-      "id": "native.android.9c8becb3b0fb5a90",
-      "source": "USB microphone",
-      "translated": "Microfono USB"
-    },
-    {
-      "id": "native.android.ba46258fadec7a39",
-      "source": "External microphone",
-      "translated": "Microfono esterno"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5139,9 +5074,9 @@
       "translated": "Controlla"
     },
     {
-      "id": "native.android.c971506716c96e91",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
-      "translated": "OpenClaw trasforma questo telefono in un'interfaccia di comando mobile essenziale per conversazioni, voce, provider e Gateway."
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw trasforma questo telefono in un'interfaccia mobile essenziale per sessioni, voce, provider e Gateway."
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5689,9 +5624,9 @@
       "translated": "Impostazioni di Talk"
     },
     {
-      "id": "native.android.36f78c8c85dc283f",
-      "source": "Recent Threads",
-      "translated": "Conversazioni recenti"
+      "id": "native.android.73f07a5d54915259",
+      "source": "Recent Sessions",
+      "translated": "Sessioni recenti"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5749,14 +5684,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online"
     },
     {
-      "id": "native.android.57177017a6a93826",
-      "source": "Threads",
-      "translated": "Conversazioni"
+      "id": "native.android.16c3425d3a594481",
+      "source": "Sessions",
+      "translated": "Sessioni"
     },
     {
-      "id": "native.android.43320b54a68b00a1",
-      "source": "No recent threads",
-      "translated": "Nessuna conversazione recente"
+      "id": "native.android.a5c0f8b3112aa58c",
+      "source": "No recent sessions",
+      "translated": "Nessuna sessione recente"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5794,14 +5729,14 @@
       "translated": "In esecuzione · $pendingRunCount esecuzioni attive"
     },
     {
-      "id": "native.android.e24db059480f1e6a",
-      "source": "Monitoring · 1 thread",
-      "translated": "Monitoraggio · 1 conversazione"
+      "id": "native.android.2c89da708b12a522",
+      "source": "Monitoring · 1 session",
+      "translated": "Monitoraggio · 1 sessione"
     },
     {
-      "id": "native.android.5a475f37d80e02bc",
-      "source": "Monitoring · $sessionCount threads",
-      "translated": "Monitoraggio · $sessionCount conversazioni"
+      "id": "native.android.8b6ee382dcb64e1f",
+      "source": "Monitoring · $sessionCount sessions",
+      "translated": "Monitoraggio · $sessionCount sessioni"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5834,9 +5769,9 @@
       "translated": "Provider"
     },
     {
-      "id": "native.android.358c5e0e838d5423",
-      "source": "Open thread",
-      "translated": "Apri conversazione"
+      "id": "native.android.a65477861c7203aa",
+      "source": "Open session",
+      "translated": "Apri sessione"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6259,9 +6194,9 @@
       "translated": "${days} g"
     },
     {
-      "id": "native.android.28a1a1acc5a0959f",
-      "source": "Main thread",
-      "translated": "Conversazione principale"
+      "id": "native.android.22d755834386db07",
+      "source": "Main session",
+      "translated": "Sessione principale"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6942,16 +6877,6 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "Riattiva audio"
-    },
-    {
-      "id": "native.android.cb608d82c5b3352a",
-      "source": "Back camera",
-      "translated": "Fotocamera posteriore"
-    },
-    {
-      "id": "native.android.e89a0e780eed2e1e",
-      "source": "Front camera",
-      "translated": "Fotocamera anteriore"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7759,9 +7684,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.0c74bc30a994dd33",
-      "source": "Loading thread",
-      "translated": "Caricamento della conversazione"
+      "id": "native.android.882cc14a58e7e105",
+      "source": "Loading session",
+      "translated": "Caricamento sessione"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7804,14 +7729,14 @@
       "translated": "Aggiornami"
     },
     {
-      "id": "native.android.cf40df9739f78f27",
-      "source": "Summarize recent threads and next steps.",
-      "translated": "Riassumi le conversazioni recenti e i prossimi passaggi."
+      "id": "native.android.1e5add56e48c99f9",
+      "source": "Summarize recent sessions and next steps.",
+      "translated": "Riassumi le sessioni recenti e i prossimi passaggi."
     },
     {
-      "id": "native.android.ebe49a8b8df80bd3",
-      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
-      "translated": "Aggiornami sulle mie conversazioni recenti in OpenClaw e suggerisci i prossimi passi."
+      "id": "native.android.06d515351bb79576",
+      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
+      "translated": "Aggiornami sulle mie sessioni recenti di OpenClaw e suggerisci i prossimi passaggi."
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8149,9 +8074,9 @@
       "translated": "Connesso"
     },
     {
-      "id": "native.android.6cf5d6fa8a4186d5",
-      "source": "Threads",
-      "translated": "Conversazioni"
+      "id": "native.android.81931886b9caf3ab",
+      "source": "Sessions",
+      "translated": "Sessioni"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,6 +10719,61 @@
       "translated": "Dettagli attività"
     },
     {
+      "id": "native.apple.29cacb53ea5e77fc",
+      "source": "Pinned",
+      "translated": "In evidenza"
+    },
+    {
+      "id": "native.apple.940062cfdce9211b",
+      "source": "Recent",
+      "translated": "Recenti"
+    },
+    {
+      "id": "native.apple.a0980128426308a9",
+      "source": "Model",
+      "translated": "Modello"
+    },
+    {
+      "id": "native.apple.9520e60f21535dde",
+      "source": "Thinking",
+      "translated": "Ragionamento"
+    },
+    {
+      "id": "native.apple.8b321f3ffce97429",
+      "source": "Fast",
+      "translated": "Veloce"
+    },
+    {
+      "id": "native.apple.989b70d64e328d55",
+      "source": "Default (inherited)",
+      "translated": "Predefinito (ereditato)"
+    },
+    {
+      "id": "native.apple.f4114e73b07eb9ae",
+      "source": "Off",
+      "translated": "Disattivato"
+    },
+    {
+      "id": "native.apple.7ed231b28d16312f",
+      "source": "On",
+      "translated": "Attivato"
+    },
+    {
+      "id": "native.apple.412a74802320a037",
+      "source": "Full",
+      "translated": "Completo"
+    },
+    {
+      "id": "native.apple.299f21a2071ff9fc",
+      "source": "Verbosity",
+      "translated": "Livello di dettaglio"
+    },
+    {
+      "id": "native.apple.faf0ef05e1496de7",
+      "source": "Default",
+      "translated": "Predefinito"
+    },
+    {
       "id": "native.apple.e5524d5756a62744",
       "source": "Unable to Export Transcript",
       "translated": "Impossibile esportare la trascrizione"
@@ -10814,9 +10794,9 @@
       "translated": "Su cosa vorresti lavorare?"
     },
     {
-      "id": "native.apple.4da775013ac9b123",
-      "source": "The thread attaches once the gateway is ready.",
-      "translated": "La conversazione si collega non appena il Gateway è pronto."
+      "id": "native.apple.32179ce0b6d4543f",
+      "source": "The session attaches once the gateway is ready.",
+      "translated": "La sessione si collega quando il Gateway è pronto."
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10859,9 +10839,14 @@
       "translated": "Nuova chat nel worktree"
     },
     {
-      "id": "native.apple.003b25ddafeb18e9",
-      "source": "Threads…",
-      "translated": "Conversazioni…"
+      "id": "native.apple.ce6ebe91fc597015",
+      "source": "New Session Options…",
+      "translated": "Opzioni nuova sessione…"
+    },
+    {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "Sessioni…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11024,14 +11009,14 @@
       "translated": "Crea"
     },
     {
-      "id": "native.apple.31d5c7287cfb3abe",
-      "source": "Delete Thread?",
-      "translated": "Eliminare la conversazione?"
+      "id": "native.apple.f488b9caf6e51ac3",
+      "source": "Delete Session?",
+      "translated": "Eliminare la sessione?"
     },
     {
-      "id": "native.apple.d3395564809f1120",
-      "source": "Delete Thread",
-      "translated": "Elimina conversazione"
+      "id": "native.apple.8634b17be9b111bc",
+      "source": "Delete Session",
+      "translated": "Elimina sessione"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11039,9 +11024,9 @@
       "translated": "Annulla"
     },
     {
-      "id": "native.apple.092659256d26cb03",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "Questa operazione elimina definitivamente la conversazione e la relativa trascrizione."
+      "id": "native.apple.4a9568ac9b18d8d3",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "La sessione e la relativa trascrizione verranno eliminate definitivamente."
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11069,9 +11054,9 @@
       "translated": "Nuovo gruppo"
     },
     {
-      "id": "native.apple.683032464c497bbd",
-      "source": "Rename Thread",
-      "translated": "Rinomina conversazione"
+      "id": "native.apple.5bccdc23a1640895",
+      "source": "Rename Session",
+      "translated": "Rinomina sessione"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11079,9 +11064,9 @@
       "translated": "Nome del gruppo"
     },
     {
-      "id": "native.apple.f887aa956588f237",
-      "source": "Thread name",
-      "translated": "Nome della conversazione"
+      "id": "native.apple.af789b2d2fda0f67",
+      "source": "Session name",
+      "translated": "Nome della sessione"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11119,14 +11104,14 @@
       "translated": "Agenti"
     },
     {
-      "id": "native.apple.7c8231b7b1ca480f",
-      "source": "Agent thread",
-      "translated": "Conversazione dell'agente"
+      "id": "native.apple.a3bde8045fe9224a",
+      "source": "Agent session",
+      "translated": "Sessione agente"
     },
     {
-      "id": "native.apple.b3c553614f762a58",
-      "source": "Recent threads",
-      "translated": "Conversazioni recenti"
+      "id": "native.apple.27f775de30b37ff8",
+      "source": "Recent sessions",
+      "translated": "Sessioni recenti"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11134,9 +11119,9 @@
       "translated": "Gateway offline"
     },
     {
-      "id": "native.apple.5aa32afda85064ea",
-      "source": "No recent threads",
-      "translated": "Nessuna conversazione recente"
+      "id": "native.apple.28c97cf23665ee01",
+      "source": "No recent sessions",
+      "translated": "Nessuna sessione recente"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11234,14 +11219,14 @@
       "translated": "Annulla"
     },
     {
-      "id": "native.apple.b6855cf19a50f477",
-      "source": "Threads",
-      "translated": "Conversazioni"
+      "id": "native.apple.9f2fd65953013b7c",
+      "source": "Sessions",
+      "translated": "Sessioni"
     },
     {
-      "id": "native.apple.9b1d0ef27a1333b0",
-      "source": "Archived threads",
-      "translated": "Conversazioni archiviate"
+      "id": "native.apple.0422818cc95d5071",
+      "source": "Archived sessions",
+      "translated": "Sessioni archiviate"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11249,34 +11234,34 @@
       "translated": "Mostra archiviate"
     },
     {
-      "id": "native.apple.98167401c7267735",
-      "source": "Threads unavailable",
-      "translated": "Conversazioni non disponibili"
+      "id": "native.apple.b272115c83f7ef58",
+      "source": "Sessions unavailable",
+      "translated": "Sessioni non disponibili"
     },
     {
-      "id": "native.apple.4d28a7def2337b9f",
-      "source": "Loading archived threads",
-      "translated": "Caricamento delle conversazioni archiviate"
+      "id": "native.apple.54f8260c9b863087",
+      "source": "Loading archived sessions",
+      "translated": "Caricamento delle sessioni archiviate"
     },
     {
-      "id": "native.apple.777d7b706933bd7b",
-      "source": "Loading recent threads",
-      "translated": "Caricamento delle conversazioni recenti"
+      "id": "native.apple.9b305868873dade2",
+      "source": "Loading recent sessions",
+      "translated": "Caricamento delle sessioni recenti"
     },
     {
-      "id": "native.apple.22f81ea94bef8410",
-      "source": "^[\\(count) thread](inflect: true)",
-      "translated": "^[\\(count) conversazione](inflect: true)"
+      "id": "native.apple.207dad20d09f3160",
+      "source": "^[\\(count) session](inflect: true)",
+      "translated": "^[\\(count) sessione](inflect: true)"
     },
     {
-      "id": "native.apple.1cad51e14db59bf9",
-      "source": "No archived threads",
-      "translated": "Nessuna conversazione archiviata"
+      "id": "native.apple.1f4501a6bf2bae4c",
+      "source": "No archived sessions",
+      "translated": "Nessuna sessione archiviata"
     },
     {
-      "id": "native.apple.18ef832d3a7ddcf8",
-      "source": "Archived threads will appear here.",
-      "translated": "Le conversazioni archiviate appariranno qui."
+      "id": "native.apple.2a1ba7a5e1979c9e",
+      "source": "Archived sessions will appear here.",
+      "translated": "Le sessioni archiviate appariranno qui."
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11359,9 +11344,9 @@
       "translated": "Condividi acquisizione"
     },
     {
-      "id": "native.apple.21d9208d86a4d1fe",
-      "source": "Loading threads",
-      "translated": "Caricamento delle conversazioni"
+      "id": "native.apple.2360d25fe6ae9946",
+      "source": "Loading sessions",
+      "translated": "Caricamento sessioni"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11369,19 +11354,19 @@
       "translated": "Recupero dell'attività recente dal gateway."
     },
     {
-      "id": "native.apple.4be1f79aa2b230ff",
-      "source": "Threads unavailable",
-      "translated": "Conversazioni non disponibili"
+      "id": "native.apple.c334f2e86702a7b8",
+      "source": "Sessions unavailable",
+      "translated": "Sessioni non disponibili"
     },
     {
-      "id": "native.apple.98b348873556bc46",
-      "source": "No recent threads",
-      "translated": "Nessuna conversazione recente"
+      "id": "native.apple.6cc6efb7a03960b6",
+      "source": "No recent sessions",
+      "translated": "Nessuna sessione recente"
     },
     {
-      "id": "native.apple.7396d205574d279f",
-      "source": "Thread activity offline",
-      "translated": "Attività delle conversazioni offline"
+      "id": "native.apple.08483af2d043bee6",
+      "source": "Session activity offline",
+      "translated": "Attività della sessione offline"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11839,9 +11824,9 @@
       "translated": "Scheda"
     },
     {
-      "id": "native.apple.c9ec1b0e18074d8a",
-      "source": "Open Thread",
-      "translated": "Apri conversazione"
+      "id": "native.apple.93eeaedb2ff61043",
+      "source": "Open Session",
+      "translated": "Apri sessione"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13329,9 +13314,9 @@
       "translated": "Predefinito"
     },
     {
-      "id": "native.apple.f4ae5664c3eda95d",
-      "source": "Used for new Chat threads and Talk sessions.",
-      "translated": "Utilizzato per le nuove conversazioni di Chat e le sessioni di Talk."
+      "id": "native.apple.3de045f17ea3c6d0",
+      "source": "Used for new Chat and Talk sessions.",
+      "translated": "Usato per nuove sessioni di Chat e Talk."
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15734,9 +15719,9 @@
       "translated": "Istanze"
     },
     {
-      "id": "native.apple.11fe8b9941954dfb",
-      "source": "Threads",
-      "translated": "Conversazioni"
+      "id": "native.apple.3579cf2750470a22",
+      "source": "Sessions",
+      "translated": "Sessioni"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19044,9 +19029,9 @@
       "translated": "Scorciatoia di Chat rapida"
     },
     {
-      "id": "native.apple.94dd793cd7d7d555",
-      "source": "Global shortcut that opens a floating chat bar for the main thread.",
-      "translated": "Scorciatoia globale che apre una barra della chat mobile per la conversazione principale."
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "Scorciatoia globale che apre una barra di chat mobile per la sessione principale."
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19624,9 +19609,9 @@
       "translated": "Critico"
     },
     {
-      "id": "native.apple.13f96467014cf344",
-      "source": "New Thread",
-      "translated": "Nuova conversazione"
+      "id": "native.apple.75102378a6775180",
+      "source": "New Session",
+      "translated": "Nuova sessione"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21914,9 +21899,9 @@
       "translated": "Nessun messaggio recente"
     },
     {
-      "id": "native.apple.3ec2afcbc298c673",
-      "source": "Threads",
-      "translated": "Conversazioni"
+      "id": "native.apple.1ff8aec0044934c3",
+      "source": "Sessions",
+      "translated": "Sessioni"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21924,9 +21909,9 @@
       "translated": "Dai un’occhiata ai bucket di conversazioni salvati che la CLI riutilizza per contesto e limiti di frequenza."
     },
     {
-      "id": "native.apple.14ccb32cd8ed1c81",
-      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
-      "translated": "Non ci sono ancora conversazioni. Appariranno dopo il primo messaggio in arrivo o heartbeat."
+      "id": "native.apple.bab897f3252b134c",
+      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
+      "translated": "Nessuna sessione ancora. Appariranno dopo il primo messaggio in entrata o heartbeat."
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -22009,9 +21994,9 @@
       "translated": "Approvazioni esecuzione"
     },
     {
-      "id": "native.apple.52e37e3a44ae516c",
-      "source": "Threads",
-      "translated": "Conversazioni"
+      "id": "native.apple.64a6dc7d49e8fb57",
+      "source": "Sessions",
+      "translated": "Sessioni"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -23014,9 +22999,9 @@
       "translated": "Aggiornami"
     },
     {
-      "id": "native.apple.fc4ce810900ec0b6",
-      "source": "Summarize what happened in my threads since yesterday.",
-      "translated": "Riassumi cosa è successo nelle mie conversazioni da ieri."
+      "id": "native.apple.234ec45f4231edc4",
+      "source": "Summarize what happened in my sessions since yesterday.",
+      "translated": "Riepiloga cosa è successo nelle mie sessioni da ieri."
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23194,9 +23179,9 @@
       "translated": "Rimuovi modello dagli elementi in evidenza"
     },
     {
-      "id": "native.apple.4edb66657f5aca1f",
-      "source": "Thread",
-      "translated": "Conversazione"
+      "id": "native.apple.5dfc0700d8dff8de",
+      "source": "Session",
+      "translated": "Sessione"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23359,51 +23344,6 @@
       "translated": "Widget non disponibile"
     },
     {
-      "id": "native.apple.d640691fd196f338",
-      "source": "Widget export failed",
-      "translated": "Esportazione del widget non riuscita"
-    },
-    {
-      "id": "native.apple.533c6e22a11e88de",
-      "source": "OK",
-      "translated": "OK"
-    },
-    {
-      "id": "native.apple.e1fb28a2a9756402",
-      "source": "Copy image",
-      "translated": "Copia immagine"
-    },
-    {
-      "id": "native.apple.ebd7bc92e1b12235",
-      "source": "Save image…",
-      "translated": "Salva immagine…"
-    },
-    {
-      "id": "native.apple.742c46d4cf2db134",
-      "source": "Save image",
-      "translated": "Salva immagine"
-    },
-    {
-      "id": "native.apple.0589cce608418f90",
-      "source": "The widget image could not be captured.",
-      "translated": "Non è stato possibile acquisire l'immagine del widget."
-    },
-    {
-      "id": "native.apple.dfe24e827fdbe9c5",
-      "source": "The widget image could not be copied.",
-      "translated": "Non è stato possibile copiare l'immagine del widget."
-    },
-    {
-      "id": "native.apple.9e611e3a80e71408",
-      "source": "The widget image could not be encoded as PNG.",
-      "translated": "Non è stato possibile codificare l'immagine del widget in formato PNG."
-    },
-    {
-      "id": "native.apple.9a6e8afbe24a262b",
-      "source": "The widget image could not be saved.",
-      "translated": "Non è stato possibile salvare l'immagine del widget."
-    },
-    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23544,19 +23484,19 @@
       "translated": "Utente"
     },
     {
-      "id": "native.apple.9d0cba09d92ee669",
-      "source": "This thread cannot be archived while it is active or running.",
-      "translated": "Questa conversazione non può essere archiviata mentre è attiva o in esecuzione."
+      "id": "native.apple.b1cdcb906a43d5d6",
+      "source": "This session cannot be archived while it is active or running.",
+      "translated": "Questa sessione non può essere archiviata mentre è attiva o in esecuzione."
     },
     {
-      "id": "native.apple.8952a111a1075051",
-      "source": "The main thread cannot be deleted.",
-      "translated": "La conversazione principale non può essere eliminata."
+      "id": "native.apple.5817e3f3dab1ee19",
+      "source": "The main session cannot be deleted.",
+      "translated": "La sessione principale non può essere eliminata."
     },
     {
-      "id": "native.apple.90d0ccf80ca28717",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
-      "translated": "Rimuovi gli allegati o attendi la consegna prima di archiviare o eliminare questa conversazione."
+      "id": "native.apple.a6b8df3f18171c91",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
+      "translated": "Rimuovi gli allegati o attendi la consegna prima di archiviare o eliminare questa sessione."
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23694,9 +23634,9 @@
       "translated": "Esecuzione terminata"
     },
     {
-      "id": "native.apple.bbccb4c8db5cac12",
-      "source": "Thread Info",
-      "translated": "Informazioni sulla conversazione"
+      "id": "native.apple.cd7c3095a22f80a9",
+      "source": "Session Info",
+      "translated": "Informazioni sulla sessione"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23729,9 +23669,9 @@
       "translated": "Aggiungi gruppo"
     },
     {
-      "id": "native.apple.7b641fed5bace855",
-      "source": "Thread Groups",
-      "translated": "Gruppi di conversazioni"
+      "id": "native.apple.23d628606fe0734f",
+      "source": "Session Groups",
+      "translated": "Gruppi della sessione"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23774,9 +23714,9 @@
       "translated": "Elimina gruppo"
     },
     {
-      "id": "native.apple.56401c79410a310d",
-      "source": "Threads in this group become ungrouped.",
-      "translated": "Le conversazioni in questo gruppo verranno separate dal gruppo."
+      "id": "native.apple.b049c8a4d2805e08",
+      "source": "Sessions in this group become ungrouped.",
+      "translated": "Le sessioni in questo gruppo non saranno più raggruppate."
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23789,9 +23729,9 @@
       "translated": "Nessun agente è disponibile su questo gateway."
     },
     {
-      "id": "native.apple.2d96aa7d3d12f85b",
-      "source": "New Thread Options",
-      "translated": "Opzioni nuova conversazione"
+      "id": "native.apple.6c89f35d53506406",
+      "source": "New Session Options",
+      "translated": "Opzioni nuova sessione"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23819,19 +23759,19 @@
       "translated": "Crea"
     },
     {
-      "id": "native.apple.87ef57319d1ddc85",
-      "source": "The thread could not be created.",
-      "translated": "Impossibile creare la conversazione."
+      "id": "native.apple.795ba37f6782cf28",
+      "source": "The session could not be created.",
+      "translated": "Non è stato possibile creare la sessione."
     },
     {
-      "id": "native.apple.6bd91c435b69d638",
-      "source": "Search threads",
-      "translated": "Cerca conversazioni"
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "Cerca sessioni"
     },
     {
-      "id": "native.apple.6fde4bdf9d5b9191",
-      "source": "No Threads",
-      "translated": "Nessuna conversazione"
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "Nessuna sessione"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23839,29 +23779,29 @@
       "translated": "Nessun risultato"
     },
     {
-      "id": "native.apple.a02fd99740d29bd3",
-      "source": "New Thread",
-      "translated": "Nuova conversazione"
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "Nuova sessione"
     },
     {
-      "id": "native.apple.b625801dd04b09f2",
-      "source": "New thread",
-      "translated": "Nuova conversazione"
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "Nuova sessione"
     },
     {
-      "id": "native.apple.851be81fcc933608",
-      "source": "New thread options",
-      "translated": "Opzioni nuova conversazione"
+      "id": "native.apple.2ef0e34db02ad255",
+      "source": "New session options",
+      "translated": "Opzioni nuova sessione"
     },
     {
-      "id": "native.apple.9ce8a4aba7b444b2",
-      "source": "Rename Thread",
-      "translated": "Rinomina conversazione"
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "Rinomina sessione"
     },
     {
-      "id": "native.apple.1dd067c44511c7f0",
-      "source": "Thread name",
-      "translated": "Nome conversazione"
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "Nome della sessione"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23874,14 +23814,14 @@
       "translated": "Annulla"
     },
     {
-      "id": "native.apple.618073d6ab3f2721",
-      "source": "Delete Thread",
-      "translated": "Elimina conversazione"
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "Elimina sessione"
     },
     {
-      "id": "native.apple.10a5e72bba3cbccc",
-      "source": "The thread and its transcript are removed from the gateway.",
-      "translated": "La conversazione e la relativa trascrizione vengono rimosse dal gateway."
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "La sessione e la relativa trascrizione vengono rimosse dal Gateway."
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23889,14 +23829,14 @@
       "translated": "Eliminare “%@”?"
     },
     {
-      "id": "native.apple.ac71e3b2aa496a2c",
-      "source": "Thread running",
-      "translated": "Conversazione in corso"
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "Sessione in corso"
     },
     {
-      "id": "native.apple.c775e87f997278b2",
-      "source": "Thread failed",
-      "translated": "Conversazione non riuscita"
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "Sessione non riuscita"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23954,9 +23894,9 @@
       "translated": "Copia chiave sessione"
     },
     {
-      "id": "native.apple.f4998cfb572f23ff",
-      "source": "Delete Thread…",
-      "translated": "Elimina conversazione…"
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "Elimina sessione…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23969,9 +23909,9 @@
       "translated": "Connessione…"
     },
     {
-      "id": "native.apple.8802e9576ffd0f65",
-      "source": "Retry thread groups",
-      "translated": "Riprova gruppi di conversazioni"
+      "id": "native.apple.79f708b3bc1d3a6c",
+      "source": "Retry session groups",
+      "translated": "Riprova gruppi di sessioni"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23994,24 +23934,24 @@
       "translated": "Ambito"
     },
     {
-      "id": "native.apple.b313b80def4bda52",
-      "source": "Search threads",
-      "translated": "Cerca conversazioni"
+      "id": "native.apple.2c37581c7b88f741",
+      "source": "Search sessions",
+      "translated": "Cerca sessioni"
     },
     {
-      "id": "native.apple.c0cc6acc36f413ce",
-      "source": "Threads",
-      "translated": "Conversazioni"
+      "id": "native.apple.43be8a2336e42faf",
+      "source": "Sessions",
+      "translated": "Sessioni"
     },
     {
-      "id": "native.apple.854d3928fe5a557c",
-      "source": "Rename Thread",
-      "translated": "Rinomina conversazione"
+      "id": "native.apple.0b379cdfcbd3247f",
+      "source": "Rename Session",
+      "translated": "Rinomina sessione"
     },
     {
-      "id": "native.apple.9d0d3f20096cc4da",
-      "source": "Thread name",
-      "translated": "Nome conversazione"
+      "id": "native.apple.54b6fbd9e41db009",
+      "source": "Session name",
+      "translated": "Nome sessione"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -24019,19 +23959,19 @@
       "translated": "Annulla"
     },
     {
-      "id": "native.apple.dc00eb94f33bae15",
-      "source": "Delete selected threads?",
-      "translated": "Eliminare le conversazioni selezionate?"
+      "id": "native.apple.751e0f6b81cd374a",
+      "source": "Delete selected sessions?",
+      "translated": "Eliminare le sessioni selezionate?"
     },
     {
-      "id": "native.apple.2053fc9f74dc3158",
-      "source": "Delete Threads",
-      "translated": "Elimina conversazioni"
+      "id": "native.apple.aa679276581b0058",
+      "source": "Delete Sessions",
+      "translated": "Elimina sessioni"
     },
     {
-      "id": "native.apple.0970247871a834a0",
-      "source": "Each selected thread and its transcript will be removed from the gateway.",
-      "translated": "Ogni conversazione selezionata e la relativa trascrizione verranno rimosse dal Gateway."
+      "id": "native.apple.f837129cbee23297",
+      "source": "Each selected session and its transcript will be removed from the gateway.",
+      "translated": "Ogni sessione selezionata e la relativa trascrizione verranno rimosse dal Gateway."
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -24039,9 +23979,9 @@
       "translated": "Gruppi"
     },
     {
-      "id": "native.apple.6f8acab2256728b5",
-      "source": "Manage thread groups",
-      "translated": "Gestisci gruppi di conversazioni"
+      "id": "native.apple.64013cfee5e25305",
+      "source": "Manage session groups",
+      "translated": "Gestisci gruppi di sessioni"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -24054,14 +23994,14 @@
       "translated": "Seleziona"
     },
     {
-      "id": "native.apple.692972314d04b184",
-      "source": "No archived threads",
-      "translated": "Nessuna conversazione archiviata"
+      "id": "native.apple.b67eaecec1b423ac",
+      "source": "No archived sessions",
+      "translated": "Nessuna sessione archiviata"
     },
     {
-      "id": "native.apple.d6a4b5711dcd26e7",
-      "source": "No threads found",
-      "translated": "Nessuna conversazione trovata"
+      "id": "native.apple.b2435a79abf0c794",
+      "source": "No sessions found",
+      "translated": "Nessuna sessione trovata"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24229,16 +24169,6 @@
       "translated": "Apri il messaggio completo"
     },
     {
-      "id": "native.apple.002bfcede229ad4b",
-      "source": "Rewind to Here",
-      "translated": "Riavvolgi fino a qui"
-    },
-    {
-      "id": "native.apple.14df2e4997689fb3",
-      "source": "Fork from Here",
-      "translated": "Crea una diramazione da qui"
-    },
-    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "Rispondi"
@@ -24324,9 +24254,9 @@
       "translated": "Rimuovi gli allegati o attendi il completamento della consegna prima di iniziare una nuova chat."
     },
     {
-      "id": "native.apple.e0f045151c8d3137",
-      "source": "Gateway changed before the thread operation started.",
-      "translated": "Il Gateway è cambiato prima dell'avvio dell'operazione sulla conversazione."
+      "id": "native.apple.980f552bb0f96c0f",
+      "source": "Gateway changed before the session operation started.",
+      "translated": "Il Gateway è cambiato prima dell'inizio dell'operazione sulla sessione."
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24334,9 +24264,9 @@
       "translated": "Rimuovi gli allegati o attendi il completamento della consegna prima di cambiare chat."
     },
     {
-      "id": "native.apple.0a5c4e15466c3acc",
-      "source": "Clear this thread's history?",
-      "translated": "Cancellare la cronologia di questa conversazione?"
+      "id": "native.apple.87ba543b42696b92",
+      "source": "Clear this session's history?",
+      "translated": "Cancellare la cronologia di questa sessione?"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24349,14 +24279,14 @@
       "translated": "Questa operazione reimposta la conversazione per %@. La chiave di sessione rimane invariata."
     },
     {
-      "id": "native.apple.67ac221dbe7179f0",
-      "source": "Rename Thread",
-      "translated": "Rinomina conversazione"
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "Rinomina sessione"
     },
     {
-      "id": "native.apple.cf0f7e049603f518",
-      "source": "Thread name",
-      "translated": "Nome della conversazione"
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "Nome sessione"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24374,9 +24304,9 @@
       "translated": "Esporta trascrizione"
     },
     {
-      "id": "native.apple.c0ada47504425f23",
-      "source": "Threads",
-      "translated": "Conversazioni"
+      "id": "native.apple.4af0f566d39d7041",
+      "source": "Sessions",
+      "translated": "Sessioni"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24449,14 +24379,14 @@
       "translated": "Predefinito"
     },
     {
-      "id": "native.apple.1a765291943599e5",
-      "source": "New Thread",
-      "translated": "Nuova conversazione"
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "Nuova sessione"
     },
     {
-      "id": "native.apple.c7a3a6d5e43dd98f",
-      "source": "New Thread Options…",
-      "translated": "Opzioni nuova conversazione…"
+      "id": "native.apple.a7119fbf9d25df5e",
+      "source": "New Session Options…",
+      "translated": "Opzioni nuova sessione…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24464,19 +24394,19 @@
       "translated": "Aggiorna"
     },
     {
-      "id": "native.apple.0e710b81808e5dcf",
-      "source": "Threads…",
-      "translated": "Conversazioni…"
+      "id": "native.apple.2bcff4a8fa503739",
+      "source": "Sessions…",
+      "translated": "Sessioni…"
     },
     {
-      "id": "native.apple.faad8f92b6bef166",
-      "source": "Rename Thread…",
-      "translated": "Rinomina conversazione…"
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "Rinomina sessione…"
     },
     {
-      "id": "native.apple.23b61d6cd26ac112",
-      "source": "Fork",
-      "translated": "Crea diramazione"
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "Crea fork della sessione"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24534,24 +24464,24 @@
       "translated": "Cancella cronologia…"
     },
     {
-      "id": "native.apple.8b4f1c5107ea8a0e",
-      "source": "Thread",
-      "translated": "Conversazione"
+      "id": "native.apple.920fe8a7a33f9e92",
+      "source": "Session",
+      "translated": "Sessione"
     },
     {
-      "id": "native.apple.4d7750c9bf699469",
-      "source": "Thread actions",
-      "translated": "Azioni conversazione"
+      "id": "native.apple.185a401f78328b0f",
+      "source": "Session actions",
+      "translated": "Azioni sessione"
     },
     {
-      "id": "native.apple.bb2f22cc43c97f8e",
-      "source": "Thread cost %@",
-      "translated": "Costo conversazione %@"
+      "id": "native.apple.9f9dedf599b2619b",
+      "source": "Session cost %@",
+      "translated": "Costo della sessione %@"
     },
     {
-      "id": "native.apple.6239ced0b86e86f8",
-      "source": "Compact Thread",
-      "translated": "Compatta conversazione"
+      "id": "native.apple.f0a4720df5f5f403",
+      "source": "Compact Session",
+      "translated": "Comprimi sessione"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/it.json
+++ b/apps/.i18n/native/it.json
@@ -1429,9 +1429,9 @@
       "translated": "Parla o detta con OpenClaw"
     },
     {
-      "id": "native.android.5876e15e5e92fd45",
-      "source": "Browse Sessions",
-      "translated": "Sfoglia sessioni"
+      "id": "native.android.e2cf5a38587382cb",
+      "source": "Browse Threads",
+      "translated": "Sfoglia le conversazioni"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "Nessuna azione trovata"
     },
     {
-      "id": "native.android.48ad0ae0e930e02b",
-      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
-      "translated": "Prova Chat, Voce, Sessioni, Provider o Impostazioni."
+      "id": "native.android.bc70a4ac965b82ba",
+      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
+      "translated": "Prova Chat, Voce, Conversazioni, Provider o Impostazioni."
     },
     {
-      "id": "native.android.d4fbd1ee4f55a5db",
-      "source": "Sessions",
-      "translated": "Sessioni"
+      "id": "native.android.670121e54dbe286f",
+      "source": "Threads",
+      "translated": "Conversazioni"
     },
     {
-      "id": "native.android.207c2170504e99e6",
-      "source": "Connect the Gateway to search sessions.",
-      "translated": "Connetti il Gateway per cercare sessioni."
+      "id": "native.android.d38be650b1bce4a0",
+      "source": "Connect the Gateway to search threads.",
+      "translated": "Connetti il Gateway per cercare le conversazioni."
     },
     {
-      "id": "native.android.25d2c2d792c952fe",
-      "source": "No matching sessions yet.",
-      "translated": "Ancora nessuna sessione corrispondente."
+      "id": "native.android.3d7754721f776ef8",
+      "source": "No matching threads yet.",
+      "translated": "Non ci sono ancora conversazioni corrispondenti."
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "Assistente al lavoro"
     },
     {
-      "id": "native.android.8f8384286317f5c9",
-      "source": "OpenClaw session",
-      "translated": "Sessione OpenClaw"
+      "id": "native.android.9a839f6e3e05a744",
+      "source": "OpenClaw thread",
+      "translated": "Conversazione OpenClaw"
     },
     {
-      "id": "native.android.15799e57704b20c6",
-      "source": "Open session",
-      "translated": "Apri sessione"
+      "id": "native.android.d83f82a1e4a5ed99",
+      "source": "Open thread",
+      "translated": "Apri conversazione"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "Nessun provider pronto"
     },
     {
-      "id": "native.android.73e6ab1a168fd381",
-      "source": "Main session",
-      "translated": "Sessione principale"
+      "id": "native.android.8a1c5365c0538908",
+      "source": "Main thread",
+      "translated": "Conversazione principale"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.0e3157c15c56944f",
-      "source": "Sessions",
-      "translated": "Sessioni"
+      "id": "native.android.a5845742daecb4ba",
+      "source": "Threads",
+      "translated": "Conversazioni"
     },
     {
-      "id": "native.android.70f5d0507d34b5c8",
-      "source": "Focus session search",
-      "translated": "Vai alla ricerca delle sessioni"
+      "id": "native.android.439b324280869527",
+      "source": "Focus thread search",
+      "translated": "Vai alla ricerca delle conversazioni"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "Archiviato"
     },
     {
-      "id": "native.android.b9cf34c137e4cf03",
-      "source": "Search sessions",
-      "translated": "Cerca sessioni"
+      "id": "native.android.03981341841b04ac",
+      "source": "Search threads",
+      "translated": "Cerca conversazioni"
     },
     {
-      "id": "native.android.10cb26723e9990fc",
-      "source": "Clear session search",
-      "translated": "Cancella la ricerca delle sessioni"
+      "id": "native.android.99570c528a41fa72",
+      "source": "Clear thread search",
+      "translated": "Cancella la ricerca delle conversazioni"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "Prima i più vecchi"
     },
     {
-      "id": "native.android.c6bf8751e2a7f5c7",
-      "source": "Toggle session layout",
-      "translated": "Cambia layout delle sessioni"
+      "id": "native.android.fd67be543e321cc9",
+      "source": "Toggle thread layout",
+      "translated": "Cambia layout delle conversazioni"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "Layout: dettagliato"
     },
     {
-      "id": "native.android.69b79a3c2c987cd4",
-      "source": "Searching sessions",
-      "translated": "Ricerca delle sessioni"
+      "id": "native.android.ebd17565e0ffd8eb",
+      "source": "Searching threads",
+      "translated": "Ricerca delle conversazioni"
     },
     {
-      "id": "native.android.dd587d341af44212",
-      "source": "No matching sessions",
-      "translated": "Nessuna sessione corrispondente"
+      "id": "native.android.472d46ae8669f860",
+      "source": "No matching threads",
+      "translated": "Nessuna conversazione corrispondente"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "Avvia chat"
     },
     {
-      "id": "native.android.f10d4df7cbc6df4f",
-      "source": "Current session",
-      "translated": "Sessione attuale"
+      "id": "native.android.ff81ad1bee00d384",
+      "source": "Current thread",
+      "translated": "Conversazione corrente"
     },
     {
-      "id": "native.android.8f0482425838ae64",
-      "source": "OpenClaw session",
-      "translated": "Sessione OpenClaw"
+      "id": "native.android.fc145645b9620e57",
+      "source": "OpenClaw thread",
+      "translated": "Conversazione OpenClaw"
     },
     {
-      "id": "native.android.786774c8a76e50d7",
-      "source": "Rename session",
-      "translated": "Rinomina sessione"
+      "id": "native.android.71cbb8dde8bf138b",
+      "source": "Rename thread",
+      "translated": "Rinomina conversazione"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "Eliminare il gruppo?"
     },
     {
-      "id": "native.android.3455fc2f77d564e3",
-      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "Le sessioni in \"$group\" vengono mantenute e tornano in Non raggruppate."
+      "id": "native.android.691e92cfe5cf106e",
+      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "Le conversazioni in \"$group\" vengono mantenute e spostate nuovamente in Senza gruppo."
     },
     {
-      "id": "native.android.4805fb9d6623e8c0",
-      "source": "Delete session?",
-      "translated": "Eliminare la sessione?"
+      "id": "native.android.d87a8217ab56999b",
+      "source": "Delete thread?",
+      "translated": "Eliminare la conversazione?"
     },
     {
-      "id": "native.android.0c3283a2b2445eae",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "Questa azione elimina definitivamente la sessione e la sua trascrizione."
+      "id": "native.android.930de97ff47113a8",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "Questa operazione elimina definitivamente il thread e la relativa trascrizione."
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "Non raggruppati"
     },
     {
-      "id": "native.android.db243d71d056afa4",
-      "source": "No sessions yet",
-      "translated": "Ancora nessuna sessione"
+      "id": "native.android.8e21a70428def6e0",
+      "source": "No threads yet",
+      "translated": "Nessun thread"
     },
     {
-      "id": "native.android.5b4eee6a8092925e",
-      "source": "No current session",
-      "translated": "Nessuna sessione attuale"
+      "id": "native.android.cda4c5ad8b17e394",
+      "source": "No current thread",
+      "translated": "Nessun thread corrente"
     },
     {
-      "id": "native.android.acbcc9c9ea53d8c0",
-      "source": "No archived sessions",
-      "translated": "Nessuna sessione archiviata"
+      "id": "native.android.be84f061047aa2da",
+      "source": "No archived threads",
+      "translated": "Nessun thread archiviato"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "Avvia una nuova conversazione e verrà visualizzata qui."
     },
     {
-      "id": "native.android.56fcd605dc7be3c0",
-      "source": "Open Chat to start or resume the current session.",
-      "translated": "Apri Chat per avviare o riprendere la sessione attuale."
+      "id": "native.android.f289d03e1d3eee98",
+      "source": "Open Chat to start or resume the current thread.",
+      "translated": "Apri Chat per avviare o riprendere il thread corrente."
     },
     {
-      "id": "native.android.085515989f8a2022",
-      "source": "Archived sessions will show up here.",
-      "translated": "Le sessioni archiviate verranno visualizzate qui."
+      "id": "native.android.504b71386e76c6ae",
+      "source": "Archived threads will show up here.",
+      "translated": "I thread archiviati verranno visualizzati qui."
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days} g"
     },
     {
-      "id": "native.android.3d4fa07acbc015c5",
-      "source": "Main session",
-      "translated": "Sessione principale"
+      "id": "native.android.ee4c727cdafbe963",
+      "source": "Main thread",
+      "translated": "Thread principale"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway in attesa"
     },
     {
-      "id": "native.android.2d8d049afe99f751",
-      "source": "Session Activity",
-      "translated": "Attività della sessione"
+      "id": "native.android.da78209effb11cfd",
+      "source": "Thread Activity",
+      "translated": "Attività del thread"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "Le richieste di approvazione dell'esecuzione verranno visualizzate qui mentre questo telefono è connesso."
     },
     {
-      "id": "native.android.dc3e7ca5a491103a",
-      "source": "Session activity",
-      "translated": "Attività della sessione"
+      "id": "native.android.f615712dfb56319a",
+      "source": "Thread activity",
+      "translated": "Attività del thread"
     },
     {
-      "id": "native.android.8551e02b060bd7d8",
-      "source": "Chat tool calls waiting in the active session remain visible here.",
-      "translated": "Le chiamate agli strumenti della chat in attesa nella sessione attiva rimangono visibili qui."
+      "id": "native.android.6c93973c13db43ae",
+      "source": "Chat tool calls waiting in the active thread remain visible here.",
+      "translated": "Le chiamate agli strumenti di Chat in attesa nel thread attivo rimangono visibili qui."
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,6 +4294,11 @@
       "translated": "Configurazione del provider Talk"
     },
     {
+      "id": "native.android.23b638094c34b916",
+      "source": "Microphone",
+      "translated": "Microfono"
+    },
+    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "Test audio"
@@ -4337,6 +4342,66 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "Fine"
+    },
+    {
+      "id": "native.android.8d9ecdfdd916b780",
+      "source": "Automatic",
+      "translated": "Automatico"
+    },
+    {
+      "id": "native.android.c1626a6700a570f6",
+      "source": "Preferred microphone unavailable; using automatic routing.",
+      "translated": "Il microfono preferito non è disponibile; viene usato l'instradamento automatico."
+    },
+    {
+      "id": "native.android.820bc5d0ce571d8b",
+      "source": "Prioritizes connected Bluetooth microphones.",
+      "translated": "Dà priorità ai microfoni Bluetooth connessi."
+    },
+    {
+      "id": "native.android.11e48038d5e8bff6",
+      "source": "Preferred microphone",
+      "translated": "Microfono preferito"
+    },
+    {
+      "id": "native.android.eaa4d7563a46d307",
+      "source": "Unavailable",
+      "translated": "Non disponibile"
+    },
+    {
+      "id": "native.android.9f5ebf17eb405ba8",
+      "source": "Next session",
+      "translated": "Prossima sessione"
+    },
+    {
+      "id": "native.android.8c4e91f53928efb2",
+      "source": "Built-in microphone",
+      "translated": "Microfono integrato"
+    },
+    {
+      "id": "native.android.14b613cb6e2446b4",
+      "source": "Bluetooth microphone",
+      "translated": "Microfono Bluetooth"
+    },
+    {
+      "id": "native.android.c885247b2d7ce271",
+      "source": "Bluetooth LE microphone",
+      "translated": "Microfono Bluetooth LE"
+    },
+    {
+      "id": "native.android.b6a4e674c5fb441a",
+      "source": "Wired headset microphone",
+      "translated": "Microfono delle cuffie cablate"
+    },
+    {
+      "id": "native.android.9c8becb3b0fb5a90",
+      "source": "USB microphone",
+      "translated": "Microfono USB"
+    },
+    {
+      "id": "native.android.ba46258fadec7a39",
+      "source": "External microphone",
+      "translated": "Microfono esterno"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5074,9 +5139,9 @@
       "translated": "Controlla"
     },
     {
-      "id": "native.android.5a540761383fa474",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
-      "translated": "OpenClaw trasforma questo telefono in un'interfaccia mobile essenziale per sessioni, voce, provider e Gateway."
+      "id": "native.android.c971506716c96e91",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
+      "translated": "OpenClaw trasforma questo telefono in un'interfaccia mobile essenziale per thread, voce, provider e Gateway."
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5624,9 +5689,9 @@
       "translated": "Impostazioni di Talk"
     },
     {
-      "id": "native.android.73f07a5d54915259",
-      "source": "Recent Sessions",
-      "translated": "Sessioni recenti"
+      "id": "native.android.36f78c8c85dc283f",
+      "source": "Recent Threads",
+      "translated": "Thread recenti"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5684,14 +5749,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online"
     },
     {
-      "id": "native.android.16c3425d3a594481",
-      "source": "Sessions",
-      "translated": "Sessioni"
+      "id": "native.android.57177017a6a93826",
+      "source": "Threads",
+      "translated": "Thread"
     },
     {
-      "id": "native.android.a5c0f8b3112aa58c",
-      "source": "No recent sessions",
-      "translated": "Nessuna sessione recente"
+      "id": "native.android.43320b54a68b00a1",
+      "source": "No recent threads",
+      "translated": "Nessun thread recente"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5729,14 +5794,14 @@
       "translated": "In esecuzione · $pendingRunCount esecuzioni attive"
     },
     {
-      "id": "native.android.2c89da708b12a522",
-      "source": "Monitoring · 1 session",
-      "translated": "Monitoraggio · 1 sessione"
+      "id": "native.android.e24db059480f1e6a",
+      "source": "Monitoring · 1 thread",
+      "translated": "Monitoraggio · 1 thread"
     },
     {
-      "id": "native.android.8b6ee382dcb64e1f",
-      "source": "Monitoring · $sessionCount sessions",
-      "translated": "Monitoraggio · $sessionCount sessioni"
+      "id": "native.android.5a475f37d80e02bc",
+      "source": "Monitoring · $sessionCount threads",
+      "translated": "Monitoraggio · $sessionCount thread"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5769,9 +5834,9 @@
       "translated": "Provider"
     },
     {
-      "id": "native.android.a65477861c7203aa",
-      "source": "Open session",
-      "translated": "Apri sessione"
+      "id": "native.android.358c5e0e838d5423",
+      "source": "Open thread",
+      "translated": "Apri thread"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6194,9 +6259,9 @@
       "translated": "${days} g"
     },
     {
-      "id": "native.android.22d755834386db07",
-      "source": "Main session",
-      "translated": "Sessione principale"
+      "id": "native.android.28a1a1acc5a0959f",
+      "source": "Main thread",
+      "translated": "Thread principale"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6877,6 +6942,16 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "Riattiva audio"
+    },
+    {
+      "id": "native.android.cb608d82c5b3352a",
+      "source": "Back camera",
+      "translated": "Fotocamera posteriore"
+    },
+    {
+      "id": "native.android.e89a0e780eed2e1e",
+      "source": "Front camera",
+      "translated": "Fotocamera anteriore"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7684,9 +7759,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.882cc14a58e7e105",
-      "source": "Loading session",
-      "translated": "Caricamento sessione"
+      "id": "native.android.0c74bc30a994dd33",
+      "source": "Loading thread",
+      "translated": "Caricamento del thread"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7729,14 +7804,14 @@
       "translated": "Aggiornami"
     },
     {
-      "id": "native.android.1e5add56e48c99f9",
-      "source": "Summarize recent sessions and next steps.",
-      "translated": "Riassumi le sessioni recenti e i prossimi passaggi."
+      "id": "native.android.cf40df9739f78f27",
+      "source": "Summarize recent threads and next steps.",
+      "translated": "Riassumi i thread recenti e i prossimi passaggi."
     },
     {
-      "id": "native.android.06d515351bb79576",
-      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
-      "translated": "Aggiornami sulle mie sessioni recenti di OpenClaw e suggerisci i prossimi passaggi."
+      "id": "native.android.ebe49a8b8df80bd3",
+      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
+      "translated": "Aggiornami sui miei thread recenti di OpenClaw e suggerisci i prossimi passaggi."
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8074,9 +8149,9 @@
       "translated": "Connesso"
     },
     {
-      "id": "native.android.81931886b9caf3ab",
-      "source": "Sessions",
-      "translated": "Sessioni"
+      "id": "native.android.6cf5d6fa8a4186d5",
+      "source": "Threads",
+      "translated": "Thread"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,9 +10869,9 @@
       "translated": "Su cosa vorresti lavorare?"
     },
     {
-      "id": "native.apple.32179ce0b6d4543f",
-      "source": "The session attaches once the gateway is ready.",
-      "translated": "La sessione si collega quando il Gateway è pronto."
+      "id": "native.apple.4da775013ac9b123",
+      "source": "The thread attaches once the gateway is ready.",
+      "translated": "Il thread verrà collegato quando il Gateway sarà pronto."
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10844,9 +10919,9 @@
       "translated": "Opzioni nuova sessione…"
     },
     {
-      "id": "native.apple.a1b0d289758e2213",
-      "source": "Sessions…",
-      "translated": "Sessioni…"
+      "id": "native.apple.003b25ddafeb18e9",
+      "source": "Threads…",
+      "translated": "Thread…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11009,14 +11084,14 @@
       "translated": "Crea"
     },
     {
-      "id": "native.apple.f488b9caf6e51ac3",
-      "source": "Delete Session?",
-      "translated": "Eliminare la sessione?"
+      "id": "native.apple.31d5c7287cfb3abe",
+      "source": "Delete Thread?",
+      "translated": "Eliminare il thread?"
     },
     {
-      "id": "native.apple.8634b17be9b111bc",
-      "source": "Delete Session",
-      "translated": "Elimina sessione"
+      "id": "native.apple.d3395564809f1120",
+      "source": "Delete Thread",
+      "translated": "Elimina conversazione"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11024,9 +11099,9 @@
       "translated": "Annulla"
     },
     {
-      "id": "native.apple.4a9568ac9b18d8d3",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "La sessione e la relativa trascrizione verranno eliminate definitivamente."
+      "id": "native.apple.092659256d26cb03",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "Questa operazione elimina definitivamente la conversazione e la relativa trascrizione."
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11054,9 +11129,9 @@
       "translated": "Nuovo gruppo"
     },
     {
-      "id": "native.apple.5bccdc23a1640895",
-      "source": "Rename Session",
-      "translated": "Rinomina sessione"
+      "id": "native.apple.683032464c497bbd",
+      "source": "Rename Thread",
+      "translated": "Rinomina conversazione"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11064,9 +11139,9 @@
       "translated": "Nome del gruppo"
     },
     {
-      "id": "native.apple.af789b2d2fda0f67",
-      "source": "Session name",
-      "translated": "Nome della sessione"
+      "id": "native.apple.f887aa956588f237",
+      "source": "Thread name",
+      "translated": "Nome della conversazione"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11104,14 +11179,14 @@
       "translated": "Agenti"
     },
     {
-      "id": "native.apple.a3bde8045fe9224a",
-      "source": "Agent session",
-      "translated": "Sessione agente"
+      "id": "native.apple.7c8231b7b1ca480f",
+      "source": "Agent thread",
+      "translated": "Conversazione dell'agente"
     },
     {
-      "id": "native.apple.27f775de30b37ff8",
-      "source": "Recent sessions",
-      "translated": "Sessioni recenti"
+      "id": "native.apple.b3c553614f762a58",
+      "source": "Recent threads",
+      "translated": "Conversazioni recenti"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11119,9 +11194,9 @@
       "translated": "Gateway offline"
     },
     {
-      "id": "native.apple.28c97cf23665ee01",
-      "source": "No recent sessions",
-      "translated": "Nessuna sessione recente"
+      "id": "native.apple.5aa32afda85064ea",
+      "source": "No recent threads",
+      "translated": "Nessuna conversazione recente"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11219,14 +11294,14 @@
       "translated": "Annulla"
     },
     {
-      "id": "native.apple.9f2fd65953013b7c",
-      "source": "Sessions",
-      "translated": "Sessioni"
+      "id": "native.apple.b6855cf19a50f477",
+      "source": "Threads",
+      "translated": "Conversazioni"
     },
     {
-      "id": "native.apple.0422818cc95d5071",
-      "source": "Archived sessions",
-      "translated": "Sessioni archiviate"
+      "id": "native.apple.9b1d0ef27a1333b0",
+      "source": "Archived threads",
+      "translated": "Conversazioni archiviate"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11234,34 +11309,34 @@
       "translated": "Mostra archiviate"
     },
     {
-      "id": "native.apple.b272115c83f7ef58",
-      "source": "Sessions unavailable",
-      "translated": "Sessioni non disponibili"
+      "id": "native.apple.98167401c7267735",
+      "source": "Threads unavailable",
+      "translated": "Conversazioni non disponibili"
     },
     {
-      "id": "native.apple.54f8260c9b863087",
-      "source": "Loading archived sessions",
-      "translated": "Caricamento delle sessioni archiviate"
+      "id": "native.apple.4d28a7def2337b9f",
+      "source": "Loading archived threads",
+      "translated": "Caricamento delle conversazioni archiviate"
     },
     {
-      "id": "native.apple.9b305868873dade2",
-      "source": "Loading recent sessions",
-      "translated": "Caricamento delle sessioni recenti"
+      "id": "native.apple.777d7b706933bd7b",
+      "source": "Loading recent threads",
+      "translated": "Caricamento delle conversazioni recenti"
     },
     {
-      "id": "native.apple.207dad20d09f3160",
-      "source": "^[\\(count) session](inflect: true)",
-      "translated": "^[\\(count) sessione](inflect: true)"
+      "id": "native.apple.22f81ea94bef8410",
+      "source": "^[\\(count) thread](inflect: true)",
+      "translated": "^[\\(count) conversazione](inflect: true)"
     },
     {
-      "id": "native.apple.1f4501a6bf2bae4c",
-      "source": "No archived sessions",
-      "translated": "Nessuna sessione archiviata"
+      "id": "native.apple.1cad51e14db59bf9",
+      "source": "No archived threads",
+      "translated": "Nessuna conversazione archiviata"
     },
     {
-      "id": "native.apple.2a1ba7a5e1979c9e",
-      "source": "Archived sessions will appear here.",
-      "translated": "Le sessioni archiviate appariranno qui."
+      "id": "native.apple.18ef832d3a7ddcf8",
+      "source": "Archived threads will appear here.",
+      "translated": "Le conversazioni archiviate appariranno qui."
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11344,9 +11419,9 @@
       "translated": "Condividi acquisizione"
     },
     {
-      "id": "native.apple.2360d25fe6ae9946",
-      "source": "Loading sessions",
-      "translated": "Caricamento sessioni"
+      "id": "native.apple.21d9208d86a4d1fe",
+      "source": "Loading threads",
+      "translated": "Caricamento delle conversazioni"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11354,19 +11429,19 @@
       "translated": "Recupero dell'attività recente dal gateway."
     },
     {
-      "id": "native.apple.c334f2e86702a7b8",
-      "source": "Sessions unavailable",
-      "translated": "Sessioni non disponibili"
+      "id": "native.apple.4be1f79aa2b230ff",
+      "source": "Threads unavailable",
+      "translated": "Conversazioni non disponibili"
     },
     {
-      "id": "native.apple.6cc6efb7a03960b6",
-      "source": "No recent sessions",
-      "translated": "Nessuna sessione recente"
+      "id": "native.apple.98b348873556bc46",
+      "source": "No recent threads",
+      "translated": "Nessuna conversazione recente"
     },
     {
-      "id": "native.apple.08483af2d043bee6",
-      "source": "Session activity offline",
-      "translated": "Attività della sessione offline"
+      "id": "native.apple.7396d205574d279f",
+      "source": "Thread activity offline",
+      "translated": "Attività delle conversazioni offline"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11824,9 +11899,9 @@
       "translated": "Scheda"
     },
     {
-      "id": "native.apple.93eeaedb2ff61043",
-      "source": "Open Session",
-      "translated": "Apri sessione"
+      "id": "native.apple.c9ec1b0e18074d8a",
+      "source": "Open Thread",
+      "translated": "Apri conversazione"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13314,9 +13389,9 @@
       "translated": "Predefinito"
     },
     {
-      "id": "native.apple.3de045f17ea3c6d0",
-      "source": "Used for new Chat and Talk sessions.",
-      "translated": "Usato per nuove sessioni di Chat e Talk."
+      "id": "native.apple.f4ae5664c3eda95d",
+      "source": "Used for new Chat threads and Talk sessions.",
+      "translated": "Utilizzato per i nuovi thread di chat e le sessioni Talk."
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15719,9 +15794,9 @@
       "translated": "Istanze"
     },
     {
-      "id": "native.apple.3579cf2750470a22",
-      "source": "Sessions",
-      "translated": "Sessioni"
+      "id": "native.apple.11fe8b9941954dfb",
+      "source": "Threads",
+      "translated": "Thread"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19029,9 +19104,9 @@
       "translated": "Scorciatoia di Chat rapida"
     },
     {
-      "id": "native.apple.6ae77665b5f4490f",
-      "source": "Global shortcut that opens a floating chat bar for the main session.",
-      "translated": "Scorciatoia globale che apre una barra di chat mobile per la sessione principale."
+      "id": "native.apple.94dd793cd7d7d555",
+      "source": "Global shortcut that opens a floating chat bar for the main thread.",
+      "translated": "Scorciatoia globale che apre una barra di chat mobile per il thread principale."
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19609,9 +19684,9 @@
       "translated": "Critico"
     },
     {
-      "id": "native.apple.75102378a6775180",
-      "source": "New Session",
-      "translated": "Nuova sessione"
+      "id": "native.apple.13f96467014cf344",
+      "source": "New Thread",
+      "translated": "Nuovo thread"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21899,9 +21974,9 @@
       "translated": "Nessun messaggio recente"
     },
     {
-      "id": "native.apple.1ff8aec0044934c3",
-      "source": "Sessions",
-      "translated": "Sessioni"
+      "id": "native.apple.3ec2afcbc298c673",
+      "source": "Threads",
+      "translated": "Thread"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21909,9 +21984,9 @@
       "translated": "Dai un’occhiata ai bucket di conversazioni salvati che la CLI riutilizza per contesto e limiti di frequenza."
     },
     {
-      "id": "native.apple.bab897f3252b134c",
-      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
-      "translated": "Nessuna sessione ancora. Appariranno dopo il primo messaggio in entrata o heartbeat."
+      "id": "native.apple.14ccb32cd8ed1c81",
+      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
+      "translated": "Nessun thread. Appariranno dopo il primo messaggio in arrivo o heartbeat."
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -21994,9 +22069,9 @@
       "translated": "Approvazioni esecuzione"
     },
     {
-      "id": "native.apple.64a6dc7d49e8fb57",
-      "source": "Sessions",
-      "translated": "Sessioni"
+      "id": "native.apple.52e37e3a44ae516c",
+      "source": "Threads",
+      "translated": "Thread"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -22999,9 +23074,9 @@
       "translated": "Aggiornami"
     },
     {
-      "id": "native.apple.234ec45f4231edc4",
-      "source": "Summarize what happened in my sessions since yesterday.",
-      "translated": "Riepiloga cosa è successo nelle mie sessioni da ieri."
+      "id": "native.apple.fc4ce810900ec0b6",
+      "source": "Summarize what happened in my threads since yesterday.",
+      "translated": "Riassumi ciò che è successo nei miei thread da ieri."
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23179,9 +23254,9 @@
       "translated": "Rimuovi modello dagli elementi in evidenza"
     },
     {
-      "id": "native.apple.5dfc0700d8dff8de",
-      "source": "Session",
-      "translated": "Sessione"
+      "id": "native.apple.4edb66657f5aca1f",
+      "source": "Thread",
+      "translated": "Thread"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23344,6 +23419,51 @@
       "translated": "Widget non disponibile"
     },
     {
+      "id": "native.apple.d640691fd196f338",
+      "source": "Widget export failed",
+      "translated": "Esportazione del widget non riuscita"
+    },
+    {
+      "id": "native.apple.533c6e22a11e88de",
+      "source": "OK",
+      "translated": "OK"
+    },
+    {
+      "id": "native.apple.e1fb28a2a9756402",
+      "source": "Copy image",
+      "translated": "Copia immagine"
+    },
+    {
+      "id": "native.apple.ebd7bc92e1b12235",
+      "source": "Save image…",
+      "translated": "Salva immagine…"
+    },
+    {
+      "id": "native.apple.742c46d4cf2db134",
+      "source": "Save image",
+      "translated": "Salva immagine"
+    },
+    {
+      "id": "native.apple.0589cce608418f90",
+      "source": "The widget image could not be captured.",
+      "translated": "Impossibile acquisire l'immagine del widget."
+    },
+    {
+      "id": "native.apple.dfe24e827fdbe9c5",
+      "source": "The widget image could not be copied.",
+      "translated": "Impossibile copiare l'immagine del widget."
+    },
+    {
+      "id": "native.apple.9e611e3a80e71408",
+      "source": "The widget image could not be encoded as PNG.",
+      "translated": "Impossibile codificare l'immagine del widget in formato PNG."
+    },
+    {
+      "id": "native.apple.9a6e8afbe24a262b",
+      "source": "The widget image could not be saved.",
+      "translated": "Impossibile salvare l'immagine del widget."
+    },
+    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23484,19 +23604,19 @@
       "translated": "Utente"
     },
     {
-      "id": "native.apple.b1cdcb906a43d5d6",
-      "source": "This session cannot be archived while it is active or running.",
-      "translated": "Questa sessione non può essere archiviata mentre è attiva o in esecuzione."
+      "id": "native.apple.9d0cba09d92ee669",
+      "source": "This thread cannot be archived while it is active or running.",
+      "translated": "Questo thread non può essere archiviato mentre è attivo o in esecuzione."
     },
     {
-      "id": "native.apple.5817e3f3dab1ee19",
-      "source": "The main session cannot be deleted.",
-      "translated": "La sessione principale non può essere eliminata."
+      "id": "native.apple.8952a111a1075051",
+      "source": "The main thread cannot be deleted.",
+      "translated": "Il thread principale non può essere eliminato."
     },
     {
-      "id": "native.apple.a6b8df3f18171c91",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
-      "translated": "Rimuovi gli allegati o attendi la consegna prima di archiviare o eliminare questa sessione."
+      "id": "native.apple.90d0ccf80ca28717",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
+      "translated": "Rimuovi gli allegati o attendi la consegna prima di archiviare o eliminare questa conversazione."
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23634,9 +23754,9 @@
       "translated": "Esecuzione terminata"
     },
     {
-      "id": "native.apple.cd7c3095a22f80a9",
-      "source": "Session Info",
-      "translated": "Informazioni sulla sessione"
+      "id": "native.apple.bbccb4c8db5cac12",
+      "source": "Thread Info",
+      "translated": "Informazioni sulla conversazione"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23669,9 +23789,9 @@
       "translated": "Aggiungi gruppo"
     },
     {
-      "id": "native.apple.23d628606fe0734f",
-      "source": "Session Groups",
-      "translated": "Gruppi della sessione"
+      "id": "native.apple.7b641fed5bace855",
+      "source": "Thread Groups",
+      "translated": "Gruppi di conversazioni"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23714,9 +23834,9 @@
       "translated": "Elimina gruppo"
     },
     {
-      "id": "native.apple.b049c8a4d2805e08",
-      "source": "Sessions in this group become ungrouped.",
-      "translated": "Le sessioni in questo gruppo non saranno più raggruppate."
+      "id": "native.apple.56401c79410a310d",
+      "source": "Threads in this group become ungrouped.",
+      "translated": "Le conversazioni in questo gruppo vengono rimosse dal gruppo."
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23729,9 +23849,9 @@
       "translated": "Nessun agente è disponibile su questo gateway."
     },
     {
-      "id": "native.apple.6c89f35d53506406",
-      "source": "New Session Options",
-      "translated": "Opzioni nuova sessione"
+      "id": "native.apple.2d96aa7d3d12f85b",
+      "source": "New Thread Options",
+      "translated": "Opzioni nuova conversazione"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23759,19 +23879,19 @@
       "translated": "Crea"
     },
     {
-      "id": "native.apple.795ba37f6782cf28",
-      "source": "The session could not be created.",
-      "translated": "Non è stato possibile creare la sessione."
+      "id": "native.apple.87ef57319d1ddc85",
+      "source": "The thread could not be created.",
+      "translated": "Impossibile creare la conversazione."
     },
     {
-      "id": "native.apple.8ec708a3605a2cc3",
-      "source": "Search sessions",
-      "translated": "Cerca sessioni"
+      "id": "native.apple.6bd91c435b69d638",
+      "source": "Search threads",
+      "translated": "Cerca conversazioni"
     },
     {
-      "id": "native.apple.23b069b4e7f97039",
-      "source": "No Sessions",
-      "translated": "Nessuna sessione"
+      "id": "native.apple.6fde4bdf9d5b9191",
+      "source": "No Threads",
+      "translated": "Nessuna conversazione"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23779,29 +23899,29 @@
       "translated": "Nessun risultato"
     },
     {
-      "id": "native.apple.0058923f2ce8a3ec",
-      "source": "New Session",
-      "translated": "Nuova sessione"
+      "id": "native.apple.a02fd99740d29bd3",
+      "source": "New Thread",
+      "translated": "Nuova conversazione"
     },
     {
-      "id": "native.apple.66ba42960eb4135b",
-      "source": "New session",
-      "translated": "Nuova sessione"
+      "id": "native.apple.b625801dd04b09f2",
+      "source": "New thread",
+      "translated": "Nuova conversazione"
     },
     {
-      "id": "native.apple.2ef0e34db02ad255",
-      "source": "New session options",
-      "translated": "Opzioni nuova sessione"
+      "id": "native.apple.851be81fcc933608",
+      "source": "New thread options",
+      "translated": "Opzioni nuova conversazione"
     },
     {
-      "id": "native.apple.36753ef2f1ed4264",
-      "source": "Rename Session",
-      "translated": "Rinomina sessione"
+      "id": "native.apple.9ce8a4aba7b444b2",
+      "source": "Rename Thread",
+      "translated": "Rinomina conversazione"
     },
     {
-      "id": "native.apple.c9de0a1510ef475f",
-      "source": "Session name",
-      "translated": "Nome della sessione"
+      "id": "native.apple.1dd067c44511c7f0",
+      "source": "Thread name",
+      "translated": "Nome della conversazione"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23814,14 +23934,14 @@
       "translated": "Annulla"
     },
     {
-      "id": "native.apple.afb4e6c99c63a28d",
-      "source": "Delete Session",
-      "translated": "Elimina sessione"
+      "id": "native.apple.618073d6ab3f2721",
+      "source": "Delete Thread",
+      "translated": "Elimina conversazione"
     },
     {
-      "id": "native.apple.3d4ef32e42f136a4",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "La sessione e la relativa trascrizione vengono rimosse dal Gateway."
+      "id": "native.apple.10a5e72bba3cbccc",
+      "source": "The thread and its transcript are removed from the gateway.",
+      "translated": "La conversazione e la relativa trascrizione vengono rimosse dal Gateway."
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23829,14 +23949,14 @@
       "translated": "Eliminare “%@”?"
     },
     {
-      "id": "native.apple.9a7dca238fba628d",
-      "source": "Session running",
-      "translated": "Sessione in corso"
+      "id": "native.apple.ac71e3b2aa496a2c",
+      "source": "Thread running",
+      "translated": "Conversazione in esecuzione"
     },
     {
-      "id": "native.apple.fcfbfe5e97a95e9c",
-      "source": "Session failed",
-      "translated": "Sessione non riuscita"
+      "id": "native.apple.c775e87f997278b2",
+      "source": "Thread failed",
+      "translated": "Conversazione non riuscita"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23894,9 +24014,9 @@
       "translated": "Copia chiave sessione"
     },
     {
-      "id": "native.apple.4aeb7c14c26dabac",
-      "source": "Delete Session…",
-      "translated": "Elimina sessione…"
+      "id": "native.apple.f4998cfb572f23ff",
+      "source": "Delete Thread…",
+      "translated": "Elimina conversazione…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23909,9 +24029,9 @@
       "translated": "Connessione…"
     },
     {
-      "id": "native.apple.79f708b3bc1d3a6c",
-      "source": "Retry session groups",
-      "translated": "Riprova gruppi di sessioni"
+      "id": "native.apple.8802e9576ffd0f65",
+      "source": "Retry thread groups",
+      "translated": "Riprova a caricare i gruppi di conversazioni"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23934,24 +24054,24 @@
       "translated": "Ambito"
     },
     {
-      "id": "native.apple.2c37581c7b88f741",
-      "source": "Search sessions",
-      "translated": "Cerca sessioni"
+      "id": "native.apple.b313b80def4bda52",
+      "source": "Search threads",
+      "translated": "Cerca conversazioni"
     },
     {
-      "id": "native.apple.43be8a2336e42faf",
-      "source": "Sessions",
-      "translated": "Sessioni"
+      "id": "native.apple.c0cc6acc36f413ce",
+      "source": "Threads",
+      "translated": "Conversazioni"
     },
     {
-      "id": "native.apple.0b379cdfcbd3247f",
-      "source": "Rename Session",
-      "translated": "Rinomina sessione"
+      "id": "native.apple.854d3928fe5a557c",
+      "source": "Rename Thread",
+      "translated": "Rinomina conversazione"
     },
     {
-      "id": "native.apple.54b6fbd9e41db009",
-      "source": "Session name",
-      "translated": "Nome sessione"
+      "id": "native.apple.9d0d3f20096cc4da",
+      "source": "Thread name",
+      "translated": "Nome della conversazione"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -23959,19 +24079,19 @@
       "translated": "Annulla"
     },
     {
-      "id": "native.apple.751e0f6b81cd374a",
-      "source": "Delete selected sessions?",
-      "translated": "Eliminare le sessioni selezionate?"
+      "id": "native.apple.dc00eb94f33bae15",
+      "source": "Delete selected threads?",
+      "translated": "Eliminare le conversazioni selezionate?"
     },
     {
-      "id": "native.apple.aa679276581b0058",
-      "source": "Delete Sessions",
-      "translated": "Elimina sessioni"
+      "id": "native.apple.2053fc9f74dc3158",
+      "source": "Delete Threads",
+      "translated": "Elimina conversazioni"
     },
     {
-      "id": "native.apple.f837129cbee23297",
-      "source": "Each selected session and its transcript will be removed from the gateway.",
-      "translated": "Ogni sessione selezionata e la relativa trascrizione verranno rimosse dal Gateway."
+      "id": "native.apple.0970247871a834a0",
+      "source": "Each selected thread and its transcript will be removed from the gateway.",
+      "translated": "Ogni conversazione selezionata e la relativa trascrizione verranno rimosse dal gateway."
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -23979,9 +24099,9 @@
       "translated": "Gruppi"
     },
     {
-      "id": "native.apple.64013cfee5e25305",
-      "source": "Manage session groups",
-      "translated": "Gestisci gruppi di sessioni"
+      "id": "native.apple.6f8acab2256728b5",
+      "source": "Manage thread groups",
+      "translated": "Gestisci gruppi di conversazioni"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -23994,14 +24114,14 @@
       "translated": "Seleziona"
     },
     {
-      "id": "native.apple.b67eaecec1b423ac",
-      "source": "No archived sessions",
-      "translated": "Nessuna sessione archiviata"
+      "id": "native.apple.692972314d04b184",
+      "source": "No archived threads",
+      "translated": "Nessuna conversazione archiviata"
     },
     {
-      "id": "native.apple.b2435a79abf0c794",
-      "source": "No sessions found",
-      "translated": "Nessuna sessione trovata"
+      "id": "native.apple.d6a4b5711dcd26e7",
+      "source": "No threads found",
+      "translated": "Nessuna conversazione trovata"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24169,6 +24289,16 @@
       "translated": "Apri il messaggio completo"
     },
     {
+      "id": "native.apple.002bfcede229ad4b",
+      "source": "Rewind to Here",
+      "translated": "Riavvolgi fino a qui"
+    },
+    {
+      "id": "native.apple.14df2e4997689fb3",
+      "source": "Fork from Here",
+      "translated": "Crea una diramazione da qui"
+    },
+    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "Rispondi"
@@ -24254,9 +24384,9 @@
       "translated": "Rimuovi gli allegati o attendi il completamento della consegna prima di iniziare una nuova chat."
     },
     {
-      "id": "native.apple.980f552bb0f96c0f",
-      "source": "Gateway changed before the session operation started.",
-      "translated": "Il Gateway è cambiato prima dell'inizio dell'operazione sulla sessione."
+      "id": "native.apple.e0f045151c8d3137",
+      "source": "Gateway changed before the thread operation started.",
+      "translated": "Il Gateway è cambiato prima dell'inizio dell'operazione sulla conversazione."
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24264,9 +24394,9 @@
       "translated": "Rimuovi gli allegati o attendi il completamento della consegna prima di cambiare chat."
     },
     {
-      "id": "native.apple.87ba543b42696b92",
-      "source": "Clear this session's history?",
-      "translated": "Cancellare la cronologia di questa sessione?"
+      "id": "native.apple.0a5c4e15466c3acc",
+      "source": "Clear this thread's history?",
+      "translated": "Cancellare la cronologia di questa conversazione?"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24279,14 +24409,14 @@
       "translated": "Questa operazione reimposta la conversazione per %@. La chiave di sessione rimane invariata."
     },
     {
-      "id": "native.apple.a92e96bed98bd553",
-      "source": "Rename Session",
-      "translated": "Rinomina sessione"
+      "id": "native.apple.67ac221dbe7179f0",
+      "source": "Rename Thread",
+      "translated": "Rinomina conversazione"
     },
     {
-      "id": "native.apple.848e2388f3466f40",
-      "source": "Session name",
-      "translated": "Nome sessione"
+      "id": "native.apple.cf0f7e049603f518",
+      "source": "Thread name",
+      "translated": "Nome della conversazione"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24304,9 +24434,9 @@
       "translated": "Esporta trascrizione"
     },
     {
-      "id": "native.apple.4af0f566d39d7041",
-      "source": "Sessions",
-      "translated": "Sessioni"
+      "id": "native.apple.c0ada47504425f23",
+      "source": "Threads",
+      "translated": "Conversazioni"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24379,14 +24509,14 @@
       "translated": "Predefinito"
     },
     {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "Nuova sessione"
+      "id": "native.apple.1a765291943599e5",
+      "source": "New Thread",
+      "translated": "Nuova conversazione"
     },
     {
-      "id": "native.apple.a7119fbf9d25df5e",
-      "source": "New Session Options…",
-      "translated": "Opzioni nuova sessione…"
+      "id": "native.apple.c7a3a6d5e43dd98f",
+      "source": "New Thread Options…",
+      "translated": "Opzioni nuova conversazione…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24394,19 +24524,19 @@
       "translated": "Aggiorna"
     },
     {
-      "id": "native.apple.2bcff4a8fa503739",
-      "source": "Sessions…",
-      "translated": "Sessioni…"
+      "id": "native.apple.0e710b81808e5dcf",
+      "source": "Threads…",
+      "translated": "Conversazioni…"
     },
     {
-      "id": "native.apple.c36e008b051adb38",
-      "source": "Rename Session…",
-      "translated": "Rinomina sessione…"
+      "id": "native.apple.faad8f92b6bef166",
+      "source": "Rename Thread…",
+      "translated": "Rinomina conversazione…"
     },
     {
-      "id": "native.apple.ea0ef95a159bffe0",
-      "source": "Fork Session",
-      "translated": "Crea fork della sessione"
+      "id": "native.apple.23b61d6cd26ac112",
+      "source": "Fork",
+      "translated": "Dirama"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24464,24 +24594,24 @@
       "translated": "Cancella cronologia…"
     },
     {
-      "id": "native.apple.920fe8a7a33f9e92",
-      "source": "Session",
-      "translated": "Sessione"
+      "id": "native.apple.8b4f1c5107ea8a0e",
+      "source": "Thread",
+      "translated": "Conversazione"
     },
     {
-      "id": "native.apple.185a401f78328b0f",
-      "source": "Session actions",
-      "translated": "Azioni sessione"
+      "id": "native.apple.4d7750c9bf699469",
+      "source": "Thread actions",
+      "translated": "Azioni conversazione"
     },
     {
-      "id": "native.apple.9f9dedf599b2619b",
-      "source": "Session cost %@",
-      "translated": "Costo della sessione %@"
+      "id": "native.apple.bb2f22cc43c97f8e",
+      "source": "Thread cost %@",
+      "translated": "Costo conversazione %@"
     },
     {
-      "id": "native.apple.f0a4720df5f5f403",
-      "source": "Compact Session",
-      "translated": "Comprimi sessione"
+      "id": "native.apple.6239ced0b86e86f8",
+      "source": "Compact Thread",
+      "translated": "Compatta conversazione"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/ja-JP.json
+++ b/apps/.i18n/native/ja-JP.json
@@ -1429,9 +1429,9 @@
       "translated": "OpenClawで会話または音声入力"
     },
     {
-      "id": "native.android.5876e15e5e92fd45",
-      "source": "Browse Sessions",
-      "translated": "セッションを参照"
+      "id": "native.android.e2cf5a38587382cb",
+      "source": "Browse Threads",
+      "translated": "スレッドを参照"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "アクションが見つかりません"
     },
     {
-      "id": "native.android.48ad0ae0e930e02b",
-      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
-      "translated": "Chat、Voice、Sessions、Providers、または Settings をお試しください。"
+      "id": "native.android.bc70a4ac965b82ba",
+      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
+      "translated": "チャット、音声、スレッド、プロバイダー、または設定をお試しください。"
     },
     {
-      "id": "native.android.d4fbd1ee4f55a5db",
-      "source": "Sessions",
-      "translated": "セッション"
+      "id": "native.android.670121e54dbe286f",
+      "source": "Threads",
+      "translated": "スレッド"
     },
     {
-      "id": "native.android.207c2170504e99e6",
-      "source": "Connect the Gateway to search sessions.",
-      "translated": "セッションを検索するには Gateway に接続してください。"
+      "id": "native.android.d38be650b1bce4a0",
+      "source": "Connect the Gateway to search threads.",
+      "translated": "スレッドを検索するにはGatewayに接続してください。"
     },
     {
-      "id": "native.android.25d2c2d792c952fe",
-      "source": "No matching sessions yet.",
-      "translated": "一致するセッションはまだありません。"
+      "id": "native.android.3d7754721f776ef8",
+      "source": "No matching threads yet.",
+      "translated": "一致するスレッドはまだありません。"
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "アシスタントが作業中"
     },
     {
-      "id": "native.android.8f8384286317f5c9",
-      "source": "OpenClaw session",
-      "translated": "OpenClaw セッション"
+      "id": "native.android.9a839f6e3e05a744",
+      "source": "OpenClaw thread",
+      "translated": "OpenClawスレッド"
     },
     {
-      "id": "native.android.15799e57704b20c6",
-      "source": "Open session",
-      "translated": "セッションを開く"
+      "id": "native.android.d83f82a1e4a5ed99",
+      "source": "Open thread",
+      "translated": "スレッドを開く"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "準備完了のプロバイダーはありません"
     },
     {
-      "id": "native.android.73e6ab1a168fd381",
-      "source": "Main session",
-      "translated": "メインセッション"
+      "id": "native.android.8a1c5365c0538908",
+      "source": "Main thread",
+      "translated": "メインスレッド"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.0e3157c15c56944f",
-      "source": "Sessions",
-      "translated": "セッション"
+      "id": "native.android.a5845742daecb4ba",
+      "source": "Threads",
+      "translated": "スレッド"
     },
     {
-      "id": "native.android.70f5d0507d34b5c8",
-      "source": "Focus session search",
-      "translated": "セッション検索にフォーカス"
+      "id": "native.android.439b324280869527",
+      "source": "Focus thread search",
+      "translated": "スレッド検索にフォーカス"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "アーカイブ済み"
     },
     {
-      "id": "native.android.b9cf34c137e4cf03",
-      "source": "Search sessions",
-      "translated": "セッションを検索"
+      "id": "native.android.03981341841b04ac",
+      "source": "Search threads",
+      "translated": "スレッドを検索"
     },
     {
-      "id": "native.android.10cb26723e9990fc",
-      "source": "Clear session search",
-      "translated": "セッション検索をクリア"
+      "id": "native.android.99570c528a41fa72",
+      "source": "Clear thread search",
+      "translated": "スレッド検索をクリア"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "古い順"
     },
     {
-      "id": "native.android.c6bf8751e2a7f5c7",
-      "source": "Toggle session layout",
-      "translated": "セッションレイアウトを切り替え"
+      "id": "native.android.fd67be543e321cc9",
+      "source": "Toggle thread layout",
+      "translated": "スレッドのレイアウトを切り替え"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "レイアウト: 詳細"
     },
     {
-      "id": "native.android.69b79a3c2c987cd4",
-      "source": "Searching sessions",
-      "translated": "セッションを検索中"
+      "id": "native.android.ebd17565e0ffd8eb",
+      "source": "Searching threads",
+      "translated": "スレッドを検索中"
     },
     {
-      "id": "native.android.dd587d341af44212",
-      "source": "No matching sessions",
-      "translated": "一致するセッションはありません"
+      "id": "native.android.472d46ae8669f860",
+      "source": "No matching threads",
+      "translated": "一致するスレッドはありません"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "チャットを開始"
     },
     {
-      "id": "native.android.f10d4df7cbc6df4f",
-      "source": "Current session",
-      "translated": "現在のセッション"
+      "id": "native.android.ff81ad1bee00d384",
+      "source": "Current thread",
+      "translated": "現在のスレッド"
     },
     {
-      "id": "native.android.8f0482425838ae64",
-      "source": "OpenClaw session",
-      "translated": "OpenClaw セッション"
+      "id": "native.android.fc145645b9620e57",
+      "source": "OpenClaw thread",
+      "translated": "OpenClawスレッド"
     },
     {
-      "id": "native.android.786774c8a76e50d7",
-      "source": "Rename session",
-      "translated": "セッション名を変更"
+      "id": "native.android.71cbb8dde8bf138b",
+      "source": "Rename thread",
+      "translated": "スレッド名を変更"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "グループを削除しますか？"
     },
     {
-      "id": "native.android.3455fc2f77d564e3",
-      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "\"$group\" 内のセッションは保持され、未グループ化に戻ります。"
+      "id": "native.android.691e92cfe5cf106e",
+      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "「$group」内のスレッドは保持され、未分類に戻ります。"
     },
     {
-      "id": "native.android.4805fb9d6623e8c0",
-      "source": "Delete session?",
-      "translated": "セッションを削除しますか？"
+      "id": "native.android.d87a8217ab56999b",
+      "source": "Delete thread?",
+      "translated": "スレッドを削除しますか？"
     },
     {
-      "id": "native.android.0c3283a2b2445eae",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "これにより、セッションとそのトランスクリプトが完全に削除されます。"
+      "id": "native.android.930de97ff47113a8",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "このスレッドとその記録を完全に削除します。"
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "グループなし"
     },
     {
-      "id": "native.android.db243d71d056afa4",
-      "source": "No sessions yet",
-      "translated": "まだセッションがありません"
+      "id": "native.android.8e21a70428def6e0",
+      "source": "No threads yet",
+      "translated": "スレッドはまだありません"
     },
     {
-      "id": "native.android.5b4eee6a8092925e",
-      "source": "No current session",
-      "translated": "現在のセッションはありません"
+      "id": "native.android.cda4c5ad8b17e394",
+      "source": "No current thread",
+      "translated": "現在のスレッドはありません"
     },
     {
-      "id": "native.android.acbcc9c9ea53d8c0",
-      "source": "No archived sessions",
-      "translated": "アーカイブ済みセッションはありません"
+      "id": "native.android.be84f061047aa2da",
+      "source": "No archived threads",
+      "translated": "アーカイブ済みのスレッドはありません"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "新しい会話を開始すると、ここに表示されます。"
     },
     {
-      "id": "native.android.56fcd605dc7be3c0",
-      "source": "Open Chat to start or resume the current session.",
-      "translated": "現在のセッションを開始または再開するには、チャットを開いてください。"
+      "id": "native.android.f289d03e1d3eee98",
+      "source": "Open Chat to start or resume the current thread.",
+      "translated": "チャットを開いて、現在のスレッドを開始または再開してください。"
     },
     {
-      "id": "native.android.085515989f8a2022",
-      "source": "Archived sessions will show up here.",
-      "translated": "アーカイブ済みセッションはここに表示されます。"
+      "id": "native.android.504b71386e76c6ae",
+      "source": "Archived threads will show up here.",
+      "translated": "アーカイブ済みのスレッドがここに表示されます。"
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days}日"
     },
     {
-      "id": "native.android.3d4fa07acbc015c5",
-      "source": "Main session",
-      "translated": "メインセッション"
+      "id": "native.android.ee4c727cdafbe963",
+      "source": "Main thread",
+      "translated": "メインスレッド"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway 保留中"
     },
     {
-      "id": "native.android.2d8d049afe99f751",
-      "source": "Session Activity",
-      "translated": "セッションアクティビティ"
+      "id": "native.android.da78209effb11cfd",
+      "source": "Thread Activity",
+      "translated": "スレッドのアクティビティ"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "このスマートフォンが接続されている間、Exec 承認リクエストがここに表示されます。"
     },
     {
-      "id": "native.android.dc3e7ca5a491103a",
-      "source": "Session activity",
-      "translated": "セッションアクティビティ"
+      "id": "native.android.f615712dfb56319a",
+      "source": "Thread activity",
+      "translated": "スレッドのアクティビティ"
     },
     {
-      "id": "native.android.8551e02b060bd7d8",
-      "source": "Chat tool calls waiting in the active session remain visible here.",
-      "translated": "アクティブなセッションで待機中のチャットツール呼び出しは、ここに表示されたままになります。"
+      "id": "native.android.6c93973c13db43ae",
+      "source": "Chat tool calls waiting in the active thread remain visible here.",
+      "translated": "アクティブなスレッドで待機中のチャットツール呼び出しは、引き続きここに表示されます。"
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,6 +4294,11 @@
       "translated": "トークプロバイダーの設定"
     },
     {
+      "id": "native.android.23b638094c34b916",
+      "source": "Microphone",
+      "translated": "マイク"
+    },
+    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "音声テスト"
@@ -4337,6 +4342,66 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "完了"
+    },
+    {
+      "id": "native.android.8d9ecdfdd916b780",
+      "source": "Automatic",
+      "translated": "自動"
+    },
+    {
+      "id": "native.android.c1626a6700a570f6",
+      "source": "Preferred microphone unavailable; using automatic routing.",
+      "translated": "優先マイクを利用できないため、自動ルーティングを使用しています。"
+    },
+    {
+      "id": "native.android.820bc5d0ce571d8b",
+      "source": "Prioritizes connected Bluetooth microphones.",
+      "translated": "接続済みのBluetoothマイクを優先します。"
+    },
+    {
+      "id": "native.android.11e48038d5e8bff6",
+      "source": "Preferred microphone",
+      "translated": "優先マイク"
+    },
+    {
+      "id": "native.android.eaa4d7563a46d307",
+      "source": "Unavailable",
+      "translated": "利用不可"
+    },
+    {
+      "id": "native.android.9f5ebf17eb405ba8",
+      "source": "Next session",
+      "translated": "次のセッション"
+    },
+    {
+      "id": "native.android.8c4e91f53928efb2",
+      "source": "Built-in microphone",
+      "translated": "内蔵マイク"
+    },
+    {
+      "id": "native.android.14b613cb6e2446b4",
+      "source": "Bluetooth microphone",
+      "translated": "Bluetoothマイク"
+    },
+    {
+      "id": "native.android.c885247b2d7ce271",
+      "source": "Bluetooth LE microphone",
+      "translated": "Bluetooth LEマイク"
+    },
+    {
+      "id": "native.android.b6a4e674c5fb441a",
+      "source": "Wired headset microphone",
+      "translated": "有線ヘッドセットのマイク"
+    },
+    {
+      "id": "native.android.9c8becb3b0fb5a90",
+      "source": "USB microphone",
+      "translated": "USBマイク"
+    },
+    {
+      "id": "native.android.ba46258fadec7a39",
+      "source": "External microphone",
+      "translated": "外部マイク"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5074,9 +5139,9 @@
       "translated": "確認"
     },
     {
-      "id": "native.android.5a540761383fa474",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
-      "translated": "OpenClawは、このスマートフォンをセッション、音声、プロバイダー、Gateway用のシンプルなモバイルコマンドインターフェースに変えます。"
+      "id": "native.android.c971506716c96e91",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
+      "translated": "OpenClawは、このスマートフォンをスレッド、音声、プロバイダー、Gatewayのためのシンプルなモバイルコマンド画面に変えます。"
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5624,9 +5689,9 @@
       "translated": "Talk 設定"
     },
     {
-      "id": "native.android.73f07a5d54915259",
-      "source": "Recent Sessions",
-      "translated": "最近のセッション"
+      "id": "native.android.36f78c8c85dc283f",
+      "source": "Recent Threads",
+      "translated": "最近のスレッド"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5684,14 +5749,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% がオンライン"
     },
     {
-      "id": "native.android.16c3425d3a594481",
-      "source": "Sessions",
-      "translated": "セッション"
+      "id": "native.android.57177017a6a93826",
+      "source": "Threads",
+      "translated": "スレッド"
     },
     {
-      "id": "native.android.a5c0f8b3112aa58c",
-      "source": "No recent sessions",
-      "translated": "最近のセッションはありません"
+      "id": "native.android.43320b54a68b00a1",
+      "source": "No recent threads",
+      "translated": "最近のスレッドはありません"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5729,14 +5794,14 @@
       "translated": "処理中 · $pendingRunCount 件の実行がアクティブ"
     },
     {
-      "id": "native.android.2c89da708b12a522",
-      "source": "Monitoring · 1 session",
-      "translated": "監視中 · 1 件のセッション"
+      "id": "native.android.e24db059480f1e6a",
+      "source": "Monitoring · 1 thread",
+      "translated": "監視中 · 1件のスレッド"
     },
     {
-      "id": "native.android.8b6ee382dcb64e1f",
-      "source": "Monitoring · $sessionCount sessions",
-      "translated": "監視中 · $sessionCount 件のセッション"
+      "id": "native.android.5a475f37d80e02bc",
+      "source": "Monitoring · $sessionCount threads",
+      "translated": "監視中 · $sessionCount件のスレッド"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5769,9 +5834,9 @@
       "translated": "プロバイダー"
     },
     {
-      "id": "native.android.a65477861c7203aa",
-      "source": "Open session",
-      "translated": "セッションを開く"
+      "id": "native.android.358c5e0e838d5423",
+      "source": "Open thread",
+      "translated": "スレッドを開く"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6194,9 +6259,9 @@
       "translated": "${days}日"
     },
     {
-      "id": "native.android.22d755834386db07",
-      "source": "Main session",
-      "translated": "メインセッション"
+      "id": "native.android.28a1a1acc5a0959f",
+      "source": "Main thread",
+      "translated": "メインスレッド"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6877,6 +6942,16 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "ミュート解除"
+    },
+    {
+      "id": "native.android.cb608d82c5b3352a",
+      "source": "Back camera",
+      "translated": "背面カメラ"
+    },
+    {
+      "id": "native.android.e89a0e780eed2e1e",
+      "source": "Front camera",
+      "translated": "前面カメラ"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7684,9 +7759,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.882cc14a58e7e105",
-      "source": "Loading session",
-      "translated": "セッションを読み込み中"
+      "id": "native.android.0c74bc30a994dd33",
+      "source": "Loading thread",
+      "translated": "スレッドを読み込み中"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7729,14 +7804,14 @@
       "translated": "最新情報を確認"
     },
     {
-      "id": "native.android.1e5add56e48c99f9",
-      "source": "Summarize recent sessions and next steps.",
-      "translated": "最近のセッションと次のステップを要約します。"
+      "id": "native.android.cf40df9739f78f27",
+      "source": "Summarize recent threads and next steps.",
+      "translated": "最近のスレッドと次のステップを要約してください。"
     },
     {
-      "id": "native.android.06d515351bb79576",
-      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
-      "translated": "最近のOpenClawセッションの内容をまとめ、次のステップを提案してください。"
+      "id": "native.android.ebe49a8b8df80bd3",
+      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
+      "translated": "最近のOpenClawスレッドの内容をまとめ、次のステップを提案してください。"
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8074,9 +8149,9 @@
       "translated": "接続済み"
     },
     {
-      "id": "native.android.81931886b9caf3ab",
-      "source": "Sessions",
-      "translated": "セッション"
+      "id": "native.android.6cf5d6fa8a4186d5",
+      "source": "Threads",
+      "translated": "スレッド"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,9 +10869,9 @@
       "translated": "何に取り組みますか？"
     },
     {
-      "id": "native.apple.32179ce0b6d4543f",
-      "source": "The session attaches once the gateway is ready.",
-      "translated": "Gateway の準備ができると、セッションが接続されます。"
+      "id": "native.apple.4da775013ac9b123",
+      "source": "The thread attaches once the gateway is ready.",
+      "translated": "Gatewayの準備が整うと、スレッドが接続されます。"
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10844,9 +10919,9 @@
       "translated": "新規セッションのオプション…"
     },
     {
-      "id": "native.apple.a1b0d289758e2213",
-      "source": "Sessions…",
-      "translated": "セッション…"
+      "id": "native.apple.003b25ddafeb18e9",
+      "source": "Threads…",
+      "translated": "スレッド…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11009,14 +11084,14 @@
       "translated": "作成"
     },
     {
-      "id": "native.apple.f488b9caf6e51ac3",
-      "source": "Delete Session?",
-      "translated": "セッションを削除しますか？"
+      "id": "native.apple.31d5c7287cfb3abe",
+      "source": "Delete Thread?",
+      "translated": "スレッドを削除しますか？"
     },
     {
-      "id": "native.apple.8634b17be9b111bc",
-      "source": "Delete Session",
-      "translated": "セッションを削除"
+      "id": "native.apple.d3395564809f1120",
+      "source": "Delete Thread",
+      "translated": "スレッドを削除"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11024,9 +11099,9 @@
       "translated": "キャンセル"
     },
     {
-      "id": "native.apple.4a9568ac9b18d8d3",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "これにより、セッションとその文字起こしが完全に削除されます。"
+      "id": "native.apple.092659256d26cb03",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "この操作を行うと、スレッドとその記録が完全に削除されます。"
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11054,9 +11129,9 @@
       "translated": "新規グループ"
     },
     {
-      "id": "native.apple.5bccdc23a1640895",
-      "source": "Rename Session",
-      "translated": "セッション名を変更"
+      "id": "native.apple.683032464c497bbd",
+      "source": "Rename Thread",
+      "translated": "スレッド名を変更"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11064,9 +11139,9 @@
       "translated": "グループ名"
     },
     {
-      "id": "native.apple.af789b2d2fda0f67",
-      "source": "Session name",
-      "translated": "セッション名"
+      "id": "native.apple.f887aa956588f237",
+      "source": "Thread name",
+      "translated": "スレッド名"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11104,14 +11179,14 @@
       "translated": "エージェント"
     },
     {
-      "id": "native.apple.a3bde8045fe9224a",
-      "source": "Agent session",
-      "translated": "エージェントセッション"
+      "id": "native.apple.7c8231b7b1ca480f",
+      "source": "Agent thread",
+      "translated": "エージェントスレッド"
     },
     {
-      "id": "native.apple.27f775de30b37ff8",
-      "source": "Recent sessions",
-      "translated": "最近のセッション"
+      "id": "native.apple.b3c553614f762a58",
+      "source": "Recent threads",
+      "translated": "最近のスレッド"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11119,9 +11194,9 @@
       "translated": "Gateway がオフラインです"
     },
     {
-      "id": "native.apple.28c97cf23665ee01",
-      "source": "No recent sessions",
-      "translated": "最近のセッションはありません"
+      "id": "native.apple.5aa32afda85064ea",
+      "source": "No recent threads",
+      "translated": "最近のスレッドはありません"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11219,14 +11294,14 @@
       "translated": "キャンセル"
     },
     {
-      "id": "native.apple.9f2fd65953013b7c",
-      "source": "Sessions",
-      "translated": "セッション"
+      "id": "native.apple.b6855cf19a50f477",
+      "source": "Threads",
+      "translated": "スレッド"
     },
     {
-      "id": "native.apple.0422818cc95d5071",
-      "source": "Archived sessions",
-      "translated": "アーカイブ済みセッション"
+      "id": "native.apple.9b1d0ef27a1333b0",
+      "source": "Archived threads",
+      "translated": "アーカイブ済みのスレッド"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11234,34 +11309,34 @@
       "translated": "アーカイブを表示"
     },
     {
-      "id": "native.apple.b272115c83f7ef58",
-      "source": "Sessions unavailable",
-      "translated": "セッションを利用できません"
+      "id": "native.apple.98167401c7267735",
+      "source": "Threads unavailable",
+      "translated": "スレッドを利用できません"
     },
     {
-      "id": "native.apple.54f8260c9b863087",
-      "source": "Loading archived sessions",
-      "translated": "アーカイブ済みセッションを読み込み中"
+      "id": "native.apple.4d28a7def2337b9f",
+      "source": "Loading archived threads",
+      "translated": "アーカイブ済みのスレッドを読み込み中"
     },
     {
-      "id": "native.apple.9b305868873dade2",
-      "source": "Loading recent sessions",
-      "translated": "最近のセッションを読み込み中"
+      "id": "native.apple.777d7b706933bd7b",
+      "source": "Loading recent threads",
+      "translated": "最近のスレッドを読み込み中"
     },
     {
-      "id": "native.apple.207dad20d09f3160",
-      "source": "^[\\(count) session](inflect: true)",
-      "translated": "^[\\(count)件のセッション](inflect: true)"
+      "id": "native.apple.22f81ea94bef8410",
+      "source": "^[\\(count) thread](inflect: true)",
+      "translated": "^[\\(count)件のスレッド](inflect: true)"
     },
     {
-      "id": "native.apple.1f4501a6bf2bae4c",
-      "source": "No archived sessions",
-      "translated": "アーカイブ済みセッションはありません"
+      "id": "native.apple.1cad51e14db59bf9",
+      "source": "No archived threads",
+      "translated": "アーカイブ済みのスレッドはありません"
     },
     {
-      "id": "native.apple.2a1ba7a5e1979c9e",
-      "source": "Archived sessions will appear here.",
-      "translated": "アーカイブされたセッションはここに表示されます。"
+      "id": "native.apple.18ef832d3a7ddcf8",
+      "source": "Archived threads will appear here.",
+      "translated": "アーカイブ済みのスレッドがここに表示されます。"
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11344,9 +11419,9 @@
       "translated": "共有取り込み"
     },
     {
-      "id": "native.apple.2360d25fe6ae9946",
-      "source": "Loading sessions",
-      "translated": "セッションを読み込み中"
+      "id": "native.apple.21d9208d86a4d1fe",
+      "source": "Loading threads",
+      "translated": "スレッドを読み込み中"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11354,19 +11429,19 @@
       "translated": "Gatewayから最近のアクティビティを取得しています。"
     },
     {
-      "id": "native.apple.c334f2e86702a7b8",
-      "source": "Sessions unavailable",
-      "translated": "セッションを利用できません"
+      "id": "native.apple.4be1f79aa2b230ff",
+      "source": "Threads unavailable",
+      "translated": "スレッドを利用できません"
     },
     {
-      "id": "native.apple.6cc6efb7a03960b6",
-      "source": "No recent sessions",
-      "translated": "最近のセッションはありません"
+      "id": "native.apple.98b348873556bc46",
+      "source": "No recent threads",
+      "translated": "最近のスレッドはありません"
     },
     {
-      "id": "native.apple.08483af2d043bee6",
-      "source": "Session activity offline",
-      "translated": "セッションアクティビティはオフラインです"
+      "id": "native.apple.7396d205574d279f",
+      "source": "Thread activity offline",
+      "translated": "スレッドのアクティビティはオフラインです"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11824,9 +11899,9 @@
       "translated": "カード"
     },
     {
-      "id": "native.apple.93eeaedb2ff61043",
-      "source": "Open Session",
-      "translated": "セッションを開く"
+      "id": "native.apple.c9ec1b0e18074d8a",
+      "source": "Open Thread",
+      "translated": "スレッドを開く"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13314,9 +13389,9 @@
       "translated": "デフォルト"
     },
     {
-      "id": "native.apple.3de045f17ea3c6d0",
-      "source": "Used for new Chat and Talk sessions.",
-      "translated": "新しいChatおよびTalkセッションに使用されます。"
+      "id": "native.apple.f4ae5664c3eda95d",
+      "source": "Used for new Chat threads and Talk sessions.",
+      "translated": "新しいチャットスレッドとトークセッションに使用されます。"
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15719,9 +15794,9 @@
       "translated": "インスタンス"
     },
     {
-      "id": "native.apple.3579cf2750470a22",
-      "source": "Sessions",
-      "translated": "セッション"
+      "id": "native.apple.11fe8b9941954dfb",
+      "source": "Threads",
+      "translated": "スレッド"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19029,9 +19104,9 @@
       "translated": "クイックチャットのショートカット"
     },
     {
-      "id": "native.apple.6ae77665b5f4490f",
-      "source": "Global shortcut that opens a floating chat bar for the main session.",
-      "translated": "メインセッション用のフローティングチャットバーを開くグローバルショートカット。"
+      "id": "native.apple.94dd793cd7d7d555",
+      "source": "Global shortcut that opens a floating chat bar for the main thread.",
+      "translated": "メインスレッド用のフローティングチャットバーを開くグローバルショートカットです。"
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19609,9 +19684,9 @@
       "translated": "Critical"
     },
     {
-      "id": "native.apple.75102378a6775180",
-      "source": "New Session",
-      "translated": "新規セッション"
+      "id": "native.apple.13f96467014cf344",
+      "source": "New Thread",
+      "translated": "新規スレッド"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21899,9 +21974,9 @@
       "translated": "最近のメッセージはありません"
     },
     {
-      "id": "native.apple.1ff8aec0044934c3",
-      "source": "Sessions",
-      "translated": "セッション"
+      "id": "native.apple.3ec2afcbc298c673",
+      "source": "Threads",
+      "translated": "スレッド"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21909,9 +21984,9 @@
       "translated": "CLI がコンテキストとレート制限に再利用する保存済みの会話バケットを確認します。"
     },
     {
-      "id": "native.apple.bab897f3252b134c",
-      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
-      "translated": "まだセッションはありません。最初の受信メッセージまたはハートビートの後に表示されます。"
+      "id": "native.apple.14ccb32cd8ed1c81",
+      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
+      "translated": "スレッドはまだありません。最初の受信メッセージまたはハートビートの後に表示されます。"
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -21994,9 +22069,9 @@
       "translated": "実行の承認"
     },
     {
-      "id": "native.apple.64a6dc7d49e8fb57",
-      "source": "Sessions",
-      "translated": "セッション"
+      "id": "native.apple.52e37e3a44ae516c",
+      "source": "Threads",
+      "translated": "スレッド"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -22999,9 +23074,9 @@
       "translated": "最新情報を教えて"
     },
     {
-      "id": "native.apple.234ec45f4231edc4",
-      "source": "Summarize what happened in my sessions since yesterday.",
-      "translated": "昨日以降、セッションで何が起きたか要約してください。"
+      "id": "native.apple.fc4ce810900ec0b6",
+      "source": "Summarize what happened in my threads since yesterday.",
+      "translated": "昨日以降、スレッドで起きたことを要約してください。"
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23179,9 +23254,9 @@
       "translated": "モデルのピン留めを解除"
     },
     {
-      "id": "native.apple.5dfc0700d8dff8de",
-      "source": "Session",
-      "translated": "セッション"
+      "id": "native.apple.4edb66657f5aca1f",
+      "source": "Thread",
+      "translated": "スレッド"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23344,6 +23419,51 @@
       "translated": "ウィジェットを利用できません"
     },
     {
+      "id": "native.apple.d640691fd196f338",
+      "source": "Widget export failed",
+      "translated": "ウィジェットの書き出しに失敗しました"
+    },
+    {
+      "id": "native.apple.533c6e22a11e88de",
+      "source": "OK",
+      "translated": "OK"
+    },
+    {
+      "id": "native.apple.e1fb28a2a9756402",
+      "source": "Copy image",
+      "translated": "画像をコピー"
+    },
+    {
+      "id": "native.apple.ebd7bc92e1b12235",
+      "source": "Save image…",
+      "translated": "画像を保存…"
+    },
+    {
+      "id": "native.apple.742c46d4cf2db134",
+      "source": "Save image",
+      "translated": "画像を保存"
+    },
+    {
+      "id": "native.apple.0589cce608418f90",
+      "source": "The widget image could not be captured.",
+      "translated": "ウィジェットの画像をキャプチャできませんでした。"
+    },
+    {
+      "id": "native.apple.dfe24e827fdbe9c5",
+      "source": "The widget image could not be copied.",
+      "translated": "ウィジェットの画像をコピーできませんでした。"
+    },
+    {
+      "id": "native.apple.9e611e3a80e71408",
+      "source": "The widget image could not be encoded as PNG.",
+      "translated": "ウィジェットの画像をPNGとしてエンコードできませんでした。"
+    },
+    {
+      "id": "native.apple.9a6e8afbe24a262b",
+      "source": "The widget image could not be saved.",
+      "translated": "ウィジェットの画像を保存できませんでした。"
+    },
+    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23484,19 +23604,19 @@
       "translated": "ユーザー"
     },
     {
-      "id": "native.apple.b1cdcb906a43d5d6",
-      "source": "This session cannot be archived while it is active or running.",
-      "translated": "このセッションは、アクティブまたは実行中のためアーカイブできません。"
+      "id": "native.apple.9d0cba09d92ee669",
+      "source": "This thread cannot be archived while it is active or running.",
+      "translated": "このスレッドは、アクティブまたは実行中のためアーカイブできません。"
     },
     {
-      "id": "native.apple.5817e3f3dab1ee19",
-      "source": "The main session cannot be deleted.",
-      "translated": "メインセッションは削除できません。"
+      "id": "native.apple.8952a111a1075051",
+      "source": "The main thread cannot be deleted.",
+      "translated": "メインスレッドは削除できません。"
     },
     {
-      "id": "native.apple.a6b8df3f18171c91",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
-      "translated": "このセッションをアーカイブまたは削除する前に、添付ファイルを削除するか、配信が完了するまでお待ちください。"
+      "id": "native.apple.90d0ccf80ca28717",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
+      "translated": "このスレッドをアーカイブまたは削除する前に、添付ファイルを削除するか、配信が完了するまでお待ちください。"
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23634,9 +23754,9 @@
       "translated": "実行終了"
     },
     {
-      "id": "native.apple.cd7c3095a22f80a9",
-      "source": "Session Info",
-      "translated": "セッション情報"
+      "id": "native.apple.bbccb4c8db5cac12",
+      "source": "Thread Info",
+      "translated": "スレッド情報"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23669,9 +23789,9 @@
       "translated": "グループを追加"
     },
     {
-      "id": "native.apple.23d628606fe0734f",
-      "source": "Session Groups",
-      "translated": "セッショングループ"
+      "id": "native.apple.7b641fed5bace855",
+      "source": "Thread Groups",
+      "translated": "スレッドグループ"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23714,9 +23834,9 @@
       "translated": "グループを削除"
     },
     {
-      "id": "native.apple.b049c8a4d2805e08",
-      "source": "Sessions in this group become ungrouped.",
-      "translated": "このグループ内のセッションはグループ化されていない状態になります。"
+      "id": "native.apple.56401c79410a310d",
+      "source": "Threads in this group become ungrouped.",
+      "translated": "このグループ内のスレッドはグループ化が解除されます。"
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23729,9 +23849,9 @@
       "translated": "このGatewayでは利用可能なエージェントがありません。"
     },
     {
-      "id": "native.apple.6c89f35d53506406",
-      "source": "New Session Options",
-      "translated": "新規セッションのオプション"
+      "id": "native.apple.2d96aa7d3d12f85b",
+      "source": "New Thread Options",
+      "translated": "新規スレッドのオプション"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23759,19 +23879,19 @@
       "translated": "作成"
     },
     {
-      "id": "native.apple.795ba37f6782cf28",
-      "source": "The session could not be created.",
-      "translated": "セッションを作成できませんでした。"
+      "id": "native.apple.87ef57319d1ddc85",
+      "source": "The thread could not be created.",
+      "translated": "スレッドを作成できませんでした。"
     },
     {
-      "id": "native.apple.8ec708a3605a2cc3",
-      "source": "Search sessions",
-      "translated": "セッションを検索"
+      "id": "native.apple.6bd91c435b69d638",
+      "source": "Search threads",
+      "translated": "スレッドを検索"
     },
     {
-      "id": "native.apple.23b069b4e7f97039",
-      "source": "No Sessions",
-      "translated": "セッションがありません"
+      "id": "native.apple.6fde4bdf9d5b9191",
+      "source": "No Threads",
+      "translated": "スレッドなし"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23779,29 +23899,29 @@
       "translated": "結果がありません"
     },
     {
-      "id": "native.apple.0058923f2ce8a3ec",
-      "source": "New Session",
-      "translated": "新規セッション"
+      "id": "native.apple.a02fd99740d29bd3",
+      "source": "New Thread",
+      "translated": "新規スレッド"
     },
     {
-      "id": "native.apple.66ba42960eb4135b",
-      "source": "New session",
-      "translated": "新規セッション"
+      "id": "native.apple.b625801dd04b09f2",
+      "source": "New thread",
+      "translated": "新規スレッド"
     },
     {
-      "id": "native.apple.2ef0e34db02ad255",
-      "source": "New session options",
-      "translated": "新規セッションのオプション"
+      "id": "native.apple.851be81fcc933608",
+      "source": "New thread options",
+      "translated": "新規スレッドのオプション"
     },
     {
-      "id": "native.apple.36753ef2f1ed4264",
-      "source": "Rename Session",
-      "translated": "セッション名を変更"
+      "id": "native.apple.9ce8a4aba7b444b2",
+      "source": "Rename Thread",
+      "translated": "スレッド名を変更"
     },
     {
-      "id": "native.apple.c9de0a1510ef475f",
-      "source": "Session name",
-      "translated": "セッション名"
+      "id": "native.apple.1dd067c44511c7f0",
+      "source": "Thread name",
+      "translated": "スレッド名"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23814,14 +23934,14 @@
       "translated": "キャンセル"
     },
     {
-      "id": "native.apple.afb4e6c99c63a28d",
-      "source": "Delete Session",
-      "translated": "セッションを削除"
+      "id": "native.apple.618073d6ab3f2721",
+      "source": "Delete Thread",
+      "translated": "スレッドを削除"
     },
     {
-      "id": "native.apple.3d4ef32e42f136a4",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "セッションとそのトランスクリプトがGatewayから削除されます。"
+      "id": "native.apple.10a5e72bba3cbccc",
+      "source": "The thread and its transcript are removed from the gateway.",
+      "translated": "スレッドとそのトランスクリプトがGatewayから削除されます。"
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23829,14 +23949,14 @@
       "translated": "「%@」を削除しますか？"
     },
     {
-      "id": "native.apple.9a7dca238fba628d",
-      "source": "Session running",
-      "translated": "セッションを実行中"
+      "id": "native.apple.ac71e3b2aa496a2c",
+      "source": "Thread running",
+      "translated": "スレッドを実行中"
     },
     {
-      "id": "native.apple.fcfbfe5e97a95e9c",
-      "source": "Session failed",
-      "translated": "セッションに失敗しました"
+      "id": "native.apple.c775e87f997278b2",
+      "source": "Thread failed",
+      "translated": "スレッドが失敗しました"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23894,9 +24014,9 @@
       "translated": "セッションキーをコピー"
     },
     {
-      "id": "native.apple.4aeb7c14c26dabac",
-      "source": "Delete Session…",
-      "translated": "セッションを削除…"
+      "id": "native.apple.f4998cfb572f23ff",
+      "source": "Delete Thread…",
+      "translated": "スレッドを削除…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23909,9 +24029,9 @@
       "translated": "接続中…"
     },
     {
-      "id": "native.apple.79f708b3bc1d3a6c",
-      "source": "Retry session groups",
-      "translated": "セッショングループを再試行"
+      "id": "native.apple.8802e9576ffd0f65",
+      "source": "Retry thread groups",
+      "translated": "スレッドグループを再試行"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23934,24 +24054,24 @@
       "translated": "スコープ"
     },
     {
-      "id": "native.apple.2c37581c7b88f741",
-      "source": "Search sessions",
-      "translated": "セッションを検索"
+      "id": "native.apple.b313b80def4bda52",
+      "source": "Search threads",
+      "translated": "スレッドを検索"
     },
     {
-      "id": "native.apple.43be8a2336e42faf",
-      "source": "Sessions",
-      "translated": "セッション"
+      "id": "native.apple.c0cc6acc36f413ce",
+      "source": "Threads",
+      "translated": "スレッド"
     },
     {
-      "id": "native.apple.0b379cdfcbd3247f",
-      "source": "Rename Session",
-      "translated": "セッション名を変更"
+      "id": "native.apple.854d3928fe5a557c",
+      "source": "Rename Thread",
+      "translated": "スレッド名を変更"
     },
     {
-      "id": "native.apple.54b6fbd9e41db009",
-      "source": "Session name",
-      "translated": "セッション名"
+      "id": "native.apple.9d0d3f20096cc4da",
+      "source": "Thread name",
+      "translated": "スレッド名"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -23959,19 +24079,19 @@
       "translated": "キャンセル"
     },
     {
-      "id": "native.apple.751e0f6b81cd374a",
-      "source": "Delete selected sessions?",
-      "translated": "選択したセッションを削除しますか？"
+      "id": "native.apple.dc00eb94f33bae15",
+      "source": "Delete selected threads?",
+      "translated": "選択したスレッドを削除しますか？"
     },
     {
-      "id": "native.apple.aa679276581b0058",
-      "source": "Delete Sessions",
-      "translated": "セッションを削除"
+      "id": "native.apple.2053fc9f74dc3158",
+      "source": "Delete Threads",
+      "translated": "スレッドを削除"
     },
     {
-      "id": "native.apple.f837129cbee23297",
-      "source": "Each selected session and its transcript will be removed from the gateway.",
-      "translated": "選択した各セッションとそのトランスクリプトがGatewayから削除されます。"
+      "id": "native.apple.0970247871a834a0",
+      "source": "Each selected thread and its transcript will be removed from the gateway.",
+      "translated": "選択した各スレッドとその記録がGatewayから削除されます。"
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -23979,9 +24099,9 @@
       "translated": "グループ"
     },
     {
-      "id": "native.apple.64013cfee5e25305",
-      "source": "Manage session groups",
-      "translated": "セッショングループを管理"
+      "id": "native.apple.6f8acab2256728b5",
+      "source": "Manage thread groups",
+      "translated": "スレッドグループを管理"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -23994,14 +24114,14 @@
       "translated": "選択"
     },
     {
-      "id": "native.apple.b67eaecec1b423ac",
-      "source": "No archived sessions",
-      "translated": "アーカイブされたセッションはありません"
+      "id": "native.apple.692972314d04b184",
+      "source": "No archived threads",
+      "translated": "アーカイブ済みのスレッドはありません"
     },
     {
-      "id": "native.apple.b2435a79abf0c794",
-      "source": "No sessions found",
-      "translated": "セッションが見つかりません"
+      "id": "native.apple.d6a4b5711dcd26e7",
+      "source": "No threads found",
+      "translated": "スレッドが見つかりません"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24169,6 +24289,16 @@
       "translated": "メッセージ全文を開く"
     },
     {
+      "id": "native.apple.002bfcede229ad4b",
+      "source": "Rewind to Here",
+      "translated": "ここまで巻き戻す"
+    },
+    {
+      "id": "native.apple.14df2e4997689fb3",
+      "source": "Fork from Here",
+      "translated": "ここから分岐"
+    },
+    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "返信"
@@ -24254,9 +24384,9 @@
       "translated": "新しいチャットを開始する前に、添付ファイルを削除するか、配信が完了するまでお待ちください。"
     },
     {
-      "id": "native.apple.980f552bb0f96c0f",
-      "source": "Gateway changed before the session operation started.",
-      "translated": "セッション操作を開始する前にGatewayが変更されました。"
+      "id": "native.apple.e0f045151c8d3137",
+      "source": "Gateway changed before the thread operation started.",
+      "translated": "スレッド操作の開始前にGatewayが変更されました。"
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24264,9 +24394,9 @@
       "translated": "チャットを切り替える前に、添付ファイルを削除するか送信が完了するのを待ってください。"
     },
     {
-      "id": "native.apple.87ba543b42696b92",
-      "source": "Clear this session's history?",
-      "translated": "このセッションの履歴を消去しますか？"
+      "id": "native.apple.0a5c4e15466c3acc",
+      "source": "Clear this thread's history?",
+      "translated": "このスレッドの履歴を消去しますか？"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24279,14 +24409,14 @@
       "translated": "%@の会話がリセットされます。セッションキーは変更されません。"
     },
     {
-      "id": "native.apple.a92e96bed98bd553",
-      "source": "Rename Session",
-      "translated": "セッション名を変更"
+      "id": "native.apple.67ac221dbe7179f0",
+      "source": "Rename Thread",
+      "translated": "スレッド名を変更"
     },
     {
-      "id": "native.apple.848e2388f3466f40",
-      "source": "Session name",
-      "translated": "セッション名"
+      "id": "native.apple.cf0f7e049603f518",
+      "source": "Thread name",
+      "translated": "スレッド名"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24304,9 +24434,9 @@
       "translated": "トランスクリプトをエクスポート"
     },
     {
-      "id": "native.apple.4af0f566d39d7041",
-      "source": "Sessions",
-      "translated": "セッション"
+      "id": "native.apple.c0ada47504425f23",
+      "source": "Threads",
+      "translated": "スレッド"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24379,14 +24509,14 @@
       "translated": "デフォルト"
     },
     {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "新規セッション"
+      "id": "native.apple.1a765291943599e5",
+      "source": "New Thread",
+      "translated": "新しいスレッド"
     },
     {
-      "id": "native.apple.a7119fbf9d25df5e",
-      "source": "New Session Options…",
-      "translated": "新規セッションのオプション…"
+      "id": "native.apple.c7a3a6d5e43dd98f",
+      "source": "New Thread Options…",
+      "translated": "新しいスレッドのオプション…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24394,19 +24524,19 @@
       "translated": "更新"
     },
     {
-      "id": "native.apple.2bcff4a8fa503739",
-      "source": "Sessions…",
-      "translated": "セッション…"
+      "id": "native.apple.0e710b81808e5dcf",
+      "source": "Threads…",
+      "translated": "スレッド…"
     },
     {
-      "id": "native.apple.c36e008b051adb38",
-      "source": "Rename Session…",
-      "translated": "セッション名を変更…"
+      "id": "native.apple.faad8f92b6bef166",
+      "source": "Rename Thread…",
+      "translated": "スレッド名を変更…"
     },
     {
-      "id": "native.apple.ea0ef95a159bffe0",
-      "source": "Fork Session",
-      "translated": "セッションをフォーク"
+      "id": "native.apple.23b61d6cd26ac112",
+      "source": "Fork",
+      "translated": "フォーク"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24464,24 +24594,24 @@
       "translated": "履歴を消去…"
     },
     {
-      "id": "native.apple.920fe8a7a33f9e92",
-      "source": "Session",
-      "translated": "セッション"
+      "id": "native.apple.8b4f1c5107ea8a0e",
+      "source": "Thread",
+      "translated": "スレッド"
     },
     {
-      "id": "native.apple.185a401f78328b0f",
-      "source": "Session actions",
-      "translated": "セッション操作"
+      "id": "native.apple.4d7750c9bf699469",
+      "source": "Thread actions",
+      "translated": "スレッドの操作"
     },
     {
-      "id": "native.apple.9f9dedf599b2619b",
-      "source": "Session cost %@",
-      "translated": "セッションコスト：%@"
+      "id": "native.apple.bb2f22cc43c97f8e",
+      "source": "Thread cost %@",
+      "translated": "スレッドのコスト %@"
     },
     {
-      "id": "native.apple.f0a4720df5f5f403",
-      "source": "Compact Session",
-      "translated": "セッションを圧縮"
+      "id": "native.apple.6239ced0b86e86f8",
+      "source": "Compact Thread",
+      "translated": "スレッドを圧縮"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/ja-JP.json
+++ b/apps/.i18n/native/ja-JP.json
@@ -1429,9 +1429,9 @@
       "translated": "OpenClawで会話または音声入力"
     },
     {
-      "id": "native.android.e2cf5a38587382cb",
-      "source": "Browse Threads",
-      "translated": "スレッドを閲覧"
+      "id": "native.android.5876e15e5e92fd45",
+      "source": "Browse Sessions",
+      "translated": "セッションを参照"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "アクションが見つかりません"
     },
     {
-      "id": "native.android.bc70a4ac965b82ba",
-      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
-      "translated": "チャット、音声、スレッド、プロバイダー、設定をお試しください。"
+      "id": "native.android.48ad0ae0e930e02b",
+      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
+      "translated": "Chat、Voice、Sessions、Providers、または Settings をお試しください。"
     },
     {
-      "id": "native.android.670121e54dbe286f",
-      "source": "Threads",
-      "translated": "スレッド"
+      "id": "native.android.d4fbd1ee4f55a5db",
+      "source": "Sessions",
+      "translated": "セッション"
     },
     {
-      "id": "native.android.d38be650b1bce4a0",
-      "source": "Connect the Gateway to search threads.",
-      "translated": "スレッドを検索するには、Gatewayに接続してください。"
+      "id": "native.android.207c2170504e99e6",
+      "source": "Connect the Gateway to search sessions.",
+      "translated": "セッションを検索するには Gateway に接続してください。"
     },
     {
-      "id": "native.android.3d7754721f776ef8",
-      "source": "No matching threads yet.",
-      "translated": "一致するスレッドはまだありません。"
+      "id": "native.android.25d2c2d792c952fe",
+      "source": "No matching sessions yet.",
+      "translated": "一致するセッションはまだありません。"
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "アシスタントが作業中"
     },
     {
-      "id": "native.android.9a839f6e3e05a744",
-      "source": "OpenClaw thread",
-      "translated": "OpenClawスレッド"
+      "id": "native.android.8f8384286317f5c9",
+      "source": "OpenClaw session",
+      "translated": "OpenClaw セッション"
     },
     {
-      "id": "native.android.d83f82a1e4a5ed99",
-      "source": "Open thread",
-      "translated": "スレッドを開く"
+      "id": "native.android.15799e57704b20c6",
+      "source": "Open session",
+      "translated": "セッションを開く"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "準備完了のプロバイダーはありません"
     },
     {
-      "id": "native.android.8a1c5365c0538908",
-      "source": "Main thread",
-      "translated": "メインスレッド"
+      "id": "native.android.73e6ab1a168fd381",
+      "source": "Main session",
+      "translated": "メインセッション"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.a5845742daecb4ba",
-      "source": "Threads",
-      "translated": "スレッド"
+      "id": "native.android.0e3157c15c56944f",
+      "source": "Sessions",
+      "translated": "セッション"
     },
     {
-      "id": "native.android.439b324280869527",
-      "source": "Focus thread search",
-      "translated": "スレッド検索にフォーカス"
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "セッション検索にフォーカス"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "アーカイブ済み"
     },
     {
-      "id": "native.android.03981341841b04ac",
-      "source": "Search threads",
-      "translated": "スレッドを検索"
+      "id": "native.android.b9cf34c137e4cf03",
+      "source": "Search sessions",
+      "translated": "セッションを検索"
     },
     {
-      "id": "native.android.99570c528a41fa72",
-      "source": "Clear thread search",
-      "translated": "スレッド検索をクリア"
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "セッション検索をクリア"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "古い順"
     },
     {
-      "id": "native.android.fd67be543e321cc9",
-      "source": "Toggle thread layout",
-      "translated": "スレッドのレイアウトを切り替え"
+      "id": "native.android.c6bf8751e2a7f5c7",
+      "source": "Toggle session layout",
+      "translated": "セッションレイアウトを切り替え"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "レイアウト: 詳細"
     },
     {
-      "id": "native.android.ebd17565e0ffd8eb",
-      "source": "Searching threads",
-      "translated": "スレッドを検索中"
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "セッションを検索中"
     },
     {
-      "id": "native.android.472d46ae8669f860",
-      "source": "No matching threads",
-      "translated": "一致するスレッドはありません"
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "一致するセッションはありません"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "チャットを開始"
     },
     {
-      "id": "native.android.ff81ad1bee00d384",
-      "source": "Current thread",
-      "translated": "現在のスレッド"
+      "id": "native.android.f10d4df7cbc6df4f",
+      "source": "Current session",
+      "translated": "現在のセッション"
     },
     {
-      "id": "native.android.fc145645b9620e57",
-      "source": "OpenClaw thread",
-      "translated": "OpenClawスレッド"
+      "id": "native.android.8f0482425838ae64",
+      "source": "OpenClaw session",
+      "translated": "OpenClaw セッション"
     },
     {
-      "id": "native.android.71cbb8dde8bf138b",
-      "source": "Rename thread",
-      "translated": "スレッド名を変更"
+      "id": "native.android.786774c8a76e50d7",
+      "source": "Rename session",
+      "translated": "セッション名を変更"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "グループを削除しますか？"
     },
     {
-      "id": "native.android.691e92cfe5cf106e",
-      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "「$group」内のスレッドは保持され、「未分類」に戻されます。"
+      "id": "native.android.3455fc2f77d564e3",
+      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "\"$group\" 内のセッションは保持され、未グループ化に戻ります。"
     },
     {
-      "id": "native.android.d87a8217ab56999b",
-      "source": "Delete thread?",
-      "translated": "スレッドを削除しますか？"
+      "id": "native.android.4805fb9d6623e8c0",
+      "source": "Delete session?",
+      "translated": "セッションを削除しますか？"
     },
     {
-      "id": "native.android.930de97ff47113a8",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "このスレッドとその記録を完全に削除します。"
+      "id": "native.android.0c3283a2b2445eae",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "これにより、セッションとそのトランスクリプトが完全に削除されます。"
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "グループなし"
     },
     {
-      "id": "native.android.8e21a70428def6e0",
-      "source": "No threads yet",
-      "translated": "スレッドはまだありません"
+      "id": "native.android.db243d71d056afa4",
+      "source": "No sessions yet",
+      "translated": "まだセッションがありません"
     },
     {
-      "id": "native.android.cda4c5ad8b17e394",
-      "source": "No current thread",
-      "translated": "現在のスレッドはありません"
+      "id": "native.android.5b4eee6a8092925e",
+      "source": "No current session",
+      "translated": "現在のセッションはありません"
     },
     {
-      "id": "native.android.be84f061047aa2da",
-      "source": "No archived threads",
-      "translated": "アーカイブ済みのスレッドはありません"
+      "id": "native.android.acbcc9c9ea53d8c0",
+      "source": "No archived sessions",
+      "translated": "アーカイブ済みセッションはありません"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "新しい会話を開始すると、ここに表示されます。"
     },
     {
-      "id": "native.android.f289d03e1d3eee98",
-      "source": "Open Chat to start or resume the current thread.",
-      "translated": "チャットを開いて、現在のスレッドを開始または再開してください。"
+      "id": "native.android.56fcd605dc7be3c0",
+      "source": "Open Chat to start or resume the current session.",
+      "translated": "現在のセッションを開始または再開するには、チャットを開いてください。"
     },
     {
-      "id": "native.android.504b71386e76c6ae",
-      "source": "Archived threads will show up here.",
-      "translated": "アーカイブ済みのスレッドがここに表示されます。"
+      "id": "native.android.085515989f8a2022",
+      "source": "Archived sessions will show up here.",
+      "translated": "アーカイブ済みセッションはここに表示されます。"
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days}日"
     },
     {
-      "id": "native.android.ee4c727cdafbe963",
-      "source": "Main thread",
-      "translated": "メインスレッド"
+      "id": "native.android.3d4fa07acbc015c5",
+      "source": "Main session",
+      "translated": "メインセッション"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway 保留中"
     },
     {
-      "id": "native.android.da78209effb11cfd",
-      "source": "Thread Activity",
-      "translated": "スレッドのアクティビティ"
+      "id": "native.android.2d8d049afe99f751",
+      "source": "Session Activity",
+      "translated": "セッションアクティビティ"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "このスマートフォンが接続されている間、Exec 承認リクエストがここに表示されます。"
     },
     {
-      "id": "native.android.f615712dfb56319a",
-      "source": "Thread activity",
-      "translated": "スレッドのアクティビティ"
+      "id": "native.android.dc3e7ca5a491103a",
+      "source": "Session activity",
+      "translated": "セッションアクティビティ"
     },
     {
-      "id": "native.android.6c93973c13db43ae",
-      "source": "Chat tool calls waiting in the active thread remain visible here.",
-      "translated": "アクティブなスレッドで待機中のチャットツール呼び出しは、引き続きここに表示されます。"
+      "id": "native.android.8551e02b060bd7d8",
+      "source": "Chat tool calls waiting in the active session remain visible here.",
+      "translated": "アクティブなセッションで待機中のチャットツール呼び出しは、ここに表示されたままになります。"
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,11 +4294,6 @@
       "translated": "トークプロバイダーの設定"
     },
     {
-      "id": "native.android.23b638094c34b916",
-      "source": "Microphone",
-      "translated": "マイク"
-    },
-    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "音声テスト"
@@ -4342,66 +4337,6 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "完了"
-    },
-    {
-      "id": "native.android.8d9ecdfdd916b780",
-      "source": "Automatic",
-      "translated": "自動"
-    },
-    {
-      "id": "native.android.c1626a6700a570f6",
-      "source": "Preferred microphone unavailable; using automatic routing.",
-      "translated": "優先マイクを利用できないため、自動ルーティングを使用します。"
-    },
-    {
-      "id": "native.android.820bc5d0ce571d8b",
-      "source": "Prioritizes connected Bluetooth microphones.",
-      "translated": "接続されているBluetoothマイクを優先します。"
-    },
-    {
-      "id": "native.android.11e48038d5e8bff6",
-      "source": "Preferred microphone",
-      "translated": "優先マイク"
-    },
-    {
-      "id": "native.android.eaa4d7563a46d307",
-      "source": "Unavailable",
-      "translated": "利用不可"
-    },
-    {
-      "id": "native.android.9f5ebf17eb405ba8",
-      "source": "Next session",
-      "translated": "次のセッション"
-    },
-    {
-      "id": "native.android.8c4e91f53928efb2",
-      "source": "Built-in microphone",
-      "translated": "内蔵マイク"
-    },
-    {
-      "id": "native.android.14b613cb6e2446b4",
-      "source": "Bluetooth microphone",
-      "translated": "Bluetoothマイク"
-    },
-    {
-      "id": "native.android.c885247b2d7ce271",
-      "source": "Bluetooth LE microphone",
-      "translated": "Bluetooth LEマイク"
-    },
-    {
-      "id": "native.android.b6a4e674c5fb441a",
-      "source": "Wired headset microphone",
-      "translated": "有線ヘッドセットのマイク"
-    },
-    {
-      "id": "native.android.9c8becb3b0fb5a90",
-      "source": "USB microphone",
-      "translated": "USBマイク"
-    },
-    {
-      "id": "native.android.ba46258fadec7a39",
-      "source": "External microphone",
-      "translated": "外部マイク"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5139,9 +5074,9 @@
       "translated": "確認"
     },
     {
-      "id": "native.android.c971506716c96e91",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
-      "translated": "OpenClawは、このスマートフォンをスレッド、音声、プロバイダー、Gateway向けのシンプルなモバイルコマンド画面に変えます。"
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClawは、このスマートフォンをセッション、音声、プロバイダー、Gateway用のシンプルなモバイルコマンドインターフェースに変えます。"
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5689,9 +5624,9 @@
       "translated": "Talk 設定"
     },
     {
-      "id": "native.android.36f78c8c85dc283f",
-      "source": "Recent Threads",
-      "translated": "最近のスレッド"
+      "id": "native.android.73f07a5d54915259",
+      "source": "Recent Sessions",
+      "translated": "最近のセッション"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5749,14 +5684,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% がオンライン"
     },
     {
-      "id": "native.android.57177017a6a93826",
-      "source": "Threads",
-      "translated": "スレッド"
+      "id": "native.android.16c3425d3a594481",
+      "source": "Sessions",
+      "translated": "セッション"
     },
     {
-      "id": "native.android.43320b54a68b00a1",
-      "source": "No recent threads",
-      "translated": "最近のスレッドはありません"
+      "id": "native.android.a5c0f8b3112aa58c",
+      "source": "No recent sessions",
+      "translated": "最近のセッションはありません"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5794,14 +5729,14 @@
       "translated": "処理中 · $pendingRunCount 件の実行がアクティブ"
     },
     {
-      "id": "native.android.e24db059480f1e6a",
-      "source": "Monitoring · 1 thread",
-      "translated": "監視中 · 1件のスレッド"
+      "id": "native.android.2c89da708b12a522",
+      "source": "Monitoring · 1 session",
+      "translated": "監視中 · 1 件のセッション"
     },
     {
-      "id": "native.android.5a475f37d80e02bc",
-      "source": "Monitoring · $sessionCount threads",
-      "translated": "監視中 · $sessionCount件のスレッド"
+      "id": "native.android.8b6ee382dcb64e1f",
+      "source": "Monitoring · $sessionCount sessions",
+      "translated": "監視中 · $sessionCount 件のセッション"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5834,9 +5769,9 @@
       "translated": "プロバイダー"
     },
     {
-      "id": "native.android.358c5e0e838d5423",
-      "source": "Open thread",
-      "translated": "スレッドを開く"
+      "id": "native.android.a65477861c7203aa",
+      "source": "Open session",
+      "translated": "セッションを開く"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6259,9 +6194,9 @@
       "translated": "${days}日"
     },
     {
-      "id": "native.android.28a1a1acc5a0959f",
-      "source": "Main thread",
-      "translated": "メインスレッド"
+      "id": "native.android.22d755834386db07",
+      "source": "Main session",
+      "translated": "メインセッション"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6942,16 +6877,6 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "ミュート解除"
-    },
-    {
-      "id": "native.android.cb608d82c5b3352a",
-      "source": "Back camera",
-      "translated": "背面カメラ"
-    },
-    {
-      "id": "native.android.e89a0e780eed2e1e",
-      "source": "Front camera",
-      "translated": "前面カメラ"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7759,9 +7684,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.0c74bc30a994dd33",
-      "source": "Loading thread",
-      "translated": "スレッドを読み込み中"
+      "id": "native.android.882cc14a58e7e105",
+      "source": "Loading session",
+      "translated": "セッションを読み込み中"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7804,14 +7729,14 @@
       "translated": "最新情報を確認"
     },
     {
-      "id": "native.android.cf40df9739f78f27",
-      "source": "Summarize recent threads and next steps.",
-      "translated": "最近のスレッドと次のステップを要約します。"
+      "id": "native.android.1e5add56e48c99f9",
+      "source": "Summarize recent sessions and next steps.",
+      "translated": "最近のセッションと次のステップを要約します。"
     },
     {
-      "id": "native.android.ebe49a8b8df80bd3",
-      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
-      "translated": "最近のOpenClawスレッドの概要と、次のステップを提案してください。"
+      "id": "native.android.06d515351bb79576",
+      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
+      "translated": "最近のOpenClawセッションの内容をまとめ、次のステップを提案してください。"
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8149,9 +8074,9 @@
       "translated": "接続済み"
     },
     {
-      "id": "native.android.6cf5d6fa8a4186d5",
-      "source": "Threads",
-      "translated": "スレッド"
+      "id": "native.android.81931886b9caf3ab",
+      "source": "Sessions",
+      "translated": "セッション"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,6 +10719,61 @@
       "translated": "タスクの詳細"
     },
     {
+      "id": "native.apple.29cacb53ea5e77fc",
+      "source": "Pinned",
+      "translated": "ピン留め"
+    },
+    {
+      "id": "native.apple.940062cfdce9211b",
+      "source": "Recent",
+      "translated": "最近"
+    },
+    {
+      "id": "native.apple.a0980128426308a9",
+      "source": "Model",
+      "translated": "モデル"
+    },
+    {
+      "id": "native.apple.9520e60f21535dde",
+      "source": "Thinking",
+      "translated": "思考"
+    },
+    {
+      "id": "native.apple.8b321f3ffce97429",
+      "source": "Fast",
+      "translated": "高速"
+    },
+    {
+      "id": "native.apple.989b70d64e328d55",
+      "source": "Default (inherited)",
+      "translated": "デフォルト（継承）"
+    },
+    {
+      "id": "native.apple.f4114e73b07eb9ae",
+      "source": "Off",
+      "translated": "オフ"
+    },
+    {
+      "id": "native.apple.7ed231b28d16312f",
+      "source": "On",
+      "translated": "オン"
+    },
+    {
+      "id": "native.apple.412a74802320a037",
+      "source": "Full",
+      "translated": "フル"
+    },
+    {
+      "id": "native.apple.299f21a2071ff9fc",
+      "source": "Verbosity",
+      "translated": "詳細度"
+    },
+    {
+      "id": "native.apple.faf0ef05e1496de7",
+      "source": "Default",
+      "translated": "デフォルト"
+    },
+    {
       "id": "native.apple.e5524d5756a62744",
       "source": "Unable to Export Transcript",
       "translated": "トランスクリプトをエクスポートできません"
@@ -10814,9 +10794,9 @@
       "translated": "何に取り組みますか？"
     },
     {
-      "id": "native.apple.4da775013ac9b123",
-      "source": "The thread attaches once the gateway is ready.",
-      "translated": "Gatewayの準備ができると、スレッドが接続されます。"
+      "id": "native.apple.32179ce0b6d4543f",
+      "source": "The session attaches once the gateway is ready.",
+      "translated": "Gateway の準備ができると、セッションが接続されます。"
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10859,9 +10839,14 @@
       "translated": "worktree で新規チャット"
     },
     {
-      "id": "native.apple.003b25ddafeb18e9",
-      "source": "Threads…",
-      "translated": "スレッド…"
+      "id": "native.apple.ce6ebe91fc597015",
+      "source": "New Session Options…",
+      "translated": "新規セッションのオプション…"
+    },
+    {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "セッション…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11024,14 +11009,14 @@
       "translated": "作成"
     },
     {
-      "id": "native.apple.31d5c7287cfb3abe",
-      "source": "Delete Thread?",
-      "translated": "スレッドを削除しますか？"
+      "id": "native.apple.f488b9caf6e51ac3",
+      "source": "Delete Session?",
+      "translated": "セッションを削除しますか？"
     },
     {
-      "id": "native.apple.d3395564809f1120",
-      "source": "Delete Thread",
-      "translated": "スレッドを削除"
+      "id": "native.apple.8634b17be9b111bc",
+      "source": "Delete Session",
+      "translated": "セッションを削除"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11039,9 +11024,9 @@
       "translated": "キャンセル"
     },
     {
-      "id": "native.apple.092659256d26cb03",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "この操作により、スレッドとその記録が完全に削除されます。"
+      "id": "native.apple.4a9568ac9b18d8d3",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "これにより、セッションとその文字起こしが完全に削除されます。"
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11069,9 +11054,9 @@
       "translated": "新規グループ"
     },
     {
-      "id": "native.apple.683032464c497bbd",
-      "source": "Rename Thread",
-      "translated": "スレッド名を変更"
+      "id": "native.apple.5bccdc23a1640895",
+      "source": "Rename Session",
+      "translated": "セッション名を変更"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11079,9 +11064,9 @@
       "translated": "グループ名"
     },
     {
-      "id": "native.apple.f887aa956588f237",
-      "source": "Thread name",
-      "translated": "スレッド名"
+      "id": "native.apple.af789b2d2fda0f67",
+      "source": "Session name",
+      "translated": "セッション名"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11119,14 +11104,14 @@
       "translated": "エージェント"
     },
     {
-      "id": "native.apple.7c8231b7b1ca480f",
-      "source": "Agent thread",
-      "translated": "エージェントスレッド"
+      "id": "native.apple.a3bde8045fe9224a",
+      "source": "Agent session",
+      "translated": "エージェントセッション"
     },
     {
-      "id": "native.apple.b3c553614f762a58",
-      "source": "Recent threads",
-      "translated": "最近のスレッド"
+      "id": "native.apple.27f775de30b37ff8",
+      "source": "Recent sessions",
+      "translated": "最近のセッション"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11134,9 +11119,9 @@
       "translated": "Gateway がオフラインです"
     },
     {
-      "id": "native.apple.5aa32afda85064ea",
-      "source": "No recent threads",
-      "translated": "最近のスレッドはありません"
+      "id": "native.apple.28c97cf23665ee01",
+      "source": "No recent sessions",
+      "translated": "最近のセッションはありません"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11234,14 +11219,14 @@
       "translated": "キャンセル"
     },
     {
-      "id": "native.apple.b6855cf19a50f477",
-      "source": "Threads",
-      "translated": "スレッド"
+      "id": "native.apple.9f2fd65953013b7c",
+      "source": "Sessions",
+      "translated": "セッション"
     },
     {
-      "id": "native.apple.9b1d0ef27a1333b0",
-      "source": "Archived threads",
-      "translated": "アーカイブ済みのスレッド"
+      "id": "native.apple.0422818cc95d5071",
+      "source": "Archived sessions",
+      "translated": "アーカイブ済みセッション"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11249,34 +11234,34 @@
       "translated": "アーカイブを表示"
     },
     {
-      "id": "native.apple.98167401c7267735",
-      "source": "Threads unavailable",
-      "translated": "スレッドを利用できません"
+      "id": "native.apple.b272115c83f7ef58",
+      "source": "Sessions unavailable",
+      "translated": "セッションを利用できません"
     },
     {
-      "id": "native.apple.4d28a7def2337b9f",
-      "source": "Loading archived threads",
-      "translated": "アーカイブ済みのスレッドを読み込んでいます"
+      "id": "native.apple.54f8260c9b863087",
+      "source": "Loading archived sessions",
+      "translated": "アーカイブ済みセッションを読み込み中"
     },
     {
-      "id": "native.apple.777d7b706933bd7b",
-      "source": "Loading recent threads",
-      "translated": "最近のスレッドを読み込んでいます"
+      "id": "native.apple.9b305868873dade2",
+      "source": "Loading recent sessions",
+      "translated": "最近のセッションを読み込み中"
     },
     {
-      "id": "native.apple.22f81ea94bef8410",
-      "source": "^[\\(count) thread](inflect: true)",
-      "translated": "^[\\(count)件のスレッド](inflect: true)"
+      "id": "native.apple.207dad20d09f3160",
+      "source": "^[\\(count) session](inflect: true)",
+      "translated": "^[\\(count)件のセッション](inflect: true)"
     },
     {
-      "id": "native.apple.1cad51e14db59bf9",
-      "source": "No archived threads",
-      "translated": "アーカイブ済みのスレッドはありません"
+      "id": "native.apple.1f4501a6bf2bae4c",
+      "source": "No archived sessions",
+      "translated": "アーカイブ済みセッションはありません"
     },
     {
-      "id": "native.apple.18ef832d3a7ddcf8",
-      "source": "Archived threads will appear here.",
-      "translated": "アーカイブ済みのスレッドがここに表示されます。"
+      "id": "native.apple.2a1ba7a5e1979c9e",
+      "source": "Archived sessions will appear here.",
+      "translated": "アーカイブされたセッションはここに表示されます。"
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11359,9 +11344,9 @@
       "translated": "共有取り込み"
     },
     {
-      "id": "native.apple.21d9208d86a4d1fe",
-      "source": "Loading threads",
-      "translated": "スレッドを読み込み中"
+      "id": "native.apple.2360d25fe6ae9946",
+      "source": "Loading sessions",
+      "translated": "セッションを読み込み中"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11369,19 +11354,19 @@
       "translated": "Gatewayから最近のアクティビティを取得しています。"
     },
     {
-      "id": "native.apple.4be1f79aa2b230ff",
-      "source": "Threads unavailable",
-      "translated": "スレッドを利用できません"
+      "id": "native.apple.c334f2e86702a7b8",
+      "source": "Sessions unavailable",
+      "translated": "セッションを利用できません"
     },
     {
-      "id": "native.apple.98b348873556bc46",
-      "source": "No recent threads",
-      "translated": "最近のスレッドはありません"
+      "id": "native.apple.6cc6efb7a03960b6",
+      "source": "No recent sessions",
+      "translated": "最近のセッションはありません"
     },
     {
-      "id": "native.apple.7396d205574d279f",
-      "source": "Thread activity offline",
-      "translated": "スレッドのアクティビティはオフラインです"
+      "id": "native.apple.08483af2d043bee6",
+      "source": "Session activity offline",
+      "translated": "セッションアクティビティはオフラインです"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11839,9 +11824,9 @@
       "translated": "カード"
     },
     {
-      "id": "native.apple.c9ec1b0e18074d8a",
-      "source": "Open Thread",
-      "translated": "スレッドを開く"
+      "id": "native.apple.93eeaedb2ff61043",
+      "source": "Open Session",
+      "translated": "セッションを開く"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13329,9 +13314,9 @@
       "translated": "デフォルト"
     },
     {
-      "id": "native.apple.f4ae5664c3eda95d",
-      "source": "Used for new Chat threads and Talk sessions.",
-      "translated": "新しいチャットスレッドとトークセッションに使用されます。"
+      "id": "native.apple.3de045f17ea3c6d0",
+      "source": "Used for new Chat and Talk sessions.",
+      "translated": "新しいChatおよびTalkセッションに使用されます。"
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15734,9 +15719,9 @@
       "translated": "インスタンス"
     },
     {
-      "id": "native.apple.11fe8b9941954dfb",
-      "source": "Threads",
-      "translated": "スレッド"
+      "id": "native.apple.3579cf2750470a22",
+      "source": "Sessions",
+      "translated": "セッション"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19044,9 +19029,9 @@
       "translated": "クイックチャットのショートカット"
     },
     {
-      "id": "native.apple.94dd793cd7d7d555",
-      "source": "Global shortcut that opens a floating chat bar for the main thread.",
-      "translated": "メインスレッドのフローティングチャットバーを開くグローバルショートカットです。"
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "メインセッション用のフローティングチャットバーを開くグローバルショートカット。"
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19624,9 +19609,9 @@
       "translated": "Critical"
     },
     {
-      "id": "native.apple.13f96467014cf344",
-      "source": "New Thread",
-      "translated": "新しいスレッド"
+      "id": "native.apple.75102378a6775180",
+      "source": "New Session",
+      "translated": "新規セッション"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21914,9 +21899,9 @@
       "translated": "最近のメッセージはありません"
     },
     {
-      "id": "native.apple.3ec2afcbc298c673",
-      "source": "Threads",
-      "translated": "スレッド"
+      "id": "native.apple.1ff8aec0044934c3",
+      "source": "Sessions",
+      "translated": "セッション"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21924,9 +21909,9 @@
       "translated": "CLI がコンテキストとレート制限に再利用する保存済みの会話バケットを確認します。"
     },
     {
-      "id": "native.apple.14ccb32cd8ed1c81",
-      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
-      "translated": "まだスレッドはありません。最初の受信メッセージまたはハートビートの後に表示されます。"
+      "id": "native.apple.bab897f3252b134c",
+      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
+      "translated": "まだセッションはありません。最初の受信メッセージまたはハートビートの後に表示されます。"
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -22009,9 +21994,9 @@
       "translated": "実行の承認"
     },
     {
-      "id": "native.apple.52e37e3a44ae516c",
-      "source": "Threads",
-      "translated": "スレッド"
+      "id": "native.apple.64a6dc7d49e8fb57",
+      "source": "Sessions",
+      "translated": "セッション"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -23014,9 +22999,9 @@
       "translated": "最新情報を教えて"
     },
     {
-      "id": "native.apple.fc4ce810900ec0b6",
-      "source": "Summarize what happened in my threads since yesterday.",
-      "translated": "昨日以降にスレッドで起きたことを要約してください。"
+      "id": "native.apple.234ec45f4231edc4",
+      "source": "Summarize what happened in my sessions since yesterday.",
+      "translated": "昨日以降、セッションで何が起きたか要約してください。"
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23194,9 +23179,9 @@
       "translated": "モデルのピン留めを解除"
     },
     {
-      "id": "native.apple.4edb66657f5aca1f",
-      "source": "Thread",
-      "translated": "スレッド"
+      "id": "native.apple.5dfc0700d8dff8de",
+      "source": "Session",
+      "translated": "セッション"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23359,51 +23344,6 @@
       "translated": "ウィジェットを利用できません"
     },
     {
-      "id": "native.apple.d640691fd196f338",
-      "source": "Widget export failed",
-      "translated": "ウィジェットの書き出しに失敗しました"
-    },
-    {
-      "id": "native.apple.533c6e22a11e88de",
-      "source": "OK",
-      "translated": "OK"
-    },
-    {
-      "id": "native.apple.e1fb28a2a9756402",
-      "source": "Copy image",
-      "translated": "画像をコピー"
-    },
-    {
-      "id": "native.apple.ebd7bc92e1b12235",
-      "source": "Save image…",
-      "translated": "画像を保存…"
-    },
-    {
-      "id": "native.apple.742c46d4cf2db134",
-      "source": "Save image",
-      "translated": "画像を保存"
-    },
-    {
-      "id": "native.apple.0589cce608418f90",
-      "source": "The widget image could not be captured.",
-      "translated": "ウィジェットの画像をキャプチャできませんでした。"
-    },
-    {
-      "id": "native.apple.dfe24e827fdbe9c5",
-      "source": "The widget image could not be copied.",
-      "translated": "ウィジェットの画像をコピーできませんでした。"
-    },
-    {
-      "id": "native.apple.9e611e3a80e71408",
-      "source": "The widget image could not be encoded as PNG.",
-      "translated": "ウィジェットの画像をPNG形式でエンコードできませんでした。"
-    },
-    {
-      "id": "native.apple.9a6e8afbe24a262b",
-      "source": "The widget image could not be saved.",
-      "translated": "ウィジェットの画像を保存できませんでした。"
-    },
-    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23544,19 +23484,19 @@
       "translated": "ユーザー"
     },
     {
-      "id": "native.apple.9d0cba09d92ee669",
-      "source": "This thread cannot be archived while it is active or running.",
-      "translated": "このスレッドはアクティブまたは実行中のため、アーカイブできません。"
+      "id": "native.apple.b1cdcb906a43d5d6",
+      "source": "This session cannot be archived while it is active or running.",
+      "translated": "このセッションは、アクティブまたは実行中のためアーカイブできません。"
     },
     {
-      "id": "native.apple.8952a111a1075051",
-      "source": "The main thread cannot be deleted.",
-      "translated": "メインスレッドは削除できません。"
+      "id": "native.apple.5817e3f3dab1ee19",
+      "source": "The main session cannot be deleted.",
+      "translated": "メインセッションは削除できません。"
     },
     {
-      "id": "native.apple.90d0ccf80ca28717",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
-      "translated": "このスレッドをアーカイブまたは削除する前に、添付ファイルを削除するか、配信が完了するまでお待ちください。"
+      "id": "native.apple.a6b8df3f18171c91",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
+      "translated": "このセッションをアーカイブまたは削除する前に、添付ファイルを削除するか、配信が完了するまでお待ちください。"
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23694,9 +23634,9 @@
       "translated": "実行終了"
     },
     {
-      "id": "native.apple.bbccb4c8db5cac12",
-      "source": "Thread Info",
-      "translated": "スレッド情報"
+      "id": "native.apple.cd7c3095a22f80a9",
+      "source": "Session Info",
+      "translated": "セッション情報"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23729,9 +23669,9 @@
       "translated": "グループを追加"
     },
     {
-      "id": "native.apple.7b641fed5bace855",
-      "source": "Thread Groups",
-      "translated": "スレッドグループ"
+      "id": "native.apple.23d628606fe0734f",
+      "source": "Session Groups",
+      "translated": "セッショングループ"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23774,9 +23714,9 @@
       "translated": "グループを削除"
     },
     {
-      "id": "native.apple.56401c79410a310d",
-      "source": "Threads in this group become ungrouped.",
-      "translated": "このグループ内のスレッドはグループ化が解除されます。"
+      "id": "native.apple.b049c8a4d2805e08",
+      "source": "Sessions in this group become ungrouped.",
+      "translated": "このグループ内のセッションはグループ化されていない状態になります。"
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23789,9 +23729,9 @@
       "translated": "このGatewayでは利用可能なエージェントがありません。"
     },
     {
-      "id": "native.apple.2d96aa7d3d12f85b",
-      "source": "New Thread Options",
-      "translated": "新しいスレッドのオプション"
+      "id": "native.apple.6c89f35d53506406",
+      "source": "New Session Options",
+      "translated": "新規セッションのオプション"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23819,19 +23759,19 @@
       "translated": "作成"
     },
     {
-      "id": "native.apple.87ef57319d1ddc85",
-      "source": "The thread could not be created.",
-      "translated": "スレッドを作成できませんでした。"
+      "id": "native.apple.795ba37f6782cf28",
+      "source": "The session could not be created.",
+      "translated": "セッションを作成できませんでした。"
     },
     {
-      "id": "native.apple.6bd91c435b69d638",
-      "source": "Search threads",
-      "translated": "スレッドを検索"
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "セッションを検索"
     },
     {
-      "id": "native.apple.6fde4bdf9d5b9191",
-      "source": "No Threads",
-      "translated": "スレッドはありません"
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "セッションがありません"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23839,29 +23779,29 @@
       "translated": "結果がありません"
     },
     {
-      "id": "native.apple.a02fd99740d29bd3",
-      "source": "New Thread",
-      "translated": "新規スレッド"
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "新規セッション"
     },
     {
-      "id": "native.apple.b625801dd04b09f2",
-      "source": "New thread",
-      "translated": "新規スレッド"
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "新規セッション"
     },
     {
-      "id": "native.apple.851be81fcc933608",
-      "source": "New thread options",
-      "translated": "新規スレッドのオプション"
+      "id": "native.apple.2ef0e34db02ad255",
+      "source": "New session options",
+      "translated": "新規セッションのオプション"
     },
     {
-      "id": "native.apple.9ce8a4aba7b444b2",
-      "source": "Rename Thread",
-      "translated": "スレッド名を変更"
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "セッション名を変更"
     },
     {
-      "id": "native.apple.1dd067c44511c7f0",
-      "source": "Thread name",
-      "translated": "スレッド名"
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "セッション名"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23874,14 +23814,14 @@
       "translated": "キャンセル"
     },
     {
-      "id": "native.apple.618073d6ab3f2721",
-      "source": "Delete Thread",
-      "translated": "スレッドを削除"
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "セッションを削除"
     },
     {
-      "id": "native.apple.10a5e72bba3cbccc",
-      "source": "The thread and its transcript are removed from the gateway.",
-      "translated": "スレッドとそのトランスクリプトがGatewayから削除されます。"
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "セッションとそのトランスクリプトがGatewayから削除されます。"
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23889,14 +23829,14 @@
       "translated": "「%@」を削除しますか？"
     },
     {
-      "id": "native.apple.ac71e3b2aa496a2c",
-      "source": "Thread running",
-      "translated": "スレッドを実行中"
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "セッションを実行中"
     },
     {
-      "id": "native.apple.c775e87f997278b2",
-      "source": "Thread failed",
-      "translated": "スレッドに失敗しました"
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "セッションに失敗しました"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23954,9 +23894,9 @@
       "translated": "セッションキーをコピー"
     },
     {
-      "id": "native.apple.f4998cfb572f23ff",
-      "source": "Delete Thread…",
-      "translated": "スレッドを削除…"
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "セッションを削除…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23969,9 +23909,9 @@
       "translated": "接続中…"
     },
     {
-      "id": "native.apple.8802e9576ffd0f65",
-      "source": "Retry thread groups",
-      "translated": "スレッドグループを再試行"
+      "id": "native.apple.79f708b3bc1d3a6c",
+      "source": "Retry session groups",
+      "translated": "セッショングループを再試行"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23994,24 +23934,24 @@
       "translated": "スコープ"
     },
     {
-      "id": "native.apple.b313b80def4bda52",
-      "source": "Search threads",
-      "translated": "スレッドを検索"
+      "id": "native.apple.2c37581c7b88f741",
+      "source": "Search sessions",
+      "translated": "セッションを検索"
     },
     {
-      "id": "native.apple.c0cc6acc36f413ce",
-      "source": "Threads",
-      "translated": "スレッド"
+      "id": "native.apple.43be8a2336e42faf",
+      "source": "Sessions",
+      "translated": "セッション"
     },
     {
-      "id": "native.apple.854d3928fe5a557c",
-      "source": "Rename Thread",
-      "translated": "スレッド名を変更"
+      "id": "native.apple.0b379cdfcbd3247f",
+      "source": "Rename Session",
+      "translated": "セッション名を変更"
     },
     {
-      "id": "native.apple.9d0d3f20096cc4da",
-      "source": "Thread name",
-      "translated": "スレッド名"
+      "id": "native.apple.54b6fbd9e41db009",
+      "source": "Session name",
+      "translated": "セッション名"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -24019,19 +23959,19 @@
       "translated": "キャンセル"
     },
     {
-      "id": "native.apple.dc00eb94f33bae15",
-      "source": "Delete selected threads?",
-      "translated": "選択したスレッドを削除しますか？"
+      "id": "native.apple.751e0f6b81cd374a",
+      "source": "Delete selected sessions?",
+      "translated": "選択したセッションを削除しますか？"
     },
     {
-      "id": "native.apple.2053fc9f74dc3158",
-      "source": "Delete Threads",
-      "translated": "スレッドを削除"
+      "id": "native.apple.aa679276581b0058",
+      "source": "Delete Sessions",
+      "translated": "セッションを削除"
     },
     {
-      "id": "native.apple.0970247871a834a0",
-      "source": "Each selected thread and its transcript will be removed from the gateway.",
-      "translated": "選択した各スレッドとそのトランスクリプトがGatewayから削除されます。"
+      "id": "native.apple.f837129cbee23297",
+      "source": "Each selected session and its transcript will be removed from the gateway.",
+      "translated": "選択した各セッションとそのトランスクリプトがGatewayから削除されます。"
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -24039,9 +23979,9 @@
       "translated": "グループ"
     },
     {
-      "id": "native.apple.6f8acab2256728b5",
-      "source": "Manage thread groups",
-      "translated": "スレッドグループを管理"
+      "id": "native.apple.64013cfee5e25305",
+      "source": "Manage session groups",
+      "translated": "セッショングループを管理"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -24054,14 +23994,14 @@
       "translated": "選択"
     },
     {
-      "id": "native.apple.692972314d04b184",
-      "source": "No archived threads",
-      "translated": "アーカイブ済みのスレッドはありません"
+      "id": "native.apple.b67eaecec1b423ac",
+      "source": "No archived sessions",
+      "translated": "アーカイブされたセッションはありません"
     },
     {
-      "id": "native.apple.d6a4b5711dcd26e7",
-      "source": "No threads found",
-      "translated": "スレッドが見つかりません"
+      "id": "native.apple.b2435a79abf0c794",
+      "source": "No sessions found",
+      "translated": "セッションが見つかりません"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24229,16 +24169,6 @@
       "translated": "メッセージ全文を開く"
     },
     {
-      "id": "native.apple.002bfcede229ad4b",
-      "source": "Rewind to Here",
-      "translated": "ここまで巻き戻す"
-    },
-    {
-      "id": "native.apple.14df2e4997689fb3",
-      "source": "Fork from Here",
-      "translated": "ここから分岐"
-    },
-    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "返信"
@@ -24324,9 +24254,9 @@
       "translated": "新しいチャットを開始する前に、添付ファイルを削除するか、配信が完了するまでお待ちください。"
     },
     {
-      "id": "native.apple.e0f045151c8d3137",
-      "source": "Gateway changed before the thread operation started.",
-      "translated": "スレッド操作の開始前にGatewayが変更されました。"
+      "id": "native.apple.980f552bb0f96c0f",
+      "source": "Gateway changed before the session operation started.",
+      "translated": "セッション操作を開始する前にGatewayが変更されました。"
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24334,9 +24264,9 @@
       "translated": "チャットを切り替える前に、添付ファイルを削除するか送信が完了するのを待ってください。"
     },
     {
-      "id": "native.apple.0a5c4e15466c3acc",
-      "source": "Clear this thread's history?",
-      "translated": "このスレッドの履歴を消去しますか？"
+      "id": "native.apple.87ba543b42696b92",
+      "source": "Clear this session's history?",
+      "translated": "このセッションの履歴を消去しますか？"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24349,14 +24279,14 @@
       "translated": "%@の会話がリセットされます。セッションキーは変更されません。"
     },
     {
-      "id": "native.apple.67ac221dbe7179f0",
-      "source": "Rename Thread",
-      "translated": "スレッド名を変更"
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "セッション名を変更"
     },
     {
-      "id": "native.apple.cf0f7e049603f518",
-      "source": "Thread name",
-      "translated": "スレッド名"
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "セッション名"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24374,9 +24304,9 @@
       "translated": "トランスクリプトをエクスポート"
     },
     {
-      "id": "native.apple.c0ada47504425f23",
-      "source": "Threads",
-      "translated": "スレッド"
+      "id": "native.apple.4af0f566d39d7041",
+      "source": "Sessions",
+      "translated": "セッション"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24449,14 +24379,14 @@
       "translated": "デフォルト"
     },
     {
-      "id": "native.apple.1a765291943599e5",
-      "source": "New Thread",
-      "translated": "新規スレッド"
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "新規セッション"
     },
     {
-      "id": "native.apple.c7a3a6d5e43dd98f",
-      "source": "New Thread Options…",
-      "translated": "新規スレッドのオプション…"
+      "id": "native.apple.a7119fbf9d25df5e",
+      "source": "New Session Options…",
+      "translated": "新規セッションのオプション…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24464,19 +24394,19 @@
       "translated": "更新"
     },
     {
-      "id": "native.apple.0e710b81808e5dcf",
-      "source": "Threads…",
-      "translated": "スレッド…"
+      "id": "native.apple.2bcff4a8fa503739",
+      "source": "Sessions…",
+      "translated": "セッション…"
     },
     {
-      "id": "native.apple.faad8f92b6bef166",
-      "source": "Rename Thread…",
-      "translated": "スレッド名を変更…"
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "セッション名を変更…"
     },
     {
-      "id": "native.apple.23b61d6cd26ac112",
-      "source": "Fork",
-      "translated": "フォーク"
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "セッションをフォーク"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24534,24 +24464,24 @@
       "translated": "履歴を消去…"
     },
     {
-      "id": "native.apple.8b4f1c5107ea8a0e",
-      "source": "Thread",
-      "translated": "スレッド"
+      "id": "native.apple.920fe8a7a33f9e92",
+      "source": "Session",
+      "translated": "セッション"
     },
     {
-      "id": "native.apple.4d7750c9bf699469",
-      "source": "Thread actions",
-      "translated": "スレッドの操作"
+      "id": "native.apple.185a401f78328b0f",
+      "source": "Session actions",
+      "translated": "セッション操作"
     },
     {
-      "id": "native.apple.bb2f22cc43c97f8e",
-      "source": "Thread cost %@",
-      "translated": "スレッドのコスト %@"
+      "id": "native.apple.9f9dedf599b2619b",
+      "source": "Session cost %@",
+      "translated": "セッションコスト：%@"
     },
     {
-      "id": "native.apple.6239ced0b86e86f8",
-      "source": "Compact Thread",
-      "translated": "スレッドを圧縮"
+      "id": "native.apple.f0a4720df5f5f403",
+      "source": "Compact Session",
+      "translated": "セッションを圧縮"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -1429,9 +1429,9 @@
       "translated": "OpenClaw로 대화하거나 받아쓰기"
     },
     {
-      "id": "native.android.e2cf5a38587382cb",
-      "source": "Browse Threads",
-      "translated": "스레드 찾아보기"
+      "id": "native.android.5876e15e5e92fd45",
+      "source": "Browse Sessions",
+      "translated": "세션 둘러보기"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "작업을 찾을 수 없음"
     },
     {
-      "id": "native.android.bc70a4ac965b82ba",
-      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
-      "translated": "채팅, 음성, 스레드, 제공업체 또는 설정을 사용해 보세요."
+      "id": "native.android.48ad0ae0e930e02b",
+      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
+      "translated": "Chat, Voice, Sessions, Providers 또는 Settings를 사용해 보세요."
     },
     {
-      "id": "native.android.670121e54dbe286f",
-      "source": "Threads",
-      "translated": "스레드"
+      "id": "native.android.d4fbd1ee4f55a5db",
+      "source": "Sessions",
+      "translated": "세션"
     },
     {
-      "id": "native.android.d38be650b1bce4a0",
-      "source": "Connect the Gateway to search threads.",
-      "translated": "스레드를 검색하려면 Gateway를 연결하세요."
+      "id": "native.android.207c2170504e99e6",
+      "source": "Connect the Gateway to search sessions.",
+      "translated": "세션을 검색하려면 Gateway를 연결하세요."
     },
     {
-      "id": "native.android.3d7754721f776ef8",
-      "source": "No matching threads yet.",
-      "translated": "아직 일치하는 스레드가 없습니다."
+      "id": "native.android.25d2c2d792c952fe",
+      "source": "No matching sessions yet.",
+      "translated": "일치하는 세션이 아직 없습니다."
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "어시스턴트 작업 중"
     },
     {
-      "id": "native.android.9a839f6e3e05a744",
-      "source": "OpenClaw thread",
-      "translated": "OpenClaw 스레드"
+      "id": "native.android.8f8384286317f5c9",
+      "source": "OpenClaw session",
+      "translated": "OpenClaw 세션"
     },
     {
-      "id": "native.android.d83f82a1e4a5ed99",
-      "source": "Open thread",
-      "translated": "스레드 열기"
+      "id": "native.android.15799e57704b20c6",
+      "source": "Open session",
+      "translated": "세션 열기"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "준비된 제공자가 없습니다"
     },
     {
-      "id": "native.android.8a1c5365c0538908",
-      "source": "Main thread",
-      "translated": "기본 스레드"
+      "id": "native.android.73e6ab1a168fd381",
+      "source": "Main session",
+      "translated": "기본 세션"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.a5845742daecb4ba",
-      "source": "Threads",
-      "translated": "스레드"
+      "id": "native.android.0e3157c15c56944f",
+      "source": "Sessions",
+      "translated": "세션"
     },
     {
-      "id": "native.android.439b324280869527",
-      "source": "Focus thread search",
-      "translated": "스레드 검색에 포커스"
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "세션 검색에 포커스"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "보관됨"
     },
     {
-      "id": "native.android.03981341841b04ac",
-      "source": "Search threads",
-      "translated": "스레드 검색"
+      "id": "native.android.b9cf34c137e4cf03",
+      "source": "Search sessions",
+      "translated": "세션 검색"
     },
     {
-      "id": "native.android.99570c528a41fa72",
-      "source": "Clear thread search",
-      "translated": "스레드 검색 지우기"
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "세션 검색 지우기"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "오래된순"
     },
     {
-      "id": "native.android.fd67be543e321cc9",
-      "source": "Toggle thread layout",
-      "translated": "스레드 레이아웃 전환"
+      "id": "native.android.c6bf8751e2a7f5c7",
+      "source": "Toggle session layout",
+      "translated": "세션 레이아웃 전환"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "레이아웃: 자세히"
     },
     {
-      "id": "native.android.ebd17565e0ffd8eb",
-      "source": "Searching threads",
-      "translated": "스레드 검색 중"
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "세션 검색 중"
     },
     {
-      "id": "native.android.472d46ae8669f860",
-      "source": "No matching threads",
-      "translated": "일치하는 스레드 없음"
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "일치하는 세션 없음"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "채팅 시작"
     },
     {
-      "id": "native.android.ff81ad1bee00d384",
-      "source": "Current thread",
-      "translated": "현재 스레드"
+      "id": "native.android.f10d4df7cbc6df4f",
+      "source": "Current session",
+      "translated": "현재 세션"
     },
     {
-      "id": "native.android.fc145645b9620e57",
-      "source": "OpenClaw thread",
-      "translated": "OpenClaw 스레드"
+      "id": "native.android.8f0482425838ae64",
+      "source": "OpenClaw session",
+      "translated": "OpenClaw 세션"
     },
     {
-      "id": "native.android.71cbb8dde8bf138b",
-      "source": "Rename thread",
-      "translated": "스레드 이름 변경"
+      "id": "native.android.786774c8a76e50d7",
+      "source": "Rename session",
+      "translated": "세션 이름 바꾸기"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "그룹을 삭제하시겠습니까?"
     },
     {
-      "id": "native.android.691e92cfe5cf106e",
-      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "\"$group\"의 스레드는 유지되며 그룹 없음으로 다시 이동됩니다."
+      "id": "native.android.3455fc2f77d564e3",
+      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "\"$group\"의 세션은 유지되며 그룹 해제로 다시 이동합니다."
     },
     {
-      "id": "native.android.d87a8217ab56999b",
-      "source": "Delete thread?",
-      "translated": "스레드를 삭제하시겠습니까?"
+      "id": "native.android.4805fb9d6623e8c0",
+      "source": "Delete session?",
+      "translated": "세션을 삭제할까요?"
     },
     {
-      "id": "native.android.930de97ff47113a8",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "스레드와 대화 기록이 영구적으로 삭제됩니다."
+      "id": "native.android.0c3283a2b2445eae",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "세션과 해당 대화 기록이 영구적으로 삭제됩니다."
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "그룹 없음"
     },
     {
-      "id": "native.android.8e21a70428def6e0",
-      "source": "No threads yet",
-      "translated": "아직 스레드가 없습니다"
+      "id": "native.android.db243d71d056afa4",
+      "source": "No sessions yet",
+      "translated": "아직 세션 없음"
     },
     {
-      "id": "native.android.cda4c5ad8b17e394",
-      "source": "No current thread",
-      "translated": "현재 스레드가 없습니다"
+      "id": "native.android.5b4eee6a8092925e",
+      "source": "No current session",
+      "translated": "현재 세션 없음"
     },
     {
-      "id": "native.android.be84f061047aa2da",
-      "source": "No archived threads",
-      "translated": "보관된 스레드가 없습니다"
+      "id": "native.android.acbcc9c9ea53d8c0",
+      "source": "No archived sessions",
+      "translated": "보관된 세션 없음"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "새 대화를 시작하면 여기에 표시됩니다."
     },
     {
-      "id": "native.android.f289d03e1d3eee98",
-      "source": "Open Chat to start or resume the current thread.",
-      "translated": "Chat을 열어 현재 스레드를 시작하거나 재개하세요."
+      "id": "native.android.56fcd605dc7be3c0",
+      "source": "Open Chat to start or resume the current session.",
+      "translated": "채팅을 열어 현재 세션을 시작하거나 재개하세요."
     },
     {
-      "id": "native.android.504b71386e76c6ae",
-      "source": "Archived threads will show up here.",
-      "translated": "보관된 스레드가 여기에 표시됩니다."
+      "id": "native.android.085515989f8a2022",
+      "source": "Archived sessions will show up here.",
+      "translated": "보관된 세션이 여기에 표시됩니다."
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days}일"
     },
     {
-      "id": "native.android.ee4c727cdafbe963",
-      "source": "Main thread",
-      "translated": "기본 스레드"
+      "id": "native.android.3d4fa07acbc015c5",
+      "source": "Main session",
+      "translated": "기본 세션"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway 대기 중"
     },
     {
-      "id": "native.android.da78209effb11cfd",
-      "source": "Thread Activity",
-      "translated": "스레드 활동"
+      "id": "native.android.2d8d049afe99f751",
+      "source": "Session Activity",
+      "translated": "세션 활동"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "이 휴대폰이 연결되어 있는 동안 Exec 승인 요청이 여기에 표시됩니다."
     },
     {
-      "id": "native.android.f615712dfb56319a",
-      "source": "Thread activity",
-      "translated": "스레드 활동"
+      "id": "native.android.dc3e7ca5a491103a",
+      "source": "Session activity",
+      "translated": "세션 활동"
     },
     {
-      "id": "native.android.6c93973c13db43ae",
-      "source": "Chat tool calls waiting in the active thread remain visible here.",
-      "translated": "활성 스레드에서 대기 중인 Chat 도구 호출이 여기에 계속 표시됩니다."
+      "id": "native.android.8551e02b060bd7d8",
+      "source": "Chat tool calls waiting in the active session remain visible here.",
+      "translated": "활성 세션에서 대기 중인 채팅 도구 호출은 여기에 계속 표시됩니다."
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,11 +4294,6 @@
       "translated": "Talk Provider 설정"
     },
     {
-      "id": "native.android.23b638094c34b916",
-      "source": "Microphone",
-      "translated": "마이크"
-    },
-    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "오디오 테스트"
@@ -4342,66 +4337,6 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "완료"
-    },
-    {
-      "id": "native.android.8d9ecdfdd916b780",
-      "source": "Automatic",
-      "translated": "자동"
-    },
-    {
-      "id": "native.android.c1626a6700a570f6",
-      "source": "Preferred microphone unavailable; using automatic routing.",
-      "translated": "선호하는 마이크를 사용할 수 없어 자동 라우팅을 사용합니다."
-    },
-    {
-      "id": "native.android.820bc5d0ce571d8b",
-      "source": "Prioritizes connected Bluetooth microphones.",
-      "translated": "연결된 Bluetooth 마이크를 우선 사용합니다."
-    },
-    {
-      "id": "native.android.11e48038d5e8bff6",
-      "source": "Preferred microphone",
-      "translated": "선호하는 마이크"
-    },
-    {
-      "id": "native.android.eaa4d7563a46d307",
-      "source": "Unavailable",
-      "translated": "사용할 수 없음"
-    },
-    {
-      "id": "native.android.9f5ebf17eb405ba8",
-      "source": "Next session",
-      "translated": "다음 세션"
-    },
-    {
-      "id": "native.android.8c4e91f53928efb2",
-      "source": "Built-in microphone",
-      "translated": "내장 마이크"
-    },
-    {
-      "id": "native.android.14b613cb6e2446b4",
-      "source": "Bluetooth microphone",
-      "translated": "Bluetooth 마이크"
-    },
-    {
-      "id": "native.android.c885247b2d7ce271",
-      "source": "Bluetooth LE microphone",
-      "translated": "Bluetooth LE 마이크"
-    },
-    {
-      "id": "native.android.b6a4e674c5fb441a",
-      "source": "Wired headset microphone",
-      "translated": "유선 헤드셋 마이크"
-    },
-    {
-      "id": "native.android.9c8becb3b0fb5a90",
-      "source": "USB microphone",
-      "translated": "USB 마이크"
-    },
-    {
-      "id": "native.android.ba46258fadec7a39",
-      "source": "External microphone",
-      "translated": "외부 마이크"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5139,9 +5074,9 @@
       "translated": "확인"
     },
     {
-      "id": "native.android.c971506716c96e91",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
-      "translated": "OpenClaw는 이 휴대전화를 스레드, 음성, 제공업체 및 Gateway를 위한 깔끔한 모바일 명령 인터페이스로 바꿔 줍니다."
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw는 이 휴대전화를 세션, 음성, 제공업체 및 Gateway를 위한 깔끔한 모바일 명령 인터페이스로 전환합니다."
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5689,9 +5624,9 @@
       "translated": "Talk 설정"
     },
     {
-      "id": "native.android.36f78c8c85dc283f",
-      "source": "Recent Threads",
-      "translated": "최근 스레드"
+      "id": "native.android.73f07a5d54915259",
+      "source": "Recent Sessions",
+      "translated": "최근 세션"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5749,14 +5684,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% 온라인"
     },
     {
-      "id": "native.android.57177017a6a93826",
-      "source": "Threads",
-      "translated": "스레드"
+      "id": "native.android.16c3425d3a594481",
+      "source": "Sessions",
+      "translated": "세션"
     },
     {
-      "id": "native.android.43320b54a68b00a1",
-      "source": "No recent threads",
-      "translated": "최근 스레드가 없습니다"
+      "id": "native.android.a5c0f8b3112aa58c",
+      "source": "No recent sessions",
+      "translated": "최근 세션 없음"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5794,14 +5729,14 @@
       "translated": "작업 중 · 활성 실행 $pendingRunCount개"
     },
     {
-      "id": "native.android.e24db059480f1e6a",
-      "source": "Monitoring · 1 thread",
-      "translated": "모니터링 · 스레드 1개"
+      "id": "native.android.2c89da708b12a522",
+      "source": "Monitoring · 1 session",
+      "translated": "모니터링 중 · 세션 1개"
     },
     {
-      "id": "native.android.5a475f37d80e02bc",
-      "source": "Monitoring · $sessionCount threads",
-      "translated": "모니터링 · 스레드 $sessionCount개"
+      "id": "native.android.8b6ee382dcb64e1f",
+      "source": "Monitoring · $sessionCount sessions",
+      "translated": "모니터링 중 · 세션 $sessionCount개"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5834,9 +5769,9 @@
       "translated": "제공자"
     },
     {
-      "id": "native.android.358c5e0e838d5423",
-      "source": "Open thread",
-      "translated": "스레드 열기"
+      "id": "native.android.a65477861c7203aa",
+      "source": "Open session",
+      "translated": "세션 열기"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6259,9 +6194,9 @@
       "translated": "${days}일"
     },
     {
-      "id": "native.android.28a1a1acc5a0959f",
-      "source": "Main thread",
-      "translated": "기본 스레드"
+      "id": "native.android.22d755834386db07",
+      "source": "Main session",
+      "translated": "기본 세션"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6942,16 +6877,6 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "음소거 해제"
-    },
-    {
-      "id": "native.android.cb608d82c5b3352a",
-      "source": "Back camera",
-      "translated": "후면 카메라"
-    },
-    {
-      "id": "native.android.e89a0e780eed2e1e",
-      "source": "Front camera",
-      "translated": "전면 카메라"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7759,9 +7684,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.0c74bc30a994dd33",
-      "source": "Loading thread",
-      "translated": "스레드 불러오는 중"
+      "id": "native.android.882cc14a58e7e105",
+      "source": "Loading session",
+      "translated": "세션 로드 중"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7804,14 +7729,14 @@
       "translated": "최근 내용 확인"
     },
     {
-      "id": "native.android.cf40df9739f78f27",
-      "source": "Summarize recent threads and next steps.",
-      "translated": "최근 스레드와 다음 단계를 요약하세요."
+      "id": "native.android.1e5add56e48c99f9",
+      "source": "Summarize recent sessions and next steps.",
+      "translated": "최근 세션과 다음 단계를 요약합니다."
     },
     {
-      "id": "native.android.ebe49a8b8df80bd3",
-      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
-      "translated": "최근 OpenClaw 스레드의 내용을 요약하고 다음 단계를 제안해 주세요."
+      "id": "native.android.06d515351bb79576",
+      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
+      "translated": "최근 OpenClaw 세션의 내용을 요약하고 다음 단계를 제안해 주세요."
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8149,9 +8074,9 @@
       "translated": "연결됨"
     },
     {
-      "id": "native.android.6cf5d6fa8a4186d5",
-      "source": "Threads",
-      "translated": "스레드"
+      "id": "native.android.81931886b9caf3ab",
+      "source": "Sessions",
+      "translated": "세션"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,6 +10719,61 @@
       "translated": "작업 세부 정보"
     },
     {
+      "id": "native.apple.29cacb53ea5e77fc",
+      "source": "Pinned",
+      "translated": "고정됨"
+    },
+    {
+      "id": "native.apple.940062cfdce9211b",
+      "source": "Recent",
+      "translated": "최근"
+    },
+    {
+      "id": "native.apple.a0980128426308a9",
+      "source": "Model",
+      "translated": "모델"
+    },
+    {
+      "id": "native.apple.9520e60f21535dde",
+      "source": "Thinking",
+      "translated": "사고"
+    },
+    {
+      "id": "native.apple.8b321f3ffce97429",
+      "source": "Fast",
+      "translated": "빠르게"
+    },
+    {
+      "id": "native.apple.989b70d64e328d55",
+      "source": "Default (inherited)",
+      "translated": "기본값(상속됨)"
+    },
+    {
+      "id": "native.apple.f4114e73b07eb9ae",
+      "source": "Off",
+      "translated": "끔"
+    },
+    {
+      "id": "native.apple.7ed231b28d16312f",
+      "source": "On",
+      "translated": "켬"
+    },
+    {
+      "id": "native.apple.412a74802320a037",
+      "source": "Full",
+      "translated": "전체"
+    },
+    {
+      "id": "native.apple.299f21a2071ff9fc",
+      "source": "Verbosity",
+      "translated": "상세도"
+    },
+    {
+      "id": "native.apple.faf0ef05e1496de7",
+      "source": "Default",
+      "translated": "기본값"
+    },
+    {
       "id": "native.apple.e5524d5756a62744",
       "source": "Unable to Export Transcript",
       "translated": "대화 기록을 내보낼 수 없음"
@@ -10814,9 +10794,9 @@
       "translated": "무엇을 작업하시겠어요?"
     },
     {
-      "id": "native.apple.4da775013ac9b123",
-      "source": "The thread attaches once the gateway is ready.",
-      "translated": "Gateway가 준비되면 스레드가 연결됩니다."
+      "id": "native.apple.32179ce0b6d4543f",
+      "source": "The session attaches once the gateway is ready.",
+      "translated": "Gateway가 준비되면 세션이 연결됩니다."
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10859,9 +10839,14 @@
       "translated": "Worktree에서 새 채팅"
     },
     {
-      "id": "native.apple.003b25ddafeb18e9",
-      "source": "Threads…",
-      "translated": "스레드…"
+      "id": "native.apple.ce6ebe91fc597015",
+      "source": "New Session Options…",
+      "translated": "새 세션 옵션…"
+    },
+    {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "세션…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11024,14 +11009,14 @@
       "translated": "생성"
     },
     {
-      "id": "native.apple.31d5c7287cfb3abe",
-      "source": "Delete Thread?",
-      "translated": "스레드를 삭제하시겠습니까?"
+      "id": "native.apple.f488b9caf6e51ac3",
+      "source": "Delete Session?",
+      "translated": "세션을 삭제하시겠습니까?"
     },
     {
-      "id": "native.apple.d3395564809f1120",
-      "source": "Delete Thread",
-      "translated": "스레드 삭제"
+      "id": "native.apple.8634b17be9b111bc",
+      "source": "Delete Session",
+      "translated": "세션 삭제"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11039,9 +11024,9 @@
       "translated": "취소"
     },
     {
-      "id": "native.apple.092659256d26cb03",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "이 작업을 수행하면 스레드와 대화 기록이 영구적으로 삭제됩니다."
+      "id": "native.apple.4a9568ac9b18d8d3",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "이 작업은 세션과 해당 대화 기록을 영구적으로 삭제합니다."
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11069,9 +11054,9 @@
       "translated": "새 그룹"
     },
     {
-      "id": "native.apple.683032464c497bbd",
-      "source": "Rename Thread",
-      "translated": "스레드 이름 변경"
+      "id": "native.apple.5bccdc23a1640895",
+      "source": "Rename Session",
+      "translated": "세션 이름 변경"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11079,9 +11064,9 @@
       "translated": "그룹 이름"
     },
     {
-      "id": "native.apple.f887aa956588f237",
-      "source": "Thread name",
-      "translated": "스레드 이름"
+      "id": "native.apple.af789b2d2fda0f67",
+      "source": "Session name",
+      "translated": "세션 이름"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11119,14 +11104,14 @@
       "translated": "에이전트"
     },
     {
-      "id": "native.apple.7c8231b7b1ca480f",
-      "source": "Agent thread",
-      "translated": "에이전트 스레드"
+      "id": "native.apple.a3bde8045fe9224a",
+      "source": "Agent session",
+      "translated": "에이전트 세션"
     },
     {
-      "id": "native.apple.b3c553614f762a58",
-      "source": "Recent threads",
-      "translated": "최근 스레드"
+      "id": "native.apple.27f775de30b37ff8",
+      "source": "Recent sessions",
+      "translated": "최근 세션"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11134,9 +11119,9 @@
       "translated": "Gateway 오프라인"
     },
     {
-      "id": "native.apple.5aa32afda85064ea",
-      "source": "No recent threads",
-      "translated": "최근 스레드 없음"
+      "id": "native.apple.28c97cf23665ee01",
+      "source": "No recent sessions",
+      "translated": "최근 세션 없음"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11234,14 +11219,14 @@
       "translated": "취소"
     },
     {
-      "id": "native.apple.b6855cf19a50f477",
-      "source": "Threads",
-      "translated": "스레드"
+      "id": "native.apple.9f2fd65953013b7c",
+      "source": "Sessions",
+      "translated": "세션"
     },
     {
-      "id": "native.apple.9b1d0ef27a1333b0",
-      "source": "Archived threads",
-      "translated": "보관된 스레드"
+      "id": "native.apple.0422818cc95d5071",
+      "source": "Archived sessions",
+      "translated": "보관된 세션"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11249,34 +11234,34 @@
       "translated": "보관 항목 표시"
     },
     {
-      "id": "native.apple.98167401c7267735",
-      "source": "Threads unavailable",
-      "translated": "스레드를 사용할 수 없음"
+      "id": "native.apple.b272115c83f7ef58",
+      "source": "Sessions unavailable",
+      "translated": "세션을 사용할 수 없음"
     },
     {
-      "id": "native.apple.4d28a7def2337b9f",
-      "source": "Loading archived threads",
-      "translated": "보관된 스레드 불러오는 중"
+      "id": "native.apple.54f8260c9b863087",
+      "source": "Loading archived sessions",
+      "translated": "보관된 세션 불러오는 중"
     },
     {
-      "id": "native.apple.777d7b706933bd7b",
-      "source": "Loading recent threads",
-      "translated": "최근 스레드 불러오는 중"
+      "id": "native.apple.9b305868873dade2",
+      "source": "Loading recent sessions",
+      "translated": "최근 세션 불러오는 중"
     },
     {
-      "id": "native.apple.22f81ea94bef8410",
-      "source": "^[\\(count) thread](inflect: true)",
-      "translated": "^[\\(count)개 스레드](inflect: true)"
+      "id": "native.apple.207dad20d09f3160",
+      "source": "^[\\(count) session](inflect: true)",
+      "translated": "^[\\(count)개 세션](inflect: true)"
     },
     {
-      "id": "native.apple.1cad51e14db59bf9",
-      "source": "No archived threads",
-      "translated": "보관된 스레드 없음"
+      "id": "native.apple.1f4501a6bf2bae4c",
+      "source": "No archived sessions",
+      "translated": "보관된 세션 없음"
     },
     {
-      "id": "native.apple.18ef832d3a7ddcf8",
-      "source": "Archived threads will appear here.",
-      "translated": "보관된 스레드가 여기에 표시됩니다."
+      "id": "native.apple.2a1ba7a5e1979c9e",
+      "source": "Archived sessions will appear here.",
+      "translated": "보관된 세션이 여기에 표시됩니다."
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11359,9 +11344,9 @@
       "translated": "공유 인테이크"
     },
     {
-      "id": "native.apple.21d9208d86a4d1fe",
-      "source": "Loading threads",
-      "translated": "스레드 로드 중"
+      "id": "native.apple.2360d25fe6ae9946",
+      "source": "Loading sessions",
+      "translated": "세션 로드 중"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11369,19 +11354,19 @@
       "translated": "Gateway에서 최근 활동을 가져오는 중입니다."
     },
     {
-      "id": "native.apple.4be1f79aa2b230ff",
-      "source": "Threads unavailable",
-      "translated": "스레드를 사용할 수 없음"
+      "id": "native.apple.c334f2e86702a7b8",
+      "source": "Sessions unavailable",
+      "translated": "세션을 사용할 수 없음"
     },
     {
-      "id": "native.apple.98b348873556bc46",
-      "source": "No recent threads",
-      "translated": "최근 스레드 없음"
+      "id": "native.apple.6cc6efb7a03960b6",
+      "source": "No recent sessions",
+      "translated": "최근 세션 없음"
     },
     {
-      "id": "native.apple.7396d205574d279f",
-      "source": "Thread activity offline",
-      "translated": "스레드 활동 오프라인"
+      "id": "native.apple.08483af2d043bee6",
+      "source": "Session activity offline",
+      "translated": "세션 활동 오프라인"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11839,9 +11824,9 @@
       "translated": "카드"
     },
     {
-      "id": "native.apple.c9ec1b0e18074d8a",
-      "source": "Open Thread",
-      "translated": "스레드 열기"
+      "id": "native.apple.93eeaedb2ff61043",
+      "source": "Open Session",
+      "translated": "세션 열기"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13329,9 +13314,9 @@
       "translated": "기본값"
     },
     {
-      "id": "native.apple.f4ae5664c3eda95d",
-      "source": "Used for new Chat threads and Talk sessions.",
-      "translated": "새 채팅 스레드 및 대화 세션에 사용됩니다."
+      "id": "native.apple.3de045f17ea3c6d0",
+      "source": "Used for new Chat and Talk sessions.",
+      "translated": "새 Chat 및 Talk 세션에 사용됩니다."
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15734,9 +15719,9 @@
       "translated": "인스턴스"
     },
     {
-      "id": "native.apple.11fe8b9941954dfb",
-      "source": "Threads",
-      "translated": "스레드"
+      "id": "native.apple.3579cf2750470a22",
+      "source": "Sessions",
+      "translated": "세션"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19044,9 +19029,9 @@
       "translated": "빠른 채팅 단축키"
     },
     {
-      "id": "native.apple.94dd793cd7d7d555",
-      "source": "Global shortcut that opens a floating chat bar for the main thread.",
-      "translated": "메인 스레드의 플로팅 채팅 바를 여는 전역 단축키입니다."
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "기본 세션의 플로팅 채팅 바를 여는 전역 단축키입니다."
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19624,9 +19609,9 @@
       "translated": "심각"
     },
     {
-      "id": "native.apple.13f96467014cf344",
-      "source": "New Thread",
-      "translated": "새 스레드"
+      "id": "native.apple.75102378a6775180",
+      "source": "New Session",
+      "translated": "새 세션"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21914,9 +21899,9 @@
       "translated": "최근 메시지 없음"
     },
     {
-      "id": "native.apple.3ec2afcbc298c673",
-      "source": "Threads",
-      "translated": "스레드"
+      "id": "native.apple.1ff8aec0044934c3",
+      "source": "Sessions",
+      "translated": "세션"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21924,9 +21909,9 @@
       "translated": "CLI가 컨텍스트와 속도 제한에 재사용하는 저장된 대화 버킷을 살펴봅니다."
     },
     {
-      "id": "native.apple.14ccb32cd8ed1c81",
-      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
-      "translated": "아직 스레드가 없습니다. 첫 수신 메시지 또는 하트비트 이후에 표시됩니다."
+      "id": "native.apple.bab897f3252b134c",
+      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
+      "translated": "아직 세션이 없습니다. 첫 인바운드 메시지 또는 하트비트 이후 표시됩니다."
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -22009,9 +21994,9 @@
       "translated": "실행 승인"
     },
     {
-      "id": "native.apple.52e37e3a44ae516c",
-      "source": "Threads",
-      "translated": "스레드"
+      "id": "native.apple.64a6dc7d49e8fb57",
+      "source": "Sessions",
+      "translated": "세션"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -23014,9 +22999,9 @@
       "translated": "최근 상황 알려주기"
     },
     {
-      "id": "native.apple.fc4ce810900ec0b6",
-      "source": "Summarize what happened in my threads since yesterday.",
-      "translated": "어제 이후 내 스레드에서 일어난 일을 요약해 주세요."
+      "id": "native.apple.234ec45f4231edc4",
+      "source": "Summarize what happened in my sessions since yesterday.",
+      "translated": "어제 이후 내 세션에서 있었던 일을 요약해 주세요."
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23194,9 +23179,9 @@
       "translated": "모델 고정 해제"
     },
     {
-      "id": "native.apple.4edb66657f5aca1f",
-      "source": "Thread",
-      "translated": "스레드"
+      "id": "native.apple.5dfc0700d8dff8de",
+      "source": "Session",
+      "translated": "세션"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23359,51 +23344,6 @@
       "translated": "위젯을 사용할 수 없음"
     },
     {
-      "id": "native.apple.d640691fd196f338",
-      "source": "Widget export failed",
-      "translated": "위젯 내보내기에 실패했습니다"
-    },
-    {
-      "id": "native.apple.533c6e22a11e88de",
-      "source": "OK",
-      "translated": "확인"
-    },
-    {
-      "id": "native.apple.e1fb28a2a9756402",
-      "source": "Copy image",
-      "translated": "이미지 복사"
-    },
-    {
-      "id": "native.apple.ebd7bc92e1b12235",
-      "source": "Save image…",
-      "translated": "이미지 저장…"
-    },
-    {
-      "id": "native.apple.742c46d4cf2db134",
-      "source": "Save image",
-      "translated": "이미지 저장"
-    },
-    {
-      "id": "native.apple.0589cce608418f90",
-      "source": "The widget image could not be captured.",
-      "translated": "위젯 이미지를 캡처할 수 없습니다."
-    },
-    {
-      "id": "native.apple.dfe24e827fdbe9c5",
-      "source": "The widget image could not be copied.",
-      "translated": "위젯 이미지를 복사할 수 없습니다."
-    },
-    {
-      "id": "native.apple.9e611e3a80e71408",
-      "source": "The widget image could not be encoded as PNG.",
-      "translated": "위젯 이미지를 PNG로 인코딩할 수 없습니다."
-    },
-    {
-      "id": "native.apple.9a6e8afbe24a262b",
-      "source": "The widget image could not be saved.",
-      "translated": "위젯 이미지를 저장할 수 없습니다."
-    },
-    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23544,19 +23484,19 @@
       "translated": "사용자"
     },
     {
-      "id": "native.apple.9d0cba09d92ee669",
-      "source": "This thread cannot be archived while it is active or running.",
-      "translated": "활성 상태이거나 실행 중인 스레드는 보관할 수 없습니다."
+      "id": "native.apple.b1cdcb906a43d5d6",
+      "source": "This session cannot be archived while it is active or running.",
+      "translated": "이 세션은 활성 상태이거나 실행 중인 동안 보관할 수 없습니다."
     },
     {
-      "id": "native.apple.8952a111a1075051",
-      "source": "The main thread cannot be deleted.",
-      "translated": "메인 스레드는 삭제할 수 없습니다."
+      "id": "native.apple.5817e3f3dab1ee19",
+      "source": "The main session cannot be deleted.",
+      "translated": "기본 세션은 삭제할 수 없습니다."
     },
     {
-      "id": "native.apple.90d0ccf80ca28717",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
-      "translated": "이 스레드를 보관하거나 삭제하기 전에 첨부 파일을 제거하거나 전송이 완료될 때까지 기다리세요."
+      "id": "native.apple.a6b8df3f18171c91",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
+      "translated": "이 세션을 보관하거나 삭제하기 전에 첨부 파일을 제거하거나 전송이 완료될 때까지 기다리세요."
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23694,9 +23634,9 @@
       "translated": "실행 종료"
     },
     {
-      "id": "native.apple.bbccb4c8db5cac12",
-      "source": "Thread Info",
-      "translated": "스레드 정보"
+      "id": "native.apple.cd7c3095a22f80a9",
+      "source": "Session Info",
+      "translated": "세션 정보"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23729,9 +23669,9 @@
       "translated": "그룹 추가"
     },
     {
-      "id": "native.apple.7b641fed5bace855",
-      "source": "Thread Groups",
-      "translated": "스레드 그룹"
+      "id": "native.apple.23d628606fe0734f",
+      "source": "Session Groups",
+      "translated": "세션 그룹"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23774,9 +23714,9 @@
       "translated": "그룹 삭제"
     },
     {
-      "id": "native.apple.56401c79410a310d",
-      "source": "Threads in this group become ungrouped.",
-      "translated": "이 그룹의 스레드는 그룹에서 해제됩니다."
+      "id": "native.apple.b049c8a4d2805e08",
+      "source": "Sessions in this group become ungrouped.",
+      "translated": "이 그룹의 세션은 그룹에서 해제됩니다."
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23789,9 +23729,9 @@
       "translated": "이 Gateway에서 사용할 수 있는 에이전트가 없습니다."
     },
     {
-      "id": "native.apple.2d96aa7d3d12f85b",
-      "source": "New Thread Options",
-      "translated": "새 스레드 옵션"
+      "id": "native.apple.6c89f35d53506406",
+      "source": "New Session Options",
+      "translated": "새 세션 옵션"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23819,19 +23759,19 @@
       "translated": "생성"
     },
     {
-      "id": "native.apple.87ef57319d1ddc85",
-      "source": "The thread could not be created.",
-      "translated": "스레드를 생성할 수 없습니다."
+      "id": "native.apple.795ba37f6782cf28",
+      "source": "The session could not be created.",
+      "translated": "세션을 생성할 수 없습니다."
     },
     {
-      "id": "native.apple.6bd91c435b69d638",
-      "source": "Search threads",
-      "translated": "스레드 검색"
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "세션 검색"
     },
     {
-      "id": "native.apple.6fde4bdf9d5b9191",
-      "source": "No Threads",
-      "translated": "스레드 없음"
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "세션 없음"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23839,29 +23779,29 @@
       "translated": "결과 없음"
     },
     {
-      "id": "native.apple.a02fd99740d29bd3",
-      "source": "New Thread",
-      "translated": "새 스레드"
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "새 세션"
     },
     {
-      "id": "native.apple.b625801dd04b09f2",
-      "source": "New thread",
-      "translated": "새 스레드"
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "새 세션"
     },
     {
-      "id": "native.apple.851be81fcc933608",
-      "source": "New thread options",
-      "translated": "새 스레드 옵션"
+      "id": "native.apple.2ef0e34db02ad255",
+      "source": "New session options",
+      "translated": "새 세션 옵션"
     },
     {
-      "id": "native.apple.9ce8a4aba7b444b2",
-      "source": "Rename Thread",
-      "translated": "스레드 이름 변경"
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "세션 이름 변경"
     },
     {
-      "id": "native.apple.1dd067c44511c7f0",
-      "source": "Thread name",
-      "translated": "스레드 이름"
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "세션 이름"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23874,14 +23814,14 @@
       "translated": "취소"
     },
     {
-      "id": "native.apple.618073d6ab3f2721",
-      "source": "Delete Thread",
-      "translated": "스레드 삭제"
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "세션 삭제"
     },
     {
-      "id": "native.apple.10a5e72bba3cbccc",
-      "source": "The thread and its transcript are removed from the gateway.",
-      "translated": "스레드와 해당 대화 기록이 Gateway에서 제거됩니다."
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "세션과 해당 대화 기록이 Gateway에서 삭제됩니다."
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23889,14 +23829,14 @@
       "translated": "“%@”을(를) 삭제하시겠습니까?"
     },
     {
-      "id": "native.apple.ac71e3b2aa496a2c",
-      "source": "Thread running",
-      "translated": "스레드 실행 중"
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "세션 실행 중"
     },
     {
-      "id": "native.apple.c775e87f997278b2",
-      "source": "Thread failed",
-      "translated": "스레드 실패"
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "세션 실패"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23954,9 +23894,9 @@
       "translated": "세션 키 복사"
     },
     {
-      "id": "native.apple.f4998cfb572f23ff",
-      "source": "Delete Thread…",
-      "translated": "스레드 삭제…"
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "세션 삭제…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23969,9 +23909,9 @@
       "translated": "연결 중…"
     },
     {
-      "id": "native.apple.8802e9576ffd0f65",
-      "source": "Retry thread groups",
-      "translated": "스레드 그룹 다시 시도"
+      "id": "native.apple.79f708b3bc1d3a6c",
+      "source": "Retry session groups",
+      "translated": "세션 그룹 다시 시도"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23994,24 +23934,24 @@
       "translated": "범위"
     },
     {
-      "id": "native.apple.b313b80def4bda52",
-      "source": "Search threads",
-      "translated": "스레드 검색"
+      "id": "native.apple.2c37581c7b88f741",
+      "source": "Search sessions",
+      "translated": "세션 검색"
     },
     {
-      "id": "native.apple.c0cc6acc36f413ce",
-      "source": "Threads",
-      "translated": "스레드"
+      "id": "native.apple.43be8a2336e42faf",
+      "source": "Sessions",
+      "translated": "세션"
     },
     {
-      "id": "native.apple.854d3928fe5a557c",
-      "source": "Rename Thread",
-      "translated": "스레드 이름 변경"
+      "id": "native.apple.0b379cdfcbd3247f",
+      "source": "Rename Session",
+      "translated": "세션 이름 바꾸기"
     },
     {
-      "id": "native.apple.9d0d3f20096cc4da",
-      "source": "Thread name",
-      "translated": "스레드 이름"
+      "id": "native.apple.54b6fbd9e41db009",
+      "source": "Session name",
+      "translated": "세션 이름"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -24019,19 +23959,19 @@
       "translated": "취소"
     },
     {
-      "id": "native.apple.dc00eb94f33bae15",
-      "source": "Delete selected threads?",
-      "translated": "선택한 스레드를 삭제하시겠습니까?"
+      "id": "native.apple.751e0f6b81cd374a",
+      "source": "Delete selected sessions?",
+      "translated": "선택한 세션을 삭제하시겠습니까?"
     },
     {
-      "id": "native.apple.2053fc9f74dc3158",
-      "source": "Delete Threads",
-      "translated": "스레드 삭제"
+      "id": "native.apple.aa679276581b0058",
+      "source": "Delete Sessions",
+      "translated": "세션 삭제"
     },
     {
-      "id": "native.apple.0970247871a834a0",
-      "source": "Each selected thread and its transcript will be removed from the gateway.",
-      "translated": "선택한 각 스레드와 해당 대화 내용이 Gateway에서 제거됩니다."
+      "id": "native.apple.f837129cbee23297",
+      "source": "Each selected session and its transcript will be removed from the gateway.",
+      "translated": "선택한 각 세션과 해당 기록이 Gateway에서 삭제됩니다."
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -24039,9 +23979,9 @@
       "translated": "그룹"
     },
     {
-      "id": "native.apple.6f8acab2256728b5",
-      "source": "Manage thread groups",
-      "translated": "스레드 그룹 관리"
+      "id": "native.apple.64013cfee5e25305",
+      "source": "Manage session groups",
+      "translated": "세션 그룹 관리"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -24054,14 +23994,14 @@
       "translated": "선택"
     },
     {
-      "id": "native.apple.692972314d04b184",
-      "source": "No archived threads",
-      "translated": "보관된 스레드 없음"
+      "id": "native.apple.b67eaecec1b423ac",
+      "source": "No archived sessions",
+      "translated": "보관된 세션 없음"
     },
     {
-      "id": "native.apple.d6a4b5711dcd26e7",
-      "source": "No threads found",
-      "translated": "스레드를 찾을 수 없음"
+      "id": "native.apple.b2435a79abf0c794",
+      "source": "No sessions found",
+      "translated": "세션을 찾을 수 없음"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24229,16 +24169,6 @@
       "translated": "전체 메시지 열기"
     },
     {
-      "id": "native.apple.002bfcede229ad4b",
-      "source": "Rewind to Here",
-      "translated": "여기까지 되돌리기"
-    },
-    {
-      "id": "native.apple.14df2e4997689fb3",
-      "source": "Fork from Here",
-      "translated": "여기에서 분기하기"
-    },
-    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "답장"
@@ -24324,9 +24254,9 @@
       "translated": "새 채팅을 시작하기 전에 첨부 파일을 제거하거나 전송이 완료될 때까지 기다리세요."
     },
     {
-      "id": "native.apple.e0f045151c8d3137",
-      "source": "Gateway changed before the thread operation started.",
-      "translated": "스레드 작업이 시작되기 전에 Gateway가 변경되었습니다."
+      "id": "native.apple.980f552bb0f96c0f",
+      "source": "Gateway changed before the session operation started.",
+      "translated": "세션 작업이 시작되기 전에 Gateway가 변경되었습니다."
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24334,9 +24264,9 @@
       "translated": "채팅을 전환하기 전에 첨부 파일을 제거하거나 전송이 완료될 때까지 기다리세요."
     },
     {
-      "id": "native.apple.0a5c4e15466c3acc",
-      "source": "Clear this thread's history?",
-      "translated": "이 스레드의 기록을 지우시겠습니까?"
+      "id": "native.apple.87ba543b42696b92",
+      "source": "Clear this session's history?",
+      "translated": "이 세션의 기록을 지우시겠습니까?"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24349,14 +24279,14 @@
       "translated": "%@의 대화가 초기화됩니다. 세션 키는 그대로 유지됩니다."
     },
     {
-      "id": "native.apple.67ac221dbe7179f0",
-      "source": "Rename Thread",
-      "translated": "스레드 이름 변경"
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "세션 이름 변경"
     },
     {
-      "id": "native.apple.cf0f7e049603f518",
-      "source": "Thread name",
-      "translated": "스레드 이름"
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "세션 이름"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24374,9 +24304,9 @@
       "translated": "기록 내보내기"
     },
     {
-      "id": "native.apple.c0ada47504425f23",
-      "source": "Threads",
-      "translated": "스레드"
+      "id": "native.apple.4af0f566d39d7041",
+      "source": "Sessions",
+      "translated": "세션"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24449,14 +24379,14 @@
       "translated": "기본값"
     },
     {
-      "id": "native.apple.1a765291943599e5",
-      "source": "New Thread",
-      "translated": "새 스레드"
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "새 세션"
     },
     {
-      "id": "native.apple.c7a3a6d5e43dd98f",
-      "source": "New Thread Options…",
-      "translated": "새 스레드 옵션…"
+      "id": "native.apple.a7119fbf9d25df5e",
+      "source": "New Session Options…",
+      "translated": "새 세션 옵션…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24464,19 +24394,19 @@
       "translated": "새로 고침"
     },
     {
-      "id": "native.apple.0e710b81808e5dcf",
-      "source": "Threads…",
-      "translated": "스레드…"
+      "id": "native.apple.2bcff4a8fa503739",
+      "source": "Sessions…",
+      "translated": "세션…"
     },
     {
-      "id": "native.apple.faad8f92b6bef166",
-      "source": "Rename Thread…",
-      "translated": "스레드 이름 변경…"
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "세션 이름 변경…"
     },
     {
-      "id": "native.apple.23b61d6cd26ac112",
-      "source": "Fork",
-      "translated": "분기"
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "세션 포크"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24534,24 +24464,24 @@
       "translated": "기록 지우기…"
     },
     {
-      "id": "native.apple.8b4f1c5107ea8a0e",
-      "source": "Thread",
-      "translated": "스레드"
+      "id": "native.apple.920fe8a7a33f9e92",
+      "source": "Session",
+      "translated": "세션"
     },
     {
-      "id": "native.apple.4d7750c9bf699469",
-      "source": "Thread actions",
-      "translated": "스레드 작업"
+      "id": "native.apple.185a401f78328b0f",
+      "source": "Session actions",
+      "translated": "세션 작업"
     },
     {
-      "id": "native.apple.bb2f22cc43c97f8e",
-      "source": "Thread cost %@",
-      "translated": "스레드 비용 %@"
+      "id": "native.apple.9f9dedf599b2619b",
+      "source": "Session cost %@",
+      "translated": "세션 비용 %@"
     },
     {
-      "id": "native.apple.6239ced0b86e86f8",
-      "source": "Compact Thread",
-      "translated": "스레드 압축"
+      "id": "native.apple.f0a4720df5f5f403",
+      "source": "Compact Session",
+      "translated": "세션 압축"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -1429,9 +1429,9 @@
       "translated": "OpenClaw로 대화하거나 받아쓰기"
     },
     {
-      "id": "native.android.5876e15e5e92fd45",
-      "source": "Browse Sessions",
-      "translated": "세션 둘러보기"
+      "id": "native.android.e2cf5a38587382cb",
+      "source": "Browse Threads",
+      "translated": "스레드 탐색"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "작업을 찾을 수 없음"
     },
     {
-      "id": "native.android.48ad0ae0e930e02b",
-      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
-      "translated": "Chat, Voice, Sessions, Providers 또는 Settings를 사용해 보세요."
+      "id": "native.android.bc70a4ac965b82ba",
+      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
+      "translated": "채팅, 음성, 스레드, 제공업체 또는 설정을 사용해 보세요."
     },
     {
-      "id": "native.android.d4fbd1ee4f55a5db",
-      "source": "Sessions",
-      "translated": "세션"
+      "id": "native.android.670121e54dbe286f",
+      "source": "Threads",
+      "translated": "스레드"
     },
     {
-      "id": "native.android.207c2170504e99e6",
-      "source": "Connect the Gateway to search sessions.",
-      "translated": "세션을 검색하려면 Gateway를 연결하세요."
+      "id": "native.android.d38be650b1bce4a0",
+      "source": "Connect the Gateway to search threads.",
+      "translated": "스레드를 검색하려면 Gateway를 연결하세요."
     },
     {
-      "id": "native.android.25d2c2d792c952fe",
-      "source": "No matching sessions yet.",
-      "translated": "일치하는 세션이 아직 없습니다."
+      "id": "native.android.3d7754721f776ef8",
+      "source": "No matching threads yet.",
+      "translated": "아직 일치하는 스레드가 없습니다."
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "어시스턴트 작업 중"
     },
     {
-      "id": "native.android.8f8384286317f5c9",
-      "source": "OpenClaw session",
-      "translated": "OpenClaw 세션"
+      "id": "native.android.9a839f6e3e05a744",
+      "source": "OpenClaw thread",
+      "translated": "OpenClaw 스레드"
     },
     {
-      "id": "native.android.15799e57704b20c6",
-      "source": "Open session",
-      "translated": "세션 열기"
+      "id": "native.android.d83f82a1e4a5ed99",
+      "source": "Open thread",
+      "translated": "스레드 열기"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "준비된 제공자가 없습니다"
     },
     {
-      "id": "native.android.73e6ab1a168fd381",
-      "source": "Main session",
-      "translated": "기본 세션"
+      "id": "native.android.8a1c5365c0538908",
+      "source": "Main thread",
+      "translated": "기본 스레드"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.0e3157c15c56944f",
-      "source": "Sessions",
-      "translated": "세션"
+      "id": "native.android.a5845742daecb4ba",
+      "source": "Threads",
+      "translated": "스레드"
     },
     {
-      "id": "native.android.70f5d0507d34b5c8",
-      "source": "Focus session search",
-      "translated": "세션 검색에 포커스"
+      "id": "native.android.439b324280869527",
+      "source": "Focus thread search",
+      "translated": "스레드 검색에 포커스"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "보관됨"
     },
     {
-      "id": "native.android.b9cf34c137e4cf03",
-      "source": "Search sessions",
-      "translated": "세션 검색"
+      "id": "native.android.03981341841b04ac",
+      "source": "Search threads",
+      "translated": "스레드 검색"
     },
     {
-      "id": "native.android.10cb26723e9990fc",
-      "source": "Clear session search",
-      "translated": "세션 검색 지우기"
+      "id": "native.android.99570c528a41fa72",
+      "source": "Clear thread search",
+      "translated": "스레드 검색 지우기"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "오래된순"
     },
     {
-      "id": "native.android.c6bf8751e2a7f5c7",
-      "source": "Toggle session layout",
-      "translated": "세션 레이아웃 전환"
+      "id": "native.android.fd67be543e321cc9",
+      "source": "Toggle thread layout",
+      "translated": "스레드 레이아웃 전환"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "레이아웃: 자세히"
     },
     {
-      "id": "native.android.69b79a3c2c987cd4",
-      "source": "Searching sessions",
-      "translated": "세션 검색 중"
+      "id": "native.android.ebd17565e0ffd8eb",
+      "source": "Searching threads",
+      "translated": "스레드 검색 중"
     },
     {
-      "id": "native.android.dd587d341af44212",
-      "source": "No matching sessions",
-      "translated": "일치하는 세션 없음"
+      "id": "native.android.472d46ae8669f860",
+      "source": "No matching threads",
+      "translated": "일치하는 스레드 없음"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "채팅 시작"
     },
     {
-      "id": "native.android.f10d4df7cbc6df4f",
-      "source": "Current session",
-      "translated": "현재 세션"
+      "id": "native.android.ff81ad1bee00d384",
+      "source": "Current thread",
+      "translated": "현재 스레드"
     },
     {
-      "id": "native.android.8f0482425838ae64",
-      "source": "OpenClaw session",
-      "translated": "OpenClaw 세션"
+      "id": "native.android.fc145645b9620e57",
+      "source": "OpenClaw thread",
+      "translated": "OpenClaw 스레드"
     },
     {
-      "id": "native.android.786774c8a76e50d7",
-      "source": "Rename session",
-      "translated": "세션 이름 바꾸기"
+      "id": "native.android.71cbb8dde8bf138b",
+      "source": "Rename thread",
+      "translated": "스레드 이름 변경"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "그룹을 삭제하시겠습니까?"
     },
     {
-      "id": "native.android.3455fc2f77d564e3",
-      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "\"$group\"의 세션은 유지되며 그룹 해제로 다시 이동합니다."
+      "id": "native.android.691e92cfe5cf106e",
+      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "\"$group\"의 스레드는 유지되며 그룹 미지정으로 다시 이동합니다."
     },
     {
-      "id": "native.android.4805fb9d6623e8c0",
-      "source": "Delete session?",
-      "translated": "세션을 삭제할까요?"
+      "id": "native.android.d87a8217ab56999b",
+      "source": "Delete thread?",
+      "translated": "스레드를 삭제하시겠습니까?"
     },
     {
-      "id": "native.android.0c3283a2b2445eae",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "세션과 해당 대화 기록이 영구적으로 삭제됩니다."
+      "id": "native.android.930de97ff47113a8",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "이 작업은 스레드와 해당 대화 내용을 영구적으로 삭제합니다."
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "그룹 없음"
     },
     {
-      "id": "native.android.db243d71d056afa4",
-      "source": "No sessions yet",
-      "translated": "아직 세션 없음"
+      "id": "native.android.8e21a70428def6e0",
+      "source": "No threads yet",
+      "translated": "아직 스레드가 없습니다"
     },
     {
-      "id": "native.android.5b4eee6a8092925e",
-      "source": "No current session",
-      "translated": "현재 세션 없음"
+      "id": "native.android.cda4c5ad8b17e394",
+      "source": "No current thread",
+      "translated": "현재 스레드가 없습니다"
     },
     {
-      "id": "native.android.acbcc9c9ea53d8c0",
-      "source": "No archived sessions",
-      "translated": "보관된 세션 없음"
+      "id": "native.android.be84f061047aa2da",
+      "source": "No archived threads",
+      "translated": "보관된 스레드가 없습니다"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "새 대화를 시작하면 여기에 표시됩니다."
     },
     {
-      "id": "native.android.56fcd605dc7be3c0",
-      "source": "Open Chat to start or resume the current session.",
-      "translated": "채팅을 열어 현재 세션을 시작하거나 재개하세요."
+      "id": "native.android.f289d03e1d3eee98",
+      "source": "Open Chat to start or resume the current thread.",
+      "translated": "현재 스레드를 시작하거나 재개하려면 채팅을 여세요."
     },
     {
-      "id": "native.android.085515989f8a2022",
-      "source": "Archived sessions will show up here.",
-      "translated": "보관된 세션이 여기에 표시됩니다."
+      "id": "native.android.504b71386e76c6ae",
+      "source": "Archived threads will show up here.",
+      "translated": "보관된 스레드가 여기에 표시됩니다."
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days}일"
     },
     {
-      "id": "native.android.3d4fa07acbc015c5",
-      "source": "Main session",
-      "translated": "기본 세션"
+      "id": "native.android.ee4c727cdafbe963",
+      "source": "Main thread",
+      "translated": "메인 스레드"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway 대기 중"
     },
     {
-      "id": "native.android.2d8d049afe99f751",
-      "source": "Session Activity",
-      "translated": "세션 활동"
+      "id": "native.android.da78209effb11cfd",
+      "source": "Thread Activity",
+      "translated": "스레드 활동"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "이 휴대폰이 연결되어 있는 동안 Exec 승인 요청이 여기에 표시됩니다."
     },
     {
-      "id": "native.android.dc3e7ca5a491103a",
-      "source": "Session activity",
-      "translated": "세션 활동"
+      "id": "native.android.f615712dfb56319a",
+      "source": "Thread activity",
+      "translated": "스레드 활동"
     },
     {
-      "id": "native.android.8551e02b060bd7d8",
-      "source": "Chat tool calls waiting in the active session remain visible here.",
-      "translated": "활성 세션에서 대기 중인 채팅 도구 호출은 여기에 계속 표시됩니다."
+      "id": "native.android.6c93973c13db43ae",
+      "source": "Chat tool calls waiting in the active thread remain visible here.",
+      "translated": "활성 스레드에서 대기 중인 채팅 도구 호출이 여기에 계속 표시됩니다."
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,6 +4294,11 @@
       "translated": "Talk Provider 설정"
     },
     {
+      "id": "native.android.23b638094c34b916",
+      "source": "Microphone",
+      "translated": "마이크"
+    },
+    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "오디오 테스트"
@@ -4337,6 +4342,66 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "완료"
+    },
+    {
+      "id": "native.android.8d9ecdfdd916b780",
+      "source": "Automatic",
+      "translated": "자동"
+    },
+    {
+      "id": "native.android.c1626a6700a570f6",
+      "source": "Preferred microphone unavailable; using automatic routing.",
+      "translated": "선호하는 마이크를 사용할 수 없어 자동 라우팅을 사용합니다."
+    },
+    {
+      "id": "native.android.820bc5d0ce571d8b",
+      "source": "Prioritizes connected Bluetooth microphones.",
+      "translated": "연결된 Bluetooth 마이크를 우선 사용합니다."
+    },
+    {
+      "id": "native.android.11e48038d5e8bff6",
+      "source": "Preferred microphone",
+      "translated": "선호하는 마이크"
+    },
+    {
+      "id": "native.android.eaa4d7563a46d307",
+      "source": "Unavailable",
+      "translated": "사용할 수 없음"
+    },
+    {
+      "id": "native.android.9f5ebf17eb405ba8",
+      "source": "Next session",
+      "translated": "다음 세션"
+    },
+    {
+      "id": "native.android.8c4e91f53928efb2",
+      "source": "Built-in microphone",
+      "translated": "내장 마이크"
+    },
+    {
+      "id": "native.android.14b613cb6e2446b4",
+      "source": "Bluetooth microphone",
+      "translated": "Bluetooth 마이크"
+    },
+    {
+      "id": "native.android.c885247b2d7ce271",
+      "source": "Bluetooth LE microphone",
+      "translated": "Bluetooth LE 마이크"
+    },
+    {
+      "id": "native.android.b6a4e674c5fb441a",
+      "source": "Wired headset microphone",
+      "translated": "유선 헤드셋 마이크"
+    },
+    {
+      "id": "native.android.9c8becb3b0fb5a90",
+      "source": "USB microphone",
+      "translated": "USB 마이크"
+    },
+    {
+      "id": "native.android.ba46258fadec7a39",
+      "source": "External microphone",
+      "translated": "외부 마이크"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5074,9 +5139,9 @@
       "translated": "확인"
     },
     {
-      "id": "native.android.5a540761383fa474",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
-      "translated": "OpenClaw는 이 휴대전화를 세션, 음성, 제공업체 및 Gateway를 위한 깔끔한 모바일 명령 인터페이스로 전환합니다."
+      "id": "native.android.c971506716c96e91",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
+      "translated": "OpenClaw은 이 휴대전화를 스레드, 음성, 제공업체 및 Gateway를 위한 깔끔한 모바일 명령 인터페이스로 바꿔 줍니다."
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5624,9 +5689,9 @@
       "translated": "Talk 설정"
     },
     {
-      "id": "native.android.73f07a5d54915259",
-      "source": "Recent Sessions",
-      "translated": "최근 세션"
+      "id": "native.android.36f78c8c85dc283f",
+      "source": "Recent Threads",
+      "translated": "최근 스레드"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5684,14 +5749,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% 온라인"
     },
     {
-      "id": "native.android.16c3425d3a594481",
-      "source": "Sessions",
-      "translated": "세션"
+      "id": "native.android.57177017a6a93826",
+      "source": "Threads",
+      "translated": "스레드"
     },
     {
-      "id": "native.android.a5c0f8b3112aa58c",
-      "source": "No recent sessions",
-      "translated": "최근 세션 없음"
+      "id": "native.android.43320b54a68b00a1",
+      "source": "No recent threads",
+      "translated": "최근 스레드 없음"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5729,14 +5794,14 @@
       "translated": "작업 중 · 활성 실행 $pendingRunCount개"
     },
     {
-      "id": "native.android.2c89da708b12a522",
-      "source": "Monitoring · 1 session",
-      "translated": "모니터링 중 · 세션 1개"
+      "id": "native.android.e24db059480f1e6a",
+      "source": "Monitoring · 1 thread",
+      "translated": "모니터링 · 스레드 1개"
     },
     {
-      "id": "native.android.8b6ee382dcb64e1f",
-      "source": "Monitoring · $sessionCount sessions",
-      "translated": "모니터링 중 · 세션 $sessionCount개"
+      "id": "native.android.5a475f37d80e02bc",
+      "source": "Monitoring · $sessionCount threads",
+      "translated": "모니터링 · 스레드 $sessionCount개"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5769,9 +5834,9 @@
       "translated": "제공자"
     },
     {
-      "id": "native.android.a65477861c7203aa",
-      "source": "Open session",
-      "translated": "세션 열기"
+      "id": "native.android.358c5e0e838d5423",
+      "source": "Open thread",
+      "translated": "스레드 열기"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6194,9 +6259,9 @@
       "translated": "${days}일"
     },
     {
-      "id": "native.android.22d755834386db07",
-      "source": "Main session",
-      "translated": "기본 세션"
+      "id": "native.android.28a1a1acc5a0959f",
+      "source": "Main thread",
+      "translated": "기본 스레드"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6877,6 +6942,16 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "음소거 해제"
+    },
+    {
+      "id": "native.android.cb608d82c5b3352a",
+      "source": "Back camera",
+      "translated": "후면 카메라"
+    },
+    {
+      "id": "native.android.e89a0e780eed2e1e",
+      "source": "Front camera",
+      "translated": "전면 카메라"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7684,9 +7759,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.882cc14a58e7e105",
-      "source": "Loading session",
-      "translated": "세션 로드 중"
+      "id": "native.android.0c74bc30a994dd33",
+      "source": "Loading thread",
+      "translated": "스레드 불러오는 중"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7729,14 +7804,14 @@
       "translated": "최근 내용 확인"
     },
     {
-      "id": "native.android.1e5add56e48c99f9",
-      "source": "Summarize recent sessions and next steps.",
-      "translated": "최근 세션과 다음 단계를 요약합니다."
+      "id": "native.android.cf40df9739f78f27",
+      "source": "Summarize recent threads and next steps.",
+      "translated": "최근 스레드와 다음 단계를 요약해 주세요."
     },
     {
-      "id": "native.android.06d515351bb79576",
-      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
-      "translated": "최근 OpenClaw 세션의 내용을 요약하고 다음 단계를 제안해 주세요."
+      "id": "native.android.ebe49a8b8df80bd3",
+      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
+      "translated": "최근 OpenClaw 스레드의 내용을 알려 주고 다음 단계를 제안해 주세요."
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8074,9 +8149,9 @@
       "translated": "연결됨"
     },
     {
-      "id": "native.android.81931886b9caf3ab",
-      "source": "Sessions",
-      "translated": "세션"
+      "id": "native.android.6cf5d6fa8a4186d5",
+      "source": "Threads",
+      "translated": "스레드"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,9 +10869,9 @@
       "translated": "무엇을 작업하시겠어요?"
     },
     {
-      "id": "native.apple.32179ce0b6d4543f",
-      "source": "The session attaches once the gateway is ready.",
-      "translated": "Gateway가 준비되면 세션이 연결됩니다."
+      "id": "native.apple.4da775013ac9b123",
+      "source": "The thread attaches once the gateway is ready.",
+      "translated": "Gateway가 준비되면 스레드가 연결됩니다."
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10844,9 +10919,9 @@
       "translated": "새 세션 옵션…"
     },
     {
-      "id": "native.apple.a1b0d289758e2213",
-      "source": "Sessions…",
-      "translated": "세션…"
+      "id": "native.apple.003b25ddafeb18e9",
+      "source": "Threads…",
+      "translated": "스레드…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11009,14 +11084,14 @@
       "translated": "생성"
     },
     {
-      "id": "native.apple.f488b9caf6e51ac3",
-      "source": "Delete Session?",
-      "translated": "세션을 삭제하시겠습니까?"
+      "id": "native.apple.31d5c7287cfb3abe",
+      "source": "Delete Thread?",
+      "translated": "스레드를 삭제하시겠습니까?"
     },
     {
-      "id": "native.apple.8634b17be9b111bc",
-      "source": "Delete Session",
-      "translated": "세션 삭제"
+      "id": "native.apple.d3395564809f1120",
+      "source": "Delete Thread",
+      "translated": "스레드 삭제"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11024,9 +11099,9 @@
       "translated": "취소"
     },
     {
-      "id": "native.apple.4a9568ac9b18d8d3",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "이 작업은 세션과 해당 대화 기록을 영구적으로 삭제합니다."
+      "id": "native.apple.092659256d26cb03",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "스레드와 대화 기록이 영구적으로 삭제됩니다."
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11054,9 +11129,9 @@
       "translated": "새 그룹"
     },
     {
-      "id": "native.apple.5bccdc23a1640895",
-      "source": "Rename Session",
-      "translated": "세션 이름 변경"
+      "id": "native.apple.683032464c497bbd",
+      "source": "Rename Thread",
+      "translated": "스레드 이름 변경"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11064,9 +11139,9 @@
       "translated": "그룹 이름"
     },
     {
-      "id": "native.apple.af789b2d2fda0f67",
-      "source": "Session name",
-      "translated": "세션 이름"
+      "id": "native.apple.f887aa956588f237",
+      "source": "Thread name",
+      "translated": "스레드 이름"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11104,14 +11179,14 @@
       "translated": "에이전트"
     },
     {
-      "id": "native.apple.a3bde8045fe9224a",
-      "source": "Agent session",
-      "translated": "에이전트 세션"
+      "id": "native.apple.7c8231b7b1ca480f",
+      "source": "Agent thread",
+      "translated": "에이전트 스레드"
     },
     {
-      "id": "native.apple.27f775de30b37ff8",
-      "source": "Recent sessions",
-      "translated": "최근 세션"
+      "id": "native.apple.b3c553614f762a58",
+      "source": "Recent threads",
+      "translated": "최근 스레드"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11119,9 +11194,9 @@
       "translated": "Gateway 오프라인"
     },
     {
-      "id": "native.apple.28c97cf23665ee01",
-      "source": "No recent sessions",
-      "translated": "최근 세션 없음"
+      "id": "native.apple.5aa32afda85064ea",
+      "source": "No recent threads",
+      "translated": "최근 스레드 없음"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11219,14 +11294,14 @@
       "translated": "취소"
     },
     {
-      "id": "native.apple.9f2fd65953013b7c",
-      "source": "Sessions",
-      "translated": "세션"
+      "id": "native.apple.b6855cf19a50f477",
+      "source": "Threads",
+      "translated": "스레드"
     },
     {
-      "id": "native.apple.0422818cc95d5071",
-      "source": "Archived sessions",
-      "translated": "보관된 세션"
+      "id": "native.apple.9b1d0ef27a1333b0",
+      "source": "Archived threads",
+      "translated": "보관된 스레드"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11234,34 +11309,34 @@
       "translated": "보관 항목 표시"
     },
     {
-      "id": "native.apple.b272115c83f7ef58",
-      "source": "Sessions unavailable",
-      "translated": "세션을 사용할 수 없음"
+      "id": "native.apple.98167401c7267735",
+      "source": "Threads unavailable",
+      "translated": "스레드를 사용할 수 없음"
     },
     {
-      "id": "native.apple.54f8260c9b863087",
-      "source": "Loading archived sessions",
-      "translated": "보관된 세션 불러오는 중"
+      "id": "native.apple.4d28a7def2337b9f",
+      "source": "Loading archived threads",
+      "translated": "보관된 스레드 불러오는 중"
     },
     {
-      "id": "native.apple.9b305868873dade2",
-      "source": "Loading recent sessions",
-      "translated": "최근 세션 불러오는 중"
+      "id": "native.apple.777d7b706933bd7b",
+      "source": "Loading recent threads",
+      "translated": "최근 스레드 불러오는 중"
     },
     {
-      "id": "native.apple.207dad20d09f3160",
-      "source": "^[\\(count) session](inflect: true)",
-      "translated": "^[\\(count)개 세션](inflect: true)"
+      "id": "native.apple.22f81ea94bef8410",
+      "source": "^[\\(count) thread](inflect: true)",
+      "translated": "^[\\(count)개 스레드](inflect: true)"
     },
     {
-      "id": "native.apple.1f4501a6bf2bae4c",
-      "source": "No archived sessions",
-      "translated": "보관된 세션 없음"
+      "id": "native.apple.1cad51e14db59bf9",
+      "source": "No archived threads",
+      "translated": "보관된 스레드 없음"
     },
     {
-      "id": "native.apple.2a1ba7a5e1979c9e",
-      "source": "Archived sessions will appear here.",
-      "translated": "보관된 세션이 여기에 표시됩니다."
+      "id": "native.apple.18ef832d3a7ddcf8",
+      "source": "Archived threads will appear here.",
+      "translated": "보관된 스레드가 여기에 표시됩니다."
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11344,9 +11419,9 @@
       "translated": "공유 인테이크"
     },
     {
-      "id": "native.apple.2360d25fe6ae9946",
-      "source": "Loading sessions",
-      "translated": "세션 로드 중"
+      "id": "native.apple.21d9208d86a4d1fe",
+      "source": "Loading threads",
+      "translated": "스레드 불러오는 중"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11354,19 +11429,19 @@
       "translated": "Gateway에서 최근 활동을 가져오는 중입니다."
     },
     {
-      "id": "native.apple.c334f2e86702a7b8",
-      "source": "Sessions unavailable",
-      "translated": "세션을 사용할 수 없음"
+      "id": "native.apple.4be1f79aa2b230ff",
+      "source": "Threads unavailable",
+      "translated": "스레드를 사용할 수 없음"
     },
     {
-      "id": "native.apple.6cc6efb7a03960b6",
-      "source": "No recent sessions",
-      "translated": "최근 세션 없음"
+      "id": "native.apple.98b348873556bc46",
+      "source": "No recent threads",
+      "translated": "최근 스레드 없음"
     },
     {
-      "id": "native.apple.08483af2d043bee6",
-      "source": "Session activity offline",
-      "translated": "세션 활동 오프라인"
+      "id": "native.apple.7396d205574d279f",
+      "source": "Thread activity offline",
+      "translated": "스레드 활동 오프라인"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11824,9 +11899,9 @@
       "translated": "카드"
     },
     {
-      "id": "native.apple.93eeaedb2ff61043",
-      "source": "Open Session",
-      "translated": "세션 열기"
+      "id": "native.apple.c9ec1b0e18074d8a",
+      "source": "Open Thread",
+      "translated": "스레드 열기"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13314,9 +13389,9 @@
       "translated": "기본값"
     },
     {
-      "id": "native.apple.3de045f17ea3c6d0",
-      "source": "Used for new Chat and Talk sessions.",
-      "translated": "새 Chat 및 Talk 세션에 사용됩니다."
+      "id": "native.apple.f4ae5664c3eda95d",
+      "source": "Used for new Chat threads and Talk sessions.",
+      "translated": "새 채팅 스레드와 Talk 세션에 사용됩니다."
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15719,9 +15794,9 @@
       "translated": "인스턴스"
     },
     {
-      "id": "native.apple.3579cf2750470a22",
-      "source": "Sessions",
-      "translated": "세션"
+      "id": "native.apple.11fe8b9941954dfb",
+      "source": "Threads",
+      "translated": "스레드"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19029,9 +19104,9 @@
       "translated": "빠른 채팅 단축키"
     },
     {
-      "id": "native.apple.6ae77665b5f4490f",
-      "source": "Global shortcut that opens a floating chat bar for the main session.",
-      "translated": "기본 세션의 플로팅 채팅 바를 여는 전역 단축키입니다."
+      "id": "native.apple.94dd793cd7d7d555",
+      "source": "Global shortcut that opens a floating chat bar for the main thread.",
+      "translated": "메인 스레드의 플로팅 채팅 바를 여는 전역 단축키입니다."
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19609,9 +19684,9 @@
       "translated": "심각"
     },
     {
-      "id": "native.apple.75102378a6775180",
-      "source": "New Session",
-      "translated": "새 세션"
+      "id": "native.apple.13f96467014cf344",
+      "source": "New Thread",
+      "translated": "새 스레드"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21899,9 +21974,9 @@
       "translated": "최근 메시지 없음"
     },
     {
-      "id": "native.apple.1ff8aec0044934c3",
-      "source": "Sessions",
-      "translated": "세션"
+      "id": "native.apple.3ec2afcbc298c673",
+      "source": "Threads",
+      "translated": "스레드"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21909,9 +21984,9 @@
       "translated": "CLI가 컨텍스트와 속도 제한에 재사용하는 저장된 대화 버킷을 살펴봅니다."
     },
     {
-      "id": "native.apple.bab897f3252b134c",
-      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
-      "translated": "아직 세션이 없습니다. 첫 인바운드 메시지 또는 하트비트 이후 표시됩니다."
+      "id": "native.apple.14ccb32cd8ed1c81",
+      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
+      "translated": "아직 스레드가 없습니다. 첫 수신 메시지 또는 하트비트 이후에 표시됩니다."
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -21994,9 +22069,9 @@
       "translated": "실행 승인"
     },
     {
-      "id": "native.apple.64a6dc7d49e8fb57",
-      "source": "Sessions",
-      "translated": "세션"
+      "id": "native.apple.52e37e3a44ae516c",
+      "source": "Threads",
+      "translated": "스레드"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -22999,9 +23074,9 @@
       "translated": "최근 상황 알려주기"
     },
     {
-      "id": "native.apple.234ec45f4231edc4",
-      "source": "Summarize what happened in my sessions since yesterday.",
-      "translated": "어제 이후 내 세션에서 있었던 일을 요약해 주세요."
+      "id": "native.apple.fc4ce810900ec0b6",
+      "source": "Summarize what happened in my threads since yesterday.",
+      "translated": "어제 이후 내 스레드에서 있었던 일을 요약해 주세요."
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23179,9 +23254,9 @@
       "translated": "모델 고정 해제"
     },
     {
-      "id": "native.apple.5dfc0700d8dff8de",
-      "source": "Session",
-      "translated": "세션"
+      "id": "native.apple.4edb66657f5aca1f",
+      "source": "Thread",
+      "translated": "스레드"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23344,6 +23419,51 @@
       "translated": "위젯을 사용할 수 없음"
     },
     {
+      "id": "native.apple.d640691fd196f338",
+      "source": "Widget export failed",
+      "translated": "위젯 내보내기 실패"
+    },
+    {
+      "id": "native.apple.533c6e22a11e88de",
+      "source": "OK",
+      "translated": "확인"
+    },
+    {
+      "id": "native.apple.e1fb28a2a9756402",
+      "source": "Copy image",
+      "translated": "이미지 복사"
+    },
+    {
+      "id": "native.apple.ebd7bc92e1b12235",
+      "source": "Save image…",
+      "translated": "이미지 저장…"
+    },
+    {
+      "id": "native.apple.742c46d4cf2db134",
+      "source": "Save image",
+      "translated": "이미지 저장"
+    },
+    {
+      "id": "native.apple.0589cce608418f90",
+      "source": "The widget image could not be captured.",
+      "translated": "위젯 이미지를 캡처할 수 없습니다."
+    },
+    {
+      "id": "native.apple.dfe24e827fdbe9c5",
+      "source": "The widget image could not be copied.",
+      "translated": "위젯 이미지를 복사할 수 없습니다."
+    },
+    {
+      "id": "native.apple.9e611e3a80e71408",
+      "source": "The widget image could not be encoded as PNG.",
+      "translated": "위젯 이미지를 PNG로 인코딩할 수 없습니다."
+    },
+    {
+      "id": "native.apple.9a6e8afbe24a262b",
+      "source": "The widget image could not be saved.",
+      "translated": "위젯 이미지를 저장할 수 없습니다."
+    },
+    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23484,19 +23604,19 @@
       "translated": "사용자"
     },
     {
-      "id": "native.apple.b1cdcb906a43d5d6",
-      "source": "This session cannot be archived while it is active or running.",
-      "translated": "이 세션은 활성 상태이거나 실행 중인 동안 보관할 수 없습니다."
+      "id": "native.apple.9d0cba09d92ee669",
+      "source": "This thread cannot be archived while it is active or running.",
+      "translated": "이 스레드가 활성 상태이거나 실행 중인 동안에는 보관할 수 없습니다."
     },
     {
-      "id": "native.apple.5817e3f3dab1ee19",
-      "source": "The main session cannot be deleted.",
-      "translated": "기본 세션은 삭제할 수 없습니다."
+      "id": "native.apple.8952a111a1075051",
+      "source": "The main thread cannot be deleted.",
+      "translated": "메인 스레드는 삭제할 수 없습니다."
     },
     {
-      "id": "native.apple.a6b8df3f18171c91",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
-      "translated": "이 세션을 보관하거나 삭제하기 전에 첨부 파일을 제거하거나 전송이 완료될 때까지 기다리세요."
+      "id": "native.apple.90d0ccf80ca28717",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
+      "translated": "이 스레드를 보관하거나 삭제하기 전에 첨부 파일을 제거하거나 전송이 완료될 때까지 기다리세요."
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23634,9 +23754,9 @@
       "translated": "실행 종료"
     },
     {
-      "id": "native.apple.cd7c3095a22f80a9",
-      "source": "Session Info",
-      "translated": "세션 정보"
+      "id": "native.apple.bbccb4c8db5cac12",
+      "source": "Thread Info",
+      "translated": "스레드 정보"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23669,9 +23789,9 @@
       "translated": "그룹 추가"
     },
     {
-      "id": "native.apple.23d628606fe0734f",
-      "source": "Session Groups",
-      "translated": "세션 그룹"
+      "id": "native.apple.7b641fed5bace855",
+      "source": "Thread Groups",
+      "translated": "스레드 그룹"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23714,9 +23834,9 @@
       "translated": "그룹 삭제"
     },
     {
-      "id": "native.apple.b049c8a4d2805e08",
-      "source": "Sessions in this group become ungrouped.",
-      "translated": "이 그룹의 세션은 그룹에서 해제됩니다."
+      "id": "native.apple.56401c79410a310d",
+      "source": "Threads in this group become ungrouped.",
+      "translated": "이 그룹의 스레드는 그룹에서 해제됩니다."
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23729,9 +23849,9 @@
       "translated": "이 Gateway에서 사용할 수 있는 에이전트가 없습니다."
     },
     {
-      "id": "native.apple.6c89f35d53506406",
-      "source": "New Session Options",
-      "translated": "새 세션 옵션"
+      "id": "native.apple.2d96aa7d3d12f85b",
+      "source": "New Thread Options",
+      "translated": "새 스레드 옵션"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23759,19 +23879,19 @@
       "translated": "생성"
     },
     {
-      "id": "native.apple.795ba37f6782cf28",
-      "source": "The session could not be created.",
-      "translated": "세션을 생성할 수 없습니다."
+      "id": "native.apple.87ef57319d1ddc85",
+      "source": "The thread could not be created.",
+      "translated": "스레드를 생성할 수 없습니다."
     },
     {
-      "id": "native.apple.8ec708a3605a2cc3",
-      "source": "Search sessions",
-      "translated": "세션 검색"
+      "id": "native.apple.6bd91c435b69d638",
+      "source": "Search threads",
+      "translated": "스레드 검색"
     },
     {
-      "id": "native.apple.23b069b4e7f97039",
-      "source": "No Sessions",
-      "translated": "세션 없음"
+      "id": "native.apple.6fde4bdf9d5b9191",
+      "source": "No Threads",
+      "translated": "스레드 없음"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23779,29 +23899,29 @@
       "translated": "결과 없음"
     },
     {
-      "id": "native.apple.0058923f2ce8a3ec",
-      "source": "New Session",
-      "translated": "새 세션"
+      "id": "native.apple.a02fd99740d29bd3",
+      "source": "New Thread",
+      "translated": "새 스레드"
     },
     {
-      "id": "native.apple.66ba42960eb4135b",
-      "source": "New session",
-      "translated": "새 세션"
+      "id": "native.apple.b625801dd04b09f2",
+      "source": "New thread",
+      "translated": "새 스레드"
     },
     {
-      "id": "native.apple.2ef0e34db02ad255",
-      "source": "New session options",
-      "translated": "새 세션 옵션"
+      "id": "native.apple.851be81fcc933608",
+      "source": "New thread options",
+      "translated": "새 스레드 옵션"
     },
     {
-      "id": "native.apple.36753ef2f1ed4264",
-      "source": "Rename Session",
-      "translated": "세션 이름 변경"
+      "id": "native.apple.9ce8a4aba7b444b2",
+      "source": "Rename Thread",
+      "translated": "스레드 이름 변경"
     },
     {
-      "id": "native.apple.c9de0a1510ef475f",
-      "source": "Session name",
-      "translated": "세션 이름"
+      "id": "native.apple.1dd067c44511c7f0",
+      "source": "Thread name",
+      "translated": "스레드 이름"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23814,14 +23934,14 @@
       "translated": "취소"
     },
     {
-      "id": "native.apple.afb4e6c99c63a28d",
-      "source": "Delete Session",
-      "translated": "세션 삭제"
+      "id": "native.apple.618073d6ab3f2721",
+      "source": "Delete Thread",
+      "translated": "스레드 삭제"
     },
     {
-      "id": "native.apple.3d4ef32e42f136a4",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "세션과 해당 대화 기록이 Gateway에서 삭제됩니다."
+      "id": "native.apple.10a5e72bba3cbccc",
+      "source": "The thread and its transcript are removed from the gateway.",
+      "translated": "스레드와 대화 기록이 Gateway에서 삭제됩니다."
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23829,14 +23949,14 @@
       "translated": "“%@”을(를) 삭제하시겠습니까?"
     },
     {
-      "id": "native.apple.9a7dca238fba628d",
-      "source": "Session running",
-      "translated": "세션 실행 중"
+      "id": "native.apple.ac71e3b2aa496a2c",
+      "source": "Thread running",
+      "translated": "스레드 실행 중"
     },
     {
-      "id": "native.apple.fcfbfe5e97a95e9c",
-      "source": "Session failed",
-      "translated": "세션 실패"
+      "id": "native.apple.c775e87f997278b2",
+      "source": "Thread failed",
+      "translated": "스레드 실패"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23894,9 +24014,9 @@
       "translated": "세션 키 복사"
     },
     {
-      "id": "native.apple.4aeb7c14c26dabac",
-      "source": "Delete Session…",
-      "translated": "세션 삭제…"
+      "id": "native.apple.f4998cfb572f23ff",
+      "source": "Delete Thread…",
+      "translated": "스레드 삭제…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23909,9 +24029,9 @@
       "translated": "연결 중…"
     },
     {
-      "id": "native.apple.79f708b3bc1d3a6c",
-      "source": "Retry session groups",
-      "translated": "세션 그룹 다시 시도"
+      "id": "native.apple.8802e9576ffd0f65",
+      "source": "Retry thread groups",
+      "translated": "스레드 그룹 다시 시도"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23934,24 +24054,24 @@
       "translated": "범위"
     },
     {
-      "id": "native.apple.2c37581c7b88f741",
-      "source": "Search sessions",
-      "translated": "세션 검색"
+      "id": "native.apple.b313b80def4bda52",
+      "source": "Search threads",
+      "translated": "스레드 검색"
     },
     {
-      "id": "native.apple.43be8a2336e42faf",
-      "source": "Sessions",
-      "translated": "세션"
+      "id": "native.apple.c0cc6acc36f413ce",
+      "source": "Threads",
+      "translated": "스레드"
     },
     {
-      "id": "native.apple.0b379cdfcbd3247f",
-      "source": "Rename Session",
-      "translated": "세션 이름 바꾸기"
+      "id": "native.apple.854d3928fe5a557c",
+      "source": "Rename Thread",
+      "translated": "스레드 이름 변경"
     },
     {
-      "id": "native.apple.54b6fbd9e41db009",
-      "source": "Session name",
-      "translated": "세션 이름"
+      "id": "native.apple.9d0d3f20096cc4da",
+      "source": "Thread name",
+      "translated": "스레드 이름"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -23959,19 +24079,19 @@
       "translated": "취소"
     },
     {
-      "id": "native.apple.751e0f6b81cd374a",
-      "source": "Delete selected sessions?",
-      "translated": "선택한 세션을 삭제하시겠습니까?"
+      "id": "native.apple.dc00eb94f33bae15",
+      "source": "Delete selected threads?",
+      "translated": "선택한 스레드를 삭제하시겠습니까?"
     },
     {
-      "id": "native.apple.aa679276581b0058",
-      "source": "Delete Sessions",
-      "translated": "세션 삭제"
+      "id": "native.apple.2053fc9f74dc3158",
+      "source": "Delete Threads",
+      "translated": "스레드 삭제"
     },
     {
-      "id": "native.apple.f837129cbee23297",
-      "source": "Each selected session and its transcript will be removed from the gateway.",
-      "translated": "선택한 각 세션과 해당 기록이 Gateway에서 삭제됩니다."
+      "id": "native.apple.0970247871a834a0",
+      "source": "Each selected thread and its transcript will be removed from the gateway.",
+      "translated": "선택한 각 스레드와 해당 대화 내용이 Gateway에서 삭제됩니다."
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -23979,9 +24099,9 @@
       "translated": "그룹"
     },
     {
-      "id": "native.apple.64013cfee5e25305",
-      "source": "Manage session groups",
-      "translated": "세션 그룹 관리"
+      "id": "native.apple.6f8acab2256728b5",
+      "source": "Manage thread groups",
+      "translated": "스레드 그룹 관리"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -23994,14 +24114,14 @@
       "translated": "선택"
     },
     {
-      "id": "native.apple.b67eaecec1b423ac",
-      "source": "No archived sessions",
-      "translated": "보관된 세션 없음"
+      "id": "native.apple.692972314d04b184",
+      "source": "No archived threads",
+      "translated": "보관된 스레드 없음"
     },
     {
-      "id": "native.apple.b2435a79abf0c794",
-      "source": "No sessions found",
-      "translated": "세션을 찾을 수 없음"
+      "id": "native.apple.d6a4b5711dcd26e7",
+      "source": "No threads found",
+      "translated": "스레드를 찾을 수 없음"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24169,6 +24289,16 @@
       "translated": "전체 메시지 열기"
     },
     {
+      "id": "native.apple.002bfcede229ad4b",
+      "source": "Rewind to Here",
+      "translated": "여기로 되돌리기"
+    },
+    {
+      "id": "native.apple.14df2e4997689fb3",
+      "source": "Fork from Here",
+      "translated": "여기에서 분기"
+    },
+    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "답장"
@@ -24254,9 +24384,9 @@
       "translated": "새 채팅을 시작하기 전에 첨부 파일을 제거하거나 전송이 완료될 때까지 기다리세요."
     },
     {
-      "id": "native.apple.980f552bb0f96c0f",
-      "source": "Gateway changed before the session operation started.",
-      "translated": "세션 작업이 시작되기 전에 Gateway가 변경되었습니다."
+      "id": "native.apple.e0f045151c8d3137",
+      "source": "Gateway changed before the thread operation started.",
+      "translated": "스레드 작업이 시작되기 전에 Gateway가 변경되었습니다."
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24264,9 +24394,9 @@
       "translated": "채팅을 전환하기 전에 첨부 파일을 제거하거나 전송이 완료될 때까지 기다리세요."
     },
     {
-      "id": "native.apple.87ba543b42696b92",
-      "source": "Clear this session's history?",
-      "translated": "이 세션의 기록을 지우시겠습니까?"
+      "id": "native.apple.0a5c4e15466c3acc",
+      "source": "Clear this thread's history?",
+      "translated": "이 스레드의 기록을 지우시겠습니까?"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24279,14 +24409,14 @@
       "translated": "%@의 대화가 초기화됩니다. 세션 키는 그대로 유지됩니다."
     },
     {
-      "id": "native.apple.a92e96bed98bd553",
-      "source": "Rename Session",
-      "translated": "세션 이름 변경"
+      "id": "native.apple.67ac221dbe7179f0",
+      "source": "Rename Thread",
+      "translated": "스레드 이름 변경"
     },
     {
-      "id": "native.apple.848e2388f3466f40",
-      "source": "Session name",
-      "translated": "세션 이름"
+      "id": "native.apple.cf0f7e049603f518",
+      "source": "Thread name",
+      "translated": "스레드 이름"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24304,9 +24434,9 @@
       "translated": "기록 내보내기"
     },
     {
-      "id": "native.apple.4af0f566d39d7041",
-      "source": "Sessions",
-      "translated": "세션"
+      "id": "native.apple.c0ada47504425f23",
+      "source": "Threads",
+      "translated": "스레드"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24379,14 +24509,14 @@
       "translated": "기본값"
     },
     {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "새 세션"
+      "id": "native.apple.1a765291943599e5",
+      "source": "New Thread",
+      "translated": "새 스레드"
     },
     {
-      "id": "native.apple.a7119fbf9d25df5e",
-      "source": "New Session Options…",
-      "translated": "새 세션 옵션…"
+      "id": "native.apple.c7a3a6d5e43dd98f",
+      "source": "New Thread Options…",
+      "translated": "새 스레드 옵션…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24394,19 +24524,19 @@
       "translated": "새로 고침"
     },
     {
-      "id": "native.apple.2bcff4a8fa503739",
-      "source": "Sessions…",
-      "translated": "세션…"
+      "id": "native.apple.0e710b81808e5dcf",
+      "source": "Threads…",
+      "translated": "스레드…"
     },
     {
-      "id": "native.apple.c36e008b051adb38",
-      "source": "Rename Session…",
-      "translated": "세션 이름 변경…"
+      "id": "native.apple.faad8f92b6bef166",
+      "source": "Rename Thread…",
+      "translated": "스레드 이름 변경…"
     },
     {
-      "id": "native.apple.ea0ef95a159bffe0",
-      "source": "Fork Session",
-      "translated": "세션 포크"
+      "id": "native.apple.23b61d6cd26ac112",
+      "source": "Fork",
+      "translated": "포크"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24464,24 +24594,24 @@
       "translated": "기록 지우기…"
     },
     {
-      "id": "native.apple.920fe8a7a33f9e92",
-      "source": "Session",
-      "translated": "세션"
+      "id": "native.apple.8b4f1c5107ea8a0e",
+      "source": "Thread",
+      "translated": "스레드"
     },
     {
-      "id": "native.apple.185a401f78328b0f",
-      "source": "Session actions",
-      "translated": "세션 작업"
+      "id": "native.apple.4d7750c9bf699469",
+      "source": "Thread actions",
+      "translated": "스레드 작업"
     },
     {
-      "id": "native.apple.9f9dedf599b2619b",
-      "source": "Session cost %@",
-      "translated": "세션 비용 %@"
+      "id": "native.apple.bb2f22cc43c97f8e",
+      "source": "Thread cost %@",
+      "translated": "스레드 비용 %@"
     },
     {
-      "id": "native.apple.f0a4720df5f5f403",
-      "source": "Compact Session",
-      "translated": "세션 압축"
+      "id": "native.apple.6239ced0b86e86f8",
+      "source": "Compact Thread",
+      "translated": "스레드 압축"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -5141,7 +5141,7 @@
     {
       "id": "native.android.c971506716c96e91",
       "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
-      "translated": "OpenClaw은 이 휴대전화를 스레드, 음성, 제공업체 및 Gateway를 위한 깔끔한 모바일 명령 인터페이스로 바꿔 줍니다."
+      "translated": "OpenClaw는 이 휴대전화를 스레드, 음성, 제공업체 및 Gateway를 위한 깔끔한 모바일 명령 인터페이스로 바꿔 줍니다."
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",

--- a/apps/.i18n/native/nl.json
+++ b/apps/.i18n/native/nl.json
@@ -1429,9 +1429,9 @@
       "translated": "Praten of dicteren met OpenClaw"
     },
     {
-      "id": "native.android.e2cf5a38587382cb",
-      "source": "Browse Threads",
-      "translated": "Threads bekijken"
+      "id": "native.android.5876e15e5e92fd45",
+      "source": "Browse Sessions",
+      "translated": "Sessies bekijken"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "Geen acties gevonden"
     },
     {
-      "id": "native.android.bc70a4ac965b82ba",
-      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
-      "translated": "Probeer Chat, Spraak, Threads, Providers of Instellingen."
+      "id": "native.android.48ad0ae0e930e02b",
+      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
+      "translated": "Probeer Chat, Voice, Sessions, Providers of Settings."
     },
     {
-      "id": "native.android.670121e54dbe286f",
-      "source": "Threads",
-      "translated": "Threads"
+      "id": "native.android.d4fbd1ee4f55a5db",
+      "source": "Sessions",
+      "translated": "Sessies"
     },
     {
-      "id": "native.android.d38be650b1bce4a0",
-      "source": "Connect the Gateway to search threads.",
-      "translated": "Verbind de Gateway om threads te zoeken."
+      "id": "native.android.207c2170504e99e6",
+      "source": "Connect the Gateway to search sessions.",
+      "translated": "Verbind de Gateway om sessies te zoeken."
     },
     {
-      "id": "native.android.3d7754721f776ef8",
-      "source": "No matching threads yet.",
-      "translated": "Nog geen overeenkomende threads."
+      "id": "native.android.25d2c2d792c952fe",
+      "source": "No matching sessions yet.",
+      "translated": "Nog geen overeenkomende sessies."
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "Assistent aan het werk"
     },
     {
-      "id": "native.android.9a839f6e3e05a744",
-      "source": "OpenClaw thread",
-      "translated": "OpenClaw-thread"
+      "id": "native.android.8f8384286317f5c9",
+      "source": "OpenClaw session",
+      "translated": "OpenClaw-sessie"
     },
     {
-      "id": "native.android.d83f82a1e4a5ed99",
-      "source": "Open thread",
-      "translated": "Thread openen"
+      "id": "native.android.15799e57704b20c6",
+      "source": "Open session",
+      "translated": "Sessie openen"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "Geen providers gereed"
     },
     {
-      "id": "native.android.8a1c5365c0538908",
-      "source": "Main thread",
-      "translated": "Hoofdthread"
+      "id": "native.android.73e6ab1a168fd381",
+      "source": "Main session",
+      "translated": "Hoofdsessie"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.a5845742daecb4ba",
-      "source": "Threads",
-      "translated": "Threads"
+      "id": "native.android.0e3157c15c56944f",
+      "source": "Sessions",
+      "translated": "Sessies"
     },
     {
-      "id": "native.android.439b324280869527",
-      "source": "Focus thread search",
-      "translated": "Zoeken naar threads activeren"
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "Zoeken in sessies"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "Gearchiveerd"
     },
     {
-      "id": "native.android.03981341841b04ac",
-      "source": "Search threads",
-      "translated": "Threads zoeken"
+      "id": "native.android.b9cf34c137e4cf03",
+      "source": "Search sessions",
+      "translated": "Sessies zoeken"
     },
     {
-      "id": "native.android.99570c528a41fa72",
-      "source": "Clear thread search",
-      "translated": "Zoekopdracht voor threads wissen"
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "Zoekopdracht voor sessies wissen"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "Oudste eerst"
     },
     {
-      "id": "native.android.fd67be543e321cc9",
-      "source": "Toggle thread layout",
-      "translated": "Threadindeling wisselen"
+      "id": "native.android.c6bf8751e2a7f5c7",
+      "source": "Toggle session layout",
+      "translated": "Sessielay-out wisselen"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "Lay-out: Gedetailleerd"
     },
     {
-      "id": "native.android.ebd17565e0ffd8eb",
-      "source": "Searching threads",
-      "translated": "Threads zoeken"
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "Sessies zoeken"
     },
     {
-      "id": "native.android.472d46ae8669f860",
-      "source": "No matching threads",
-      "translated": "Geen overeenkomende threads"
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "Geen overeenkomende sessies"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "Chat starten"
     },
     {
-      "id": "native.android.ff81ad1bee00d384",
-      "source": "Current thread",
-      "translated": "Huidige thread"
+      "id": "native.android.f10d4df7cbc6df4f",
+      "source": "Current session",
+      "translated": "Huidige sessie"
     },
     {
-      "id": "native.android.fc145645b9620e57",
-      "source": "OpenClaw thread",
-      "translated": "OpenClaw-thread"
+      "id": "native.android.8f0482425838ae64",
+      "source": "OpenClaw session",
+      "translated": "OpenClaw-sessie"
     },
     {
-      "id": "native.android.71cbb8dde8bf138b",
-      "source": "Rename thread",
-      "translated": "Thread hernoemen"
+      "id": "native.android.786774c8a76e50d7",
+      "source": "Rename session",
+      "translated": "Sessie hernoemen"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "Groep verwijderen?"
     },
     {
-      "id": "native.android.691e92cfe5cf106e",
-      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "Threads in \"$group\" blijven behouden en worden teruggeplaatst naar Niet gegroepeerd."
+      "id": "native.android.3455fc2f77d564e3",
+      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "Sessies in \"$group\" blijven behouden en gaan terug naar Niet-gegroepeerd."
     },
     {
-      "id": "native.android.d87a8217ab56999b",
-      "source": "Delete thread?",
-      "translated": "Thread verwijderen?"
+      "id": "native.android.4805fb9d6623e8c0",
+      "source": "Delete session?",
+      "translated": "Sessie verwijderen?"
     },
     {
-      "id": "native.android.930de97ff47113a8",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "Hiermee worden de thread en het transcript permanent verwijderd."
+      "id": "native.android.0c3283a2b2445eae",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "Hiermee worden de sessie en het transcript permanent verwijderd."
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "Niet gegroepeerd"
     },
     {
-      "id": "native.android.8e21a70428def6e0",
-      "source": "No threads yet",
-      "translated": "Nog geen threads"
+      "id": "native.android.db243d71d056afa4",
+      "source": "No sessions yet",
+      "translated": "Nog geen sessies"
     },
     {
-      "id": "native.android.cda4c5ad8b17e394",
-      "source": "No current thread",
-      "translated": "Geen huidige thread"
+      "id": "native.android.5b4eee6a8092925e",
+      "source": "No current session",
+      "translated": "Geen huidige sessie"
     },
     {
-      "id": "native.android.be84f061047aa2da",
-      "source": "No archived threads",
-      "translated": "Geen gearchiveerde threads"
+      "id": "native.android.acbcc9c9ea53d8c0",
+      "source": "No archived sessions",
+      "translated": "Geen gearchiveerde sessies"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "Start een nieuw gesprek en het verschijnt hier."
     },
     {
-      "id": "native.android.f289d03e1d3eee98",
-      "source": "Open Chat to start or resume the current thread.",
-      "translated": "Open Chat om de huidige thread te starten of te hervatten."
+      "id": "native.android.56fcd605dc7be3c0",
+      "source": "Open Chat to start or resume the current session.",
+      "translated": "Open Chat om de huidige sessie te starten of te hervatten."
     },
     {
-      "id": "native.android.504b71386e76c6ae",
-      "source": "Archived threads will show up here.",
-      "translated": "Gearchiveerde threads worden hier weergegeven."
+      "id": "native.android.085515989f8a2022",
+      "source": "Archived sessions will show up here.",
+      "translated": "Gearchiveerde sessies worden hier weergegeven."
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days} d"
     },
     {
-      "id": "native.android.ee4c727cdafbe963",
-      "source": "Main thread",
-      "translated": "Hoofdthread"
+      "id": "native.android.3d4fa07acbc015c5",
+      "source": "Main session",
+      "translated": "Hoofdsessie"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway in afwachting"
     },
     {
-      "id": "native.android.da78209effb11cfd",
-      "source": "Thread Activity",
-      "translated": "Threadactiviteit"
+      "id": "native.android.2d8d049afe99f751",
+      "source": "Session Activity",
+      "translated": "Sessieactiviteit"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "Exec-goedkeuringsverzoeken verschijnen hier terwijl deze telefoon is verbonden."
     },
     {
-      "id": "native.android.f615712dfb56319a",
-      "source": "Thread activity",
-      "translated": "Threadactiviteit"
+      "id": "native.android.dc3e7ca5a491103a",
+      "source": "Session activity",
+      "translated": "Sessieactiviteit"
     },
     {
-      "id": "native.android.6c93973c13db43ae",
-      "source": "Chat tool calls waiting in the active thread remain visible here.",
-      "translated": "Aanroepen van Chat-tools die in de actieve thread wachten, blijven hier zichtbaar."
+      "id": "native.android.8551e02b060bd7d8",
+      "source": "Chat tool calls waiting in the active session remain visible here.",
+      "translated": "Chattool-aanroepen die wachten in de actieve sessie blijven hier zichtbaar."
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,11 +4294,6 @@
       "translated": "Talk Provider instellen"
     },
     {
-      "id": "native.android.23b638094c34b916",
-      "source": "Microphone",
-      "translated": "Microfoon"
-    },
-    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "Audiotest"
@@ -4342,66 +4337,6 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "Gereed"
-    },
-    {
-      "id": "native.android.8d9ecdfdd916b780",
-      "source": "Automatic",
-      "translated": "Automatisch"
-    },
-    {
-      "id": "native.android.c1626a6700a570f6",
-      "source": "Preferred microphone unavailable; using automatic routing.",
-      "translated": "Voorkeursmicrofoon niet beschikbaar; automatische routering wordt gebruikt."
-    },
-    {
-      "id": "native.android.820bc5d0ce571d8b",
-      "source": "Prioritizes connected Bluetooth microphones.",
-      "translated": "Geeft prioriteit aan verbonden Bluetooth-microfoons."
-    },
-    {
-      "id": "native.android.11e48038d5e8bff6",
-      "source": "Preferred microphone",
-      "translated": "Voorkeursmicrofoon"
-    },
-    {
-      "id": "native.android.eaa4d7563a46d307",
-      "source": "Unavailable",
-      "translated": "Niet beschikbaar"
-    },
-    {
-      "id": "native.android.9f5ebf17eb405ba8",
-      "source": "Next session",
-      "translated": "Volgende sessie"
-    },
-    {
-      "id": "native.android.8c4e91f53928efb2",
-      "source": "Built-in microphone",
-      "translated": "Ingebouwde microfoon"
-    },
-    {
-      "id": "native.android.14b613cb6e2446b4",
-      "source": "Bluetooth microphone",
-      "translated": "Bluetooth-microfoon"
-    },
-    {
-      "id": "native.android.c885247b2d7ce271",
-      "source": "Bluetooth LE microphone",
-      "translated": "Bluetooth LE-microfoon"
-    },
-    {
-      "id": "native.android.b6a4e674c5fb441a",
-      "source": "Wired headset microphone",
-      "translated": "Microfoon van bedrade headset"
-    },
-    {
-      "id": "native.android.9c8becb3b0fb5a90",
-      "source": "USB microphone",
-      "translated": "USB-microfoon"
-    },
-    {
-      "id": "native.android.ba46258fadec7a39",
-      "source": "External microphone",
-      "translated": "Externe microfoon"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5139,9 +5074,9 @@
       "translated": "Controleren"
     },
     {
-      "id": "native.android.c971506716c96e91",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
-      "translated": "OpenClaw maakt van deze telefoon een overzichtelijk mobiel bedieningspaneel voor threads, spraak, providers en Gateway."
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw verandert deze telefoon in een overzichtelijk mobiel bedieningspaneel voor sessies, spraak, providers en Gateway."
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5689,9 +5624,9 @@
       "translated": "Talk-instellingen"
     },
     {
-      "id": "native.android.36f78c8c85dc283f",
-      "source": "Recent Threads",
-      "translated": "Recente threads"
+      "id": "native.android.73f07a5d54915259",
+      "source": "Recent Sessions",
+      "translated": "Recente sessies"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5749,14 +5684,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online"
     },
     {
-      "id": "native.android.57177017a6a93826",
-      "source": "Threads",
-      "translated": "Threads"
+      "id": "native.android.16c3425d3a594481",
+      "source": "Sessions",
+      "translated": "Sessies"
     },
     {
-      "id": "native.android.43320b54a68b00a1",
-      "source": "No recent threads",
-      "translated": "Geen recente threads"
+      "id": "native.android.a5c0f8b3112aa58c",
+      "source": "No recent sessions",
+      "translated": "Geen recente sessies"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5794,14 +5729,14 @@
       "translated": "Bezig · $pendingRunCount actieve uitvoeringen"
     },
     {
-      "id": "native.android.e24db059480f1e6a",
-      "source": "Monitoring · 1 thread",
-      "translated": "Bewaking · 1 thread"
+      "id": "native.android.2c89da708b12a522",
+      "source": "Monitoring · 1 session",
+      "translated": "Monitoren · 1 sessie"
     },
     {
-      "id": "native.android.5a475f37d80e02bc",
-      "source": "Monitoring · $sessionCount threads",
-      "translated": "Bewaking · $sessionCount threads"
+      "id": "native.android.8b6ee382dcb64e1f",
+      "source": "Monitoring · $sessionCount sessions",
+      "translated": "Monitoren · $sessionCount sessies"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5834,9 +5769,9 @@
       "translated": "Providers"
     },
     {
-      "id": "native.android.358c5e0e838d5423",
-      "source": "Open thread",
-      "translated": "Thread openen"
+      "id": "native.android.a65477861c7203aa",
+      "source": "Open session",
+      "translated": "Sessie openen"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6259,9 +6194,9 @@
       "translated": "${days}d"
     },
     {
-      "id": "native.android.28a1a1acc5a0959f",
-      "source": "Main thread",
-      "translated": "Hoofdthread"
+      "id": "native.android.22d755834386db07",
+      "source": "Main session",
+      "translated": "Hoofdsessie"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6942,16 +6877,6 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "Dempen opheffen"
-    },
-    {
-      "id": "native.android.cb608d82c5b3352a",
-      "source": "Back camera",
-      "translated": "Achtercamera"
-    },
-    {
-      "id": "native.android.e89a0e780eed2e1e",
-      "source": "Front camera",
-      "translated": "Frontcamera"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7759,9 +7684,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.0c74bc30a994dd33",
-      "source": "Loading thread",
-      "translated": "Thread laden"
+      "id": "native.android.882cc14a58e7e105",
+      "source": "Loading session",
+      "translated": "Sessie laden"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7804,14 +7729,14 @@
       "translated": "Praat me bij"
     },
     {
-      "id": "native.android.cf40df9739f78f27",
-      "source": "Summarize recent threads and next steps.",
-      "translated": "Vat recente threads en vervolgstappen samen."
+      "id": "native.android.1e5add56e48c99f9",
+      "source": "Summarize recent sessions and next steps.",
+      "translated": "Vat recente sessies en vervolgstappen samen."
     },
     {
-      "id": "native.android.ebe49a8b8df80bd3",
-      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
-      "translated": "Praat me bij over mijn recente OpenClaw-gesprekken en stel vervolgstappen voor."
+      "id": "native.android.06d515351bb79576",
+      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
+      "translated": "Praat me bij over mijn recente OpenClaw-sessies en stel vervolgstappen voor."
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8149,9 +8074,9 @@
       "translated": "Verbonden"
     },
     {
-      "id": "native.android.6cf5d6fa8a4186d5",
-      "source": "Threads",
-      "translated": "Gesprekken"
+      "id": "native.android.81931886b9caf3ab",
+      "source": "Sessions",
+      "translated": "Sessies"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,6 +10719,61 @@
       "translated": "Taakdetails"
     },
     {
+      "id": "native.apple.29cacb53ea5e77fc",
+      "source": "Pinned",
+      "translated": "Vastgezet"
+    },
+    {
+      "id": "native.apple.940062cfdce9211b",
+      "source": "Recent",
+      "translated": "Recent"
+    },
+    {
+      "id": "native.apple.a0980128426308a9",
+      "source": "Model",
+      "translated": "Model"
+    },
+    {
+      "id": "native.apple.9520e60f21535dde",
+      "source": "Thinking",
+      "translated": "Denkmodus"
+    },
+    {
+      "id": "native.apple.8b321f3ffce97429",
+      "source": "Fast",
+      "translated": "Snel"
+    },
+    {
+      "id": "native.apple.989b70d64e328d55",
+      "source": "Default (inherited)",
+      "translated": "Standaard (overgenomen)"
+    },
+    {
+      "id": "native.apple.f4114e73b07eb9ae",
+      "source": "Off",
+      "translated": "Uit"
+    },
+    {
+      "id": "native.apple.7ed231b28d16312f",
+      "source": "On",
+      "translated": "Aan"
+    },
+    {
+      "id": "native.apple.412a74802320a037",
+      "source": "Full",
+      "translated": "Volledig"
+    },
+    {
+      "id": "native.apple.299f21a2071ff9fc",
+      "source": "Verbosity",
+      "translated": "Uitgebreidheid"
+    },
+    {
+      "id": "native.apple.faf0ef05e1496de7",
+      "source": "Default",
+      "translated": "Standaard"
+    },
+    {
       "id": "native.apple.e5524d5756a62744",
       "source": "Unable to Export Transcript",
       "translated": "Kan transcript niet exporteren"
@@ -10814,9 +10794,9 @@
       "translated": "Waar wilt u aan werken?"
     },
     {
-      "id": "native.apple.4da775013ac9b123",
-      "source": "The thread attaches once the gateway is ready.",
-      "translated": "Het gesprek wordt gekoppeld zodra de Gateway klaar is."
+      "id": "native.apple.32179ce0b6d4543f",
+      "source": "The session attaches once the gateway is ready.",
+      "translated": "De sessie wordt gekoppeld zodra de Gateway gereed is."
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10859,9 +10839,14 @@
       "translated": "Nieuwe chat in worktree"
     },
     {
-      "id": "native.apple.003b25ddafeb18e9",
-      "source": "Threads…",
-      "translated": "Gesprekken…"
+      "id": "native.apple.ce6ebe91fc597015",
+      "source": "New Session Options…",
+      "translated": "Opties voor nieuwe sessie…"
+    },
+    {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "Sessies…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11024,14 +11009,14 @@
       "translated": "Aanmaken"
     },
     {
-      "id": "native.apple.31d5c7287cfb3abe",
-      "source": "Delete Thread?",
-      "translated": "Gesprek verwijderen?"
+      "id": "native.apple.f488b9caf6e51ac3",
+      "source": "Delete Session?",
+      "translated": "Sessie verwijderen?"
     },
     {
-      "id": "native.apple.d3395564809f1120",
-      "source": "Delete Thread",
-      "translated": "Gesprek verwijderen"
+      "id": "native.apple.8634b17be9b111bc",
+      "source": "Delete Session",
+      "translated": "Sessie verwijderen"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11039,9 +11024,9 @@
       "translated": "Annuleren"
     },
     {
-      "id": "native.apple.092659256d26cb03",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "Hiermee worden het gesprek en het transcript permanent verwijderd."
+      "id": "native.apple.4a9568ac9b18d8d3",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "Hiermee verwijder je de sessie en het transcript permanent."
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11069,9 +11054,9 @@
       "translated": "Nieuwe groep"
     },
     {
-      "id": "native.apple.683032464c497bbd",
-      "source": "Rename Thread",
-      "translated": "Gesprek hernoemen"
+      "id": "native.apple.5bccdc23a1640895",
+      "source": "Rename Session",
+      "translated": "Sessie hernoemen"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11079,9 +11064,9 @@
       "translated": "Groepsnaam"
     },
     {
-      "id": "native.apple.f887aa956588f237",
-      "source": "Thread name",
-      "translated": "Gespreksnaam"
+      "id": "native.apple.af789b2d2fda0f67",
+      "source": "Session name",
+      "translated": "Sessienaam"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11119,14 +11104,14 @@
       "translated": "Agents"
     },
     {
-      "id": "native.apple.7c8231b7b1ca480f",
-      "source": "Agent thread",
-      "translated": "Agentgesprek"
+      "id": "native.apple.a3bde8045fe9224a",
+      "source": "Agent session",
+      "translated": "Agentsessie"
     },
     {
-      "id": "native.apple.b3c553614f762a58",
-      "source": "Recent threads",
-      "translated": "Recente gesprekken"
+      "id": "native.apple.27f775de30b37ff8",
+      "source": "Recent sessions",
+      "translated": "Recente sessies"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11134,9 +11119,9 @@
       "translated": "Gateway offline"
     },
     {
-      "id": "native.apple.5aa32afda85064ea",
-      "source": "No recent threads",
-      "translated": "Geen recente gesprekken"
+      "id": "native.apple.28c97cf23665ee01",
+      "source": "No recent sessions",
+      "translated": "Geen recente sessies"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11234,14 +11219,14 @@
       "translated": "Annuleren"
     },
     {
-      "id": "native.apple.b6855cf19a50f477",
-      "source": "Threads",
-      "translated": "Gesprekken"
+      "id": "native.apple.9f2fd65953013b7c",
+      "source": "Sessions",
+      "translated": "Sessies"
     },
     {
-      "id": "native.apple.9b1d0ef27a1333b0",
-      "source": "Archived threads",
-      "translated": "Gearchiveerde gesprekken"
+      "id": "native.apple.0422818cc95d5071",
+      "source": "Archived sessions",
+      "translated": "Gearchiveerde sessies"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11249,34 +11234,34 @@
       "translated": "Gearchiveerde tonen"
     },
     {
-      "id": "native.apple.98167401c7267735",
-      "source": "Threads unavailable",
-      "translated": "Gesprekken niet beschikbaar"
+      "id": "native.apple.b272115c83f7ef58",
+      "source": "Sessions unavailable",
+      "translated": "Sessies niet beschikbaar"
     },
     {
-      "id": "native.apple.4d28a7def2337b9f",
-      "source": "Loading archived threads",
-      "translated": "Gearchiveerde gesprekken laden"
+      "id": "native.apple.54f8260c9b863087",
+      "source": "Loading archived sessions",
+      "translated": "Gearchiveerde sessies laden"
     },
     {
-      "id": "native.apple.777d7b706933bd7b",
-      "source": "Loading recent threads",
-      "translated": "Recente gesprekken laden"
+      "id": "native.apple.9b305868873dade2",
+      "source": "Loading recent sessions",
+      "translated": "Recente sessies laden"
     },
     {
-      "id": "native.apple.22f81ea94bef8410",
-      "source": "^[\\(count) thread](inflect: true)",
-      "translated": "^[\\(count) gesprek](inflect: true)"
+      "id": "native.apple.207dad20d09f3160",
+      "source": "^[\\(count) session](inflect: true)",
+      "translated": "^[\\(count) sessie](inflect: true)"
     },
     {
-      "id": "native.apple.1cad51e14db59bf9",
-      "source": "No archived threads",
-      "translated": "Geen gearchiveerde gesprekken"
+      "id": "native.apple.1f4501a6bf2bae4c",
+      "source": "No archived sessions",
+      "translated": "Geen gearchiveerde sessies"
     },
     {
-      "id": "native.apple.18ef832d3a7ddcf8",
-      "source": "Archived threads will appear here.",
-      "translated": "Gearchiveerde gesprekken verschijnen hier."
+      "id": "native.apple.2a1ba7a5e1979c9e",
+      "source": "Archived sessions will appear here.",
+      "translated": "Gearchiveerde sessies verschijnen hier."
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11359,9 +11344,9 @@
       "translated": "Intake delen"
     },
     {
-      "id": "native.apple.21d9208d86a4d1fe",
-      "source": "Loading threads",
-      "translated": "Gesprekken laden"
+      "id": "native.apple.2360d25fe6ae9946",
+      "source": "Loading sessions",
+      "translated": "Sessies laden"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11369,19 +11354,19 @@
       "translated": "Recente activiteit ophalen van de gateway."
     },
     {
-      "id": "native.apple.4be1f79aa2b230ff",
-      "source": "Threads unavailable",
-      "translated": "Gesprekken niet beschikbaar"
+      "id": "native.apple.c334f2e86702a7b8",
+      "source": "Sessions unavailable",
+      "translated": "Sessies niet beschikbaar"
     },
     {
-      "id": "native.apple.98b348873556bc46",
-      "source": "No recent threads",
-      "translated": "Geen recente gesprekken"
+      "id": "native.apple.6cc6efb7a03960b6",
+      "source": "No recent sessions",
+      "translated": "Geen recente sessies"
     },
     {
-      "id": "native.apple.7396d205574d279f",
-      "source": "Thread activity offline",
-      "translated": "Gespreksactiviteit offline"
+      "id": "native.apple.08483af2d043bee6",
+      "source": "Session activity offline",
+      "translated": "Sessieactiviteit offline"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11839,9 +11824,9 @@
       "translated": "Kaart"
     },
     {
-      "id": "native.apple.c9ec1b0e18074d8a",
-      "source": "Open Thread",
-      "translated": "Gesprek openen"
+      "id": "native.apple.93eeaedb2ff61043",
+      "source": "Open Session",
+      "translated": "Sessie openen"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13329,9 +13314,9 @@
       "translated": "Standaard"
     },
     {
-      "id": "native.apple.f4ae5664c3eda95d",
-      "source": "Used for new Chat threads and Talk sessions.",
-      "translated": "Wordt gebruikt voor nieuwe chatgesprekken en praatsessies."
+      "id": "native.apple.3de045f17ea3c6d0",
+      "source": "Used for new Chat and Talk sessions.",
+      "translated": "Gebruikt voor nieuwe Chat- en Talk-sessies."
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15734,9 +15719,9 @@
       "translated": "Instances"
     },
     {
-      "id": "native.apple.11fe8b9941954dfb",
-      "source": "Threads",
-      "translated": "Gesprekken"
+      "id": "native.apple.3579cf2750470a22",
+      "source": "Sessions",
+      "translated": "Sessions"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19044,9 +19029,9 @@
       "translated": "Snelkoppeling voor Quick Chat"
     },
     {
-      "id": "native.apple.94dd793cd7d7d555",
-      "source": "Global shortcut that opens a floating chat bar for the main thread.",
-      "translated": "Algemene sneltoets die een zwevende chatbalk voor het hoofdgesprek opent."
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "Algemene snelkoppeling die een zwevende chatbalk voor de hoofdsessie opent."
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19624,9 +19609,9 @@
       "translated": "Kritiek"
     },
     {
-      "id": "native.apple.13f96467014cf344",
-      "source": "New Thread",
-      "translated": "Nieuw gesprek"
+      "id": "native.apple.75102378a6775180",
+      "source": "New Session",
+      "translated": "Nieuwe sessie"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21914,9 +21899,9 @@
       "translated": "Geen recente berichten"
     },
     {
-      "id": "native.apple.3ec2afcbc298c673",
-      "source": "Threads",
-      "translated": "Gesprekken"
+      "id": "native.apple.1ff8aec0044934c3",
+      "source": "Sessions",
+      "translated": "Sessies"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21924,9 +21909,9 @@
       "translated": "Bekijk de opgeslagen gespreksbuckets die de CLI opnieuw gebruikt voor context en snelheidslimieten."
     },
     {
-      "id": "native.apple.14ccb32cd8ed1c81",
-      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
-      "translated": "Nog geen gesprekken. Ze verschijnen na het eerste inkomende bericht of heartbeatsignaal."
+      "id": "native.apple.bab897f3252b134c",
+      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
+      "translated": "Nog geen sessies. Ze verschijnen na het eerste inkomende bericht of heartbeat."
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -22009,9 +21994,9 @@
       "translated": "Uitvoeringsgoedkeuringen"
     },
     {
-      "id": "native.apple.52e37e3a44ae516c",
-      "source": "Threads",
-      "translated": "Gesprekken"
+      "id": "native.apple.64a6dc7d49e8fb57",
+      "source": "Sessions",
+      "translated": "Sessies"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -23014,9 +22999,9 @@
       "translated": "Praat me bij"
     },
     {
-      "id": "native.apple.fc4ce810900ec0b6",
-      "source": "Summarize what happened in my threads since yesterday.",
-      "translated": "Vat samen wat er sinds gisteren in mijn gesprekken is gebeurd."
+      "id": "native.apple.234ec45f4231edc4",
+      "source": "Summarize what happened in my sessions since yesterday.",
+      "translated": "Vat samen wat er sinds gisteren in mijn sessies is gebeurd."
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23194,9 +23179,9 @@
       "translated": "Model losmaken"
     },
     {
-      "id": "native.apple.4edb66657f5aca1f",
-      "source": "Thread",
-      "translated": "Gesprek"
+      "id": "native.apple.5dfc0700d8dff8de",
+      "source": "Session",
+      "translated": "Sessie"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23359,51 +23344,6 @@
       "translated": "Widget niet beschikbaar"
     },
     {
-      "id": "native.apple.d640691fd196f338",
-      "source": "Widget export failed",
-      "translated": "Exporteren van widget mislukt"
-    },
-    {
-      "id": "native.apple.533c6e22a11e88de",
-      "source": "OK",
-      "translated": "OK"
-    },
-    {
-      "id": "native.apple.e1fb28a2a9756402",
-      "source": "Copy image",
-      "translated": "Afbeelding kopiëren"
-    },
-    {
-      "id": "native.apple.ebd7bc92e1b12235",
-      "source": "Save image…",
-      "translated": "Afbeelding bewaren…"
-    },
-    {
-      "id": "native.apple.742c46d4cf2db134",
-      "source": "Save image",
-      "translated": "Afbeelding bewaren"
-    },
-    {
-      "id": "native.apple.0589cce608418f90",
-      "source": "The widget image could not be captured.",
-      "translated": "De widgetafbeelding kon niet worden vastgelegd."
-    },
-    {
-      "id": "native.apple.dfe24e827fdbe9c5",
-      "source": "The widget image could not be copied.",
-      "translated": "De widgetafbeelding kon niet worden gekopieerd."
-    },
-    {
-      "id": "native.apple.9e611e3a80e71408",
-      "source": "The widget image could not be encoded as PNG.",
-      "translated": "De widgetafbeelding kon niet als PNG worden gecodeerd."
-    },
-    {
-      "id": "native.apple.9a6e8afbe24a262b",
-      "source": "The widget image could not be saved.",
-      "translated": "De widgetafbeelding kon niet worden opgeslagen."
-    },
-    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23544,19 +23484,19 @@
       "translated": "Gebruiker"
     },
     {
-      "id": "native.apple.9d0cba09d92ee669",
-      "source": "This thread cannot be archived while it is active or running.",
-      "translated": "Dit gesprek kan niet worden gearchiveerd zolang het actief is of wordt uitgevoerd."
+      "id": "native.apple.b1cdcb906a43d5d6",
+      "source": "This session cannot be archived while it is active or running.",
+      "translated": "Deze sessie kan niet worden gearchiveerd terwijl deze actief of in uitvoering is."
     },
     {
-      "id": "native.apple.8952a111a1075051",
-      "source": "The main thread cannot be deleted.",
-      "translated": "Het hoofdgesprek kan niet worden verwijderd."
+      "id": "native.apple.5817e3f3dab1ee19",
+      "source": "The main session cannot be deleted.",
+      "translated": "De hoofdsessie kan niet worden verwijderd."
     },
     {
-      "id": "native.apple.90d0ccf80ca28717",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
-      "translated": "Verwijder bijlagen of wacht tot ze zijn afgeleverd voordat u dit gesprek archiveert of verwijdert."
+      "id": "native.apple.a6b8df3f18171c91",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
+      "translated": "Verwijder bijlagen of wacht op de bezorging voordat u deze sessie archiveert of verwijdert."
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23694,9 +23634,9 @@
       "translated": "Uitvoering beëindigd"
     },
     {
-      "id": "native.apple.bbccb4c8db5cac12",
-      "source": "Thread Info",
-      "translated": "Gespreksinformatie"
+      "id": "native.apple.cd7c3095a22f80a9",
+      "source": "Session Info",
+      "translated": "Sessie-informatie"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23729,9 +23669,9 @@
       "translated": "Groep toevoegen"
     },
     {
-      "id": "native.apple.7b641fed5bace855",
-      "source": "Thread Groups",
-      "translated": "Gespreksgroepen"
+      "id": "native.apple.23d628606fe0734f",
+      "source": "Session Groups",
+      "translated": "Sessiegroepen"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23774,9 +23714,9 @@
       "translated": "Groep verwijderen"
     },
     {
-      "id": "native.apple.56401c79410a310d",
-      "source": "Threads in this group become ungrouped.",
-      "translated": "Gesprekken in deze groep worden uit de groep gehaald."
+      "id": "native.apple.b049c8a4d2805e08",
+      "source": "Sessions in this group become ungrouped.",
+      "translated": "Sessies in deze groep worden uit de groep gehaald."
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23789,9 +23729,9 @@
       "translated": "Er zijn geen agents beschikbaar op deze gateway."
     },
     {
-      "id": "native.apple.2d96aa7d3d12f85b",
-      "source": "New Thread Options",
-      "translated": "Opties voor nieuwe thread"
+      "id": "native.apple.6c89f35d53506406",
+      "source": "New Session Options",
+      "translated": "Opties voor nieuwe sessie"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23819,19 +23759,19 @@
       "translated": "Aanmaken"
     },
     {
-      "id": "native.apple.87ef57319d1ddc85",
-      "source": "The thread could not be created.",
-      "translated": "De thread kon niet worden aangemaakt."
+      "id": "native.apple.795ba37f6782cf28",
+      "source": "The session could not be created.",
+      "translated": "De sessie kon niet worden aangemaakt."
     },
     {
-      "id": "native.apple.6bd91c435b69d638",
-      "source": "Search threads",
-      "translated": "Threads zoeken"
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "Sessies zoeken"
     },
     {
-      "id": "native.apple.6fde4bdf9d5b9191",
-      "source": "No Threads",
-      "translated": "Geen threads"
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "Geen sessies"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23839,29 +23779,29 @@
       "translated": "Geen resultaten"
     },
     {
-      "id": "native.apple.a02fd99740d29bd3",
-      "source": "New Thread",
-      "translated": "Nieuwe thread"
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "Nieuwe sessie"
     },
     {
-      "id": "native.apple.b625801dd04b09f2",
-      "source": "New thread",
-      "translated": "Nieuwe thread"
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "Nieuwe sessie"
     },
     {
-      "id": "native.apple.851be81fcc933608",
-      "source": "New thread options",
-      "translated": "Opties voor nieuwe thread"
+      "id": "native.apple.2ef0e34db02ad255",
+      "source": "New session options",
+      "translated": "Opties voor nieuwe sessie"
     },
     {
-      "id": "native.apple.9ce8a4aba7b444b2",
-      "source": "Rename Thread",
-      "translated": "Thread hernoemen"
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "Sessie hernoemen"
     },
     {
-      "id": "native.apple.1dd067c44511c7f0",
-      "source": "Thread name",
-      "translated": "Threadnaam"
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "Sessienaam"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23874,14 +23814,14 @@
       "translated": "Annuleren"
     },
     {
-      "id": "native.apple.618073d6ab3f2721",
-      "source": "Delete Thread",
-      "translated": "Thread verwijderen"
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "Sessie verwijderen"
     },
     {
-      "id": "native.apple.10a5e72bba3cbccc",
-      "source": "The thread and its transcript are removed from the gateway.",
-      "translated": "De thread en het transcript ervan worden uit de gateway verwijderd."
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "De sessie en het transcript ervan worden uit de Gateway verwijderd."
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23889,14 +23829,14 @@
       "translated": "‘%@’ verwijderen?"
     },
     {
-      "id": "native.apple.ac71e3b2aa496a2c",
-      "source": "Thread running",
-      "translated": "Thread wordt uitgevoerd"
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "Sessie actief"
     },
     {
-      "id": "native.apple.c775e87f997278b2",
-      "source": "Thread failed",
-      "translated": "Thread mislukt"
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "Sessie mislukt"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23954,9 +23894,9 @@
       "translated": "Kopieer sessiesleutel"
     },
     {
-      "id": "native.apple.f4998cfb572f23ff",
-      "source": "Delete Thread…",
-      "translated": "Thread verwijderen…"
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "Verwijder sessie…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23969,9 +23909,9 @@
       "translated": "Verbinden…"
     },
     {
-      "id": "native.apple.8802e9576ffd0f65",
-      "source": "Retry thread groups",
-      "translated": "Threadgroepen opnieuw proberen"
+      "id": "native.apple.79f708b3bc1d3a6c",
+      "source": "Retry session groups",
+      "translated": "Sessiegroepen opnieuw proberen"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23994,24 +23934,24 @@
       "translated": "Bereik"
     },
     {
-      "id": "native.apple.b313b80def4bda52",
-      "source": "Search threads",
-      "translated": "Threads zoeken"
+      "id": "native.apple.2c37581c7b88f741",
+      "source": "Search sessions",
+      "translated": "Sessies zoeken"
     },
     {
-      "id": "native.apple.c0cc6acc36f413ce",
-      "source": "Threads",
-      "translated": "Threads"
+      "id": "native.apple.43be8a2336e42faf",
+      "source": "Sessions",
+      "translated": "Sessies"
     },
     {
-      "id": "native.apple.854d3928fe5a557c",
-      "source": "Rename Thread",
-      "translated": "Thread hernoemen"
+      "id": "native.apple.0b379cdfcbd3247f",
+      "source": "Rename Session",
+      "translated": "Sessie hernoemen"
     },
     {
-      "id": "native.apple.9d0d3f20096cc4da",
-      "source": "Thread name",
-      "translated": "Threadnaam"
+      "id": "native.apple.54b6fbd9e41db009",
+      "source": "Session name",
+      "translated": "Sessienaam"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -24019,19 +23959,19 @@
       "translated": "Annuleren"
     },
     {
-      "id": "native.apple.dc00eb94f33bae15",
-      "source": "Delete selected threads?",
-      "translated": "Geselecteerde threads verwijderen?"
+      "id": "native.apple.751e0f6b81cd374a",
+      "source": "Delete selected sessions?",
+      "translated": "Geselecteerde sessies verwijderen?"
     },
     {
-      "id": "native.apple.2053fc9f74dc3158",
-      "source": "Delete Threads",
-      "translated": "Threads verwijderen"
+      "id": "native.apple.aa679276581b0058",
+      "source": "Delete Sessions",
+      "translated": "Sessies verwijderen"
     },
     {
-      "id": "native.apple.0970247871a834a0",
-      "source": "Each selected thread and its transcript will be removed from the gateway.",
-      "translated": "Elke geselecteerde thread en de bijbehorende transcriptie worden van de Gateway verwijderd."
+      "id": "native.apple.f837129cbee23297",
+      "source": "Each selected session and its transcript will be removed from the gateway.",
+      "translated": "Elke geselecteerde sessie en het bijbehorende transcript worden van de Gateway verwijderd."
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -24039,9 +23979,9 @@
       "translated": "Groepen"
     },
     {
-      "id": "native.apple.6f8acab2256728b5",
-      "source": "Manage thread groups",
-      "translated": "Threadgroepen beheren"
+      "id": "native.apple.64013cfee5e25305",
+      "source": "Manage session groups",
+      "translated": "Sessiegroepen beheren"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -24054,14 +23994,14 @@
       "translated": "Selecteer"
     },
     {
-      "id": "native.apple.692972314d04b184",
-      "source": "No archived threads",
-      "translated": "Geen gearchiveerde threads"
+      "id": "native.apple.b67eaecec1b423ac",
+      "source": "No archived sessions",
+      "translated": "Geen gearchiveerde sessies"
     },
     {
-      "id": "native.apple.d6a4b5711dcd26e7",
-      "source": "No threads found",
-      "translated": "Geen threads gevonden"
+      "id": "native.apple.b2435a79abf0c794",
+      "source": "No sessions found",
+      "translated": "Geen sessies gevonden"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24229,16 +24169,6 @@
       "translated": "Volledig bericht openen"
     },
     {
-      "id": "native.apple.002bfcede229ad4b",
-      "source": "Rewind to Here",
-      "translated": "Terugspoelen naar hier"
-    },
-    {
-      "id": "native.apple.14df2e4997689fb3",
-      "source": "Fork from Here",
-      "translated": "Vanaf hier afsplitsen"
-    },
-    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "Antwoorden"
@@ -24324,9 +24254,9 @@
       "translated": "Verwijder bijlagen of wacht tot de bezorging is afgerond voordat je een nieuwe chat start."
     },
     {
-      "id": "native.apple.e0f045151c8d3137",
-      "source": "Gateway changed before the thread operation started.",
-      "translated": "De Gateway is gewijzigd voordat de threadbewerking begon."
+      "id": "native.apple.980f552bb0f96c0f",
+      "source": "Gateway changed before the session operation started.",
+      "translated": "De Gateway is gewijzigd voordat de sessiebewerking is gestart."
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24334,9 +24264,9 @@
       "translated": "Verwijder bijlagen of wacht tot de bezorging is voltooid voordat je van chat wisselt."
     },
     {
-      "id": "native.apple.0a5c4e15466c3acc",
-      "source": "Clear this thread's history?",
-      "translated": "De geschiedenis van deze thread wissen?"
+      "id": "native.apple.87ba543b42696b92",
+      "source": "Clear this session's history?",
+      "translated": "Geschiedenis van deze sessie wissen?"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24349,14 +24279,14 @@
       "translated": "Hiermee wordt het gesprek voor %@ gereset. De sessiesleutel blijft hetzelfde."
     },
     {
-      "id": "native.apple.67ac221dbe7179f0",
-      "source": "Rename Thread",
-      "translated": "Thread hernoemen"
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "Hernoem sessie"
     },
     {
-      "id": "native.apple.cf0f7e049603f518",
-      "source": "Thread name",
-      "translated": "Threadnaam"
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "Sessienaam"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24374,9 +24304,9 @@
       "translated": "Transcript exporteren"
     },
     {
-      "id": "native.apple.c0ada47504425f23",
-      "source": "Threads",
-      "translated": "Threads"
+      "id": "native.apple.4af0f566d39d7041",
+      "source": "Sessions",
+      "translated": "Sessies"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24449,14 +24379,14 @@
       "translated": "Standaard"
     },
     {
-      "id": "native.apple.1a765291943599e5",
-      "source": "New Thread",
-      "translated": "Nieuwe thread"
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "Nieuwe sessie"
     },
     {
-      "id": "native.apple.c7a3a6d5e43dd98f",
-      "source": "New Thread Options…",
-      "translated": "Opties voor nieuwe thread…"
+      "id": "native.apple.a7119fbf9d25df5e",
+      "source": "New Session Options…",
+      "translated": "Opties voor nieuwe sessie…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24464,19 +24394,19 @@
       "translated": "Vernieuwen"
     },
     {
-      "id": "native.apple.0e710b81808e5dcf",
-      "source": "Threads…",
-      "translated": "Threads…"
+      "id": "native.apple.2bcff4a8fa503739",
+      "source": "Sessions…",
+      "translated": "Sessies…"
     },
     {
-      "id": "native.apple.faad8f92b6bef166",
-      "source": "Rename Thread…",
-      "translated": "Thread hernoemen…"
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "Hernoem sessie…"
     },
     {
-      "id": "native.apple.23b61d6cd26ac112",
-      "source": "Fork",
-      "translated": "Afsplitsen"
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "Splits sessie af"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24534,24 +24464,24 @@
       "translated": "Geschiedenis wissen…"
     },
     {
-      "id": "native.apple.8b4f1c5107ea8a0e",
-      "source": "Thread",
-      "translated": "Thread"
+      "id": "native.apple.920fe8a7a33f9e92",
+      "source": "Session",
+      "translated": "Sessie"
     },
     {
-      "id": "native.apple.4d7750c9bf699469",
-      "source": "Thread actions",
-      "translated": "Threadacties"
+      "id": "native.apple.185a401f78328b0f",
+      "source": "Session actions",
+      "translated": "Sessieacties"
     },
     {
-      "id": "native.apple.bb2f22cc43c97f8e",
-      "source": "Thread cost %@",
-      "translated": "Threadkosten %@"
+      "id": "native.apple.9f9dedf599b2619b",
+      "source": "Session cost %@",
+      "translated": "Sessiekosten %@"
     },
     {
-      "id": "native.apple.6239ced0b86e86f8",
-      "source": "Compact Thread",
-      "translated": "Thread comprimeren"
+      "id": "native.apple.f0a4720df5f5f403",
+      "source": "Compact Session",
+      "translated": "Sessie comprimeren"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/nl.json
+++ b/apps/.i18n/native/nl.json
@@ -1429,9 +1429,9 @@
       "translated": "Praten of dicteren met OpenClaw"
     },
     {
-      "id": "native.android.5876e15e5e92fd45",
-      "source": "Browse Sessions",
-      "translated": "Sessies bekijken"
+      "id": "native.android.e2cf5a38587382cb",
+      "source": "Browse Threads",
+      "translated": "Door threads bladeren"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "Geen acties gevonden"
     },
     {
-      "id": "native.android.48ad0ae0e930e02b",
-      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
-      "translated": "Probeer Chat, Voice, Sessions, Providers of Settings."
+      "id": "native.android.bc70a4ac965b82ba",
+      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
+      "translated": "Probeer Chat, Spraak, Threads, Providers of Instellingen."
     },
     {
-      "id": "native.android.d4fbd1ee4f55a5db",
-      "source": "Sessions",
-      "translated": "Sessies"
+      "id": "native.android.670121e54dbe286f",
+      "source": "Threads",
+      "translated": "Threads"
     },
     {
-      "id": "native.android.207c2170504e99e6",
-      "source": "Connect the Gateway to search sessions.",
-      "translated": "Verbind de Gateway om sessies te zoeken."
+      "id": "native.android.d38be650b1bce4a0",
+      "source": "Connect the Gateway to search threads.",
+      "translated": "Verbind de Gateway om threads te zoeken."
     },
     {
-      "id": "native.android.25d2c2d792c952fe",
-      "source": "No matching sessions yet.",
-      "translated": "Nog geen overeenkomende sessies."
+      "id": "native.android.3d7754721f776ef8",
+      "source": "No matching threads yet.",
+      "translated": "Nog geen overeenkomende threads."
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "Assistent aan het werk"
     },
     {
-      "id": "native.android.8f8384286317f5c9",
-      "source": "OpenClaw session",
-      "translated": "OpenClaw-sessie"
+      "id": "native.android.9a839f6e3e05a744",
+      "source": "OpenClaw thread",
+      "translated": "OpenClaw-thread"
     },
     {
-      "id": "native.android.15799e57704b20c6",
-      "source": "Open session",
-      "translated": "Sessie openen"
+      "id": "native.android.d83f82a1e4a5ed99",
+      "source": "Open thread",
+      "translated": "Thread openen"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "Geen providers gereed"
     },
     {
-      "id": "native.android.73e6ab1a168fd381",
-      "source": "Main session",
-      "translated": "Hoofdsessie"
+      "id": "native.android.8a1c5365c0538908",
+      "source": "Main thread",
+      "translated": "Hoofdthread"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.0e3157c15c56944f",
-      "source": "Sessions",
-      "translated": "Sessies"
+      "id": "native.android.a5845742daecb4ba",
+      "source": "Threads",
+      "translated": "Threads"
     },
     {
-      "id": "native.android.70f5d0507d34b5c8",
-      "source": "Focus session search",
-      "translated": "Zoeken in sessies"
+      "id": "native.android.439b324280869527",
+      "source": "Focus thread search",
+      "translated": "Zoeken in threads activeren"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "Gearchiveerd"
     },
     {
-      "id": "native.android.b9cf34c137e4cf03",
-      "source": "Search sessions",
-      "translated": "Sessies zoeken"
+      "id": "native.android.03981341841b04ac",
+      "source": "Search threads",
+      "translated": "Threads zoeken"
     },
     {
-      "id": "native.android.10cb26723e9990fc",
-      "source": "Clear session search",
-      "translated": "Zoekopdracht voor sessies wissen"
+      "id": "native.android.99570c528a41fa72",
+      "source": "Clear thread search",
+      "translated": "Zoekopdracht voor threads wissen"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "Oudste eerst"
     },
     {
-      "id": "native.android.c6bf8751e2a7f5c7",
-      "source": "Toggle session layout",
-      "translated": "Sessielay-out wisselen"
+      "id": "native.android.fd67be543e321cc9",
+      "source": "Toggle thread layout",
+      "translated": "Threadindeling wijzigen"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "Lay-out: Gedetailleerd"
     },
     {
-      "id": "native.android.69b79a3c2c987cd4",
-      "source": "Searching sessions",
-      "translated": "Sessies zoeken"
+      "id": "native.android.ebd17565e0ffd8eb",
+      "source": "Searching threads",
+      "translated": "Threads zoeken"
     },
     {
-      "id": "native.android.dd587d341af44212",
-      "source": "No matching sessions",
-      "translated": "Geen overeenkomende sessies"
+      "id": "native.android.472d46ae8669f860",
+      "source": "No matching threads",
+      "translated": "Geen overeenkomende threads"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "Chat starten"
     },
     {
-      "id": "native.android.f10d4df7cbc6df4f",
-      "source": "Current session",
-      "translated": "Huidige sessie"
+      "id": "native.android.ff81ad1bee00d384",
+      "source": "Current thread",
+      "translated": "Huidige thread"
     },
     {
-      "id": "native.android.8f0482425838ae64",
-      "source": "OpenClaw session",
-      "translated": "OpenClaw-sessie"
+      "id": "native.android.fc145645b9620e57",
+      "source": "OpenClaw thread",
+      "translated": "OpenClaw-thread"
     },
     {
-      "id": "native.android.786774c8a76e50d7",
-      "source": "Rename session",
-      "translated": "Sessie hernoemen"
+      "id": "native.android.71cbb8dde8bf138b",
+      "source": "Rename thread",
+      "translated": "Thread hernoemen"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "Groep verwijderen?"
     },
     {
-      "id": "native.android.3455fc2f77d564e3",
-      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "Sessies in \"$group\" blijven behouden en gaan terug naar Niet-gegroepeerd."
+      "id": "native.android.691e92cfe5cf106e",
+      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "Threads in \"$group\" worden behouden en teruggezet naar Niet gegroepeerd."
     },
     {
-      "id": "native.android.4805fb9d6623e8c0",
-      "source": "Delete session?",
-      "translated": "Sessie verwijderen?"
+      "id": "native.android.d87a8217ab56999b",
+      "source": "Delete thread?",
+      "translated": "Thread verwijderen?"
     },
     {
-      "id": "native.android.0c3283a2b2445eae",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "Hiermee worden de sessie en het transcript permanent verwijderd."
+      "id": "native.android.930de97ff47113a8",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "Hiermee worden de thread en het transcript ervan permanent verwijderd."
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "Niet gegroepeerd"
     },
     {
-      "id": "native.android.db243d71d056afa4",
-      "source": "No sessions yet",
-      "translated": "Nog geen sessies"
+      "id": "native.android.8e21a70428def6e0",
+      "source": "No threads yet",
+      "translated": "Nog geen threads"
     },
     {
-      "id": "native.android.5b4eee6a8092925e",
-      "source": "No current session",
-      "translated": "Geen huidige sessie"
+      "id": "native.android.cda4c5ad8b17e394",
+      "source": "No current thread",
+      "translated": "Geen huidige thread"
     },
     {
-      "id": "native.android.acbcc9c9ea53d8c0",
-      "source": "No archived sessions",
-      "translated": "Geen gearchiveerde sessies"
+      "id": "native.android.be84f061047aa2da",
+      "source": "No archived threads",
+      "translated": "Geen gearchiveerde threads"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "Start een nieuw gesprek en het verschijnt hier."
     },
     {
-      "id": "native.android.56fcd605dc7be3c0",
-      "source": "Open Chat to start or resume the current session.",
-      "translated": "Open Chat om de huidige sessie te starten of te hervatten."
+      "id": "native.android.f289d03e1d3eee98",
+      "source": "Open Chat to start or resume the current thread.",
+      "translated": "Open Chat om de huidige thread te starten of te hervatten."
     },
     {
-      "id": "native.android.085515989f8a2022",
-      "source": "Archived sessions will show up here.",
-      "translated": "Gearchiveerde sessies worden hier weergegeven."
+      "id": "native.android.504b71386e76c6ae",
+      "source": "Archived threads will show up here.",
+      "translated": "Gearchiveerde threads worden hier weergegeven."
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days} d"
     },
     {
-      "id": "native.android.3d4fa07acbc015c5",
-      "source": "Main session",
-      "translated": "Hoofdsessie"
+      "id": "native.android.ee4c727cdafbe963",
+      "source": "Main thread",
+      "translated": "Hoofdthread"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway in afwachting"
     },
     {
-      "id": "native.android.2d8d049afe99f751",
-      "source": "Session Activity",
-      "translated": "Sessieactiviteit"
+      "id": "native.android.da78209effb11cfd",
+      "source": "Thread Activity",
+      "translated": "Threadactiviteit"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "Exec-goedkeuringsverzoeken verschijnen hier terwijl deze telefoon is verbonden."
     },
     {
-      "id": "native.android.dc3e7ca5a491103a",
-      "source": "Session activity",
-      "translated": "Sessieactiviteit"
+      "id": "native.android.f615712dfb56319a",
+      "source": "Thread activity",
+      "translated": "Threadactiviteit"
     },
     {
-      "id": "native.android.8551e02b060bd7d8",
-      "source": "Chat tool calls waiting in the active session remain visible here.",
-      "translated": "Chattool-aanroepen die wachten in de actieve sessie blijven hier zichtbaar."
+      "id": "native.android.6c93973c13db43ae",
+      "source": "Chat tool calls waiting in the active thread remain visible here.",
+      "translated": "Aanroepen van Chat-tools die in de actieve thread wachten, blijven hier zichtbaar."
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,6 +4294,11 @@
       "translated": "Talk Provider instellen"
     },
     {
+      "id": "native.android.23b638094c34b916",
+      "source": "Microphone",
+      "translated": "Microfoon"
+    },
+    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "Audiotest"
@@ -4337,6 +4342,66 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "Gereed"
+    },
+    {
+      "id": "native.android.8d9ecdfdd916b780",
+      "source": "Automatic",
+      "translated": "Automatisch"
+    },
+    {
+      "id": "native.android.c1626a6700a570f6",
+      "source": "Preferred microphone unavailable; using automatic routing.",
+      "translated": "Voorkeursmicrofoon niet beschikbaar; automatische routering wordt gebruikt."
+    },
+    {
+      "id": "native.android.820bc5d0ce571d8b",
+      "source": "Prioritizes connected Bluetooth microphones.",
+      "translated": "Geeft prioriteit aan verbonden Bluetooth-microfoons."
+    },
+    {
+      "id": "native.android.11e48038d5e8bff6",
+      "source": "Preferred microphone",
+      "translated": "Voorkeursmicrofoon"
+    },
+    {
+      "id": "native.android.eaa4d7563a46d307",
+      "source": "Unavailable",
+      "translated": "Niet beschikbaar"
+    },
+    {
+      "id": "native.android.9f5ebf17eb405ba8",
+      "source": "Next session",
+      "translated": "Volgende sessie"
+    },
+    {
+      "id": "native.android.8c4e91f53928efb2",
+      "source": "Built-in microphone",
+      "translated": "Ingebouwde microfoon"
+    },
+    {
+      "id": "native.android.14b613cb6e2446b4",
+      "source": "Bluetooth microphone",
+      "translated": "Bluetooth-microfoon"
+    },
+    {
+      "id": "native.android.c885247b2d7ce271",
+      "source": "Bluetooth LE microphone",
+      "translated": "Bluetooth LE-microfoon"
+    },
+    {
+      "id": "native.android.b6a4e674c5fb441a",
+      "source": "Wired headset microphone",
+      "translated": "Microfoon van bedrade headset"
+    },
+    {
+      "id": "native.android.9c8becb3b0fb5a90",
+      "source": "USB microphone",
+      "translated": "USB-microfoon"
+    },
+    {
+      "id": "native.android.ba46258fadec7a39",
+      "source": "External microphone",
+      "translated": "Externe microfoon"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5074,9 +5139,9 @@
       "translated": "Controleren"
     },
     {
-      "id": "native.android.5a540761383fa474",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
-      "translated": "OpenClaw verandert deze telefoon in een overzichtelijk mobiel bedieningspaneel voor sessies, spraak, providers en Gateway."
+      "id": "native.android.c971506716c96e91",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
+      "translated": "OpenClaw maakt van deze telefoon een overzichtelijk mobiel bedieningspaneel voor threads, spraak, providers en Gateway."
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5624,9 +5689,9 @@
       "translated": "Talk-instellingen"
     },
     {
-      "id": "native.android.73f07a5d54915259",
-      "source": "Recent Sessions",
-      "translated": "Recente sessies"
+      "id": "native.android.36f78c8c85dc283f",
+      "source": "Recent Threads",
+      "translated": "Recente threads"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5684,14 +5749,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online"
     },
     {
-      "id": "native.android.16c3425d3a594481",
-      "source": "Sessions",
-      "translated": "Sessies"
+      "id": "native.android.57177017a6a93826",
+      "source": "Threads",
+      "translated": "Threads"
     },
     {
-      "id": "native.android.a5c0f8b3112aa58c",
-      "source": "No recent sessions",
-      "translated": "Geen recente sessies"
+      "id": "native.android.43320b54a68b00a1",
+      "source": "No recent threads",
+      "translated": "Geen recente threads"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5729,14 +5794,14 @@
       "translated": "Bezig · $pendingRunCount actieve uitvoeringen"
     },
     {
-      "id": "native.android.2c89da708b12a522",
-      "source": "Monitoring · 1 session",
-      "translated": "Monitoren · 1 sessie"
+      "id": "native.android.e24db059480f1e6a",
+      "source": "Monitoring · 1 thread",
+      "translated": "Monitoren · 1 thread"
     },
     {
-      "id": "native.android.8b6ee382dcb64e1f",
-      "source": "Monitoring · $sessionCount sessions",
-      "translated": "Monitoren · $sessionCount sessies"
+      "id": "native.android.5a475f37d80e02bc",
+      "source": "Monitoring · $sessionCount threads",
+      "translated": "Monitoren · $sessionCount threads"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5769,9 +5834,9 @@
       "translated": "Providers"
     },
     {
-      "id": "native.android.a65477861c7203aa",
-      "source": "Open session",
-      "translated": "Sessie openen"
+      "id": "native.android.358c5e0e838d5423",
+      "source": "Open thread",
+      "translated": "Thread openen"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6194,9 +6259,9 @@
       "translated": "${days}d"
     },
     {
-      "id": "native.android.22d755834386db07",
-      "source": "Main session",
-      "translated": "Hoofdsessie"
+      "id": "native.android.28a1a1acc5a0959f",
+      "source": "Main thread",
+      "translated": "Hoofdthread"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6877,6 +6942,16 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "Dempen opheffen"
+    },
+    {
+      "id": "native.android.cb608d82c5b3352a",
+      "source": "Back camera",
+      "translated": "Camera aan de achterkant"
+    },
+    {
+      "id": "native.android.e89a0e780eed2e1e",
+      "source": "Front camera",
+      "translated": "Camera aan de voorkant"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7684,9 +7759,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.882cc14a58e7e105",
-      "source": "Loading session",
-      "translated": "Sessie laden"
+      "id": "native.android.0c74bc30a994dd33",
+      "source": "Loading thread",
+      "translated": "Thread laden"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7729,14 +7804,14 @@
       "translated": "Praat me bij"
     },
     {
-      "id": "native.android.1e5add56e48c99f9",
-      "source": "Summarize recent sessions and next steps.",
-      "translated": "Vat recente sessies en vervolgstappen samen."
+      "id": "native.android.cf40df9739f78f27",
+      "source": "Summarize recent threads and next steps.",
+      "translated": "Vat recente threads en vervolgstappen samen."
     },
     {
-      "id": "native.android.06d515351bb79576",
-      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
-      "translated": "Praat me bij over mijn recente OpenClaw-sessies en stel vervolgstappen voor."
+      "id": "native.android.ebe49a8b8df80bd3",
+      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
+      "translated": "Praat me bij over mijn recente OpenClaw-threads en stel vervolgstappen voor."
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8074,9 +8149,9 @@
       "translated": "Verbonden"
     },
     {
-      "id": "native.android.81931886b9caf3ab",
-      "source": "Sessions",
-      "translated": "Sessies"
+      "id": "native.android.6cf5d6fa8a4186d5",
+      "source": "Threads",
+      "translated": "Threads"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,9 +10869,9 @@
       "translated": "Waar wilt u aan werken?"
     },
     {
-      "id": "native.apple.32179ce0b6d4543f",
-      "source": "The session attaches once the gateway is ready.",
-      "translated": "De sessie wordt gekoppeld zodra de Gateway gereed is."
+      "id": "native.apple.4da775013ac9b123",
+      "source": "The thread attaches once the gateway is ready.",
+      "translated": "De thread wordt gekoppeld zodra de Gateway gereed is."
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10844,9 +10919,9 @@
       "translated": "Opties voor nieuwe sessie…"
     },
     {
-      "id": "native.apple.a1b0d289758e2213",
-      "source": "Sessions…",
-      "translated": "Sessies…"
+      "id": "native.apple.003b25ddafeb18e9",
+      "source": "Threads…",
+      "translated": "Threads…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11009,14 +11084,14 @@
       "translated": "Aanmaken"
     },
     {
-      "id": "native.apple.f488b9caf6e51ac3",
-      "source": "Delete Session?",
-      "translated": "Sessie verwijderen?"
+      "id": "native.apple.31d5c7287cfb3abe",
+      "source": "Delete Thread?",
+      "translated": "Thread verwijderen?"
     },
     {
-      "id": "native.apple.8634b17be9b111bc",
-      "source": "Delete Session",
-      "translated": "Sessie verwijderen"
+      "id": "native.apple.d3395564809f1120",
+      "source": "Delete Thread",
+      "translated": "Thread verwijderen"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11024,9 +11099,9 @@
       "translated": "Annuleren"
     },
     {
-      "id": "native.apple.4a9568ac9b18d8d3",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "Hiermee verwijder je de sessie en het transcript permanent."
+      "id": "native.apple.092659256d26cb03",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "Hiermee worden de thread en het transcript permanent verwijderd."
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11054,9 +11129,9 @@
       "translated": "Nieuwe groep"
     },
     {
-      "id": "native.apple.5bccdc23a1640895",
-      "source": "Rename Session",
-      "translated": "Sessie hernoemen"
+      "id": "native.apple.683032464c497bbd",
+      "source": "Rename Thread",
+      "translated": "Thread hernoemen"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11064,9 +11139,9 @@
       "translated": "Groepsnaam"
     },
     {
-      "id": "native.apple.af789b2d2fda0f67",
-      "source": "Session name",
-      "translated": "Sessienaam"
+      "id": "native.apple.f887aa956588f237",
+      "source": "Thread name",
+      "translated": "Threadnaam"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11104,14 +11179,14 @@
       "translated": "Agents"
     },
     {
-      "id": "native.apple.a3bde8045fe9224a",
-      "source": "Agent session",
-      "translated": "Agentsessie"
+      "id": "native.apple.7c8231b7b1ca480f",
+      "source": "Agent thread",
+      "translated": "Agentthread"
     },
     {
-      "id": "native.apple.27f775de30b37ff8",
-      "source": "Recent sessions",
-      "translated": "Recente sessies"
+      "id": "native.apple.b3c553614f762a58",
+      "source": "Recent threads",
+      "translated": "Recente threads"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11119,9 +11194,9 @@
       "translated": "Gateway offline"
     },
     {
-      "id": "native.apple.28c97cf23665ee01",
-      "source": "No recent sessions",
-      "translated": "Geen recente sessies"
+      "id": "native.apple.5aa32afda85064ea",
+      "source": "No recent threads",
+      "translated": "Geen recente threads"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11219,14 +11294,14 @@
       "translated": "Annuleren"
     },
     {
-      "id": "native.apple.9f2fd65953013b7c",
-      "source": "Sessions",
-      "translated": "Sessies"
+      "id": "native.apple.b6855cf19a50f477",
+      "source": "Threads",
+      "translated": "Threads"
     },
     {
-      "id": "native.apple.0422818cc95d5071",
-      "source": "Archived sessions",
-      "translated": "Gearchiveerde sessies"
+      "id": "native.apple.9b1d0ef27a1333b0",
+      "source": "Archived threads",
+      "translated": "Gearchiveerde threads"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11234,34 +11309,34 @@
       "translated": "Gearchiveerde tonen"
     },
     {
-      "id": "native.apple.b272115c83f7ef58",
-      "source": "Sessions unavailable",
-      "translated": "Sessies niet beschikbaar"
+      "id": "native.apple.98167401c7267735",
+      "source": "Threads unavailable",
+      "translated": "Threads niet beschikbaar"
     },
     {
-      "id": "native.apple.54f8260c9b863087",
-      "source": "Loading archived sessions",
-      "translated": "Gearchiveerde sessies laden"
+      "id": "native.apple.4d28a7def2337b9f",
+      "source": "Loading archived threads",
+      "translated": "Gearchiveerde threads laden"
     },
     {
-      "id": "native.apple.9b305868873dade2",
-      "source": "Loading recent sessions",
-      "translated": "Recente sessies laden"
+      "id": "native.apple.777d7b706933bd7b",
+      "source": "Loading recent threads",
+      "translated": "Recente threads laden"
     },
     {
-      "id": "native.apple.207dad20d09f3160",
-      "source": "^[\\(count) session](inflect: true)",
-      "translated": "^[\\(count) sessie](inflect: true)"
+      "id": "native.apple.22f81ea94bef8410",
+      "source": "^[\\(count) thread](inflect: true)",
+      "translated": "^[\\(count) thread](inflect: true)"
     },
     {
-      "id": "native.apple.1f4501a6bf2bae4c",
-      "source": "No archived sessions",
-      "translated": "Geen gearchiveerde sessies"
+      "id": "native.apple.1cad51e14db59bf9",
+      "source": "No archived threads",
+      "translated": "Geen gearchiveerde threads"
     },
     {
-      "id": "native.apple.2a1ba7a5e1979c9e",
-      "source": "Archived sessions will appear here.",
-      "translated": "Gearchiveerde sessies verschijnen hier."
+      "id": "native.apple.18ef832d3a7ddcf8",
+      "source": "Archived threads will appear here.",
+      "translated": "Gearchiveerde threads worden hier weergegeven."
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11344,9 +11419,9 @@
       "translated": "Intake delen"
     },
     {
-      "id": "native.apple.2360d25fe6ae9946",
-      "source": "Loading sessions",
-      "translated": "Sessies laden"
+      "id": "native.apple.21d9208d86a4d1fe",
+      "source": "Loading threads",
+      "translated": "Threads laden"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11354,19 +11429,19 @@
       "translated": "Recente activiteit ophalen van de gateway."
     },
     {
-      "id": "native.apple.c334f2e86702a7b8",
-      "source": "Sessions unavailable",
-      "translated": "Sessies niet beschikbaar"
+      "id": "native.apple.4be1f79aa2b230ff",
+      "source": "Threads unavailable",
+      "translated": "Threads niet beschikbaar"
     },
     {
-      "id": "native.apple.6cc6efb7a03960b6",
-      "source": "No recent sessions",
-      "translated": "Geen recente sessies"
+      "id": "native.apple.98b348873556bc46",
+      "source": "No recent threads",
+      "translated": "Geen recente threads"
     },
     {
-      "id": "native.apple.08483af2d043bee6",
-      "source": "Session activity offline",
-      "translated": "Sessieactiviteit offline"
+      "id": "native.apple.7396d205574d279f",
+      "source": "Thread activity offline",
+      "translated": "Threadactiviteit offline"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11824,9 +11899,9 @@
       "translated": "Kaart"
     },
     {
-      "id": "native.apple.93eeaedb2ff61043",
-      "source": "Open Session",
-      "translated": "Sessie openen"
+      "id": "native.apple.c9ec1b0e18074d8a",
+      "source": "Open Thread",
+      "translated": "Thread openen"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13314,9 +13389,9 @@
       "translated": "Standaard"
     },
     {
-      "id": "native.apple.3de045f17ea3c6d0",
-      "source": "Used for new Chat and Talk sessions.",
-      "translated": "Gebruikt voor nieuwe Chat- en Talk-sessies."
+      "id": "native.apple.f4ae5664c3eda95d",
+      "source": "Used for new Chat threads and Talk sessions.",
+      "translated": "Wordt gebruikt voor nieuwe chatgesprekken en praatsessies."
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15719,9 +15794,9 @@
       "translated": "Instances"
     },
     {
-      "id": "native.apple.3579cf2750470a22",
-      "source": "Sessions",
-      "translated": "Sessions"
+      "id": "native.apple.11fe8b9941954dfb",
+      "source": "Threads",
+      "translated": "Gesprekken"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19029,9 +19104,9 @@
       "translated": "Snelkoppeling voor Quick Chat"
     },
     {
-      "id": "native.apple.6ae77665b5f4490f",
-      "source": "Global shortcut that opens a floating chat bar for the main session.",
-      "translated": "Algemene snelkoppeling die een zwevende chatbalk voor de hoofdsessie opent."
+      "id": "native.apple.94dd793cd7d7d555",
+      "source": "Global shortcut that opens a floating chat bar for the main thread.",
+      "translated": "Algemene sneltoets waarmee een zwevende chatbalk voor het hoofdgesprek wordt geopend."
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19609,9 +19684,9 @@
       "translated": "Kritiek"
     },
     {
-      "id": "native.apple.75102378a6775180",
-      "source": "New Session",
-      "translated": "Nieuwe sessie"
+      "id": "native.apple.13f96467014cf344",
+      "source": "New Thread",
+      "translated": "Nieuw gesprek"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21899,9 +21974,9 @@
       "translated": "Geen recente berichten"
     },
     {
-      "id": "native.apple.1ff8aec0044934c3",
-      "source": "Sessions",
-      "translated": "Sessies"
+      "id": "native.apple.3ec2afcbc298c673",
+      "source": "Threads",
+      "translated": "Gesprekken"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21909,9 +21984,9 @@
       "translated": "Bekijk de opgeslagen gespreksbuckets die de CLI opnieuw gebruikt voor context en snelheidslimieten."
     },
     {
-      "id": "native.apple.bab897f3252b134c",
-      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
-      "translated": "Nog geen sessies. Ze verschijnen na het eerste inkomende bericht of heartbeat."
+      "id": "native.apple.14ccb32cd8ed1c81",
+      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
+      "translated": "Nog geen gesprekken. Ze verschijnen na het eerste inkomende bericht of de eerste heartbeat."
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -21994,9 +22069,9 @@
       "translated": "Uitvoeringsgoedkeuringen"
     },
     {
-      "id": "native.apple.64a6dc7d49e8fb57",
-      "source": "Sessions",
-      "translated": "Sessies"
+      "id": "native.apple.52e37e3a44ae516c",
+      "source": "Threads",
+      "translated": "Gesprekken"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -22999,9 +23074,9 @@
       "translated": "Praat me bij"
     },
     {
-      "id": "native.apple.234ec45f4231edc4",
-      "source": "Summarize what happened in my sessions since yesterday.",
-      "translated": "Vat samen wat er sinds gisteren in mijn sessies is gebeurd."
+      "id": "native.apple.fc4ce810900ec0b6",
+      "source": "Summarize what happened in my threads since yesterday.",
+      "translated": "Vat samen wat er sinds gisteren in mijn gesprekken is gebeurd."
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23179,9 +23254,9 @@
       "translated": "Model losmaken"
     },
     {
-      "id": "native.apple.5dfc0700d8dff8de",
-      "source": "Session",
-      "translated": "Sessie"
+      "id": "native.apple.4edb66657f5aca1f",
+      "source": "Thread",
+      "translated": "Gesprek"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23344,6 +23419,51 @@
       "translated": "Widget niet beschikbaar"
     },
     {
+      "id": "native.apple.d640691fd196f338",
+      "source": "Widget export failed",
+      "translated": "Exporteren van widget mislukt"
+    },
+    {
+      "id": "native.apple.533c6e22a11e88de",
+      "source": "OK",
+      "translated": "OK"
+    },
+    {
+      "id": "native.apple.e1fb28a2a9756402",
+      "source": "Copy image",
+      "translated": "Afbeelding kopiëren"
+    },
+    {
+      "id": "native.apple.ebd7bc92e1b12235",
+      "source": "Save image…",
+      "translated": "Afbeelding bewaren…"
+    },
+    {
+      "id": "native.apple.742c46d4cf2db134",
+      "source": "Save image",
+      "translated": "Afbeelding bewaren"
+    },
+    {
+      "id": "native.apple.0589cce608418f90",
+      "source": "The widget image could not be captured.",
+      "translated": "De widgetafbeelding kon niet worden vastgelegd."
+    },
+    {
+      "id": "native.apple.dfe24e827fdbe9c5",
+      "source": "The widget image could not be copied.",
+      "translated": "De widgetafbeelding kon niet worden gekopieerd."
+    },
+    {
+      "id": "native.apple.9e611e3a80e71408",
+      "source": "The widget image could not be encoded as PNG.",
+      "translated": "De widgetafbeelding kon niet als PNG worden gecodeerd."
+    },
+    {
+      "id": "native.apple.9a6e8afbe24a262b",
+      "source": "The widget image could not be saved.",
+      "translated": "De widgetafbeelding kon niet worden bewaard."
+    },
+    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23484,19 +23604,19 @@
       "translated": "Gebruiker"
     },
     {
-      "id": "native.apple.b1cdcb906a43d5d6",
-      "source": "This session cannot be archived while it is active or running.",
-      "translated": "Deze sessie kan niet worden gearchiveerd terwijl deze actief of in uitvoering is."
+      "id": "native.apple.9d0cba09d92ee669",
+      "source": "This thread cannot be archived while it is active or running.",
+      "translated": "Dit gesprek kan niet worden gearchiveerd zolang het actief is of wordt uitgevoerd."
     },
     {
-      "id": "native.apple.5817e3f3dab1ee19",
-      "source": "The main session cannot be deleted.",
-      "translated": "De hoofdsessie kan niet worden verwijderd."
+      "id": "native.apple.8952a111a1075051",
+      "source": "The main thread cannot be deleted.",
+      "translated": "Het hoofdgesprek kan niet worden verwijderd."
     },
     {
-      "id": "native.apple.a6b8df3f18171c91",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
-      "translated": "Verwijder bijlagen of wacht op de bezorging voordat u deze sessie archiveert of verwijdert."
+      "id": "native.apple.90d0ccf80ca28717",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
+      "translated": "Verwijder bijlagen of wacht op de bezorging voordat je deze thread archiveert of verwijdert."
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23634,9 +23754,9 @@
       "translated": "Uitvoering beëindigd"
     },
     {
-      "id": "native.apple.cd7c3095a22f80a9",
-      "source": "Session Info",
-      "translated": "Sessie-informatie"
+      "id": "native.apple.bbccb4c8db5cac12",
+      "source": "Thread Info",
+      "translated": "Threadinformatie"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23669,9 +23789,9 @@
       "translated": "Groep toevoegen"
     },
     {
-      "id": "native.apple.23d628606fe0734f",
-      "source": "Session Groups",
-      "translated": "Sessiegroepen"
+      "id": "native.apple.7b641fed5bace855",
+      "source": "Thread Groups",
+      "translated": "Threadgroepen"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23714,9 +23834,9 @@
       "translated": "Groep verwijderen"
     },
     {
-      "id": "native.apple.b049c8a4d2805e08",
-      "source": "Sessions in this group become ungrouped.",
-      "translated": "Sessies in deze groep worden uit de groep gehaald."
+      "id": "native.apple.56401c79410a310d",
+      "source": "Threads in this group become ungrouped.",
+      "translated": "Threads in deze groep worden uit de groep gehaald."
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23729,9 +23849,9 @@
       "translated": "Er zijn geen agents beschikbaar op deze gateway."
     },
     {
-      "id": "native.apple.6c89f35d53506406",
-      "source": "New Session Options",
-      "translated": "Opties voor nieuwe sessie"
+      "id": "native.apple.2d96aa7d3d12f85b",
+      "source": "New Thread Options",
+      "translated": "Opties voor nieuwe thread"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23759,19 +23879,19 @@
       "translated": "Aanmaken"
     },
     {
-      "id": "native.apple.795ba37f6782cf28",
-      "source": "The session could not be created.",
-      "translated": "De sessie kon niet worden aangemaakt."
+      "id": "native.apple.87ef57319d1ddc85",
+      "source": "The thread could not be created.",
+      "translated": "De thread kon niet worden aangemaakt."
     },
     {
-      "id": "native.apple.8ec708a3605a2cc3",
-      "source": "Search sessions",
-      "translated": "Sessies zoeken"
+      "id": "native.apple.6bd91c435b69d638",
+      "source": "Search threads",
+      "translated": "Threads zoeken"
     },
     {
-      "id": "native.apple.23b069b4e7f97039",
-      "source": "No Sessions",
-      "translated": "Geen sessies"
+      "id": "native.apple.6fde4bdf9d5b9191",
+      "source": "No Threads",
+      "translated": "Geen threads"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23779,29 +23899,29 @@
       "translated": "Geen resultaten"
     },
     {
-      "id": "native.apple.0058923f2ce8a3ec",
-      "source": "New Session",
-      "translated": "Nieuwe sessie"
+      "id": "native.apple.a02fd99740d29bd3",
+      "source": "New Thread",
+      "translated": "Nieuwe thread"
     },
     {
-      "id": "native.apple.66ba42960eb4135b",
-      "source": "New session",
-      "translated": "Nieuwe sessie"
+      "id": "native.apple.b625801dd04b09f2",
+      "source": "New thread",
+      "translated": "Nieuwe thread"
     },
     {
-      "id": "native.apple.2ef0e34db02ad255",
-      "source": "New session options",
-      "translated": "Opties voor nieuwe sessie"
+      "id": "native.apple.851be81fcc933608",
+      "source": "New thread options",
+      "translated": "Opties voor nieuwe thread"
     },
     {
-      "id": "native.apple.36753ef2f1ed4264",
-      "source": "Rename Session",
-      "translated": "Sessie hernoemen"
+      "id": "native.apple.9ce8a4aba7b444b2",
+      "source": "Rename Thread",
+      "translated": "Thread hernoemen"
     },
     {
-      "id": "native.apple.c9de0a1510ef475f",
-      "source": "Session name",
-      "translated": "Sessienaam"
+      "id": "native.apple.1dd067c44511c7f0",
+      "source": "Thread name",
+      "translated": "Threadnaam"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23814,14 +23934,14 @@
       "translated": "Annuleren"
     },
     {
-      "id": "native.apple.afb4e6c99c63a28d",
-      "source": "Delete Session",
-      "translated": "Sessie verwijderen"
+      "id": "native.apple.618073d6ab3f2721",
+      "source": "Delete Thread",
+      "translated": "Thread verwijderen"
     },
     {
-      "id": "native.apple.3d4ef32e42f136a4",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "De sessie en het transcript ervan worden uit de Gateway verwijderd."
+      "id": "native.apple.10a5e72bba3cbccc",
+      "source": "The thread and its transcript are removed from the gateway.",
+      "translated": "De thread en het transcript ervan worden uit de Gateway verwijderd."
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23829,14 +23949,14 @@
       "translated": "‘%@’ verwijderen?"
     },
     {
-      "id": "native.apple.9a7dca238fba628d",
-      "source": "Session running",
-      "translated": "Sessie actief"
+      "id": "native.apple.ac71e3b2aa496a2c",
+      "source": "Thread running",
+      "translated": "Thread wordt uitgevoerd"
     },
     {
-      "id": "native.apple.fcfbfe5e97a95e9c",
-      "source": "Session failed",
-      "translated": "Sessie mislukt"
+      "id": "native.apple.c775e87f997278b2",
+      "source": "Thread failed",
+      "translated": "Thread mislukt"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23894,9 +24014,9 @@
       "translated": "Kopieer sessiesleutel"
     },
     {
-      "id": "native.apple.4aeb7c14c26dabac",
-      "source": "Delete Session…",
-      "translated": "Verwijder sessie…"
+      "id": "native.apple.f4998cfb572f23ff",
+      "source": "Delete Thread…",
+      "translated": "Thread verwijderen…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23909,9 +24029,9 @@
       "translated": "Verbinden…"
     },
     {
-      "id": "native.apple.79f708b3bc1d3a6c",
-      "source": "Retry session groups",
-      "translated": "Sessiegroepen opnieuw proberen"
+      "id": "native.apple.8802e9576ffd0f65",
+      "source": "Retry thread groups",
+      "translated": "Threadgroepen opnieuw proberen"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23934,24 +24054,24 @@
       "translated": "Bereik"
     },
     {
-      "id": "native.apple.2c37581c7b88f741",
-      "source": "Search sessions",
-      "translated": "Sessies zoeken"
+      "id": "native.apple.b313b80def4bda52",
+      "source": "Search threads",
+      "translated": "Threads zoeken"
     },
     {
-      "id": "native.apple.43be8a2336e42faf",
-      "source": "Sessions",
-      "translated": "Sessies"
+      "id": "native.apple.c0cc6acc36f413ce",
+      "source": "Threads",
+      "translated": "Gesprekken"
     },
     {
-      "id": "native.apple.0b379cdfcbd3247f",
-      "source": "Rename Session",
-      "translated": "Sessie hernoemen"
+      "id": "native.apple.854d3928fe5a557c",
+      "source": "Rename Thread",
+      "translated": "Gesprek hernoemen"
     },
     {
-      "id": "native.apple.54b6fbd9e41db009",
-      "source": "Session name",
-      "translated": "Sessienaam"
+      "id": "native.apple.9d0d3f20096cc4da",
+      "source": "Thread name",
+      "translated": "Gespreksnaam"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -23959,19 +24079,19 @@
       "translated": "Annuleren"
     },
     {
-      "id": "native.apple.751e0f6b81cd374a",
-      "source": "Delete selected sessions?",
-      "translated": "Geselecteerde sessies verwijderen?"
+      "id": "native.apple.dc00eb94f33bae15",
+      "source": "Delete selected threads?",
+      "translated": "Geselecteerde gesprekken verwijderen?"
     },
     {
-      "id": "native.apple.aa679276581b0058",
-      "source": "Delete Sessions",
-      "translated": "Sessies verwijderen"
+      "id": "native.apple.2053fc9f74dc3158",
+      "source": "Delete Threads",
+      "translated": "Gesprekken verwijderen"
     },
     {
-      "id": "native.apple.f837129cbee23297",
-      "source": "Each selected session and its transcript will be removed from the gateway.",
-      "translated": "Elke geselecteerde sessie en het bijbehorende transcript worden van de Gateway verwijderd."
+      "id": "native.apple.0970247871a834a0",
+      "source": "Each selected thread and its transcript will be removed from the gateway.",
+      "translated": "Elk geselecteerd gesprek en het bijbehorende transcript worden uit de gateway verwijderd."
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -23979,9 +24099,9 @@
       "translated": "Groepen"
     },
     {
-      "id": "native.apple.64013cfee5e25305",
-      "source": "Manage session groups",
-      "translated": "Sessiegroepen beheren"
+      "id": "native.apple.6f8acab2256728b5",
+      "source": "Manage thread groups",
+      "translated": "Gespreksgroepen beheren"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -23994,14 +24114,14 @@
       "translated": "Selecteer"
     },
     {
-      "id": "native.apple.b67eaecec1b423ac",
-      "source": "No archived sessions",
-      "translated": "Geen gearchiveerde sessies"
+      "id": "native.apple.692972314d04b184",
+      "source": "No archived threads",
+      "translated": "Geen gearchiveerde gesprekken"
     },
     {
-      "id": "native.apple.b2435a79abf0c794",
-      "source": "No sessions found",
-      "translated": "Geen sessies gevonden"
+      "id": "native.apple.d6a4b5711dcd26e7",
+      "source": "No threads found",
+      "translated": "Geen gesprekken gevonden"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24169,6 +24289,16 @@
       "translated": "Volledig bericht openen"
     },
     {
+      "id": "native.apple.002bfcede229ad4b",
+      "source": "Rewind to Here",
+      "translated": "Tot hier terugspoelen"
+    },
+    {
+      "id": "native.apple.14df2e4997689fb3",
+      "source": "Fork from Here",
+      "translated": "Vanaf hier afsplitsen"
+    },
+    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "Antwoorden"
@@ -24254,9 +24384,9 @@
       "translated": "Verwijder bijlagen of wacht tot de bezorging is afgerond voordat je een nieuwe chat start."
     },
     {
-      "id": "native.apple.980f552bb0f96c0f",
-      "source": "Gateway changed before the session operation started.",
-      "translated": "De Gateway is gewijzigd voordat de sessiebewerking is gestart."
+      "id": "native.apple.e0f045151c8d3137",
+      "source": "Gateway changed before the thread operation started.",
+      "translated": "De Gateway is gewijzigd voordat de gespreksbewerking begon."
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24264,9 +24394,9 @@
       "translated": "Verwijder bijlagen of wacht tot de bezorging is voltooid voordat je van chat wisselt."
     },
     {
-      "id": "native.apple.87ba543b42696b92",
-      "source": "Clear this session's history?",
-      "translated": "Geschiedenis van deze sessie wissen?"
+      "id": "native.apple.0a5c4e15466c3acc",
+      "source": "Clear this thread's history?",
+      "translated": "De geschiedenis van dit gesprek wissen?"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24279,14 +24409,14 @@
       "translated": "Hiermee wordt het gesprek voor %@ gereset. De sessiesleutel blijft hetzelfde."
     },
     {
-      "id": "native.apple.a92e96bed98bd553",
-      "source": "Rename Session",
-      "translated": "Hernoem sessie"
+      "id": "native.apple.67ac221dbe7179f0",
+      "source": "Rename Thread",
+      "translated": "Gesprek hernoemen"
     },
     {
-      "id": "native.apple.848e2388f3466f40",
-      "source": "Session name",
-      "translated": "Sessienaam"
+      "id": "native.apple.cf0f7e049603f518",
+      "source": "Thread name",
+      "translated": "Gespreksnaam"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24304,9 +24434,9 @@
       "translated": "Transcript exporteren"
     },
     {
-      "id": "native.apple.4af0f566d39d7041",
-      "source": "Sessions",
-      "translated": "Sessies"
+      "id": "native.apple.c0ada47504425f23",
+      "source": "Threads",
+      "translated": "Gesprekken"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24379,14 +24509,14 @@
       "translated": "Standaard"
     },
     {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "Nieuwe sessie"
+      "id": "native.apple.1a765291943599e5",
+      "source": "New Thread",
+      "translated": "Nieuw gesprek"
     },
     {
-      "id": "native.apple.a7119fbf9d25df5e",
-      "source": "New Session Options…",
-      "translated": "Opties voor nieuwe sessie…"
+      "id": "native.apple.c7a3a6d5e43dd98f",
+      "source": "New Thread Options…",
+      "translated": "Opties voor nieuw gesprek…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24394,19 +24524,19 @@
       "translated": "Vernieuwen"
     },
     {
-      "id": "native.apple.2bcff4a8fa503739",
-      "source": "Sessions…",
-      "translated": "Sessies…"
+      "id": "native.apple.0e710b81808e5dcf",
+      "source": "Threads…",
+      "translated": "Gesprekken…"
     },
     {
-      "id": "native.apple.c36e008b051adb38",
-      "source": "Rename Session…",
-      "translated": "Hernoem sessie…"
+      "id": "native.apple.faad8f92b6bef166",
+      "source": "Rename Thread…",
+      "translated": "Gesprek hernoemen…"
     },
     {
-      "id": "native.apple.ea0ef95a159bffe0",
-      "source": "Fork Session",
-      "translated": "Splits sessie af"
+      "id": "native.apple.23b61d6cd26ac112",
+      "source": "Fork",
+      "translated": "Afsplitsen"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24464,24 +24594,24 @@
       "translated": "Geschiedenis wissen…"
     },
     {
-      "id": "native.apple.920fe8a7a33f9e92",
-      "source": "Session",
-      "translated": "Sessie"
+      "id": "native.apple.8b4f1c5107ea8a0e",
+      "source": "Thread",
+      "translated": "Thread"
     },
     {
-      "id": "native.apple.185a401f78328b0f",
-      "source": "Session actions",
-      "translated": "Sessieacties"
+      "id": "native.apple.4d7750c9bf699469",
+      "source": "Thread actions",
+      "translated": "Threadacties"
     },
     {
-      "id": "native.apple.9f9dedf599b2619b",
-      "source": "Session cost %@",
-      "translated": "Sessiekosten %@"
+      "id": "native.apple.bb2f22cc43c97f8e",
+      "source": "Thread cost %@",
+      "translated": "Threadkosten %@"
     },
     {
-      "id": "native.apple.f0a4720df5f5f403",
-      "source": "Compact Session",
-      "translated": "Sessie comprimeren"
+      "id": "native.apple.6239ced0b86e86f8",
+      "source": "Compact Thread",
+      "translated": "Thread comprimeren"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/pl.json
+++ b/apps/.i18n/native/pl.json
@@ -1429,9 +1429,9 @@
       "translated": "Rozmawiaj lub dyktuj z OpenClaw"
     },
     {
-      "id": "native.android.5876e15e5e92fd45",
-      "source": "Browse Sessions",
-      "translated": "Przeglądaj sesje"
+      "id": "native.android.e2cf5a38587382cb",
+      "source": "Browse Threads",
+      "translated": "Przeglądaj wątki"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "Nie znaleziono działań"
     },
     {
-      "id": "native.android.48ad0ae0e930e02b",
-      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
-      "translated": "Wypróbuj czat, głos, sesje, dostawców lub ustawienia."
+      "id": "native.android.bc70a4ac965b82ba",
+      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
+      "translated": "Wypróbuj czat, głos, wątki, dostawców lub ustawienia."
     },
     {
-      "id": "native.android.d4fbd1ee4f55a5db",
-      "source": "Sessions",
-      "translated": "Sesje"
+      "id": "native.android.670121e54dbe286f",
+      "source": "Threads",
+      "translated": "Wątki"
     },
     {
-      "id": "native.android.207c2170504e99e6",
-      "source": "Connect the Gateway to search sessions.",
-      "translated": "Połącz Gateway, aby wyszukiwać sesje."
+      "id": "native.android.d38be650b1bce4a0",
+      "source": "Connect the Gateway to search threads.",
+      "translated": "Połącz Gateway, aby wyszukiwać wątki."
     },
     {
-      "id": "native.android.25d2c2d792c952fe",
-      "source": "No matching sessions yet.",
-      "translated": "Nie ma jeszcze pasujących sesji."
+      "id": "native.android.3d7754721f776ef8",
+      "source": "No matching threads yet.",
+      "translated": "Nie ma jeszcze pasujących wątków."
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "Asystent pracuje"
     },
     {
-      "id": "native.android.8f8384286317f5c9",
-      "source": "OpenClaw session",
-      "translated": "Sesja OpenClaw"
+      "id": "native.android.9a839f6e3e05a744",
+      "source": "OpenClaw thread",
+      "translated": "Wątek OpenClaw"
     },
     {
-      "id": "native.android.15799e57704b20c6",
-      "source": "Open session",
-      "translated": "Otwórz sesję"
+      "id": "native.android.d83f82a1e4a5ed99",
+      "source": "Open thread",
+      "translated": "Otwórz wątek"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "Brak gotowych dostawców"
     },
     {
-      "id": "native.android.73e6ab1a168fd381",
-      "source": "Main session",
-      "translated": "Sesja główna"
+      "id": "native.android.8a1c5365c0538908",
+      "source": "Main thread",
+      "translated": "Główny wątek"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.0e3157c15c56944f",
-      "source": "Sessions",
-      "translated": "Sesje"
+      "id": "native.android.a5845742daecb4ba",
+      "source": "Threads",
+      "translated": "Wątki"
     },
     {
-      "id": "native.android.70f5d0507d34b5c8",
-      "source": "Focus session search",
-      "translated": "Wyszukaj sesję"
+      "id": "native.android.439b324280869527",
+      "source": "Focus thread search",
+      "translated": "Ustaw fokus na wyszukiwaniu wątków"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "Zarchiwizowane"
     },
     {
-      "id": "native.android.b9cf34c137e4cf03",
-      "source": "Search sessions",
-      "translated": "Szukaj sesji"
+      "id": "native.android.03981341841b04ac",
+      "source": "Search threads",
+      "translated": "Szukaj wątków"
     },
     {
-      "id": "native.android.10cb26723e9990fc",
-      "source": "Clear session search",
-      "translated": "Wyczyść wyszukiwanie sesji"
+      "id": "native.android.99570c528a41fa72",
+      "source": "Clear thread search",
+      "translated": "Wyczyść wyszukiwanie wątków"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "Najpierw najstarsze"
     },
     {
-      "id": "native.android.c6bf8751e2a7f5c7",
-      "source": "Toggle session layout",
-      "translated": "Przełącz układ sesji"
+      "id": "native.android.fd67be543e321cc9",
+      "source": "Toggle thread layout",
+      "translated": "Przełącz układ wątków"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "Układ: szczegółowy"
     },
     {
-      "id": "native.android.69b79a3c2c987cd4",
-      "source": "Searching sessions",
-      "translated": "Wyszukiwanie sesji"
+      "id": "native.android.ebd17565e0ffd8eb",
+      "source": "Searching threads",
+      "translated": "Wyszukiwanie wątków"
     },
     {
-      "id": "native.android.dd587d341af44212",
-      "source": "No matching sessions",
-      "translated": "Brak pasujących sesji"
+      "id": "native.android.472d46ae8669f860",
+      "source": "No matching threads",
+      "translated": "Brak pasujących wątków"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "Rozpocznij czat"
     },
     {
-      "id": "native.android.f10d4df7cbc6df4f",
-      "source": "Current session",
-      "translated": "Bieżąca sesja"
+      "id": "native.android.ff81ad1bee00d384",
+      "source": "Current thread",
+      "translated": "Bieżący wątek"
     },
     {
-      "id": "native.android.8f0482425838ae64",
-      "source": "OpenClaw session",
-      "translated": "Sesja OpenClaw"
+      "id": "native.android.fc145645b9620e57",
+      "source": "OpenClaw thread",
+      "translated": "Wątek OpenClaw"
     },
     {
-      "id": "native.android.786774c8a76e50d7",
-      "source": "Rename session",
-      "translated": "Zmień nazwę sesji"
+      "id": "native.android.71cbb8dde8bf138b",
+      "source": "Rename thread",
+      "translated": "Zmień nazwę wątku"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "Usunąć grupę?"
     },
     {
-      "id": "native.android.3455fc2f77d564e3",
-      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "Sesje w „$group” zostaną zachowane i przeniesione z powrotem do Bez grupy."
+      "id": "native.android.691e92cfe5cf106e",
+      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "Wątki w grupie „$group” zostaną zachowane i przeniesione z powrotem do sekcji Bez grupy."
     },
     {
-      "id": "native.android.4805fb9d6623e8c0",
-      "source": "Delete session?",
-      "translated": "Usunąć sesję?"
+      "id": "native.android.d87a8217ab56999b",
+      "source": "Delete thread?",
+      "translated": "Usunąć wątek?"
     },
     {
-      "id": "native.android.0c3283a2b2445eae",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "Spowoduje to trwałe usunięcie sesji i jej transkrypcji."
+      "id": "native.android.930de97ff47113a8",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "Spowoduje to trwałe usunięcie wątku i jego transkrypcji."
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "Bez grupy"
     },
     {
-      "id": "native.android.db243d71d056afa4",
-      "source": "No sessions yet",
-      "translated": "Nie ma jeszcze sesji"
+      "id": "native.android.8e21a70428def6e0",
+      "source": "No threads yet",
+      "translated": "Nie ma jeszcze żadnych wątków"
     },
     {
-      "id": "native.android.5b4eee6a8092925e",
-      "source": "No current session",
-      "translated": "Brak bieżącej sesji"
+      "id": "native.android.cda4c5ad8b17e394",
+      "source": "No current thread",
+      "translated": "Brak bieżącego wątku"
     },
     {
-      "id": "native.android.acbcc9c9ea53d8c0",
-      "source": "No archived sessions",
-      "translated": "Brak zarchiwizowanych sesji"
+      "id": "native.android.be84f061047aa2da",
+      "source": "No archived threads",
+      "translated": "Brak zarchiwizowanych wątków"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "Rozpocznij nową rozmowę, a pojawi się tutaj."
     },
     {
-      "id": "native.android.56fcd605dc7be3c0",
-      "source": "Open Chat to start or resume the current session.",
-      "translated": "Otwórz czat, aby rozpocząć lub wznowić bieżącą sesję."
+      "id": "native.android.f289d03e1d3eee98",
+      "source": "Open Chat to start or resume the current thread.",
+      "translated": "Otwórz czat, aby rozpocząć lub wznowić bieżący wątek."
     },
     {
-      "id": "native.android.085515989f8a2022",
-      "source": "Archived sessions will show up here.",
-      "translated": "Zarchiwizowane sesje pojawią się tutaj."
+      "id": "native.android.504b71386e76c6ae",
+      "source": "Archived threads will show up here.",
+      "translated": "Zarchiwizowane wątki pojawią się tutaj."
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days} d"
     },
     {
-      "id": "native.android.3d4fa07acbc015c5",
-      "source": "Main session",
-      "translated": "Sesja główna"
+      "id": "native.android.ee4c727cdafbe963",
+      "source": "Main thread",
+      "translated": "Wątek główny"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway oczekuje"
     },
     {
-      "id": "native.android.2d8d049afe99f751",
-      "source": "Session Activity",
-      "translated": "Aktywność sesji"
+      "id": "native.android.da78209effb11cfd",
+      "source": "Thread Activity",
+      "translated": "Aktywność wątku"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "Prośby o zatwierdzenie wykonania pojawią się tutaj, gdy ten telefon będzie połączony."
     },
     {
-      "id": "native.android.dc3e7ca5a491103a",
-      "source": "Session activity",
-      "translated": "Aktywność sesji"
+      "id": "native.android.f615712dfb56319a",
+      "source": "Thread activity",
+      "translated": "Aktywność wątku"
     },
     {
-      "id": "native.android.8551e02b060bd7d8",
-      "source": "Chat tool calls waiting in the active session remain visible here.",
-      "translated": "Wywołania narzędzi czatu oczekujące w aktywnej sesji pozostają widoczne tutaj."
+      "id": "native.android.6c93973c13db43ae",
+      "source": "Chat tool calls waiting in the active thread remain visible here.",
+      "translated": "Oczekujące wywołania narzędzi czatu w aktywnym wątku pozostają widoczne tutaj."
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,6 +4294,11 @@
       "translated": "Konfiguracja dostawcy rozmów"
     },
     {
+      "id": "native.android.23b638094c34b916",
+      "source": "Microphone",
+      "translated": "Mikrofon"
+    },
+    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "Test dźwięku"
@@ -4337,6 +4342,66 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "Gotowe"
+    },
+    {
+      "id": "native.android.8d9ecdfdd916b780",
+      "source": "Automatic",
+      "translated": "Automatycznie"
+    },
+    {
+      "id": "native.android.c1626a6700a570f6",
+      "source": "Preferred microphone unavailable; using automatic routing.",
+      "translated": "Preferowany mikrofon jest niedostępny; używane jest automatyczne przekierowanie."
+    },
+    {
+      "id": "native.android.820bc5d0ce571d8b",
+      "source": "Prioritizes connected Bluetooth microphones.",
+      "translated": "Nadaje priorytet podłączonym mikrofonom Bluetooth."
+    },
+    {
+      "id": "native.android.11e48038d5e8bff6",
+      "source": "Preferred microphone",
+      "translated": "Preferowany mikrofon"
+    },
+    {
+      "id": "native.android.eaa4d7563a46d307",
+      "source": "Unavailable",
+      "translated": "Niedostępny"
+    },
+    {
+      "id": "native.android.9f5ebf17eb405ba8",
+      "source": "Next session",
+      "translated": "Następna sesja"
+    },
+    {
+      "id": "native.android.8c4e91f53928efb2",
+      "source": "Built-in microphone",
+      "translated": "Wbudowany mikrofon"
+    },
+    {
+      "id": "native.android.14b613cb6e2446b4",
+      "source": "Bluetooth microphone",
+      "translated": "Mikrofon Bluetooth"
+    },
+    {
+      "id": "native.android.c885247b2d7ce271",
+      "source": "Bluetooth LE microphone",
+      "translated": "Mikrofon Bluetooth LE"
+    },
+    {
+      "id": "native.android.b6a4e674c5fb441a",
+      "source": "Wired headset microphone",
+      "translated": "Mikrofon przewodowego zestawu słuchawkowego"
+    },
+    {
+      "id": "native.android.9c8becb3b0fb5a90",
+      "source": "USB microphone",
+      "translated": "Mikrofon USB"
+    },
+    {
+      "id": "native.android.ba46258fadec7a39",
+      "source": "External microphone",
+      "translated": "Mikrofon zewnętrzny"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5074,9 +5139,9 @@
       "translated": "Sprawdź"
     },
     {
-      "id": "native.android.5a540761383fa474",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
-      "translated": "OpenClaw zmienia ten telefon w przejrzysty mobilny interfejs do obsługi sesji, głosu, dostawców i Gateway."
+      "id": "native.android.c971506716c96e91",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
+      "translated": "OpenClaw zmienia ten telefon w przejrzysty mobilny interfejs do obsługi wątków, głosu, dostawców i Gateway."
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5624,9 +5689,9 @@
       "translated": "Ustawienia Rozmowy"
     },
     {
-      "id": "native.android.73f07a5d54915259",
-      "source": "Recent Sessions",
-      "translated": "Ostatnie sesje"
+      "id": "native.android.36f78c8c85dc283f",
+      "source": "Recent Threads",
+      "translated": "Ostatnie wątki"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5684,14 +5749,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online"
     },
     {
-      "id": "native.android.16c3425d3a594481",
-      "source": "Sessions",
-      "translated": "Sesje"
+      "id": "native.android.57177017a6a93826",
+      "source": "Threads",
+      "translated": "Wątki"
     },
     {
-      "id": "native.android.a5c0f8b3112aa58c",
-      "source": "No recent sessions",
-      "translated": "Brak ostatnich sesji"
+      "id": "native.android.43320b54a68b00a1",
+      "source": "No recent threads",
+      "translated": "Brak ostatnich wątków"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5729,14 +5794,14 @@
       "translated": "Praca · $pendingRunCount aktywnych uruchomień"
     },
     {
-      "id": "native.android.2c89da708b12a522",
-      "source": "Monitoring · 1 session",
-      "translated": "Monitorowanie · 1 sesja"
+      "id": "native.android.e24db059480f1e6a",
+      "source": "Monitoring · 1 thread",
+      "translated": "Monitorowanie · 1 wątek"
     },
     {
-      "id": "native.android.8b6ee382dcb64e1f",
-      "source": "Monitoring · $sessionCount sessions",
-      "translated": "Monitorowanie · $sessionCount sesji"
+      "id": "native.android.5a475f37d80e02bc",
+      "source": "Monitoring · $sessionCount threads",
+      "translated": "Monitorowanie · $sessionCount wątków"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5769,9 +5834,9 @@
       "translated": "Dostawcy"
     },
     {
-      "id": "native.android.a65477861c7203aa",
-      "source": "Open session",
-      "translated": "Otwórz sesję"
+      "id": "native.android.358c5e0e838d5423",
+      "source": "Open thread",
+      "translated": "Otwórz wątek"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6194,9 +6259,9 @@
       "translated": "${days} d"
     },
     {
-      "id": "native.android.22d755834386db07",
-      "source": "Main session",
-      "translated": "Sesja główna"
+      "id": "native.android.28a1a1acc5a0959f",
+      "source": "Main thread",
+      "translated": "Główny wątek"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6877,6 +6942,16 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "Wyłącz wyciszenie"
+    },
+    {
+      "id": "native.android.cb608d82c5b3352a",
+      "source": "Back camera",
+      "translated": "Tylny aparat"
+    },
+    {
+      "id": "native.android.e89a0e780eed2e1e",
+      "source": "Front camera",
+      "translated": "Przedni aparat"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7684,9 +7759,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.882cc14a58e7e105",
-      "source": "Loading session",
-      "translated": "Ładowanie sesji"
+      "id": "native.android.0c74bc30a994dd33",
+      "source": "Loading thread",
+      "translated": "Ładowanie wątku"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7729,14 +7804,14 @@
       "translated": "Nadrób zaległości"
     },
     {
-      "id": "native.android.1e5add56e48c99f9",
-      "source": "Summarize recent sessions and next steps.",
-      "translated": "Podsumuj ostatnie sesje i kolejne kroki."
+      "id": "native.android.cf40df9739f78f27",
+      "source": "Summarize recent threads and next steps.",
+      "translated": "Podsumuj ostatnie wątki i kolejne kroki."
     },
     {
-      "id": "native.android.06d515351bb79576",
-      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
-      "translated": "Podsumuj moje ostatnie sesje OpenClaw i zaproponuj kolejne kroki."
+      "id": "native.android.ebe49a8b8df80bd3",
+      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
+      "translated": "Przedstaw mi podsumowanie ostatnich wątków OpenClaw i zaproponuj kolejne kroki."
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8074,9 +8149,9 @@
       "translated": "Połączono"
     },
     {
-      "id": "native.android.81931886b9caf3ab",
-      "source": "Sessions",
-      "translated": "Sesje"
+      "id": "native.android.6cf5d6fa8a4186d5",
+      "source": "Threads",
+      "translated": "Wątki"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,9 +10869,9 @@
       "translated": "Nad czym chcesz popracować?"
     },
     {
-      "id": "native.apple.32179ce0b6d4543f",
-      "source": "The session attaches once the gateway is ready.",
-      "translated": "Sesja zostanie dołączona, gdy Gateway będzie gotowy."
+      "id": "native.apple.4da775013ac9b123",
+      "source": "The thread attaches once the gateway is ready.",
+      "translated": "Wątek zostanie dołączony, gdy Gateway będzie gotowy."
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10844,9 +10919,9 @@
       "translated": "Opcje nowej sesji…"
     },
     {
-      "id": "native.apple.a1b0d289758e2213",
-      "source": "Sessions…",
-      "translated": "Sesje…"
+      "id": "native.apple.003b25ddafeb18e9",
+      "source": "Threads…",
+      "translated": "Wątki…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11009,14 +11084,14 @@
       "translated": "Utwórz"
     },
     {
-      "id": "native.apple.f488b9caf6e51ac3",
-      "source": "Delete Session?",
-      "translated": "Usunąć sesję?"
+      "id": "native.apple.31d5c7287cfb3abe",
+      "source": "Delete Thread?",
+      "translated": "Usunąć wątek?"
     },
     {
-      "id": "native.apple.8634b17be9b111bc",
-      "source": "Delete Session",
-      "translated": "Usuń sesję"
+      "id": "native.apple.d3395564809f1120",
+      "source": "Delete Thread",
+      "translated": "Usuń wątek"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11024,9 +11099,9 @@
       "translated": "Anuluj"
     },
     {
-      "id": "native.apple.4a9568ac9b18d8d3",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "Spowoduje to trwałe usunięcie sesji i jej transkrypcji."
+      "id": "native.apple.092659256d26cb03",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "Spowoduje to trwałe usunięcie wątku i jego transkrypcji."
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11054,9 +11129,9 @@
       "translated": "Nowa grupa"
     },
     {
-      "id": "native.apple.5bccdc23a1640895",
-      "source": "Rename Session",
-      "translated": "Zmień nazwę sesji"
+      "id": "native.apple.683032464c497bbd",
+      "source": "Rename Thread",
+      "translated": "Zmień nazwę wątku"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11064,9 +11139,9 @@
       "translated": "Nazwa grupy"
     },
     {
-      "id": "native.apple.af789b2d2fda0f67",
-      "source": "Session name",
-      "translated": "Nazwa sesji"
+      "id": "native.apple.f887aa956588f237",
+      "source": "Thread name",
+      "translated": "Nazwa wątku"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11104,14 +11179,14 @@
       "translated": "Agenci"
     },
     {
-      "id": "native.apple.a3bde8045fe9224a",
-      "source": "Agent session",
-      "translated": "Sesja agenta"
+      "id": "native.apple.7c8231b7b1ca480f",
+      "source": "Agent thread",
+      "translated": "Wątek agenta"
     },
     {
-      "id": "native.apple.27f775de30b37ff8",
-      "source": "Recent sessions",
-      "translated": "Ostatnie sesje"
+      "id": "native.apple.b3c553614f762a58",
+      "source": "Recent threads",
+      "translated": "Ostatnie wątki"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11119,9 +11194,9 @@
       "translated": "Gateway offline"
     },
     {
-      "id": "native.apple.28c97cf23665ee01",
-      "source": "No recent sessions",
-      "translated": "Brak ostatnich sesji"
+      "id": "native.apple.5aa32afda85064ea",
+      "source": "No recent threads",
+      "translated": "Brak ostatnich wątków"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11219,14 +11294,14 @@
       "translated": "Anuluj"
     },
     {
-      "id": "native.apple.9f2fd65953013b7c",
-      "source": "Sessions",
-      "translated": "Sesje"
+      "id": "native.apple.b6855cf19a50f477",
+      "source": "Threads",
+      "translated": "Wątki"
     },
     {
-      "id": "native.apple.0422818cc95d5071",
-      "source": "Archived sessions",
-      "translated": "Zarchiwizowane sesje"
+      "id": "native.apple.9b1d0ef27a1333b0",
+      "source": "Archived threads",
+      "translated": "Zarchiwizowane wątki"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11234,34 +11309,34 @@
       "translated": "Pokaż zarchiwizowane"
     },
     {
-      "id": "native.apple.b272115c83f7ef58",
-      "source": "Sessions unavailable",
-      "translated": "Sesje niedostępne"
+      "id": "native.apple.98167401c7267735",
+      "source": "Threads unavailable",
+      "translated": "Wątki są niedostępne"
     },
     {
-      "id": "native.apple.54f8260c9b863087",
-      "source": "Loading archived sessions",
-      "translated": "Ładowanie zarchiwizowanych sesji"
+      "id": "native.apple.4d28a7def2337b9f",
+      "source": "Loading archived threads",
+      "translated": "Wczytywanie zarchiwizowanych wątków"
     },
     {
-      "id": "native.apple.9b305868873dade2",
-      "source": "Loading recent sessions",
-      "translated": "Ładowanie ostatnich sesji"
+      "id": "native.apple.777d7b706933bd7b",
+      "source": "Loading recent threads",
+      "translated": "Wczytywanie ostatnich wątków"
     },
     {
-      "id": "native.apple.207dad20d09f3160",
-      "source": "^[\\(count) session](inflect: true)",
-      "translated": "^[\\(count) sesja](inflect: true)"
+      "id": "native.apple.22f81ea94bef8410",
+      "source": "^[\\(count) thread](inflect: true)",
+      "translated": "^[\\(count) wątek](inflect: true)"
     },
     {
-      "id": "native.apple.1f4501a6bf2bae4c",
-      "source": "No archived sessions",
-      "translated": "Brak zarchiwizowanych sesji"
+      "id": "native.apple.1cad51e14db59bf9",
+      "source": "No archived threads",
+      "translated": "Brak zarchiwizowanych wątków"
     },
     {
-      "id": "native.apple.2a1ba7a5e1979c9e",
-      "source": "Archived sessions will appear here.",
-      "translated": "Zarchiwizowane sesje pojawią się tutaj."
+      "id": "native.apple.18ef832d3a7ddcf8",
+      "source": "Archived threads will appear here.",
+      "translated": "Zarchiwizowane wątki pojawią się tutaj."
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11344,9 +11419,9 @@
       "translated": "Udostępnij dane wejściowe"
     },
     {
-      "id": "native.apple.2360d25fe6ae9946",
-      "source": "Loading sessions",
-      "translated": "Ładowanie sesji"
+      "id": "native.apple.21d9208d86a4d1fe",
+      "source": "Loading threads",
+      "translated": "Wczytywanie wątków"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11354,19 +11429,19 @@
       "translated": "Pobieranie ostatniej aktywności z gateway."
     },
     {
-      "id": "native.apple.c334f2e86702a7b8",
-      "source": "Sessions unavailable",
-      "translated": "Sesje niedostępne"
+      "id": "native.apple.4be1f79aa2b230ff",
+      "source": "Threads unavailable",
+      "translated": "Wątki są niedostępne"
     },
     {
-      "id": "native.apple.6cc6efb7a03960b6",
-      "source": "No recent sessions",
-      "translated": "Brak ostatnich sesji"
+      "id": "native.apple.98b348873556bc46",
+      "source": "No recent threads",
+      "translated": "Brak ostatnich wątków"
     },
     {
-      "id": "native.apple.08483af2d043bee6",
-      "source": "Session activity offline",
-      "translated": "Aktywność sesji offline"
+      "id": "native.apple.7396d205574d279f",
+      "source": "Thread activity offline",
+      "translated": "Aktywność wątku jest niedostępna offline"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11824,9 +11899,9 @@
       "translated": "Karta"
     },
     {
-      "id": "native.apple.93eeaedb2ff61043",
-      "source": "Open Session",
-      "translated": "Otwórz sesję"
+      "id": "native.apple.c9ec1b0e18074d8a",
+      "source": "Open Thread",
+      "translated": "Otwórz wątek"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13314,9 +13389,9 @@
       "translated": "Domyślnie"
     },
     {
-      "id": "native.apple.3de045f17ea3c6d0",
-      "source": "Used for new Chat and Talk sessions.",
-      "translated": "Używane dla nowych sesji Chat i Talk."
+      "id": "native.apple.f4ae5664c3eda95d",
+      "source": "Used for new Chat threads and Talk sessions.",
+      "translated": "Używane w nowych wątkach czatu i sesjach rozmów."
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15719,9 +15794,9 @@
       "translated": "Instancje"
     },
     {
-      "id": "native.apple.3579cf2750470a22",
-      "source": "Sessions",
-      "translated": "Sesje"
+      "id": "native.apple.11fe8b9941954dfb",
+      "source": "Threads",
+      "translated": "Wątki"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19029,9 +19104,9 @@
       "translated": "Skrót szybkiego czatu"
     },
     {
-      "id": "native.apple.6ae77665b5f4490f",
-      "source": "Global shortcut that opens a floating chat bar for the main session.",
-      "translated": "Globalny skrót otwierający pływający pasek czatu dla sesji głównej."
+      "id": "native.apple.94dd793cd7d7d555",
+      "source": "Global shortcut that opens a floating chat bar for the main thread.",
+      "translated": "Globalny skrót otwierający pływający pasek czatu dla głównego wątku."
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19609,9 +19684,9 @@
       "translated": "Krytyczny"
     },
     {
-      "id": "native.apple.75102378a6775180",
-      "source": "New Session",
-      "translated": "Nowa sesja"
+      "id": "native.apple.13f96467014cf344",
+      "source": "New Thread",
+      "translated": "Nowy wątek"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21899,9 +21974,9 @@
       "translated": "Brak ostatnich wiadomości"
     },
     {
-      "id": "native.apple.1ff8aec0044934c3",
-      "source": "Sessions",
-      "translated": "Sesje"
+      "id": "native.apple.3ec2afcbc298c673",
+      "source": "Threads",
+      "translated": "Wątki"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21909,9 +21984,9 @@
       "translated": "Zajrzyj do zapisanych zasobników konwersacji, których CLI ponownie używa na potrzeby kontekstu i limitów szybkości."
     },
     {
-      "id": "native.apple.bab897f3252b134c",
-      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
-      "translated": "Nie ma jeszcze sesji. Pojawią się po pierwszej wiadomości przychodzącej lub sygnale heartbeat."
+      "id": "native.apple.14ccb32cd8ed1c81",
+      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
+      "translated": "Nie ma jeszcze żadnych wątków. Pojawią się po pierwszej wiadomości przychodzącej lub sygnale heartbeat."
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -21994,9 +22069,9 @@
       "translated": "Zatwierdzenia uruchomień"
     },
     {
-      "id": "native.apple.64a6dc7d49e8fb57",
-      "source": "Sessions",
-      "translated": "Sesje"
+      "id": "native.apple.52e37e3a44ae516c",
+      "source": "Threads",
+      "translated": "Wątki"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -22999,9 +23074,9 @@
       "translated": "Wprowadź mnie w temat"
     },
     {
-      "id": "native.apple.234ec45f4231edc4",
-      "source": "Summarize what happened in my sessions since yesterday.",
-      "translated": "Podsumuj, co wydarzyło się w moich sesjach od wczoraj."
+      "id": "native.apple.fc4ce810900ec0b6",
+      "source": "Summarize what happened in my threads since yesterday.",
+      "translated": "Podsumuj, co wydarzyło się w moich wątkach od wczoraj."
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23179,9 +23254,9 @@
       "translated": "Odepnij model"
     },
     {
-      "id": "native.apple.5dfc0700d8dff8de",
-      "source": "Session",
-      "translated": "Sesja"
+      "id": "native.apple.4edb66657f5aca1f",
+      "source": "Thread",
+      "translated": "Wątek"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23344,6 +23419,51 @@
       "translated": "Widżet niedostępny"
     },
     {
+      "id": "native.apple.d640691fd196f338",
+      "source": "Widget export failed",
+      "translated": "Eksport widżetu nie powiódł się"
+    },
+    {
+      "id": "native.apple.533c6e22a11e88de",
+      "source": "OK",
+      "translated": "OK"
+    },
+    {
+      "id": "native.apple.e1fb28a2a9756402",
+      "source": "Copy image",
+      "translated": "Kopiuj obraz"
+    },
+    {
+      "id": "native.apple.ebd7bc92e1b12235",
+      "source": "Save image…",
+      "translated": "Zapisz obraz…"
+    },
+    {
+      "id": "native.apple.742c46d4cf2db134",
+      "source": "Save image",
+      "translated": "Zapisz obraz"
+    },
+    {
+      "id": "native.apple.0589cce608418f90",
+      "source": "The widget image could not be captured.",
+      "translated": "Nie udało się przechwycić obrazu widżetu."
+    },
+    {
+      "id": "native.apple.dfe24e827fdbe9c5",
+      "source": "The widget image could not be copied.",
+      "translated": "Nie udało się skopiować obrazu widżetu."
+    },
+    {
+      "id": "native.apple.9e611e3a80e71408",
+      "source": "The widget image could not be encoded as PNG.",
+      "translated": "Nie udało się zakodować obrazu widżetu w formacie PNG."
+    },
+    {
+      "id": "native.apple.9a6e8afbe24a262b",
+      "source": "The widget image could not be saved.",
+      "translated": "Nie udało się zapisać obrazu widżetu."
+    },
+    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23484,19 +23604,19 @@
       "translated": "Użytkownik"
     },
     {
-      "id": "native.apple.b1cdcb906a43d5d6",
-      "source": "This session cannot be archived while it is active or running.",
-      "translated": "Nie można zarchiwizować tej sesji, gdy jest aktywna lub uruchomiona."
+      "id": "native.apple.9d0cba09d92ee669",
+      "source": "This thread cannot be archived while it is active or running.",
+      "translated": "Nie można zarchiwizować tego wątku, gdy jest aktywny lub uruchomiony."
     },
     {
-      "id": "native.apple.5817e3f3dab1ee19",
-      "source": "The main session cannot be deleted.",
-      "translated": "Nie można usunąć sesji głównej."
+      "id": "native.apple.8952a111a1075051",
+      "source": "The main thread cannot be deleted.",
+      "translated": "Nie można usunąć głównego wątku."
     },
     {
-      "id": "native.apple.a6b8df3f18171c91",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
-      "translated": "Usuń załączniki lub poczekaj na ich dostarczenie przed zarchiwizowaniem albo usunięciem tej sesji."
+      "id": "native.apple.90d0ccf80ca28717",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
+      "translated": "Usuń załączniki lub poczekaj na ich dostarczenie przed zarchiwizowaniem albo usunięciem tego wątku."
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23634,9 +23754,9 @@
       "translated": "Zakończenie uruchomienia"
     },
     {
-      "id": "native.apple.cd7c3095a22f80a9",
-      "source": "Session Info",
-      "translated": "Informacje o sesji"
+      "id": "native.apple.bbccb4c8db5cac12",
+      "source": "Thread Info",
+      "translated": "Informacje o wątku"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23669,9 +23789,9 @@
       "translated": "Dodaj grupę"
     },
     {
-      "id": "native.apple.23d628606fe0734f",
-      "source": "Session Groups",
-      "translated": "Grupy sesji"
+      "id": "native.apple.7b641fed5bace855",
+      "source": "Thread Groups",
+      "translated": "Grupy wątków"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23714,9 +23834,9 @@
       "translated": "Usuń grupę"
     },
     {
-      "id": "native.apple.b049c8a4d2805e08",
-      "source": "Sessions in this group become ungrouped.",
-      "translated": "Sesje w tej grupie przestaną być przypisane do grupy."
+      "id": "native.apple.56401c79410a310d",
+      "source": "Threads in this group become ungrouped.",
+      "translated": "Wątki w tej grupie przestaną być pogrupowane."
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23729,9 +23849,9 @@
       "translated": "Na tym gatewayu nie są dostępni żadni agenci."
     },
     {
-      "id": "native.apple.6c89f35d53506406",
-      "source": "New Session Options",
-      "translated": "Opcje nowej sesji"
+      "id": "native.apple.2d96aa7d3d12f85b",
+      "source": "New Thread Options",
+      "translated": "Opcje nowego wątku"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23759,19 +23879,19 @@
       "translated": "Utwórz"
     },
     {
-      "id": "native.apple.795ba37f6782cf28",
-      "source": "The session could not be created.",
-      "translated": "Nie udało się utworzyć sesji."
+      "id": "native.apple.87ef57319d1ddc85",
+      "source": "The thread could not be created.",
+      "translated": "Nie udało się utworzyć wątku."
     },
     {
-      "id": "native.apple.8ec708a3605a2cc3",
-      "source": "Search sessions",
-      "translated": "Szukaj sesji"
+      "id": "native.apple.6bd91c435b69d638",
+      "source": "Search threads",
+      "translated": "Szukaj wątków"
     },
     {
-      "id": "native.apple.23b069b4e7f97039",
-      "source": "No Sessions",
-      "translated": "Brak sesji"
+      "id": "native.apple.6fde4bdf9d5b9191",
+      "source": "No Threads",
+      "translated": "Brak wątków"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23779,29 +23899,29 @@
       "translated": "Brak wyników"
     },
     {
-      "id": "native.apple.0058923f2ce8a3ec",
-      "source": "New Session",
-      "translated": "Nowa sesja"
+      "id": "native.apple.a02fd99740d29bd3",
+      "source": "New Thread",
+      "translated": "Nowy wątek"
     },
     {
-      "id": "native.apple.66ba42960eb4135b",
-      "source": "New session",
-      "translated": "Nowa sesja"
+      "id": "native.apple.b625801dd04b09f2",
+      "source": "New thread",
+      "translated": "Nowy wątek"
     },
     {
-      "id": "native.apple.2ef0e34db02ad255",
-      "source": "New session options",
-      "translated": "Opcje nowej sesji"
+      "id": "native.apple.851be81fcc933608",
+      "source": "New thread options",
+      "translated": "Opcje nowego wątku"
     },
     {
-      "id": "native.apple.36753ef2f1ed4264",
-      "source": "Rename Session",
-      "translated": "Zmień nazwę sesji"
+      "id": "native.apple.9ce8a4aba7b444b2",
+      "source": "Rename Thread",
+      "translated": "Zmień nazwę wątku"
     },
     {
-      "id": "native.apple.c9de0a1510ef475f",
-      "source": "Session name",
-      "translated": "Nazwa sesji"
+      "id": "native.apple.1dd067c44511c7f0",
+      "source": "Thread name",
+      "translated": "Nazwa wątku"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23814,14 +23934,14 @@
       "translated": "Anuluj"
     },
     {
-      "id": "native.apple.afb4e6c99c63a28d",
-      "source": "Delete Session",
-      "translated": "Usuń sesję"
+      "id": "native.apple.618073d6ab3f2721",
+      "source": "Delete Thread",
+      "translated": "Usuń wątek"
     },
     {
-      "id": "native.apple.3d4ef32e42f136a4",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "Sesja i jej transkrypcja zostaną usunięte z Gateway."
+      "id": "native.apple.10a5e72bba3cbccc",
+      "source": "The thread and its transcript are removed from the gateway.",
+      "translated": "Wątek i jego transkrypcja zostaną usunięte z Gateway."
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23829,14 +23949,14 @@
       "translated": "Usunąć „%@”?"
     },
     {
-      "id": "native.apple.9a7dca238fba628d",
-      "source": "Session running",
-      "translated": "Sesja jest uruchomiona"
+      "id": "native.apple.ac71e3b2aa496a2c",
+      "source": "Thread running",
+      "translated": "Wątek jest uruchomiony"
     },
     {
-      "id": "native.apple.fcfbfe5e97a95e9c",
-      "source": "Session failed",
-      "translated": "Sesja nie powiodła się"
+      "id": "native.apple.c775e87f997278b2",
+      "source": "Thread failed",
+      "translated": "Wątek zakończył się niepowodzeniem"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23894,9 +24014,9 @@
       "translated": "Kopiuj klucz sesji"
     },
     {
-      "id": "native.apple.4aeb7c14c26dabac",
-      "source": "Delete Session…",
-      "translated": "Usuń sesję…"
+      "id": "native.apple.f4998cfb572f23ff",
+      "source": "Delete Thread…",
+      "translated": "Usuń wątek…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23909,9 +24029,9 @@
       "translated": "Łączenie…"
     },
     {
-      "id": "native.apple.79f708b3bc1d3a6c",
-      "source": "Retry session groups",
-      "translated": "Ponów próbę wczytania grup sesji"
+      "id": "native.apple.8802e9576ffd0f65",
+      "source": "Retry thread groups",
+      "translated": "Ponów próbę wczytania grup wątków"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23934,24 +24054,24 @@
       "translated": "Zakres"
     },
     {
-      "id": "native.apple.2c37581c7b88f741",
-      "source": "Search sessions",
-      "translated": "Szukaj sesji"
+      "id": "native.apple.b313b80def4bda52",
+      "source": "Search threads",
+      "translated": "Szukaj wątków"
     },
     {
-      "id": "native.apple.43be8a2336e42faf",
-      "source": "Sessions",
-      "translated": "Sesje"
+      "id": "native.apple.c0cc6acc36f413ce",
+      "source": "Threads",
+      "translated": "Wątki"
     },
     {
-      "id": "native.apple.0b379cdfcbd3247f",
-      "source": "Rename Session",
-      "translated": "Zmień nazwę sesji"
+      "id": "native.apple.854d3928fe5a557c",
+      "source": "Rename Thread",
+      "translated": "Zmień nazwę wątku"
     },
     {
-      "id": "native.apple.54b6fbd9e41db009",
-      "source": "Session name",
-      "translated": "Nazwa sesji"
+      "id": "native.apple.9d0d3f20096cc4da",
+      "source": "Thread name",
+      "translated": "Nazwa wątku"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -23959,19 +24079,19 @@
       "translated": "Anuluj"
     },
     {
-      "id": "native.apple.751e0f6b81cd374a",
-      "source": "Delete selected sessions?",
-      "translated": "Usunąć wybrane sesje?"
+      "id": "native.apple.dc00eb94f33bae15",
+      "source": "Delete selected threads?",
+      "translated": "Usunąć wybrane wątki?"
     },
     {
-      "id": "native.apple.aa679276581b0058",
-      "source": "Delete Sessions",
-      "translated": "Usuń sesje"
+      "id": "native.apple.2053fc9f74dc3158",
+      "source": "Delete Threads",
+      "translated": "Usuń wątki"
     },
     {
-      "id": "native.apple.f837129cbee23297",
-      "source": "Each selected session and its transcript will be removed from the gateway.",
-      "translated": "Każda wybrana sesja i jej transkrypcja zostaną usunięte z Gateway."
+      "id": "native.apple.0970247871a834a0",
+      "source": "Each selected thread and its transcript will be removed from the gateway.",
+      "translated": "Każdy wybrany wątek wraz z jego transkrypcją zostanie usunięty z Gateway."
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -23979,9 +24099,9 @@
       "translated": "Grupy"
     },
     {
-      "id": "native.apple.64013cfee5e25305",
-      "source": "Manage session groups",
-      "translated": "Zarządzaj grupami sesji"
+      "id": "native.apple.6f8acab2256728b5",
+      "source": "Manage thread groups",
+      "translated": "Zarządzaj grupami wątków"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -23994,14 +24114,14 @@
       "translated": "Wybierz"
     },
     {
-      "id": "native.apple.b67eaecec1b423ac",
-      "source": "No archived sessions",
-      "translated": "Brak zarchiwizowanych sesji"
+      "id": "native.apple.692972314d04b184",
+      "source": "No archived threads",
+      "translated": "Brak zarchiwizowanych wątków"
     },
     {
-      "id": "native.apple.b2435a79abf0c794",
-      "source": "No sessions found",
-      "translated": "Nie znaleziono sesji"
+      "id": "native.apple.d6a4b5711dcd26e7",
+      "source": "No threads found",
+      "translated": "Nie znaleziono wątków"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24169,6 +24289,16 @@
       "translated": "Otwórz pełną wiadomość"
     },
     {
+      "id": "native.apple.002bfcede229ad4b",
+      "source": "Rewind to Here",
+      "translated": "Cofnij do tego miejsca"
+    },
+    {
+      "id": "native.apple.14df2e4997689fb3",
+      "source": "Fork from Here",
+      "translated": "Utwórz odgałęzienie od tego miejsca"
+    },
+    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "Odpowiedz"
@@ -24254,9 +24384,9 @@
       "translated": "Usuń załączniki lub poczekaj na zakończenie dostarczania przed rozpoczęciem nowego czatu."
     },
     {
-      "id": "native.apple.980f552bb0f96c0f",
-      "source": "Gateway changed before the session operation started.",
-      "translated": "Gateway zmienił się przed rozpoczęciem operacji na sesji."
+      "id": "native.apple.e0f045151c8d3137",
+      "source": "Gateway changed before the thread operation started.",
+      "translated": "Gateway zmienił się przed rozpoczęciem operacji na wątku."
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24264,9 +24394,9 @@
       "translated": "Usuń załączniki lub poczekaj na zakończenie dostarczania przed przełączeniem czatów."
     },
     {
-      "id": "native.apple.87ba543b42696b92",
-      "source": "Clear this session's history?",
-      "translated": "Wyczyścić historię tej sesji?"
+      "id": "native.apple.0a5c4e15466c3acc",
+      "source": "Clear this thread's history?",
+      "translated": "Wyczyścić historię tego wątku?"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24279,14 +24409,14 @@
       "translated": "Spowoduje to zresetowanie rozmowy dla %@. Klucz sesji pozostanie bez zmian."
     },
     {
-      "id": "native.apple.a92e96bed98bd553",
-      "source": "Rename Session",
-      "translated": "Zmień nazwę sesji"
+      "id": "native.apple.67ac221dbe7179f0",
+      "source": "Rename Thread",
+      "translated": "Zmień nazwę wątku"
     },
     {
-      "id": "native.apple.848e2388f3466f40",
-      "source": "Session name",
-      "translated": "Nazwa sesji"
+      "id": "native.apple.cf0f7e049603f518",
+      "source": "Thread name",
+      "translated": "Nazwa wątku"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24304,9 +24434,9 @@
       "translated": "Eksportuj transkrypcję"
     },
     {
-      "id": "native.apple.4af0f566d39d7041",
-      "source": "Sessions",
-      "translated": "Sesje"
+      "id": "native.apple.c0ada47504425f23",
+      "source": "Threads",
+      "translated": "Wątki"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24379,14 +24509,14 @@
       "translated": "Domyślne"
     },
     {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "Nowa sesja"
+      "id": "native.apple.1a765291943599e5",
+      "source": "New Thread",
+      "translated": "Nowy wątek"
     },
     {
-      "id": "native.apple.a7119fbf9d25df5e",
-      "source": "New Session Options…",
-      "translated": "Opcje nowej sesji…"
+      "id": "native.apple.c7a3a6d5e43dd98f",
+      "source": "New Thread Options…",
+      "translated": "Opcje nowego wątku…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24394,19 +24524,19 @@
       "translated": "Odśwież"
     },
     {
-      "id": "native.apple.2bcff4a8fa503739",
-      "source": "Sessions…",
-      "translated": "Sesje…"
+      "id": "native.apple.0e710b81808e5dcf",
+      "source": "Threads…",
+      "translated": "Wątki…"
     },
     {
-      "id": "native.apple.c36e008b051adb38",
-      "source": "Rename Session…",
-      "translated": "Zmień nazwę sesji…"
+      "id": "native.apple.faad8f92b6bef166",
+      "source": "Rename Thread…",
+      "translated": "Zmień nazwę wątku…"
     },
     {
-      "id": "native.apple.ea0ef95a159bffe0",
-      "source": "Fork Session",
-      "translated": "Utwórz odgałęzienie sesji"
+      "id": "native.apple.23b61d6cd26ac112",
+      "source": "Fork",
+      "translated": "Rozgałęź"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24464,24 +24594,24 @@
       "translated": "Wyczyść historię…"
     },
     {
-      "id": "native.apple.920fe8a7a33f9e92",
-      "source": "Session",
-      "translated": "Sesja"
+      "id": "native.apple.8b4f1c5107ea8a0e",
+      "source": "Thread",
+      "translated": "Wątek"
     },
     {
-      "id": "native.apple.185a401f78328b0f",
-      "source": "Session actions",
-      "translated": "Akcje sesji"
+      "id": "native.apple.4d7750c9bf699469",
+      "source": "Thread actions",
+      "translated": "Działania wątku"
     },
     {
-      "id": "native.apple.9f9dedf599b2619b",
-      "source": "Session cost %@",
-      "translated": "Koszt sesji: %@"
+      "id": "native.apple.bb2f22cc43c97f8e",
+      "source": "Thread cost %@",
+      "translated": "Koszt wątku %@"
     },
     {
-      "id": "native.apple.f0a4720df5f5f403",
-      "source": "Compact Session",
-      "translated": "Kompaktuj sesję"
+      "id": "native.apple.6239ced0b86e86f8",
+      "source": "Compact Thread",
+      "translated": "Kompaktuj wątek"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/pl.json
+++ b/apps/.i18n/native/pl.json
@@ -1429,9 +1429,9 @@
       "translated": "Rozmawiaj lub dyktuj z OpenClaw"
     },
     {
-      "id": "native.android.e2cf5a38587382cb",
-      "source": "Browse Threads",
-      "translated": "Przeglądaj wątki"
+      "id": "native.android.5876e15e5e92fd45",
+      "source": "Browse Sessions",
+      "translated": "Przeglądaj sesje"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "Nie znaleziono działań"
     },
     {
-      "id": "native.android.bc70a4ac965b82ba",
-      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
-      "translated": "Wypróbuj czat, głos, wątki, dostawców lub ustawienia."
+      "id": "native.android.48ad0ae0e930e02b",
+      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
+      "translated": "Wypróbuj czat, głos, sesje, dostawców lub ustawienia."
     },
     {
-      "id": "native.android.670121e54dbe286f",
-      "source": "Threads",
-      "translated": "Wątki"
+      "id": "native.android.d4fbd1ee4f55a5db",
+      "source": "Sessions",
+      "translated": "Sesje"
     },
     {
-      "id": "native.android.d38be650b1bce4a0",
-      "source": "Connect the Gateway to search threads.",
-      "translated": "Połącz Gateway, aby wyszukiwać wątki."
+      "id": "native.android.207c2170504e99e6",
+      "source": "Connect the Gateway to search sessions.",
+      "translated": "Połącz Gateway, aby wyszukiwać sesje."
     },
     {
-      "id": "native.android.3d7754721f776ef8",
-      "source": "No matching threads yet.",
-      "translated": "Nie ma jeszcze pasujących wątków."
+      "id": "native.android.25d2c2d792c952fe",
+      "source": "No matching sessions yet.",
+      "translated": "Nie ma jeszcze pasujących sesji."
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "Asystent pracuje"
     },
     {
-      "id": "native.android.9a839f6e3e05a744",
-      "source": "OpenClaw thread",
-      "translated": "Wątek OpenClaw"
+      "id": "native.android.8f8384286317f5c9",
+      "source": "OpenClaw session",
+      "translated": "Sesja OpenClaw"
     },
     {
-      "id": "native.android.d83f82a1e4a5ed99",
-      "source": "Open thread",
-      "translated": "Otwórz wątek"
+      "id": "native.android.15799e57704b20c6",
+      "source": "Open session",
+      "translated": "Otwórz sesję"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "Brak gotowych dostawców"
     },
     {
-      "id": "native.android.8a1c5365c0538908",
-      "source": "Main thread",
-      "translated": "Główny wątek"
+      "id": "native.android.73e6ab1a168fd381",
+      "source": "Main session",
+      "translated": "Sesja główna"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.a5845742daecb4ba",
-      "source": "Threads",
-      "translated": "Wątki"
+      "id": "native.android.0e3157c15c56944f",
+      "source": "Sessions",
+      "translated": "Sesje"
     },
     {
-      "id": "native.android.439b324280869527",
-      "source": "Focus thread search",
-      "translated": "Przejdź do wyszukiwania wątków"
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "Wyszukaj sesję"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "Zarchiwizowane"
     },
     {
-      "id": "native.android.03981341841b04ac",
-      "source": "Search threads",
-      "translated": "Szukaj wątków"
+      "id": "native.android.b9cf34c137e4cf03",
+      "source": "Search sessions",
+      "translated": "Szukaj sesji"
     },
     {
-      "id": "native.android.99570c528a41fa72",
-      "source": "Clear thread search",
-      "translated": "Wyczyść wyszukiwanie wątków"
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "Wyczyść wyszukiwanie sesji"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "Najpierw najstarsze"
     },
     {
-      "id": "native.android.fd67be543e321cc9",
-      "source": "Toggle thread layout",
-      "translated": "Przełącz układ wątków"
+      "id": "native.android.c6bf8751e2a7f5c7",
+      "source": "Toggle session layout",
+      "translated": "Przełącz układ sesji"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "Układ: szczegółowy"
     },
     {
-      "id": "native.android.ebd17565e0ffd8eb",
-      "source": "Searching threads",
-      "translated": "Wyszukiwanie wątków"
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "Wyszukiwanie sesji"
     },
     {
-      "id": "native.android.472d46ae8669f860",
-      "source": "No matching threads",
-      "translated": "Brak pasujących wątków"
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "Brak pasujących sesji"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "Rozpocznij czat"
     },
     {
-      "id": "native.android.ff81ad1bee00d384",
-      "source": "Current thread",
-      "translated": "Bieżący wątek"
+      "id": "native.android.f10d4df7cbc6df4f",
+      "source": "Current session",
+      "translated": "Bieżąca sesja"
     },
     {
-      "id": "native.android.fc145645b9620e57",
-      "source": "OpenClaw thread",
-      "translated": "Wątek OpenClaw"
+      "id": "native.android.8f0482425838ae64",
+      "source": "OpenClaw session",
+      "translated": "Sesja OpenClaw"
     },
     {
-      "id": "native.android.71cbb8dde8bf138b",
-      "source": "Rename thread",
-      "translated": "Zmień nazwę wątku"
+      "id": "native.android.786774c8a76e50d7",
+      "source": "Rename session",
+      "translated": "Zmień nazwę sesji"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "Usunąć grupę?"
     },
     {
-      "id": "native.android.691e92cfe5cf106e",
-      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "Wątki w grupie „$group” zostaną zachowane i przeniesione z powrotem do sekcji Bez grupy."
+      "id": "native.android.3455fc2f77d564e3",
+      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "Sesje w „$group” zostaną zachowane i przeniesione z powrotem do Bez grupy."
     },
     {
-      "id": "native.android.d87a8217ab56999b",
-      "source": "Delete thread?",
-      "translated": "Usunąć wątek?"
+      "id": "native.android.4805fb9d6623e8c0",
+      "source": "Delete session?",
+      "translated": "Usunąć sesję?"
     },
     {
-      "id": "native.android.930de97ff47113a8",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "Spowoduje to trwałe usunięcie wątku i jego transkrypcji."
+      "id": "native.android.0c3283a2b2445eae",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "Spowoduje to trwałe usunięcie sesji i jej transkrypcji."
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "Bez grupy"
     },
     {
-      "id": "native.android.8e21a70428def6e0",
-      "source": "No threads yet",
-      "translated": "Nie ma jeszcze żadnych wątków"
+      "id": "native.android.db243d71d056afa4",
+      "source": "No sessions yet",
+      "translated": "Nie ma jeszcze sesji"
     },
     {
-      "id": "native.android.cda4c5ad8b17e394",
-      "source": "No current thread",
-      "translated": "Brak bieżącego wątku"
+      "id": "native.android.5b4eee6a8092925e",
+      "source": "No current session",
+      "translated": "Brak bieżącej sesji"
     },
     {
-      "id": "native.android.be84f061047aa2da",
-      "source": "No archived threads",
-      "translated": "Brak zarchiwizowanych wątków"
+      "id": "native.android.acbcc9c9ea53d8c0",
+      "source": "No archived sessions",
+      "translated": "Brak zarchiwizowanych sesji"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "Rozpocznij nową rozmowę, a pojawi się tutaj."
     },
     {
-      "id": "native.android.f289d03e1d3eee98",
-      "source": "Open Chat to start or resume the current thread.",
-      "translated": "Otwórz czat, aby rozpocząć lub wznowić bieżący wątek."
+      "id": "native.android.56fcd605dc7be3c0",
+      "source": "Open Chat to start or resume the current session.",
+      "translated": "Otwórz czat, aby rozpocząć lub wznowić bieżącą sesję."
     },
     {
-      "id": "native.android.504b71386e76c6ae",
-      "source": "Archived threads will show up here.",
-      "translated": "Zarchiwizowane wątki pojawią się tutaj."
+      "id": "native.android.085515989f8a2022",
+      "source": "Archived sessions will show up here.",
+      "translated": "Zarchiwizowane sesje pojawią się tutaj."
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days} d"
     },
     {
-      "id": "native.android.ee4c727cdafbe963",
-      "source": "Main thread",
-      "translated": "Główny wątek"
+      "id": "native.android.3d4fa07acbc015c5",
+      "source": "Main session",
+      "translated": "Sesja główna"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway oczekuje"
     },
     {
-      "id": "native.android.da78209effb11cfd",
-      "source": "Thread Activity",
-      "translated": "Aktywność wątku"
+      "id": "native.android.2d8d049afe99f751",
+      "source": "Session Activity",
+      "translated": "Aktywność sesji"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "Prośby o zatwierdzenie wykonania pojawią się tutaj, gdy ten telefon będzie połączony."
     },
     {
-      "id": "native.android.f615712dfb56319a",
-      "source": "Thread activity",
-      "translated": "Aktywność wątku"
+      "id": "native.android.dc3e7ca5a491103a",
+      "source": "Session activity",
+      "translated": "Aktywność sesji"
     },
     {
-      "id": "native.android.6c93973c13db43ae",
-      "source": "Chat tool calls waiting in the active thread remain visible here.",
-      "translated": "Oczekujące wywołania narzędzi czatu w aktywnym wątku pozostają widoczne tutaj."
+      "id": "native.android.8551e02b060bd7d8",
+      "source": "Chat tool calls waiting in the active session remain visible here.",
+      "translated": "Wywołania narzędzi czatu oczekujące w aktywnej sesji pozostają widoczne tutaj."
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,11 +4294,6 @@
       "translated": "Konfiguracja dostawcy rozmów"
     },
     {
-      "id": "native.android.23b638094c34b916",
-      "source": "Microphone",
-      "translated": "Mikrofon"
-    },
-    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "Test dźwięku"
@@ -4342,66 +4337,6 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "Gotowe"
-    },
-    {
-      "id": "native.android.8d9ecdfdd916b780",
-      "source": "Automatic",
-      "translated": "Automatycznie"
-    },
-    {
-      "id": "native.android.c1626a6700a570f6",
-      "source": "Preferred microphone unavailable; using automatic routing.",
-      "translated": "Preferowany mikrofon jest niedostępny; używane jest automatyczne kierowanie dźwięku."
-    },
-    {
-      "id": "native.android.820bc5d0ce571d8b",
-      "source": "Prioritizes connected Bluetooth microphones.",
-      "translated": "Nadaje priorytet podłączonym mikrofonom Bluetooth."
-    },
-    {
-      "id": "native.android.11e48038d5e8bff6",
-      "source": "Preferred microphone",
-      "translated": "Preferowany mikrofon"
-    },
-    {
-      "id": "native.android.eaa4d7563a46d307",
-      "source": "Unavailable",
-      "translated": "Niedostępny"
-    },
-    {
-      "id": "native.android.9f5ebf17eb405ba8",
-      "source": "Next session",
-      "translated": "Następna sesja"
-    },
-    {
-      "id": "native.android.8c4e91f53928efb2",
-      "source": "Built-in microphone",
-      "translated": "Wbudowany mikrofon"
-    },
-    {
-      "id": "native.android.14b613cb6e2446b4",
-      "source": "Bluetooth microphone",
-      "translated": "Mikrofon Bluetooth"
-    },
-    {
-      "id": "native.android.c885247b2d7ce271",
-      "source": "Bluetooth LE microphone",
-      "translated": "Mikrofon Bluetooth LE"
-    },
-    {
-      "id": "native.android.b6a4e674c5fb441a",
-      "source": "Wired headset microphone",
-      "translated": "Mikrofon przewodowego zestawu słuchawkowego"
-    },
-    {
-      "id": "native.android.9c8becb3b0fb5a90",
-      "source": "USB microphone",
-      "translated": "Mikrofon USB"
-    },
-    {
-      "id": "native.android.ba46258fadec7a39",
-      "source": "External microphone",
-      "translated": "Mikrofon zewnętrzny"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5139,9 +5074,9 @@
       "translated": "Sprawdź"
     },
     {
-      "id": "native.android.c971506716c96e91",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
-      "translated": "OpenClaw zmienia ten telefon w przejrzysty mobilny interfejs sterowania wątkami, głosem, dostawcami i Gateway."
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw zmienia ten telefon w przejrzysty mobilny interfejs do obsługi sesji, głosu, dostawców i Gateway."
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5689,9 +5624,9 @@
       "translated": "Ustawienia Rozmowy"
     },
     {
-      "id": "native.android.36f78c8c85dc283f",
-      "source": "Recent Threads",
-      "translated": "Ostatnie wątki"
+      "id": "native.android.73f07a5d54915259",
+      "source": "Recent Sessions",
+      "translated": "Ostatnie sesje"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5749,14 +5684,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online"
     },
     {
-      "id": "native.android.57177017a6a93826",
-      "source": "Threads",
-      "translated": "Wątki"
+      "id": "native.android.16c3425d3a594481",
+      "source": "Sessions",
+      "translated": "Sesje"
     },
     {
-      "id": "native.android.43320b54a68b00a1",
-      "source": "No recent threads",
-      "translated": "Brak ostatnich wątków"
+      "id": "native.android.a5c0f8b3112aa58c",
+      "source": "No recent sessions",
+      "translated": "Brak ostatnich sesji"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5794,14 +5729,14 @@
       "translated": "Praca · $pendingRunCount aktywnych uruchomień"
     },
     {
-      "id": "native.android.e24db059480f1e6a",
-      "source": "Monitoring · 1 thread",
-      "translated": "Monitorowanie · 1 wątek"
+      "id": "native.android.2c89da708b12a522",
+      "source": "Monitoring · 1 session",
+      "translated": "Monitorowanie · 1 sesja"
     },
     {
-      "id": "native.android.5a475f37d80e02bc",
-      "source": "Monitoring · $sessionCount threads",
-      "translated": "Monitorowanie · $sessionCount wątków"
+      "id": "native.android.8b6ee382dcb64e1f",
+      "source": "Monitoring · $sessionCount sessions",
+      "translated": "Monitorowanie · $sessionCount sesji"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5834,9 +5769,9 @@
       "translated": "Dostawcy"
     },
     {
-      "id": "native.android.358c5e0e838d5423",
-      "source": "Open thread",
-      "translated": "Otwórz wątek"
+      "id": "native.android.a65477861c7203aa",
+      "source": "Open session",
+      "translated": "Otwórz sesję"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6259,9 +6194,9 @@
       "translated": "${days} d"
     },
     {
-      "id": "native.android.28a1a1acc5a0959f",
-      "source": "Main thread",
-      "translated": "Główny wątek"
+      "id": "native.android.22d755834386db07",
+      "source": "Main session",
+      "translated": "Sesja główna"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6942,16 +6877,6 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "Wyłącz wyciszenie"
-    },
-    {
-      "id": "native.android.cb608d82c5b3352a",
-      "source": "Back camera",
-      "translated": "Tylna kamera"
-    },
-    {
-      "id": "native.android.e89a0e780eed2e1e",
-      "source": "Front camera",
-      "translated": "Przednia kamera"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7759,9 +7684,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.0c74bc30a994dd33",
-      "source": "Loading thread",
-      "translated": "Wczytywanie wątku"
+      "id": "native.android.882cc14a58e7e105",
+      "source": "Loading session",
+      "translated": "Ładowanie sesji"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7804,14 +7729,14 @@
       "translated": "Nadrób zaległości"
     },
     {
-      "id": "native.android.cf40df9739f78f27",
-      "source": "Summarize recent threads and next steps.",
-      "translated": "Podsumuj ostatnie wątki i kolejne kroki."
+      "id": "native.android.1e5add56e48c99f9",
+      "source": "Summarize recent sessions and next steps.",
+      "translated": "Podsumuj ostatnie sesje i kolejne kroki."
     },
     {
-      "id": "native.android.ebe49a8b8df80bd3",
-      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
-      "translated": "Podsumuj moje ostatnie wątki w OpenClaw i zaproponuj kolejne kroki."
+      "id": "native.android.06d515351bb79576",
+      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
+      "translated": "Podsumuj moje ostatnie sesje OpenClaw i zaproponuj kolejne kroki."
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8149,9 +8074,9 @@
       "translated": "Połączono"
     },
     {
-      "id": "native.android.6cf5d6fa8a4186d5",
-      "source": "Threads",
-      "translated": "Wątki"
+      "id": "native.android.81931886b9caf3ab",
+      "source": "Sessions",
+      "translated": "Sesje"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,6 +10719,61 @@
       "translated": "Szczegóły zadania"
     },
     {
+      "id": "native.apple.29cacb53ea5e77fc",
+      "source": "Pinned",
+      "translated": "Przypięte"
+    },
+    {
+      "id": "native.apple.940062cfdce9211b",
+      "source": "Recent",
+      "translated": "Ostatnie"
+    },
+    {
+      "id": "native.apple.a0980128426308a9",
+      "source": "Model",
+      "translated": "Model"
+    },
+    {
+      "id": "native.apple.9520e60f21535dde",
+      "source": "Thinking",
+      "translated": "Rozumowanie"
+    },
+    {
+      "id": "native.apple.8b321f3ffce97429",
+      "source": "Fast",
+      "translated": "Szybkie"
+    },
+    {
+      "id": "native.apple.989b70d64e328d55",
+      "source": "Default (inherited)",
+      "translated": "Domyślne (dziedziczone)"
+    },
+    {
+      "id": "native.apple.f4114e73b07eb9ae",
+      "source": "Off",
+      "translated": "Wyłączone"
+    },
+    {
+      "id": "native.apple.7ed231b28d16312f",
+      "source": "On",
+      "translated": "Włączone"
+    },
+    {
+      "id": "native.apple.412a74802320a037",
+      "source": "Full",
+      "translated": "Pełne"
+    },
+    {
+      "id": "native.apple.299f21a2071ff9fc",
+      "source": "Verbosity",
+      "translated": "Szczegółowość"
+    },
+    {
+      "id": "native.apple.faf0ef05e1496de7",
+      "source": "Default",
+      "translated": "Domyślne"
+    },
+    {
       "id": "native.apple.e5524d5756a62744",
       "source": "Unable to Export Transcript",
       "translated": "Nie można wyeksportować transkrypcji"
@@ -10814,9 +10794,9 @@
       "translated": "Nad czym chcesz popracować?"
     },
     {
-      "id": "native.apple.4da775013ac9b123",
-      "source": "The thread attaches once the gateway is ready.",
-      "translated": "Wątek zostanie dołączony, gdy Gateway będzie gotowy."
+      "id": "native.apple.32179ce0b6d4543f",
+      "source": "The session attaches once the gateway is ready.",
+      "translated": "Sesja zostanie dołączona, gdy Gateway będzie gotowy."
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10859,9 +10839,14 @@
       "translated": "Nowy czat w worktree"
     },
     {
-      "id": "native.apple.003b25ddafeb18e9",
-      "source": "Threads…",
-      "translated": "Wątki…"
+      "id": "native.apple.ce6ebe91fc597015",
+      "source": "New Session Options…",
+      "translated": "Opcje nowej sesji…"
+    },
+    {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "Sesje…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11024,14 +11009,14 @@
       "translated": "Utwórz"
     },
     {
-      "id": "native.apple.31d5c7287cfb3abe",
-      "source": "Delete Thread?",
-      "translated": "Usunąć wątek?"
+      "id": "native.apple.f488b9caf6e51ac3",
+      "source": "Delete Session?",
+      "translated": "Usunąć sesję?"
     },
     {
-      "id": "native.apple.d3395564809f1120",
-      "source": "Delete Thread",
-      "translated": "Usuń wątek"
+      "id": "native.apple.8634b17be9b111bc",
+      "source": "Delete Session",
+      "translated": "Usuń sesję"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11039,9 +11024,9 @@
       "translated": "Anuluj"
     },
     {
-      "id": "native.apple.092659256d26cb03",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "Spowoduje to trwałe usunięcie wątku i jego transkrypcji."
+      "id": "native.apple.4a9568ac9b18d8d3",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "Spowoduje to trwałe usunięcie sesji i jej transkrypcji."
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11069,9 +11054,9 @@
       "translated": "Nowa grupa"
     },
     {
-      "id": "native.apple.683032464c497bbd",
-      "source": "Rename Thread",
-      "translated": "Zmień nazwę wątku"
+      "id": "native.apple.5bccdc23a1640895",
+      "source": "Rename Session",
+      "translated": "Zmień nazwę sesji"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11079,9 +11064,9 @@
       "translated": "Nazwa grupy"
     },
     {
-      "id": "native.apple.f887aa956588f237",
-      "source": "Thread name",
-      "translated": "Nazwa wątku"
+      "id": "native.apple.af789b2d2fda0f67",
+      "source": "Session name",
+      "translated": "Nazwa sesji"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11119,14 +11104,14 @@
       "translated": "Agenci"
     },
     {
-      "id": "native.apple.7c8231b7b1ca480f",
-      "source": "Agent thread",
-      "translated": "Wątek agenta"
+      "id": "native.apple.a3bde8045fe9224a",
+      "source": "Agent session",
+      "translated": "Sesja agenta"
     },
     {
-      "id": "native.apple.b3c553614f762a58",
-      "source": "Recent threads",
-      "translated": "Ostatnie wątki"
+      "id": "native.apple.27f775de30b37ff8",
+      "source": "Recent sessions",
+      "translated": "Ostatnie sesje"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11134,9 +11119,9 @@
       "translated": "Gateway offline"
     },
     {
-      "id": "native.apple.5aa32afda85064ea",
-      "source": "No recent threads",
-      "translated": "Brak ostatnich wątków"
+      "id": "native.apple.28c97cf23665ee01",
+      "source": "No recent sessions",
+      "translated": "Brak ostatnich sesji"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11234,14 +11219,14 @@
       "translated": "Anuluj"
     },
     {
-      "id": "native.apple.b6855cf19a50f477",
-      "source": "Threads",
-      "translated": "Wątki"
+      "id": "native.apple.9f2fd65953013b7c",
+      "source": "Sessions",
+      "translated": "Sesje"
     },
     {
-      "id": "native.apple.9b1d0ef27a1333b0",
-      "source": "Archived threads",
-      "translated": "Zarchiwizowane wątki"
+      "id": "native.apple.0422818cc95d5071",
+      "source": "Archived sessions",
+      "translated": "Zarchiwizowane sesje"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11249,34 +11234,34 @@
       "translated": "Pokaż zarchiwizowane"
     },
     {
-      "id": "native.apple.98167401c7267735",
-      "source": "Threads unavailable",
-      "translated": "Wątki są niedostępne"
+      "id": "native.apple.b272115c83f7ef58",
+      "source": "Sessions unavailable",
+      "translated": "Sesje niedostępne"
     },
     {
-      "id": "native.apple.4d28a7def2337b9f",
-      "source": "Loading archived threads",
-      "translated": "Wczytywanie zarchiwizowanych wątków"
+      "id": "native.apple.54f8260c9b863087",
+      "source": "Loading archived sessions",
+      "translated": "Ładowanie zarchiwizowanych sesji"
     },
     {
-      "id": "native.apple.777d7b706933bd7b",
-      "source": "Loading recent threads",
-      "translated": "Wczytywanie ostatnich wątków"
+      "id": "native.apple.9b305868873dade2",
+      "source": "Loading recent sessions",
+      "translated": "Ładowanie ostatnich sesji"
     },
     {
-      "id": "native.apple.22f81ea94bef8410",
-      "source": "^[\\(count) thread](inflect: true)",
-      "translated": "^[\\(count) wątek](inflect: true)"
+      "id": "native.apple.207dad20d09f3160",
+      "source": "^[\\(count) session](inflect: true)",
+      "translated": "^[\\(count) sesja](inflect: true)"
     },
     {
-      "id": "native.apple.1cad51e14db59bf9",
-      "source": "No archived threads",
-      "translated": "Brak zarchiwizowanych wątków"
+      "id": "native.apple.1f4501a6bf2bae4c",
+      "source": "No archived sessions",
+      "translated": "Brak zarchiwizowanych sesji"
     },
     {
-      "id": "native.apple.18ef832d3a7ddcf8",
-      "source": "Archived threads will appear here.",
-      "translated": "Zarchiwizowane wątki pojawią się tutaj."
+      "id": "native.apple.2a1ba7a5e1979c9e",
+      "source": "Archived sessions will appear here.",
+      "translated": "Zarchiwizowane sesje pojawią się tutaj."
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11359,9 +11344,9 @@
       "translated": "Udostępnij dane wejściowe"
     },
     {
-      "id": "native.apple.21d9208d86a4d1fe",
-      "source": "Loading threads",
-      "translated": "Wczytywanie wątków"
+      "id": "native.apple.2360d25fe6ae9946",
+      "source": "Loading sessions",
+      "translated": "Ładowanie sesji"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11369,19 +11354,19 @@
       "translated": "Pobieranie ostatniej aktywności z gateway."
     },
     {
-      "id": "native.apple.4be1f79aa2b230ff",
-      "source": "Threads unavailable",
-      "translated": "Wątki są niedostępne"
+      "id": "native.apple.c334f2e86702a7b8",
+      "source": "Sessions unavailable",
+      "translated": "Sesje niedostępne"
     },
     {
-      "id": "native.apple.98b348873556bc46",
-      "source": "No recent threads",
-      "translated": "Brak ostatnich wątków"
+      "id": "native.apple.6cc6efb7a03960b6",
+      "source": "No recent sessions",
+      "translated": "Brak ostatnich sesji"
     },
     {
-      "id": "native.apple.7396d205574d279f",
-      "source": "Thread activity offline",
-      "translated": "Aktywność wątków w trybie offline"
+      "id": "native.apple.08483af2d043bee6",
+      "source": "Session activity offline",
+      "translated": "Aktywność sesji offline"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11839,9 +11824,9 @@
       "translated": "Karta"
     },
     {
-      "id": "native.apple.c9ec1b0e18074d8a",
-      "source": "Open Thread",
-      "translated": "Otwórz wątek"
+      "id": "native.apple.93eeaedb2ff61043",
+      "source": "Open Session",
+      "translated": "Otwórz sesję"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13329,9 +13314,9 @@
       "translated": "Domyślnie"
     },
     {
-      "id": "native.apple.f4ae5664c3eda95d",
-      "source": "Used for new Chat threads and Talk sessions.",
-      "translated": "Używane w nowych wątkach czatu i sesjach rozmów."
+      "id": "native.apple.3de045f17ea3c6d0",
+      "source": "Used for new Chat and Talk sessions.",
+      "translated": "Używane dla nowych sesji Chat i Talk."
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15734,9 +15719,9 @@
       "translated": "Instancje"
     },
     {
-      "id": "native.apple.11fe8b9941954dfb",
-      "source": "Threads",
-      "translated": "Wątki"
+      "id": "native.apple.3579cf2750470a22",
+      "source": "Sessions",
+      "translated": "Sesje"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19044,9 +19029,9 @@
       "translated": "Skrót szybkiego czatu"
     },
     {
-      "id": "native.apple.94dd793cd7d7d555",
-      "source": "Global shortcut that opens a floating chat bar for the main thread.",
-      "translated": "Globalny skrót otwierający pływający pasek czatu dla głównego wątku."
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "Globalny skrót otwierający pływający pasek czatu dla sesji głównej."
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19624,9 +19609,9 @@
       "translated": "Krytyczny"
     },
     {
-      "id": "native.apple.13f96467014cf344",
-      "source": "New Thread",
-      "translated": "Nowy wątek"
+      "id": "native.apple.75102378a6775180",
+      "source": "New Session",
+      "translated": "Nowa sesja"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21914,9 +21899,9 @@
       "translated": "Brak ostatnich wiadomości"
     },
     {
-      "id": "native.apple.3ec2afcbc298c673",
-      "source": "Threads",
-      "translated": "Wątki"
+      "id": "native.apple.1ff8aec0044934c3",
+      "source": "Sessions",
+      "translated": "Sesje"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21924,9 +21909,9 @@
       "translated": "Zajrzyj do zapisanych zasobników konwersacji, których CLI ponownie używa na potrzeby kontekstu i limitów szybkości."
     },
     {
-      "id": "native.apple.14ccb32cd8ed1c81",
-      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
-      "translated": "Nie ma jeszcze żadnych wątków. Pojawią się po pierwszej wiadomości przychodzącej lub sygnale heartbeat."
+      "id": "native.apple.bab897f3252b134c",
+      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
+      "translated": "Nie ma jeszcze sesji. Pojawią się po pierwszej wiadomości przychodzącej lub sygnale heartbeat."
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -22009,9 +21994,9 @@
       "translated": "Zatwierdzenia uruchomień"
     },
     {
-      "id": "native.apple.52e37e3a44ae516c",
-      "source": "Threads",
-      "translated": "Wątki"
+      "id": "native.apple.64a6dc7d49e8fb57",
+      "source": "Sessions",
+      "translated": "Sesje"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -23014,9 +22999,9 @@
       "translated": "Wprowadź mnie w temat"
     },
     {
-      "id": "native.apple.fc4ce810900ec0b6",
-      "source": "Summarize what happened in my threads since yesterday.",
-      "translated": "Podsumuj, co wydarzyło się w moich wątkach od wczoraj."
+      "id": "native.apple.234ec45f4231edc4",
+      "source": "Summarize what happened in my sessions since yesterday.",
+      "translated": "Podsumuj, co wydarzyło się w moich sesjach od wczoraj."
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23194,9 +23179,9 @@
       "translated": "Odepnij model"
     },
     {
-      "id": "native.apple.4edb66657f5aca1f",
-      "source": "Thread",
-      "translated": "Wątek"
+      "id": "native.apple.5dfc0700d8dff8de",
+      "source": "Session",
+      "translated": "Sesja"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23359,51 +23344,6 @@
       "translated": "Widżet niedostępny"
     },
     {
-      "id": "native.apple.d640691fd196f338",
-      "source": "Widget export failed",
-      "translated": "Eksport widżetu nie powiódł się"
-    },
-    {
-      "id": "native.apple.533c6e22a11e88de",
-      "source": "OK",
-      "translated": "OK"
-    },
-    {
-      "id": "native.apple.e1fb28a2a9756402",
-      "source": "Copy image",
-      "translated": "Kopiuj obraz"
-    },
-    {
-      "id": "native.apple.ebd7bc92e1b12235",
-      "source": "Save image…",
-      "translated": "Zapisz obraz…"
-    },
-    {
-      "id": "native.apple.742c46d4cf2db134",
-      "source": "Save image",
-      "translated": "Zapisz obraz"
-    },
-    {
-      "id": "native.apple.0589cce608418f90",
-      "source": "The widget image could not be captured.",
-      "translated": "Nie udało się przechwycić obrazu widżetu."
-    },
-    {
-      "id": "native.apple.dfe24e827fdbe9c5",
-      "source": "The widget image could not be copied.",
-      "translated": "Nie udało się skopiować obrazu widżetu."
-    },
-    {
-      "id": "native.apple.9e611e3a80e71408",
-      "source": "The widget image could not be encoded as PNG.",
-      "translated": "Nie udało się zakodować obrazu widżetu w formacie PNG."
-    },
-    {
-      "id": "native.apple.9a6e8afbe24a262b",
-      "source": "The widget image could not be saved.",
-      "translated": "Nie udało się zapisać obrazu widżetu."
-    },
-    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23544,19 +23484,19 @@
       "translated": "Użytkownik"
     },
     {
-      "id": "native.apple.9d0cba09d92ee669",
-      "source": "This thread cannot be archived while it is active or running.",
-      "translated": "Nie można zarchiwizować tego wątku, gdy jest aktywny lub uruchomiony."
+      "id": "native.apple.b1cdcb906a43d5d6",
+      "source": "This session cannot be archived while it is active or running.",
+      "translated": "Nie można zarchiwizować tej sesji, gdy jest aktywna lub uruchomiona."
     },
     {
-      "id": "native.apple.8952a111a1075051",
-      "source": "The main thread cannot be deleted.",
-      "translated": "Nie można usunąć głównego wątku."
+      "id": "native.apple.5817e3f3dab1ee19",
+      "source": "The main session cannot be deleted.",
+      "translated": "Nie można usunąć sesji głównej."
     },
     {
-      "id": "native.apple.90d0ccf80ca28717",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
-      "translated": "Usuń załączniki lub poczekaj na ich dostarczenie przed zarchiwizowaniem albo usunięciem tego wątku."
+      "id": "native.apple.a6b8df3f18171c91",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
+      "translated": "Usuń załączniki lub poczekaj na ich dostarczenie przed zarchiwizowaniem albo usunięciem tej sesji."
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23694,9 +23634,9 @@
       "translated": "Zakończenie uruchomienia"
     },
     {
-      "id": "native.apple.bbccb4c8db5cac12",
-      "source": "Thread Info",
-      "translated": "Informacje o wątku"
+      "id": "native.apple.cd7c3095a22f80a9",
+      "source": "Session Info",
+      "translated": "Informacje o sesji"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23729,9 +23669,9 @@
       "translated": "Dodaj grupę"
     },
     {
-      "id": "native.apple.7b641fed5bace855",
-      "source": "Thread Groups",
-      "translated": "Grupy wątków"
+      "id": "native.apple.23d628606fe0734f",
+      "source": "Session Groups",
+      "translated": "Grupy sesji"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23774,9 +23714,9 @@
       "translated": "Usuń grupę"
     },
     {
-      "id": "native.apple.56401c79410a310d",
-      "source": "Threads in this group become ungrouped.",
-      "translated": "Wątki w tej grupie zostaną rozgrupowane."
+      "id": "native.apple.b049c8a4d2805e08",
+      "source": "Sessions in this group become ungrouped.",
+      "translated": "Sesje w tej grupie przestaną być przypisane do grupy."
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23789,9 +23729,9 @@
       "translated": "Na tym gatewayu nie są dostępni żadni agenci."
     },
     {
-      "id": "native.apple.2d96aa7d3d12f85b",
-      "source": "New Thread Options",
-      "translated": "Opcje nowego wątku"
+      "id": "native.apple.6c89f35d53506406",
+      "source": "New Session Options",
+      "translated": "Opcje nowej sesji"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23819,19 +23759,19 @@
       "translated": "Utwórz"
     },
     {
-      "id": "native.apple.87ef57319d1ddc85",
-      "source": "The thread could not be created.",
-      "translated": "Nie udało się utworzyć wątku."
+      "id": "native.apple.795ba37f6782cf28",
+      "source": "The session could not be created.",
+      "translated": "Nie udało się utworzyć sesji."
     },
     {
-      "id": "native.apple.6bd91c435b69d638",
-      "source": "Search threads",
-      "translated": "Szukaj wątków"
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "Szukaj sesji"
     },
     {
-      "id": "native.apple.6fde4bdf9d5b9191",
-      "source": "No Threads",
-      "translated": "Brak wątków"
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "Brak sesji"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23839,29 +23779,29 @@
       "translated": "Brak wyników"
     },
     {
-      "id": "native.apple.a02fd99740d29bd3",
-      "source": "New Thread",
-      "translated": "Nowy wątek"
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "Nowa sesja"
     },
     {
-      "id": "native.apple.b625801dd04b09f2",
-      "source": "New thread",
-      "translated": "Nowy wątek"
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "Nowa sesja"
     },
     {
-      "id": "native.apple.851be81fcc933608",
-      "source": "New thread options",
-      "translated": "Opcje nowego wątku"
+      "id": "native.apple.2ef0e34db02ad255",
+      "source": "New session options",
+      "translated": "Opcje nowej sesji"
     },
     {
-      "id": "native.apple.9ce8a4aba7b444b2",
-      "source": "Rename Thread",
-      "translated": "Zmień nazwę wątku"
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "Zmień nazwę sesji"
     },
     {
-      "id": "native.apple.1dd067c44511c7f0",
-      "source": "Thread name",
-      "translated": "Nazwa wątku"
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "Nazwa sesji"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23874,14 +23814,14 @@
       "translated": "Anuluj"
     },
     {
-      "id": "native.apple.618073d6ab3f2721",
-      "source": "Delete Thread",
-      "translated": "Usuń wątek"
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "Usuń sesję"
     },
     {
-      "id": "native.apple.10a5e72bba3cbccc",
-      "source": "The thread and its transcript are removed from the gateway.",
-      "translated": "Wątek i jego transkrypcja zostaną usunięte z gateway."
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "Sesja i jej transkrypcja zostaną usunięte z Gateway."
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23889,14 +23829,14 @@
       "translated": "Usunąć „%@”?"
     },
     {
-      "id": "native.apple.ac71e3b2aa496a2c",
-      "source": "Thread running",
-      "translated": "Wątek jest uruchomiony"
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "Sesja jest uruchomiona"
     },
     {
-      "id": "native.apple.c775e87f997278b2",
-      "source": "Thread failed",
-      "translated": "Wątek zakończył się niepowodzeniem"
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "Sesja nie powiodła się"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23954,9 +23894,9 @@
       "translated": "Kopiuj klucz sesji"
     },
     {
-      "id": "native.apple.f4998cfb572f23ff",
-      "source": "Delete Thread…",
-      "translated": "Usuń wątek…"
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "Usuń sesję…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23969,9 +23909,9 @@
       "translated": "Łączenie…"
     },
     {
-      "id": "native.apple.8802e9576ffd0f65",
-      "source": "Retry thread groups",
-      "translated": "Ponów próbę dla grup wątków"
+      "id": "native.apple.79f708b3bc1d3a6c",
+      "source": "Retry session groups",
+      "translated": "Ponów próbę wczytania grup sesji"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23994,24 +23934,24 @@
       "translated": "Zakres"
     },
     {
-      "id": "native.apple.b313b80def4bda52",
-      "source": "Search threads",
-      "translated": "Szukaj wątków"
+      "id": "native.apple.2c37581c7b88f741",
+      "source": "Search sessions",
+      "translated": "Szukaj sesji"
     },
     {
-      "id": "native.apple.c0cc6acc36f413ce",
-      "source": "Threads",
-      "translated": "Wątki"
+      "id": "native.apple.43be8a2336e42faf",
+      "source": "Sessions",
+      "translated": "Sesje"
     },
     {
-      "id": "native.apple.854d3928fe5a557c",
-      "source": "Rename Thread",
-      "translated": "Zmień nazwę wątku"
+      "id": "native.apple.0b379cdfcbd3247f",
+      "source": "Rename Session",
+      "translated": "Zmień nazwę sesji"
     },
     {
-      "id": "native.apple.9d0d3f20096cc4da",
-      "source": "Thread name",
-      "translated": "Nazwa wątku"
+      "id": "native.apple.54b6fbd9e41db009",
+      "source": "Session name",
+      "translated": "Nazwa sesji"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -24019,19 +23959,19 @@
       "translated": "Anuluj"
     },
     {
-      "id": "native.apple.dc00eb94f33bae15",
-      "source": "Delete selected threads?",
-      "translated": "Usunąć wybrane wątki?"
+      "id": "native.apple.751e0f6b81cd374a",
+      "source": "Delete selected sessions?",
+      "translated": "Usunąć wybrane sesje?"
     },
     {
-      "id": "native.apple.2053fc9f74dc3158",
-      "source": "Delete Threads",
-      "translated": "Usuń wątki"
+      "id": "native.apple.aa679276581b0058",
+      "source": "Delete Sessions",
+      "translated": "Usuń sesje"
     },
     {
-      "id": "native.apple.0970247871a834a0",
-      "source": "Each selected thread and its transcript will be removed from the gateway.",
-      "translated": "Każdy wybrany wątek i jego transkrypcja zostaną usunięte z Gateway."
+      "id": "native.apple.f837129cbee23297",
+      "source": "Each selected session and its transcript will be removed from the gateway.",
+      "translated": "Każda wybrana sesja i jej transkrypcja zostaną usunięte z Gateway."
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -24039,9 +23979,9 @@
       "translated": "Grupy"
     },
     {
-      "id": "native.apple.6f8acab2256728b5",
-      "source": "Manage thread groups",
-      "translated": "Zarządzaj grupami wątków"
+      "id": "native.apple.64013cfee5e25305",
+      "source": "Manage session groups",
+      "translated": "Zarządzaj grupami sesji"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -24054,14 +23994,14 @@
       "translated": "Wybierz"
     },
     {
-      "id": "native.apple.692972314d04b184",
-      "source": "No archived threads",
-      "translated": "Brak zarchiwizowanych wątków"
+      "id": "native.apple.b67eaecec1b423ac",
+      "source": "No archived sessions",
+      "translated": "Brak zarchiwizowanych sesji"
     },
     {
-      "id": "native.apple.d6a4b5711dcd26e7",
-      "source": "No threads found",
-      "translated": "Nie znaleziono wątków"
+      "id": "native.apple.b2435a79abf0c794",
+      "source": "No sessions found",
+      "translated": "Nie znaleziono sesji"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24229,16 +24169,6 @@
       "translated": "Otwórz pełną wiadomość"
     },
     {
-      "id": "native.apple.002bfcede229ad4b",
-      "source": "Rewind to Here",
-      "translated": "Przewiń do tego miejsca"
-    },
-    {
-      "id": "native.apple.14df2e4997689fb3",
-      "source": "Fork from Here",
-      "translated": "Utwórz odgałęzienie od tego miejsca"
-    },
-    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "Odpowiedz"
@@ -24324,9 +24254,9 @@
       "translated": "Usuń załączniki lub poczekaj na zakończenie dostarczania przed rozpoczęciem nowego czatu."
     },
     {
-      "id": "native.apple.e0f045151c8d3137",
-      "source": "Gateway changed before the thread operation started.",
-      "translated": "Gateway zmienił się przed rozpoczęciem operacji na wątku."
+      "id": "native.apple.980f552bb0f96c0f",
+      "source": "Gateway changed before the session operation started.",
+      "translated": "Gateway zmienił się przed rozpoczęciem operacji na sesji."
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24334,9 +24264,9 @@
       "translated": "Usuń załączniki lub poczekaj na zakończenie dostarczania przed przełączeniem czatów."
     },
     {
-      "id": "native.apple.0a5c4e15466c3acc",
-      "source": "Clear this thread's history?",
-      "translated": "Wyczyścić historię tego wątku?"
+      "id": "native.apple.87ba543b42696b92",
+      "source": "Clear this session's history?",
+      "translated": "Wyczyścić historię tej sesji?"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24349,14 +24279,14 @@
       "translated": "Spowoduje to zresetowanie rozmowy dla %@. Klucz sesji pozostanie bez zmian."
     },
     {
-      "id": "native.apple.67ac221dbe7179f0",
-      "source": "Rename Thread",
-      "translated": "Zmień nazwę wątku"
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "Zmień nazwę sesji"
     },
     {
-      "id": "native.apple.cf0f7e049603f518",
-      "source": "Thread name",
-      "translated": "Nazwa wątku"
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "Nazwa sesji"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24374,9 +24304,9 @@
       "translated": "Eksportuj transkrypcję"
     },
     {
-      "id": "native.apple.c0ada47504425f23",
-      "source": "Threads",
-      "translated": "Wątki"
+      "id": "native.apple.4af0f566d39d7041",
+      "source": "Sessions",
+      "translated": "Sesje"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24449,14 +24379,14 @@
       "translated": "Domyślne"
     },
     {
-      "id": "native.apple.1a765291943599e5",
-      "source": "New Thread",
-      "translated": "Nowy wątek"
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "Nowa sesja"
     },
     {
-      "id": "native.apple.c7a3a6d5e43dd98f",
-      "source": "New Thread Options…",
-      "translated": "Opcje nowego wątku…"
+      "id": "native.apple.a7119fbf9d25df5e",
+      "source": "New Session Options…",
+      "translated": "Opcje nowej sesji…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24464,19 +24394,19 @@
       "translated": "Odśwież"
     },
     {
-      "id": "native.apple.0e710b81808e5dcf",
-      "source": "Threads…",
-      "translated": "Wątki…"
+      "id": "native.apple.2bcff4a8fa503739",
+      "source": "Sessions…",
+      "translated": "Sesje…"
     },
     {
-      "id": "native.apple.faad8f92b6bef166",
-      "source": "Rename Thread…",
-      "translated": "Zmień nazwę wątku…"
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "Zmień nazwę sesji…"
     },
     {
-      "id": "native.apple.23b61d6cd26ac112",
-      "source": "Fork",
-      "translated": "Utwórz odgałęzienie"
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "Utwórz odgałęzienie sesji"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24534,24 +24464,24 @@
       "translated": "Wyczyść historię…"
     },
     {
-      "id": "native.apple.8b4f1c5107ea8a0e",
-      "source": "Thread",
-      "translated": "Wątek"
+      "id": "native.apple.920fe8a7a33f9e92",
+      "source": "Session",
+      "translated": "Sesja"
     },
     {
-      "id": "native.apple.4d7750c9bf699469",
-      "source": "Thread actions",
-      "translated": "Działania wątku"
+      "id": "native.apple.185a401f78328b0f",
+      "source": "Session actions",
+      "translated": "Akcje sesji"
     },
     {
-      "id": "native.apple.bb2f22cc43c97f8e",
-      "source": "Thread cost %@",
-      "translated": "Koszt wątku %@"
+      "id": "native.apple.9f9dedf599b2619b",
+      "source": "Session cost %@",
+      "translated": "Koszt sesji: %@"
     },
     {
-      "id": "native.apple.6239ced0b86e86f8",
-      "source": "Compact Thread",
-      "translated": "Kompaktuj wątek"
+      "id": "native.apple.f0a4720df5f5f403",
+      "source": "Compact Session",
+      "translated": "Kompaktuj sesję"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/pt-BR.json
+++ b/apps/.i18n/native/pt-BR.json
@@ -1429,9 +1429,9 @@
       "translated": "Fale ou dite com o OpenClaw"
     },
     {
-      "id": "native.android.5876e15e5e92fd45",
-      "source": "Browse Sessions",
-      "translated": "Explorar sessões"
+      "id": "native.android.e2cf5a38587382cb",
+      "source": "Browse Threads",
+      "translated": "Navegar pelas conversas"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "Nenhuma ação encontrada"
     },
     {
-      "id": "native.android.48ad0ae0e930e02b",
-      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
-      "translated": "Experimente Chat, Voice, Sessions, Providers ou Settings."
+      "id": "native.android.bc70a4ac965b82ba",
+      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
+      "translated": "Experimente Chat, Voz, Conversas, Provedores ou Configurações."
     },
     {
-      "id": "native.android.d4fbd1ee4f55a5db",
-      "source": "Sessions",
-      "translated": "Sessões"
+      "id": "native.android.670121e54dbe286f",
+      "source": "Threads",
+      "translated": "Conversas"
     },
     {
-      "id": "native.android.207c2170504e99e6",
-      "source": "Connect the Gateway to search sessions.",
-      "translated": "Conecte o Gateway para pesquisar sessões."
+      "id": "native.android.d38be650b1bce4a0",
+      "source": "Connect the Gateway to search threads.",
+      "translated": "Conecte o Gateway para pesquisar conversas."
     },
     {
-      "id": "native.android.25d2c2d792c952fe",
-      "source": "No matching sessions yet.",
-      "translated": "Ainda não há sessões correspondentes."
+      "id": "native.android.3d7754721f776ef8",
+      "source": "No matching threads yet.",
+      "translated": "Ainda não há conversas correspondentes."
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "Assistente trabalhando"
     },
     {
-      "id": "native.android.8f8384286317f5c9",
-      "source": "OpenClaw session",
-      "translated": "Sessão do OpenClaw"
+      "id": "native.android.9a839f6e3e05a744",
+      "source": "OpenClaw thread",
+      "translated": "Conversa do OpenClaw"
     },
     {
-      "id": "native.android.15799e57704b20c6",
-      "source": "Open session",
-      "translated": "Abrir sessão"
+      "id": "native.android.d83f82a1e4a5ed99",
+      "source": "Open thread",
+      "translated": "Abrir conversa"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "Nenhum provedor pronto"
     },
     {
-      "id": "native.android.73e6ab1a168fd381",
-      "source": "Main session",
-      "translated": "Sessão principal"
+      "id": "native.android.8a1c5365c0538908",
+      "source": "Main thread",
+      "translated": "Conversa principal"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.0e3157c15c56944f",
-      "source": "Sessions",
-      "translated": "Sessões"
+      "id": "native.android.a5845742daecb4ba",
+      "source": "Threads",
+      "translated": "Conversas"
     },
     {
-      "id": "native.android.70f5d0507d34b5c8",
-      "source": "Focus session search",
-      "translated": "Focar na busca de sessões"
+      "id": "native.android.439b324280869527",
+      "source": "Focus thread search",
+      "translated": "Focar na pesquisa de conversas"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "Arquivadas"
     },
     {
-      "id": "native.android.b9cf34c137e4cf03",
-      "source": "Search sessions",
-      "translated": "Pesquisar sessões"
+      "id": "native.android.03981341841b04ac",
+      "source": "Search threads",
+      "translated": "Pesquisar conversas"
     },
     {
-      "id": "native.android.10cb26723e9990fc",
-      "source": "Clear session search",
-      "translated": "Limpar busca de sessões"
+      "id": "native.android.99570c528a41fa72",
+      "source": "Clear thread search",
+      "translated": "Limpar pesquisa de conversas"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "Mais antigos primeiro"
     },
     {
-      "id": "native.android.c6bf8751e2a7f5c7",
-      "source": "Toggle session layout",
-      "translated": "Alternar layout de sessões"
+      "id": "native.android.fd67be543e321cc9",
+      "source": "Toggle thread layout",
+      "translated": "Alternar layout das conversas"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "Layout: Detalhado"
     },
     {
-      "id": "native.android.69b79a3c2c987cd4",
-      "source": "Searching sessions",
-      "translated": "Buscando sessões"
+      "id": "native.android.ebd17565e0ffd8eb",
+      "source": "Searching threads",
+      "translated": "Pesquisando conversas"
     },
     {
-      "id": "native.android.dd587d341af44212",
-      "source": "No matching sessions",
-      "translated": "Nenhuma sessão correspondente"
+      "id": "native.android.472d46ae8669f860",
+      "source": "No matching threads",
+      "translated": "Nenhuma conversa correspondente"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "Iniciar chat"
     },
     {
-      "id": "native.android.f10d4df7cbc6df4f",
-      "source": "Current session",
-      "translated": "Sessão atual"
+      "id": "native.android.ff81ad1bee00d384",
+      "source": "Current thread",
+      "translated": "Conversa atual"
     },
     {
-      "id": "native.android.8f0482425838ae64",
-      "source": "OpenClaw session",
-      "translated": "Sessão do OpenClaw"
+      "id": "native.android.fc145645b9620e57",
+      "source": "OpenClaw thread",
+      "translated": "Conversa do OpenClaw"
     },
     {
-      "id": "native.android.786774c8a76e50d7",
-      "source": "Rename session",
-      "translated": "Renomear sessão"
+      "id": "native.android.71cbb8dde8bf138b",
+      "source": "Rename thread",
+      "translated": "Renomear conversa"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "Excluir grupo?"
     },
     {
-      "id": "native.android.3455fc2f77d564e3",
-      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "As sessões em \"$group\" são mantidas e voltam para Sem grupo."
+      "id": "native.android.691e92cfe5cf106e",
+      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "As conversas em \"$group\" são mantidas e movidas de volta para Sem grupo."
     },
     {
-      "id": "native.android.4805fb9d6623e8c0",
-      "source": "Delete session?",
-      "translated": "Excluir sessão?"
+      "id": "native.android.d87a8217ab56999b",
+      "source": "Delete thread?",
+      "translated": "Excluir conversa?"
     },
     {
-      "id": "native.android.0c3283a2b2445eae",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "Isso exclui permanentemente a sessão e sua transcrição."
+      "id": "native.android.930de97ff47113a8",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "Isso exclui permanentemente a conversa e sua transcrição."
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "Sem grupo"
     },
     {
-      "id": "native.android.db243d71d056afa4",
-      "source": "No sessions yet",
-      "translated": "Ainda não há sessões"
+      "id": "native.android.8e21a70428def6e0",
+      "source": "No threads yet",
+      "translated": "Ainda não há conversas"
     },
     {
-      "id": "native.android.5b4eee6a8092925e",
-      "source": "No current session",
-      "translated": "Nenhuma sessão atual"
+      "id": "native.android.cda4c5ad8b17e394",
+      "source": "No current thread",
+      "translated": "Nenhuma conversa atual"
     },
     {
-      "id": "native.android.acbcc9c9ea53d8c0",
-      "source": "No archived sessions",
-      "translated": "Nenhuma sessão arquivada"
+      "id": "native.android.be84f061047aa2da",
+      "source": "No archived threads",
+      "translated": "Nenhuma conversa arquivada"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "Inicie uma nova conversa e ela aparecerá aqui."
     },
     {
-      "id": "native.android.56fcd605dc7be3c0",
-      "source": "Open Chat to start or resume the current session.",
-      "translated": "Abra o chat para iniciar ou retomar a sessão atual."
+      "id": "native.android.f289d03e1d3eee98",
+      "source": "Open Chat to start or resume the current thread.",
+      "translated": "Abra o Chat para iniciar ou retomar a conversa atual."
     },
     {
-      "id": "native.android.085515989f8a2022",
-      "source": "Archived sessions will show up here.",
-      "translated": "As sessões arquivadas aparecerão aqui."
+      "id": "native.android.504b71386e76c6ae",
+      "source": "Archived threads will show up here.",
+      "translated": "As conversas arquivadas aparecerão aqui."
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days}d"
     },
     {
-      "id": "native.android.3d4fa07acbc015c5",
-      "source": "Main session",
-      "translated": "Sessão principal"
+      "id": "native.android.ee4c727cdafbe963",
+      "source": "Main thread",
+      "translated": "Conversa principal"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway pendente"
     },
     {
-      "id": "native.android.2d8d049afe99f751",
-      "source": "Session Activity",
-      "translated": "Atividade da sessão"
+      "id": "native.android.da78209effb11cfd",
+      "source": "Thread Activity",
+      "translated": "Atividade da conversa"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "As solicitações de aprovação de execução aparecerão aqui enquanto este telefone estiver conectado."
     },
     {
-      "id": "native.android.dc3e7ca5a491103a",
-      "source": "Session activity",
-      "translated": "Atividade da sessão"
+      "id": "native.android.f615712dfb56319a",
+      "source": "Thread activity",
+      "translated": "Atividade da conversa"
     },
     {
-      "id": "native.android.8551e02b060bd7d8",
-      "source": "Chat tool calls waiting in the active session remain visible here.",
-      "translated": "As chamadas de ferramentas do chat aguardando na sessão ativa permanecem visíveis aqui."
+      "id": "native.android.6c93973c13db43ae",
+      "source": "Chat tool calls waiting in the active thread remain visible here.",
+      "translated": "As chamadas de ferramentas do Chat que aguardam na conversa ativa permanecem visíveis aqui."
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,6 +4294,11 @@
       "translated": "Configuração do provedor de fala"
     },
     {
+      "id": "native.android.23b638094c34b916",
+      "source": "Microphone",
+      "translated": "Microfone"
+    },
+    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "Teste de áudio"
@@ -4337,6 +4342,66 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "Concluído"
+    },
+    {
+      "id": "native.android.8d9ecdfdd916b780",
+      "source": "Automatic",
+      "translated": "Automático"
+    },
+    {
+      "id": "native.android.c1626a6700a570f6",
+      "source": "Preferred microphone unavailable; using automatic routing.",
+      "translated": "O microfone preferido não está disponível; usando o roteamento automático."
+    },
+    {
+      "id": "native.android.820bc5d0ce571d8b",
+      "source": "Prioritizes connected Bluetooth microphones.",
+      "translated": "Prioriza microfones Bluetooth conectados."
+    },
+    {
+      "id": "native.android.11e48038d5e8bff6",
+      "source": "Preferred microphone",
+      "translated": "Microfone preferido"
+    },
+    {
+      "id": "native.android.eaa4d7563a46d307",
+      "source": "Unavailable",
+      "translated": "Indisponível"
+    },
+    {
+      "id": "native.android.9f5ebf17eb405ba8",
+      "source": "Next session",
+      "translated": "Próxima sessão"
+    },
+    {
+      "id": "native.android.8c4e91f53928efb2",
+      "source": "Built-in microphone",
+      "translated": "Microfone integrado"
+    },
+    {
+      "id": "native.android.14b613cb6e2446b4",
+      "source": "Bluetooth microphone",
+      "translated": "Microfone Bluetooth"
+    },
+    {
+      "id": "native.android.c885247b2d7ce271",
+      "source": "Bluetooth LE microphone",
+      "translated": "Microfone Bluetooth LE"
+    },
+    {
+      "id": "native.android.b6a4e674c5fb441a",
+      "source": "Wired headset microphone",
+      "translated": "Microfone do headset com fio"
+    },
+    {
+      "id": "native.android.9c8becb3b0fb5a90",
+      "source": "USB microphone",
+      "translated": "Microfone USB"
+    },
+    {
+      "id": "native.android.ba46258fadec7a39",
+      "source": "External microphone",
+      "translated": "Microfone externo"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5074,9 +5139,9 @@
       "translated": "Verificar"
     },
     {
-      "id": "native.android.5a540761383fa474",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
-      "translated": "O OpenClaw transforma este telefone em uma interface móvel simples para sessões, voz, provedores e Gateway."
+      "id": "native.android.c971506716c96e91",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
+      "translated": "O OpenClaw transforma este celular em uma interface móvel simples para conversas, voz, provedores e Gateway."
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5624,9 +5689,9 @@
       "translated": "Configurações do Talk"
     },
     {
-      "id": "native.android.73f07a5d54915259",
-      "source": "Recent Sessions",
-      "translated": "Sessões recentes"
+      "id": "native.android.36f78c8c85dc283f",
+      "source": "Recent Threads",
+      "translated": "Conversas recentes"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5684,14 +5749,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online"
     },
     {
-      "id": "native.android.16c3425d3a594481",
-      "source": "Sessions",
-      "translated": "Sessões"
+      "id": "native.android.57177017a6a93826",
+      "source": "Threads",
+      "translated": "Conversas"
     },
     {
-      "id": "native.android.a5c0f8b3112aa58c",
-      "source": "No recent sessions",
-      "translated": "Nenhuma sessão recente"
+      "id": "native.android.43320b54a68b00a1",
+      "source": "No recent threads",
+      "translated": "Nenhuma conversa recente"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5729,14 +5794,14 @@
       "translated": "Em execução · $pendingRunCount execuções ativas"
     },
     {
-      "id": "native.android.2c89da708b12a522",
-      "source": "Monitoring · 1 session",
-      "translated": "Monitorando · 1 sessão"
+      "id": "native.android.e24db059480f1e6a",
+      "source": "Monitoring · 1 thread",
+      "translated": "Monitorando · 1 conversa"
     },
     {
-      "id": "native.android.8b6ee382dcb64e1f",
-      "source": "Monitoring · $sessionCount sessions",
-      "translated": "Monitorando · $sessionCount sessões"
+      "id": "native.android.5a475f37d80e02bc",
+      "source": "Monitoring · $sessionCount threads",
+      "translated": "Monitorando · $sessionCount conversas"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5769,9 +5834,9 @@
       "translated": "Provedores"
     },
     {
-      "id": "native.android.a65477861c7203aa",
-      "source": "Open session",
-      "translated": "Abrir sessão"
+      "id": "native.android.358c5e0e838d5423",
+      "source": "Open thread",
+      "translated": "Abrir conversa"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6194,9 +6259,9 @@
       "translated": "${days}d"
     },
     {
-      "id": "native.android.22d755834386db07",
-      "source": "Main session",
-      "translated": "Sessão principal"
+      "id": "native.android.28a1a1acc5a0959f",
+      "source": "Main thread",
+      "translated": "Conversa principal"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6877,6 +6942,16 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "Ativar som"
+    },
+    {
+      "id": "native.android.cb608d82c5b3352a",
+      "source": "Back camera",
+      "translated": "Câmera traseira"
+    },
+    {
+      "id": "native.android.e89a0e780eed2e1e",
+      "source": "Front camera",
+      "translated": "Câmera frontal"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7684,9 +7759,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.882cc14a58e7e105",
-      "source": "Loading session",
-      "translated": "Carregando sessão"
+      "id": "native.android.0c74bc30a994dd33",
+      "source": "Loading thread",
+      "translated": "Carregando conversa"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7729,14 +7804,14 @@
       "translated": "Atualize-me"
     },
     {
-      "id": "native.android.1e5add56e48c99f9",
-      "source": "Summarize recent sessions and next steps.",
-      "translated": "Resuma as sessões recentes e os próximos passos."
+      "id": "native.android.cf40df9739f78f27",
+      "source": "Summarize recent threads and next steps.",
+      "translated": "Resuma as conversas recentes e os próximos passos."
     },
     {
-      "id": "native.android.06d515351bb79576",
-      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
-      "translated": "Atualize-me sobre minhas sessões recentes do OpenClaw e sugira os próximos passos."
+      "id": "native.android.ebe49a8b8df80bd3",
+      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
+      "translated": "Atualize-me sobre minhas conversas recentes no OpenClaw e sugira os próximos passos."
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8074,9 +8149,9 @@
       "translated": "Conectado"
     },
     {
-      "id": "native.android.81931886b9caf3ab",
-      "source": "Sessions",
-      "translated": "Sessões"
+      "id": "native.android.6cf5d6fa8a4186d5",
+      "source": "Threads",
+      "translated": "Conversas"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,9 +10869,9 @@
       "translated": "Em que você gostaria de trabalhar?"
     },
     {
-      "id": "native.apple.32179ce0b6d4543f",
-      "source": "The session attaches once the gateway is ready.",
-      "translated": "A sessão será anexada assim que o Gateway estiver pronto."
+      "id": "native.apple.4da775013ac9b123",
+      "source": "The thread attaches once the gateway is ready.",
+      "translated": "A conversa será anexada assim que o Gateway estiver pronto."
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10844,9 +10919,9 @@
       "translated": "Opções da nova sessão…"
     },
     {
-      "id": "native.apple.a1b0d289758e2213",
-      "source": "Sessions…",
-      "translated": "Sessões…"
+      "id": "native.apple.003b25ddafeb18e9",
+      "source": "Threads…",
+      "translated": "Conversas…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11009,14 +11084,14 @@
       "translated": "Criar"
     },
     {
-      "id": "native.apple.f488b9caf6e51ac3",
-      "source": "Delete Session?",
-      "translated": "Excluir sessão?"
+      "id": "native.apple.31d5c7287cfb3abe",
+      "source": "Delete Thread?",
+      "translated": "Excluir conversa?"
     },
     {
-      "id": "native.apple.8634b17be9b111bc",
-      "source": "Delete Session",
-      "translated": "Excluir sessão"
+      "id": "native.apple.d3395564809f1120",
+      "source": "Delete Thread",
+      "translated": "Excluir conversa"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11024,9 +11099,9 @@
       "translated": "Cancelar"
     },
     {
-      "id": "native.apple.4a9568ac9b18d8d3",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "Isso exclui permanentemente a sessão e sua transcrição."
+      "id": "native.apple.092659256d26cb03",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "Isso exclui permanentemente a conversa e sua transcrição."
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11054,9 +11129,9 @@
       "translated": "Novo grupo"
     },
     {
-      "id": "native.apple.5bccdc23a1640895",
-      "source": "Rename Session",
-      "translated": "Renomear sessão"
+      "id": "native.apple.683032464c497bbd",
+      "source": "Rename Thread",
+      "translated": "Renomear conversa"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11064,9 +11139,9 @@
       "translated": "Nome do grupo"
     },
     {
-      "id": "native.apple.af789b2d2fda0f67",
-      "source": "Session name",
-      "translated": "Nome da sessão"
+      "id": "native.apple.f887aa956588f237",
+      "source": "Thread name",
+      "translated": "Nome da conversa"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11104,14 +11179,14 @@
       "translated": "Agentes"
     },
     {
-      "id": "native.apple.a3bde8045fe9224a",
-      "source": "Agent session",
-      "translated": "Sessão do agente"
+      "id": "native.apple.7c8231b7b1ca480f",
+      "source": "Agent thread",
+      "translated": "Conversa do agente"
     },
     {
-      "id": "native.apple.27f775de30b37ff8",
-      "source": "Recent sessions",
-      "translated": "Sessões recentes"
+      "id": "native.apple.b3c553614f762a58",
+      "source": "Recent threads",
+      "translated": "Conversas recentes"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11119,9 +11194,9 @@
       "translated": "Gateway offline"
     },
     {
-      "id": "native.apple.28c97cf23665ee01",
-      "source": "No recent sessions",
-      "translated": "Nenhuma sessão recente"
+      "id": "native.apple.5aa32afda85064ea",
+      "source": "No recent threads",
+      "translated": "Nenhuma conversa recente"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11219,14 +11294,14 @@
       "translated": "Cancelar"
     },
     {
-      "id": "native.apple.9f2fd65953013b7c",
-      "source": "Sessions",
-      "translated": "Sessões"
+      "id": "native.apple.b6855cf19a50f477",
+      "source": "Threads",
+      "translated": "Conversas"
     },
     {
-      "id": "native.apple.0422818cc95d5071",
-      "source": "Archived sessions",
-      "translated": "Sessões arquivadas"
+      "id": "native.apple.9b1d0ef27a1333b0",
+      "source": "Archived threads",
+      "translated": "Conversas arquivadas"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11234,34 +11309,34 @@
       "translated": "Mostrar arquivadas"
     },
     {
-      "id": "native.apple.b272115c83f7ef58",
-      "source": "Sessions unavailable",
-      "translated": "Sessões indisponíveis"
+      "id": "native.apple.98167401c7267735",
+      "source": "Threads unavailable",
+      "translated": "Conversas indisponíveis"
     },
     {
-      "id": "native.apple.54f8260c9b863087",
-      "source": "Loading archived sessions",
-      "translated": "Carregando sessões arquivadas"
+      "id": "native.apple.4d28a7def2337b9f",
+      "source": "Loading archived threads",
+      "translated": "Carregando conversas arquivadas"
     },
     {
-      "id": "native.apple.9b305868873dade2",
-      "source": "Loading recent sessions",
-      "translated": "Carregando sessões recentes"
+      "id": "native.apple.777d7b706933bd7b",
+      "source": "Loading recent threads",
+      "translated": "Carregando conversas recentes"
     },
     {
-      "id": "native.apple.207dad20d09f3160",
-      "source": "^[\\(count) session](inflect: true)",
-      "translated": "^[\\(count) sessão](inflect: true)"
+      "id": "native.apple.22f81ea94bef8410",
+      "source": "^[\\(count) thread](inflect: true)",
+      "translated": "^[\\(count) conversa](inflect: true)"
     },
     {
-      "id": "native.apple.1f4501a6bf2bae4c",
-      "source": "No archived sessions",
-      "translated": "Nenhuma sessão arquivada"
+      "id": "native.apple.1cad51e14db59bf9",
+      "source": "No archived threads",
+      "translated": "Nenhuma conversa arquivada"
     },
     {
-      "id": "native.apple.2a1ba7a5e1979c9e",
-      "source": "Archived sessions will appear here.",
-      "translated": "Sessões arquivadas aparecerão aqui."
+      "id": "native.apple.18ef832d3a7ddcf8",
+      "source": "Archived threads will appear here.",
+      "translated": "As conversas arquivadas aparecerão aqui."
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11344,9 +11419,9 @@
       "translated": "Compartilhar entrada"
     },
     {
-      "id": "native.apple.2360d25fe6ae9946",
-      "source": "Loading sessions",
-      "translated": "Carregando sessões"
+      "id": "native.apple.21d9208d86a4d1fe",
+      "source": "Loading threads",
+      "translated": "Carregando conversas"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11354,19 +11429,19 @@
       "translated": "Buscando atividade recente no gateway."
     },
     {
-      "id": "native.apple.c334f2e86702a7b8",
-      "source": "Sessions unavailable",
-      "translated": "Sessões indisponíveis"
+      "id": "native.apple.4be1f79aa2b230ff",
+      "source": "Threads unavailable",
+      "translated": "Conversas indisponíveis"
     },
     {
-      "id": "native.apple.6cc6efb7a03960b6",
-      "source": "No recent sessions",
-      "translated": "Nenhuma sessão recente"
+      "id": "native.apple.98b348873556bc46",
+      "source": "No recent threads",
+      "translated": "Nenhuma conversa recente"
     },
     {
-      "id": "native.apple.08483af2d043bee6",
-      "source": "Session activity offline",
-      "translated": "Atividade da sessão offline"
+      "id": "native.apple.7396d205574d279f",
+      "source": "Thread activity offline",
+      "translated": "Atividade das conversas offline"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11824,9 +11899,9 @@
       "translated": "Cartão"
     },
     {
-      "id": "native.apple.93eeaedb2ff61043",
-      "source": "Open Session",
-      "translated": "Abrir sessão"
+      "id": "native.apple.c9ec1b0e18074d8a",
+      "source": "Open Thread",
+      "translated": "Abrir conversa"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13314,9 +13389,9 @@
       "translated": "Padrão"
     },
     {
-      "id": "native.apple.3de045f17ea3c6d0",
-      "source": "Used for new Chat and Talk sessions.",
-      "translated": "Usado para novas sessões de Chat e Talk."
+      "id": "native.apple.f4ae5664c3eda95d",
+      "source": "Used for new Chat threads and Talk sessions.",
+      "translated": "Usado para novas conversas de Chat e sessões de Talk."
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15719,9 +15794,9 @@
       "translated": "Instâncias"
     },
     {
-      "id": "native.apple.3579cf2750470a22",
-      "source": "Sessions",
-      "translated": "Sessões"
+      "id": "native.apple.11fe8b9941954dfb",
+      "source": "Threads",
+      "translated": "Conversas"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19029,9 +19104,9 @@
       "translated": "Atalho do Chat Rápido"
     },
     {
-      "id": "native.apple.6ae77665b5f4490f",
-      "source": "Global shortcut that opens a floating chat bar for the main session.",
-      "translated": "Atalho global que abre uma barra de chat flutuante para a sessão principal."
+      "id": "native.apple.94dd793cd7d7d555",
+      "source": "Global shortcut that opens a floating chat bar for the main thread.",
+      "translated": "Atalho global que abre uma barra de chat flutuante para a conversa principal."
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19609,9 +19684,9 @@
       "translated": "Crítico"
     },
     {
-      "id": "native.apple.75102378a6775180",
-      "source": "New Session",
-      "translated": "Nova sessão"
+      "id": "native.apple.13f96467014cf344",
+      "source": "New Thread",
+      "translated": "Nova conversa"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21899,9 +21974,9 @@
       "translated": "Nenhuma mensagem recente"
     },
     {
-      "id": "native.apple.1ff8aec0044934c3",
-      "source": "Sessions",
-      "translated": "Sessões"
+      "id": "native.apple.3ec2afcbc298c673",
+      "source": "Threads",
+      "translated": "Conversas"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21909,9 +21984,9 @@
       "translated": "Veja os buckets de conversas armazenados que a CLI reutiliza para contexto e limites de taxa."
     },
     {
-      "id": "native.apple.bab897f3252b134c",
-      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
-      "translated": "Ainda não há sessões. Elas aparecem após a primeira mensagem recebida ou heartbeat."
+      "id": "native.apple.14ccb32cd8ed1c81",
+      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
+      "translated": "Ainda não há conversas. Elas aparecem após a primeira mensagem recebida ou heartbeat."
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -21994,9 +22069,9 @@
       "translated": "Aprovações de execução"
     },
     {
-      "id": "native.apple.64a6dc7d49e8fb57",
-      "source": "Sessions",
-      "translated": "Sessões"
+      "id": "native.apple.52e37e3a44ae516c",
+      "source": "Threads",
+      "translated": "Conversas"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -22999,9 +23074,9 @@
       "translated": "Coloque-me a par"
     },
     {
-      "id": "native.apple.234ec45f4231edc4",
-      "source": "Summarize what happened in my sessions since yesterday.",
-      "translated": "Resuma o que aconteceu nas minhas sessões desde ontem."
+      "id": "native.apple.fc4ce810900ec0b6",
+      "source": "Summarize what happened in my threads since yesterday.",
+      "translated": "Resuma o que aconteceu nas minhas conversas desde ontem."
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23179,9 +23254,9 @@
       "translated": "Desafixar modelo"
     },
     {
-      "id": "native.apple.5dfc0700d8dff8de",
-      "source": "Session",
-      "translated": "Sessão"
+      "id": "native.apple.4edb66657f5aca1f",
+      "source": "Thread",
+      "translated": "Conversa"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23344,6 +23419,51 @@
       "translated": "Widget indisponível"
     },
     {
+      "id": "native.apple.d640691fd196f338",
+      "source": "Widget export failed",
+      "translated": "Falha ao exportar o widget"
+    },
+    {
+      "id": "native.apple.533c6e22a11e88de",
+      "source": "OK",
+      "translated": "OK"
+    },
+    {
+      "id": "native.apple.e1fb28a2a9756402",
+      "source": "Copy image",
+      "translated": "Copiar imagem"
+    },
+    {
+      "id": "native.apple.ebd7bc92e1b12235",
+      "source": "Save image…",
+      "translated": "Salvar imagem…"
+    },
+    {
+      "id": "native.apple.742c46d4cf2db134",
+      "source": "Save image",
+      "translated": "Salvar imagem"
+    },
+    {
+      "id": "native.apple.0589cce608418f90",
+      "source": "The widget image could not be captured.",
+      "translated": "Não foi possível capturar a imagem do widget."
+    },
+    {
+      "id": "native.apple.dfe24e827fdbe9c5",
+      "source": "The widget image could not be copied.",
+      "translated": "Não foi possível copiar a imagem do widget."
+    },
+    {
+      "id": "native.apple.9e611e3a80e71408",
+      "source": "The widget image could not be encoded as PNG.",
+      "translated": "Não foi possível codificar a imagem do widget como PNG."
+    },
+    {
+      "id": "native.apple.9a6e8afbe24a262b",
+      "source": "The widget image could not be saved.",
+      "translated": "Não foi possível salvar a imagem do widget."
+    },
+    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23484,19 +23604,19 @@
       "translated": "Usuário"
     },
     {
-      "id": "native.apple.b1cdcb906a43d5d6",
-      "source": "This session cannot be archived while it is active or running.",
-      "translated": "Esta sessão não pode ser arquivada enquanto estiver ativa ou em execução."
+      "id": "native.apple.9d0cba09d92ee669",
+      "source": "This thread cannot be archived while it is active or running.",
+      "translated": "Esta conversa não pode ser arquivada enquanto estiver ativa ou em execução."
     },
     {
-      "id": "native.apple.5817e3f3dab1ee19",
-      "source": "The main session cannot be deleted.",
-      "translated": "A sessão principal não pode ser excluída."
+      "id": "native.apple.8952a111a1075051",
+      "source": "The main thread cannot be deleted.",
+      "translated": "A conversa principal não pode ser excluída."
     },
     {
-      "id": "native.apple.a6b8df3f18171c91",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
-      "translated": "Remova os anexos ou aguarde a entrega antes de arquivar ou excluir esta sessão."
+      "id": "native.apple.90d0ccf80ca28717",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
+      "translated": "Remova os anexos ou aguarde a entrega antes de arquivar ou excluir esta conversa."
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23634,9 +23754,9 @@
       "translated": "Execução encerrada"
     },
     {
-      "id": "native.apple.cd7c3095a22f80a9",
-      "source": "Session Info",
-      "translated": "Informações da sessão"
+      "id": "native.apple.bbccb4c8db5cac12",
+      "source": "Thread Info",
+      "translated": "Informações da conversa"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23669,9 +23789,9 @@
       "translated": "Adicionar grupo"
     },
     {
-      "id": "native.apple.23d628606fe0734f",
-      "source": "Session Groups",
-      "translated": "Grupos da sessão"
+      "id": "native.apple.7b641fed5bace855",
+      "source": "Thread Groups",
+      "translated": "Grupos de conversas"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23714,9 +23834,9 @@
       "translated": "Excluir grupo"
     },
     {
-      "id": "native.apple.b049c8a4d2805e08",
-      "source": "Sessions in this group become ungrouped.",
-      "translated": "As sessões deste grupo ficarão sem grupo."
+      "id": "native.apple.56401c79410a310d",
+      "source": "Threads in this group become ungrouped.",
+      "translated": "As conversas deste grupo deixam de ser agrupadas."
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23729,9 +23849,9 @@
       "translated": "Nenhum agente está disponível neste gateway."
     },
     {
-      "id": "native.apple.6c89f35d53506406",
-      "source": "New Session Options",
-      "translated": "Opções da nova sessão"
+      "id": "native.apple.2d96aa7d3d12f85b",
+      "source": "New Thread Options",
+      "translated": "Opções da nova conversa"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23759,19 +23879,19 @@
       "translated": "Criar"
     },
     {
-      "id": "native.apple.795ba37f6782cf28",
-      "source": "The session could not be created.",
-      "translated": "Não foi possível criar a sessão."
+      "id": "native.apple.87ef57319d1ddc85",
+      "source": "The thread could not be created.",
+      "translated": "Não foi possível criar a conversa."
     },
     {
-      "id": "native.apple.8ec708a3605a2cc3",
-      "source": "Search sessions",
-      "translated": "Buscar sessões"
+      "id": "native.apple.6bd91c435b69d638",
+      "source": "Search threads",
+      "translated": "Buscar conversas"
     },
     {
-      "id": "native.apple.23b069b4e7f97039",
-      "source": "No Sessions",
-      "translated": "Nenhuma sessão"
+      "id": "native.apple.6fde4bdf9d5b9191",
+      "source": "No Threads",
+      "translated": "Nenhuma conversa"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23779,29 +23899,29 @@
       "translated": "Nenhum resultado"
     },
     {
-      "id": "native.apple.0058923f2ce8a3ec",
-      "source": "New Session",
-      "translated": "Nova sessão"
+      "id": "native.apple.a02fd99740d29bd3",
+      "source": "New Thread",
+      "translated": "Nova conversa"
     },
     {
-      "id": "native.apple.66ba42960eb4135b",
-      "source": "New session",
-      "translated": "Nova sessão"
+      "id": "native.apple.b625801dd04b09f2",
+      "source": "New thread",
+      "translated": "Nova conversa"
     },
     {
-      "id": "native.apple.2ef0e34db02ad255",
-      "source": "New session options",
-      "translated": "Opções da nova sessão"
+      "id": "native.apple.851be81fcc933608",
+      "source": "New thread options",
+      "translated": "Opções da nova conversa"
     },
     {
-      "id": "native.apple.36753ef2f1ed4264",
-      "source": "Rename Session",
-      "translated": "Renomear sessão"
+      "id": "native.apple.9ce8a4aba7b444b2",
+      "source": "Rename Thread",
+      "translated": "Renomear conversa"
     },
     {
-      "id": "native.apple.c9de0a1510ef475f",
-      "source": "Session name",
-      "translated": "Nome da sessão"
+      "id": "native.apple.1dd067c44511c7f0",
+      "source": "Thread name",
+      "translated": "Nome da conversa"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23814,14 +23934,14 @@
       "translated": "Cancelar"
     },
     {
-      "id": "native.apple.afb4e6c99c63a28d",
-      "source": "Delete Session",
-      "translated": "Excluir sessão"
+      "id": "native.apple.618073d6ab3f2721",
+      "source": "Delete Thread",
+      "translated": "Excluir conversa"
     },
     {
-      "id": "native.apple.3d4ef32e42f136a4",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "A sessão e sua transcrição são removidas do Gateway."
+      "id": "native.apple.10a5e72bba3cbccc",
+      "source": "The thread and its transcript are removed from the gateway.",
+      "translated": "A conversa e sua transcrição são removidas do Gateway."
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23829,14 +23949,14 @@
       "translated": "Excluir “%@”?"
     },
     {
-      "id": "native.apple.9a7dca238fba628d",
-      "source": "Session running",
-      "translated": "Sessão em execução"
+      "id": "native.apple.ac71e3b2aa496a2c",
+      "source": "Thread running",
+      "translated": "Conversa em andamento"
     },
     {
-      "id": "native.apple.fcfbfe5e97a95e9c",
-      "source": "Session failed",
-      "translated": "Falha na sessão"
+      "id": "native.apple.c775e87f997278b2",
+      "source": "Thread failed",
+      "translated": "Falha na conversa"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23894,9 +24014,9 @@
       "translated": "Copiar chave da sessão"
     },
     {
-      "id": "native.apple.4aeb7c14c26dabac",
-      "source": "Delete Session…",
-      "translated": "Excluir sessão…"
+      "id": "native.apple.f4998cfb572f23ff",
+      "source": "Delete Thread…",
+      "translated": "Excluir conversa…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23909,9 +24029,9 @@
       "translated": "Conectando…"
     },
     {
-      "id": "native.apple.79f708b3bc1d3a6c",
-      "source": "Retry session groups",
-      "translated": "Tentar carregar os grupos de sessões novamente"
+      "id": "native.apple.8802e9576ffd0f65",
+      "source": "Retry thread groups",
+      "translated": "Tentar carregar os grupos de conversas novamente"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23934,24 +24054,24 @@
       "translated": "Escopo"
     },
     {
-      "id": "native.apple.2c37581c7b88f741",
-      "source": "Search sessions",
-      "translated": "Buscar sessões"
+      "id": "native.apple.b313b80def4bda52",
+      "source": "Search threads",
+      "translated": "Buscar conversas"
     },
     {
-      "id": "native.apple.43be8a2336e42faf",
-      "source": "Sessions",
-      "translated": "Sessões"
+      "id": "native.apple.c0cc6acc36f413ce",
+      "source": "Threads",
+      "translated": "Conversas"
     },
     {
-      "id": "native.apple.0b379cdfcbd3247f",
-      "source": "Rename Session",
-      "translated": "Renomear sessão"
+      "id": "native.apple.854d3928fe5a557c",
+      "source": "Rename Thread",
+      "translated": "Renomear conversa"
     },
     {
-      "id": "native.apple.54b6fbd9e41db009",
-      "source": "Session name",
-      "translated": "Nome da sessão"
+      "id": "native.apple.9d0d3f20096cc4da",
+      "source": "Thread name",
+      "translated": "Nome da conversa"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -23959,19 +24079,19 @@
       "translated": "Cancelar"
     },
     {
-      "id": "native.apple.751e0f6b81cd374a",
-      "source": "Delete selected sessions?",
-      "translated": "Excluir as sessões selecionadas?"
+      "id": "native.apple.dc00eb94f33bae15",
+      "source": "Delete selected threads?",
+      "translated": "Excluir as conversas selecionadas?"
     },
     {
-      "id": "native.apple.aa679276581b0058",
-      "source": "Delete Sessions",
-      "translated": "Excluir sessões"
+      "id": "native.apple.2053fc9f74dc3158",
+      "source": "Delete Threads",
+      "translated": "Excluir conversas"
     },
     {
-      "id": "native.apple.f837129cbee23297",
-      "source": "Each selected session and its transcript will be removed from the gateway.",
-      "translated": "Cada sessão selecionada e sua transcrição serão removidas do gateway."
+      "id": "native.apple.0970247871a834a0",
+      "source": "Each selected thread and its transcript will be removed from the gateway.",
+      "translated": "Cada conversa selecionada e sua transcrição serão removidas do Gateway."
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -23979,9 +24099,9 @@
       "translated": "Grupos"
     },
     {
-      "id": "native.apple.64013cfee5e25305",
-      "source": "Manage session groups",
-      "translated": "Gerenciar grupos de sessões"
+      "id": "native.apple.6f8acab2256728b5",
+      "source": "Manage thread groups",
+      "translated": "Gerenciar grupos de conversas"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -23994,14 +24114,14 @@
       "translated": "Selecionar"
     },
     {
-      "id": "native.apple.b67eaecec1b423ac",
-      "source": "No archived sessions",
-      "translated": "Nenhuma sessão arquivada"
+      "id": "native.apple.692972314d04b184",
+      "source": "No archived threads",
+      "translated": "Nenhuma conversa arquivada"
     },
     {
-      "id": "native.apple.b2435a79abf0c794",
-      "source": "No sessions found",
-      "translated": "Nenhuma sessão encontrada"
+      "id": "native.apple.d6a4b5711dcd26e7",
+      "source": "No threads found",
+      "translated": "Nenhuma conversa encontrada"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24169,6 +24289,16 @@
       "translated": "Abrir mensagem completa"
     },
     {
+      "id": "native.apple.002bfcede229ad4b",
+      "source": "Rewind to Here",
+      "translated": "Retroceder até aqui"
+    },
+    {
+      "id": "native.apple.14df2e4997689fb3",
+      "source": "Fork from Here",
+      "translated": "Criar ramificação a partir daqui"
+    },
+    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "Responder"
@@ -24254,9 +24384,9 @@
       "translated": "Remova os anexos ou aguarde a conclusão da entrega antes de iniciar uma nova conversa."
     },
     {
-      "id": "native.apple.980f552bb0f96c0f",
-      "source": "Gateway changed before the session operation started.",
-      "translated": "O Gateway foi alterado antes do início da operação da sessão."
+      "id": "native.apple.e0f045151c8d3137",
+      "source": "Gateway changed before the thread operation started.",
+      "translated": "O Gateway foi alterado antes do início da operação da conversa."
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24264,9 +24394,9 @@
       "translated": "Remova os anexos ou aguarde a entrega ser concluída antes de trocar de conversa."
     },
     {
-      "id": "native.apple.87ba543b42696b92",
-      "source": "Clear this session's history?",
-      "translated": "Limpar o histórico desta sessão?"
+      "id": "native.apple.0a5c4e15466c3acc",
+      "source": "Clear this thread's history?",
+      "translated": "Limpar o histórico desta conversa?"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24279,14 +24409,14 @@
       "translated": "Isso redefine a conversa para %@. A chave da sessão permanece a mesma."
     },
     {
-      "id": "native.apple.a92e96bed98bd553",
-      "source": "Rename Session",
-      "translated": "Renomear sessão"
+      "id": "native.apple.67ac221dbe7179f0",
+      "source": "Rename Thread",
+      "translated": "Renomear conversa"
     },
     {
-      "id": "native.apple.848e2388f3466f40",
-      "source": "Session name",
-      "translated": "Nome da sessão"
+      "id": "native.apple.cf0f7e049603f518",
+      "source": "Thread name",
+      "translated": "Nome da conversa"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24304,9 +24434,9 @@
       "translated": "Exportar transcrição"
     },
     {
-      "id": "native.apple.4af0f566d39d7041",
-      "source": "Sessions",
-      "translated": "Sessões"
+      "id": "native.apple.c0ada47504425f23",
+      "source": "Threads",
+      "translated": "Conversas"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24379,14 +24509,14 @@
       "translated": "Padrão"
     },
     {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "Nova sessão"
+      "id": "native.apple.1a765291943599e5",
+      "source": "New Thread",
+      "translated": "Nova conversa"
     },
     {
-      "id": "native.apple.a7119fbf9d25df5e",
-      "source": "New Session Options…",
-      "translated": "Opções de Nova Sessão…"
+      "id": "native.apple.c7a3a6d5e43dd98f",
+      "source": "New Thread Options…",
+      "translated": "Opções da nova conversa…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24394,19 +24524,19 @@
       "translated": "Atualizar"
     },
     {
-      "id": "native.apple.2bcff4a8fa503739",
-      "source": "Sessions…",
-      "translated": "Sessões…"
+      "id": "native.apple.0e710b81808e5dcf",
+      "source": "Threads…",
+      "translated": "Conversas…"
     },
     {
-      "id": "native.apple.c36e008b051adb38",
-      "source": "Rename Session…",
-      "translated": "Renomear sessão…"
+      "id": "native.apple.faad8f92b6bef166",
+      "source": "Rename Thread…",
+      "translated": "Renomear conversa…"
     },
     {
-      "id": "native.apple.ea0ef95a159bffe0",
-      "source": "Fork Session",
-      "translated": "Bifurcar sessão"
+      "id": "native.apple.23b61d6cd26ac112",
+      "source": "Fork",
+      "translated": "Ramificar"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24464,24 +24594,24 @@
       "translated": "Limpar histórico…"
     },
     {
-      "id": "native.apple.920fe8a7a33f9e92",
-      "source": "Session",
-      "translated": "Sessão"
+      "id": "native.apple.8b4f1c5107ea8a0e",
+      "source": "Thread",
+      "translated": "Conversa"
     },
     {
-      "id": "native.apple.185a401f78328b0f",
-      "source": "Session actions",
-      "translated": "Ações da sessão"
+      "id": "native.apple.4d7750c9bf699469",
+      "source": "Thread actions",
+      "translated": "Ações da conversa"
     },
     {
-      "id": "native.apple.9f9dedf599b2619b",
-      "source": "Session cost %@",
-      "translated": "Custo da sessão: %@"
+      "id": "native.apple.bb2f22cc43c97f8e",
+      "source": "Thread cost %@",
+      "translated": "Custo da conversa %@"
     },
     {
-      "id": "native.apple.f0a4720df5f5f403",
-      "source": "Compact Session",
-      "translated": "Compactar sessão"
+      "id": "native.apple.6239ced0b86e86f8",
+      "source": "Compact Thread",
+      "translated": "Compactar conversa"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/pt-BR.json
+++ b/apps/.i18n/native/pt-BR.json
@@ -1429,9 +1429,9 @@
       "translated": "Fale ou dite com o OpenClaw"
     },
     {
-      "id": "native.android.e2cf5a38587382cb",
-      "source": "Browse Threads",
-      "translated": "Explorar conversas"
+      "id": "native.android.5876e15e5e92fd45",
+      "source": "Browse Sessions",
+      "translated": "Explorar sessões"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "Nenhuma ação encontrada"
     },
     {
-      "id": "native.android.bc70a4ac965b82ba",
-      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
-      "translated": "Experimente Chat, Voz, Conversas, Provedores ou Configurações."
+      "id": "native.android.48ad0ae0e930e02b",
+      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
+      "translated": "Experimente Chat, Voice, Sessions, Providers ou Settings."
     },
     {
-      "id": "native.android.670121e54dbe286f",
-      "source": "Threads",
-      "translated": "Conversas"
+      "id": "native.android.d4fbd1ee4f55a5db",
+      "source": "Sessions",
+      "translated": "Sessões"
     },
     {
-      "id": "native.android.d38be650b1bce4a0",
-      "source": "Connect the Gateway to search threads.",
-      "translated": "Conecte o Gateway para pesquisar conversas."
+      "id": "native.android.207c2170504e99e6",
+      "source": "Connect the Gateway to search sessions.",
+      "translated": "Conecte o Gateway para pesquisar sessões."
     },
     {
-      "id": "native.android.3d7754721f776ef8",
-      "source": "No matching threads yet.",
-      "translated": "Ainda não há conversas correspondentes."
+      "id": "native.android.25d2c2d792c952fe",
+      "source": "No matching sessions yet.",
+      "translated": "Ainda não há sessões correspondentes."
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "Assistente trabalhando"
     },
     {
-      "id": "native.android.9a839f6e3e05a744",
-      "source": "OpenClaw thread",
-      "translated": "Conversa do OpenClaw"
+      "id": "native.android.8f8384286317f5c9",
+      "source": "OpenClaw session",
+      "translated": "Sessão do OpenClaw"
     },
     {
-      "id": "native.android.d83f82a1e4a5ed99",
-      "source": "Open thread",
-      "translated": "Abrir conversa"
+      "id": "native.android.15799e57704b20c6",
+      "source": "Open session",
+      "translated": "Abrir sessão"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "Nenhum provedor pronto"
     },
     {
-      "id": "native.android.8a1c5365c0538908",
-      "source": "Main thread",
-      "translated": "Conversa principal"
+      "id": "native.android.73e6ab1a168fd381",
+      "source": "Main session",
+      "translated": "Sessão principal"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.a5845742daecb4ba",
-      "source": "Threads",
-      "translated": "Conversas"
+      "id": "native.android.0e3157c15c56944f",
+      "source": "Sessions",
+      "translated": "Sessões"
     },
     {
-      "id": "native.android.439b324280869527",
-      "source": "Focus thread search",
-      "translated": "Focar na pesquisa de conversas"
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "Focar na busca de sessões"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "Arquivadas"
     },
     {
-      "id": "native.android.03981341841b04ac",
-      "source": "Search threads",
-      "translated": "Pesquisar conversas"
+      "id": "native.android.b9cf34c137e4cf03",
+      "source": "Search sessions",
+      "translated": "Pesquisar sessões"
     },
     {
-      "id": "native.android.99570c528a41fa72",
-      "source": "Clear thread search",
-      "translated": "Limpar pesquisa de conversas"
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "Limpar busca de sessões"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "Mais antigos primeiro"
     },
     {
-      "id": "native.android.fd67be543e321cc9",
-      "source": "Toggle thread layout",
-      "translated": "Alternar layout das conversas"
+      "id": "native.android.c6bf8751e2a7f5c7",
+      "source": "Toggle session layout",
+      "translated": "Alternar layout de sessões"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "Layout: Detalhado"
     },
     {
-      "id": "native.android.ebd17565e0ffd8eb",
-      "source": "Searching threads",
-      "translated": "Pesquisando conversas"
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "Buscando sessões"
     },
     {
-      "id": "native.android.472d46ae8669f860",
-      "source": "No matching threads",
-      "translated": "Nenhuma conversa correspondente"
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "Nenhuma sessão correspondente"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "Iniciar chat"
     },
     {
-      "id": "native.android.ff81ad1bee00d384",
-      "source": "Current thread",
-      "translated": "Conversa atual"
+      "id": "native.android.f10d4df7cbc6df4f",
+      "source": "Current session",
+      "translated": "Sessão atual"
     },
     {
-      "id": "native.android.fc145645b9620e57",
-      "source": "OpenClaw thread",
-      "translated": "Conversa do OpenClaw"
+      "id": "native.android.8f0482425838ae64",
+      "source": "OpenClaw session",
+      "translated": "Sessão do OpenClaw"
     },
     {
-      "id": "native.android.71cbb8dde8bf138b",
-      "source": "Rename thread",
-      "translated": "Renomear conversa"
+      "id": "native.android.786774c8a76e50d7",
+      "source": "Rename session",
+      "translated": "Renomear sessão"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "Excluir grupo?"
     },
     {
-      "id": "native.android.691e92cfe5cf106e",
-      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "As conversas em \"$group\" são mantidas e retornam para Sem grupo."
+      "id": "native.android.3455fc2f77d564e3",
+      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "As sessões em \"$group\" são mantidas e voltam para Sem grupo."
     },
     {
-      "id": "native.android.d87a8217ab56999b",
-      "source": "Delete thread?",
-      "translated": "Excluir conversa?"
+      "id": "native.android.4805fb9d6623e8c0",
+      "source": "Delete session?",
+      "translated": "Excluir sessão?"
     },
     {
-      "id": "native.android.930de97ff47113a8",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "Isso exclui permanentemente a conversa e sua transcrição."
+      "id": "native.android.0c3283a2b2445eae",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "Isso exclui permanentemente a sessão e sua transcrição."
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "Sem grupo"
     },
     {
-      "id": "native.android.8e21a70428def6e0",
-      "source": "No threads yet",
-      "translated": "Ainda não há conversas"
+      "id": "native.android.db243d71d056afa4",
+      "source": "No sessions yet",
+      "translated": "Ainda não há sessões"
     },
     {
-      "id": "native.android.cda4c5ad8b17e394",
-      "source": "No current thread",
-      "translated": "Nenhuma conversa atual"
+      "id": "native.android.5b4eee6a8092925e",
+      "source": "No current session",
+      "translated": "Nenhuma sessão atual"
     },
     {
-      "id": "native.android.be84f061047aa2da",
-      "source": "No archived threads",
-      "translated": "Nenhuma conversa arquivada"
+      "id": "native.android.acbcc9c9ea53d8c0",
+      "source": "No archived sessions",
+      "translated": "Nenhuma sessão arquivada"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "Inicie uma nova conversa e ela aparecerá aqui."
     },
     {
-      "id": "native.android.f289d03e1d3eee98",
-      "source": "Open Chat to start or resume the current thread.",
-      "translated": "Abra o Chat para iniciar ou retomar a conversa atual."
+      "id": "native.android.56fcd605dc7be3c0",
+      "source": "Open Chat to start or resume the current session.",
+      "translated": "Abra o chat para iniciar ou retomar a sessão atual."
     },
     {
-      "id": "native.android.504b71386e76c6ae",
-      "source": "Archived threads will show up here.",
-      "translated": "As conversas arquivadas aparecerão aqui."
+      "id": "native.android.085515989f8a2022",
+      "source": "Archived sessions will show up here.",
+      "translated": "As sessões arquivadas aparecerão aqui."
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days}d"
     },
     {
-      "id": "native.android.ee4c727cdafbe963",
-      "source": "Main thread",
-      "translated": "Conversa principal"
+      "id": "native.android.3d4fa07acbc015c5",
+      "source": "Main session",
+      "translated": "Sessão principal"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway pendente"
     },
     {
-      "id": "native.android.da78209effb11cfd",
-      "source": "Thread Activity",
-      "translated": "Atividade da conversa"
+      "id": "native.android.2d8d049afe99f751",
+      "source": "Session Activity",
+      "translated": "Atividade da sessão"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "As solicitações de aprovação de execução aparecerão aqui enquanto este telefone estiver conectado."
     },
     {
-      "id": "native.android.f615712dfb56319a",
-      "source": "Thread activity",
-      "translated": "Atividade da conversa"
+      "id": "native.android.dc3e7ca5a491103a",
+      "source": "Session activity",
+      "translated": "Atividade da sessão"
     },
     {
-      "id": "native.android.6c93973c13db43ae",
-      "source": "Chat tool calls waiting in the active thread remain visible here.",
-      "translated": "As chamadas de ferramentas do Chat que aguardam na conversa ativa permanecem visíveis aqui."
+      "id": "native.android.8551e02b060bd7d8",
+      "source": "Chat tool calls waiting in the active session remain visible here.",
+      "translated": "As chamadas de ferramentas do chat aguardando na sessão ativa permanecem visíveis aqui."
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,11 +4294,6 @@
       "translated": "Configuração do provedor de fala"
     },
     {
-      "id": "native.android.23b638094c34b916",
-      "source": "Microphone",
-      "translated": "Microfone"
-    },
-    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "Teste de áudio"
@@ -4342,66 +4337,6 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "Concluído"
-    },
-    {
-      "id": "native.android.8d9ecdfdd916b780",
-      "source": "Automatic",
-      "translated": "Automático"
-    },
-    {
-      "id": "native.android.c1626a6700a570f6",
-      "source": "Preferred microphone unavailable; using automatic routing.",
-      "translated": "O microfone preferido não está disponível; usando o roteamento automático."
-    },
-    {
-      "id": "native.android.820bc5d0ce571d8b",
-      "source": "Prioritizes connected Bluetooth microphones.",
-      "translated": "Prioriza microfones Bluetooth conectados."
-    },
-    {
-      "id": "native.android.11e48038d5e8bff6",
-      "source": "Preferred microphone",
-      "translated": "Microfone preferido"
-    },
-    {
-      "id": "native.android.eaa4d7563a46d307",
-      "source": "Unavailable",
-      "translated": "Indisponível"
-    },
-    {
-      "id": "native.android.9f5ebf17eb405ba8",
-      "source": "Next session",
-      "translated": "Próxima sessão"
-    },
-    {
-      "id": "native.android.8c4e91f53928efb2",
-      "source": "Built-in microphone",
-      "translated": "Microfone integrado"
-    },
-    {
-      "id": "native.android.14b613cb6e2446b4",
-      "source": "Bluetooth microphone",
-      "translated": "Microfone Bluetooth"
-    },
-    {
-      "id": "native.android.c885247b2d7ce271",
-      "source": "Bluetooth LE microphone",
-      "translated": "Microfone Bluetooth LE"
-    },
-    {
-      "id": "native.android.b6a4e674c5fb441a",
-      "source": "Wired headset microphone",
-      "translated": "Microfone de headset com fio"
-    },
-    {
-      "id": "native.android.9c8becb3b0fb5a90",
-      "source": "USB microphone",
-      "translated": "Microfone USB"
-    },
-    {
-      "id": "native.android.ba46258fadec7a39",
-      "source": "External microphone",
-      "translated": "Microfone externo"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5139,9 +5074,9 @@
       "translated": "Verificar"
     },
     {
-      "id": "native.android.c971506716c96e91",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
-      "translated": "O OpenClaw transforma este telefone em uma interface móvel organizada para comandos de conversas, voz, provedores e Gateway."
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "O OpenClaw transforma este telefone em uma interface móvel simples para sessões, voz, provedores e Gateway."
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5689,9 +5624,9 @@
       "translated": "Configurações do Talk"
     },
     {
-      "id": "native.android.36f78c8c85dc283f",
-      "source": "Recent Threads",
-      "translated": "Conversas recentes"
+      "id": "native.android.73f07a5d54915259",
+      "source": "Recent Sessions",
+      "translated": "Sessões recentes"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5749,14 +5684,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online"
     },
     {
-      "id": "native.android.57177017a6a93826",
-      "source": "Threads",
-      "translated": "Conversas"
+      "id": "native.android.16c3425d3a594481",
+      "source": "Sessions",
+      "translated": "Sessões"
     },
     {
-      "id": "native.android.43320b54a68b00a1",
-      "source": "No recent threads",
-      "translated": "Nenhuma conversa recente"
+      "id": "native.android.a5c0f8b3112aa58c",
+      "source": "No recent sessions",
+      "translated": "Nenhuma sessão recente"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5794,14 +5729,14 @@
       "translated": "Em execução · $pendingRunCount execuções ativas"
     },
     {
-      "id": "native.android.e24db059480f1e6a",
-      "source": "Monitoring · 1 thread",
-      "translated": "Monitorando · 1 conversa"
+      "id": "native.android.2c89da708b12a522",
+      "source": "Monitoring · 1 session",
+      "translated": "Monitorando · 1 sessão"
     },
     {
-      "id": "native.android.5a475f37d80e02bc",
-      "source": "Monitoring · $sessionCount threads",
-      "translated": "Monitorando · $sessionCount conversas"
+      "id": "native.android.8b6ee382dcb64e1f",
+      "source": "Monitoring · $sessionCount sessions",
+      "translated": "Monitorando · $sessionCount sessões"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5834,9 +5769,9 @@
       "translated": "Provedores"
     },
     {
-      "id": "native.android.358c5e0e838d5423",
-      "source": "Open thread",
-      "translated": "Abrir conversa"
+      "id": "native.android.a65477861c7203aa",
+      "source": "Open session",
+      "translated": "Abrir sessão"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6259,9 +6194,9 @@
       "translated": "${days}d"
     },
     {
-      "id": "native.android.28a1a1acc5a0959f",
-      "source": "Main thread",
-      "translated": "Conversa principal"
+      "id": "native.android.22d755834386db07",
+      "source": "Main session",
+      "translated": "Sessão principal"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6942,16 +6877,6 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "Ativar som"
-    },
-    {
-      "id": "native.android.cb608d82c5b3352a",
-      "source": "Back camera",
-      "translated": "Câmera traseira"
-    },
-    {
-      "id": "native.android.e89a0e780eed2e1e",
-      "source": "Front camera",
-      "translated": "Câmera frontal"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7759,9 +7684,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.0c74bc30a994dd33",
-      "source": "Loading thread",
-      "translated": "Carregando conversa"
+      "id": "native.android.882cc14a58e7e105",
+      "source": "Loading session",
+      "translated": "Carregando sessão"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7804,14 +7729,14 @@
       "translated": "Atualize-me"
     },
     {
-      "id": "native.android.cf40df9739f78f27",
-      "source": "Summarize recent threads and next steps.",
-      "translated": "Resuma as conversas recentes e os próximos passos."
+      "id": "native.android.1e5add56e48c99f9",
+      "source": "Summarize recent sessions and next steps.",
+      "translated": "Resuma as sessões recentes e os próximos passos."
     },
     {
-      "id": "native.android.ebe49a8b8df80bd3",
-      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
-      "translated": "Atualize-me sobre minhas conversas recentes no OpenClaw e sugira os próximos passos."
+      "id": "native.android.06d515351bb79576",
+      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
+      "translated": "Atualize-me sobre minhas sessões recentes do OpenClaw e sugira os próximos passos."
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8149,9 +8074,9 @@
       "translated": "Conectado"
     },
     {
-      "id": "native.android.6cf5d6fa8a4186d5",
-      "source": "Threads",
-      "translated": "Conversas"
+      "id": "native.android.81931886b9caf3ab",
+      "source": "Sessions",
+      "translated": "Sessões"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,6 +10719,61 @@
       "translated": "Detalhes da tarefa"
     },
     {
+      "id": "native.apple.29cacb53ea5e77fc",
+      "source": "Pinned",
+      "translated": "Fixados"
+    },
+    {
+      "id": "native.apple.940062cfdce9211b",
+      "source": "Recent",
+      "translated": "Recentes"
+    },
+    {
+      "id": "native.apple.a0980128426308a9",
+      "source": "Model",
+      "translated": "Modelo"
+    },
+    {
+      "id": "native.apple.9520e60f21535dde",
+      "source": "Thinking",
+      "translated": "Raciocínio"
+    },
+    {
+      "id": "native.apple.8b321f3ffce97429",
+      "source": "Fast",
+      "translated": "Rápido"
+    },
+    {
+      "id": "native.apple.989b70d64e328d55",
+      "source": "Default (inherited)",
+      "translated": "Padrão (herdado)"
+    },
+    {
+      "id": "native.apple.f4114e73b07eb9ae",
+      "source": "Off",
+      "translated": "Desativado"
+    },
+    {
+      "id": "native.apple.7ed231b28d16312f",
+      "source": "On",
+      "translated": "Ativado"
+    },
+    {
+      "id": "native.apple.412a74802320a037",
+      "source": "Full",
+      "translated": "Completo"
+    },
+    {
+      "id": "native.apple.299f21a2071ff9fc",
+      "source": "Verbosity",
+      "translated": "Nível de detalhe"
+    },
+    {
+      "id": "native.apple.faf0ef05e1496de7",
+      "source": "Default",
+      "translated": "Padrão"
+    },
+    {
       "id": "native.apple.e5524d5756a62744",
       "source": "Unable to Export Transcript",
       "translated": "Não foi possível exportar a transcrição"
@@ -10814,9 +10794,9 @@
       "translated": "Em que você gostaria de trabalhar?"
     },
     {
-      "id": "native.apple.4da775013ac9b123",
-      "source": "The thread attaches once the gateway is ready.",
-      "translated": "A conversa será anexada assim que o Gateway estiver pronto."
+      "id": "native.apple.32179ce0b6d4543f",
+      "source": "The session attaches once the gateway is ready.",
+      "translated": "A sessão será anexada assim que o Gateway estiver pronto."
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10859,9 +10839,14 @@
       "translated": "Novo Chat no Worktree"
     },
     {
-      "id": "native.apple.003b25ddafeb18e9",
-      "source": "Threads…",
-      "translated": "Conversas…"
+      "id": "native.apple.ce6ebe91fc597015",
+      "source": "New Session Options…",
+      "translated": "Opções da nova sessão…"
+    },
+    {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "Sessões…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11024,14 +11009,14 @@
       "translated": "Criar"
     },
     {
-      "id": "native.apple.31d5c7287cfb3abe",
-      "source": "Delete Thread?",
-      "translated": "Excluir conversa?"
+      "id": "native.apple.f488b9caf6e51ac3",
+      "source": "Delete Session?",
+      "translated": "Excluir sessão?"
     },
     {
-      "id": "native.apple.d3395564809f1120",
-      "source": "Delete Thread",
-      "translated": "Excluir conversa"
+      "id": "native.apple.8634b17be9b111bc",
+      "source": "Delete Session",
+      "translated": "Excluir sessão"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11039,9 +11024,9 @@
       "translated": "Cancelar"
     },
     {
-      "id": "native.apple.092659256d26cb03",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "Isso exclui permanentemente a conversa e sua transcrição."
+      "id": "native.apple.4a9568ac9b18d8d3",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "Isso exclui permanentemente a sessão e sua transcrição."
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11069,9 +11054,9 @@
       "translated": "Novo grupo"
     },
     {
-      "id": "native.apple.683032464c497bbd",
-      "source": "Rename Thread",
-      "translated": "Renomear conversa"
+      "id": "native.apple.5bccdc23a1640895",
+      "source": "Rename Session",
+      "translated": "Renomear sessão"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11079,9 +11064,9 @@
       "translated": "Nome do grupo"
     },
     {
-      "id": "native.apple.f887aa956588f237",
-      "source": "Thread name",
-      "translated": "Nome da conversa"
+      "id": "native.apple.af789b2d2fda0f67",
+      "source": "Session name",
+      "translated": "Nome da sessão"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11119,14 +11104,14 @@
       "translated": "Agentes"
     },
     {
-      "id": "native.apple.7c8231b7b1ca480f",
-      "source": "Agent thread",
-      "translated": "Conversa do agente"
+      "id": "native.apple.a3bde8045fe9224a",
+      "source": "Agent session",
+      "translated": "Sessão do agente"
     },
     {
-      "id": "native.apple.b3c553614f762a58",
-      "source": "Recent threads",
-      "translated": "Conversas recentes"
+      "id": "native.apple.27f775de30b37ff8",
+      "source": "Recent sessions",
+      "translated": "Sessões recentes"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11134,9 +11119,9 @@
       "translated": "Gateway offline"
     },
     {
-      "id": "native.apple.5aa32afda85064ea",
-      "source": "No recent threads",
-      "translated": "Nenhuma conversa recente"
+      "id": "native.apple.28c97cf23665ee01",
+      "source": "No recent sessions",
+      "translated": "Nenhuma sessão recente"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11234,14 +11219,14 @@
       "translated": "Cancelar"
     },
     {
-      "id": "native.apple.b6855cf19a50f477",
-      "source": "Threads",
-      "translated": "Conversas"
+      "id": "native.apple.9f2fd65953013b7c",
+      "source": "Sessions",
+      "translated": "Sessões"
     },
     {
-      "id": "native.apple.9b1d0ef27a1333b0",
-      "source": "Archived threads",
-      "translated": "Conversas arquivadas"
+      "id": "native.apple.0422818cc95d5071",
+      "source": "Archived sessions",
+      "translated": "Sessões arquivadas"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11249,34 +11234,34 @@
       "translated": "Mostrar arquivadas"
     },
     {
-      "id": "native.apple.98167401c7267735",
-      "source": "Threads unavailable",
-      "translated": "Conversas indisponíveis"
+      "id": "native.apple.b272115c83f7ef58",
+      "source": "Sessions unavailable",
+      "translated": "Sessões indisponíveis"
     },
     {
-      "id": "native.apple.4d28a7def2337b9f",
-      "source": "Loading archived threads",
-      "translated": "Carregando conversas arquivadas"
+      "id": "native.apple.54f8260c9b863087",
+      "source": "Loading archived sessions",
+      "translated": "Carregando sessões arquivadas"
     },
     {
-      "id": "native.apple.777d7b706933bd7b",
-      "source": "Loading recent threads",
-      "translated": "Carregando conversas recentes"
+      "id": "native.apple.9b305868873dade2",
+      "source": "Loading recent sessions",
+      "translated": "Carregando sessões recentes"
     },
     {
-      "id": "native.apple.22f81ea94bef8410",
-      "source": "^[\\(count) thread](inflect: true)",
-      "translated": "^[\\(count) conversa](inflect: true)"
+      "id": "native.apple.207dad20d09f3160",
+      "source": "^[\\(count) session](inflect: true)",
+      "translated": "^[\\(count) sessão](inflect: true)"
     },
     {
-      "id": "native.apple.1cad51e14db59bf9",
-      "source": "No archived threads",
-      "translated": "Nenhuma conversa arquivada"
+      "id": "native.apple.1f4501a6bf2bae4c",
+      "source": "No archived sessions",
+      "translated": "Nenhuma sessão arquivada"
     },
     {
-      "id": "native.apple.18ef832d3a7ddcf8",
-      "source": "Archived threads will appear here.",
-      "translated": "As conversas arquivadas aparecerão aqui."
+      "id": "native.apple.2a1ba7a5e1979c9e",
+      "source": "Archived sessions will appear here.",
+      "translated": "Sessões arquivadas aparecerão aqui."
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11359,9 +11344,9 @@
       "translated": "Compartilhar entrada"
     },
     {
-      "id": "native.apple.21d9208d86a4d1fe",
-      "source": "Loading threads",
-      "translated": "Carregando conversas"
+      "id": "native.apple.2360d25fe6ae9946",
+      "source": "Loading sessions",
+      "translated": "Carregando sessões"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11369,19 +11354,19 @@
       "translated": "Buscando atividade recente no gateway."
     },
     {
-      "id": "native.apple.4be1f79aa2b230ff",
-      "source": "Threads unavailable",
-      "translated": "Conversas indisponíveis"
+      "id": "native.apple.c334f2e86702a7b8",
+      "source": "Sessions unavailable",
+      "translated": "Sessões indisponíveis"
     },
     {
-      "id": "native.apple.98b348873556bc46",
-      "source": "No recent threads",
-      "translated": "Nenhuma conversa recente"
+      "id": "native.apple.6cc6efb7a03960b6",
+      "source": "No recent sessions",
+      "translated": "Nenhuma sessão recente"
     },
     {
-      "id": "native.apple.7396d205574d279f",
-      "source": "Thread activity offline",
-      "translated": "Atividade das conversas offline"
+      "id": "native.apple.08483af2d043bee6",
+      "source": "Session activity offline",
+      "translated": "Atividade da sessão offline"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11839,9 +11824,9 @@
       "translated": "Cartão"
     },
     {
-      "id": "native.apple.c9ec1b0e18074d8a",
-      "source": "Open Thread",
-      "translated": "Abrir conversa"
+      "id": "native.apple.93eeaedb2ff61043",
+      "source": "Open Session",
+      "translated": "Abrir sessão"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13329,9 +13314,9 @@
       "translated": "Padrão"
     },
     {
-      "id": "native.apple.f4ae5664c3eda95d",
-      "source": "Used for new Chat threads and Talk sessions.",
-      "translated": "Usado para novas conversas no Chat e sessões do Talk."
+      "id": "native.apple.3de045f17ea3c6d0",
+      "source": "Used for new Chat and Talk sessions.",
+      "translated": "Usado para novas sessões de Chat e Talk."
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15734,9 +15719,9 @@
       "translated": "Instâncias"
     },
     {
-      "id": "native.apple.11fe8b9941954dfb",
-      "source": "Threads",
-      "translated": "Conversas"
+      "id": "native.apple.3579cf2750470a22",
+      "source": "Sessions",
+      "translated": "Sessões"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19044,9 +19029,9 @@
       "translated": "Atalho do Chat Rápido"
     },
     {
-      "id": "native.apple.94dd793cd7d7d555",
-      "source": "Global shortcut that opens a floating chat bar for the main thread.",
-      "translated": "Atalho global que abre uma barra de chat flutuante para a conversa principal."
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "Atalho global que abre uma barra de chat flutuante para a sessão principal."
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19624,9 +19609,9 @@
       "translated": "Crítico"
     },
     {
-      "id": "native.apple.13f96467014cf344",
-      "source": "New Thread",
-      "translated": "Nova conversa"
+      "id": "native.apple.75102378a6775180",
+      "source": "New Session",
+      "translated": "Nova sessão"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21914,9 +21899,9 @@
       "translated": "Nenhuma mensagem recente"
     },
     {
-      "id": "native.apple.3ec2afcbc298c673",
-      "source": "Threads",
-      "translated": "Conversas"
+      "id": "native.apple.1ff8aec0044934c3",
+      "source": "Sessions",
+      "translated": "Sessões"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21924,9 +21909,9 @@
       "translated": "Veja os buckets de conversas armazenados que a CLI reutiliza para contexto e limites de taxa."
     },
     {
-      "id": "native.apple.14ccb32cd8ed1c81",
-      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
-      "translated": "Ainda não há conversas. Elas aparecem após a primeira mensagem recebida ou sinal de atividade."
+      "id": "native.apple.bab897f3252b134c",
+      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
+      "translated": "Ainda não há sessões. Elas aparecem após a primeira mensagem recebida ou heartbeat."
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -22009,9 +21994,9 @@
       "translated": "Aprovações de execução"
     },
     {
-      "id": "native.apple.52e37e3a44ae516c",
-      "source": "Threads",
-      "translated": "Conversas"
+      "id": "native.apple.64a6dc7d49e8fb57",
+      "source": "Sessions",
+      "translated": "Sessões"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -23014,9 +22999,9 @@
       "translated": "Coloque-me a par"
     },
     {
-      "id": "native.apple.fc4ce810900ec0b6",
-      "source": "Summarize what happened in my threads since yesterday.",
-      "translated": "Resuma o que aconteceu nas minhas conversas desde ontem."
+      "id": "native.apple.234ec45f4231edc4",
+      "source": "Summarize what happened in my sessions since yesterday.",
+      "translated": "Resuma o que aconteceu nas minhas sessões desde ontem."
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23194,9 +23179,9 @@
       "translated": "Desafixar modelo"
     },
     {
-      "id": "native.apple.4edb66657f5aca1f",
-      "source": "Thread",
-      "translated": "Conversa"
+      "id": "native.apple.5dfc0700d8dff8de",
+      "source": "Session",
+      "translated": "Sessão"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23359,51 +23344,6 @@
       "translated": "Widget indisponível"
     },
     {
-      "id": "native.apple.d640691fd196f338",
-      "source": "Widget export failed",
-      "translated": "Falha ao exportar o widget"
-    },
-    {
-      "id": "native.apple.533c6e22a11e88de",
-      "source": "OK",
-      "translated": "OK"
-    },
-    {
-      "id": "native.apple.e1fb28a2a9756402",
-      "source": "Copy image",
-      "translated": "Copiar imagem"
-    },
-    {
-      "id": "native.apple.ebd7bc92e1b12235",
-      "source": "Save image…",
-      "translated": "Salvar imagem…"
-    },
-    {
-      "id": "native.apple.742c46d4cf2db134",
-      "source": "Save image",
-      "translated": "Salvar imagem"
-    },
-    {
-      "id": "native.apple.0589cce608418f90",
-      "source": "The widget image could not be captured.",
-      "translated": "Não foi possível capturar a imagem do widget."
-    },
-    {
-      "id": "native.apple.dfe24e827fdbe9c5",
-      "source": "The widget image could not be copied.",
-      "translated": "Não foi possível copiar a imagem do widget."
-    },
-    {
-      "id": "native.apple.9e611e3a80e71408",
-      "source": "The widget image could not be encoded as PNG.",
-      "translated": "Não foi possível codificar a imagem do widget como PNG."
-    },
-    {
-      "id": "native.apple.9a6e8afbe24a262b",
-      "source": "The widget image could not be saved.",
-      "translated": "Não foi possível salvar a imagem do widget."
-    },
-    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23544,19 +23484,19 @@
       "translated": "Usuário"
     },
     {
-      "id": "native.apple.9d0cba09d92ee669",
-      "source": "This thread cannot be archived while it is active or running.",
-      "translated": "Esta conversa não pode ser arquivada enquanto estiver ativa ou em execução."
+      "id": "native.apple.b1cdcb906a43d5d6",
+      "source": "This session cannot be archived while it is active or running.",
+      "translated": "Esta sessão não pode ser arquivada enquanto estiver ativa ou em execução."
     },
     {
-      "id": "native.apple.8952a111a1075051",
-      "source": "The main thread cannot be deleted.",
-      "translated": "A conversa principal não pode ser excluída."
+      "id": "native.apple.5817e3f3dab1ee19",
+      "source": "The main session cannot be deleted.",
+      "translated": "A sessão principal não pode ser excluída."
     },
     {
-      "id": "native.apple.90d0ccf80ca28717",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
-      "translated": "Remova os anexos ou aguarde a entrega antes de arquivar ou excluir esta conversa."
+      "id": "native.apple.a6b8df3f18171c91",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
+      "translated": "Remova os anexos ou aguarde a entrega antes de arquivar ou excluir esta sessão."
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23694,9 +23634,9 @@
       "translated": "Execução encerrada"
     },
     {
-      "id": "native.apple.bbccb4c8db5cac12",
-      "source": "Thread Info",
-      "translated": "Informações da conversa"
+      "id": "native.apple.cd7c3095a22f80a9",
+      "source": "Session Info",
+      "translated": "Informações da sessão"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23729,9 +23669,9 @@
       "translated": "Adicionar grupo"
     },
     {
-      "id": "native.apple.7b641fed5bace855",
-      "source": "Thread Groups",
-      "translated": "Grupos de conversas"
+      "id": "native.apple.23d628606fe0734f",
+      "source": "Session Groups",
+      "translated": "Grupos da sessão"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23774,9 +23714,9 @@
       "translated": "Excluir grupo"
     },
     {
-      "id": "native.apple.56401c79410a310d",
-      "source": "Threads in this group become ungrouped.",
-      "translated": "As conversas deste grupo deixarão de fazer parte de um grupo."
+      "id": "native.apple.b049c8a4d2805e08",
+      "source": "Sessions in this group become ungrouped.",
+      "translated": "As sessões deste grupo ficarão sem grupo."
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23789,9 +23729,9 @@
       "translated": "Nenhum agente está disponível neste gateway."
     },
     {
-      "id": "native.apple.2d96aa7d3d12f85b",
-      "source": "New Thread Options",
-      "translated": "Opções da nova conversa"
+      "id": "native.apple.6c89f35d53506406",
+      "source": "New Session Options",
+      "translated": "Opções da nova sessão"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23819,19 +23759,19 @@
       "translated": "Criar"
     },
     {
-      "id": "native.apple.87ef57319d1ddc85",
-      "source": "The thread could not be created.",
-      "translated": "Não foi possível criar a conversa."
+      "id": "native.apple.795ba37f6782cf28",
+      "source": "The session could not be created.",
+      "translated": "Não foi possível criar a sessão."
     },
     {
-      "id": "native.apple.6bd91c435b69d638",
-      "source": "Search threads",
-      "translated": "Pesquisar conversas"
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "Buscar sessões"
     },
     {
-      "id": "native.apple.6fde4bdf9d5b9191",
-      "source": "No Threads",
-      "translated": "Nenhuma conversa"
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "Nenhuma sessão"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23839,29 +23779,29 @@
       "translated": "Nenhum resultado"
     },
     {
-      "id": "native.apple.a02fd99740d29bd3",
-      "source": "New Thread",
-      "translated": "Nova conversa"
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "Nova sessão"
     },
     {
-      "id": "native.apple.b625801dd04b09f2",
-      "source": "New thread",
-      "translated": "Nova conversa"
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "Nova sessão"
     },
     {
-      "id": "native.apple.851be81fcc933608",
-      "source": "New thread options",
-      "translated": "Opções da nova conversa"
+      "id": "native.apple.2ef0e34db02ad255",
+      "source": "New session options",
+      "translated": "Opções da nova sessão"
     },
     {
-      "id": "native.apple.9ce8a4aba7b444b2",
-      "source": "Rename Thread",
-      "translated": "Renomear conversa"
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "Renomear sessão"
     },
     {
-      "id": "native.apple.1dd067c44511c7f0",
-      "source": "Thread name",
-      "translated": "Nome da conversa"
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "Nome da sessão"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23874,14 +23814,14 @@
       "translated": "Cancelar"
     },
     {
-      "id": "native.apple.618073d6ab3f2721",
-      "source": "Delete Thread",
-      "translated": "Excluir conversa"
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "Excluir sessão"
     },
     {
-      "id": "native.apple.10a5e72bba3cbccc",
-      "source": "The thread and its transcript are removed from the gateway.",
-      "translated": "A conversa e sua transcrição serão removidas do Gateway."
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "A sessão e sua transcrição são removidas do Gateway."
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23889,14 +23829,14 @@
       "translated": "Excluir “%@”?"
     },
     {
-      "id": "native.apple.ac71e3b2aa496a2c",
-      "source": "Thread running",
-      "translated": "Conversa em andamento"
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "Sessão em execução"
     },
     {
-      "id": "native.apple.c775e87f997278b2",
-      "source": "Thread failed",
-      "translated": "Falha na conversa"
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "Falha na sessão"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23954,9 +23894,9 @@
       "translated": "Copiar chave da sessão"
     },
     {
-      "id": "native.apple.f4998cfb572f23ff",
-      "source": "Delete Thread…",
-      "translated": "Excluir conversa…"
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "Excluir sessão…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23969,9 +23909,9 @@
       "translated": "Conectando…"
     },
     {
-      "id": "native.apple.8802e9576ffd0f65",
-      "source": "Retry thread groups",
-      "translated": "Tentar novamente os grupos de conversas"
+      "id": "native.apple.79f708b3bc1d3a6c",
+      "source": "Retry session groups",
+      "translated": "Tentar carregar os grupos de sessões novamente"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23994,24 +23934,24 @@
       "translated": "Escopo"
     },
     {
-      "id": "native.apple.b313b80def4bda52",
-      "source": "Search threads",
-      "translated": "Buscar conversas"
+      "id": "native.apple.2c37581c7b88f741",
+      "source": "Search sessions",
+      "translated": "Buscar sessões"
     },
     {
-      "id": "native.apple.c0cc6acc36f413ce",
-      "source": "Threads",
-      "translated": "Conversas"
+      "id": "native.apple.43be8a2336e42faf",
+      "source": "Sessions",
+      "translated": "Sessões"
     },
     {
-      "id": "native.apple.854d3928fe5a557c",
-      "source": "Rename Thread",
-      "translated": "Renomear conversa"
+      "id": "native.apple.0b379cdfcbd3247f",
+      "source": "Rename Session",
+      "translated": "Renomear sessão"
     },
     {
-      "id": "native.apple.9d0d3f20096cc4da",
-      "source": "Thread name",
-      "translated": "Nome da conversa"
+      "id": "native.apple.54b6fbd9e41db009",
+      "source": "Session name",
+      "translated": "Nome da sessão"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -24019,19 +23959,19 @@
       "translated": "Cancelar"
     },
     {
-      "id": "native.apple.dc00eb94f33bae15",
-      "source": "Delete selected threads?",
-      "translated": "Excluir as conversas selecionadas?"
+      "id": "native.apple.751e0f6b81cd374a",
+      "source": "Delete selected sessions?",
+      "translated": "Excluir as sessões selecionadas?"
     },
     {
-      "id": "native.apple.2053fc9f74dc3158",
-      "source": "Delete Threads",
-      "translated": "Excluir conversas"
+      "id": "native.apple.aa679276581b0058",
+      "source": "Delete Sessions",
+      "translated": "Excluir sessões"
     },
     {
-      "id": "native.apple.0970247871a834a0",
-      "source": "Each selected thread and its transcript will be removed from the gateway.",
-      "translated": "Cada conversa selecionada e sua transcrição serão removidas do Gateway."
+      "id": "native.apple.f837129cbee23297",
+      "source": "Each selected session and its transcript will be removed from the gateway.",
+      "translated": "Cada sessão selecionada e sua transcrição serão removidas do gateway."
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -24039,9 +23979,9 @@
       "translated": "Grupos"
     },
     {
-      "id": "native.apple.6f8acab2256728b5",
-      "source": "Manage thread groups",
-      "translated": "Gerenciar grupos de conversas"
+      "id": "native.apple.64013cfee5e25305",
+      "source": "Manage session groups",
+      "translated": "Gerenciar grupos de sessões"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -24054,14 +23994,14 @@
       "translated": "Selecionar"
     },
     {
-      "id": "native.apple.692972314d04b184",
-      "source": "No archived threads",
-      "translated": "Nenhuma conversa arquivada"
+      "id": "native.apple.b67eaecec1b423ac",
+      "source": "No archived sessions",
+      "translated": "Nenhuma sessão arquivada"
     },
     {
-      "id": "native.apple.d6a4b5711dcd26e7",
-      "source": "No threads found",
-      "translated": "Nenhuma conversa encontrada"
+      "id": "native.apple.b2435a79abf0c794",
+      "source": "No sessions found",
+      "translated": "Nenhuma sessão encontrada"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24229,16 +24169,6 @@
       "translated": "Abrir mensagem completa"
     },
     {
-      "id": "native.apple.002bfcede229ad4b",
-      "source": "Rewind to Here",
-      "translated": "Rebobinar até aqui"
-    },
-    {
-      "id": "native.apple.14df2e4997689fb3",
-      "source": "Fork from Here",
-      "translated": "Criar bifurcação a partir daqui"
-    },
-    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "Responder"
@@ -24324,9 +24254,9 @@
       "translated": "Remova os anexos ou aguarde a conclusão da entrega antes de iniciar uma nova conversa."
     },
     {
-      "id": "native.apple.e0f045151c8d3137",
-      "source": "Gateway changed before the thread operation started.",
-      "translated": "O Gateway foi alterado antes do início da operação na conversa."
+      "id": "native.apple.980f552bb0f96c0f",
+      "source": "Gateway changed before the session operation started.",
+      "translated": "O Gateway foi alterado antes do início da operação da sessão."
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24334,9 +24264,9 @@
       "translated": "Remova os anexos ou aguarde a entrega ser concluída antes de trocar de conversa."
     },
     {
-      "id": "native.apple.0a5c4e15466c3acc",
-      "source": "Clear this thread's history?",
-      "translated": "Limpar o histórico desta conversa?"
+      "id": "native.apple.87ba543b42696b92",
+      "source": "Clear this session's history?",
+      "translated": "Limpar o histórico desta sessão?"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24349,14 +24279,14 @@
       "translated": "Isso redefine a conversa para %@. A chave da sessão permanece a mesma."
     },
     {
-      "id": "native.apple.67ac221dbe7179f0",
-      "source": "Rename Thread",
-      "translated": "Renomear conversa"
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "Renomear sessão"
     },
     {
-      "id": "native.apple.cf0f7e049603f518",
-      "source": "Thread name",
-      "translated": "Nome da conversa"
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "Nome da sessão"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24374,9 +24304,9 @@
       "translated": "Exportar transcrição"
     },
     {
-      "id": "native.apple.c0ada47504425f23",
-      "source": "Threads",
-      "translated": "Conversas"
+      "id": "native.apple.4af0f566d39d7041",
+      "source": "Sessions",
+      "translated": "Sessões"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24449,14 +24379,14 @@
       "translated": "Padrão"
     },
     {
-      "id": "native.apple.1a765291943599e5",
-      "source": "New Thread",
-      "translated": "Nova conversa"
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "Nova sessão"
     },
     {
-      "id": "native.apple.c7a3a6d5e43dd98f",
-      "source": "New Thread Options…",
-      "translated": "Opções da nova conversa…"
+      "id": "native.apple.a7119fbf9d25df5e",
+      "source": "New Session Options…",
+      "translated": "Opções de Nova Sessão…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24464,19 +24394,19 @@
       "translated": "Atualizar"
     },
     {
-      "id": "native.apple.0e710b81808e5dcf",
-      "source": "Threads…",
-      "translated": "Conversas…"
+      "id": "native.apple.2bcff4a8fa503739",
+      "source": "Sessions…",
+      "translated": "Sessões…"
     },
     {
-      "id": "native.apple.faad8f92b6bef166",
-      "source": "Rename Thread…",
-      "translated": "Renomear conversa…"
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "Renomear sessão…"
     },
     {
-      "id": "native.apple.23b61d6cd26ac112",
-      "source": "Fork",
-      "translated": "Bifurcar"
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "Bifurcar sessão"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24534,24 +24464,24 @@
       "translated": "Limpar histórico…"
     },
     {
-      "id": "native.apple.8b4f1c5107ea8a0e",
-      "source": "Thread",
-      "translated": "Conversa"
+      "id": "native.apple.920fe8a7a33f9e92",
+      "source": "Session",
+      "translated": "Sessão"
     },
     {
-      "id": "native.apple.4d7750c9bf699469",
-      "source": "Thread actions",
-      "translated": "Ações da conversa"
+      "id": "native.apple.185a401f78328b0f",
+      "source": "Session actions",
+      "translated": "Ações da sessão"
     },
     {
-      "id": "native.apple.bb2f22cc43c97f8e",
-      "source": "Thread cost %@",
-      "translated": "Custo da conversa %@"
+      "id": "native.apple.9f9dedf599b2619b",
+      "source": "Session cost %@",
+      "translated": "Custo da sessão: %@"
     },
     {
-      "id": "native.apple.6239ced0b86e86f8",
-      "source": "Compact Thread",
-      "translated": "Compactar conversa"
+      "id": "native.apple.f0a4720df5f5f403",
+      "source": "Compact Session",
+      "translated": "Compactar sessão"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/ru.json
+++ b/apps/.i18n/native/ru.json
@@ -1429,9 +1429,9 @@
       "translated": "Говорите или диктуйте с помощью OpenClaw"
     },
     {
-      "id": "native.android.5876e15e5e92fd45",
-      "source": "Browse Sessions",
-      "translated": "Просмотреть сеансы"
+      "id": "native.android.e2cf5a38587382cb",
+      "source": "Browse Threads",
+      "translated": "Просмотреть ветки"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "Действия не найдены"
     },
     {
-      "id": "native.android.48ad0ae0e930e02b",
-      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
-      "translated": "Попробуйте Chat, Voice, Sessions, Providers или Settings."
+      "id": "native.android.bc70a4ac965b82ba",
+      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
+      "translated": "Попробуйте Чат, Голос, Ветки, Провайдеры или Настройки."
     },
     {
-      "id": "native.android.d4fbd1ee4f55a5db",
-      "source": "Sessions",
-      "translated": "Сеансы"
+      "id": "native.android.670121e54dbe286f",
+      "source": "Threads",
+      "translated": "Ветки"
     },
     {
-      "id": "native.android.207c2170504e99e6",
-      "source": "Connect the Gateway to search sessions.",
-      "translated": "Подключите Gateway, чтобы искать сеансы."
+      "id": "native.android.d38be650b1bce4a0",
+      "source": "Connect the Gateway to search threads.",
+      "translated": "Подключите Gateway для поиска веток."
     },
     {
-      "id": "native.android.25d2c2d792c952fe",
-      "source": "No matching sessions yet.",
-      "translated": "Подходящих сеансов пока нет."
+      "id": "native.android.3d7754721f776ef8",
+      "source": "No matching threads yet.",
+      "translated": "Подходящих веток пока нет."
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "Ассистент работает"
     },
     {
-      "id": "native.android.8f8384286317f5c9",
-      "source": "OpenClaw session",
-      "translated": "Сеанс OpenClaw"
+      "id": "native.android.9a839f6e3e05a744",
+      "source": "OpenClaw thread",
+      "translated": "Ветка OpenClaw"
     },
     {
-      "id": "native.android.15799e57704b20c6",
-      "source": "Open session",
-      "translated": "Открыть сеанс"
+      "id": "native.android.d83f82a1e4a5ed99",
+      "source": "Open thread",
+      "translated": "Открыть ветку"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "Нет готовых провайдеров"
     },
     {
-      "id": "native.android.73e6ab1a168fd381",
-      "source": "Main session",
-      "translated": "Основная сессия"
+      "id": "native.android.8a1c5365c0538908",
+      "source": "Main thread",
+      "translated": "Основная ветка"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.0e3157c15c56944f",
-      "source": "Sessions",
-      "translated": "Сессии"
+      "id": "native.android.a5845742daecb4ba",
+      "source": "Threads",
+      "translated": "Ветки"
     },
     {
-      "id": "native.android.70f5d0507d34b5c8",
-      "source": "Focus session search",
-      "translated": "Перейти к поиску сеансов"
+      "id": "native.android.439b324280869527",
+      "source": "Focus thread search",
+      "translated": "Перейти к поиску веток"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "В архиве"
     },
     {
-      "id": "native.android.b9cf34c137e4cf03",
-      "source": "Search sessions",
-      "translated": "Поиск сессий"
+      "id": "native.android.03981341841b04ac",
+      "source": "Search threads",
+      "translated": "Поиск веток"
     },
     {
-      "id": "native.android.10cb26723e9990fc",
-      "source": "Clear session search",
-      "translated": "Очистить поиск сеансов"
+      "id": "native.android.99570c528a41fa72",
+      "source": "Clear thread search",
+      "translated": "Очистить поиск веток"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "Сначала старые"
     },
     {
-      "id": "native.android.c6bf8751e2a7f5c7",
-      "source": "Toggle session layout",
-      "translated": "Переключить макет сессий"
+      "id": "native.android.fd67be543e321cc9",
+      "source": "Toggle thread layout",
+      "translated": "Переключить вид веток"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "Макет: подробный"
     },
     {
-      "id": "native.android.69b79a3c2c987cd4",
-      "source": "Searching sessions",
-      "translated": "Поиск сеансов"
+      "id": "native.android.ebd17565e0ffd8eb",
+      "source": "Searching threads",
+      "translated": "Поиск веток"
     },
     {
-      "id": "native.android.dd587d341af44212",
-      "source": "No matching sessions",
-      "translated": "Подходящие сеансы не найдены"
+      "id": "native.android.472d46ae8669f860",
+      "source": "No matching threads",
+      "translated": "Подходящих веток нет"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "Начать чат"
     },
     {
-      "id": "native.android.f10d4df7cbc6df4f",
-      "source": "Current session",
-      "translated": "Текущая сессия"
+      "id": "native.android.ff81ad1bee00d384",
+      "source": "Current thread",
+      "translated": "Текущая ветка"
     },
     {
-      "id": "native.android.8f0482425838ae64",
-      "source": "OpenClaw session",
-      "translated": "Сессия OpenClaw"
+      "id": "native.android.fc145645b9620e57",
+      "source": "OpenClaw thread",
+      "translated": "Ветка OpenClaw"
     },
     {
-      "id": "native.android.786774c8a76e50d7",
-      "source": "Rename session",
-      "translated": "Переименовать сеанс"
+      "id": "native.android.71cbb8dde8bf138b",
+      "source": "Rename thread",
+      "translated": "Переименовать ветку"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "Удалить группу?"
     },
     {
-      "id": "native.android.3455fc2f77d564e3",
-      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "Сессии в «$group» сохраняются и перемещаются обратно в «Без группы»."
+      "id": "native.android.691e92cfe5cf106e",
+      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "Ветки в группе \"$group\" сохранятся и вернутся в раздел «Без группы»."
     },
     {
-      "id": "native.android.4805fb9d6623e8c0",
-      "source": "Delete session?",
-      "translated": "Удалить сессию?"
+      "id": "native.android.d87a8217ab56999b",
+      "source": "Delete thread?",
+      "translated": "Удалить ветку?"
     },
     {
-      "id": "native.android.0c3283a2b2445eae",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "Это навсегда удалит сессию и ее расшифровку."
+      "id": "native.android.930de97ff47113a8",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "Это навсегда удалит ветку и её историю."
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "Без группы"
     },
     {
-      "id": "native.android.db243d71d056afa4",
-      "source": "No sessions yet",
-      "translated": "Сессий пока нет"
+      "id": "native.android.8e21a70428def6e0",
+      "source": "No threads yet",
+      "translated": "Веток пока нет"
     },
     {
-      "id": "native.android.5b4eee6a8092925e",
-      "source": "No current session",
-      "translated": "Нет текущей сессии"
+      "id": "native.android.cda4c5ad8b17e394",
+      "source": "No current thread",
+      "translated": "Нет текущей ветки"
     },
     {
-      "id": "native.android.acbcc9c9ea53d8c0",
-      "source": "No archived sessions",
-      "translated": "Нет архивных сессий"
+      "id": "native.android.be84f061047aa2da",
+      "source": "No archived threads",
+      "translated": "Нет архивных веток"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "Начните новый разговор, и он появится здесь."
     },
     {
-      "id": "native.android.56fcd605dc7be3c0",
-      "source": "Open Chat to start or resume the current session.",
-      "translated": "Откройте чат, чтобы начать или возобновить текущую сессию."
+      "id": "native.android.f289d03e1d3eee98",
+      "source": "Open Chat to start or resume the current thread.",
+      "translated": "Откройте чат, чтобы начать или продолжить текущую ветку."
     },
     {
-      "id": "native.android.085515989f8a2022",
-      "source": "Archived sessions will show up here.",
-      "translated": "Архивные сессии появятся здесь."
+      "id": "native.android.504b71386e76c6ae",
+      "source": "Archived threads will show up here.",
+      "translated": "Здесь появятся архивные ветки."
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days} дн."
     },
     {
-      "id": "native.android.3d4fa07acbc015c5",
-      "source": "Main session",
-      "translated": "Основная сессия"
+      "id": "native.android.ee4c727cdafbe963",
+      "source": "Main thread",
+      "translated": "Основная ветка"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Ожидание Gateway"
     },
     {
-      "id": "native.android.2d8d049afe99f751",
-      "source": "Session Activity",
-      "translated": "Активность сессии"
+      "id": "native.android.da78209effb11cfd",
+      "source": "Thread Activity",
+      "translated": "Активность ветки"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "Запросы на подтверждение выполнения будут отображаться здесь, пока этот телефон подключен."
     },
     {
-      "id": "native.android.dc3e7ca5a491103a",
-      "source": "Session activity",
-      "translated": "Активность сеанса"
+      "id": "native.android.f615712dfb56319a",
+      "source": "Thread activity",
+      "translated": "Активность ветки"
     },
     {
-      "id": "native.android.8551e02b060bd7d8",
-      "source": "Chat tool calls waiting in the active session remain visible here.",
-      "translated": "Вызовы инструментов чата, ожидающие в активном сеансе, остаются видимыми здесь."
+      "id": "native.android.6c93973c13db43ae",
+      "source": "Chat tool calls waiting in the active thread remain visible here.",
+      "translated": "Здесь отображаются ожидающие вызовы инструментов чата в активной ветке."
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,6 +4294,11 @@
       "translated": "Настройка провайдера разговоров"
     },
     {
+      "id": "native.android.23b638094c34b916",
+      "source": "Microphone",
+      "translated": "Микрофон"
+    },
+    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "Тест аудио"
@@ -4337,6 +4342,66 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "Готово"
+    },
+    {
+      "id": "native.android.8d9ecdfdd916b780",
+      "source": "Automatic",
+      "translated": "Автоматически"
+    },
+    {
+      "id": "native.android.c1626a6700a570f6",
+      "source": "Preferred microphone unavailable; using automatic routing.",
+      "translated": "Предпочитаемый микрофон недоступен; используется автоматическая маршрутизация."
+    },
+    {
+      "id": "native.android.820bc5d0ce571d8b",
+      "source": "Prioritizes connected Bluetooth microphones.",
+      "translated": "Приоритет отдаётся подключённым Bluetooth-микрофонам."
+    },
+    {
+      "id": "native.android.11e48038d5e8bff6",
+      "source": "Preferred microphone",
+      "translated": "Предпочитаемый микрофон"
+    },
+    {
+      "id": "native.android.eaa4d7563a46d307",
+      "source": "Unavailable",
+      "translated": "Недоступен"
+    },
+    {
+      "id": "native.android.9f5ebf17eb405ba8",
+      "source": "Next session",
+      "translated": "Следующий сеанс"
+    },
+    {
+      "id": "native.android.8c4e91f53928efb2",
+      "source": "Built-in microphone",
+      "translated": "Встроенный микрофон"
+    },
+    {
+      "id": "native.android.14b613cb6e2446b4",
+      "source": "Bluetooth microphone",
+      "translated": "Bluetooth-микрофон"
+    },
+    {
+      "id": "native.android.c885247b2d7ce271",
+      "source": "Bluetooth LE microphone",
+      "translated": "Bluetooth LE-микрофон"
+    },
+    {
+      "id": "native.android.b6a4e674c5fb441a",
+      "source": "Wired headset microphone",
+      "translated": "Микрофон проводной гарнитуры"
+    },
+    {
+      "id": "native.android.9c8becb3b0fb5a90",
+      "source": "USB microphone",
+      "translated": "USB-микрофон"
+    },
+    {
+      "id": "native.android.ba46258fadec7a39",
+      "source": "External microphone",
+      "translated": "Внешний микрофон"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5074,9 +5139,9 @@
       "translated": "Проверить"
     },
     {
-      "id": "native.android.5a540761383fa474",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
-      "translated": "OpenClaw превращает этот телефон в удобный мобильный интерфейс управления сеансами, голосовыми функциями, провайдерами и Gateway."
+      "id": "native.android.c971506716c96e91",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
+      "translated": "OpenClaw превращает этот телефон в удобный мобильный интерфейс для управления ветками, голосом, провайдерами и Gateway."
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5624,9 +5689,9 @@
       "translated": "Настройки Разговора"
     },
     {
-      "id": "native.android.73f07a5d54915259",
-      "source": "Recent Sessions",
-      "translated": "Недавние сеансы"
+      "id": "native.android.36f78c8c85dc283f",
+      "source": "Recent Threads",
+      "translated": "Недавние ветки"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5684,14 +5749,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% в сети"
     },
     {
-      "id": "native.android.16c3425d3a594481",
-      "source": "Sessions",
-      "translated": "Сеансы"
+      "id": "native.android.57177017a6a93826",
+      "source": "Threads",
+      "translated": "Ветки"
     },
     {
-      "id": "native.android.a5c0f8b3112aa58c",
-      "source": "No recent sessions",
-      "translated": "Нет недавних сеансов"
+      "id": "native.android.43320b54a68b00a1",
+      "source": "No recent threads",
+      "translated": "Нет недавних веток"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5729,14 +5794,14 @@
       "translated": "Выполняется · $pendingRunCount активных запусков"
     },
     {
-      "id": "native.android.2c89da708b12a522",
-      "source": "Monitoring · 1 session",
-      "translated": "Мониторинг · 1 сеанс"
+      "id": "native.android.e24db059480f1e6a",
+      "source": "Monitoring · 1 thread",
+      "translated": "Мониторинг · 1 ветка"
     },
     {
-      "id": "native.android.8b6ee382dcb64e1f",
-      "source": "Monitoring · $sessionCount sessions",
-      "translated": "Мониторинг · $sessionCount сеансов"
+      "id": "native.android.5a475f37d80e02bc",
+      "source": "Monitoring · $sessionCount threads",
+      "translated": "Мониторинг · $sessionCount веток"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5769,9 +5834,9 @@
       "translated": "Провайдеры"
     },
     {
-      "id": "native.android.a65477861c7203aa",
-      "source": "Open session",
-      "translated": "Открыть сеанс"
+      "id": "native.android.358c5e0e838d5423",
+      "source": "Open thread",
+      "translated": "Открыть ветку"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6194,9 +6259,9 @@
       "translated": "${days} дн."
     },
     {
-      "id": "native.android.22d755834386db07",
-      "source": "Main session",
-      "translated": "Основной сеанс"
+      "id": "native.android.28a1a1acc5a0959f",
+      "source": "Main thread",
+      "translated": "Основная ветка"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6877,6 +6942,16 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "Включить микрофон"
+    },
+    {
+      "id": "native.android.cb608d82c5b3352a",
+      "source": "Back camera",
+      "translated": "Задняя камера"
+    },
+    {
+      "id": "native.android.e89a0e780eed2e1e",
+      "source": "Front camera",
+      "translated": "Фронтальная камера"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7684,9 +7759,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.882cc14a58e7e105",
-      "source": "Loading session",
-      "translated": "Загрузка сеанса"
+      "id": "native.android.0c74bc30a994dd33",
+      "source": "Loading thread",
+      "translated": "Загрузка ветки"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7729,14 +7804,14 @@
       "translated": "Введите меня в курс дела"
     },
     {
-      "id": "native.android.1e5add56e48c99f9",
-      "source": "Summarize recent sessions and next steps.",
-      "translated": "Подведите итоги недавних сеансов и предложите следующие шаги."
+      "id": "native.android.cf40df9739f78f27",
+      "source": "Summarize recent threads and next steps.",
+      "translated": "Подведите итоги недавних веток и предложите дальнейшие шаги."
     },
     {
-      "id": "native.android.06d515351bb79576",
-      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
-      "translated": "Введите меня в курс моих недавних сеансов OpenClaw и предложите следующие шаги."
+      "id": "native.android.ebe49a8b8df80bd3",
+      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
+      "translated": "Расскажите о последних событиях в моих недавних ветках OpenClaw и предложите дальнейшие шаги."
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8074,9 +8149,9 @@
       "translated": "Подключено"
     },
     {
-      "id": "native.android.81931886b9caf3ab",
-      "source": "Sessions",
-      "translated": "Сессии"
+      "id": "native.android.6cf5d6fa8a4186d5",
+      "source": "Threads",
+      "translated": "Ветки"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,9 +10869,9 @@
       "translated": "Над чем вы хотите поработать?"
     },
     {
-      "id": "native.apple.32179ce0b6d4543f",
-      "source": "The session attaches once the gateway is ready.",
-      "translated": "Сеанс подключится, когда Gateway будет готов."
+      "id": "native.apple.4da775013ac9b123",
+      "source": "The thread attaches once the gateway is ready.",
+      "translated": "Ветка подключится, когда Gateway будет готов."
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10844,9 +10919,9 @@
       "translated": "Параметры нового сеанса…"
     },
     {
-      "id": "native.apple.a1b0d289758e2213",
-      "source": "Sessions…",
-      "translated": "Сеансы…"
+      "id": "native.apple.003b25ddafeb18e9",
+      "source": "Threads…",
+      "translated": "Ветки…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11009,14 +11084,14 @@
       "translated": "Создать"
     },
     {
-      "id": "native.apple.f488b9caf6e51ac3",
-      "source": "Delete Session?",
-      "translated": "Удалить сеанс?"
+      "id": "native.apple.31d5c7287cfb3abe",
+      "source": "Delete Thread?",
+      "translated": "Удалить ветку?"
     },
     {
-      "id": "native.apple.8634b17be9b111bc",
-      "source": "Delete Session",
-      "translated": "Удалить сеанс"
+      "id": "native.apple.d3395564809f1120",
+      "source": "Delete Thread",
+      "translated": "Удалить ветку"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11024,9 +11099,9 @@
       "translated": "Отмена"
     },
     {
-      "id": "native.apple.4a9568ac9b18d8d3",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "Это безвозвратно удалит сеанс и его стенограмму."
+      "id": "native.apple.092659256d26cb03",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "Это действие безвозвратно удалит ветку и её расшифровку."
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11054,9 +11129,9 @@
       "translated": "Новая группа"
     },
     {
-      "id": "native.apple.5bccdc23a1640895",
-      "source": "Rename Session",
-      "translated": "Переименовать сеанс"
+      "id": "native.apple.683032464c497bbd",
+      "source": "Rename Thread",
+      "translated": "Переименовать ветку"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11064,9 +11139,9 @@
       "translated": "Название группы"
     },
     {
-      "id": "native.apple.af789b2d2fda0f67",
-      "source": "Session name",
-      "translated": "Название сеанса"
+      "id": "native.apple.f887aa956588f237",
+      "source": "Thread name",
+      "translated": "Название ветки"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11104,14 +11179,14 @@
       "translated": "Агенты"
     },
     {
-      "id": "native.apple.a3bde8045fe9224a",
-      "source": "Agent session",
-      "translated": "Сеанс агента"
+      "id": "native.apple.7c8231b7b1ca480f",
+      "source": "Agent thread",
+      "translated": "Ветка агента"
     },
     {
-      "id": "native.apple.27f775de30b37ff8",
-      "source": "Recent sessions",
-      "translated": "Недавние сеансы"
+      "id": "native.apple.b3c553614f762a58",
+      "source": "Recent threads",
+      "translated": "Недавние ветки"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11119,9 +11194,9 @@
       "translated": "Gateway офлайн"
     },
     {
-      "id": "native.apple.28c97cf23665ee01",
-      "source": "No recent sessions",
-      "translated": "Нет недавних сеансов"
+      "id": "native.apple.5aa32afda85064ea",
+      "source": "No recent threads",
+      "translated": "Нет недавних веток"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11219,14 +11294,14 @@
       "translated": "Отмена"
     },
     {
-      "id": "native.apple.9f2fd65953013b7c",
-      "source": "Sessions",
-      "translated": "Сеансы"
+      "id": "native.apple.b6855cf19a50f477",
+      "source": "Threads",
+      "translated": "Ветки"
     },
     {
-      "id": "native.apple.0422818cc95d5071",
-      "source": "Archived sessions",
-      "translated": "Архивные сеансы"
+      "id": "native.apple.9b1d0ef27a1333b0",
+      "source": "Archived threads",
+      "translated": "Архивные ветки"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11234,34 +11309,34 @@
       "translated": "Показать архив"
     },
     {
-      "id": "native.apple.b272115c83f7ef58",
-      "source": "Sessions unavailable",
-      "translated": "Сеансы недоступны"
+      "id": "native.apple.98167401c7267735",
+      "source": "Threads unavailable",
+      "translated": "Ветки недоступны"
     },
     {
-      "id": "native.apple.54f8260c9b863087",
-      "source": "Loading archived sessions",
-      "translated": "Загрузка архивных сеансов"
+      "id": "native.apple.4d28a7def2337b9f",
+      "source": "Loading archived threads",
+      "translated": "Загрузка архивных веток"
     },
     {
-      "id": "native.apple.9b305868873dade2",
-      "source": "Loading recent sessions",
-      "translated": "Загрузка недавних сеансов"
+      "id": "native.apple.777d7b706933bd7b",
+      "source": "Loading recent threads",
+      "translated": "Загрузка недавних веток"
     },
     {
-      "id": "native.apple.207dad20d09f3160",
-      "source": "^[\\(count) session](inflect: true)",
-      "translated": "^[\\(count) сеанс](inflect: true)"
+      "id": "native.apple.22f81ea94bef8410",
+      "source": "^[\\(count) thread](inflect: true)",
+      "translated": "^[\\(count) ветка](inflect: true)"
     },
     {
-      "id": "native.apple.1f4501a6bf2bae4c",
-      "source": "No archived sessions",
-      "translated": "Нет архивных сеансов"
+      "id": "native.apple.1cad51e14db59bf9",
+      "source": "No archived threads",
+      "translated": "Нет архивных веток"
     },
     {
-      "id": "native.apple.2a1ba7a5e1979c9e",
-      "source": "Archived sessions will appear here.",
-      "translated": "Архивные сеансы появятся здесь."
+      "id": "native.apple.18ef832d3a7ddcf8",
+      "source": "Archived threads will appear here.",
+      "translated": "Архивные ветки появятся здесь."
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11344,9 +11419,9 @@
       "translated": "Поделиться приемом"
     },
     {
-      "id": "native.apple.2360d25fe6ae9946",
-      "source": "Loading sessions",
-      "translated": "Загрузка сеансов"
+      "id": "native.apple.21d9208d86a4d1fe",
+      "source": "Loading threads",
+      "translated": "Загрузка веток"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11354,19 +11429,19 @@
       "translated": "Получение недавней активности из Gateway."
     },
     {
-      "id": "native.apple.c334f2e86702a7b8",
-      "source": "Sessions unavailable",
-      "translated": "Сеансы недоступны"
+      "id": "native.apple.4be1f79aa2b230ff",
+      "source": "Threads unavailable",
+      "translated": "Ветки недоступны"
     },
     {
-      "id": "native.apple.6cc6efb7a03960b6",
-      "source": "No recent sessions",
-      "translated": "Нет недавних сеансов"
+      "id": "native.apple.98b348873556bc46",
+      "source": "No recent threads",
+      "translated": "Нет недавних веток"
     },
     {
-      "id": "native.apple.08483af2d043bee6",
-      "source": "Session activity offline",
-      "translated": "Активность сеансов офлайн"
+      "id": "native.apple.7396d205574d279f",
+      "source": "Thread activity offline",
+      "translated": "Активность ветки недоступна офлайн"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11824,9 +11899,9 @@
       "translated": "Карточка"
     },
     {
-      "id": "native.apple.93eeaedb2ff61043",
-      "source": "Open Session",
-      "translated": "Открыть сеанс"
+      "id": "native.apple.c9ec1b0e18074d8a",
+      "source": "Open Thread",
+      "translated": "Открыть ветку"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13314,9 +13389,9 @@
       "translated": "По умолчанию"
     },
     {
-      "id": "native.apple.3de045f17ea3c6d0",
-      "source": "Used for new Chat and Talk sessions.",
-      "translated": "Используется для новых сеансов Chat и Talk."
+      "id": "native.apple.f4ae5664c3eda95d",
+      "source": "Used for new Chat threads and Talk sessions.",
+      "translated": "Используется для новых веток чата и сеансов разговора."
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15719,9 +15794,9 @@
       "translated": "Экземпляры"
     },
     {
-      "id": "native.apple.3579cf2750470a22",
-      "source": "Sessions",
-      "translated": "Сеансы"
+      "id": "native.apple.11fe8b9941954dfb",
+      "source": "Threads",
+      "translated": "Ветки"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19029,9 +19104,9 @@
       "translated": "Сочетание клавиш для быстрого чата"
     },
     {
-      "id": "native.apple.6ae77665b5f4490f",
-      "source": "Global shortcut that opens a floating chat bar for the main session.",
-      "translated": "Глобальное сочетание клавиш, открывающее плавающую панель чата для основного сеанса."
+      "id": "native.apple.94dd793cd7d7d555",
+      "source": "Global shortcut that opens a floating chat bar for the main thread.",
+      "translated": "Глобальное сочетание клавиш, открывающее плавающую панель чата для основной ветки."
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19609,9 +19684,9 @@
       "translated": "Критическая"
     },
     {
-      "id": "native.apple.75102378a6775180",
-      "source": "New Session",
-      "translated": "Новый сеанс"
+      "id": "native.apple.13f96467014cf344",
+      "source": "New Thread",
+      "translated": "Новая ветка"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21899,9 +21974,9 @@
       "translated": "Нет недавних сообщений"
     },
     {
-      "id": "native.apple.1ff8aec0044934c3",
-      "source": "Sessions",
-      "translated": "Сеансы"
+      "id": "native.apple.3ec2afcbc298c673",
+      "source": "Threads",
+      "translated": "Ветки"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21909,9 +21984,9 @@
       "translated": "Просматривайте сохраненные группы разговоров, которые CLI повторно использует для контекста и ограничений частоты."
     },
     {
-      "id": "native.apple.bab897f3252b134c",
-      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
-      "translated": "Сеансов пока нет. Они появятся после первого входящего сообщения или heartbeat."
+      "id": "native.apple.14ccb32cd8ed1c81",
+      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
+      "translated": "Веток пока нет. Они появятся после первого входящего сообщения или сигнала активности."
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -21994,9 +22069,9 @@
       "translated": "Подтверждения выполнения"
     },
     {
-      "id": "native.apple.64a6dc7d49e8fb57",
-      "source": "Sessions",
-      "translated": "Сеансы"
+      "id": "native.apple.52e37e3a44ae516c",
+      "source": "Threads",
+      "translated": "Ветки"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -22999,9 +23074,9 @@
       "translated": "Введи меня в курс дела"
     },
     {
-      "id": "native.apple.234ec45f4231edc4",
-      "source": "Summarize what happened in my sessions since yesterday.",
-      "translated": "Кратко опиши, что произошло в моих сеансах со вчерашнего дня."
+      "id": "native.apple.fc4ce810900ec0b6",
+      "source": "Summarize what happened in my threads since yesterday.",
+      "translated": "Подведи итог событий в моих ветках со вчерашнего дня."
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23179,9 +23254,9 @@
       "translated": "Открепить модель"
     },
     {
-      "id": "native.apple.5dfc0700d8dff8de",
-      "source": "Session",
-      "translated": "Сеанс"
+      "id": "native.apple.4edb66657f5aca1f",
+      "source": "Thread",
+      "translated": "Ветка"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23344,6 +23419,51 @@
       "translated": "Виджет недоступен"
     },
     {
+      "id": "native.apple.d640691fd196f338",
+      "source": "Widget export failed",
+      "translated": "Не удалось экспортировать виджет"
+    },
+    {
+      "id": "native.apple.533c6e22a11e88de",
+      "source": "OK",
+      "translated": "ОК"
+    },
+    {
+      "id": "native.apple.e1fb28a2a9756402",
+      "source": "Copy image",
+      "translated": "Копировать изображение"
+    },
+    {
+      "id": "native.apple.ebd7bc92e1b12235",
+      "source": "Save image…",
+      "translated": "Сохранить изображение…"
+    },
+    {
+      "id": "native.apple.742c46d4cf2db134",
+      "source": "Save image",
+      "translated": "Сохранить изображение"
+    },
+    {
+      "id": "native.apple.0589cce608418f90",
+      "source": "The widget image could not be captured.",
+      "translated": "Не удалось сделать снимок виджета."
+    },
+    {
+      "id": "native.apple.dfe24e827fdbe9c5",
+      "source": "The widget image could not be copied.",
+      "translated": "Не удалось скопировать изображение виджета."
+    },
+    {
+      "id": "native.apple.9e611e3a80e71408",
+      "source": "The widget image could not be encoded as PNG.",
+      "translated": "Не удалось закодировать изображение виджета в формате PNG."
+    },
+    {
+      "id": "native.apple.9a6e8afbe24a262b",
+      "source": "The widget image could not be saved.",
+      "translated": "Не удалось сохранить изображение виджета."
+    },
+    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23484,19 +23604,19 @@
       "translated": "Пользователь"
     },
     {
-      "id": "native.apple.b1cdcb906a43d5d6",
-      "source": "This session cannot be archived while it is active or running.",
-      "translated": "Этот сеанс нельзя архивировать, пока он активен или выполняется."
+      "id": "native.apple.9d0cba09d92ee669",
+      "source": "This thread cannot be archived while it is active or running.",
+      "translated": "Эту ветку нельзя архивировать, пока она активна или выполняется."
     },
     {
-      "id": "native.apple.5817e3f3dab1ee19",
-      "source": "The main session cannot be deleted.",
-      "translated": "Основной сеанс нельзя удалить."
+      "id": "native.apple.8952a111a1075051",
+      "source": "The main thread cannot be deleted.",
+      "translated": "Основную ветку нельзя удалить."
     },
     {
-      "id": "native.apple.a6b8df3f18171c91",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
-      "translated": "Удалите вложения или дождитесь доставки, прежде чем архивировать или удалять этот сеанс."
+      "id": "native.apple.90d0ccf80ca28717",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
+      "translated": "Удалите вложения или дождитесь их доставки, прежде чем архивировать или удалять эту ветку."
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23634,9 +23754,9 @@
       "translated": "Запуск завершён"
     },
     {
-      "id": "native.apple.cd7c3095a22f80a9",
-      "source": "Session Info",
-      "translated": "Информация о сеансе"
+      "id": "native.apple.bbccb4c8db5cac12",
+      "source": "Thread Info",
+      "translated": "Информация о ветке"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23669,9 +23789,9 @@
       "translated": "Добавить группу"
     },
     {
-      "id": "native.apple.23d628606fe0734f",
-      "source": "Session Groups",
-      "translated": "Группы сеансов"
+      "id": "native.apple.7b641fed5bace855",
+      "source": "Thread Groups",
+      "translated": "Группы веток"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23714,9 +23834,9 @@
       "translated": "Удалить группу"
     },
     {
-      "id": "native.apple.b049c8a4d2805e08",
-      "source": "Sessions in this group become ungrouped.",
-      "translated": "Сеансы в этой группе останутся без группы."
+      "id": "native.apple.56401c79410a310d",
+      "source": "Threads in this group become ungrouped.",
+      "translated": "Ветки в этой группе будут разгруппированы."
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23729,9 +23849,9 @@
       "translated": "На этом Gateway нет доступных агентов."
     },
     {
-      "id": "native.apple.6c89f35d53506406",
-      "source": "New Session Options",
-      "translated": "Параметры нового сеанса"
+      "id": "native.apple.2d96aa7d3d12f85b",
+      "source": "New Thread Options",
+      "translated": "Параметры новой ветки"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23759,19 +23879,19 @@
       "translated": "Создать"
     },
     {
-      "id": "native.apple.795ba37f6782cf28",
-      "source": "The session could not be created.",
-      "translated": "Не удалось создать сеанс."
+      "id": "native.apple.87ef57319d1ddc85",
+      "source": "The thread could not be created.",
+      "translated": "Не удалось создать ветку."
     },
     {
-      "id": "native.apple.8ec708a3605a2cc3",
-      "source": "Search sessions",
-      "translated": "Поиск сессий"
+      "id": "native.apple.6bd91c435b69d638",
+      "source": "Search threads",
+      "translated": "Поиск веток"
     },
     {
-      "id": "native.apple.23b069b4e7f97039",
-      "source": "No Sessions",
-      "translated": "Нет сессий"
+      "id": "native.apple.6fde4bdf9d5b9191",
+      "source": "No Threads",
+      "translated": "Нет веток"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23779,29 +23899,29 @@
       "translated": "Нет результатов"
     },
     {
-      "id": "native.apple.0058923f2ce8a3ec",
-      "source": "New Session",
-      "translated": "Новая сессия"
+      "id": "native.apple.a02fd99740d29bd3",
+      "source": "New Thread",
+      "translated": "Новая ветка"
     },
     {
-      "id": "native.apple.66ba42960eb4135b",
-      "source": "New session",
-      "translated": "Новая сессия"
+      "id": "native.apple.b625801dd04b09f2",
+      "source": "New thread",
+      "translated": "Новая ветка"
     },
     {
-      "id": "native.apple.2ef0e34db02ad255",
-      "source": "New session options",
-      "translated": "Параметры нового сеанса"
+      "id": "native.apple.851be81fcc933608",
+      "source": "New thread options",
+      "translated": "Параметры новой ветки"
     },
     {
-      "id": "native.apple.36753ef2f1ed4264",
-      "source": "Rename Session",
-      "translated": "Переименовать сессию"
+      "id": "native.apple.9ce8a4aba7b444b2",
+      "source": "Rename Thread",
+      "translated": "Переименовать ветку"
     },
     {
-      "id": "native.apple.c9de0a1510ef475f",
-      "source": "Session name",
-      "translated": "Название сессии"
+      "id": "native.apple.1dd067c44511c7f0",
+      "source": "Thread name",
+      "translated": "Название ветки"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23814,14 +23934,14 @@
       "translated": "Отмена"
     },
     {
-      "id": "native.apple.afb4e6c99c63a28d",
-      "source": "Delete Session",
-      "translated": "Удалить сессию"
+      "id": "native.apple.618073d6ab3f2721",
+      "source": "Delete Thread",
+      "translated": "Удалить ветку"
     },
     {
-      "id": "native.apple.3d4ef32e42f136a4",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "Сессия и её расшифровка будут удалены из Gateway."
+      "id": "native.apple.10a5e72bba3cbccc",
+      "source": "The thread and its transcript are removed from the gateway.",
+      "translated": "Ветка и её расшифровка будут удалены из Gateway."
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23829,14 +23949,14 @@
       "translated": "Удалить «%@»?"
     },
     {
-      "id": "native.apple.9a7dca238fba628d",
-      "source": "Session running",
-      "translated": "Сессия выполняется"
+      "id": "native.apple.ac71e3b2aa496a2c",
+      "source": "Thread running",
+      "translated": "Ветка выполняется"
     },
     {
-      "id": "native.apple.fcfbfe5e97a95e9c",
-      "source": "Session failed",
-      "translated": "Сессия завершилась с ошибкой"
+      "id": "native.apple.c775e87f997278b2",
+      "source": "Thread failed",
+      "translated": "Ошибка выполнения ветки"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23894,9 +24014,9 @@
       "translated": "Скопировать ключ сеанса"
     },
     {
-      "id": "native.apple.4aeb7c14c26dabac",
-      "source": "Delete Session…",
-      "translated": "Удалить сеанс…"
+      "id": "native.apple.f4998cfb572f23ff",
+      "source": "Delete Thread…",
+      "translated": "Удалить ветку…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23909,9 +24029,9 @@
       "translated": "Подключение…"
     },
     {
-      "id": "native.apple.79f708b3bc1d3a6c",
-      "source": "Retry session groups",
-      "translated": "Повторить загрузку групп сеансов"
+      "id": "native.apple.8802e9576ffd0f65",
+      "source": "Retry thread groups",
+      "translated": "Повторить загрузку групп веток"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23934,24 +24054,24 @@
       "translated": "Область"
     },
     {
-      "id": "native.apple.2c37581c7b88f741",
-      "source": "Search sessions",
-      "translated": "Поиск сессий"
+      "id": "native.apple.b313b80def4bda52",
+      "source": "Search threads",
+      "translated": "Поиск веток"
     },
     {
-      "id": "native.apple.43be8a2336e42faf",
-      "source": "Sessions",
-      "translated": "Сеансы"
+      "id": "native.apple.c0cc6acc36f413ce",
+      "source": "Threads",
+      "translated": "Ветки"
     },
     {
-      "id": "native.apple.0b379cdfcbd3247f",
-      "source": "Rename Session",
-      "translated": "Переименовать сессию"
+      "id": "native.apple.854d3928fe5a557c",
+      "source": "Rename Thread",
+      "translated": "Переименовать ветку"
     },
     {
-      "id": "native.apple.54b6fbd9e41db009",
-      "source": "Session name",
-      "translated": "Имя сессии"
+      "id": "native.apple.9d0d3f20096cc4da",
+      "source": "Thread name",
+      "translated": "Название ветки"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -23959,19 +24079,19 @@
       "translated": "Отмена"
     },
     {
-      "id": "native.apple.751e0f6b81cd374a",
-      "source": "Delete selected sessions?",
-      "translated": "Удалить выбранные сеансы?"
+      "id": "native.apple.dc00eb94f33bae15",
+      "source": "Delete selected threads?",
+      "translated": "Удалить выбранные ветки?"
     },
     {
-      "id": "native.apple.aa679276581b0058",
-      "source": "Delete Sessions",
-      "translated": "Удалить сеансы"
+      "id": "native.apple.2053fc9f74dc3158",
+      "source": "Delete Threads",
+      "translated": "Удалить ветки"
     },
     {
-      "id": "native.apple.f837129cbee23297",
-      "source": "Each selected session and its transcript will be removed from the gateway.",
-      "translated": "Все выбранные сеансы и их расшифровки будут удалены из Gateway."
+      "id": "native.apple.0970247871a834a0",
+      "source": "Each selected thread and its transcript will be removed from the gateway.",
+      "translated": "Все выбранные ветки и их расшифровки будут удалены из Gateway."
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -23979,9 +24099,9 @@
       "translated": "Группы"
     },
     {
-      "id": "native.apple.64013cfee5e25305",
-      "source": "Manage session groups",
-      "translated": "Управление группами сеансов"
+      "id": "native.apple.6f8acab2256728b5",
+      "source": "Manage thread groups",
+      "translated": "Управление группами веток"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -23994,14 +24114,14 @@
       "translated": "Выбрать"
     },
     {
-      "id": "native.apple.b67eaecec1b423ac",
-      "source": "No archived sessions",
-      "translated": "Нет архивных сессий"
+      "id": "native.apple.692972314d04b184",
+      "source": "No archived threads",
+      "translated": "Нет архивных веток"
     },
     {
-      "id": "native.apple.b2435a79abf0c794",
-      "source": "No sessions found",
-      "translated": "Сессии не найдены"
+      "id": "native.apple.d6a4b5711dcd26e7",
+      "source": "No threads found",
+      "translated": "Ветки не найдены"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24169,6 +24289,16 @@
       "translated": "Открыть полное сообщение"
     },
     {
+      "id": "native.apple.002bfcede229ad4b",
+      "source": "Rewind to Here",
+      "translated": "Вернуться сюда"
+    },
+    {
+      "id": "native.apple.14df2e4997689fb3",
+      "source": "Fork from Here",
+      "translated": "Создать ответвление отсюда"
+    },
+    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "Ответ"
@@ -24254,9 +24384,9 @@
       "translated": "Удалите вложения или дождитесь завершения доставки, прежде чем начинать новый чат."
     },
     {
-      "id": "native.apple.980f552bb0f96c0f",
-      "source": "Gateway changed before the session operation started.",
-      "translated": "Gateway изменился до начала операции с сеансом."
+      "id": "native.apple.e0f045151c8d3137",
+      "source": "Gateway changed before the thread operation started.",
+      "translated": "Gateway был изменён до начала операции с веткой."
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24264,9 +24394,9 @@
       "translated": "Удалите вложения или дождитесь доставки, прежде чем переключать чаты."
     },
     {
-      "id": "native.apple.87ba543b42696b92",
-      "source": "Clear this session's history?",
-      "translated": "Очистить историю этой сессии?"
+      "id": "native.apple.0a5c4e15466c3acc",
+      "source": "Clear this thread's history?",
+      "translated": "Очистить историю этой ветки?"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24279,14 +24409,14 @@
       "translated": "Это сбросит разговор для %@. Ключ сеанса останется прежним."
     },
     {
-      "id": "native.apple.a92e96bed98bd553",
-      "source": "Rename Session",
-      "translated": "Переименовать сеанс"
+      "id": "native.apple.67ac221dbe7179f0",
+      "source": "Rename Thread",
+      "translated": "Переименовать ветку"
     },
     {
-      "id": "native.apple.848e2388f3466f40",
-      "source": "Session name",
-      "translated": "Название сеанса"
+      "id": "native.apple.cf0f7e049603f518",
+      "source": "Thread name",
+      "translated": "Название ветки"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24304,9 +24434,9 @@
       "translated": "Экспорт транскрипта"
     },
     {
-      "id": "native.apple.4af0f566d39d7041",
-      "source": "Sessions",
-      "translated": "Сеансы"
+      "id": "native.apple.c0ada47504425f23",
+      "source": "Threads",
+      "translated": "Ветки"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24379,14 +24509,14 @@
       "translated": "По умолчанию"
     },
     {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "Новая сессия"
+      "id": "native.apple.1a765291943599e5",
+      "source": "New Thread",
+      "translated": "Новая ветка"
     },
     {
-      "id": "native.apple.a7119fbf9d25df5e",
-      "source": "New Session Options…",
-      "translated": "Параметры нового сеанса…"
+      "id": "native.apple.c7a3a6d5e43dd98f",
+      "source": "New Thread Options…",
+      "translated": "Параметры новой ветки…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24394,19 +24524,19 @@
       "translated": "Обновить"
     },
     {
-      "id": "native.apple.2bcff4a8fa503739",
-      "source": "Sessions…",
-      "translated": "Сеансы…"
+      "id": "native.apple.0e710b81808e5dcf",
+      "source": "Threads…",
+      "translated": "Ветки…"
     },
     {
-      "id": "native.apple.c36e008b051adb38",
-      "source": "Rename Session…",
-      "translated": "Переименовать сеанс…"
+      "id": "native.apple.faad8f92b6bef166",
+      "source": "Rename Thread…",
+      "translated": "Переименовать ветку…"
     },
     {
-      "id": "native.apple.ea0ef95a159bffe0",
-      "source": "Fork Session",
-      "translated": "Создать ответвление сеанса"
+      "id": "native.apple.23b61d6cd26ac112",
+      "source": "Fork",
+      "translated": "Ответвить"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24464,24 +24594,24 @@
       "translated": "Очистить историю…"
     },
     {
-      "id": "native.apple.920fe8a7a33f9e92",
-      "source": "Session",
-      "translated": "Сессия"
+      "id": "native.apple.8b4f1c5107ea8a0e",
+      "source": "Thread",
+      "translated": "Ветка"
     },
     {
-      "id": "native.apple.185a401f78328b0f",
-      "source": "Session actions",
-      "translated": "Действия сессии"
+      "id": "native.apple.4d7750c9bf699469",
+      "source": "Thread actions",
+      "translated": "Действия с веткой"
     },
     {
-      "id": "native.apple.9f9dedf599b2619b",
-      "source": "Session cost %@",
-      "translated": "Стоимость сеанса: %@"
+      "id": "native.apple.bb2f22cc43c97f8e",
+      "source": "Thread cost %@",
+      "translated": "Стоимость ветки %@"
     },
     {
-      "id": "native.apple.f0a4720df5f5f403",
-      "source": "Compact Session",
-      "translated": "Сжать сессию"
+      "id": "native.apple.6239ced0b86e86f8",
+      "source": "Compact Thread",
+      "translated": "Сжать ветку"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/ru.json
+++ b/apps/.i18n/native/ru.json
@@ -1429,9 +1429,9 @@
       "translated": "Говорите или диктуйте с помощью OpenClaw"
     },
     {
-      "id": "native.android.e2cf5a38587382cb",
-      "source": "Browse Threads",
-      "translated": "Просмотреть ветки"
+      "id": "native.android.5876e15e5e92fd45",
+      "source": "Browse Sessions",
+      "translated": "Просмотреть сеансы"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "Действия не найдены"
     },
     {
-      "id": "native.android.bc70a4ac965b82ba",
-      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
-      "translated": "Попробуйте чат, голосовой режим, ветки, провайдеров или настройки."
+      "id": "native.android.48ad0ae0e930e02b",
+      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
+      "translated": "Попробуйте Chat, Voice, Sessions, Providers или Settings."
     },
     {
-      "id": "native.android.670121e54dbe286f",
-      "source": "Threads",
-      "translated": "Ветки"
+      "id": "native.android.d4fbd1ee4f55a5db",
+      "source": "Sessions",
+      "translated": "Сеансы"
     },
     {
-      "id": "native.android.d38be650b1bce4a0",
-      "source": "Connect the Gateway to search threads.",
-      "translated": "Подключите Gateway для поиска веток."
+      "id": "native.android.207c2170504e99e6",
+      "source": "Connect the Gateway to search sessions.",
+      "translated": "Подключите Gateway, чтобы искать сеансы."
     },
     {
-      "id": "native.android.3d7754721f776ef8",
-      "source": "No matching threads yet.",
-      "translated": "Подходящих веток пока нет."
+      "id": "native.android.25d2c2d792c952fe",
+      "source": "No matching sessions yet.",
+      "translated": "Подходящих сеансов пока нет."
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "Ассистент работает"
     },
     {
-      "id": "native.android.9a839f6e3e05a744",
-      "source": "OpenClaw thread",
-      "translated": "Ветка OpenClaw"
+      "id": "native.android.8f8384286317f5c9",
+      "source": "OpenClaw session",
+      "translated": "Сеанс OpenClaw"
     },
     {
-      "id": "native.android.d83f82a1e4a5ed99",
-      "source": "Open thread",
-      "translated": "Открыть ветку"
+      "id": "native.android.15799e57704b20c6",
+      "source": "Open session",
+      "translated": "Открыть сеанс"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "Нет готовых провайдеров"
     },
     {
-      "id": "native.android.8a1c5365c0538908",
-      "source": "Main thread",
-      "translated": "Основная ветка"
+      "id": "native.android.73e6ab1a168fd381",
+      "source": "Main session",
+      "translated": "Основная сессия"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.a5845742daecb4ba",
-      "source": "Threads",
-      "translated": "Ветки"
+      "id": "native.android.0e3157c15c56944f",
+      "source": "Sessions",
+      "translated": "Сессии"
     },
     {
-      "id": "native.android.439b324280869527",
-      "source": "Focus thread search",
-      "translated": "Перейти к поиску веток"
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "Перейти к поиску сеансов"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "В архиве"
     },
     {
-      "id": "native.android.03981341841b04ac",
-      "source": "Search threads",
-      "translated": "Поиск веток"
+      "id": "native.android.b9cf34c137e4cf03",
+      "source": "Search sessions",
+      "translated": "Поиск сессий"
     },
     {
-      "id": "native.android.99570c528a41fa72",
-      "source": "Clear thread search",
-      "translated": "Очистить поиск веток"
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "Очистить поиск сеансов"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "Сначала старые"
     },
     {
-      "id": "native.android.fd67be543e321cc9",
-      "source": "Toggle thread layout",
-      "translated": "Переключить вид веток"
+      "id": "native.android.c6bf8751e2a7f5c7",
+      "source": "Toggle session layout",
+      "translated": "Переключить макет сессий"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "Макет: подробный"
     },
     {
-      "id": "native.android.ebd17565e0ffd8eb",
-      "source": "Searching threads",
-      "translated": "Поиск веток"
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "Поиск сеансов"
     },
     {
-      "id": "native.android.472d46ae8669f860",
-      "source": "No matching threads",
-      "translated": "Подходящих веток нет"
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "Подходящие сеансы не найдены"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "Начать чат"
     },
     {
-      "id": "native.android.ff81ad1bee00d384",
-      "source": "Current thread",
-      "translated": "Текущая ветка"
+      "id": "native.android.f10d4df7cbc6df4f",
+      "source": "Current session",
+      "translated": "Текущая сессия"
     },
     {
-      "id": "native.android.fc145645b9620e57",
-      "source": "OpenClaw thread",
-      "translated": "Ветка OpenClaw"
+      "id": "native.android.8f0482425838ae64",
+      "source": "OpenClaw session",
+      "translated": "Сессия OpenClaw"
     },
     {
-      "id": "native.android.71cbb8dde8bf138b",
-      "source": "Rename thread",
-      "translated": "Переименовать ветку"
+      "id": "native.android.786774c8a76e50d7",
+      "source": "Rename session",
+      "translated": "Переименовать сеанс"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "Удалить группу?"
     },
     {
-      "id": "native.android.691e92cfe5cf106e",
-      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "Ветки в группе \"$group\" будут сохранены и перемещены обратно в раздел «Без группы»."
+      "id": "native.android.3455fc2f77d564e3",
+      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "Сессии в «$group» сохраняются и перемещаются обратно в «Без группы»."
     },
     {
-      "id": "native.android.d87a8217ab56999b",
-      "source": "Delete thread?",
-      "translated": "Удалить ветку?"
+      "id": "native.android.4805fb9d6623e8c0",
+      "source": "Delete session?",
+      "translated": "Удалить сессию?"
     },
     {
-      "id": "native.android.930de97ff47113a8",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "Это навсегда удалит ветку и её историю."
+      "id": "native.android.0c3283a2b2445eae",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "Это навсегда удалит сессию и ее расшифровку."
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "Без группы"
     },
     {
-      "id": "native.android.8e21a70428def6e0",
-      "source": "No threads yet",
-      "translated": "Веток пока нет"
+      "id": "native.android.db243d71d056afa4",
+      "source": "No sessions yet",
+      "translated": "Сессий пока нет"
     },
     {
-      "id": "native.android.cda4c5ad8b17e394",
-      "source": "No current thread",
-      "translated": "Нет текущей ветки"
+      "id": "native.android.5b4eee6a8092925e",
+      "source": "No current session",
+      "translated": "Нет текущей сессии"
     },
     {
-      "id": "native.android.be84f061047aa2da",
-      "source": "No archived threads",
-      "translated": "Нет архивных веток"
+      "id": "native.android.acbcc9c9ea53d8c0",
+      "source": "No archived sessions",
+      "translated": "Нет архивных сессий"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "Начните новый разговор, и он появится здесь."
     },
     {
-      "id": "native.android.f289d03e1d3eee98",
-      "source": "Open Chat to start or resume the current thread.",
-      "translated": "Откройте чат, чтобы начать или продолжить текущую ветку."
+      "id": "native.android.56fcd605dc7be3c0",
+      "source": "Open Chat to start or resume the current session.",
+      "translated": "Откройте чат, чтобы начать или возобновить текущую сессию."
     },
     {
-      "id": "native.android.504b71386e76c6ae",
-      "source": "Archived threads will show up here.",
-      "translated": "Здесь появятся архивные ветки."
+      "id": "native.android.085515989f8a2022",
+      "source": "Archived sessions will show up here.",
+      "translated": "Архивные сессии появятся здесь."
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days} дн."
     },
     {
-      "id": "native.android.ee4c727cdafbe963",
-      "source": "Main thread",
-      "translated": "Основная ветка"
+      "id": "native.android.3d4fa07acbc015c5",
+      "source": "Main session",
+      "translated": "Основная сессия"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Ожидание Gateway"
     },
     {
-      "id": "native.android.da78209effb11cfd",
-      "source": "Thread Activity",
-      "translated": "Активность ветки"
+      "id": "native.android.2d8d049afe99f751",
+      "source": "Session Activity",
+      "translated": "Активность сессии"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "Запросы на подтверждение выполнения будут отображаться здесь, пока этот телефон подключен."
     },
     {
-      "id": "native.android.f615712dfb56319a",
-      "source": "Thread activity",
-      "translated": "Активность ветки"
+      "id": "native.android.dc3e7ca5a491103a",
+      "source": "Session activity",
+      "translated": "Активность сеанса"
     },
     {
-      "id": "native.android.6c93973c13db43ae",
-      "source": "Chat tool calls waiting in the active thread remain visible here.",
-      "translated": "Ожидающие вызовы инструментов чата в активной ветке остаются видимыми здесь."
+      "id": "native.android.8551e02b060bd7d8",
+      "source": "Chat tool calls waiting in the active session remain visible here.",
+      "translated": "Вызовы инструментов чата, ожидающие в активном сеансе, остаются видимыми здесь."
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,11 +4294,6 @@
       "translated": "Настройка провайдера разговоров"
     },
     {
-      "id": "native.android.23b638094c34b916",
-      "source": "Microphone",
-      "translated": "Микрофон"
-    },
-    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "Тест аудио"
@@ -4342,66 +4337,6 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "Готово"
-    },
-    {
-      "id": "native.android.8d9ecdfdd916b780",
-      "source": "Automatic",
-      "translated": "Автоматически"
-    },
-    {
-      "id": "native.android.c1626a6700a570f6",
-      "source": "Preferred microphone unavailable; using automatic routing.",
-      "translated": "Предпочтительный микрофон недоступен; используется автоматическая маршрутизация."
-    },
-    {
-      "id": "native.android.820bc5d0ce571d8b",
-      "source": "Prioritizes connected Bluetooth microphones.",
-      "translated": "Приоритет отдается подключенным Bluetooth-микрофонам."
-    },
-    {
-      "id": "native.android.11e48038d5e8bff6",
-      "source": "Preferred microphone",
-      "translated": "Предпочтительный микрофон"
-    },
-    {
-      "id": "native.android.eaa4d7563a46d307",
-      "source": "Unavailable",
-      "translated": "Недоступен"
-    },
-    {
-      "id": "native.android.9f5ebf17eb405ba8",
-      "source": "Next session",
-      "translated": "Следующий сеанс"
-    },
-    {
-      "id": "native.android.8c4e91f53928efb2",
-      "source": "Built-in microphone",
-      "translated": "Встроенный микрофон"
-    },
-    {
-      "id": "native.android.14b613cb6e2446b4",
-      "source": "Bluetooth microphone",
-      "translated": "Bluetooth-микрофон"
-    },
-    {
-      "id": "native.android.c885247b2d7ce271",
-      "source": "Bluetooth LE microphone",
-      "translated": "Микрофон Bluetooth LE"
-    },
-    {
-      "id": "native.android.b6a4e674c5fb441a",
-      "source": "Wired headset microphone",
-      "translated": "Микрофон проводной гарнитуры"
-    },
-    {
-      "id": "native.android.9c8becb3b0fb5a90",
-      "source": "USB microphone",
-      "translated": "USB-микрофон"
-    },
-    {
-      "id": "native.android.ba46258fadec7a39",
-      "source": "External microphone",
-      "translated": "Внешний микрофон"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5139,9 +5074,9 @@
       "translated": "Проверить"
     },
     {
-      "id": "native.android.c971506716c96e91",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
-      "translated": "OpenClaw превращает этот телефон в удобный мобильный интерфейс управления ветками, голосом, провайдерами и Gateway."
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw превращает этот телефон в удобный мобильный интерфейс управления сеансами, голосовыми функциями, провайдерами и Gateway."
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5689,9 +5624,9 @@
       "translated": "Настройки Разговора"
     },
     {
-      "id": "native.android.36f78c8c85dc283f",
-      "source": "Recent Threads",
-      "translated": "Недавние ветки"
+      "id": "native.android.73f07a5d54915259",
+      "source": "Recent Sessions",
+      "translated": "Недавние сеансы"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5749,14 +5684,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% в сети"
     },
     {
-      "id": "native.android.57177017a6a93826",
-      "source": "Threads",
-      "translated": "Ветки"
+      "id": "native.android.16c3425d3a594481",
+      "source": "Sessions",
+      "translated": "Сеансы"
     },
     {
-      "id": "native.android.43320b54a68b00a1",
-      "source": "No recent threads",
-      "translated": "Нет недавних веток"
+      "id": "native.android.a5c0f8b3112aa58c",
+      "source": "No recent sessions",
+      "translated": "Нет недавних сеансов"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5794,14 +5729,14 @@
       "translated": "Выполняется · $pendingRunCount активных запусков"
     },
     {
-      "id": "native.android.e24db059480f1e6a",
-      "source": "Monitoring · 1 thread",
-      "translated": "Мониторинг · 1 ветка"
+      "id": "native.android.2c89da708b12a522",
+      "source": "Monitoring · 1 session",
+      "translated": "Мониторинг · 1 сеанс"
     },
     {
-      "id": "native.android.5a475f37d80e02bc",
-      "source": "Monitoring · $sessionCount threads",
-      "translated": "Мониторинг · $sessionCount веток"
+      "id": "native.android.8b6ee382dcb64e1f",
+      "source": "Monitoring · $sessionCount sessions",
+      "translated": "Мониторинг · $sessionCount сеансов"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5834,9 +5769,9 @@
       "translated": "Провайдеры"
     },
     {
-      "id": "native.android.358c5e0e838d5423",
-      "source": "Open thread",
-      "translated": "Открыть ветку"
+      "id": "native.android.a65477861c7203aa",
+      "source": "Open session",
+      "translated": "Открыть сеанс"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6259,9 +6194,9 @@
       "translated": "${days} дн."
     },
     {
-      "id": "native.android.28a1a1acc5a0959f",
-      "source": "Main thread",
-      "translated": "Основная ветка"
+      "id": "native.android.22d755834386db07",
+      "source": "Main session",
+      "translated": "Основной сеанс"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6942,16 +6877,6 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "Включить микрофон"
-    },
-    {
-      "id": "native.android.cb608d82c5b3352a",
-      "source": "Back camera",
-      "translated": "Основная камера"
-    },
-    {
-      "id": "native.android.e89a0e780eed2e1e",
-      "source": "Front camera",
-      "translated": "Фронтальная камера"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7759,9 +7684,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.0c74bc30a994dd33",
-      "source": "Loading thread",
-      "translated": "Загрузка ветки"
+      "id": "native.android.882cc14a58e7e105",
+      "source": "Loading session",
+      "translated": "Загрузка сеанса"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7804,14 +7729,14 @@
       "translated": "Введите меня в курс дела"
     },
     {
-      "id": "native.android.cf40df9739f78f27",
-      "source": "Summarize recent threads and next steps.",
-      "translated": "Сводка недавних веток и дальнейших действий."
+      "id": "native.android.1e5add56e48c99f9",
+      "source": "Summarize recent sessions and next steps.",
+      "translated": "Подведите итоги недавних сеансов и предложите следующие шаги."
     },
     {
-      "id": "native.android.ebe49a8b8df80bd3",
-      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
-      "translated": "Расскажи о последних обсуждениях в OpenClaw и предложи следующие шаги."
+      "id": "native.android.06d515351bb79576",
+      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
+      "translated": "Введите меня в курс моих недавних сеансов OpenClaw и предложите следующие шаги."
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8149,9 +8074,9 @@
       "translated": "Подключено"
     },
     {
-      "id": "native.android.6cf5d6fa8a4186d5",
-      "source": "Threads",
-      "translated": "Обсуждения"
+      "id": "native.android.81931886b9caf3ab",
+      "source": "Sessions",
+      "translated": "Сессии"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,6 +10719,61 @@
       "translated": "Сведения о задаче"
     },
     {
+      "id": "native.apple.29cacb53ea5e77fc",
+      "source": "Pinned",
+      "translated": "Закреплённые"
+    },
+    {
+      "id": "native.apple.940062cfdce9211b",
+      "source": "Recent",
+      "translated": "Недавние"
+    },
+    {
+      "id": "native.apple.a0980128426308a9",
+      "source": "Model",
+      "translated": "Модель"
+    },
+    {
+      "id": "native.apple.9520e60f21535dde",
+      "source": "Thinking",
+      "translated": "Рассуждение"
+    },
+    {
+      "id": "native.apple.8b321f3ffce97429",
+      "source": "Fast",
+      "translated": "Быстро"
+    },
+    {
+      "id": "native.apple.989b70d64e328d55",
+      "source": "Default (inherited)",
+      "translated": "По умолчанию (унаследовано)"
+    },
+    {
+      "id": "native.apple.f4114e73b07eb9ae",
+      "source": "Off",
+      "translated": "Выкл."
+    },
+    {
+      "id": "native.apple.7ed231b28d16312f",
+      "source": "On",
+      "translated": "Вкл."
+    },
+    {
+      "id": "native.apple.412a74802320a037",
+      "source": "Full",
+      "translated": "Полное"
+    },
+    {
+      "id": "native.apple.299f21a2071ff9fc",
+      "source": "Verbosity",
+      "translated": "Подробность"
+    },
+    {
+      "id": "native.apple.faf0ef05e1496de7",
+      "source": "Default",
+      "translated": "По умолчанию"
+    },
+    {
       "id": "native.apple.e5524d5756a62744",
       "source": "Unable to Export Transcript",
       "translated": "Не удалось экспортировать стенограмму"
@@ -10814,9 +10794,9 @@
       "translated": "Над чем вы хотите поработать?"
     },
     {
-      "id": "native.apple.4da775013ac9b123",
-      "source": "The thread attaches once the gateway is ready.",
-      "translated": "Обсуждение будет подключено, когда Gateway будет готов."
+      "id": "native.apple.32179ce0b6d4543f",
+      "source": "The session attaches once the gateway is ready.",
+      "translated": "Сеанс подключится, когда Gateway будет готов."
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10859,9 +10839,14 @@
       "translated": "Новый чат в Worktree"
     },
     {
-      "id": "native.apple.003b25ddafeb18e9",
-      "source": "Threads…",
-      "translated": "Обсуждения…"
+      "id": "native.apple.ce6ebe91fc597015",
+      "source": "New Session Options…",
+      "translated": "Параметры нового сеанса…"
+    },
+    {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "Сеансы…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11024,14 +11009,14 @@
       "translated": "Создать"
     },
     {
-      "id": "native.apple.31d5c7287cfb3abe",
-      "source": "Delete Thread?",
-      "translated": "Удалить обсуждение?"
+      "id": "native.apple.f488b9caf6e51ac3",
+      "source": "Delete Session?",
+      "translated": "Удалить сеанс?"
     },
     {
-      "id": "native.apple.d3395564809f1120",
-      "source": "Delete Thread",
-      "translated": "Удалить обсуждение"
+      "id": "native.apple.8634b17be9b111bc",
+      "source": "Delete Session",
+      "translated": "Удалить сеанс"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11039,9 +11024,9 @@
       "translated": "Отмена"
     },
     {
-      "id": "native.apple.092659256d26cb03",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "Обсуждение и его расшифровка будут удалены без возможности восстановления."
+      "id": "native.apple.4a9568ac9b18d8d3",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "Это безвозвратно удалит сеанс и его стенограмму."
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11069,9 +11054,9 @@
       "translated": "Новая группа"
     },
     {
-      "id": "native.apple.683032464c497bbd",
-      "source": "Rename Thread",
-      "translated": "Переименовать обсуждение"
+      "id": "native.apple.5bccdc23a1640895",
+      "source": "Rename Session",
+      "translated": "Переименовать сеанс"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11079,9 +11064,9 @@
       "translated": "Название группы"
     },
     {
-      "id": "native.apple.f887aa956588f237",
-      "source": "Thread name",
-      "translated": "Название обсуждения"
+      "id": "native.apple.af789b2d2fda0f67",
+      "source": "Session name",
+      "translated": "Название сеанса"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11119,14 +11104,14 @@
       "translated": "Агенты"
     },
     {
-      "id": "native.apple.7c8231b7b1ca480f",
-      "source": "Agent thread",
-      "translated": "Обсуждение агента"
+      "id": "native.apple.a3bde8045fe9224a",
+      "source": "Agent session",
+      "translated": "Сеанс агента"
     },
     {
-      "id": "native.apple.b3c553614f762a58",
-      "source": "Recent threads",
-      "translated": "Недавние обсуждения"
+      "id": "native.apple.27f775de30b37ff8",
+      "source": "Recent sessions",
+      "translated": "Недавние сеансы"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11134,9 +11119,9 @@
       "translated": "Gateway офлайн"
     },
     {
-      "id": "native.apple.5aa32afda85064ea",
-      "source": "No recent threads",
-      "translated": "Нет недавних обсуждений"
+      "id": "native.apple.28c97cf23665ee01",
+      "source": "No recent sessions",
+      "translated": "Нет недавних сеансов"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11234,14 +11219,14 @@
       "translated": "Отмена"
     },
     {
-      "id": "native.apple.b6855cf19a50f477",
-      "source": "Threads",
-      "translated": "Обсуждения"
+      "id": "native.apple.9f2fd65953013b7c",
+      "source": "Sessions",
+      "translated": "Сеансы"
     },
     {
-      "id": "native.apple.9b1d0ef27a1333b0",
-      "source": "Archived threads",
-      "translated": "Архивные обсуждения"
+      "id": "native.apple.0422818cc95d5071",
+      "source": "Archived sessions",
+      "translated": "Архивные сеансы"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11249,34 +11234,34 @@
       "translated": "Показать архив"
     },
     {
-      "id": "native.apple.98167401c7267735",
-      "source": "Threads unavailable",
-      "translated": "Обсуждения недоступны"
+      "id": "native.apple.b272115c83f7ef58",
+      "source": "Sessions unavailable",
+      "translated": "Сеансы недоступны"
     },
     {
-      "id": "native.apple.4d28a7def2337b9f",
-      "source": "Loading archived threads",
-      "translated": "Загрузка архивных обсуждений"
+      "id": "native.apple.54f8260c9b863087",
+      "source": "Loading archived sessions",
+      "translated": "Загрузка архивных сеансов"
     },
     {
-      "id": "native.apple.777d7b706933bd7b",
-      "source": "Loading recent threads",
-      "translated": "Загрузка недавних обсуждений"
+      "id": "native.apple.9b305868873dade2",
+      "source": "Loading recent sessions",
+      "translated": "Загрузка недавних сеансов"
     },
     {
-      "id": "native.apple.22f81ea94bef8410",
-      "source": "^[\\(count) thread](inflect: true)",
-      "translated": "^[\\(count) обсуждение](inflect: true)"
+      "id": "native.apple.207dad20d09f3160",
+      "source": "^[\\(count) session](inflect: true)",
+      "translated": "^[\\(count) сеанс](inflect: true)"
     },
     {
-      "id": "native.apple.1cad51e14db59bf9",
-      "source": "No archived threads",
-      "translated": "Нет архивных обсуждений"
+      "id": "native.apple.1f4501a6bf2bae4c",
+      "source": "No archived sessions",
+      "translated": "Нет архивных сеансов"
     },
     {
-      "id": "native.apple.18ef832d3a7ddcf8",
-      "source": "Archived threads will appear here.",
-      "translated": "Архивные обсуждения появятся здесь."
+      "id": "native.apple.2a1ba7a5e1979c9e",
+      "source": "Archived sessions will appear here.",
+      "translated": "Архивные сеансы появятся здесь."
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11359,9 +11344,9 @@
       "translated": "Поделиться приемом"
     },
     {
-      "id": "native.apple.21d9208d86a4d1fe",
-      "source": "Loading threads",
-      "translated": "Загрузка веток"
+      "id": "native.apple.2360d25fe6ae9946",
+      "source": "Loading sessions",
+      "translated": "Загрузка сеансов"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11369,19 +11354,19 @@
       "translated": "Получение недавней активности из Gateway."
     },
     {
-      "id": "native.apple.4be1f79aa2b230ff",
-      "source": "Threads unavailable",
-      "translated": "Ветки недоступны"
+      "id": "native.apple.c334f2e86702a7b8",
+      "source": "Sessions unavailable",
+      "translated": "Сеансы недоступны"
     },
     {
-      "id": "native.apple.98b348873556bc46",
-      "source": "No recent threads",
-      "translated": "Нет недавних веток"
+      "id": "native.apple.6cc6efb7a03960b6",
+      "source": "No recent sessions",
+      "translated": "Нет недавних сеансов"
     },
     {
-      "id": "native.apple.7396d205574d279f",
-      "source": "Thread activity offline",
-      "translated": "Активность веток недоступна"
+      "id": "native.apple.08483af2d043bee6",
+      "source": "Session activity offline",
+      "translated": "Активность сеансов офлайн"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11839,9 +11824,9 @@
       "translated": "Карточка"
     },
     {
-      "id": "native.apple.c9ec1b0e18074d8a",
-      "source": "Open Thread",
-      "translated": "Открыть ветку"
+      "id": "native.apple.93eeaedb2ff61043",
+      "source": "Open Session",
+      "translated": "Открыть сеанс"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13329,9 +13314,9 @@
       "translated": "По умолчанию"
     },
     {
-      "id": "native.apple.f4ae5664c3eda95d",
-      "source": "Used for new Chat threads and Talk sessions.",
-      "translated": "Используется для новых веток чата и сеансов разговора."
+      "id": "native.apple.3de045f17ea3c6d0",
+      "source": "Used for new Chat and Talk sessions.",
+      "translated": "Используется для новых сеансов Chat и Talk."
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15734,9 +15719,9 @@
       "translated": "Экземпляры"
     },
     {
-      "id": "native.apple.11fe8b9941954dfb",
-      "source": "Threads",
-      "translated": "Ветки"
+      "id": "native.apple.3579cf2750470a22",
+      "source": "Sessions",
+      "translated": "Сеансы"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19044,9 +19029,9 @@
       "translated": "Сочетание клавиш для быстрого чата"
     },
     {
-      "id": "native.apple.94dd793cd7d7d555",
-      "source": "Global shortcut that opens a floating chat bar for the main thread.",
-      "translated": "Глобальное сочетание клавиш, открывающее плавающую панель чата для основной ветки."
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "Глобальное сочетание клавиш, открывающее плавающую панель чата для основного сеанса."
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19624,9 +19609,9 @@
       "translated": "Критическая"
     },
     {
-      "id": "native.apple.13f96467014cf344",
-      "source": "New Thread",
-      "translated": "Новая ветка"
+      "id": "native.apple.75102378a6775180",
+      "source": "New Session",
+      "translated": "Новый сеанс"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21914,9 +21899,9 @@
       "translated": "Нет недавних сообщений"
     },
     {
-      "id": "native.apple.3ec2afcbc298c673",
-      "source": "Threads",
-      "translated": "Ветки"
+      "id": "native.apple.1ff8aec0044934c3",
+      "source": "Sessions",
+      "translated": "Сеансы"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21924,9 +21909,9 @@
       "translated": "Просматривайте сохраненные группы разговоров, которые CLI повторно использует для контекста и ограничений частоты."
     },
     {
-      "id": "native.apple.14ccb32cd8ed1c81",
-      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
-      "translated": "Веток пока нет. Они появятся после первого входящего сообщения или сигнала активности."
+      "id": "native.apple.bab897f3252b134c",
+      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
+      "translated": "Сеансов пока нет. Они появятся после первого входящего сообщения или heartbeat."
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -22009,9 +21994,9 @@
       "translated": "Подтверждения выполнения"
     },
     {
-      "id": "native.apple.52e37e3a44ae516c",
-      "source": "Threads",
-      "translated": "Ветки"
+      "id": "native.apple.64a6dc7d49e8fb57",
+      "source": "Sessions",
+      "translated": "Сеансы"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -23014,9 +22999,9 @@
       "translated": "Введи меня в курс дела"
     },
     {
-      "id": "native.apple.fc4ce810900ec0b6",
-      "source": "Summarize what happened in my threads since yesterday.",
-      "translated": "Подведи итог того, что произошло в моих ветках со вчерашнего дня."
+      "id": "native.apple.234ec45f4231edc4",
+      "source": "Summarize what happened in my sessions since yesterday.",
+      "translated": "Кратко опиши, что произошло в моих сеансах со вчерашнего дня."
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23194,9 +23179,9 @@
       "translated": "Открепить модель"
     },
     {
-      "id": "native.apple.4edb66657f5aca1f",
-      "source": "Thread",
-      "translated": "Ветка"
+      "id": "native.apple.5dfc0700d8dff8de",
+      "source": "Session",
+      "translated": "Сеанс"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23359,51 +23344,6 @@
       "translated": "Виджет недоступен"
     },
     {
-      "id": "native.apple.d640691fd196f338",
-      "source": "Widget export failed",
-      "translated": "Не удалось экспортировать виджет"
-    },
-    {
-      "id": "native.apple.533c6e22a11e88de",
-      "source": "OK",
-      "translated": "ОК"
-    },
-    {
-      "id": "native.apple.e1fb28a2a9756402",
-      "source": "Copy image",
-      "translated": "Копировать изображение"
-    },
-    {
-      "id": "native.apple.ebd7bc92e1b12235",
-      "source": "Save image…",
-      "translated": "Сохранить изображение…"
-    },
-    {
-      "id": "native.apple.742c46d4cf2db134",
-      "source": "Save image",
-      "translated": "Сохранить изображение"
-    },
-    {
-      "id": "native.apple.0589cce608418f90",
-      "source": "The widget image could not be captured.",
-      "translated": "Не удалось сделать снимок виджета."
-    },
-    {
-      "id": "native.apple.dfe24e827fdbe9c5",
-      "source": "The widget image could not be copied.",
-      "translated": "Не удалось скопировать изображение виджета."
-    },
-    {
-      "id": "native.apple.9e611e3a80e71408",
-      "source": "The widget image could not be encoded as PNG.",
-      "translated": "Не удалось преобразовать изображение виджета в формат PNG."
-    },
-    {
-      "id": "native.apple.9a6e8afbe24a262b",
-      "source": "The widget image could not be saved.",
-      "translated": "Не удалось сохранить изображение виджета."
-    },
-    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23544,19 +23484,19 @@
       "translated": "Пользователь"
     },
     {
-      "id": "native.apple.9d0cba09d92ee669",
-      "source": "This thread cannot be archived while it is active or running.",
-      "translated": "Эту ветку нельзя архивировать, пока она активна или выполняется."
+      "id": "native.apple.b1cdcb906a43d5d6",
+      "source": "This session cannot be archived while it is active or running.",
+      "translated": "Этот сеанс нельзя архивировать, пока он активен или выполняется."
     },
     {
-      "id": "native.apple.8952a111a1075051",
-      "source": "The main thread cannot be deleted.",
-      "translated": "Основную ветку нельзя удалить."
+      "id": "native.apple.5817e3f3dab1ee19",
+      "source": "The main session cannot be deleted.",
+      "translated": "Основной сеанс нельзя удалить."
     },
     {
-      "id": "native.apple.90d0ccf80ca28717",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
-      "translated": "Удалите вложения или дождитесь доставки, прежде чем архивировать или удалять эту ветку."
+      "id": "native.apple.a6b8df3f18171c91",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
+      "translated": "Удалите вложения или дождитесь доставки, прежде чем архивировать или удалять этот сеанс."
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23694,9 +23634,9 @@
       "translated": "Запуск завершён"
     },
     {
-      "id": "native.apple.bbccb4c8db5cac12",
-      "source": "Thread Info",
-      "translated": "Сведения о ветке"
+      "id": "native.apple.cd7c3095a22f80a9",
+      "source": "Session Info",
+      "translated": "Информация о сеансе"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23729,9 +23669,9 @@
       "translated": "Добавить группу"
     },
     {
-      "id": "native.apple.7b641fed5bace855",
-      "source": "Thread Groups",
-      "translated": "Группы веток"
+      "id": "native.apple.23d628606fe0734f",
+      "source": "Session Groups",
+      "translated": "Группы сеансов"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23774,9 +23714,9 @@
       "translated": "Удалить группу"
     },
     {
-      "id": "native.apple.56401c79410a310d",
-      "source": "Threads in this group become ungrouped.",
-      "translated": "Ветки в этой группе будут исключены из неё."
+      "id": "native.apple.b049c8a4d2805e08",
+      "source": "Sessions in this group become ungrouped.",
+      "translated": "Сеансы в этой группе останутся без группы."
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23789,9 +23729,9 @@
       "translated": "На этом Gateway нет доступных агентов."
     },
     {
-      "id": "native.apple.2d96aa7d3d12f85b",
-      "source": "New Thread Options",
-      "translated": "Параметры новой ветки"
+      "id": "native.apple.6c89f35d53506406",
+      "source": "New Session Options",
+      "translated": "Параметры нового сеанса"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23819,19 +23759,19 @@
       "translated": "Создать"
     },
     {
-      "id": "native.apple.87ef57319d1ddc85",
-      "source": "The thread could not be created.",
-      "translated": "Не удалось создать ветку."
+      "id": "native.apple.795ba37f6782cf28",
+      "source": "The session could not be created.",
+      "translated": "Не удалось создать сеанс."
     },
     {
-      "id": "native.apple.6bd91c435b69d638",
-      "source": "Search threads",
-      "translated": "Поиск веток"
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "Поиск сессий"
     },
     {
-      "id": "native.apple.6fde4bdf9d5b9191",
-      "source": "No Threads",
-      "translated": "Нет веток"
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "Нет сессий"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23839,29 +23779,29 @@
       "translated": "Нет результатов"
     },
     {
-      "id": "native.apple.a02fd99740d29bd3",
-      "source": "New Thread",
-      "translated": "Новая ветка"
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "Новая сессия"
     },
     {
-      "id": "native.apple.b625801dd04b09f2",
-      "source": "New thread",
-      "translated": "Новая ветка"
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "Новая сессия"
     },
     {
-      "id": "native.apple.851be81fcc933608",
-      "source": "New thread options",
-      "translated": "Параметры новой ветки"
+      "id": "native.apple.2ef0e34db02ad255",
+      "source": "New session options",
+      "translated": "Параметры нового сеанса"
     },
     {
-      "id": "native.apple.9ce8a4aba7b444b2",
-      "source": "Rename Thread",
-      "translated": "Переименовать ветку"
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "Переименовать сессию"
     },
     {
-      "id": "native.apple.1dd067c44511c7f0",
-      "source": "Thread name",
-      "translated": "Название ветки"
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "Название сессии"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23874,14 +23814,14 @@
       "translated": "Отмена"
     },
     {
-      "id": "native.apple.618073d6ab3f2721",
-      "source": "Delete Thread",
-      "translated": "Удалить ветку"
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "Удалить сессию"
     },
     {
-      "id": "native.apple.10a5e72bba3cbccc",
-      "source": "The thread and its transcript are removed from the gateway.",
-      "translated": "Ветка и её история удаляются из Gateway."
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "Сессия и её расшифровка будут удалены из Gateway."
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23889,14 +23829,14 @@
       "translated": "Удалить «%@»?"
     },
     {
-      "id": "native.apple.ac71e3b2aa496a2c",
-      "source": "Thread running",
-      "translated": "Ветка выполняется"
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "Сессия выполняется"
     },
     {
-      "id": "native.apple.c775e87f997278b2",
-      "source": "Thread failed",
-      "translated": "Сбой ветки"
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "Сессия завершилась с ошибкой"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23954,9 +23894,9 @@
       "translated": "Скопировать ключ сеанса"
     },
     {
-      "id": "native.apple.f4998cfb572f23ff",
-      "source": "Delete Thread…",
-      "translated": "Удалить ветку…"
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "Удалить сеанс…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23969,9 +23909,9 @@
       "translated": "Подключение…"
     },
     {
-      "id": "native.apple.8802e9576ffd0f65",
-      "source": "Retry thread groups",
-      "translated": "Повторить загрузку групп веток"
+      "id": "native.apple.79f708b3bc1d3a6c",
+      "source": "Retry session groups",
+      "translated": "Повторить загрузку групп сеансов"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23994,24 +23934,24 @@
       "translated": "Область"
     },
     {
-      "id": "native.apple.b313b80def4bda52",
-      "source": "Search threads",
-      "translated": "Поиск веток"
+      "id": "native.apple.2c37581c7b88f741",
+      "source": "Search sessions",
+      "translated": "Поиск сессий"
     },
     {
-      "id": "native.apple.c0cc6acc36f413ce",
-      "source": "Threads",
-      "translated": "Ветки"
+      "id": "native.apple.43be8a2336e42faf",
+      "source": "Sessions",
+      "translated": "Сеансы"
     },
     {
-      "id": "native.apple.854d3928fe5a557c",
-      "source": "Rename Thread",
-      "translated": "Переименовать ветку"
+      "id": "native.apple.0b379cdfcbd3247f",
+      "source": "Rename Session",
+      "translated": "Переименовать сессию"
     },
     {
-      "id": "native.apple.9d0d3f20096cc4da",
-      "source": "Thread name",
-      "translated": "Название ветки"
+      "id": "native.apple.54b6fbd9e41db009",
+      "source": "Session name",
+      "translated": "Имя сессии"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -24019,19 +23959,19 @@
       "translated": "Отмена"
     },
     {
-      "id": "native.apple.dc00eb94f33bae15",
-      "source": "Delete selected threads?",
-      "translated": "Удалить выбранные ветки?"
+      "id": "native.apple.751e0f6b81cd374a",
+      "source": "Delete selected sessions?",
+      "translated": "Удалить выбранные сеансы?"
     },
     {
-      "id": "native.apple.2053fc9f74dc3158",
-      "source": "Delete Threads",
-      "translated": "Удалить ветки"
+      "id": "native.apple.aa679276581b0058",
+      "source": "Delete Sessions",
+      "translated": "Удалить сеансы"
     },
     {
-      "id": "native.apple.0970247871a834a0",
-      "source": "Each selected thread and its transcript will be removed from the gateway.",
-      "translated": "Все выбранные ветки и их стенограммы будут удалены из Gateway."
+      "id": "native.apple.f837129cbee23297",
+      "source": "Each selected session and its transcript will be removed from the gateway.",
+      "translated": "Все выбранные сеансы и их расшифровки будут удалены из Gateway."
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -24039,9 +23979,9 @@
       "translated": "Группы"
     },
     {
-      "id": "native.apple.6f8acab2256728b5",
-      "source": "Manage thread groups",
-      "translated": "Управление группами веток"
+      "id": "native.apple.64013cfee5e25305",
+      "source": "Manage session groups",
+      "translated": "Управление группами сеансов"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -24054,14 +23994,14 @@
       "translated": "Выбрать"
     },
     {
-      "id": "native.apple.692972314d04b184",
-      "source": "No archived threads",
-      "translated": "Нет архивных веток"
+      "id": "native.apple.b67eaecec1b423ac",
+      "source": "No archived sessions",
+      "translated": "Нет архивных сессий"
     },
     {
-      "id": "native.apple.d6a4b5711dcd26e7",
-      "source": "No threads found",
-      "translated": "Ветки не найдены"
+      "id": "native.apple.b2435a79abf0c794",
+      "source": "No sessions found",
+      "translated": "Сессии не найдены"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24229,16 +24169,6 @@
       "translated": "Открыть полное сообщение"
     },
     {
-      "id": "native.apple.002bfcede229ad4b",
-      "source": "Rewind to Here",
-      "translated": "Перемотать сюда"
-    },
-    {
-      "id": "native.apple.14df2e4997689fb3",
-      "source": "Fork from Here",
-      "translated": "Создать ответвление отсюда"
-    },
-    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "Ответ"
@@ -24324,9 +24254,9 @@
       "translated": "Удалите вложения или дождитесь завершения доставки, прежде чем начинать новый чат."
     },
     {
-      "id": "native.apple.e0f045151c8d3137",
-      "source": "Gateway changed before the thread operation started.",
-      "translated": "Gateway был изменён до начала операции с веткой."
+      "id": "native.apple.980f552bb0f96c0f",
+      "source": "Gateway changed before the session operation started.",
+      "translated": "Gateway изменился до начала операции с сеансом."
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24334,9 +24264,9 @@
       "translated": "Удалите вложения или дождитесь доставки, прежде чем переключать чаты."
     },
     {
-      "id": "native.apple.0a5c4e15466c3acc",
-      "source": "Clear this thread's history?",
-      "translated": "Очистить историю этой ветки?"
+      "id": "native.apple.87ba543b42696b92",
+      "source": "Clear this session's history?",
+      "translated": "Очистить историю этой сессии?"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24349,14 +24279,14 @@
       "translated": "Это сбросит разговор для %@. Ключ сеанса останется прежним."
     },
     {
-      "id": "native.apple.67ac221dbe7179f0",
-      "source": "Rename Thread",
-      "translated": "Переименовать ветку"
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "Переименовать сеанс"
     },
     {
-      "id": "native.apple.cf0f7e049603f518",
-      "source": "Thread name",
-      "translated": "Название ветки"
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "Название сеанса"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24374,9 +24304,9 @@
       "translated": "Экспорт транскрипта"
     },
     {
-      "id": "native.apple.c0ada47504425f23",
-      "source": "Threads",
-      "translated": "Ветки"
+      "id": "native.apple.4af0f566d39d7041",
+      "source": "Sessions",
+      "translated": "Сеансы"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24449,14 +24379,14 @@
       "translated": "По умолчанию"
     },
     {
-      "id": "native.apple.1a765291943599e5",
-      "source": "New Thread",
-      "translated": "Новая ветка"
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "Новая сессия"
     },
     {
-      "id": "native.apple.c7a3a6d5e43dd98f",
-      "source": "New Thread Options…",
-      "translated": "Параметры новой ветки…"
+      "id": "native.apple.a7119fbf9d25df5e",
+      "source": "New Session Options…",
+      "translated": "Параметры нового сеанса…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24464,19 +24394,19 @@
       "translated": "Обновить"
     },
     {
-      "id": "native.apple.0e710b81808e5dcf",
-      "source": "Threads…",
-      "translated": "Ветки…"
+      "id": "native.apple.2bcff4a8fa503739",
+      "source": "Sessions…",
+      "translated": "Сеансы…"
     },
     {
-      "id": "native.apple.faad8f92b6bef166",
-      "source": "Rename Thread…",
-      "translated": "Переименовать ветку…"
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "Переименовать сеанс…"
     },
     {
-      "id": "native.apple.23b61d6cd26ac112",
-      "source": "Fork",
-      "translated": "Создать ответвление"
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "Создать ответвление сеанса"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24534,24 +24464,24 @@
       "translated": "Очистить историю…"
     },
     {
-      "id": "native.apple.8b4f1c5107ea8a0e",
-      "source": "Thread",
-      "translated": "Ветка"
+      "id": "native.apple.920fe8a7a33f9e92",
+      "source": "Session",
+      "translated": "Сессия"
     },
     {
-      "id": "native.apple.4d7750c9bf699469",
-      "source": "Thread actions",
-      "translated": "Действия с веткой"
+      "id": "native.apple.185a401f78328b0f",
+      "source": "Session actions",
+      "translated": "Действия сессии"
     },
     {
-      "id": "native.apple.bb2f22cc43c97f8e",
-      "source": "Thread cost %@",
-      "translated": "Стоимость ветки %@"
+      "id": "native.apple.9f9dedf599b2619b",
+      "source": "Session cost %@",
+      "translated": "Стоимость сеанса: %@"
     },
     {
-      "id": "native.apple.6239ced0b86e86f8",
-      "source": "Compact Thread",
-      "translated": "Сжать ветку"
+      "id": "native.apple.f0a4720df5f5f403",
+      "source": "Compact Session",
+      "translated": "Сжать сессию"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/sv.json
+++ b/apps/.i18n/native/sv.json
@@ -1429,9 +1429,9 @@
       "translated": "Prata eller diktera med OpenClaw"
     },
     {
-      "id": "native.android.5876e15e5e92fd45",
-      "source": "Browse Sessions",
-      "translated": "Bläddra bland sessioner"
+      "id": "native.android.e2cf5a38587382cb",
+      "source": "Browse Threads",
+      "translated": "Bläddra bland trådar"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "Inga åtgärder hittades"
     },
     {
-      "id": "native.android.48ad0ae0e930e02b",
-      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
-      "translated": "Prova Chatt, Röst, Sessioner, Providers eller Inställningar."
+      "id": "native.android.bc70a4ac965b82ba",
+      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
+      "translated": "Prova Chatt, Röst, Trådar, Leverantörer eller Inställningar."
     },
     {
-      "id": "native.android.d4fbd1ee4f55a5db",
-      "source": "Sessions",
-      "translated": "Sessioner"
+      "id": "native.android.670121e54dbe286f",
+      "source": "Threads",
+      "translated": "Trådar"
     },
     {
-      "id": "native.android.207c2170504e99e6",
-      "source": "Connect the Gateway to search sessions.",
-      "translated": "Anslut Gateway för att söka i sessioner."
+      "id": "native.android.d38be650b1bce4a0",
+      "source": "Connect the Gateway to search threads.",
+      "translated": "Anslut Gateway för att söka efter trådar."
     },
     {
-      "id": "native.android.25d2c2d792c952fe",
-      "source": "No matching sessions yet.",
-      "translated": "Inga matchande sessioner ännu."
+      "id": "native.android.3d7754721f776ef8",
+      "source": "No matching threads yet.",
+      "translated": "Inga matchande trådar än."
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "Assistenten arbetar"
     },
     {
-      "id": "native.android.8f8384286317f5c9",
-      "source": "OpenClaw session",
-      "translated": "OpenClaw-session"
+      "id": "native.android.9a839f6e3e05a744",
+      "source": "OpenClaw thread",
+      "translated": "OpenClaw-tråd"
     },
     {
-      "id": "native.android.15799e57704b20c6",
-      "source": "Open session",
-      "translated": "Öppna session"
+      "id": "native.android.d83f82a1e4a5ed99",
+      "source": "Open thread",
+      "translated": "Öppna tråd"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "Inga leverantörer redo"
     },
     {
-      "id": "native.android.73e6ab1a168fd381",
-      "source": "Main session",
-      "translated": "Huvudsession"
+      "id": "native.android.8a1c5365c0538908",
+      "source": "Main thread",
+      "translated": "Huvudtråd"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.0e3157c15c56944f",
-      "source": "Sessions",
-      "translated": "Sessioner"
+      "id": "native.android.a5845742daecb4ba",
+      "source": "Threads",
+      "translated": "Trådar"
     },
     {
-      "id": "native.android.70f5d0507d34b5c8",
-      "source": "Focus session search",
-      "translated": "Fokusera sessionssökningen"
+      "id": "native.android.439b324280869527",
+      "source": "Focus thread search",
+      "translated": "Fokusera trådsökningen"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "Arkiverad"
     },
     {
-      "id": "native.android.b9cf34c137e4cf03",
-      "source": "Search sessions",
-      "translated": "Sök sessioner"
+      "id": "native.android.03981341841b04ac",
+      "source": "Search threads",
+      "translated": "Sök efter trådar"
     },
     {
-      "id": "native.android.10cb26723e9990fc",
-      "source": "Clear session search",
-      "translated": "Rensa sessionssökningen"
+      "id": "native.android.99570c528a41fa72",
+      "source": "Clear thread search",
+      "translated": "Rensa trådsökningen"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "Äldsta först"
     },
     {
-      "id": "native.android.c6bf8751e2a7f5c7",
-      "source": "Toggle session layout",
-      "translated": "Växla sessionslayout"
+      "id": "native.android.fd67be543e321cc9",
+      "source": "Toggle thread layout",
+      "translated": "Växla trådlayout"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "Layout: Detaljerad"
     },
     {
-      "id": "native.android.69b79a3c2c987cd4",
-      "source": "Searching sessions",
-      "translated": "Söker efter sessioner"
+      "id": "native.android.ebd17565e0ffd8eb",
+      "source": "Searching threads",
+      "translated": "Söker efter trådar"
     },
     {
-      "id": "native.android.dd587d341af44212",
-      "source": "No matching sessions",
-      "translated": "Inga matchande sessioner"
+      "id": "native.android.472d46ae8669f860",
+      "source": "No matching threads",
+      "translated": "Inga matchande trådar"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "Starta chatt"
     },
     {
-      "id": "native.android.f10d4df7cbc6df4f",
-      "source": "Current session",
-      "translated": "Aktuell session"
+      "id": "native.android.ff81ad1bee00d384",
+      "source": "Current thread",
+      "translated": "Aktuell tråd"
     },
     {
-      "id": "native.android.8f0482425838ae64",
-      "source": "OpenClaw session",
-      "translated": "OpenClaw-session"
+      "id": "native.android.fc145645b9620e57",
+      "source": "OpenClaw thread",
+      "translated": "OpenClaw-tråd"
     },
     {
-      "id": "native.android.786774c8a76e50d7",
-      "source": "Rename session",
-      "translated": "Byt namn på session"
+      "id": "native.android.71cbb8dde8bf138b",
+      "source": "Rename thread",
+      "translated": "Byt namn på tråd"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "Ta bort grupp?"
     },
     {
-      "id": "native.android.3455fc2f77d564e3",
-      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "Sessioner i \"$group\" behålls och flyttas tillbaka till Ogrupperade."
+      "id": "native.android.691e92cfe5cf106e",
+      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "Trådar i \"$group\" behålls och flyttas tillbaka till Ogrupperade."
     },
     {
-      "id": "native.android.4805fb9d6623e8c0",
-      "source": "Delete session?",
-      "translated": "Ta bort session?"
+      "id": "native.android.d87a8217ab56999b",
+      "source": "Delete thread?",
+      "translated": "Ta bort tråden?"
     },
     {
-      "id": "native.android.0c3283a2b2445eae",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "Detta tar bort sessionen och dess transkript permanent."
+      "id": "native.android.930de97ff47113a8",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "Detta tar permanent bort tråden och dess transkription."
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "Ogrupperade"
     },
     {
-      "id": "native.android.db243d71d056afa4",
-      "source": "No sessions yet",
-      "translated": "Inga sessioner än"
+      "id": "native.android.8e21a70428def6e0",
+      "source": "No threads yet",
+      "translated": "Inga trådar ännu"
     },
     {
-      "id": "native.android.5b4eee6a8092925e",
-      "source": "No current session",
-      "translated": "Ingen aktuell session"
+      "id": "native.android.cda4c5ad8b17e394",
+      "source": "No current thread",
+      "translated": "Ingen aktuell tråd"
     },
     {
-      "id": "native.android.acbcc9c9ea53d8c0",
-      "source": "No archived sessions",
-      "translated": "Inga arkiverade sessioner"
+      "id": "native.android.be84f061047aa2da",
+      "source": "No archived threads",
+      "translated": "Inga arkiverade trådar"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "Starta en ny konversation så visas den här."
     },
     {
-      "id": "native.android.56fcd605dc7be3c0",
-      "source": "Open Chat to start or resume the current session.",
-      "translated": "Öppna Chat för att starta eller återuppta den aktuella sessionen."
+      "id": "native.android.f289d03e1d3eee98",
+      "source": "Open Chat to start or resume the current thread.",
+      "translated": "Öppna Chat för att starta eller återuppta den aktuella tråden."
     },
     {
-      "id": "native.android.085515989f8a2022",
-      "source": "Archived sessions will show up here.",
-      "translated": "Arkiverade sessioner visas här."
+      "id": "native.android.504b71386e76c6ae",
+      "source": "Archived threads will show up here.",
+      "translated": "Arkiverade trådar visas här."
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days} d"
     },
     {
-      "id": "native.android.3d4fa07acbc015c5",
-      "source": "Main session",
-      "translated": "Huvudsession"
+      "id": "native.android.ee4c727cdafbe963",
+      "source": "Main thread",
+      "translated": "Huvudtråd"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway väntar"
     },
     {
-      "id": "native.android.2d8d049afe99f751",
-      "source": "Session Activity",
-      "translated": "Sessionsaktivitet"
+      "id": "native.android.da78209effb11cfd",
+      "source": "Thread Activity",
+      "translated": "Trådaktivitet"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "Begäranden om Exec-godkännande visas här medan den här telefonen är ansluten."
     },
     {
-      "id": "native.android.dc3e7ca5a491103a",
-      "source": "Session activity",
-      "translated": "Sessionsaktivitet"
+      "id": "native.android.f615712dfb56319a",
+      "source": "Thread activity",
+      "translated": "Trådaktivitet"
     },
     {
-      "id": "native.android.8551e02b060bd7d8",
-      "source": "Chat tool calls waiting in the active session remain visible here.",
-      "translated": "Anrop till chattverktyg som väntar i den aktiva sessionen förblir synliga här."
+      "id": "native.android.6c93973c13db43ae",
+      "source": "Chat tool calls waiting in the active thread remain visible here.",
+      "translated": "Anrop till chattverktyg som väntar i den aktiva tråden visas fortfarande här."
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,6 +4294,11 @@
       "translated": "Konfiguration av Talk Provider"
     },
     {
+      "id": "native.android.23b638094c34b916",
+      "source": "Microphone",
+      "translated": "Mikrofon"
+    },
+    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "Ljudtest"
@@ -4337,6 +4342,66 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "Klart"
+    },
+    {
+      "id": "native.android.8d9ecdfdd916b780",
+      "source": "Automatic",
+      "translated": "Automatiskt"
+    },
+    {
+      "id": "native.android.c1626a6700a570f6",
+      "source": "Preferred microphone unavailable; using automatic routing.",
+      "translated": "Den föredragna mikrofonen är inte tillgänglig. Automatisk dirigering används."
+    },
+    {
+      "id": "native.android.820bc5d0ce571d8b",
+      "source": "Prioritizes connected Bluetooth microphones.",
+      "translated": "Prioriterar anslutna Bluetooth-mikrofoner."
+    },
+    {
+      "id": "native.android.11e48038d5e8bff6",
+      "source": "Preferred microphone",
+      "translated": "Föredragen mikrofon"
+    },
+    {
+      "id": "native.android.eaa4d7563a46d307",
+      "source": "Unavailable",
+      "translated": "Inte tillgänglig"
+    },
+    {
+      "id": "native.android.9f5ebf17eb405ba8",
+      "source": "Next session",
+      "translated": "Nästa session"
+    },
+    {
+      "id": "native.android.8c4e91f53928efb2",
+      "source": "Built-in microphone",
+      "translated": "Inbyggd mikrofon"
+    },
+    {
+      "id": "native.android.14b613cb6e2446b4",
+      "source": "Bluetooth microphone",
+      "translated": "Bluetooth-mikrofon"
+    },
+    {
+      "id": "native.android.c885247b2d7ce271",
+      "source": "Bluetooth LE microphone",
+      "translated": "Bluetooth LE-mikrofon"
+    },
+    {
+      "id": "native.android.b6a4e674c5fb441a",
+      "source": "Wired headset microphone",
+      "translated": "Mikrofon på trådbundet headset"
+    },
+    {
+      "id": "native.android.9c8becb3b0fb5a90",
+      "source": "USB microphone",
+      "translated": "USB-mikrofon"
+    },
+    {
+      "id": "native.android.ba46258fadec7a39",
+      "source": "External microphone",
+      "translated": "Extern mikrofon"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5074,9 +5139,9 @@
       "translated": "Kontrollera"
     },
     {
-      "id": "native.android.5a540761383fa474",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
-      "translated": "OpenClaw förvandlar telefonen till en ren mobil kommandoyta för sessioner, röst, leverantörer och Gateway."
+      "id": "native.android.c971506716c96e91",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
+      "translated": "OpenClaw förvandlar den här telefonen till en ren mobil kommandoyta för trådar, röst, leverantörer och Gateway."
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5624,9 +5689,9 @@
       "translated": "Talk-inställningar"
     },
     {
-      "id": "native.android.73f07a5d54915259",
-      "source": "Recent Sessions",
-      "translated": "Senaste sessioner"
+      "id": "native.android.36f78c8c85dc283f",
+      "source": "Recent Threads",
+      "translated": "Senaste trådarna"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5684,14 +5749,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online"
     },
     {
-      "id": "native.android.16c3425d3a594481",
-      "source": "Sessions",
-      "translated": "Sessioner"
+      "id": "native.android.57177017a6a93826",
+      "source": "Threads",
+      "translated": "Trådar"
     },
     {
-      "id": "native.android.a5c0f8b3112aa58c",
-      "source": "No recent sessions",
-      "translated": "Inga senaste sessioner"
+      "id": "native.android.43320b54a68b00a1",
+      "source": "No recent threads",
+      "translated": "Inga senaste trådar"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5729,14 +5794,14 @@
       "translated": "Arbetar · $pendingRunCount aktiva körningar"
     },
     {
-      "id": "native.android.2c89da708b12a522",
-      "source": "Monitoring · 1 session",
-      "translated": "Övervakar · 1 session"
+      "id": "native.android.e24db059480f1e6a",
+      "source": "Monitoring · 1 thread",
+      "translated": "Övervakning · 1 tråd"
     },
     {
-      "id": "native.android.8b6ee382dcb64e1f",
-      "source": "Monitoring · $sessionCount sessions",
-      "translated": "Övervakar · $sessionCount sessioner"
+      "id": "native.android.5a475f37d80e02bc",
+      "source": "Monitoring · $sessionCount threads",
+      "translated": "Övervakning · $sessionCount trådar"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5769,9 +5834,9 @@
       "translated": "Leverantörer"
     },
     {
-      "id": "native.android.a65477861c7203aa",
-      "source": "Open session",
-      "translated": "Öppna session"
+      "id": "native.android.358c5e0e838d5423",
+      "source": "Open thread",
+      "translated": "Öppna tråd"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6194,9 +6259,9 @@
       "translated": "${days} d"
     },
     {
-      "id": "native.android.22d755834386db07",
-      "source": "Main session",
-      "translated": "Huvudsession"
+      "id": "native.android.28a1a1acc5a0959f",
+      "source": "Main thread",
+      "translated": "Huvudtråd"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6877,6 +6942,16 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "Slå på ljud"
+    },
+    {
+      "id": "native.android.cb608d82c5b3352a",
+      "source": "Back camera",
+      "translated": "Bakre kamera"
+    },
+    {
+      "id": "native.android.e89a0e780eed2e1e",
+      "source": "Front camera",
+      "translated": "Främre kamera"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7684,9 +7759,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.882cc14a58e7e105",
-      "source": "Loading session",
-      "translated": "Läser in session"
+      "id": "native.android.0c74bc30a994dd33",
+      "source": "Loading thread",
+      "translated": "Läser in tråd"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7729,14 +7804,14 @@
       "translated": "Uppdatera mig"
     },
     {
-      "id": "native.android.1e5add56e48c99f9",
-      "source": "Summarize recent sessions and next steps.",
-      "translated": "Sammanfatta de senaste sessionerna och nästa steg."
+      "id": "native.android.cf40df9739f78f27",
+      "source": "Summarize recent threads and next steps.",
+      "translated": "Sammanfatta de senaste trådarna och nästa steg."
     },
     {
-      "id": "native.android.06d515351bb79576",
-      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
-      "translated": "Uppdatera mig om mina senaste OpenClaw-sessioner och föreslå nästa steg."
+      "id": "native.android.ebe49a8b8df80bd3",
+      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
+      "translated": "Uppdatera mig om mina senaste OpenClaw-trådar och föreslå nästa steg."
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8074,9 +8149,9 @@
       "translated": "Ansluten"
     },
     {
-      "id": "native.android.81931886b9caf3ab",
-      "source": "Sessions",
-      "translated": "Sessioner"
+      "id": "native.android.6cf5d6fa8a4186d5",
+      "source": "Threads",
+      "translated": "Trådar"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,9 +10869,9 @@
       "translated": "Vad vill du arbeta med?"
     },
     {
-      "id": "native.apple.32179ce0b6d4543f",
-      "source": "The session attaches once the gateway is ready.",
-      "translated": "Sessionen ansluter när Gateway är redo."
+      "id": "native.apple.4da775013ac9b123",
+      "source": "The thread attaches once the gateway is ready.",
+      "translated": "Tråden ansluts när Gateway är redo."
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10844,9 +10919,9 @@
       "translated": "Alternativ för ny session…"
     },
     {
-      "id": "native.apple.a1b0d289758e2213",
-      "source": "Sessions…",
-      "translated": "Sessioner…"
+      "id": "native.apple.003b25ddafeb18e9",
+      "source": "Threads…",
+      "translated": "Trådar…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11009,14 +11084,14 @@
       "translated": "Skapa"
     },
     {
-      "id": "native.apple.f488b9caf6e51ac3",
-      "source": "Delete Session?",
-      "translated": "Radera session?"
+      "id": "native.apple.31d5c7287cfb3abe",
+      "source": "Delete Thread?",
+      "translated": "Ta bort tråden?"
     },
     {
-      "id": "native.apple.8634b17be9b111bc",
-      "source": "Delete Session",
-      "translated": "Radera session"
+      "id": "native.apple.d3395564809f1120",
+      "source": "Delete Thread",
+      "translated": "Radera tråd"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11024,9 +11099,9 @@
       "translated": "Avbryt"
     },
     {
-      "id": "native.apple.4a9568ac9b18d8d3",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "Detta raderar sessionen och dess transkript permanent."
+      "id": "native.apple.092659256d26cb03",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "Detta raderar tråden och dess transkription permanent."
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11054,9 +11129,9 @@
       "translated": "Ny grupp"
     },
     {
-      "id": "native.apple.5bccdc23a1640895",
-      "source": "Rename Session",
-      "translated": "Byt namn på session"
+      "id": "native.apple.683032464c497bbd",
+      "source": "Rename Thread",
+      "translated": "Byt namn på tråd"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11064,9 +11139,9 @@
       "translated": "Gruppnamn"
     },
     {
-      "id": "native.apple.af789b2d2fda0f67",
-      "source": "Session name",
-      "translated": "Sessionsnamn"
+      "id": "native.apple.f887aa956588f237",
+      "source": "Thread name",
+      "translated": "Trådnamn"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11104,14 +11179,14 @@
       "translated": "Agenter"
     },
     {
-      "id": "native.apple.a3bde8045fe9224a",
-      "source": "Agent session",
-      "translated": "Agentsession"
+      "id": "native.apple.7c8231b7b1ca480f",
+      "source": "Agent thread",
+      "translated": "Agenttråd"
     },
     {
-      "id": "native.apple.27f775de30b37ff8",
-      "source": "Recent sessions",
-      "translated": "Senaste sessioner"
+      "id": "native.apple.b3c553614f762a58",
+      "source": "Recent threads",
+      "translated": "Senaste trådarna"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11119,9 +11194,9 @@
       "translated": "Gateway offline"
     },
     {
-      "id": "native.apple.28c97cf23665ee01",
-      "source": "No recent sessions",
-      "translated": "Inga senaste sessioner"
+      "id": "native.apple.5aa32afda85064ea",
+      "source": "No recent threads",
+      "translated": "Inga senaste trådar"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11219,14 +11294,14 @@
       "translated": "Avbryt"
     },
     {
-      "id": "native.apple.9f2fd65953013b7c",
-      "source": "Sessions",
-      "translated": "Sessioner"
+      "id": "native.apple.b6855cf19a50f477",
+      "source": "Threads",
+      "translated": "Trådar"
     },
     {
-      "id": "native.apple.0422818cc95d5071",
-      "source": "Archived sessions",
-      "translated": "Arkiverade sessioner"
+      "id": "native.apple.9b1d0ef27a1333b0",
+      "source": "Archived threads",
+      "translated": "Arkiverade trådar"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11234,34 +11309,34 @@
       "translated": "Visa arkiverade"
     },
     {
-      "id": "native.apple.b272115c83f7ef58",
-      "source": "Sessions unavailable",
-      "translated": "Sessioner är inte tillgängliga"
+      "id": "native.apple.98167401c7267735",
+      "source": "Threads unavailable",
+      "translated": "Trådarna är inte tillgängliga"
     },
     {
-      "id": "native.apple.54f8260c9b863087",
-      "source": "Loading archived sessions",
-      "translated": "Läser in arkiverade sessioner"
+      "id": "native.apple.4d28a7def2337b9f",
+      "source": "Loading archived threads",
+      "translated": "Läser in arkiverade trådar"
     },
     {
-      "id": "native.apple.9b305868873dade2",
-      "source": "Loading recent sessions",
-      "translated": "Läser in senaste sessioner"
+      "id": "native.apple.777d7b706933bd7b",
+      "source": "Loading recent threads",
+      "translated": "Läser in senaste trådarna"
     },
     {
-      "id": "native.apple.207dad20d09f3160",
-      "source": "^[\\(count) session](inflect: true)",
-      "translated": "^[\\(count) session](inflect: true)"
+      "id": "native.apple.22f81ea94bef8410",
+      "source": "^[\\(count) thread](inflect: true)",
+      "translated": "^[\\(count) tråd](inflect: true)"
     },
     {
-      "id": "native.apple.1f4501a6bf2bae4c",
-      "source": "No archived sessions",
-      "translated": "Inga arkiverade sessioner"
+      "id": "native.apple.1cad51e14db59bf9",
+      "source": "No archived threads",
+      "translated": "Inga arkiverade trådar"
     },
     {
-      "id": "native.apple.2a1ba7a5e1979c9e",
-      "source": "Archived sessions will appear here.",
-      "translated": "Arkiverade sessioner visas här."
+      "id": "native.apple.18ef832d3a7ddcf8",
+      "source": "Archived threads will appear here.",
+      "translated": "Arkiverade trådar visas här."
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11344,9 +11419,9 @@
       "translated": "Dela intag"
     },
     {
-      "id": "native.apple.2360d25fe6ae9946",
-      "source": "Loading sessions",
-      "translated": "Läser in sessioner"
+      "id": "native.apple.21d9208d86a4d1fe",
+      "source": "Loading threads",
+      "translated": "Läser in trådar"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11354,19 +11429,19 @@
       "translated": "Hämtar senaste aktivitet från gatewayen."
     },
     {
-      "id": "native.apple.c334f2e86702a7b8",
-      "source": "Sessions unavailable",
-      "translated": "Sessioner är inte tillgängliga"
+      "id": "native.apple.4be1f79aa2b230ff",
+      "source": "Threads unavailable",
+      "translated": "Trådarna är inte tillgängliga"
     },
     {
-      "id": "native.apple.6cc6efb7a03960b6",
-      "source": "No recent sessions",
-      "translated": "Inga senaste sessioner"
+      "id": "native.apple.98b348873556bc46",
+      "source": "No recent threads",
+      "translated": "Inga senaste trådar"
     },
     {
-      "id": "native.apple.08483af2d043bee6",
-      "source": "Session activity offline",
-      "translated": "Sessionsaktivitet offline"
+      "id": "native.apple.7396d205574d279f",
+      "source": "Thread activity offline",
+      "translated": "Trådaktiviteten är offline"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11824,9 +11899,9 @@
       "translated": "Kort"
     },
     {
-      "id": "native.apple.93eeaedb2ff61043",
-      "source": "Open Session",
-      "translated": "Öppna session"
+      "id": "native.apple.c9ec1b0e18074d8a",
+      "source": "Open Thread",
+      "translated": "Öppna tråd"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13314,9 +13389,9 @@
       "translated": "Standard"
     },
     {
-      "id": "native.apple.3de045f17ea3c6d0",
-      "source": "Used for new Chat and Talk sessions.",
-      "translated": "Används för nya chatt- och samtalssessioner."
+      "id": "native.apple.f4ae5664c3eda95d",
+      "source": "Used for new Chat threads and Talk sessions.",
+      "translated": "Används för nya chatttrådar och samtalssessioner."
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15719,9 +15794,9 @@
       "translated": "Instanser"
     },
     {
-      "id": "native.apple.3579cf2750470a22",
-      "source": "Sessions",
-      "translated": "Sessioner"
+      "id": "native.apple.11fe8b9941954dfb",
+      "source": "Threads",
+      "translated": "Trådar"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19029,9 +19104,9 @@
       "translated": "Kortkommando för snabbchatt"
     },
     {
-      "id": "native.apple.6ae77665b5f4490f",
-      "source": "Global shortcut that opens a floating chat bar for the main session.",
-      "translated": "Globalt kortkommando som öppnar ett flytande chattfält för huvudsessionen."
+      "id": "native.apple.94dd793cd7d7d555",
+      "source": "Global shortcut that opens a floating chat bar for the main thread.",
+      "translated": "Globalt kortkommando som öppnar ett flytande chattfält för huvudtråden."
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19609,9 +19684,9 @@
       "translated": "Kritisk"
     },
     {
-      "id": "native.apple.75102378a6775180",
-      "source": "New Session",
-      "translated": "Ny session"
+      "id": "native.apple.13f96467014cf344",
+      "source": "New Thread",
+      "translated": "Ny tråd"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21899,9 +21974,9 @@
       "translated": "Inga senaste meddelanden"
     },
     {
-      "id": "native.apple.1ff8aec0044934c3",
-      "source": "Sessions",
-      "translated": "Sessioner"
+      "id": "native.apple.3ec2afcbc298c673",
+      "source": "Threads",
+      "translated": "Trådar"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21909,9 +21984,9 @@
       "translated": "Titta på de lagrade konversationsbuckets som CLI återanvänder för kontext och hastighetsbegränsningar."
     },
     {
-      "id": "native.apple.bab897f3252b134c",
-      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
-      "translated": "Inga sessioner än. De visas efter det första inkommande meddelandet eller heartbeat."
+      "id": "native.apple.14ccb32cd8ed1c81",
+      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
+      "translated": "Inga trådar än. De visas efter det första inkommande meddelandet eller den första heartbeat-signalen."
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -21994,9 +22069,9 @@
       "translated": "Körningsgodkännanden"
     },
     {
-      "id": "native.apple.64a6dc7d49e8fb57",
-      "source": "Sessions",
-      "translated": "Sessioner"
+      "id": "native.apple.52e37e3a44ae516c",
+      "source": "Threads",
+      "translated": "Trådar"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -22999,9 +23074,9 @@
       "translated": "Uppdatera mig"
     },
     {
-      "id": "native.apple.234ec45f4231edc4",
-      "source": "Summarize what happened in my sessions since yesterday.",
-      "translated": "Sammanfatta vad som har hänt i mina sessioner sedan i går."
+      "id": "native.apple.fc4ce810900ec0b6",
+      "source": "Summarize what happened in my threads since yesterday.",
+      "translated": "Sammanfatta vad som har hänt i mina trådar sedan i går."
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23179,9 +23254,9 @@
       "translated": "Lossa modell"
     },
     {
-      "id": "native.apple.5dfc0700d8dff8de",
-      "source": "Session",
-      "translated": "Session"
+      "id": "native.apple.4edb66657f5aca1f",
+      "source": "Thread",
+      "translated": "Tråd"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23344,6 +23419,51 @@
       "translated": "Widgeten är inte tillgänglig"
     },
     {
+      "id": "native.apple.d640691fd196f338",
+      "source": "Widget export failed",
+      "translated": "Det gick inte att exportera widgeten"
+    },
+    {
+      "id": "native.apple.533c6e22a11e88de",
+      "source": "OK",
+      "translated": "OK"
+    },
+    {
+      "id": "native.apple.e1fb28a2a9756402",
+      "source": "Copy image",
+      "translated": "Kopiera bild"
+    },
+    {
+      "id": "native.apple.ebd7bc92e1b12235",
+      "source": "Save image…",
+      "translated": "Spara bild…"
+    },
+    {
+      "id": "native.apple.742c46d4cf2db134",
+      "source": "Save image",
+      "translated": "Spara bild"
+    },
+    {
+      "id": "native.apple.0589cce608418f90",
+      "source": "The widget image could not be captured.",
+      "translated": "Det gick inte att ta en bild av widgeten."
+    },
+    {
+      "id": "native.apple.dfe24e827fdbe9c5",
+      "source": "The widget image could not be copied.",
+      "translated": "Det gick inte att kopiera widgetbilden."
+    },
+    {
+      "id": "native.apple.9e611e3a80e71408",
+      "source": "The widget image could not be encoded as PNG.",
+      "translated": "Det gick inte att koda widgetbilden som PNG."
+    },
+    {
+      "id": "native.apple.9a6e8afbe24a262b",
+      "source": "The widget image could not be saved.",
+      "translated": "Det gick inte att spara widgetbilden."
+    },
+    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23484,19 +23604,19 @@
       "translated": "Användare"
     },
     {
-      "id": "native.apple.b1cdcb906a43d5d6",
-      "source": "This session cannot be archived while it is active or running.",
-      "translated": "Den här sessionen kan inte arkiveras medan den är aktiv eller körs."
+      "id": "native.apple.9d0cba09d92ee669",
+      "source": "This thread cannot be archived while it is active or running.",
+      "translated": "Den här tråden kan inte arkiveras medan den är aktiv eller körs."
     },
     {
-      "id": "native.apple.5817e3f3dab1ee19",
-      "source": "The main session cannot be deleted.",
-      "translated": "Huvudsessionen kan inte tas bort."
+      "id": "native.apple.8952a111a1075051",
+      "source": "The main thread cannot be deleted.",
+      "translated": "Huvudtråden kan inte raderas."
     },
     {
-      "id": "native.apple.a6b8df3f18171c91",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
-      "translated": "Ta bort bilagor eller vänta på leverans innan du arkiverar eller tar bort den här sessionen."
+      "id": "native.apple.90d0ccf80ca28717",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
+      "translated": "Ta bort bilagor eller vänta tills de har levererats innan du arkiverar eller tar bort den här tråden."
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23634,9 +23754,9 @@
       "translated": "Körning avslutad"
     },
     {
-      "id": "native.apple.cd7c3095a22f80a9",
-      "source": "Session Info",
-      "translated": "Sessionsinformation"
+      "id": "native.apple.bbccb4c8db5cac12",
+      "source": "Thread Info",
+      "translated": "Trådinformation"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23669,9 +23789,9 @@
       "translated": "Lägg till grupp"
     },
     {
-      "id": "native.apple.23d628606fe0734f",
-      "source": "Session Groups",
-      "translated": "Sessionsgrupper"
+      "id": "native.apple.7b641fed5bace855",
+      "source": "Thread Groups",
+      "translated": "Trådgrupper"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23714,9 +23834,9 @@
       "translated": "Ta bort grupp"
     },
     {
-      "id": "native.apple.b049c8a4d2805e08",
-      "source": "Sessions in this group become ungrouped.",
-      "translated": "Sessioner i den här gruppen blir ogrupperade."
+      "id": "native.apple.56401c79410a310d",
+      "source": "Threads in this group become ungrouped.",
+      "translated": "Trådar i den här gruppen blir ogrupperade."
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23729,9 +23849,9 @@
       "translated": "Inga agenter är tillgängliga på denna gateway."
     },
     {
-      "id": "native.apple.6c89f35d53506406",
-      "source": "New Session Options",
-      "translated": "Alternativ för ny session"
+      "id": "native.apple.2d96aa7d3d12f85b",
+      "source": "New Thread Options",
+      "translated": "Alternativ för ny tråd"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23759,19 +23879,19 @@
       "translated": "Skapa"
     },
     {
-      "id": "native.apple.795ba37f6782cf28",
-      "source": "The session could not be created.",
-      "translated": "Sessionen kunde inte skapas."
+      "id": "native.apple.87ef57319d1ddc85",
+      "source": "The thread could not be created.",
+      "translated": "Det gick inte att skapa tråden."
     },
     {
-      "id": "native.apple.8ec708a3605a2cc3",
-      "source": "Search sessions",
-      "translated": "Sök sessioner"
+      "id": "native.apple.6bd91c435b69d638",
+      "source": "Search threads",
+      "translated": "Sök efter trådar"
     },
     {
-      "id": "native.apple.23b069b4e7f97039",
-      "source": "No Sessions",
-      "translated": "Inga sessioner"
+      "id": "native.apple.6fde4bdf9d5b9191",
+      "source": "No Threads",
+      "translated": "Inga trådar"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23779,29 +23899,29 @@
       "translated": "Inga resultat"
     },
     {
-      "id": "native.apple.0058923f2ce8a3ec",
-      "source": "New Session",
-      "translated": "Ny session"
+      "id": "native.apple.a02fd99740d29bd3",
+      "source": "New Thread",
+      "translated": "Ny tråd"
     },
     {
-      "id": "native.apple.66ba42960eb4135b",
-      "source": "New session",
-      "translated": "Ny session"
+      "id": "native.apple.b625801dd04b09f2",
+      "source": "New thread",
+      "translated": "Ny tråd"
     },
     {
-      "id": "native.apple.2ef0e34db02ad255",
-      "source": "New session options",
-      "translated": "Alternativ för ny session"
+      "id": "native.apple.851be81fcc933608",
+      "source": "New thread options",
+      "translated": "Alternativ för ny tråd"
     },
     {
-      "id": "native.apple.36753ef2f1ed4264",
-      "source": "Rename Session",
-      "translated": "Byt namn på session"
+      "id": "native.apple.9ce8a4aba7b444b2",
+      "source": "Rename Thread",
+      "translated": "Byt namn på tråd"
     },
     {
-      "id": "native.apple.c9de0a1510ef475f",
-      "source": "Session name",
-      "translated": "Sessionsnamn"
+      "id": "native.apple.1dd067c44511c7f0",
+      "source": "Thread name",
+      "translated": "Trådnamn"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23814,14 +23934,14 @@
       "translated": "Avbryt"
     },
     {
-      "id": "native.apple.afb4e6c99c63a28d",
-      "source": "Delete Session",
-      "translated": "Radera session"
+      "id": "native.apple.618073d6ab3f2721",
+      "source": "Delete Thread",
+      "translated": "Ta bort tråd"
     },
     {
-      "id": "native.apple.3d4ef32e42f136a4",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "Sessionen och dess transkription tas bort från Gateway."
+      "id": "native.apple.10a5e72bba3cbccc",
+      "source": "The thread and its transcript are removed from the gateway.",
+      "translated": "Tråden och dess transkript tas bort från gatewayen."
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23829,14 +23949,14 @@
       "translated": "Radera ”%@”?"
     },
     {
-      "id": "native.apple.9a7dca238fba628d",
-      "source": "Session running",
-      "translated": "Sessionen körs"
+      "id": "native.apple.ac71e3b2aa496a2c",
+      "source": "Thread running",
+      "translated": "Tråden körs"
     },
     {
-      "id": "native.apple.fcfbfe5e97a95e9c",
-      "source": "Session failed",
-      "translated": "Sessionen misslyckades"
+      "id": "native.apple.c775e87f997278b2",
+      "source": "Thread failed",
+      "translated": "Tråden misslyckades"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23894,9 +24014,9 @@
       "translated": "Kopiera sessionsnyckel"
     },
     {
-      "id": "native.apple.4aeb7c14c26dabac",
-      "source": "Delete Session…",
-      "translated": "Radera session…"
+      "id": "native.apple.f4998cfb572f23ff",
+      "source": "Delete Thread…",
+      "translated": "Ta bort tråd…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23909,9 +24029,9 @@
       "translated": "Ansluter…"
     },
     {
-      "id": "native.apple.79f708b3bc1d3a6c",
-      "source": "Retry session groups",
-      "translated": "Försök läsa in sessionsgrupper igen"
+      "id": "native.apple.8802e9576ffd0f65",
+      "source": "Retry thread groups",
+      "translated": "Försök läsa in trådgrupper igen"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23934,24 +24054,24 @@
       "translated": "Omfattning"
     },
     {
-      "id": "native.apple.2c37581c7b88f741",
-      "source": "Search sessions",
-      "translated": "Sök sessioner"
+      "id": "native.apple.b313b80def4bda52",
+      "source": "Search threads",
+      "translated": "Sök efter trådar"
     },
     {
-      "id": "native.apple.43be8a2336e42faf",
-      "source": "Sessions",
-      "translated": "Sessioner"
+      "id": "native.apple.c0cc6acc36f413ce",
+      "source": "Threads",
+      "translated": "Trådar"
     },
     {
-      "id": "native.apple.0b379cdfcbd3247f",
-      "source": "Rename Session",
-      "translated": "Byt namn på session"
+      "id": "native.apple.854d3928fe5a557c",
+      "source": "Rename Thread",
+      "translated": "Byt namn på tråd"
     },
     {
-      "id": "native.apple.54b6fbd9e41db009",
-      "source": "Session name",
-      "translated": "Sessionsnamn"
+      "id": "native.apple.9d0d3f20096cc4da",
+      "source": "Thread name",
+      "translated": "Trådnamn"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -23959,19 +24079,19 @@
       "translated": "Avbryt"
     },
     {
-      "id": "native.apple.751e0f6b81cd374a",
-      "source": "Delete selected sessions?",
-      "translated": "Ta bort valda sessioner?"
+      "id": "native.apple.dc00eb94f33bae15",
+      "source": "Delete selected threads?",
+      "translated": "Ta bort markerade trådar?"
     },
     {
-      "id": "native.apple.aa679276581b0058",
-      "source": "Delete Sessions",
-      "translated": "Ta bort sessioner"
+      "id": "native.apple.2053fc9f74dc3158",
+      "source": "Delete Threads",
+      "translated": "Ta bort trådar"
     },
     {
-      "id": "native.apple.f837129cbee23297",
-      "source": "Each selected session and its transcript will be removed from the gateway.",
-      "translated": "Varje vald session och dess transkription tas bort från Gateway."
+      "id": "native.apple.0970247871a834a0",
+      "source": "Each selected thread and its transcript will be removed from the gateway.",
+      "translated": "Varje markerad tråd och dess transkript tas bort från gatewayen."
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -23979,9 +24099,9 @@
       "translated": "Grupper"
     },
     {
-      "id": "native.apple.64013cfee5e25305",
-      "source": "Manage session groups",
-      "translated": "Hantera sessionsgrupper"
+      "id": "native.apple.6f8acab2256728b5",
+      "source": "Manage thread groups",
+      "translated": "Hantera trådgrupper"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -23994,14 +24114,14 @@
       "translated": "Välj"
     },
     {
-      "id": "native.apple.b67eaecec1b423ac",
-      "source": "No archived sessions",
-      "translated": "Inga arkiverade sessioner"
+      "id": "native.apple.692972314d04b184",
+      "source": "No archived threads",
+      "translated": "Inga arkiverade trådar"
     },
     {
-      "id": "native.apple.b2435a79abf0c794",
-      "source": "No sessions found",
-      "translated": "Inga sessioner hittades"
+      "id": "native.apple.d6a4b5711dcd26e7",
+      "source": "No threads found",
+      "translated": "Inga trådar hittades"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24169,6 +24289,16 @@
       "translated": "Öppna hela meddelandet"
     },
     {
+      "id": "native.apple.002bfcede229ad4b",
+      "source": "Rewind to Here",
+      "translated": "Spola tillbaka hit"
+    },
+    {
+      "id": "native.apple.14df2e4997689fb3",
+      "source": "Fork from Here",
+      "translated": "Förgrena härifrån"
+    },
+    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "Svara"
@@ -24254,9 +24384,9 @@
       "translated": "Ta bort bilagor eller vänta tills leveransen är klar innan du startar en ny chatt."
     },
     {
-      "id": "native.apple.980f552bb0f96c0f",
-      "source": "Gateway changed before the session operation started.",
-      "translated": "Gateway ändrades innan sessionsåtgärden startade."
+      "id": "native.apple.e0f045151c8d3137",
+      "source": "Gateway changed before the thread operation started.",
+      "translated": "Gateway ändrades innan trådåtgärden startade."
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24264,9 +24394,9 @@
       "translated": "Ta bort bilagor eller vänta på att leveransen slutförs innan du byter chatt."
     },
     {
-      "id": "native.apple.87ba543b42696b92",
-      "source": "Clear this session's history?",
-      "translated": "Rensa den här sessionens historik?"
+      "id": "native.apple.0a5c4e15466c3acc",
+      "source": "Clear this thread's history?",
+      "translated": "Rensa den här trådens historik?"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24279,14 +24409,14 @@
       "translated": "Detta återställer konversationen för %@. Sessionsnyckeln förblir densamma."
     },
     {
-      "id": "native.apple.a92e96bed98bd553",
-      "source": "Rename Session",
-      "translated": "Byt namn på session"
+      "id": "native.apple.67ac221dbe7179f0",
+      "source": "Rename Thread",
+      "translated": "Byt namn på tråd"
     },
     {
-      "id": "native.apple.848e2388f3466f40",
-      "source": "Session name",
-      "translated": "Sessionsnamn"
+      "id": "native.apple.cf0f7e049603f518",
+      "source": "Thread name",
+      "translated": "Trådnamn"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24304,9 +24434,9 @@
       "translated": "Exportera transkription"
     },
     {
-      "id": "native.apple.4af0f566d39d7041",
-      "source": "Sessions",
-      "translated": "Sessioner"
+      "id": "native.apple.c0ada47504425f23",
+      "source": "Threads",
+      "translated": "Trådar"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24379,14 +24509,14 @@
       "translated": "Standard"
     },
     {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "Ny session"
+      "id": "native.apple.1a765291943599e5",
+      "source": "New Thread",
+      "translated": "Ny tråd"
     },
     {
-      "id": "native.apple.a7119fbf9d25df5e",
-      "source": "New Session Options…",
-      "translated": "Alternativ för ny session…"
+      "id": "native.apple.c7a3a6d5e43dd98f",
+      "source": "New Thread Options…",
+      "translated": "Alternativ för ny tråd…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24394,19 +24524,19 @@
       "translated": "Uppdatera"
     },
     {
-      "id": "native.apple.2bcff4a8fa503739",
-      "source": "Sessions…",
-      "translated": "Sessioner…"
+      "id": "native.apple.0e710b81808e5dcf",
+      "source": "Threads…",
+      "translated": "Trådar…"
     },
     {
-      "id": "native.apple.c36e008b051adb38",
-      "source": "Rename Session…",
-      "translated": "Byt namn på session…"
+      "id": "native.apple.faad8f92b6bef166",
+      "source": "Rename Thread…",
+      "translated": "Byt namn på tråd…"
     },
     {
-      "id": "native.apple.ea0ef95a159bffe0",
-      "source": "Fork Session",
-      "translated": "Förgrena session"
+      "id": "native.apple.23b61d6cd26ac112",
+      "source": "Fork",
+      "translated": "Förgrena"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24464,24 +24594,24 @@
       "translated": "Rensa historik…"
     },
     {
-      "id": "native.apple.920fe8a7a33f9e92",
-      "source": "Session",
-      "translated": "Session"
+      "id": "native.apple.8b4f1c5107ea8a0e",
+      "source": "Thread",
+      "translated": "Tråd"
     },
     {
-      "id": "native.apple.185a401f78328b0f",
-      "source": "Session actions",
-      "translated": "Sessionsåtgärder"
+      "id": "native.apple.4d7750c9bf699469",
+      "source": "Thread actions",
+      "translated": "Trådåtgärder"
     },
     {
-      "id": "native.apple.9f9dedf599b2619b",
-      "source": "Session cost %@",
-      "translated": "Sessionskostnad %@"
+      "id": "native.apple.bb2f22cc43c97f8e",
+      "source": "Thread cost %@",
+      "translated": "Trådkostnad %@"
     },
     {
-      "id": "native.apple.f0a4720df5f5f403",
-      "source": "Compact Session",
-      "translated": "Komprimera session"
+      "id": "native.apple.6239ced0b86e86f8",
+      "source": "Compact Thread",
+      "translated": "Komprimera tråd"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/sv.json
+++ b/apps/.i18n/native/sv.json
@@ -1429,9 +1429,9 @@
       "translated": "Prata eller diktera med OpenClaw"
     },
     {
-      "id": "native.android.e2cf5a38587382cb",
-      "source": "Browse Threads",
-      "translated": "Bläddra bland trådar"
+      "id": "native.android.5876e15e5e92fd45",
+      "source": "Browse Sessions",
+      "translated": "Bläddra bland sessioner"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "Inga åtgärder hittades"
     },
     {
-      "id": "native.android.bc70a4ac965b82ba",
-      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
-      "translated": "Prova Chatt, Röst, Trådar, Leverantörer eller Inställningar."
+      "id": "native.android.48ad0ae0e930e02b",
+      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
+      "translated": "Prova Chatt, Röst, Sessioner, Providers eller Inställningar."
     },
     {
-      "id": "native.android.670121e54dbe286f",
-      "source": "Threads",
-      "translated": "Trådar"
+      "id": "native.android.d4fbd1ee4f55a5db",
+      "source": "Sessions",
+      "translated": "Sessioner"
     },
     {
-      "id": "native.android.d38be650b1bce4a0",
-      "source": "Connect the Gateway to search threads.",
-      "translated": "Anslut Gateway för att söka efter trådar."
+      "id": "native.android.207c2170504e99e6",
+      "source": "Connect the Gateway to search sessions.",
+      "translated": "Anslut Gateway för att söka i sessioner."
     },
     {
-      "id": "native.android.3d7754721f776ef8",
-      "source": "No matching threads yet.",
-      "translated": "Inga matchande trådar ännu."
+      "id": "native.android.25d2c2d792c952fe",
+      "source": "No matching sessions yet.",
+      "translated": "Inga matchande sessioner ännu."
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "Assistenten arbetar"
     },
     {
-      "id": "native.android.9a839f6e3e05a744",
-      "source": "OpenClaw thread",
-      "translated": "OpenClaw-tråd"
+      "id": "native.android.8f8384286317f5c9",
+      "source": "OpenClaw session",
+      "translated": "OpenClaw-session"
     },
     {
-      "id": "native.android.d83f82a1e4a5ed99",
-      "source": "Open thread",
-      "translated": "Öppna tråd"
+      "id": "native.android.15799e57704b20c6",
+      "source": "Open session",
+      "translated": "Öppna session"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "Inga leverantörer redo"
     },
     {
-      "id": "native.android.8a1c5365c0538908",
-      "source": "Main thread",
-      "translated": "Huvudtråd"
+      "id": "native.android.73e6ab1a168fd381",
+      "source": "Main session",
+      "translated": "Huvudsession"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.a5845742daecb4ba",
-      "source": "Threads",
-      "translated": "Trådar"
+      "id": "native.android.0e3157c15c56944f",
+      "source": "Sessions",
+      "translated": "Sessioner"
     },
     {
-      "id": "native.android.439b324280869527",
-      "source": "Focus thread search",
-      "translated": "Fokusera trådsökningen"
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "Fokusera sessionssökningen"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "Arkiverad"
     },
     {
-      "id": "native.android.03981341841b04ac",
-      "source": "Search threads",
-      "translated": "Sök efter trådar"
+      "id": "native.android.b9cf34c137e4cf03",
+      "source": "Search sessions",
+      "translated": "Sök sessioner"
     },
     {
-      "id": "native.android.99570c528a41fa72",
-      "source": "Clear thread search",
-      "translated": "Rensa trådsökningen"
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "Rensa sessionssökningen"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "Äldsta först"
     },
     {
-      "id": "native.android.fd67be543e321cc9",
-      "source": "Toggle thread layout",
-      "translated": "Växla trådlayout"
+      "id": "native.android.c6bf8751e2a7f5c7",
+      "source": "Toggle session layout",
+      "translated": "Växla sessionslayout"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "Layout: Detaljerad"
     },
     {
-      "id": "native.android.ebd17565e0ffd8eb",
-      "source": "Searching threads",
-      "translated": "Söker efter trådar"
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "Söker efter sessioner"
     },
     {
-      "id": "native.android.472d46ae8669f860",
-      "source": "No matching threads",
-      "translated": "Inga matchande trådar"
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "Inga matchande sessioner"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "Starta chatt"
     },
     {
-      "id": "native.android.ff81ad1bee00d384",
-      "source": "Current thread",
-      "translated": "Aktuell tråd"
+      "id": "native.android.f10d4df7cbc6df4f",
+      "source": "Current session",
+      "translated": "Aktuell session"
     },
     {
-      "id": "native.android.fc145645b9620e57",
-      "source": "OpenClaw thread",
-      "translated": "OpenClaw-tråd"
+      "id": "native.android.8f0482425838ae64",
+      "source": "OpenClaw session",
+      "translated": "OpenClaw-session"
     },
     {
-      "id": "native.android.71cbb8dde8bf138b",
-      "source": "Rename thread",
-      "translated": "Byt namn på tråd"
+      "id": "native.android.786774c8a76e50d7",
+      "source": "Rename session",
+      "translated": "Byt namn på session"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "Ta bort grupp?"
     },
     {
-      "id": "native.android.691e92cfe5cf106e",
-      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "Trådar i \"$group\" behålls och flyttas tillbaka till Ogrupperade."
+      "id": "native.android.3455fc2f77d564e3",
+      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "Sessioner i \"$group\" behålls och flyttas tillbaka till Ogrupperade."
     },
     {
-      "id": "native.android.d87a8217ab56999b",
-      "source": "Delete thread?",
-      "translated": "Ta bort tråden?"
+      "id": "native.android.4805fb9d6623e8c0",
+      "source": "Delete session?",
+      "translated": "Ta bort session?"
     },
     {
-      "id": "native.android.930de97ff47113a8",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "Detta tar permanent bort tråden och dess transkript."
+      "id": "native.android.0c3283a2b2445eae",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "Detta tar bort sessionen och dess transkript permanent."
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "Ogrupperade"
     },
     {
-      "id": "native.android.8e21a70428def6e0",
-      "source": "No threads yet",
-      "translated": "Inga trådar ännu"
+      "id": "native.android.db243d71d056afa4",
+      "source": "No sessions yet",
+      "translated": "Inga sessioner än"
     },
     {
-      "id": "native.android.cda4c5ad8b17e394",
-      "source": "No current thread",
-      "translated": "Ingen aktuell tråd"
+      "id": "native.android.5b4eee6a8092925e",
+      "source": "No current session",
+      "translated": "Ingen aktuell session"
     },
     {
-      "id": "native.android.be84f061047aa2da",
-      "source": "No archived threads",
-      "translated": "Inga arkiverade trådar"
+      "id": "native.android.acbcc9c9ea53d8c0",
+      "source": "No archived sessions",
+      "translated": "Inga arkiverade sessioner"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "Starta en ny konversation så visas den här."
     },
     {
-      "id": "native.android.f289d03e1d3eee98",
-      "source": "Open Chat to start or resume the current thread.",
-      "translated": "Öppna Chat för att starta eller återuppta den aktuella tråden."
+      "id": "native.android.56fcd605dc7be3c0",
+      "source": "Open Chat to start or resume the current session.",
+      "translated": "Öppna Chat för att starta eller återuppta den aktuella sessionen."
     },
     {
-      "id": "native.android.504b71386e76c6ae",
-      "source": "Archived threads will show up here.",
-      "translated": "Arkiverade trådar visas här."
+      "id": "native.android.085515989f8a2022",
+      "source": "Archived sessions will show up here.",
+      "translated": "Arkiverade sessioner visas här."
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days} d"
     },
     {
-      "id": "native.android.ee4c727cdafbe963",
-      "source": "Main thread",
-      "translated": "Huvudtråd"
+      "id": "native.android.3d4fa07acbc015c5",
+      "source": "Main session",
+      "translated": "Huvudsession"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway väntar"
     },
     {
-      "id": "native.android.da78209effb11cfd",
-      "source": "Thread Activity",
-      "translated": "Trådaktivitet"
+      "id": "native.android.2d8d049afe99f751",
+      "source": "Session Activity",
+      "translated": "Sessionsaktivitet"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "Begäranden om Exec-godkännande visas här medan den här telefonen är ansluten."
     },
     {
-      "id": "native.android.f615712dfb56319a",
-      "source": "Thread activity",
-      "translated": "Trådaktivitet"
+      "id": "native.android.dc3e7ca5a491103a",
+      "source": "Session activity",
+      "translated": "Sessionsaktivitet"
     },
     {
-      "id": "native.android.6c93973c13db43ae",
-      "source": "Chat tool calls waiting in the active thread remain visible here.",
-      "translated": "Anrop till chattverktyg som väntar i den aktiva tråden visas fortfarande här."
+      "id": "native.android.8551e02b060bd7d8",
+      "source": "Chat tool calls waiting in the active session remain visible here.",
+      "translated": "Anrop till chattverktyg som väntar i den aktiva sessionen förblir synliga här."
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,11 +4294,6 @@
       "translated": "Konfiguration av Talk Provider"
     },
     {
-      "id": "native.android.23b638094c34b916",
-      "source": "Microphone",
-      "translated": "Mikrofon"
-    },
-    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "Ljudtest"
@@ -4342,66 +4337,6 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "Klart"
-    },
-    {
-      "id": "native.android.8d9ecdfdd916b780",
-      "source": "Automatic",
-      "translated": "Automatisk"
-    },
-    {
-      "id": "native.android.c1626a6700a570f6",
-      "source": "Preferred microphone unavailable; using automatic routing.",
-      "translated": "Den föredragna mikrofonen är inte tillgänglig; automatisk dirigering används."
-    },
-    {
-      "id": "native.android.820bc5d0ce571d8b",
-      "source": "Prioritizes connected Bluetooth microphones.",
-      "translated": "Prioriterar anslutna Bluetooth-mikrofoner."
-    },
-    {
-      "id": "native.android.11e48038d5e8bff6",
-      "source": "Preferred microphone",
-      "translated": "Föredragen mikrofon"
-    },
-    {
-      "id": "native.android.eaa4d7563a46d307",
-      "source": "Unavailable",
-      "translated": "Inte tillgänglig"
-    },
-    {
-      "id": "native.android.9f5ebf17eb405ba8",
-      "source": "Next session",
-      "translated": "Nästa session"
-    },
-    {
-      "id": "native.android.8c4e91f53928efb2",
-      "source": "Built-in microphone",
-      "translated": "Inbyggd mikrofon"
-    },
-    {
-      "id": "native.android.14b613cb6e2446b4",
-      "source": "Bluetooth microphone",
-      "translated": "Bluetooth-mikrofon"
-    },
-    {
-      "id": "native.android.c885247b2d7ce271",
-      "source": "Bluetooth LE microphone",
-      "translated": "Bluetooth LE-mikrofon"
-    },
-    {
-      "id": "native.android.b6a4e674c5fb441a",
-      "source": "Wired headset microphone",
-      "translated": "Mikrofon i trådbundet headset"
-    },
-    {
-      "id": "native.android.9c8becb3b0fb5a90",
-      "source": "USB microphone",
-      "translated": "USB-mikrofon"
-    },
-    {
-      "id": "native.android.ba46258fadec7a39",
-      "source": "External microphone",
-      "translated": "Extern mikrofon"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5139,9 +5074,9 @@
       "translated": "Kontrollera"
     },
     {
-      "id": "native.android.c971506716c96e91",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
-      "translated": "OpenClaw gör den här telefonen till en stilren mobil kommandoyta för trådar, röst, leverantörer och Gateway."
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw förvandlar telefonen till en ren mobil kommandoyta för sessioner, röst, leverantörer och Gateway."
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5689,9 +5624,9 @@
       "translated": "Talk-inställningar"
     },
     {
-      "id": "native.android.36f78c8c85dc283f",
-      "source": "Recent Threads",
-      "translated": "Senaste trådarna"
+      "id": "native.android.73f07a5d54915259",
+      "source": "Recent Sessions",
+      "translated": "Senaste sessioner"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5749,14 +5684,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% online"
     },
     {
-      "id": "native.android.57177017a6a93826",
-      "source": "Threads",
-      "translated": "Trådar"
+      "id": "native.android.16c3425d3a594481",
+      "source": "Sessions",
+      "translated": "Sessioner"
     },
     {
-      "id": "native.android.43320b54a68b00a1",
-      "source": "No recent threads",
-      "translated": "Inga senaste trådar"
+      "id": "native.android.a5c0f8b3112aa58c",
+      "source": "No recent sessions",
+      "translated": "Inga senaste sessioner"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5794,14 +5729,14 @@
       "translated": "Arbetar · $pendingRunCount aktiva körningar"
     },
     {
-      "id": "native.android.e24db059480f1e6a",
-      "source": "Monitoring · 1 thread",
-      "translated": "Övervakning · 1 tråd"
+      "id": "native.android.2c89da708b12a522",
+      "source": "Monitoring · 1 session",
+      "translated": "Övervakar · 1 session"
     },
     {
-      "id": "native.android.5a475f37d80e02bc",
-      "source": "Monitoring · $sessionCount threads",
-      "translated": "Övervakning · $sessionCount trådar"
+      "id": "native.android.8b6ee382dcb64e1f",
+      "source": "Monitoring · $sessionCount sessions",
+      "translated": "Övervakar · $sessionCount sessioner"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5834,9 +5769,9 @@
       "translated": "Leverantörer"
     },
     {
-      "id": "native.android.358c5e0e838d5423",
-      "source": "Open thread",
-      "translated": "Öppna tråd"
+      "id": "native.android.a65477861c7203aa",
+      "source": "Open session",
+      "translated": "Öppna session"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6259,9 +6194,9 @@
       "translated": "${days} d"
     },
     {
-      "id": "native.android.28a1a1acc5a0959f",
-      "source": "Main thread",
-      "translated": "Huvudtråd"
+      "id": "native.android.22d755834386db07",
+      "source": "Main session",
+      "translated": "Huvudsession"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6942,16 +6877,6 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "Slå på ljud"
-    },
-    {
-      "id": "native.android.cb608d82c5b3352a",
-      "source": "Back camera",
-      "translated": "Bakre kamera"
-    },
-    {
-      "id": "native.android.e89a0e780eed2e1e",
-      "source": "Front camera",
-      "translated": "Främre kamera"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7759,9 +7684,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.0c74bc30a994dd33",
-      "source": "Loading thread",
-      "translated": "Läser in tråd"
+      "id": "native.android.882cc14a58e7e105",
+      "source": "Loading session",
+      "translated": "Läser in session"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7804,14 +7729,14 @@
       "translated": "Uppdatera mig"
     },
     {
-      "id": "native.android.cf40df9739f78f27",
-      "source": "Summarize recent threads and next steps.",
-      "translated": "Sammanfatta de senaste trådarna och nästa steg."
+      "id": "native.android.1e5add56e48c99f9",
+      "source": "Summarize recent sessions and next steps.",
+      "translated": "Sammanfatta de senaste sessionerna och nästa steg."
     },
     {
-      "id": "native.android.ebe49a8b8df80bd3",
-      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
-      "translated": "Ge mig en uppdatering om mina senaste OpenClaw-trådar och föreslå nästa steg."
+      "id": "native.android.06d515351bb79576",
+      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
+      "translated": "Uppdatera mig om mina senaste OpenClaw-sessioner och föreslå nästa steg."
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8149,9 +8074,9 @@
       "translated": "Ansluten"
     },
     {
-      "id": "native.android.6cf5d6fa8a4186d5",
-      "source": "Threads",
-      "translated": "Trådar"
+      "id": "native.android.81931886b9caf3ab",
+      "source": "Sessions",
+      "translated": "Sessioner"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,6 +10719,61 @@
       "translated": "Uppgiftsinformation"
     },
     {
+      "id": "native.apple.29cacb53ea5e77fc",
+      "source": "Pinned",
+      "translated": "Fäst"
+    },
+    {
+      "id": "native.apple.940062cfdce9211b",
+      "source": "Recent",
+      "translated": "Senaste"
+    },
+    {
+      "id": "native.apple.a0980128426308a9",
+      "source": "Model",
+      "translated": "Modell"
+    },
+    {
+      "id": "native.apple.9520e60f21535dde",
+      "source": "Thinking",
+      "translated": "Tänkande"
+    },
+    {
+      "id": "native.apple.8b321f3ffce97429",
+      "source": "Fast",
+      "translated": "Snabb"
+    },
+    {
+      "id": "native.apple.989b70d64e328d55",
+      "source": "Default (inherited)",
+      "translated": "Standard (ärvd)"
+    },
+    {
+      "id": "native.apple.f4114e73b07eb9ae",
+      "source": "Off",
+      "translated": "Av"
+    },
+    {
+      "id": "native.apple.7ed231b28d16312f",
+      "source": "On",
+      "translated": "På"
+    },
+    {
+      "id": "native.apple.412a74802320a037",
+      "source": "Full",
+      "translated": "Fullständig"
+    },
+    {
+      "id": "native.apple.299f21a2071ff9fc",
+      "source": "Verbosity",
+      "translated": "Detaljnivå"
+    },
+    {
+      "id": "native.apple.faf0ef05e1496de7",
+      "source": "Default",
+      "translated": "Standard"
+    },
+    {
       "id": "native.apple.e5524d5756a62744",
       "source": "Unable to Export Transcript",
       "translated": "Det gick inte att exportera transkript"
@@ -10814,9 +10794,9 @@
       "translated": "Vad vill du arbeta med?"
     },
     {
-      "id": "native.apple.4da775013ac9b123",
-      "source": "The thread attaches once the gateway is ready.",
-      "translated": "Tråden ansluts när Gateway är redo."
+      "id": "native.apple.32179ce0b6d4543f",
+      "source": "The session attaches once the gateway is ready.",
+      "translated": "Sessionen ansluter när Gateway är redo."
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10859,9 +10839,14 @@
       "translated": "Ny chatt i worktree"
     },
     {
-      "id": "native.apple.003b25ddafeb18e9",
-      "source": "Threads…",
-      "translated": "Trådar…"
+      "id": "native.apple.ce6ebe91fc597015",
+      "source": "New Session Options…",
+      "translated": "Alternativ för ny session…"
+    },
+    {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "Sessioner…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11024,14 +11009,14 @@
       "translated": "Skapa"
     },
     {
-      "id": "native.apple.31d5c7287cfb3abe",
-      "source": "Delete Thread?",
-      "translated": "Radera tråden?"
+      "id": "native.apple.f488b9caf6e51ac3",
+      "source": "Delete Session?",
+      "translated": "Radera session?"
     },
     {
-      "id": "native.apple.d3395564809f1120",
-      "source": "Delete Thread",
-      "translated": "Radera tråd"
+      "id": "native.apple.8634b17be9b111bc",
+      "source": "Delete Session",
+      "translated": "Radera session"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11039,9 +11024,9 @@
       "translated": "Avbryt"
     },
     {
-      "id": "native.apple.092659256d26cb03",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "Detta raderar tråden och dess transkript permanent."
+      "id": "native.apple.4a9568ac9b18d8d3",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "Detta raderar sessionen och dess transkript permanent."
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11069,9 +11054,9 @@
       "translated": "Ny grupp"
     },
     {
-      "id": "native.apple.683032464c497bbd",
-      "source": "Rename Thread",
-      "translated": "Byt namn på tråd"
+      "id": "native.apple.5bccdc23a1640895",
+      "source": "Rename Session",
+      "translated": "Byt namn på session"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11079,9 +11064,9 @@
       "translated": "Gruppnamn"
     },
     {
-      "id": "native.apple.f887aa956588f237",
-      "source": "Thread name",
-      "translated": "Trådens namn"
+      "id": "native.apple.af789b2d2fda0f67",
+      "source": "Session name",
+      "translated": "Sessionsnamn"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11119,14 +11104,14 @@
       "translated": "Agenter"
     },
     {
-      "id": "native.apple.7c8231b7b1ca480f",
-      "source": "Agent thread",
-      "translated": "Agenttråd"
+      "id": "native.apple.a3bde8045fe9224a",
+      "source": "Agent session",
+      "translated": "Agentsession"
     },
     {
-      "id": "native.apple.b3c553614f762a58",
-      "source": "Recent threads",
-      "translated": "Senaste trådarna"
+      "id": "native.apple.27f775de30b37ff8",
+      "source": "Recent sessions",
+      "translated": "Senaste sessioner"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11134,9 +11119,9 @@
       "translated": "Gateway offline"
     },
     {
-      "id": "native.apple.5aa32afda85064ea",
-      "source": "No recent threads",
-      "translated": "Inga senaste trådar"
+      "id": "native.apple.28c97cf23665ee01",
+      "source": "No recent sessions",
+      "translated": "Inga senaste sessioner"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11234,14 +11219,14 @@
       "translated": "Avbryt"
     },
     {
-      "id": "native.apple.b6855cf19a50f477",
-      "source": "Threads",
-      "translated": "Trådar"
+      "id": "native.apple.9f2fd65953013b7c",
+      "source": "Sessions",
+      "translated": "Sessioner"
     },
     {
-      "id": "native.apple.9b1d0ef27a1333b0",
-      "source": "Archived threads",
-      "translated": "Arkiverade trådar"
+      "id": "native.apple.0422818cc95d5071",
+      "source": "Archived sessions",
+      "translated": "Arkiverade sessioner"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11249,34 +11234,34 @@
       "translated": "Visa arkiverade"
     },
     {
-      "id": "native.apple.98167401c7267735",
-      "source": "Threads unavailable",
-      "translated": "Trådarna är inte tillgängliga"
+      "id": "native.apple.b272115c83f7ef58",
+      "source": "Sessions unavailable",
+      "translated": "Sessioner är inte tillgängliga"
     },
     {
-      "id": "native.apple.4d28a7def2337b9f",
-      "source": "Loading archived threads",
-      "translated": "Läser in arkiverade trådar"
+      "id": "native.apple.54f8260c9b863087",
+      "source": "Loading archived sessions",
+      "translated": "Läser in arkiverade sessioner"
     },
     {
-      "id": "native.apple.777d7b706933bd7b",
-      "source": "Loading recent threads",
-      "translated": "Läser in senaste trådar"
+      "id": "native.apple.9b305868873dade2",
+      "source": "Loading recent sessions",
+      "translated": "Läser in senaste sessioner"
     },
     {
-      "id": "native.apple.22f81ea94bef8410",
-      "source": "^[\\(count) thread](inflect: true)",
-      "translated": "^[\\(count) tråd](inflect: true)"
+      "id": "native.apple.207dad20d09f3160",
+      "source": "^[\\(count) session](inflect: true)",
+      "translated": "^[\\(count) session](inflect: true)"
     },
     {
-      "id": "native.apple.1cad51e14db59bf9",
-      "source": "No archived threads",
-      "translated": "Inga arkiverade trådar"
+      "id": "native.apple.1f4501a6bf2bae4c",
+      "source": "No archived sessions",
+      "translated": "Inga arkiverade sessioner"
     },
     {
-      "id": "native.apple.18ef832d3a7ddcf8",
-      "source": "Archived threads will appear here.",
-      "translated": "Arkiverade trådar visas här."
+      "id": "native.apple.2a1ba7a5e1979c9e",
+      "source": "Archived sessions will appear here.",
+      "translated": "Arkiverade sessioner visas här."
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11359,9 +11344,9 @@
       "translated": "Dela intag"
     },
     {
-      "id": "native.apple.21d9208d86a4d1fe",
-      "source": "Loading threads",
-      "translated": "Läser in trådar"
+      "id": "native.apple.2360d25fe6ae9946",
+      "source": "Loading sessions",
+      "translated": "Läser in sessioner"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11369,19 +11354,19 @@
       "translated": "Hämtar senaste aktivitet från gatewayen."
     },
     {
-      "id": "native.apple.4be1f79aa2b230ff",
-      "source": "Threads unavailable",
-      "translated": "Trådar är inte tillgängliga"
+      "id": "native.apple.c334f2e86702a7b8",
+      "source": "Sessions unavailable",
+      "translated": "Sessioner är inte tillgängliga"
     },
     {
-      "id": "native.apple.98b348873556bc46",
-      "source": "No recent threads",
-      "translated": "Inga senaste trådar"
+      "id": "native.apple.6cc6efb7a03960b6",
+      "source": "No recent sessions",
+      "translated": "Inga senaste sessioner"
     },
     {
-      "id": "native.apple.7396d205574d279f",
-      "source": "Thread activity offline",
-      "translated": "Trådaktivitet offline"
+      "id": "native.apple.08483af2d043bee6",
+      "source": "Session activity offline",
+      "translated": "Sessionsaktivitet offline"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11839,9 +11824,9 @@
       "translated": "Kort"
     },
     {
-      "id": "native.apple.c9ec1b0e18074d8a",
-      "source": "Open Thread",
-      "translated": "Öppna tråd"
+      "id": "native.apple.93eeaedb2ff61043",
+      "source": "Open Session",
+      "translated": "Öppna session"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13329,9 +13314,9 @@
       "translated": "Standard"
     },
     {
-      "id": "native.apple.f4ae5664c3eda95d",
-      "source": "Used for new Chat threads and Talk sessions.",
-      "translated": "Används för nya chatttrådar och samtalssessioner."
+      "id": "native.apple.3de045f17ea3c6d0",
+      "source": "Used for new Chat and Talk sessions.",
+      "translated": "Används för nya chatt- och samtalssessioner."
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15734,9 +15719,9 @@
       "translated": "Instanser"
     },
     {
-      "id": "native.apple.11fe8b9941954dfb",
-      "source": "Threads",
-      "translated": "Trådar"
+      "id": "native.apple.3579cf2750470a22",
+      "source": "Sessions",
+      "translated": "Sessioner"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19044,9 +19029,9 @@
       "translated": "Kortkommando för snabbchatt"
     },
     {
-      "id": "native.apple.94dd793cd7d7d555",
-      "source": "Global shortcut that opens a floating chat bar for the main thread.",
-      "translated": "Globalt kortkommando som öppnar ett flytande chattfält för huvudtråden."
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "Globalt kortkommando som öppnar ett flytande chattfält för huvudsessionen."
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19624,9 +19609,9 @@
       "translated": "Kritisk"
     },
     {
-      "id": "native.apple.13f96467014cf344",
-      "source": "New Thread",
-      "translated": "Ny tråd"
+      "id": "native.apple.75102378a6775180",
+      "source": "New Session",
+      "translated": "Ny session"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21914,9 +21899,9 @@
       "translated": "Inga senaste meddelanden"
     },
     {
-      "id": "native.apple.3ec2afcbc298c673",
-      "source": "Threads",
-      "translated": "Trådar"
+      "id": "native.apple.1ff8aec0044934c3",
+      "source": "Sessions",
+      "translated": "Sessioner"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21924,9 +21909,9 @@
       "translated": "Titta på de lagrade konversationsbuckets som CLI återanvänder för kontext och hastighetsbegränsningar."
     },
     {
-      "id": "native.apple.14ccb32cd8ed1c81",
-      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
-      "translated": "Inga trådar ännu. De visas efter det första inkommande meddelandet eller den första pulssignalen."
+      "id": "native.apple.bab897f3252b134c",
+      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
+      "translated": "Inga sessioner än. De visas efter det första inkommande meddelandet eller heartbeat."
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -22009,9 +21994,9 @@
       "translated": "Körningsgodkännanden"
     },
     {
-      "id": "native.apple.52e37e3a44ae516c",
-      "source": "Threads",
-      "translated": "Trådar"
+      "id": "native.apple.64a6dc7d49e8fb57",
+      "source": "Sessions",
+      "translated": "Sessioner"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -23014,9 +22999,9 @@
       "translated": "Uppdatera mig"
     },
     {
-      "id": "native.apple.fc4ce810900ec0b6",
-      "source": "Summarize what happened in my threads since yesterday.",
-      "translated": "Sammanfatta vad som har hänt i mina trådar sedan i går."
+      "id": "native.apple.234ec45f4231edc4",
+      "source": "Summarize what happened in my sessions since yesterday.",
+      "translated": "Sammanfatta vad som har hänt i mina sessioner sedan i går."
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23194,9 +23179,9 @@
       "translated": "Lossa modell"
     },
     {
-      "id": "native.apple.4edb66657f5aca1f",
-      "source": "Thread",
-      "translated": "Tråd"
+      "id": "native.apple.5dfc0700d8dff8de",
+      "source": "Session",
+      "translated": "Session"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23359,51 +23344,6 @@
       "translated": "Widgeten är inte tillgänglig"
     },
     {
-      "id": "native.apple.d640691fd196f338",
-      "source": "Widget export failed",
-      "translated": "Det gick inte att exportera widgeten"
-    },
-    {
-      "id": "native.apple.533c6e22a11e88de",
-      "source": "OK",
-      "translated": "OK"
-    },
-    {
-      "id": "native.apple.e1fb28a2a9756402",
-      "source": "Copy image",
-      "translated": "Kopiera bild"
-    },
-    {
-      "id": "native.apple.ebd7bc92e1b12235",
-      "source": "Save image…",
-      "translated": "Spara bild…"
-    },
-    {
-      "id": "native.apple.742c46d4cf2db134",
-      "source": "Save image",
-      "translated": "Spara bild"
-    },
-    {
-      "id": "native.apple.0589cce608418f90",
-      "source": "The widget image could not be captured.",
-      "translated": "Widgetbilden kunde inte tas."
-    },
-    {
-      "id": "native.apple.dfe24e827fdbe9c5",
-      "source": "The widget image could not be copied.",
-      "translated": "Widgetbilden kunde inte kopieras."
-    },
-    {
-      "id": "native.apple.9e611e3a80e71408",
-      "source": "The widget image could not be encoded as PNG.",
-      "translated": "Widgetbilden kunde inte kodas som PNG."
-    },
-    {
-      "id": "native.apple.9a6e8afbe24a262b",
-      "source": "The widget image could not be saved.",
-      "translated": "Widgetbilden kunde inte sparas."
-    },
-    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23544,19 +23484,19 @@
       "translated": "Användare"
     },
     {
-      "id": "native.apple.9d0cba09d92ee669",
-      "source": "This thread cannot be archived while it is active or running.",
-      "translated": "Den här tråden kan inte arkiveras medan den är aktiv eller körs."
+      "id": "native.apple.b1cdcb906a43d5d6",
+      "source": "This session cannot be archived while it is active or running.",
+      "translated": "Den här sessionen kan inte arkiveras medan den är aktiv eller körs."
     },
     {
-      "id": "native.apple.8952a111a1075051",
-      "source": "The main thread cannot be deleted.",
-      "translated": "Huvudtråden kan inte tas bort."
+      "id": "native.apple.5817e3f3dab1ee19",
+      "source": "The main session cannot be deleted.",
+      "translated": "Huvudsessionen kan inte tas bort."
     },
     {
-      "id": "native.apple.90d0ccf80ca28717",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
-      "translated": "Ta bort bilagor eller vänta på leverans innan du arkiverar eller tar bort den här tråden."
+      "id": "native.apple.a6b8df3f18171c91",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
+      "translated": "Ta bort bilagor eller vänta på leverans innan du arkiverar eller tar bort den här sessionen."
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23694,9 +23634,9 @@
       "translated": "Körning avslutad"
     },
     {
-      "id": "native.apple.bbccb4c8db5cac12",
-      "source": "Thread Info",
-      "translated": "Trådinfo"
+      "id": "native.apple.cd7c3095a22f80a9",
+      "source": "Session Info",
+      "translated": "Sessionsinformation"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23729,9 +23669,9 @@
       "translated": "Lägg till grupp"
     },
     {
-      "id": "native.apple.7b641fed5bace855",
-      "source": "Thread Groups",
-      "translated": "Trådgrupper"
+      "id": "native.apple.23d628606fe0734f",
+      "source": "Session Groups",
+      "translated": "Sessionsgrupper"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23774,9 +23714,9 @@
       "translated": "Ta bort grupp"
     },
     {
-      "id": "native.apple.56401c79410a310d",
-      "source": "Threads in this group become ungrouped.",
-      "translated": "Trådarna i den här gruppen blir ogrupperade."
+      "id": "native.apple.b049c8a4d2805e08",
+      "source": "Sessions in this group become ungrouped.",
+      "translated": "Sessioner i den här gruppen blir ogrupperade."
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23789,9 +23729,9 @@
       "translated": "Inga agenter är tillgängliga på denna gateway."
     },
     {
-      "id": "native.apple.2d96aa7d3d12f85b",
-      "source": "New Thread Options",
-      "translated": "Alternativ för ny tråd"
+      "id": "native.apple.6c89f35d53506406",
+      "source": "New Session Options",
+      "translated": "Alternativ för ny session"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23819,19 +23759,19 @@
       "translated": "Skapa"
     },
     {
-      "id": "native.apple.87ef57319d1ddc85",
-      "source": "The thread could not be created.",
-      "translated": "Det gick inte att skapa tråden."
+      "id": "native.apple.795ba37f6782cf28",
+      "source": "The session could not be created.",
+      "translated": "Sessionen kunde inte skapas."
     },
     {
-      "id": "native.apple.6bd91c435b69d638",
-      "source": "Search threads",
-      "translated": "Sök bland trådar"
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "Sök sessioner"
     },
     {
-      "id": "native.apple.6fde4bdf9d5b9191",
-      "source": "No Threads",
-      "translated": "Inga trådar"
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "Inga sessioner"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23839,29 +23779,29 @@
       "translated": "Inga resultat"
     },
     {
-      "id": "native.apple.a02fd99740d29bd3",
-      "source": "New Thread",
-      "translated": "Ny tråd"
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "Ny session"
     },
     {
-      "id": "native.apple.b625801dd04b09f2",
-      "source": "New thread",
-      "translated": "Ny tråd"
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "Ny session"
     },
     {
-      "id": "native.apple.851be81fcc933608",
-      "source": "New thread options",
-      "translated": "Alternativ för ny tråd"
+      "id": "native.apple.2ef0e34db02ad255",
+      "source": "New session options",
+      "translated": "Alternativ för ny session"
     },
     {
-      "id": "native.apple.9ce8a4aba7b444b2",
-      "source": "Rename Thread",
-      "translated": "Byt namn på tråd"
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "Byt namn på session"
     },
     {
-      "id": "native.apple.1dd067c44511c7f0",
-      "source": "Thread name",
-      "translated": "Trådens namn"
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "Sessionsnamn"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23874,14 +23814,14 @@
       "translated": "Avbryt"
     },
     {
-      "id": "native.apple.618073d6ab3f2721",
-      "source": "Delete Thread",
-      "translated": "Radera tråd"
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "Radera session"
     },
     {
-      "id": "native.apple.10a5e72bba3cbccc",
-      "source": "The thread and its transcript are removed from the gateway.",
-      "translated": "Tråden och dess transkription tas bort från Gateway."
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "Sessionen och dess transkription tas bort från Gateway."
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23889,14 +23829,14 @@
       "translated": "Radera ”%@”?"
     },
     {
-      "id": "native.apple.ac71e3b2aa496a2c",
-      "source": "Thread running",
-      "translated": "Tråden körs"
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "Sessionen körs"
     },
     {
-      "id": "native.apple.c775e87f997278b2",
-      "source": "Thread failed",
-      "translated": "Tråden misslyckades"
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "Sessionen misslyckades"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23954,9 +23894,9 @@
       "translated": "Kopiera sessionsnyckel"
     },
     {
-      "id": "native.apple.f4998cfb572f23ff",
-      "source": "Delete Thread…",
-      "translated": "Radera tråd…"
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "Radera session…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23969,9 +23909,9 @@
       "translated": "Ansluter…"
     },
     {
-      "id": "native.apple.8802e9576ffd0f65",
-      "source": "Retry thread groups",
-      "translated": "Försök läsa in trådgrupper igen"
+      "id": "native.apple.79f708b3bc1d3a6c",
+      "source": "Retry session groups",
+      "translated": "Försök läsa in sessionsgrupper igen"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23994,24 +23934,24 @@
       "translated": "Omfattning"
     },
     {
-      "id": "native.apple.b313b80def4bda52",
-      "source": "Search threads",
-      "translated": "Sök bland trådar"
+      "id": "native.apple.2c37581c7b88f741",
+      "source": "Search sessions",
+      "translated": "Sök sessioner"
     },
     {
-      "id": "native.apple.c0cc6acc36f413ce",
-      "source": "Threads",
-      "translated": "Trådar"
+      "id": "native.apple.43be8a2336e42faf",
+      "source": "Sessions",
+      "translated": "Sessioner"
     },
     {
-      "id": "native.apple.854d3928fe5a557c",
-      "source": "Rename Thread",
-      "translated": "Byt namn på tråd"
+      "id": "native.apple.0b379cdfcbd3247f",
+      "source": "Rename Session",
+      "translated": "Byt namn på session"
     },
     {
-      "id": "native.apple.9d0d3f20096cc4da",
-      "source": "Thread name",
-      "translated": "Trådens namn"
+      "id": "native.apple.54b6fbd9e41db009",
+      "source": "Session name",
+      "translated": "Sessionsnamn"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -24019,19 +23959,19 @@
       "translated": "Avbryt"
     },
     {
-      "id": "native.apple.dc00eb94f33bae15",
-      "source": "Delete selected threads?",
-      "translated": "Radera valda trådar?"
+      "id": "native.apple.751e0f6b81cd374a",
+      "source": "Delete selected sessions?",
+      "translated": "Ta bort valda sessioner?"
     },
     {
-      "id": "native.apple.2053fc9f74dc3158",
-      "source": "Delete Threads",
-      "translated": "Ta bort trådar"
+      "id": "native.apple.aa679276581b0058",
+      "source": "Delete Sessions",
+      "translated": "Ta bort sessioner"
     },
     {
-      "id": "native.apple.0970247871a834a0",
-      "source": "Each selected thread and its transcript will be removed from the gateway.",
-      "translated": "Varje vald tråd och dess transkription tas bort från Gateway."
+      "id": "native.apple.f837129cbee23297",
+      "source": "Each selected session and its transcript will be removed from the gateway.",
+      "translated": "Varje vald session och dess transkription tas bort från Gateway."
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -24039,9 +23979,9 @@
       "translated": "Grupper"
     },
     {
-      "id": "native.apple.6f8acab2256728b5",
-      "source": "Manage thread groups",
-      "translated": "Hantera trådgrupper"
+      "id": "native.apple.64013cfee5e25305",
+      "source": "Manage session groups",
+      "translated": "Hantera sessionsgrupper"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -24054,14 +23994,14 @@
       "translated": "Välj"
     },
     {
-      "id": "native.apple.692972314d04b184",
-      "source": "No archived threads",
-      "translated": "Inga arkiverade trådar"
+      "id": "native.apple.b67eaecec1b423ac",
+      "source": "No archived sessions",
+      "translated": "Inga arkiverade sessioner"
     },
     {
-      "id": "native.apple.d6a4b5711dcd26e7",
-      "source": "No threads found",
-      "translated": "Inga trådar hittades"
+      "id": "native.apple.b2435a79abf0c794",
+      "source": "No sessions found",
+      "translated": "Inga sessioner hittades"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24229,16 +24169,6 @@
       "translated": "Öppna hela meddelandet"
     },
     {
-      "id": "native.apple.002bfcede229ad4b",
-      "source": "Rewind to Here",
-      "translated": "Spola tillbaka hit"
-    },
-    {
-      "id": "native.apple.14df2e4997689fb3",
-      "source": "Fork from Here",
-      "translated": "Förgrena härifrån"
-    },
-    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "Svara"
@@ -24324,9 +24254,9 @@
       "translated": "Ta bort bilagor eller vänta tills leveransen är klar innan du startar en ny chatt."
     },
     {
-      "id": "native.apple.e0f045151c8d3137",
-      "source": "Gateway changed before the thread operation started.",
-      "translated": "Gateway ändrades innan trådåtgärden startade."
+      "id": "native.apple.980f552bb0f96c0f",
+      "source": "Gateway changed before the session operation started.",
+      "translated": "Gateway ändrades innan sessionsåtgärden startade."
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24334,9 +24264,9 @@
       "translated": "Ta bort bilagor eller vänta på att leveransen slutförs innan du byter chatt."
     },
     {
-      "id": "native.apple.0a5c4e15466c3acc",
-      "source": "Clear this thread's history?",
-      "translated": "Rensa historiken för den här tråden?"
+      "id": "native.apple.87ba543b42696b92",
+      "source": "Clear this session's history?",
+      "translated": "Rensa den här sessionens historik?"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24349,14 +24279,14 @@
       "translated": "Detta återställer konversationen för %@. Sessionsnyckeln förblir densamma."
     },
     {
-      "id": "native.apple.67ac221dbe7179f0",
-      "source": "Rename Thread",
-      "translated": "Byt namn på tråd"
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "Byt namn på session"
     },
     {
-      "id": "native.apple.cf0f7e049603f518",
-      "source": "Thread name",
-      "translated": "Trådnamn"
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "Sessionsnamn"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24374,9 +24304,9 @@
       "translated": "Exportera transkription"
     },
     {
-      "id": "native.apple.c0ada47504425f23",
-      "source": "Threads",
-      "translated": "Trådar"
+      "id": "native.apple.4af0f566d39d7041",
+      "source": "Sessions",
+      "translated": "Sessioner"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24449,14 +24379,14 @@
       "translated": "Standard"
     },
     {
-      "id": "native.apple.1a765291943599e5",
-      "source": "New Thread",
-      "translated": "Ny tråd"
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "Ny session"
     },
     {
-      "id": "native.apple.c7a3a6d5e43dd98f",
-      "source": "New Thread Options…",
-      "translated": "Alternativ för ny tråd…"
+      "id": "native.apple.a7119fbf9d25df5e",
+      "source": "New Session Options…",
+      "translated": "Alternativ för ny session…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24464,19 +24394,19 @@
       "translated": "Uppdatera"
     },
     {
-      "id": "native.apple.0e710b81808e5dcf",
-      "source": "Threads…",
-      "translated": "Trådar…"
+      "id": "native.apple.2bcff4a8fa503739",
+      "source": "Sessions…",
+      "translated": "Sessioner…"
     },
     {
-      "id": "native.apple.faad8f92b6bef166",
-      "source": "Rename Thread…",
-      "translated": "Byt namn på tråd…"
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "Byt namn på session…"
     },
     {
-      "id": "native.apple.23b61d6cd26ac112",
-      "source": "Fork",
-      "translated": "Förgrena"
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "Förgrena session"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24534,24 +24464,24 @@
       "translated": "Rensa historik…"
     },
     {
-      "id": "native.apple.8b4f1c5107ea8a0e",
-      "source": "Thread",
-      "translated": "Tråd"
+      "id": "native.apple.920fe8a7a33f9e92",
+      "source": "Session",
+      "translated": "Session"
     },
     {
-      "id": "native.apple.4d7750c9bf699469",
-      "source": "Thread actions",
-      "translated": "Trådåtgärder"
+      "id": "native.apple.185a401f78328b0f",
+      "source": "Session actions",
+      "translated": "Sessionsåtgärder"
     },
     {
-      "id": "native.apple.bb2f22cc43c97f8e",
-      "source": "Thread cost %@",
-      "translated": "Trådkostnad %@"
+      "id": "native.apple.9f9dedf599b2619b",
+      "source": "Session cost %@",
+      "translated": "Sessionskostnad %@"
     },
     {
-      "id": "native.apple.6239ced0b86e86f8",
-      "source": "Compact Thread",
-      "translated": "Komprimera tråd"
+      "id": "native.apple.f0a4720df5f5f403",
+      "source": "Compact Session",
+      "translated": "Komprimera session"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -1429,9 +1429,9 @@
       "translated": "พูดหรือป้อนตามคำบอกด้วย OpenClaw"
     },
     {
-      "id": "native.android.e2cf5a38587382cb",
-      "source": "Browse Threads",
-      "translated": "เรียกดูกระทู้"
+      "id": "native.android.5876e15e5e92fd45",
+      "source": "Browse Sessions",
+      "translated": "เรียกดูเซสชัน"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "ไม่พบการดำเนินการ"
     },
     {
-      "id": "native.android.bc70a4ac965b82ba",
-      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
-      "translated": "ลองใช้แชท เสียง กระทู้ ผู้ให้บริการ หรือการตั้งค่า"
+      "id": "native.android.48ad0ae0e930e02b",
+      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
+      "translated": "ลองใช้ Chat, Voice, Sessions, Providers หรือ Settings"
     },
     {
-      "id": "native.android.670121e54dbe286f",
-      "source": "Threads",
-      "translated": "กระทู้"
+      "id": "native.android.d4fbd1ee4f55a5db",
+      "source": "Sessions",
+      "translated": "เซสชัน"
     },
     {
-      "id": "native.android.d38be650b1bce4a0",
-      "source": "Connect the Gateway to search threads.",
-      "translated": "เชื่อมต่อ Gateway เพื่อค้นหากระทู้"
+      "id": "native.android.207c2170504e99e6",
+      "source": "Connect the Gateway to search sessions.",
+      "translated": "เชื่อมต่อ Gateway เพื่อค้นหาเซสชัน"
     },
     {
-      "id": "native.android.3d7754721f776ef8",
-      "source": "No matching threads yet.",
-      "translated": "ยังไม่มีกระทู้ที่ตรงกัน"
+      "id": "native.android.25d2c2d792c952fe",
+      "source": "No matching sessions yet.",
+      "translated": "ยังไม่มีเซสชันที่ตรงกัน"
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "ผู้ช่วยกำลังทำงาน"
     },
     {
-      "id": "native.android.9a839f6e3e05a744",
-      "source": "OpenClaw thread",
-      "translated": "กระทู้ OpenClaw"
+      "id": "native.android.8f8384286317f5c9",
+      "source": "OpenClaw session",
+      "translated": "เซสชัน OpenClaw"
     },
     {
-      "id": "native.android.d83f82a1e4a5ed99",
-      "source": "Open thread",
-      "translated": "เปิดกระทู้"
+      "id": "native.android.15799e57704b20c6",
+      "source": "Open session",
+      "translated": "เปิดเซสชัน"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "ไม่มีผู้ให้บริการที่พร้อมใช้งาน"
     },
     {
-      "id": "native.android.8a1c5365c0538908",
-      "source": "Main thread",
-      "translated": "กระทู้หลัก"
+      "id": "native.android.73e6ab1a168fd381",
+      "source": "Main session",
+      "translated": "เซสชันหลัก"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.a5845742daecb4ba",
-      "source": "Threads",
-      "translated": "กระทู้"
+      "id": "native.android.0e3157c15c56944f",
+      "source": "Sessions",
+      "translated": "เซสชัน"
     },
     {
-      "id": "native.android.439b324280869527",
-      "source": "Focus thread search",
-      "translated": "โฟกัสการค้นหากระทู้"
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "โฟกัสช่องค้นหาเซสชัน"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "เก็บถาวรแล้ว"
     },
     {
-      "id": "native.android.03981341841b04ac",
-      "source": "Search threads",
-      "translated": "ค้นหากระทู้"
+      "id": "native.android.b9cf34c137e4cf03",
+      "source": "Search sessions",
+      "translated": "ค้นหาเซสชัน"
     },
     {
-      "id": "native.android.99570c528a41fa72",
-      "source": "Clear thread search",
-      "translated": "ล้างการค้นหากระทู้"
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "ล้างการค้นหาเซสชัน"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "เก่าสุดก่อน"
     },
     {
-      "id": "native.android.fd67be543e321cc9",
-      "source": "Toggle thread layout",
-      "translated": "สลับเค้าโครงกระทู้"
+      "id": "native.android.c6bf8751e2a7f5c7",
+      "source": "Toggle session layout",
+      "translated": "สลับเลย์เอาต์เซสชัน"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "เลย์เอาต์: รายละเอียด"
     },
     {
-      "id": "native.android.ebd17565e0ffd8eb",
-      "source": "Searching threads",
-      "translated": "กำลังค้นหากระทู้"
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "กำลังค้นหาเซสชัน"
     },
     {
-      "id": "native.android.472d46ae8669f860",
-      "source": "No matching threads",
-      "translated": "ไม่มีกระทู้ที่ตรงกัน"
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "ไม่พบเซสชันที่ตรงกัน"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "เริ่มแชท"
     },
     {
-      "id": "native.android.ff81ad1bee00d384",
-      "source": "Current thread",
-      "translated": "กระทู้ปัจจุบัน"
+      "id": "native.android.f10d4df7cbc6df4f",
+      "source": "Current session",
+      "translated": "เซสชันปัจจุบัน"
     },
     {
-      "id": "native.android.fc145645b9620e57",
-      "source": "OpenClaw thread",
-      "translated": "กระทู้ OpenClaw"
+      "id": "native.android.8f0482425838ae64",
+      "source": "OpenClaw session",
+      "translated": "เซสชัน OpenClaw"
     },
     {
-      "id": "native.android.71cbb8dde8bf138b",
-      "source": "Rename thread",
-      "translated": "เปลี่ยนชื่อกระทู้"
+      "id": "native.android.786774c8a76e50d7",
+      "source": "Rename session",
+      "translated": "เปลี่ยนชื่อเซสชัน"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "ลบกลุ่มหรือไม่?"
     },
     {
-      "id": "native.android.691e92cfe5cf106e",
-      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "กระทู้ใน \"$group\" จะยังคงอยู่และย้ายกลับไปยังไม่ได้จัดกลุ่ม"
+      "id": "native.android.3455fc2f77d564e3",
+      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "เซสชันใน \"$group\" จะถูกเก็บไว้และย้ายกลับไปยังไม่จัดกลุ่ม"
     },
     {
-      "id": "native.android.d87a8217ab56999b",
-      "source": "Delete thread?",
-      "translated": "ลบกระทู้หรือไม่?"
+      "id": "native.android.4805fb9d6623e8c0",
+      "source": "Delete session?",
+      "translated": "ลบเซสชันหรือไม่?"
     },
     {
-      "id": "native.android.930de97ff47113a8",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "การดำเนินการนี้จะลบเธรดและบทสนทนาของเธรดอย่างถาวร"
+      "id": "native.android.0c3283a2b2445eae",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "การดำเนินการนี้จะลบเซสชันและข้อความถอดเสียงอย่างถาวร"
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "ไม่ได้จัดกลุ่ม"
     },
     {
-      "id": "native.android.8e21a70428def6e0",
-      "source": "No threads yet",
-      "translated": "ยังไม่มีเธรด"
+      "id": "native.android.db243d71d056afa4",
+      "source": "No sessions yet",
+      "translated": "ยังไม่มีเซสชัน"
     },
     {
-      "id": "native.android.cda4c5ad8b17e394",
-      "source": "No current thread",
-      "translated": "ไม่มีเธรดปัจจุบัน"
+      "id": "native.android.5b4eee6a8092925e",
+      "source": "No current session",
+      "translated": "ไม่มีเซสชันปัจจุบัน"
     },
     {
-      "id": "native.android.be84f061047aa2da",
-      "source": "No archived threads",
-      "translated": "ไม่มีเธรดที่เก็บถาวร"
+      "id": "native.android.acbcc9c9ea53d8c0",
+      "source": "No archived sessions",
+      "translated": "ไม่มีเซสชันที่เก็บถาวร"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "เริ่มการสนทนาใหม่ แล้วจะแสดงที่นี่"
     },
     {
-      "id": "native.android.f289d03e1d3eee98",
-      "source": "Open Chat to start or resume the current thread.",
-      "translated": "เปิดแชทเพื่อเริ่มหรือดำเนินการต่อในเธรดปัจจุบัน"
+      "id": "native.android.56fcd605dc7be3c0",
+      "source": "Open Chat to start or resume the current session.",
+      "translated": "เปิดแชทเพื่อเริ่มหรือกลับไปใช้เซสชันปัจจุบัน"
     },
     {
-      "id": "native.android.504b71386e76c6ae",
-      "source": "Archived threads will show up here.",
-      "translated": "เธรดที่เก็บถาวรจะแสดงที่นี่"
+      "id": "native.android.085515989f8a2022",
+      "source": "Archived sessions will show up here.",
+      "translated": "เซสชันที่เก็บถาวรจะแสดงที่นี่"
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days} วัน"
     },
     {
-      "id": "native.android.ee4c727cdafbe963",
-      "source": "Main thread",
-      "translated": "เธรดหลัก"
+      "id": "native.android.3d4fa07acbc015c5",
+      "source": "Main session",
+      "translated": "เซสชันหลัก"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway กำลังรอดำเนินการ"
     },
     {
-      "id": "native.android.da78209effb11cfd",
-      "source": "Thread Activity",
-      "translated": "กิจกรรมของเธรด"
+      "id": "native.android.2d8d049afe99f751",
+      "source": "Session Activity",
+      "translated": "กิจกรรมของเซสชัน"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "คำขออนุมัติการ Exec จะปรากฏที่นี่ขณะที่โทรศัพท์เครื่องนี้เชื่อมต่ออยู่"
     },
     {
-      "id": "native.android.f615712dfb56319a",
-      "source": "Thread activity",
-      "translated": "กิจกรรมของเธรด"
+      "id": "native.android.dc3e7ca5a491103a",
+      "source": "Session activity",
+      "translated": "กิจกรรมเซสชัน"
     },
     {
-      "id": "native.android.6c93973c13db43ae",
-      "source": "Chat tool calls waiting in the active thread remain visible here.",
-      "translated": "การเรียกใช้เครื่องมือแชทที่กำลังรอในเธรดที่ใช้งานอยู่จะยังคงแสดงที่นี่"
+      "id": "native.android.8551e02b060bd7d8",
+      "source": "Chat tool calls waiting in the active session remain visible here.",
+      "translated": "การเรียกใช้เครื่องมือแชทที่รออยู่ในเซสชันที่ใช้งานอยู่จะยังคงแสดงที่นี่"
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,11 +4294,6 @@
       "translated": "การตั้งค่าผู้ให้บริการ Talk"
     },
     {
-      "id": "native.android.23b638094c34b916",
-      "source": "Microphone",
-      "translated": "ไมโครโฟน"
-    },
-    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "ทดสอบเสียง"
@@ -4342,66 +4337,6 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "เสร็จสิ้น"
-    },
-    {
-      "id": "native.android.8d9ecdfdd916b780",
-      "source": "Automatic",
-      "translated": "อัตโนมัติ"
-    },
-    {
-      "id": "native.android.c1626a6700a570f6",
-      "source": "Preferred microphone unavailable; using automatic routing.",
-      "translated": "ไมโครโฟนที่ต้องการไม่พร้อมใช้งาน กำลังใช้การกำหนดเส้นทางอัตโนมัติ"
-    },
-    {
-      "id": "native.android.820bc5d0ce571d8b",
-      "source": "Prioritizes connected Bluetooth microphones.",
-      "translated": "ให้ความสำคัญกับไมโครโฟน Bluetooth ที่เชื่อมต่ออยู่"
-    },
-    {
-      "id": "native.android.11e48038d5e8bff6",
-      "source": "Preferred microphone",
-      "translated": "ไมโครโฟนที่ต้องการ"
-    },
-    {
-      "id": "native.android.eaa4d7563a46d307",
-      "source": "Unavailable",
-      "translated": "ไม่พร้อมใช้งาน"
-    },
-    {
-      "id": "native.android.9f5ebf17eb405ba8",
-      "source": "Next session",
-      "translated": "เซสชันถัดไป"
-    },
-    {
-      "id": "native.android.8c4e91f53928efb2",
-      "source": "Built-in microphone",
-      "translated": "ไมโครโฟนในตัว"
-    },
-    {
-      "id": "native.android.14b613cb6e2446b4",
-      "source": "Bluetooth microphone",
-      "translated": "ไมโครโฟน Bluetooth"
-    },
-    {
-      "id": "native.android.c885247b2d7ce271",
-      "source": "Bluetooth LE microphone",
-      "translated": "ไมโครโฟน Bluetooth LE"
-    },
-    {
-      "id": "native.android.b6a4e674c5fb441a",
-      "source": "Wired headset microphone",
-      "translated": "ไมโครโฟนชุดหูฟังแบบมีสาย"
-    },
-    {
-      "id": "native.android.9c8becb3b0fb5a90",
-      "source": "USB microphone",
-      "translated": "ไมโครโฟน USB"
-    },
-    {
-      "id": "native.android.ba46258fadec7a39",
-      "source": "External microphone",
-      "translated": "ไมโครโฟนภายนอก"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5139,9 +5074,9 @@
       "translated": "ตรวจสอบ"
     },
     {
-      "id": "native.android.c971506716c96e91",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
-      "translated": "OpenClaw เปลี่ยนโทรศัพท์เครื่องนี้ให้เป็นอินเทอร์เฟซคำสั่งบนมือถือที่เรียบง่ายสำหรับเธรด เสียง ผู้ให้บริการ และ Gateway"
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw เปลี่ยนโทรศัพท์เครื่องนี้ให้เป็นอินเทอร์เฟซคำสั่งบนมือถือที่เรียบง่ายสำหรับเซสชัน เสียง ผู้ให้บริการ และ Gateway"
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5689,9 +5624,9 @@
       "translated": "การตั้งค่าพูดคุย"
     },
     {
-      "id": "native.android.36f78c8c85dc283f",
-      "source": "Recent Threads",
-      "translated": "เธรดล่าสุด"
+      "id": "native.android.73f07a5d54915259",
+      "source": "Recent Sessions",
+      "translated": "เซสชันล่าสุด"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5749,14 +5684,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% ออนไลน์"
     },
     {
-      "id": "native.android.57177017a6a93826",
-      "source": "Threads",
-      "translated": "เธรด"
+      "id": "native.android.16c3425d3a594481",
+      "source": "Sessions",
+      "translated": "เซสชัน"
     },
     {
-      "id": "native.android.43320b54a68b00a1",
-      "source": "No recent threads",
-      "translated": "ไม่มีเธรดล่าสุด"
+      "id": "native.android.a5c0f8b3112aa58c",
+      "source": "No recent sessions",
+      "translated": "ไม่มีเซสชันล่าสุด"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5794,14 +5729,14 @@
       "translated": "กำลังทำงาน · มีงานที่ใช้งานอยู่ $pendingRunCount รายการ"
     },
     {
-      "id": "native.android.e24db059480f1e6a",
-      "source": "Monitoring · 1 thread",
-      "translated": "กำลังติดตาม · 1 เธรด"
+      "id": "native.android.2c89da708b12a522",
+      "source": "Monitoring · 1 session",
+      "translated": "กำลังตรวจสอบ · 1 เซสชัน"
     },
     {
-      "id": "native.android.5a475f37d80e02bc",
-      "source": "Monitoring · $sessionCount threads",
-      "translated": "กำลังติดตาม · $sessionCount เธรด"
+      "id": "native.android.8b6ee382dcb64e1f",
+      "source": "Monitoring · $sessionCount sessions",
+      "translated": "กำลังตรวจสอบ · $sessionCount เซสชัน"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5834,9 +5769,9 @@
       "translated": "ผู้ให้บริการ"
     },
     {
-      "id": "native.android.358c5e0e838d5423",
-      "source": "Open thread",
-      "translated": "เปิดเธรด"
+      "id": "native.android.a65477861c7203aa",
+      "source": "Open session",
+      "translated": "เปิดเซสชัน"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6259,9 +6194,9 @@
       "translated": "${days} วัน"
     },
     {
-      "id": "native.android.28a1a1acc5a0959f",
-      "source": "Main thread",
-      "translated": "เธรดหลัก"
+      "id": "native.android.22d755834386db07",
+      "source": "Main session",
+      "translated": "เซสชันหลัก"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6942,16 +6877,6 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "เปิดเสียง"
-    },
-    {
-      "id": "native.android.cb608d82c5b3352a",
-      "source": "Back camera",
-      "translated": "กล้องหลัง"
-    },
-    {
-      "id": "native.android.e89a0e780eed2e1e",
-      "source": "Front camera",
-      "translated": "กล้องหน้า"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7759,9 +7684,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.0c74bc30a994dd33",
-      "source": "Loading thread",
-      "translated": "กำลังโหลดเธรด"
+      "id": "native.android.882cc14a58e7e105",
+      "source": "Loading session",
+      "translated": "กำลังโหลดเซสชัน"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7804,14 +7729,14 @@
       "translated": "สรุปความคืบหน้าให้ฉัน"
     },
     {
-      "id": "native.android.cf40df9739f78f27",
-      "source": "Summarize recent threads and next steps.",
-      "translated": "สรุปเธรดล่าสุดและขั้นตอนถัดไป"
+      "id": "native.android.1e5add56e48c99f9",
+      "source": "Summarize recent sessions and next steps.",
+      "translated": "สรุปเซสชันล่าสุดและขั้นตอนถัดไป"
     },
     {
-      "id": "native.android.ebe49a8b8df80bd3",
-      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
-      "translated": "สรุปเธรด OpenClaw ล่าสุดของฉันและแนะนำขั้นตอนถัดไป"
+      "id": "native.android.06d515351bb79576",
+      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
+      "translated": "สรุปเซสชัน OpenClaw ล่าสุดของฉันและแนะนำขั้นตอนถัดไป"
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8149,9 +8074,9 @@
       "translated": "เชื่อมต่อแล้ว"
     },
     {
-      "id": "native.android.6cf5d6fa8a4186d5",
-      "source": "Threads",
-      "translated": "เธรด"
+      "id": "native.android.81931886b9caf3ab",
+      "source": "Sessions",
+      "translated": "เซสชัน"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,6 +10719,61 @@
       "translated": "รายละเอียดงาน"
     },
     {
+      "id": "native.apple.29cacb53ea5e77fc",
+      "source": "Pinned",
+      "translated": "ปักหมุดแล้ว"
+    },
+    {
+      "id": "native.apple.940062cfdce9211b",
+      "source": "Recent",
+      "translated": "ล่าสุด"
+    },
+    {
+      "id": "native.apple.a0980128426308a9",
+      "source": "Model",
+      "translated": "โมเดล"
+    },
+    {
+      "id": "native.apple.9520e60f21535dde",
+      "source": "Thinking",
+      "translated": "การคิด"
+    },
+    {
+      "id": "native.apple.8b321f3ffce97429",
+      "source": "Fast",
+      "translated": "เร็ว"
+    },
+    {
+      "id": "native.apple.989b70d64e328d55",
+      "source": "Default (inherited)",
+      "translated": "ค่าเริ่มต้น (สืบทอดมา)"
+    },
+    {
+      "id": "native.apple.f4114e73b07eb9ae",
+      "source": "Off",
+      "translated": "ปิด"
+    },
+    {
+      "id": "native.apple.7ed231b28d16312f",
+      "source": "On",
+      "translated": "เปิด"
+    },
+    {
+      "id": "native.apple.412a74802320a037",
+      "source": "Full",
+      "translated": "เต็มรูปแบบ"
+    },
+    {
+      "id": "native.apple.299f21a2071ff9fc",
+      "source": "Verbosity",
+      "translated": "ระดับรายละเอียด"
+    },
+    {
+      "id": "native.apple.faf0ef05e1496de7",
+      "source": "Default",
+      "translated": "ค่าเริ่มต้น"
+    },
+    {
       "id": "native.apple.e5524d5756a62744",
       "source": "Unable to Export Transcript",
       "translated": "ไม่สามารถส่งออกบันทึกการสนทนาได้"
@@ -10814,9 +10794,9 @@
       "translated": "คุณต้องการทำงานอะไร?"
     },
     {
-      "id": "native.apple.4da775013ac9b123",
-      "source": "The thread attaches once the gateway is ready.",
-      "translated": "เธรดจะแนบเมื่อ Gateway พร้อมใช้งาน"
+      "id": "native.apple.32179ce0b6d4543f",
+      "source": "The session attaches once the gateway is ready.",
+      "translated": "เซสชันจะเชื่อมต่อเมื่อ gateway พร้อมใช้งาน"
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10859,9 +10839,14 @@
       "translated": "แชทใหม่ใน Worktree"
     },
     {
-      "id": "native.apple.003b25ddafeb18e9",
-      "source": "Threads…",
-      "translated": "เธรด…"
+      "id": "native.apple.ce6ebe91fc597015",
+      "source": "New Session Options…",
+      "translated": "ตัวเลือกเซสชันใหม่…"
+    },
+    {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "เซสชัน…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11024,14 +11009,14 @@
       "translated": "สร้าง"
     },
     {
-      "id": "native.apple.31d5c7287cfb3abe",
-      "source": "Delete Thread?",
-      "translated": "ลบเธรดหรือไม่?"
+      "id": "native.apple.f488b9caf6e51ac3",
+      "source": "Delete Session?",
+      "translated": "ลบเซสชัน?"
     },
     {
-      "id": "native.apple.d3395564809f1120",
-      "source": "Delete Thread",
-      "translated": "ลบเธรด"
+      "id": "native.apple.8634b17be9b111bc",
+      "source": "Delete Session",
+      "translated": "ลบเซสชัน"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11039,9 +11024,9 @@
       "translated": "ยกเลิก"
     },
     {
-      "id": "native.apple.092659256d26cb03",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "การดำเนินการนี้จะลบเธรดและบทสนทนาอย่างถาวร"
+      "id": "native.apple.4a9568ac9b18d8d3",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "การดำเนินการนี้จะลบเซสชันและบันทึกการสนทนาของเซสชันนี้อย่างถาวร"
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11069,9 +11054,9 @@
       "translated": "กลุ่มใหม่"
     },
     {
-      "id": "native.apple.683032464c497bbd",
-      "source": "Rename Thread",
-      "translated": "เปลี่ยนชื่อเธรด"
+      "id": "native.apple.5bccdc23a1640895",
+      "source": "Rename Session",
+      "translated": "เปลี่ยนชื่อเซสชัน"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11079,9 +11064,9 @@
       "translated": "ชื่อกลุ่ม"
     },
     {
-      "id": "native.apple.f887aa956588f237",
-      "source": "Thread name",
-      "translated": "ชื่อเธรด"
+      "id": "native.apple.af789b2d2fda0f67",
+      "source": "Session name",
+      "translated": "ชื่อเซสชัน"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11119,14 +11104,14 @@
       "translated": "เอเจนต์"
     },
     {
-      "id": "native.apple.7c8231b7b1ca480f",
-      "source": "Agent thread",
-      "translated": "เธรดของเอเจนต์"
+      "id": "native.apple.a3bde8045fe9224a",
+      "source": "Agent session",
+      "translated": "เซสชันเอเจนต์"
     },
     {
-      "id": "native.apple.b3c553614f762a58",
-      "source": "Recent threads",
-      "translated": "เธรดล่าสุด"
+      "id": "native.apple.27f775de30b37ff8",
+      "source": "Recent sessions",
+      "translated": "เซสชันล่าสุด"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11134,9 +11119,9 @@
       "translated": "Gateway ออฟไลน์"
     },
     {
-      "id": "native.apple.5aa32afda85064ea",
-      "source": "No recent threads",
-      "translated": "ไม่มีเธรดล่าสุด"
+      "id": "native.apple.28c97cf23665ee01",
+      "source": "No recent sessions",
+      "translated": "ไม่มีเซสชันล่าสุด"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11234,14 +11219,14 @@
       "translated": "ยกเลิก"
     },
     {
-      "id": "native.apple.b6855cf19a50f477",
-      "source": "Threads",
-      "translated": "เธรด"
+      "id": "native.apple.9f2fd65953013b7c",
+      "source": "Sessions",
+      "translated": "เซสชัน"
     },
     {
-      "id": "native.apple.9b1d0ef27a1333b0",
-      "source": "Archived threads",
-      "translated": "เธรดที่เก็บถาวร"
+      "id": "native.apple.0422818cc95d5071",
+      "source": "Archived sessions",
+      "translated": "เซสชันที่เก็บถาวร"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11249,34 +11234,34 @@
       "translated": "แสดงที่เก็บถาวร"
     },
     {
-      "id": "native.apple.98167401c7267735",
-      "source": "Threads unavailable",
-      "translated": "ไม่สามารถใช้งานเธรดได้"
+      "id": "native.apple.b272115c83f7ef58",
+      "source": "Sessions unavailable",
+      "translated": "เซสชันไม่พร้อมใช้งาน"
     },
     {
-      "id": "native.apple.4d28a7def2337b9f",
-      "source": "Loading archived threads",
-      "translated": "กำลังโหลดเธรดที่เก็บถาวร"
+      "id": "native.apple.54f8260c9b863087",
+      "source": "Loading archived sessions",
+      "translated": "กำลังโหลดเซสชันที่เก็บถาวร"
     },
     {
-      "id": "native.apple.777d7b706933bd7b",
-      "source": "Loading recent threads",
-      "translated": "กำลังโหลดเธรดล่าสุด"
+      "id": "native.apple.9b305868873dade2",
+      "source": "Loading recent sessions",
+      "translated": "กำลังโหลดเซสชันล่าสุด"
     },
     {
-      "id": "native.apple.22f81ea94bef8410",
-      "source": "^[\\(count) thread](inflect: true)",
-      "translated": "^[\\(count) เธรด](inflect: true)"
+      "id": "native.apple.207dad20d09f3160",
+      "source": "^[\\(count) session](inflect: true)",
+      "translated": "^[\\(count) เซสชัน](inflect: true)"
     },
     {
-      "id": "native.apple.1cad51e14db59bf9",
-      "source": "No archived threads",
-      "translated": "ไม่มีเธรดที่เก็บถาวร"
+      "id": "native.apple.1f4501a6bf2bae4c",
+      "source": "No archived sessions",
+      "translated": "ไม่มีเซสชันที่เก็บถาวร"
     },
     {
-      "id": "native.apple.18ef832d3a7ddcf8",
-      "source": "Archived threads will appear here.",
-      "translated": "เธรดที่เก็บถาวรจะปรากฏที่นี่"
+      "id": "native.apple.2a1ba7a5e1979c9e",
+      "source": "Archived sessions will appear here.",
+      "translated": "เซสชันที่เก็บถาวรแล้วจะแสดงที่นี่"
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11359,9 +11344,9 @@
       "translated": "แชร์ข้อมูลนำเข้า"
     },
     {
-      "id": "native.apple.21d9208d86a4d1fe",
-      "source": "Loading threads",
-      "translated": "กำลังโหลดเธรด"
+      "id": "native.apple.2360d25fe6ae9946",
+      "source": "Loading sessions",
+      "translated": "กำลังโหลดเซสชัน"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11369,19 +11354,19 @@
       "translated": "กำลังดึงกิจกรรมล่าสุดจาก Gateway"
     },
     {
-      "id": "native.apple.4be1f79aa2b230ff",
-      "source": "Threads unavailable",
-      "translated": "เธรดไม่พร้อมใช้งาน"
+      "id": "native.apple.c334f2e86702a7b8",
+      "source": "Sessions unavailable",
+      "translated": "เซสชันไม่พร้อมใช้งาน"
     },
     {
-      "id": "native.apple.98b348873556bc46",
-      "source": "No recent threads",
-      "translated": "ไม่มีเธรดล่าสุด"
+      "id": "native.apple.6cc6efb7a03960b6",
+      "source": "No recent sessions",
+      "translated": "ไม่มีเซสชันล่าสุด"
     },
     {
-      "id": "native.apple.7396d205574d279f",
-      "source": "Thread activity offline",
-      "translated": "กิจกรรมของเธรดออฟไลน์"
+      "id": "native.apple.08483af2d043bee6",
+      "source": "Session activity offline",
+      "translated": "กิจกรรมเซสชันออฟไลน์"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11839,9 +11824,9 @@
       "translated": "การ์ด"
     },
     {
-      "id": "native.apple.c9ec1b0e18074d8a",
-      "source": "Open Thread",
-      "translated": "เปิดเธรด"
+      "id": "native.apple.93eeaedb2ff61043",
+      "source": "Open Session",
+      "translated": "เปิดเซสชัน"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13329,9 +13314,9 @@
       "translated": "ค่าเริ่มต้น"
     },
     {
-      "id": "native.apple.f4ae5664c3eda95d",
-      "source": "Used for new Chat threads and Talk sessions.",
-      "translated": "ใช้สำหรับเธรดแชทใหม่และเซสชันการพูดคุย"
+      "id": "native.apple.3de045f17ea3c6d0",
+      "source": "Used for new Chat and Talk sessions.",
+      "translated": "ใช้สำหรับเซสชัน Chat และ Talk ใหม่"
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15734,9 +15719,9 @@
       "translated": "อินสแตนซ์"
     },
     {
-      "id": "native.apple.11fe8b9941954dfb",
-      "source": "Threads",
-      "translated": "เธรด"
+      "id": "native.apple.3579cf2750470a22",
+      "source": "Sessions",
+      "translated": "เซสชัน"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19044,9 +19029,9 @@
       "translated": "ปุ่มลัดแชตด่วน"
     },
     {
-      "id": "native.apple.94dd793cd7d7d555",
-      "source": "Global shortcut that opens a floating chat bar for the main thread.",
-      "translated": "ปุ่มลัดส่วนกลางที่ใช้เปิดแถบแชทแบบลอยสำหรับเธรดหลัก"
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "ปุ่มลัดส่วนกลางที่เปิดแถบแชตแบบลอยสำหรับเซสชันหลัก"
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19624,9 +19609,9 @@
       "translated": "ร้ายแรง"
     },
     {
-      "id": "native.apple.13f96467014cf344",
-      "source": "New Thread",
-      "translated": "เธรดใหม่"
+      "id": "native.apple.75102378a6775180",
+      "source": "New Session",
+      "translated": "เซสชันใหม่"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21914,9 +21899,9 @@
       "translated": "ไม่มีข้อความล่าสุด"
     },
     {
-      "id": "native.apple.3ec2afcbc298c673",
-      "source": "Threads",
-      "translated": "เธรด"
+      "id": "native.apple.1ff8aec0044934c3",
+      "source": "Sessions",
+      "translated": "เซสชัน"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21924,9 +21909,9 @@
       "translated": "ดูบัคเก็ตการสนทนาที่จัดเก็บไว้ ซึ่ง CLI นำกลับมาใช้ซ้ำสำหรับบริบทและขีดจำกัดอัตรา"
     },
     {
-      "id": "native.apple.14ccb32cd8ed1c81",
-      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
-      "translated": "ยังไม่มีเธรด เธรดจะปรากฏหลังจากได้รับข้อความขาเข้าหรือสัญญาณ heartbeat ครั้งแรก"
+      "id": "native.apple.bab897f3252b134c",
+      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
+      "translated": "ยังไม่มีเซสชัน รายการจะแสดงหลังจากมีข้อความขาเข้าหรือ heartbeat ครั้งแรก"
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -22009,9 +21994,9 @@
       "translated": "การอนุมัติการดำเนินการ"
     },
     {
-      "id": "native.apple.52e37e3a44ae516c",
-      "source": "Threads",
-      "translated": "เธรด"
+      "id": "native.apple.64a6dc7d49e8fb57",
+      "source": "Sessions",
+      "translated": "เซสชัน"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -23014,9 +22999,9 @@
       "translated": "อัปเดตให้ฉันทราบ"
     },
     {
-      "id": "native.apple.fc4ce810900ec0b6",
-      "source": "Summarize what happened in my threads since yesterday.",
-      "translated": "สรุปสิ่งที่เกิดขึ้นในเธรดของฉันตั้งแต่เมื่อวาน"
+      "id": "native.apple.234ec45f4231edc4",
+      "source": "Summarize what happened in my sessions since yesterday.",
+      "translated": "สรุปสิ่งที่เกิดขึ้นในเซสชันของฉันตั้งแต่เมื่อวาน"
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23194,9 +23179,9 @@
       "translated": "เลิกปักหมุดโมเดล"
     },
     {
-      "id": "native.apple.4edb66657f5aca1f",
-      "source": "Thread",
-      "translated": "เธรด"
+      "id": "native.apple.5dfc0700d8dff8de",
+      "source": "Session",
+      "translated": "เซสชัน"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23359,51 +23344,6 @@
       "translated": "วิดเจ็ตไม่พร้อมใช้งาน"
     },
     {
-      "id": "native.apple.d640691fd196f338",
-      "source": "Widget export failed",
-      "translated": "ส่งออกวิดเจ็ตไม่สำเร็จ"
-    },
-    {
-      "id": "native.apple.533c6e22a11e88de",
-      "source": "OK",
-      "translated": "ตกลง"
-    },
-    {
-      "id": "native.apple.e1fb28a2a9756402",
-      "source": "Copy image",
-      "translated": "คัดลอกรูปภาพ"
-    },
-    {
-      "id": "native.apple.ebd7bc92e1b12235",
-      "source": "Save image…",
-      "translated": "บันทึกรูปภาพ…"
-    },
-    {
-      "id": "native.apple.742c46d4cf2db134",
-      "source": "Save image",
-      "translated": "บันทึกรูปภาพ"
-    },
-    {
-      "id": "native.apple.0589cce608418f90",
-      "source": "The widget image could not be captured.",
-      "translated": "ไม่สามารถจับภาพวิดเจ็ตได้"
-    },
-    {
-      "id": "native.apple.dfe24e827fdbe9c5",
-      "source": "The widget image could not be copied.",
-      "translated": "ไม่สามารถคัดลอกภาพวิดเจ็ตได้"
-    },
-    {
-      "id": "native.apple.9e611e3a80e71408",
-      "source": "The widget image could not be encoded as PNG.",
-      "translated": "ไม่สามารถเข้ารหัสภาพวิดเจ็ตเป็น PNG ได้"
-    },
-    {
-      "id": "native.apple.9a6e8afbe24a262b",
-      "source": "The widget image could not be saved.",
-      "translated": "ไม่สามารถบันทึกภาพวิดเจ็ตได้"
-    },
-    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23544,19 +23484,19 @@
       "translated": "ผู้ใช้"
     },
     {
-      "id": "native.apple.9d0cba09d92ee669",
-      "source": "This thread cannot be archived while it is active or running.",
-      "translated": "ไม่สามารถเก็บเธรดนี้ถาวรได้ขณะที่ยังทำงานอยู่หรือกำลังประมวลผล"
+      "id": "native.apple.b1cdcb906a43d5d6",
+      "source": "This session cannot be archived while it is active or running.",
+      "translated": "ไม่สามารถเก็บเซสชันนี้เข้าคลังขณะที่ยังใช้งานหรือกำลังทำงานอยู่ได้"
     },
     {
-      "id": "native.apple.8952a111a1075051",
-      "source": "The main thread cannot be deleted.",
-      "translated": "ไม่สามารถลบเธรดหลักได้"
+      "id": "native.apple.5817e3f3dab1ee19",
+      "source": "The main session cannot be deleted.",
+      "translated": "ไม่สามารถลบเซสชันหลักได้"
     },
     {
-      "id": "native.apple.90d0ccf80ca28717",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
-      "translated": "นำไฟล์แนบออกหรือรอให้ส่งเสร็จก่อนเก็บถาวรหรือลบเธรดนี้"
+      "id": "native.apple.a6b8df3f18171c91",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
+      "translated": "นำไฟล์แนบออกหรือรอให้ส่งเสร็จก่อนเก็บเซสชันนี้เข้าคลังหรือลบ"
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23694,9 +23634,9 @@
       "translated": "สิ้นสุดการทำงาน"
     },
     {
-      "id": "native.apple.bbccb4c8db5cac12",
-      "source": "Thread Info",
-      "translated": "ข้อมูลเธรด"
+      "id": "native.apple.cd7c3095a22f80a9",
+      "source": "Session Info",
+      "translated": "ข้อมูลเซสชัน"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23729,9 +23669,9 @@
       "translated": "เพิ่มกลุ่ม"
     },
     {
-      "id": "native.apple.7b641fed5bace855",
-      "source": "Thread Groups",
-      "translated": "กลุ่มเธรด"
+      "id": "native.apple.23d628606fe0734f",
+      "source": "Session Groups",
+      "translated": "กลุ่มเซสชัน"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23774,9 +23714,9 @@
       "translated": "ลบกลุ่ม"
     },
     {
-      "id": "native.apple.56401c79410a310d",
-      "source": "Threads in this group become ungrouped.",
-      "translated": "เธรดในกลุ่มนี้จะถูกยกเลิกการจัดกลุ่ม"
+      "id": "native.apple.b049c8a4d2805e08",
+      "source": "Sessions in this group become ungrouped.",
+      "translated": "เซสชันในกลุ่มนี้จะไม่อยู่ในกลุ่มใด"
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23789,9 +23729,9 @@
       "translated": "ไม่มีเอเจนต์ที่พร้อมใช้งานบน Gateway นี้"
     },
     {
-      "id": "native.apple.2d96aa7d3d12f85b",
-      "source": "New Thread Options",
-      "translated": "ตัวเลือกเธรดใหม่"
+      "id": "native.apple.6c89f35d53506406",
+      "source": "New Session Options",
+      "translated": "ตัวเลือกเซสชันใหม่"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23819,19 +23759,19 @@
       "translated": "สร้าง"
     },
     {
-      "id": "native.apple.87ef57319d1ddc85",
-      "source": "The thread could not be created.",
-      "translated": "ไม่สามารถสร้างเธรดได้"
+      "id": "native.apple.795ba37f6782cf28",
+      "source": "The session could not be created.",
+      "translated": "ไม่สามารถสร้างเซสชันได้"
     },
     {
-      "id": "native.apple.6bd91c435b69d638",
-      "source": "Search threads",
-      "translated": "ค้นหาเธรด"
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "ค้นหาเซสชัน"
     },
     {
-      "id": "native.apple.6fde4bdf9d5b9191",
-      "source": "No Threads",
-      "translated": "ไม่มีเธรด"
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "ไม่มีเซสชัน"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23839,29 +23779,29 @@
       "translated": "ไม่พบผลลัพธ์"
     },
     {
-      "id": "native.apple.a02fd99740d29bd3",
-      "source": "New Thread",
-      "translated": "เธรดใหม่"
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "เซสชันใหม่"
     },
     {
-      "id": "native.apple.b625801dd04b09f2",
-      "source": "New thread",
-      "translated": "เธรดใหม่"
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "เซสชันใหม่"
     },
     {
-      "id": "native.apple.851be81fcc933608",
-      "source": "New thread options",
-      "translated": "ตัวเลือกเธรดใหม่"
+      "id": "native.apple.2ef0e34db02ad255",
+      "source": "New session options",
+      "translated": "ตัวเลือกเซสชันใหม่"
     },
     {
-      "id": "native.apple.9ce8a4aba7b444b2",
-      "source": "Rename Thread",
-      "translated": "เปลี่ยนชื่อเธรด"
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "เปลี่ยนชื่อเซสชัน"
     },
     {
-      "id": "native.apple.1dd067c44511c7f0",
-      "source": "Thread name",
-      "translated": "ชื่อเธรด"
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "ชื่อเซสชัน"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23874,14 +23814,14 @@
       "translated": "ยกเลิก"
     },
     {
-      "id": "native.apple.618073d6ab3f2721",
-      "source": "Delete Thread",
-      "translated": "ลบเธรด"
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "ลบเซสชัน"
     },
     {
-      "id": "native.apple.10a5e72bba3cbccc",
-      "source": "The thread and its transcript are removed from the gateway.",
-      "translated": "เธรดและบันทึกการสนทนาจะถูกลบออกจาก Gateway"
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "เซสชันและบันทึกการสนทนาจะถูกลบออกจาก Gateway"
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23889,14 +23829,14 @@
       "translated": "ลบ “%@” หรือไม่?"
     },
     {
-      "id": "native.apple.ac71e3b2aa496a2c",
-      "source": "Thread running",
-      "translated": "เธรดกำลังทำงาน"
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "เซสชันกำลังทำงาน"
     },
     {
-      "id": "native.apple.c775e87f997278b2",
-      "source": "Thread failed",
-      "translated": "เธรดล้มเหลว"
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "เซสชันล้มเหลว"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23954,9 +23894,9 @@
       "translated": "คัดลอกคีย์เซสชัน"
     },
     {
-      "id": "native.apple.f4998cfb572f23ff",
-      "source": "Delete Thread…",
-      "translated": "ลบเธรด…"
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "ลบเซสชัน…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23969,9 +23909,9 @@
       "translated": "กำลังเชื่อมต่อ…"
     },
     {
-      "id": "native.apple.8802e9576ffd0f65",
-      "source": "Retry thread groups",
-      "translated": "ลองโหลดกลุ่มเธรดอีกครั้ง"
+      "id": "native.apple.79f708b3bc1d3a6c",
+      "source": "Retry session groups",
+      "translated": "ลองโหลดกลุ่มเซสชันอีกครั้ง"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23994,24 +23934,24 @@
       "translated": "ขอบเขต"
     },
     {
-      "id": "native.apple.b313b80def4bda52",
-      "source": "Search threads",
-      "translated": "ค้นหาเธรด"
+      "id": "native.apple.2c37581c7b88f741",
+      "source": "Search sessions",
+      "translated": "ค้นหาเซสชัน"
     },
     {
-      "id": "native.apple.c0cc6acc36f413ce",
-      "source": "Threads",
-      "translated": "เธรด"
+      "id": "native.apple.43be8a2336e42faf",
+      "source": "Sessions",
+      "translated": "เซสชัน"
     },
     {
-      "id": "native.apple.854d3928fe5a557c",
-      "source": "Rename Thread",
-      "translated": "เปลี่ยนชื่อเธรด"
+      "id": "native.apple.0b379cdfcbd3247f",
+      "source": "Rename Session",
+      "translated": "เปลี่ยนชื่อเซสชัน"
     },
     {
-      "id": "native.apple.9d0d3f20096cc4da",
-      "source": "Thread name",
-      "translated": "ชื่อเธรด"
+      "id": "native.apple.54b6fbd9e41db009",
+      "source": "Session name",
+      "translated": "ชื่อเซสชัน"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -24019,19 +23959,19 @@
       "translated": "ยกเลิก"
     },
     {
-      "id": "native.apple.dc00eb94f33bae15",
-      "source": "Delete selected threads?",
-      "translated": "ลบเธรดที่เลือกหรือไม่?"
+      "id": "native.apple.751e0f6b81cd374a",
+      "source": "Delete selected sessions?",
+      "translated": "ลบเซสชันที่เลือกหรือไม่?"
     },
     {
-      "id": "native.apple.2053fc9f74dc3158",
-      "source": "Delete Threads",
-      "translated": "ลบเธรด"
+      "id": "native.apple.aa679276581b0058",
+      "source": "Delete Sessions",
+      "translated": "ลบเซสชัน"
     },
     {
-      "id": "native.apple.0970247871a834a0",
-      "source": "Each selected thread and its transcript will be removed from the gateway.",
-      "translated": "เธรดที่เลือกแต่ละรายการและบทสนทนาจะถูกลบออกจาก Gateway"
+      "id": "native.apple.f837129cbee23297",
+      "source": "Each selected session and its transcript will be removed from the gateway.",
+      "translated": "เซสชันที่เลือกแต่ละรายการและบันทึกการสนทนาจะถูกลบออกจาก Gateway"
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -24039,9 +23979,9 @@
       "translated": "กลุ่ม"
     },
     {
-      "id": "native.apple.6f8acab2256728b5",
-      "source": "Manage thread groups",
-      "translated": "จัดการกลุ่มเธรด"
+      "id": "native.apple.64013cfee5e25305",
+      "source": "Manage session groups",
+      "translated": "จัดการกลุ่มเซสชัน"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -24054,14 +23994,14 @@
       "translated": "เลือก"
     },
     {
-      "id": "native.apple.692972314d04b184",
-      "source": "No archived threads",
-      "translated": "ไม่มีเธรดที่เก็บถาวร"
+      "id": "native.apple.b67eaecec1b423ac",
+      "source": "No archived sessions",
+      "translated": "ไม่มีเซสชันที่เก็บถาวร"
     },
     {
-      "id": "native.apple.d6a4b5711dcd26e7",
-      "source": "No threads found",
-      "translated": "ไม่พบเธรด"
+      "id": "native.apple.b2435a79abf0c794",
+      "source": "No sessions found",
+      "translated": "ไม่พบเซสชัน"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24229,16 +24169,6 @@
       "translated": "เปิดข้อความฉบับเต็ม"
     },
     {
-      "id": "native.apple.002bfcede229ad4b",
-      "source": "Rewind to Here",
-      "translated": "ย้อนกลับมาที่นี่"
-    },
-    {
-      "id": "native.apple.14df2e4997689fb3",
-      "source": "Fork from Here",
-      "translated": "แยกแขนงจากตรงนี้"
-    },
-    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "ตอบกลับ"
@@ -24324,9 +24254,9 @@
       "translated": "นำไฟล์แนบออกหรือรอให้การส่งเสร็จสิ้นก่อนเริ่มแชตใหม่"
     },
     {
-      "id": "native.apple.e0f045151c8d3137",
-      "source": "Gateway changed before the thread operation started.",
-      "translated": "Gateway มีการเปลี่ยนแปลงก่อนเริ่มดำเนินการกับเธรด"
+      "id": "native.apple.980f552bb0f96c0f",
+      "source": "Gateway changed before the session operation started.",
+      "translated": "Gateway มีการเปลี่ยนแปลงก่อนเริ่มดำเนินการกับเซสชัน"
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24334,9 +24264,9 @@
       "translated": "ลบไฟล์แนบหรือรอให้การส่งเสร็จสิ้นก่อนสลับแชท"
     },
     {
-      "id": "native.apple.0a5c4e15466c3acc",
-      "source": "Clear this thread's history?",
-      "translated": "ล้างประวัติของเธรดนี้หรือไม่?"
+      "id": "native.apple.87ba543b42696b92",
+      "source": "Clear this session's history?",
+      "translated": "ล้างประวัติของเซสชันนี้หรือไม่?"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24349,14 +24279,14 @@
       "translated": "การดำเนินการนี้จะรีเซ็ตการสนทนาสำหรับ %@ โดยคีย์เซสชันจะยังคงเดิม"
     },
     {
-      "id": "native.apple.67ac221dbe7179f0",
-      "source": "Rename Thread",
-      "translated": "เปลี่ยนชื่อเธรด"
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "เปลี่ยนชื่อเซสชัน"
     },
     {
-      "id": "native.apple.cf0f7e049603f518",
-      "source": "Thread name",
-      "translated": "ชื่อเธรด"
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "ชื่อเซสชัน"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24374,9 +24304,9 @@
       "translated": "ส่งออกสำเนาบทสนทนา"
     },
     {
-      "id": "native.apple.c0ada47504425f23",
-      "source": "Threads",
-      "translated": "เธรด"
+      "id": "native.apple.4af0f566d39d7041",
+      "source": "Sessions",
+      "translated": "เซสชัน"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24449,14 +24379,14 @@
       "translated": "ค่าเริ่มต้น"
     },
     {
-      "id": "native.apple.1a765291943599e5",
-      "source": "New Thread",
-      "translated": "เธรดใหม่"
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "เซสชันใหม่"
     },
     {
-      "id": "native.apple.c7a3a6d5e43dd98f",
-      "source": "New Thread Options…",
-      "translated": "ตัวเลือกเธรดใหม่…"
+      "id": "native.apple.a7119fbf9d25df5e",
+      "source": "New Session Options…",
+      "translated": "ตัวเลือกเซสชันใหม่…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24464,19 +24394,19 @@
       "translated": "รีเฟรช"
     },
     {
-      "id": "native.apple.0e710b81808e5dcf",
-      "source": "Threads…",
-      "translated": "เธรด…"
+      "id": "native.apple.2bcff4a8fa503739",
+      "source": "Sessions…",
+      "translated": "เซสชัน…"
     },
     {
-      "id": "native.apple.faad8f92b6bef166",
-      "source": "Rename Thread…",
-      "translated": "เปลี่ยนชื่อเธรด…"
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "เปลี่ยนชื่อเซสชัน…"
     },
     {
-      "id": "native.apple.23b61d6cd26ac112",
-      "source": "Fork",
-      "translated": "แยกแขนง"
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "แยกเซสชัน"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24534,24 +24464,24 @@
       "translated": "ล้างประวัติ…"
     },
     {
-      "id": "native.apple.8b4f1c5107ea8a0e",
-      "source": "Thread",
-      "translated": "เธรด"
+      "id": "native.apple.920fe8a7a33f9e92",
+      "source": "Session",
+      "translated": "เซสชัน"
     },
     {
-      "id": "native.apple.4d7750c9bf699469",
-      "source": "Thread actions",
-      "translated": "การดำเนินการกับเธรด"
+      "id": "native.apple.185a401f78328b0f",
+      "source": "Session actions",
+      "translated": "การดำเนินการเซสชัน"
     },
     {
-      "id": "native.apple.bb2f22cc43c97f8e",
-      "source": "Thread cost %@",
-      "translated": "ค่าใช้จ่ายของเธรด %@"
+      "id": "native.apple.9f9dedf599b2619b",
+      "source": "Session cost %@",
+      "translated": "ค่าใช้จ่ายของเซสชัน %@"
     },
     {
-      "id": "native.apple.6239ced0b86e86f8",
-      "source": "Compact Thread",
-      "translated": "ย่อเธรด"
+      "id": "native.apple.f0a4720df5f5f403",
+      "source": "Compact Session",
+      "translated": "ย่อเซสชัน"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -1429,9 +1429,9 @@
       "translated": "พูดหรือป้อนตามคำบอกด้วย OpenClaw"
     },
     {
-      "id": "native.android.5876e15e5e92fd45",
-      "source": "Browse Sessions",
-      "translated": "เรียกดูเซสชัน"
+      "id": "native.android.e2cf5a38587382cb",
+      "source": "Browse Threads",
+      "translated": "เรียกดูเธรด"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "ไม่พบการดำเนินการ"
     },
     {
-      "id": "native.android.48ad0ae0e930e02b",
-      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
-      "translated": "ลองใช้ Chat, Voice, Sessions, Providers หรือ Settings"
+      "id": "native.android.bc70a4ac965b82ba",
+      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
+      "translated": "ลองใช้แชท เสียง เธรด ผู้ให้บริการ หรือการตั้งค่า"
     },
     {
-      "id": "native.android.d4fbd1ee4f55a5db",
-      "source": "Sessions",
-      "translated": "เซสชัน"
+      "id": "native.android.670121e54dbe286f",
+      "source": "Threads",
+      "translated": "เธรด"
     },
     {
-      "id": "native.android.207c2170504e99e6",
-      "source": "Connect the Gateway to search sessions.",
-      "translated": "เชื่อมต่อ Gateway เพื่อค้นหาเซสชัน"
+      "id": "native.android.d38be650b1bce4a0",
+      "source": "Connect the Gateway to search threads.",
+      "translated": "เชื่อมต่อ Gateway เพื่อค้นหาเธรด"
     },
     {
-      "id": "native.android.25d2c2d792c952fe",
-      "source": "No matching sessions yet.",
-      "translated": "ยังไม่มีเซสชันที่ตรงกัน"
+      "id": "native.android.3d7754721f776ef8",
+      "source": "No matching threads yet.",
+      "translated": "ยังไม่มีเธรดที่ตรงกัน"
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "ผู้ช่วยกำลังทำงาน"
     },
     {
-      "id": "native.android.8f8384286317f5c9",
-      "source": "OpenClaw session",
-      "translated": "เซสชัน OpenClaw"
+      "id": "native.android.9a839f6e3e05a744",
+      "source": "OpenClaw thread",
+      "translated": "เธรด OpenClaw"
     },
     {
-      "id": "native.android.15799e57704b20c6",
-      "source": "Open session",
-      "translated": "เปิดเซสชัน"
+      "id": "native.android.d83f82a1e4a5ed99",
+      "source": "Open thread",
+      "translated": "เปิดเธรด"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "ไม่มีผู้ให้บริการที่พร้อมใช้งาน"
     },
     {
-      "id": "native.android.73e6ab1a168fd381",
-      "source": "Main session",
-      "translated": "เซสชันหลัก"
+      "id": "native.android.8a1c5365c0538908",
+      "source": "Main thread",
+      "translated": "เธรดหลัก"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.0e3157c15c56944f",
-      "source": "Sessions",
-      "translated": "เซสชัน"
+      "id": "native.android.a5845742daecb4ba",
+      "source": "Threads",
+      "translated": "เธรด"
     },
     {
-      "id": "native.android.70f5d0507d34b5c8",
-      "source": "Focus session search",
-      "translated": "โฟกัสช่องค้นหาเซสชัน"
+      "id": "native.android.439b324280869527",
+      "source": "Focus thread search",
+      "translated": "โฟกัสการค้นหาเธรด"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "เก็บถาวรแล้ว"
     },
     {
-      "id": "native.android.b9cf34c137e4cf03",
-      "source": "Search sessions",
-      "translated": "ค้นหาเซสชัน"
+      "id": "native.android.03981341841b04ac",
+      "source": "Search threads",
+      "translated": "ค้นหาเธรด"
     },
     {
-      "id": "native.android.10cb26723e9990fc",
-      "source": "Clear session search",
-      "translated": "ล้างการค้นหาเซสชัน"
+      "id": "native.android.99570c528a41fa72",
+      "source": "Clear thread search",
+      "translated": "ล้างการค้นหาเธรด"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "เก่าสุดก่อน"
     },
     {
-      "id": "native.android.c6bf8751e2a7f5c7",
-      "source": "Toggle session layout",
-      "translated": "สลับเลย์เอาต์เซสชัน"
+      "id": "native.android.fd67be543e321cc9",
+      "source": "Toggle thread layout",
+      "translated": "สลับเค้าโครงเธรด"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "เลย์เอาต์: รายละเอียด"
     },
     {
-      "id": "native.android.69b79a3c2c987cd4",
-      "source": "Searching sessions",
-      "translated": "กำลังค้นหาเซสชัน"
+      "id": "native.android.ebd17565e0ffd8eb",
+      "source": "Searching threads",
+      "translated": "กำลังค้นหาเธรด"
     },
     {
-      "id": "native.android.dd587d341af44212",
-      "source": "No matching sessions",
-      "translated": "ไม่พบเซสชันที่ตรงกัน"
+      "id": "native.android.472d46ae8669f860",
+      "source": "No matching threads",
+      "translated": "ไม่มีเธรดที่ตรงกัน"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "เริ่มแชท"
     },
     {
-      "id": "native.android.f10d4df7cbc6df4f",
-      "source": "Current session",
-      "translated": "เซสชันปัจจุบัน"
+      "id": "native.android.ff81ad1bee00d384",
+      "source": "Current thread",
+      "translated": "เธรดปัจจุบัน"
     },
     {
-      "id": "native.android.8f0482425838ae64",
-      "source": "OpenClaw session",
-      "translated": "เซสชัน OpenClaw"
+      "id": "native.android.fc145645b9620e57",
+      "source": "OpenClaw thread",
+      "translated": "เธรด OpenClaw"
     },
     {
-      "id": "native.android.786774c8a76e50d7",
-      "source": "Rename session",
-      "translated": "เปลี่ยนชื่อเซสชัน"
+      "id": "native.android.71cbb8dde8bf138b",
+      "source": "Rename thread",
+      "translated": "เปลี่ยนชื่อเธรด"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "ลบกลุ่มหรือไม่?"
     },
     {
-      "id": "native.android.3455fc2f77d564e3",
-      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "เซสชันใน \"$group\" จะถูกเก็บไว้และย้ายกลับไปยังไม่จัดกลุ่ม"
+      "id": "native.android.691e92cfe5cf106e",
+      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "เธรดใน \"$group\" จะยังคงอยู่และย้ายกลับไปที่ไม่ได้จัดกลุ่ม"
     },
     {
-      "id": "native.android.4805fb9d6623e8c0",
-      "source": "Delete session?",
-      "translated": "ลบเซสชันหรือไม่?"
+      "id": "native.android.d87a8217ab56999b",
+      "source": "Delete thread?",
+      "translated": "ลบเธรดหรือไม่?"
     },
     {
-      "id": "native.android.0c3283a2b2445eae",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "การดำเนินการนี้จะลบเซสชันและข้อความถอดเสียงอย่างถาวร"
+      "id": "native.android.930de97ff47113a8",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "การดำเนินการนี้จะลบเธรดและบันทึกการสนทนาอย่างถาวร"
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "ไม่ได้จัดกลุ่ม"
     },
     {
-      "id": "native.android.db243d71d056afa4",
-      "source": "No sessions yet",
-      "translated": "ยังไม่มีเซสชัน"
+      "id": "native.android.8e21a70428def6e0",
+      "source": "No threads yet",
+      "translated": "ยังไม่มีเธรด"
     },
     {
-      "id": "native.android.5b4eee6a8092925e",
-      "source": "No current session",
-      "translated": "ไม่มีเซสชันปัจจุบัน"
+      "id": "native.android.cda4c5ad8b17e394",
+      "source": "No current thread",
+      "translated": "ไม่มีเธรดปัจจุบัน"
     },
     {
-      "id": "native.android.acbcc9c9ea53d8c0",
-      "source": "No archived sessions",
-      "translated": "ไม่มีเซสชันที่เก็บถาวร"
+      "id": "native.android.be84f061047aa2da",
+      "source": "No archived threads",
+      "translated": "ไม่มีเธดที่เก็บถาวร"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "เริ่มการสนทนาใหม่ แล้วจะแสดงที่นี่"
     },
     {
-      "id": "native.android.56fcd605dc7be3c0",
-      "source": "Open Chat to start or resume the current session.",
-      "translated": "เปิดแชทเพื่อเริ่มหรือกลับไปใช้เซสชันปัจจุบัน"
+      "id": "native.android.f289d03e1d3eee98",
+      "source": "Open Chat to start or resume the current thread.",
+      "translated": "เปิดแชทเพื่อเริ่มหรือดำเนินการต่อในเธรดปัจจุบัน"
     },
     {
-      "id": "native.android.085515989f8a2022",
-      "source": "Archived sessions will show up here.",
-      "translated": "เซสชันที่เก็บถาวรจะแสดงที่นี่"
+      "id": "native.android.504b71386e76c6ae",
+      "source": "Archived threads will show up here.",
+      "translated": "เธรดที่เก็บถาวรจะแสดงที่นี่"
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days} วัน"
     },
     {
-      "id": "native.android.3d4fa07acbc015c5",
-      "source": "Main session",
-      "translated": "เซสชันหลัก"
+      "id": "native.android.ee4c727cdafbe963",
+      "source": "Main thread",
+      "translated": "เธรดหลัก"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway กำลังรอดำเนินการ"
     },
     {
-      "id": "native.android.2d8d049afe99f751",
-      "source": "Session Activity",
-      "translated": "กิจกรรมของเซสชัน"
+      "id": "native.android.da78209effb11cfd",
+      "source": "Thread Activity",
+      "translated": "กิจกรรมของเธรด"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "คำขออนุมัติการ Exec จะปรากฏที่นี่ขณะที่โทรศัพท์เครื่องนี้เชื่อมต่ออยู่"
     },
     {
-      "id": "native.android.dc3e7ca5a491103a",
-      "source": "Session activity",
-      "translated": "กิจกรรมเซสชัน"
+      "id": "native.android.f615712dfb56319a",
+      "source": "Thread activity",
+      "translated": "กิจกรรมของเธรด"
     },
     {
-      "id": "native.android.8551e02b060bd7d8",
-      "source": "Chat tool calls waiting in the active session remain visible here.",
-      "translated": "การเรียกใช้เครื่องมือแชทที่รออยู่ในเซสชันที่ใช้งานอยู่จะยังคงแสดงที่นี่"
+      "id": "native.android.6c93973c13db43ae",
+      "source": "Chat tool calls waiting in the active thread remain visible here.",
+      "translated": "การเรียกใช้เครื่องมือแชทที่รอดำเนินการในเธรดที่ใช้งานอยู่จะยังคงแสดงที่นี่"
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,6 +4294,11 @@
       "translated": "การตั้งค่าผู้ให้บริการ Talk"
     },
     {
+      "id": "native.android.23b638094c34b916",
+      "source": "Microphone",
+      "translated": "ไมโครโฟน"
+    },
+    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "ทดสอบเสียง"
@@ -4337,6 +4342,66 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "เสร็จสิ้น"
+    },
+    {
+      "id": "native.android.8d9ecdfdd916b780",
+      "source": "Automatic",
+      "translated": "อัตโนมัติ"
+    },
+    {
+      "id": "native.android.c1626a6700a570f6",
+      "source": "Preferred microphone unavailable; using automatic routing.",
+      "translated": "ไมโครโฟนที่ต้องการไม่พร้อมใช้งาน กำลังใช้การกำหนดเส้นทางอัตโนมัติ"
+    },
+    {
+      "id": "native.android.820bc5d0ce571d8b",
+      "source": "Prioritizes connected Bluetooth microphones.",
+      "translated": "ให้ความสำคัญกับไมโครโฟน Bluetooth ที่เชื่อมต่ออยู่"
+    },
+    {
+      "id": "native.android.11e48038d5e8bff6",
+      "source": "Preferred microphone",
+      "translated": "ไมโครโฟนที่ต้องการ"
+    },
+    {
+      "id": "native.android.eaa4d7563a46d307",
+      "source": "Unavailable",
+      "translated": "ไม่พร้อมใช้งาน"
+    },
+    {
+      "id": "native.android.9f5ebf17eb405ba8",
+      "source": "Next session",
+      "translated": "เซสชันถัดไป"
+    },
+    {
+      "id": "native.android.8c4e91f53928efb2",
+      "source": "Built-in microphone",
+      "translated": "ไมโครโฟนในตัว"
+    },
+    {
+      "id": "native.android.14b613cb6e2446b4",
+      "source": "Bluetooth microphone",
+      "translated": "ไมโครโฟน Bluetooth"
+    },
+    {
+      "id": "native.android.c885247b2d7ce271",
+      "source": "Bluetooth LE microphone",
+      "translated": "ไมโครโฟน Bluetooth LE"
+    },
+    {
+      "id": "native.android.b6a4e674c5fb441a",
+      "source": "Wired headset microphone",
+      "translated": "ไมโครโฟนชุดหูฟังแบบมีสาย"
+    },
+    {
+      "id": "native.android.9c8becb3b0fb5a90",
+      "source": "USB microphone",
+      "translated": "ไมโครโฟน USB"
+    },
+    {
+      "id": "native.android.ba46258fadec7a39",
+      "source": "External microphone",
+      "translated": "ไมโครโฟนภายนอก"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5074,9 +5139,9 @@
       "translated": "ตรวจสอบ"
     },
     {
-      "id": "native.android.5a540761383fa474",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
-      "translated": "OpenClaw เปลี่ยนโทรศัพท์เครื่องนี้ให้เป็นอินเทอร์เฟซคำสั่งบนมือถือที่เรียบง่ายสำหรับเซสชัน เสียง ผู้ให้บริการ และ Gateway"
+      "id": "native.android.c971506716c96e91",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
+      "translated": "OpenClaw เปลี่ยนโทรศัพท์เครื่องนี้ให้เป็นอินเทอร์เฟซคำสั่งบนมือถือที่เรียบง่ายสำหรับเธรด เสียง ผู้ให้บริการ และ Gateway"
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5624,9 +5689,9 @@
       "translated": "การตั้งค่าพูดคุย"
     },
     {
-      "id": "native.android.73f07a5d54915259",
-      "source": "Recent Sessions",
-      "translated": "เซสชันล่าสุด"
+      "id": "native.android.36f78c8c85dc283f",
+      "source": "Recent Threads",
+      "translated": "เธรดล่าสุด"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5684,14 +5749,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% ออนไลน์"
     },
     {
-      "id": "native.android.16c3425d3a594481",
-      "source": "Sessions",
-      "translated": "เซสชัน"
+      "id": "native.android.57177017a6a93826",
+      "source": "Threads",
+      "translated": "เธรด"
     },
     {
-      "id": "native.android.a5c0f8b3112aa58c",
-      "source": "No recent sessions",
-      "translated": "ไม่มีเซสชันล่าสุด"
+      "id": "native.android.43320b54a68b00a1",
+      "source": "No recent threads",
+      "translated": "ไม่มีเธรดล่าสุด"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5729,14 +5794,14 @@
       "translated": "กำลังทำงาน · มีงานที่ใช้งานอยู่ $pendingRunCount รายการ"
     },
     {
-      "id": "native.android.2c89da708b12a522",
-      "source": "Monitoring · 1 session",
-      "translated": "กำลังตรวจสอบ · 1 เซสชัน"
+      "id": "native.android.e24db059480f1e6a",
+      "source": "Monitoring · 1 thread",
+      "translated": "กำลังตรวจสอบ · 1 เธรด"
     },
     {
-      "id": "native.android.8b6ee382dcb64e1f",
-      "source": "Monitoring · $sessionCount sessions",
-      "translated": "กำลังตรวจสอบ · $sessionCount เซสชัน"
+      "id": "native.android.5a475f37d80e02bc",
+      "source": "Monitoring · $sessionCount threads",
+      "translated": "กำลังตรวจสอบ · $sessionCount เธรด"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5769,9 +5834,9 @@
       "translated": "ผู้ให้บริการ"
     },
     {
-      "id": "native.android.a65477861c7203aa",
-      "source": "Open session",
-      "translated": "เปิดเซสชัน"
+      "id": "native.android.358c5e0e838d5423",
+      "source": "Open thread",
+      "translated": "เปิดเธรด"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6194,9 +6259,9 @@
       "translated": "${days} วัน"
     },
     {
-      "id": "native.android.22d755834386db07",
-      "source": "Main session",
-      "translated": "เซสชันหลัก"
+      "id": "native.android.28a1a1acc5a0959f",
+      "source": "Main thread",
+      "translated": "เธรดหลัก"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6877,6 +6942,16 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "เปิดเสียง"
+    },
+    {
+      "id": "native.android.cb608d82c5b3352a",
+      "source": "Back camera",
+      "translated": "กล้องหลัง"
+    },
+    {
+      "id": "native.android.e89a0e780eed2e1e",
+      "source": "Front camera",
+      "translated": "กล้องหน้า"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7684,9 +7759,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.882cc14a58e7e105",
-      "source": "Loading session",
-      "translated": "กำลังโหลดเซสชัน"
+      "id": "native.android.0c74bc30a994dd33",
+      "source": "Loading thread",
+      "translated": "กำลังโหลดเธรด"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7729,14 +7804,14 @@
       "translated": "สรุปความคืบหน้าให้ฉัน"
     },
     {
-      "id": "native.android.1e5add56e48c99f9",
-      "source": "Summarize recent sessions and next steps.",
-      "translated": "สรุปเซสชันล่าสุดและขั้นตอนถัดไป"
+      "id": "native.android.cf40df9739f78f27",
+      "source": "Summarize recent threads and next steps.",
+      "translated": "สรุปเธรดล่าสุดและขั้นตอนถัดไป"
     },
     {
-      "id": "native.android.06d515351bb79576",
-      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
-      "translated": "สรุปเซสชัน OpenClaw ล่าสุดของฉันและแนะนำขั้นตอนถัดไป"
+      "id": "native.android.ebe49a8b8df80bd3",
+      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
+      "translated": "สรุปความคืบหน้าจากเธรด OpenClaw ล่าสุดของฉันและแนะนำขั้นตอนถัดไป"
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8074,9 +8149,9 @@
       "translated": "เชื่อมต่อแล้ว"
     },
     {
-      "id": "native.android.81931886b9caf3ab",
-      "source": "Sessions",
-      "translated": "เซสชัน"
+      "id": "native.android.6cf5d6fa8a4186d5",
+      "source": "Threads",
+      "translated": "เธรด"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,9 +10869,9 @@
       "translated": "คุณต้องการทำงานอะไร?"
     },
     {
-      "id": "native.apple.32179ce0b6d4543f",
-      "source": "The session attaches once the gateway is ready.",
-      "translated": "เซสชันจะเชื่อมต่อเมื่อ gateway พร้อมใช้งาน"
+      "id": "native.apple.4da775013ac9b123",
+      "source": "The thread attaches once the gateway is ready.",
+      "translated": "ระบบจะแนบเธรดเมื่อ Gateway พร้อมใช้งาน"
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10844,9 +10919,9 @@
       "translated": "ตัวเลือกเซสชันใหม่…"
     },
     {
-      "id": "native.apple.a1b0d289758e2213",
-      "source": "Sessions…",
-      "translated": "เซสชัน…"
+      "id": "native.apple.003b25ddafeb18e9",
+      "source": "Threads…",
+      "translated": "เธรด…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11009,14 +11084,14 @@
       "translated": "สร้าง"
     },
     {
-      "id": "native.apple.f488b9caf6e51ac3",
-      "source": "Delete Session?",
-      "translated": "ลบเซสชัน?"
+      "id": "native.apple.31d5c7287cfb3abe",
+      "source": "Delete Thread?",
+      "translated": "ลบเธรดหรือไม่?"
     },
     {
-      "id": "native.apple.8634b17be9b111bc",
-      "source": "Delete Session",
-      "translated": "ลบเซสชัน"
+      "id": "native.apple.d3395564809f1120",
+      "source": "Delete Thread",
+      "translated": "ลบเธรด"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11024,9 +11099,9 @@
       "translated": "ยกเลิก"
     },
     {
-      "id": "native.apple.4a9568ac9b18d8d3",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "การดำเนินการนี้จะลบเซสชันและบันทึกการสนทนาของเซสชันนี้อย่างถาวร"
+      "id": "native.apple.092659256d26cb03",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "การดำเนินการนี้จะลบเธรดและบันทึกการสนทนาอย่างถาวร"
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11054,9 +11129,9 @@
       "translated": "กลุ่มใหม่"
     },
     {
-      "id": "native.apple.5bccdc23a1640895",
-      "source": "Rename Session",
-      "translated": "เปลี่ยนชื่อเซสชัน"
+      "id": "native.apple.683032464c497bbd",
+      "source": "Rename Thread",
+      "translated": "เปลี่ยนชื่อเธรด"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11064,9 +11139,9 @@
       "translated": "ชื่อกลุ่ม"
     },
     {
-      "id": "native.apple.af789b2d2fda0f67",
-      "source": "Session name",
-      "translated": "ชื่อเซสชัน"
+      "id": "native.apple.f887aa956588f237",
+      "source": "Thread name",
+      "translated": "ชื่อเธรด"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11104,14 +11179,14 @@
       "translated": "เอเจนต์"
     },
     {
-      "id": "native.apple.a3bde8045fe9224a",
-      "source": "Agent session",
-      "translated": "เซสชันเอเจนต์"
+      "id": "native.apple.7c8231b7b1ca480f",
+      "source": "Agent thread",
+      "translated": "เธรดของเอเจนต์"
     },
     {
-      "id": "native.apple.27f775de30b37ff8",
-      "source": "Recent sessions",
-      "translated": "เซสชันล่าสุด"
+      "id": "native.apple.b3c553614f762a58",
+      "source": "Recent threads",
+      "translated": "เธรดล่าสุด"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11119,9 +11194,9 @@
       "translated": "Gateway ออฟไลน์"
     },
     {
-      "id": "native.apple.28c97cf23665ee01",
-      "source": "No recent sessions",
-      "translated": "ไม่มีเซสชันล่าสุด"
+      "id": "native.apple.5aa32afda85064ea",
+      "source": "No recent threads",
+      "translated": "ไม่มีเธรดล่าสุด"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11219,14 +11294,14 @@
       "translated": "ยกเลิก"
     },
     {
-      "id": "native.apple.9f2fd65953013b7c",
-      "source": "Sessions",
-      "translated": "เซสชัน"
+      "id": "native.apple.b6855cf19a50f477",
+      "source": "Threads",
+      "translated": "เธรด"
     },
     {
-      "id": "native.apple.0422818cc95d5071",
-      "source": "Archived sessions",
-      "translated": "เซสชันที่เก็บถาวร"
+      "id": "native.apple.9b1d0ef27a1333b0",
+      "source": "Archived threads",
+      "translated": "เธรดที่เก็บถาวร"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11234,34 +11309,34 @@
       "translated": "แสดงที่เก็บถาวร"
     },
     {
-      "id": "native.apple.b272115c83f7ef58",
-      "source": "Sessions unavailable",
-      "translated": "เซสชันไม่พร้อมใช้งาน"
+      "id": "native.apple.98167401c7267735",
+      "source": "Threads unavailable",
+      "translated": "เธรดไม่พร้อมใช้งาน"
     },
     {
-      "id": "native.apple.54f8260c9b863087",
-      "source": "Loading archived sessions",
-      "translated": "กำลังโหลดเซสชันที่เก็บถาวร"
+      "id": "native.apple.4d28a7def2337b9f",
+      "source": "Loading archived threads",
+      "translated": "กำลังโหลดเธรดที่เก็บถาวร"
     },
     {
-      "id": "native.apple.9b305868873dade2",
-      "source": "Loading recent sessions",
-      "translated": "กำลังโหลดเซสชันล่าสุด"
+      "id": "native.apple.777d7b706933bd7b",
+      "source": "Loading recent threads",
+      "translated": "กำลังโหลดเธรดล่าสุด"
     },
     {
-      "id": "native.apple.207dad20d09f3160",
-      "source": "^[\\(count) session](inflect: true)",
-      "translated": "^[\\(count) เซสชัน](inflect: true)"
+      "id": "native.apple.22f81ea94bef8410",
+      "source": "^[\\(count) thread](inflect: true)",
+      "translated": "^[\\(count) เธรด](inflect: true)"
     },
     {
-      "id": "native.apple.1f4501a6bf2bae4c",
-      "source": "No archived sessions",
-      "translated": "ไม่มีเซสชันที่เก็บถาวร"
+      "id": "native.apple.1cad51e14db59bf9",
+      "source": "No archived threads",
+      "translated": "ไม่มีเธรดที่เก็บถาวร"
     },
     {
-      "id": "native.apple.2a1ba7a5e1979c9e",
-      "source": "Archived sessions will appear here.",
-      "translated": "เซสชันที่เก็บถาวรแล้วจะแสดงที่นี่"
+      "id": "native.apple.18ef832d3a7ddcf8",
+      "source": "Archived threads will appear here.",
+      "translated": "เธรดที่เก็บถาวรจะแสดงที่นี่"
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11344,9 +11419,9 @@
       "translated": "แชร์ข้อมูลนำเข้า"
     },
     {
-      "id": "native.apple.2360d25fe6ae9946",
-      "source": "Loading sessions",
-      "translated": "กำลังโหลดเซสชัน"
+      "id": "native.apple.21d9208d86a4d1fe",
+      "source": "Loading threads",
+      "translated": "กำลังโหลดเธรด"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11354,19 +11429,19 @@
       "translated": "กำลังดึงกิจกรรมล่าสุดจาก Gateway"
     },
     {
-      "id": "native.apple.c334f2e86702a7b8",
-      "source": "Sessions unavailable",
-      "translated": "เซสชันไม่พร้อมใช้งาน"
+      "id": "native.apple.4be1f79aa2b230ff",
+      "source": "Threads unavailable",
+      "translated": "เธรดไม่พร้อมใช้งาน"
     },
     {
-      "id": "native.apple.6cc6efb7a03960b6",
-      "source": "No recent sessions",
-      "translated": "ไม่มีเซสชันล่าสุด"
+      "id": "native.apple.98b348873556bc46",
+      "source": "No recent threads",
+      "translated": "ไม่มีเธรดล่าสุด"
     },
     {
-      "id": "native.apple.08483af2d043bee6",
-      "source": "Session activity offline",
-      "translated": "กิจกรรมเซสชันออฟไลน์"
+      "id": "native.apple.7396d205574d279f",
+      "source": "Thread activity offline",
+      "translated": "กิจกรรมของเธรดออฟไลน์"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11824,9 +11899,9 @@
       "translated": "การ์ด"
     },
     {
-      "id": "native.apple.93eeaedb2ff61043",
-      "source": "Open Session",
-      "translated": "เปิดเซสชัน"
+      "id": "native.apple.c9ec1b0e18074d8a",
+      "source": "Open Thread",
+      "translated": "เปิดเธรด"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13314,9 +13389,9 @@
       "translated": "ค่าเริ่มต้น"
     },
     {
-      "id": "native.apple.3de045f17ea3c6d0",
-      "source": "Used for new Chat and Talk sessions.",
-      "translated": "ใช้สำหรับเซสชัน Chat และ Talk ใหม่"
+      "id": "native.apple.f4ae5664c3eda95d",
+      "source": "Used for new Chat threads and Talk sessions.",
+      "translated": "ใช้สำหรับเธรดแชทและเซสชันการสนทนาใหม่"
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15719,9 +15794,9 @@
       "translated": "อินสแตนซ์"
     },
     {
-      "id": "native.apple.3579cf2750470a22",
-      "source": "Sessions",
-      "translated": "เซสชัน"
+      "id": "native.apple.11fe8b9941954dfb",
+      "source": "Threads",
+      "translated": "เธรด"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19029,9 +19104,9 @@
       "translated": "ปุ่มลัดแชตด่วน"
     },
     {
-      "id": "native.apple.6ae77665b5f4490f",
-      "source": "Global shortcut that opens a floating chat bar for the main session.",
-      "translated": "ปุ่มลัดส่วนกลางที่เปิดแถบแชตแบบลอยสำหรับเซสชันหลัก"
+      "id": "native.apple.94dd793cd7d7d555",
+      "source": "Global shortcut that opens a floating chat bar for the main thread.",
+      "translated": "ปุ่มลัดส่วนกลางที่ใช้เปิดแถบแชทแบบลอยสำหรับเธรดหลัก"
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19609,9 +19684,9 @@
       "translated": "ร้ายแรง"
     },
     {
-      "id": "native.apple.75102378a6775180",
-      "source": "New Session",
-      "translated": "เซสชันใหม่"
+      "id": "native.apple.13f96467014cf344",
+      "source": "New Thread",
+      "translated": "เธรดใหม่"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21899,9 +21974,9 @@
       "translated": "ไม่มีข้อความล่าสุด"
     },
     {
-      "id": "native.apple.1ff8aec0044934c3",
-      "source": "Sessions",
-      "translated": "เซสชัน"
+      "id": "native.apple.3ec2afcbc298c673",
+      "source": "Threads",
+      "translated": "เธรด"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21909,9 +21984,9 @@
       "translated": "ดูบัคเก็ตการสนทนาที่จัดเก็บไว้ ซึ่ง CLI นำกลับมาใช้ซ้ำสำหรับบริบทและขีดจำกัดอัตรา"
     },
     {
-      "id": "native.apple.bab897f3252b134c",
-      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
-      "translated": "ยังไม่มีเซสชัน รายการจะแสดงหลังจากมีข้อความขาเข้าหรือ heartbeat ครั้งแรก"
+      "id": "native.apple.14ccb32cd8ed1c81",
+      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
+      "translated": "ยังไม่มีเธรด เธรดจะปรากฏหลังจากได้รับข้อความขาเข้าหรือสัญญาณ heartbeat ครั้งแรก"
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -21994,9 +22069,9 @@
       "translated": "การอนุมัติการดำเนินการ"
     },
     {
-      "id": "native.apple.64a6dc7d49e8fb57",
-      "source": "Sessions",
-      "translated": "เซสชัน"
+      "id": "native.apple.52e37e3a44ae516c",
+      "source": "Threads",
+      "translated": "เธรด"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -22999,9 +23074,9 @@
       "translated": "อัปเดตให้ฉันทราบ"
     },
     {
-      "id": "native.apple.234ec45f4231edc4",
-      "source": "Summarize what happened in my sessions since yesterday.",
-      "translated": "สรุปสิ่งที่เกิดขึ้นในเซสชันของฉันตั้งแต่เมื่อวาน"
+      "id": "native.apple.fc4ce810900ec0b6",
+      "source": "Summarize what happened in my threads since yesterday.",
+      "translated": "สรุปสิ่งที่เกิดขึ้นในเธรดของฉันตั้งแต่เมื่อวาน"
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23179,9 +23254,9 @@
       "translated": "เลิกปักหมุดโมเดล"
     },
     {
-      "id": "native.apple.5dfc0700d8dff8de",
-      "source": "Session",
-      "translated": "เซสชัน"
+      "id": "native.apple.4edb66657f5aca1f",
+      "source": "Thread",
+      "translated": "เธรด"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23344,6 +23419,51 @@
       "translated": "วิดเจ็ตไม่พร้อมใช้งาน"
     },
     {
+      "id": "native.apple.d640691fd196f338",
+      "source": "Widget export failed",
+      "translated": "ส่งออกวิดเจ็ตไม่สำเร็จ"
+    },
+    {
+      "id": "native.apple.533c6e22a11e88de",
+      "source": "OK",
+      "translated": "ตกลง"
+    },
+    {
+      "id": "native.apple.e1fb28a2a9756402",
+      "source": "Copy image",
+      "translated": "คัดลอกรูปภาพ"
+    },
+    {
+      "id": "native.apple.ebd7bc92e1b12235",
+      "source": "Save image…",
+      "translated": "บันทึกรูปภาพ…"
+    },
+    {
+      "id": "native.apple.742c46d4cf2db134",
+      "source": "Save image",
+      "translated": "บันทึกรูปภาพ"
+    },
+    {
+      "id": "native.apple.0589cce608418f90",
+      "source": "The widget image could not be captured.",
+      "translated": "ไม่สามารถจับภาพวิดเจ็ตได้"
+    },
+    {
+      "id": "native.apple.dfe24e827fdbe9c5",
+      "source": "The widget image could not be copied.",
+      "translated": "ไม่สามารถคัดลอกรูปภาพวิดเจ็ตได้"
+    },
+    {
+      "id": "native.apple.9e611e3a80e71408",
+      "source": "The widget image could not be encoded as PNG.",
+      "translated": "ไม่สามารถเข้ารหัสรูปภาพวิดเจ็ตเป็น PNG ได้"
+    },
+    {
+      "id": "native.apple.9a6e8afbe24a262b",
+      "source": "The widget image could not be saved.",
+      "translated": "ไม่สามารถบันทึกรูปภาพวิดเจ็ตได้"
+    },
+    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23484,19 +23604,19 @@
       "translated": "ผู้ใช้"
     },
     {
-      "id": "native.apple.b1cdcb906a43d5d6",
-      "source": "This session cannot be archived while it is active or running.",
-      "translated": "ไม่สามารถเก็บเซสชันนี้เข้าคลังขณะที่ยังใช้งานหรือกำลังทำงานอยู่ได้"
+      "id": "native.apple.9d0cba09d92ee669",
+      "source": "This thread cannot be archived while it is active or running.",
+      "translated": "ไม่สามารถเก็บเธรดนี้เข้าคลังขณะที่ยังเปิดใช้งานหรือกำลังทำงานอยู่"
     },
     {
-      "id": "native.apple.5817e3f3dab1ee19",
-      "source": "The main session cannot be deleted.",
-      "translated": "ไม่สามารถลบเซสชันหลักได้"
+      "id": "native.apple.8952a111a1075051",
+      "source": "The main thread cannot be deleted.",
+      "translated": "ไม่สามารถลบเธรดหลักได้"
     },
     {
-      "id": "native.apple.a6b8df3f18171c91",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
-      "translated": "นำไฟล์แนบออกหรือรอให้ส่งเสร็จก่อนเก็บเซสชันนี้เข้าคลังหรือลบ"
+      "id": "native.apple.90d0ccf80ca28717",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
+      "translated": "นำไฟล์แนบออกหรือรอให้ส่งเสร็จก่อนเก็บถาวรหรือลบเธรดนี้"
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23634,9 +23754,9 @@
       "translated": "สิ้นสุดการทำงาน"
     },
     {
-      "id": "native.apple.cd7c3095a22f80a9",
-      "source": "Session Info",
-      "translated": "ข้อมูลเซสชัน"
+      "id": "native.apple.bbccb4c8db5cac12",
+      "source": "Thread Info",
+      "translated": "ข้อมูลเธรด"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23669,9 +23789,9 @@
       "translated": "เพิ่มกลุ่ม"
     },
     {
-      "id": "native.apple.23d628606fe0734f",
-      "source": "Session Groups",
-      "translated": "กลุ่มเซสชัน"
+      "id": "native.apple.7b641fed5bace855",
+      "source": "Thread Groups",
+      "translated": "กลุ่มเธรด"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23714,9 +23834,9 @@
       "translated": "ลบกลุ่ม"
     },
     {
-      "id": "native.apple.b049c8a4d2805e08",
-      "source": "Sessions in this group become ungrouped.",
-      "translated": "เซสชันในกลุ่มนี้จะไม่อยู่ในกลุ่มใด"
+      "id": "native.apple.56401c79410a310d",
+      "source": "Threads in this group become ungrouped.",
+      "translated": "เธรดในกลุ่มนี้จะถูกยกเลิกการจัดกลุ่ม"
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23729,9 +23849,9 @@
       "translated": "ไม่มีเอเจนต์ที่พร้อมใช้งานบน Gateway นี้"
     },
     {
-      "id": "native.apple.6c89f35d53506406",
-      "source": "New Session Options",
-      "translated": "ตัวเลือกเซสชันใหม่"
+      "id": "native.apple.2d96aa7d3d12f85b",
+      "source": "New Thread Options",
+      "translated": "ตัวเลือกเธรดใหม่"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23759,19 +23879,19 @@
       "translated": "สร้าง"
     },
     {
-      "id": "native.apple.795ba37f6782cf28",
-      "source": "The session could not be created.",
-      "translated": "ไม่สามารถสร้างเซสชันได้"
+      "id": "native.apple.87ef57319d1ddc85",
+      "source": "The thread could not be created.",
+      "translated": "ไม่สามารถสร้างเธรดได้"
     },
     {
-      "id": "native.apple.8ec708a3605a2cc3",
-      "source": "Search sessions",
-      "translated": "ค้นหาเซสชัน"
+      "id": "native.apple.6bd91c435b69d638",
+      "source": "Search threads",
+      "translated": "ค้นหาเธรด"
     },
     {
-      "id": "native.apple.23b069b4e7f97039",
-      "source": "No Sessions",
-      "translated": "ไม่มีเซสชัน"
+      "id": "native.apple.6fde4bdf9d5b9191",
+      "source": "No Threads",
+      "translated": "ไม่มีเธรด"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23779,29 +23899,29 @@
       "translated": "ไม่พบผลลัพธ์"
     },
     {
-      "id": "native.apple.0058923f2ce8a3ec",
-      "source": "New Session",
-      "translated": "เซสชันใหม่"
+      "id": "native.apple.a02fd99740d29bd3",
+      "source": "New Thread",
+      "translated": "เธรดใหม่"
     },
     {
-      "id": "native.apple.66ba42960eb4135b",
-      "source": "New session",
-      "translated": "เซสชันใหม่"
+      "id": "native.apple.b625801dd04b09f2",
+      "source": "New thread",
+      "translated": "เธรดใหม่"
     },
     {
-      "id": "native.apple.2ef0e34db02ad255",
-      "source": "New session options",
-      "translated": "ตัวเลือกเซสชันใหม่"
+      "id": "native.apple.851be81fcc933608",
+      "source": "New thread options",
+      "translated": "ตัวเลือกเธรดใหม่"
     },
     {
-      "id": "native.apple.36753ef2f1ed4264",
-      "source": "Rename Session",
-      "translated": "เปลี่ยนชื่อเซสชัน"
+      "id": "native.apple.9ce8a4aba7b444b2",
+      "source": "Rename Thread",
+      "translated": "เปลี่ยนชื่อเธรด"
     },
     {
-      "id": "native.apple.c9de0a1510ef475f",
-      "source": "Session name",
-      "translated": "ชื่อเซสชัน"
+      "id": "native.apple.1dd067c44511c7f0",
+      "source": "Thread name",
+      "translated": "ชื่อเธรด"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23814,14 +23934,14 @@
       "translated": "ยกเลิก"
     },
     {
-      "id": "native.apple.afb4e6c99c63a28d",
-      "source": "Delete Session",
-      "translated": "ลบเซสชัน"
+      "id": "native.apple.618073d6ab3f2721",
+      "source": "Delete Thread",
+      "translated": "ลบเธรด"
     },
     {
-      "id": "native.apple.3d4ef32e42f136a4",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "เซสชันและบันทึกการสนทนาจะถูกลบออกจาก Gateway"
+      "id": "native.apple.10a5e72bba3cbccc",
+      "source": "The thread and its transcript are removed from the gateway.",
+      "translated": "เธรดและบทถอดเสียงจะถูกนำออกจาก Gateway"
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23829,14 +23949,14 @@
       "translated": "ลบ “%@” หรือไม่?"
     },
     {
-      "id": "native.apple.9a7dca238fba628d",
-      "source": "Session running",
-      "translated": "เซสชันกำลังทำงาน"
+      "id": "native.apple.ac71e3b2aa496a2c",
+      "source": "Thread running",
+      "translated": "เธรดกำลังทำงาน"
     },
     {
-      "id": "native.apple.fcfbfe5e97a95e9c",
-      "source": "Session failed",
-      "translated": "เซสชันล้มเหลว"
+      "id": "native.apple.c775e87f997278b2",
+      "source": "Thread failed",
+      "translated": "เธรดล้มเหลว"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23894,9 +24014,9 @@
       "translated": "คัดลอกคีย์เซสชัน"
     },
     {
-      "id": "native.apple.4aeb7c14c26dabac",
-      "source": "Delete Session…",
-      "translated": "ลบเซสชัน…"
+      "id": "native.apple.f4998cfb572f23ff",
+      "source": "Delete Thread…",
+      "translated": "ลบเธรด…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23909,9 +24029,9 @@
       "translated": "กำลังเชื่อมต่อ…"
     },
     {
-      "id": "native.apple.79f708b3bc1d3a6c",
-      "source": "Retry session groups",
-      "translated": "ลองโหลดกลุ่มเซสชันอีกครั้ง"
+      "id": "native.apple.8802e9576ffd0f65",
+      "source": "Retry thread groups",
+      "translated": "ลองโหลดกลุ่มเธรดอีกครั้ง"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23934,24 +24054,24 @@
       "translated": "ขอบเขต"
     },
     {
-      "id": "native.apple.2c37581c7b88f741",
-      "source": "Search sessions",
-      "translated": "ค้นหาเซสชัน"
+      "id": "native.apple.b313b80def4bda52",
+      "source": "Search threads",
+      "translated": "ค้นหาเธรด"
     },
     {
-      "id": "native.apple.43be8a2336e42faf",
-      "source": "Sessions",
-      "translated": "เซสชัน"
+      "id": "native.apple.c0cc6acc36f413ce",
+      "source": "Threads",
+      "translated": "เธรด"
     },
     {
-      "id": "native.apple.0b379cdfcbd3247f",
-      "source": "Rename Session",
-      "translated": "เปลี่ยนชื่อเซสชัน"
+      "id": "native.apple.854d3928fe5a557c",
+      "source": "Rename Thread",
+      "translated": "เปลี่ยนชื่อเธรด"
     },
     {
-      "id": "native.apple.54b6fbd9e41db009",
-      "source": "Session name",
-      "translated": "ชื่อเซสชัน"
+      "id": "native.apple.9d0d3f20096cc4da",
+      "source": "Thread name",
+      "translated": "ชื่อเธรด"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -23959,19 +24079,19 @@
       "translated": "ยกเลิก"
     },
     {
-      "id": "native.apple.751e0f6b81cd374a",
-      "source": "Delete selected sessions?",
-      "translated": "ลบเซสชันที่เลือกหรือไม่?"
+      "id": "native.apple.dc00eb94f33bae15",
+      "source": "Delete selected threads?",
+      "translated": "ลบเธรดที่เลือกหรือไม่?"
     },
     {
-      "id": "native.apple.aa679276581b0058",
-      "source": "Delete Sessions",
-      "translated": "ลบเซสชัน"
+      "id": "native.apple.2053fc9f74dc3158",
+      "source": "Delete Threads",
+      "translated": "ลบเธรด"
     },
     {
-      "id": "native.apple.f837129cbee23297",
-      "source": "Each selected session and its transcript will be removed from the gateway.",
-      "translated": "เซสชันที่เลือกแต่ละรายการและบันทึกการสนทนาจะถูกลบออกจาก Gateway"
+      "id": "native.apple.0970247871a834a0",
+      "source": "Each selected thread and its transcript will be removed from the gateway.",
+      "translated": "เธรดที่เลือกแต่ละรายการและบันทึกการสนทนาจะถูกลบออกจาก Gateway"
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -23979,9 +24099,9 @@
       "translated": "กลุ่ม"
     },
     {
-      "id": "native.apple.64013cfee5e25305",
-      "source": "Manage session groups",
-      "translated": "จัดการกลุ่มเซสชัน"
+      "id": "native.apple.6f8acab2256728b5",
+      "source": "Manage thread groups",
+      "translated": "จัดการกลุ่มเธรด"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -23994,14 +24114,14 @@
       "translated": "เลือก"
     },
     {
-      "id": "native.apple.b67eaecec1b423ac",
-      "source": "No archived sessions",
-      "translated": "ไม่มีเซสชันที่เก็บถาวร"
+      "id": "native.apple.692972314d04b184",
+      "source": "No archived threads",
+      "translated": "ไม่มีเธรดที่เก็บถาวร"
     },
     {
-      "id": "native.apple.b2435a79abf0c794",
-      "source": "No sessions found",
-      "translated": "ไม่พบเซสชัน"
+      "id": "native.apple.d6a4b5711dcd26e7",
+      "source": "No threads found",
+      "translated": "ไม่พบเธรด"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24169,6 +24289,16 @@
       "translated": "เปิดข้อความฉบับเต็ม"
     },
     {
+      "id": "native.apple.002bfcede229ad4b",
+      "source": "Rewind to Here",
+      "translated": "ย้อนกลับมาที่นี่"
+    },
+    {
+      "id": "native.apple.14df2e4997689fb3",
+      "source": "Fork from Here",
+      "translated": "แยกแขนงจากที่นี่"
+    },
+    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "ตอบกลับ"
@@ -24254,9 +24384,9 @@
       "translated": "นำไฟล์แนบออกหรือรอให้การส่งเสร็จสิ้นก่อนเริ่มแชตใหม่"
     },
     {
-      "id": "native.apple.980f552bb0f96c0f",
-      "source": "Gateway changed before the session operation started.",
-      "translated": "Gateway มีการเปลี่ยนแปลงก่อนเริ่มดำเนินการกับเซสชัน"
+      "id": "native.apple.e0f045151c8d3137",
+      "source": "Gateway changed before the thread operation started.",
+      "translated": "Gateway มีการเปลี่ยนแปลงก่อนเริ่มดำเนินการกับเธรด"
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24264,9 +24394,9 @@
       "translated": "ลบไฟล์แนบหรือรอให้การส่งเสร็จสิ้นก่อนสลับแชท"
     },
     {
-      "id": "native.apple.87ba543b42696b92",
-      "source": "Clear this session's history?",
-      "translated": "ล้างประวัติของเซสชันนี้หรือไม่?"
+      "id": "native.apple.0a5c4e15466c3acc",
+      "source": "Clear this thread's history?",
+      "translated": "ล้างประวัติของเธรดนี้หรือไม่?"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24279,14 +24409,14 @@
       "translated": "การดำเนินการนี้จะรีเซ็ตการสนทนาสำหรับ %@ โดยคีย์เซสชันจะยังคงเดิม"
     },
     {
-      "id": "native.apple.a92e96bed98bd553",
-      "source": "Rename Session",
-      "translated": "เปลี่ยนชื่อเซสชัน"
+      "id": "native.apple.67ac221dbe7179f0",
+      "source": "Rename Thread",
+      "translated": "เปลี่ยนชื่อเธรด"
     },
     {
-      "id": "native.apple.848e2388f3466f40",
-      "source": "Session name",
-      "translated": "ชื่อเซสชัน"
+      "id": "native.apple.cf0f7e049603f518",
+      "source": "Thread name",
+      "translated": "ชื่อเธรด"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24304,9 +24434,9 @@
       "translated": "ส่งออกสำเนาบทสนทนา"
     },
     {
-      "id": "native.apple.4af0f566d39d7041",
-      "source": "Sessions",
-      "translated": "เซสชัน"
+      "id": "native.apple.c0ada47504425f23",
+      "source": "Threads",
+      "translated": "เธรด"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24379,14 +24509,14 @@
       "translated": "ค่าเริ่มต้น"
     },
     {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "เซสชันใหม่"
+      "id": "native.apple.1a765291943599e5",
+      "source": "New Thread",
+      "translated": "เธรดใหม่"
     },
     {
-      "id": "native.apple.a7119fbf9d25df5e",
-      "source": "New Session Options…",
-      "translated": "ตัวเลือกเซสชันใหม่…"
+      "id": "native.apple.c7a3a6d5e43dd98f",
+      "source": "New Thread Options…",
+      "translated": "ตัวเลือกเธรดใหม่…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24394,19 +24524,19 @@
       "translated": "รีเฟรช"
     },
     {
-      "id": "native.apple.2bcff4a8fa503739",
-      "source": "Sessions…",
-      "translated": "เซสชัน…"
+      "id": "native.apple.0e710b81808e5dcf",
+      "source": "Threads…",
+      "translated": "เธรด…"
     },
     {
-      "id": "native.apple.c36e008b051adb38",
-      "source": "Rename Session…",
-      "translated": "เปลี่ยนชื่อเซสชัน…"
+      "id": "native.apple.faad8f92b6bef166",
+      "source": "Rename Thread…",
+      "translated": "เปลี่ยนชื่อเธรด…"
     },
     {
-      "id": "native.apple.ea0ef95a159bffe0",
-      "source": "Fork Session",
-      "translated": "แยกเซสชัน"
+      "id": "native.apple.23b61d6cd26ac112",
+      "source": "Fork",
+      "translated": "แยกแขนง"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24464,24 +24594,24 @@
       "translated": "ล้างประวัติ…"
     },
     {
-      "id": "native.apple.920fe8a7a33f9e92",
-      "source": "Session",
-      "translated": "เซสชัน"
+      "id": "native.apple.8b4f1c5107ea8a0e",
+      "source": "Thread",
+      "translated": "เธรด"
     },
     {
-      "id": "native.apple.185a401f78328b0f",
-      "source": "Session actions",
-      "translated": "การดำเนินการเซสชัน"
+      "id": "native.apple.4d7750c9bf699469",
+      "source": "Thread actions",
+      "translated": "การดำเนินการกับเธรด"
     },
     {
-      "id": "native.apple.9f9dedf599b2619b",
-      "source": "Session cost %@",
-      "translated": "ค่าใช้จ่ายของเซสชัน %@"
+      "id": "native.apple.bb2f22cc43c97f8e",
+      "source": "Thread cost %@",
+      "translated": "ค่าใช้จ่ายของเธรด %@"
     },
     {
-      "id": "native.apple.f0a4720df5f5f403",
-      "source": "Compact Session",
-      "translated": "ย่อเซสชัน"
+      "id": "native.apple.6239ced0b86e86f8",
+      "source": "Compact Thread",
+      "translated": "ย่อเธรด"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -3951,7 +3951,7 @@
     {
       "id": "native.android.be84f061047aa2da",
       "source": "No archived threads",
-      "translated": "ไม่มีเธดที่เก็บถาวร"
+      "translated": "ไม่มีเธรดที่เก็บถาวร"
     },
     {
       "id": "native.android.0a38a1167c6b6941",

--- a/apps/.i18n/native/tr.json
+++ b/apps/.i18n/native/tr.json
@@ -1429,9 +1429,9 @@
       "translated": "OpenClaw ile konuşun veya dikte edin"
     },
     {
-      "id": "native.android.5876e15e5e92fd45",
-      "source": "Browse Sessions",
-      "translated": "Oturumlara Göz At"
+      "id": "native.android.e2cf5a38587382cb",
+      "source": "Browse Threads",
+      "translated": "Konulara Göz At"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "İşlem bulunamadı"
     },
     {
-      "id": "native.android.48ad0ae0e930e02b",
-      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
-      "translated": "Chat, Voice, Sessions, Providers veya Settings’i deneyin."
+      "id": "native.android.bc70a4ac965b82ba",
+      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
+      "translated": "Sohbet, Ses, Konular, Sağlayıcılar veya Ayarlar'ı deneyin."
     },
     {
-      "id": "native.android.d4fbd1ee4f55a5db",
-      "source": "Sessions",
-      "translated": "Oturumlar"
+      "id": "native.android.670121e54dbe286f",
+      "source": "Threads",
+      "translated": "Konular"
     },
     {
-      "id": "native.android.207c2170504e99e6",
-      "source": "Connect the Gateway to search sessions.",
-      "translated": "Oturumları aramak için Gateway'i bağlayın."
+      "id": "native.android.d38be650b1bce4a0",
+      "source": "Connect the Gateway to search threads.",
+      "translated": "Konuları aramak için Gateway'e bağlanın."
     },
     {
-      "id": "native.android.25d2c2d792c952fe",
-      "source": "No matching sessions yet.",
-      "translated": "Henüz eşleşen oturum yok."
+      "id": "native.android.3d7754721f776ef8",
+      "source": "No matching threads yet.",
+      "translated": "Henüz eşleşen konu yok."
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "Asistan çalışıyor"
     },
     {
-      "id": "native.android.8f8384286317f5c9",
-      "source": "OpenClaw session",
-      "translated": "OpenClaw oturumu"
+      "id": "native.android.9a839f6e3e05a744",
+      "source": "OpenClaw thread",
+      "translated": "OpenClaw konusu"
     },
     {
-      "id": "native.android.15799e57704b20c6",
-      "source": "Open session",
-      "translated": "Oturumu aç"
+      "id": "native.android.d83f82a1e4a5ed99",
+      "source": "Open thread",
+      "translated": "Konuyu aç"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "Hazır sağlayıcı yok"
     },
     {
-      "id": "native.android.73e6ab1a168fd381",
-      "source": "Main session",
-      "translated": "Ana oturum"
+      "id": "native.android.8a1c5365c0538908",
+      "source": "Main thread",
+      "translated": "Ana konu"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.0e3157c15c56944f",
-      "source": "Sessions",
-      "translated": "Oturumlar"
+      "id": "native.android.a5845742daecb4ba",
+      "source": "Threads",
+      "translated": "Konular"
     },
     {
-      "id": "native.android.70f5d0507d34b5c8",
-      "source": "Focus session search",
-      "translated": "Oturum aramasına odaklan"
+      "id": "native.android.439b324280869527",
+      "source": "Focus thread search",
+      "translated": "Konu aramasına odaklan"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "Arşivlendi"
     },
     {
-      "id": "native.android.b9cf34c137e4cf03",
-      "source": "Search sessions",
-      "translated": "Oturumlarda ara"
+      "id": "native.android.03981341841b04ac",
+      "source": "Search threads",
+      "translated": "Konuları ara"
     },
     {
-      "id": "native.android.10cb26723e9990fc",
-      "source": "Clear session search",
-      "translated": "Oturum aramasını temizle"
+      "id": "native.android.99570c528a41fa72",
+      "source": "Clear thread search",
+      "translated": "Konu aramasını temizle"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "Önce en eski"
     },
     {
-      "id": "native.android.c6bf8751e2a7f5c7",
-      "source": "Toggle session layout",
-      "translated": "Oturum düzenini değiştir"
+      "id": "native.android.fd67be543e321cc9",
+      "source": "Toggle thread layout",
+      "translated": "Konu düzenini değiştir"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "Düzen: Ayrıntılı"
     },
     {
-      "id": "native.android.69b79a3c2c987cd4",
-      "source": "Searching sessions",
-      "translated": "Oturumlar aranıyor"
+      "id": "native.android.ebd17565e0ffd8eb",
+      "source": "Searching threads",
+      "translated": "Konular aranıyor"
     },
     {
-      "id": "native.android.dd587d341af44212",
-      "source": "No matching sessions",
-      "translated": "Eşleşen oturum yok"
+      "id": "native.android.472d46ae8669f860",
+      "source": "No matching threads",
+      "translated": "Eşleşen konu yok"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "Sohbet Başlat"
     },
     {
-      "id": "native.android.f10d4df7cbc6df4f",
-      "source": "Current session",
-      "translated": "Geçerli oturum"
+      "id": "native.android.ff81ad1bee00d384",
+      "source": "Current thread",
+      "translated": "Geçerli konu"
     },
     {
-      "id": "native.android.8f0482425838ae64",
-      "source": "OpenClaw session",
-      "translated": "OpenClaw oturumu"
+      "id": "native.android.fc145645b9620e57",
+      "source": "OpenClaw thread",
+      "translated": "OpenClaw konusu"
     },
     {
-      "id": "native.android.786774c8a76e50d7",
-      "source": "Rename session",
-      "translated": "Oturumu yeniden adlandır"
+      "id": "native.android.71cbb8dde8bf138b",
+      "source": "Rename thread",
+      "translated": "Konuyu yeniden adlandır"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "Grup silinsin mi?"
     },
     {
-      "id": "native.android.3455fc2f77d564e3",
-      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "\"$group\" içindeki oturumlar korunur ve Gruplanmamış'a geri taşınır."
+      "id": "native.android.691e92cfe5cf106e",
+      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "\"$group\" grubundaki konular korunur ve Gruplandırılmamış'a geri taşınır."
     },
     {
-      "id": "native.android.4805fb9d6623e8c0",
-      "source": "Delete session?",
-      "translated": "Oturum silinsin mi?"
+      "id": "native.android.d87a8217ab56999b",
+      "source": "Delete thread?",
+      "translated": "Konu silinsin mi?"
     },
     {
-      "id": "native.android.0c3283a2b2445eae",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "Bu işlem oturumu ve dökümünü kalıcı olarak siler."
+      "id": "native.android.930de97ff47113a8",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "Bu işlem, konu dizisini ve dökümünü kalıcı olarak siler."
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "Gruplandırılmamış"
     },
     {
-      "id": "native.android.db243d71d056afa4",
-      "source": "No sessions yet",
-      "translated": "Henüz oturum yok"
+      "id": "native.android.8e21a70428def6e0",
+      "source": "No threads yet",
+      "translated": "Henüz konu dizisi yok"
     },
     {
-      "id": "native.android.5b4eee6a8092925e",
-      "source": "No current session",
-      "translated": "Geçerli oturum yok"
+      "id": "native.android.cda4c5ad8b17e394",
+      "source": "No current thread",
+      "translated": "Geçerli konu dizisi yok"
     },
     {
-      "id": "native.android.acbcc9c9ea53d8c0",
-      "source": "No archived sessions",
-      "translated": "Arşivlenmiş oturum yok"
+      "id": "native.android.be84f061047aa2da",
+      "source": "No archived threads",
+      "translated": "Arşivlenmiş konu dizisi yok"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "Yeni bir konuşma başlatın; burada görünecektir."
     },
     {
-      "id": "native.android.56fcd605dc7be3c0",
-      "source": "Open Chat to start or resume the current session.",
-      "translated": "Geçerli oturumu başlatmak veya sürdürmek için Sohbet’i açın."
+      "id": "native.android.f289d03e1d3eee98",
+      "source": "Open Chat to start or resume the current thread.",
+      "translated": "Geçerli konu dizisini başlatmak veya sürdürmek için Sohbet'i açın."
     },
     {
-      "id": "native.android.085515989f8a2022",
-      "source": "Archived sessions will show up here.",
-      "translated": "Arşivlenmiş oturumlar burada görünecek."
+      "id": "native.android.504b71386e76c6ae",
+      "source": "Archived threads will show up here.",
+      "translated": "Arşivlenen konu dizileri burada görünür."
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days} gün"
     },
     {
-      "id": "native.android.3d4fa07acbc015c5",
-      "source": "Main session",
-      "translated": "Ana oturum"
+      "id": "native.android.ee4c727cdafbe963",
+      "source": "Main thread",
+      "translated": "Ana konu dizisi"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway Beklemede"
     },
     {
-      "id": "native.android.2d8d049afe99f751",
-      "source": "Session Activity",
-      "translated": "Oturum Etkinliği"
+      "id": "native.android.da78209effb11cfd",
+      "source": "Thread Activity",
+      "translated": "Konu Dizisi Etkinliği"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "Exec onay istekleri, bu telefon bağlıyken burada görünecek."
     },
     {
-      "id": "native.android.dc3e7ca5a491103a",
-      "source": "Session activity",
-      "translated": "Oturum etkinliği"
+      "id": "native.android.f615712dfb56319a",
+      "source": "Thread activity",
+      "translated": "Konu dizisi etkinliği"
     },
     {
-      "id": "native.android.8551e02b060bd7d8",
-      "source": "Chat tool calls waiting in the active session remain visible here.",
-      "translated": "Etkin oturumda bekleyen sohbet aracı çağrıları burada görünür kalır."
+      "id": "native.android.6c93973c13db43ae",
+      "source": "Chat tool calls waiting in the active thread remain visible here.",
+      "translated": "Etkin konu dizisinde bekleyen sohbet aracı çağrıları burada görünmeye devam eder."
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,6 +4294,11 @@
       "translated": "Konuşma Sağlayıcısı Kurulumu"
     },
     {
+      "id": "native.android.23b638094c34b916",
+      "source": "Microphone",
+      "translated": "Mikrofon"
+    },
+    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "Ses Testi"
@@ -4337,6 +4342,66 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "Bitti"
+    },
+    {
+      "id": "native.android.8d9ecdfdd916b780",
+      "source": "Automatic",
+      "translated": "Otomatik"
+    },
+    {
+      "id": "native.android.c1626a6700a570f6",
+      "source": "Preferred microphone unavailable; using automatic routing.",
+      "translated": "Tercih edilen mikrofon kullanılamıyor; otomatik yönlendirme kullanılıyor."
+    },
+    {
+      "id": "native.android.820bc5d0ce571d8b",
+      "source": "Prioritizes connected Bluetooth microphones.",
+      "translated": "Bağlı Bluetooth mikrofonlarına öncelik verir."
+    },
+    {
+      "id": "native.android.11e48038d5e8bff6",
+      "source": "Preferred microphone",
+      "translated": "Tercih edilen mikrofon"
+    },
+    {
+      "id": "native.android.eaa4d7563a46d307",
+      "source": "Unavailable",
+      "translated": "Kullanılamıyor"
+    },
+    {
+      "id": "native.android.9f5ebf17eb405ba8",
+      "source": "Next session",
+      "translated": "Sonraki oturum"
+    },
+    {
+      "id": "native.android.8c4e91f53928efb2",
+      "source": "Built-in microphone",
+      "translated": "Yerleşik mikrofon"
+    },
+    {
+      "id": "native.android.14b613cb6e2446b4",
+      "source": "Bluetooth microphone",
+      "translated": "Bluetooth mikrofonu"
+    },
+    {
+      "id": "native.android.c885247b2d7ce271",
+      "source": "Bluetooth LE microphone",
+      "translated": "Bluetooth LE mikrofonu"
+    },
+    {
+      "id": "native.android.b6a4e674c5fb441a",
+      "source": "Wired headset microphone",
+      "translated": "Kablolu kulaklık mikrofonu"
+    },
+    {
+      "id": "native.android.9c8becb3b0fb5a90",
+      "source": "USB microphone",
+      "translated": "USB mikrofonu"
+    },
+    {
+      "id": "native.android.ba46258fadec7a39",
+      "source": "External microphone",
+      "translated": "Harici mikrofon"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5074,9 +5139,9 @@
       "translated": "Kontrol et"
     },
     {
-      "id": "native.android.5a540761383fa474",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
-      "translated": "OpenClaw, bu telefonu oturumlar, ses, sağlayıcılar ve Gateway için sade bir mobil komut arayüzüne dönüştürür."
+      "id": "native.android.c971506716c96e91",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
+      "translated": "OpenClaw bu telefonu ileti dizileri, ses, sağlayıcılar ve Gateway için sade bir mobil komuta arayüzüne dönüştürür."
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5624,9 +5689,9 @@
       "translated": "Talk ayarları"
     },
     {
-      "id": "native.android.73f07a5d54915259",
-      "source": "Recent Sessions",
-      "translated": "Son Oturumlar"
+      "id": "native.android.36f78c8c85dc283f",
+      "source": "Recent Threads",
+      "translated": "Son İletişim Dizileri"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5684,14 +5749,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% çevrimiçi"
     },
     {
-      "id": "native.android.16c3425d3a594481",
-      "source": "Sessions",
-      "translated": "Oturumlar"
+      "id": "native.android.57177017a6a93826",
+      "source": "Threads",
+      "translated": "İletişim Dizileri"
     },
     {
-      "id": "native.android.a5c0f8b3112aa58c",
-      "source": "No recent sessions",
-      "translated": "Yakın zamanda oturum yok"
+      "id": "native.android.43320b54a68b00a1",
+      "source": "No recent threads",
+      "translated": "Son iletişim dizisi yok"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5729,14 +5794,14 @@
       "translated": "Çalışıyor · $pendingRunCount etkin çalıştırma"
     },
     {
-      "id": "native.android.2c89da708b12a522",
-      "source": "Monitoring · 1 session",
-      "translated": "İzleniyor · 1 oturum"
+      "id": "native.android.e24db059480f1e6a",
+      "source": "Monitoring · 1 thread",
+      "translated": "İzleniyor · 1 iletişim dizisi"
     },
     {
-      "id": "native.android.8b6ee382dcb64e1f",
-      "source": "Monitoring · $sessionCount sessions",
-      "translated": "İzleniyor · $sessionCount oturum"
+      "id": "native.android.5a475f37d80e02bc",
+      "source": "Monitoring · $sessionCount threads",
+      "translated": "İzleniyor · $sessionCount iletişim dizisi"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5769,9 +5834,9 @@
       "translated": "Sağlayıcılar"
     },
     {
-      "id": "native.android.a65477861c7203aa",
-      "source": "Open session",
-      "translated": "Oturumu aç"
+      "id": "native.android.358c5e0e838d5423",
+      "source": "Open thread",
+      "translated": "İletişim dizisini aç"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6194,9 +6259,9 @@
       "translated": "${days} gün"
     },
     {
-      "id": "native.android.22d755834386db07",
-      "source": "Main session",
-      "translated": "Ana oturum"
+      "id": "native.android.28a1a1acc5a0959f",
+      "source": "Main thread",
+      "translated": "Ana iletişim dizisi"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6877,6 +6942,16 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "Sessizden çıkar"
+    },
+    {
+      "id": "native.android.cb608d82c5b3352a",
+      "source": "Back camera",
+      "translated": "Arka kamera"
+    },
+    {
+      "id": "native.android.e89a0e780eed2e1e",
+      "source": "Front camera",
+      "translated": "Ön kamera"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7684,9 +7759,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.882cc14a58e7e105",
-      "source": "Loading session",
-      "translated": "Oturum yükleniyor"
+      "id": "native.android.0c74bc30a994dd33",
+      "source": "Loading thread",
+      "translated": "İletişim dizisi yükleniyor"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7729,14 +7804,14 @@
       "translated": "Beni bilgilendir"
     },
     {
-      "id": "native.android.1e5add56e48c99f9",
-      "source": "Summarize recent sessions and next steps.",
-      "translated": "Son oturumları ve sonraki adımları özetleyin."
+      "id": "native.android.cf40df9739f78f27",
+      "source": "Summarize recent threads and next steps.",
+      "translated": "Son iletişim dizilerini ve sonraki adımları özetle."
     },
     {
-      "id": "native.android.06d515351bb79576",
-      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
-      "translated": "Son OpenClaw oturumlarım hakkında beni bilgilendirin ve sonraki adımları önerin."
+      "id": "native.android.ebe49a8b8df80bd3",
+      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
+      "translated": "Son OpenClaw iletişim dizilerimdeki gelişmeleri aktar ve sonraki adımları öner."
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8074,9 +8149,9 @@
       "translated": "Bağlandı"
     },
     {
-      "id": "native.android.81931886b9caf3ab",
-      "source": "Sessions",
-      "translated": "Oturumlar"
+      "id": "native.android.6cf5d6fa8a4186d5",
+      "source": "Threads",
+      "translated": "İletişim Dizileri"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,9 +10869,9 @@
       "translated": "Ne üzerinde çalışmak istersiniz?"
     },
     {
-      "id": "native.apple.32179ce0b6d4543f",
-      "source": "The session attaches once the gateway is ready.",
-      "translated": "Gateway hazır olduğunda oturum bağlanır."
+      "id": "native.apple.4da775013ac9b123",
+      "source": "The thread attaches once the gateway is ready.",
+      "translated": "Gateway hazır olduğunda iletişim dizisi bağlanır."
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10844,9 +10919,9 @@
       "translated": "Yeni Oturum Seçenekleri…"
     },
     {
-      "id": "native.apple.a1b0d289758e2213",
-      "source": "Sessions…",
-      "translated": "Oturumlar…"
+      "id": "native.apple.003b25ddafeb18e9",
+      "source": "Threads…",
+      "translated": "İletişim Dizileri…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11009,14 +11084,14 @@
       "translated": "Oluştur"
     },
     {
-      "id": "native.apple.f488b9caf6e51ac3",
-      "source": "Delete Session?",
-      "translated": "Oturum silinsin mi?"
+      "id": "native.apple.31d5c7287cfb3abe",
+      "source": "Delete Thread?",
+      "translated": "İletişim Dizisi Silinsin mi?"
     },
     {
-      "id": "native.apple.8634b17be9b111bc",
-      "source": "Delete Session",
-      "translated": "Oturumu Sil"
+      "id": "native.apple.d3395564809f1120",
+      "source": "Delete Thread",
+      "translated": "İş Parçacığını Sil"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11024,9 +11099,9 @@
       "translated": "İptal"
     },
     {
-      "id": "native.apple.4a9568ac9b18d8d3",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "Bu işlem oturumu ve dökümünü kalıcı olarak siler."
+      "id": "native.apple.092659256d26cb03",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "Bu işlem, iş parçacığını ve dökümünü kalıcı olarak siler."
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11054,9 +11129,9 @@
       "translated": "Yeni Grup"
     },
     {
-      "id": "native.apple.5bccdc23a1640895",
-      "source": "Rename Session",
-      "translated": "Oturumu Yeniden Adlandır"
+      "id": "native.apple.683032464c497bbd",
+      "source": "Rename Thread",
+      "translated": "İş Parçacığını Yeniden Adlandır"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11064,9 +11139,9 @@
       "translated": "Grup adı"
     },
     {
-      "id": "native.apple.af789b2d2fda0f67",
-      "source": "Session name",
-      "translated": "Oturum adı"
+      "id": "native.apple.f887aa956588f237",
+      "source": "Thread name",
+      "translated": "İş parçacığı adı"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11104,14 +11179,14 @@
       "translated": "Aracılar"
     },
     {
-      "id": "native.apple.a3bde8045fe9224a",
-      "source": "Agent session",
-      "translated": "Aracı oturumu"
+      "id": "native.apple.7c8231b7b1ca480f",
+      "source": "Agent thread",
+      "translated": "Aracı iş parçacığı"
     },
     {
-      "id": "native.apple.27f775de30b37ff8",
-      "source": "Recent sessions",
-      "translated": "Son oturumlar"
+      "id": "native.apple.b3c553614f762a58",
+      "source": "Recent threads",
+      "translated": "Son iş parçacıkları"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11119,9 +11194,9 @@
       "translated": "Gateway çevrimdışı"
     },
     {
-      "id": "native.apple.28c97cf23665ee01",
-      "source": "No recent sessions",
-      "translated": "Son oturum yok"
+      "id": "native.apple.5aa32afda85064ea",
+      "source": "No recent threads",
+      "translated": "Son iş parçacığı yok"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11219,14 +11294,14 @@
       "translated": "İptal"
     },
     {
-      "id": "native.apple.9f2fd65953013b7c",
-      "source": "Sessions",
-      "translated": "Oturumlar"
+      "id": "native.apple.b6855cf19a50f477",
+      "source": "Threads",
+      "translated": "İş Parçacıkları"
     },
     {
-      "id": "native.apple.0422818cc95d5071",
-      "source": "Archived sessions",
-      "translated": "Arşivlenmiş oturumlar"
+      "id": "native.apple.9b1d0ef27a1333b0",
+      "source": "Archived threads",
+      "translated": "Arşivlenmiş iş parçacıkları"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11234,34 +11309,34 @@
       "translated": "Arşivlenenleri Göster"
     },
     {
-      "id": "native.apple.b272115c83f7ef58",
-      "source": "Sessions unavailable",
-      "translated": "Oturumlar kullanılamıyor"
+      "id": "native.apple.98167401c7267735",
+      "source": "Threads unavailable",
+      "translated": "İş parçacıkları kullanılamıyor"
     },
     {
-      "id": "native.apple.54f8260c9b863087",
-      "source": "Loading archived sessions",
-      "translated": "Arşivlenmiş oturumlar yükleniyor"
+      "id": "native.apple.4d28a7def2337b9f",
+      "source": "Loading archived threads",
+      "translated": "Arşivlenmiş iş parçacıkları yükleniyor"
     },
     {
-      "id": "native.apple.9b305868873dade2",
-      "source": "Loading recent sessions",
-      "translated": "Son oturumlar yükleniyor"
+      "id": "native.apple.777d7b706933bd7b",
+      "source": "Loading recent threads",
+      "translated": "Son iş parçacıkları yükleniyor"
     },
     {
-      "id": "native.apple.207dad20d09f3160",
-      "source": "^[\\(count) session](inflect: true)",
-      "translated": "^[\\(count) oturum](inflect: true)"
+      "id": "native.apple.22f81ea94bef8410",
+      "source": "^[\\(count) thread](inflect: true)",
+      "translated": "^[\\(count) iş parçacığı](inflect: true)"
     },
     {
-      "id": "native.apple.1f4501a6bf2bae4c",
-      "source": "No archived sessions",
-      "translated": "Arşivlenmiş oturum yok"
+      "id": "native.apple.1cad51e14db59bf9",
+      "source": "No archived threads",
+      "translated": "Arşivlenmiş iş parçacığı yok"
     },
     {
-      "id": "native.apple.2a1ba7a5e1979c9e",
-      "source": "Archived sessions will appear here.",
-      "translated": "Arşivlenen oturumlar burada görünecek."
+      "id": "native.apple.18ef832d3a7ddcf8",
+      "source": "Archived threads will appear here.",
+      "translated": "Arşivlenmiş iş parçacıkları burada görünür."
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11344,9 +11419,9 @@
       "translated": "Paylaşım alımı"
     },
     {
-      "id": "native.apple.2360d25fe6ae9946",
-      "source": "Loading sessions",
-      "translated": "Oturumlar yükleniyor"
+      "id": "native.apple.21d9208d86a4d1fe",
+      "source": "Loading threads",
+      "translated": "İş parçacıkları yükleniyor"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11354,19 +11429,19 @@
       "translated": "Gateway üzerinden son etkinlik alınıyor."
     },
     {
-      "id": "native.apple.c334f2e86702a7b8",
-      "source": "Sessions unavailable",
-      "translated": "Oturumlar kullanılamıyor"
+      "id": "native.apple.4be1f79aa2b230ff",
+      "source": "Threads unavailable",
+      "translated": "İş parçacıkları kullanılamıyor"
     },
     {
-      "id": "native.apple.6cc6efb7a03960b6",
-      "source": "No recent sessions",
-      "translated": "Yakın zamanda oturum yok"
+      "id": "native.apple.98b348873556bc46",
+      "source": "No recent threads",
+      "translated": "Son iş parçacığı yok"
     },
     {
-      "id": "native.apple.08483af2d043bee6",
-      "source": "Session activity offline",
-      "translated": "Oturum etkinliği çevrimdışı"
+      "id": "native.apple.7396d205574d279f",
+      "source": "Thread activity offline",
+      "translated": "İş parçacığı etkinliği çevrimdışı"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11824,9 +11899,9 @@
       "translated": "Kart"
     },
     {
-      "id": "native.apple.93eeaedb2ff61043",
-      "source": "Open Session",
-      "translated": "Oturumu Aç"
+      "id": "native.apple.c9ec1b0e18074d8a",
+      "source": "Open Thread",
+      "translated": "İş Parçacığını Aç"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13314,9 +13389,9 @@
       "translated": "Varsayılan"
     },
     {
-      "id": "native.apple.3de045f17ea3c6d0",
-      "source": "Used for new Chat and Talk sessions.",
-      "translated": "Yeni Chat ve Talk oturumları için kullanılır."
+      "id": "native.apple.f4ae5664c3eda95d",
+      "source": "Used for new Chat threads and Talk sessions.",
+      "translated": "Yeni Sohbet dizileri ve Konuşma oturumları için kullanılır."
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15719,9 +15794,9 @@
       "translated": "Örnekler"
     },
     {
-      "id": "native.apple.3579cf2750470a22",
-      "source": "Sessions",
-      "translated": "Oturumlar"
+      "id": "native.apple.11fe8b9941954dfb",
+      "source": "Threads",
+      "translated": "Diziler"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19029,9 +19104,9 @@
       "translated": "Hızlı Sohbet kestirmesi"
     },
     {
-      "id": "native.apple.6ae77665b5f4490f",
-      "source": "Global shortcut that opens a floating chat bar for the main session.",
-      "translated": "Ana oturum için yüzen bir sohbet çubuğu açan genel kestirme."
+      "id": "native.apple.94dd793cd7d7d555",
+      "source": "Global shortcut that opens a floating chat bar for the main thread.",
+      "translated": "Ana dizi için yüzen bir sohbet çubuğu açan genel kısayol."
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19609,9 +19684,9 @@
       "translated": "Kritik"
     },
     {
-      "id": "native.apple.75102378a6775180",
-      "source": "New Session",
-      "translated": "Yeni Oturum"
+      "id": "native.apple.13f96467014cf344",
+      "source": "New Thread",
+      "translated": "Yeni Dizi"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21899,9 +21974,9 @@
       "translated": "Yakın zamanda mesaj yok"
     },
     {
-      "id": "native.apple.1ff8aec0044934c3",
-      "source": "Sessions",
-      "translated": "Oturumlar"
+      "id": "native.apple.3ec2afcbc298c673",
+      "source": "Threads",
+      "translated": "Diziler"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21909,9 +21984,9 @@
       "translated": "CLI'ın bağlam ve hız sınırları için yeniden kullandığı depolanmış konuşma kümelerine göz atın."
     },
     {
-      "id": "native.apple.bab897f3252b134c",
-      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
-      "translated": "Henüz oturum yok. İlk gelen mesaj veya heartbeat'ten sonra görünürler."
+      "id": "native.apple.14ccb32cd8ed1c81",
+      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
+      "translated": "Henüz dizi yok. İlk gelen mesajdan veya heartbeat'ten sonra görünürler."
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -21994,9 +22069,9 @@
       "translated": "Yürütme Onayları"
     },
     {
-      "id": "native.apple.64a6dc7d49e8fb57",
-      "source": "Sessions",
-      "translated": "Oturumlar"
+      "id": "native.apple.52e37e3a44ae516c",
+      "source": "Threads",
+      "translated": "Diziler"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -22999,9 +23074,9 @@
       "translated": "Beni bilgilendir"
     },
     {
-      "id": "native.apple.234ec45f4231edc4",
-      "source": "Summarize what happened in my sessions since yesterday.",
-      "translated": "Dünden bu yana oturumlarımda neler olduğunu özetle."
+      "id": "native.apple.fc4ce810900ec0b6",
+      "source": "Summarize what happened in my threads since yesterday.",
+      "translated": "Dünden beri dizilerimde neler olduğunu özetle."
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23179,9 +23254,9 @@
       "translated": "Modelin sabitlemesini kaldır"
     },
     {
-      "id": "native.apple.5dfc0700d8dff8de",
-      "source": "Session",
-      "translated": "Oturum"
+      "id": "native.apple.4edb66657f5aca1f",
+      "source": "Thread",
+      "translated": "Dizi"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23344,6 +23419,51 @@
       "translated": "Widget kullanılamıyor"
     },
     {
+      "id": "native.apple.d640691fd196f338",
+      "source": "Widget export failed",
+      "translated": "Widget dışa aktarılamadı"
+    },
+    {
+      "id": "native.apple.533c6e22a11e88de",
+      "source": "OK",
+      "translated": "Tamam"
+    },
+    {
+      "id": "native.apple.e1fb28a2a9756402",
+      "source": "Copy image",
+      "translated": "Görüntüyü kopyala"
+    },
+    {
+      "id": "native.apple.ebd7bc92e1b12235",
+      "source": "Save image…",
+      "translated": "Görüntüyü kaydet…"
+    },
+    {
+      "id": "native.apple.742c46d4cf2db134",
+      "source": "Save image",
+      "translated": "Görüntüyü kaydet"
+    },
+    {
+      "id": "native.apple.0589cce608418f90",
+      "source": "The widget image could not be captured.",
+      "translated": "Widget görüntüsü yakalanamadı."
+    },
+    {
+      "id": "native.apple.dfe24e827fdbe9c5",
+      "source": "The widget image could not be copied.",
+      "translated": "Widget görüntüsü kopyalanamadı."
+    },
+    {
+      "id": "native.apple.9e611e3a80e71408",
+      "source": "The widget image could not be encoded as PNG.",
+      "translated": "Widget görüntüsü PNG olarak kodlanamadı."
+    },
+    {
+      "id": "native.apple.9a6e8afbe24a262b",
+      "source": "The widget image could not be saved.",
+      "translated": "Widget görüntüsü kaydedilemedi."
+    },
+    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23484,19 +23604,19 @@
       "translated": "Kullanıcı"
     },
     {
-      "id": "native.apple.b1cdcb906a43d5d6",
-      "source": "This session cannot be archived while it is active or running.",
-      "translated": "Bu oturum etkinken veya çalışırken arşivlenemez."
+      "id": "native.apple.9d0cba09d92ee669",
+      "source": "This thread cannot be archived while it is active or running.",
+      "translated": "Bu dizi etkinken veya çalışırken arşivlenemez."
     },
     {
-      "id": "native.apple.5817e3f3dab1ee19",
-      "source": "The main session cannot be deleted.",
-      "translated": "Ana oturum silinemez."
+      "id": "native.apple.8952a111a1075051",
+      "source": "The main thread cannot be deleted.",
+      "translated": "Ana dizi silinemez."
     },
     {
-      "id": "native.apple.a6b8df3f18171c91",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
-      "translated": "Bu oturumu arşivlemeden veya silmeden önce ekleri kaldırın ya da teslim edilmelerini bekleyin."
+      "id": "native.apple.90d0ccf80ca28717",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
+      "translated": "Bu ileti dizisini arşivlemeden veya silmeden önce ekleri kaldırın ya da teslim edilmelerini bekleyin."
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23634,9 +23754,9 @@
       "translated": "Çalıştırma sona erdi"
     },
     {
-      "id": "native.apple.cd7c3095a22f80a9",
-      "source": "Session Info",
-      "translated": "Oturum Bilgileri"
+      "id": "native.apple.bbccb4c8db5cac12",
+      "source": "Thread Info",
+      "translated": "İleti Dizisi Bilgileri"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23669,9 +23789,9 @@
       "translated": "Grup Ekle"
     },
     {
-      "id": "native.apple.23d628606fe0734f",
-      "source": "Session Groups",
-      "translated": "Oturum Grupları"
+      "id": "native.apple.7b641fed5bace855",
+      "source": "Thread Groups",
+      "translated": "İleti Dizisi Grupları"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23714,9 +23834,9 @@
       "translated": "Grubu Sil"
     },
     {
-      "id": "native.apple.b049c8a4d2805e08",
-      "source": "Sessions in this group become ungrouped.",
-      "translated": "Bu gruptaki oturumlar gruptan çıkarılır."
+      "id": "native.apple.56401c79410a310d",
+      "source": "Threads in this group become ungrouped.",
+      "translated": "Bu gruptaki ileti dizilerinin gruplandırması kaldırılır."
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23729,9 +23849,9 @@
       "translated": "Bu Gateway'de kullanılabilir aracı yok."
     },
     {
-      "id": "native.apple.6c89f35d53506406",
-      "source": "New Session Options",
-      "translated": "Yeni Oturum Seçenekleri"
+      "id": "native.apple.2d96aa7d3d12f85b",
+      "source": "New Thread Options",
+      "translated": "Yeni İleti Dizisi Seçenekleri"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23759,19 +23879,19 @@
       "translated": "Oluştur"
     },
     {
-      "id": "native.apple.795ba37f6782cf28",
-      "source": "The session could not be created.",
-      "translated": "Oturum oluşturulamadı."
+      "id": "native.apple.87ef57319d1ddc85",
+      "source": "The thread could not be created.",
+      "translated": "İleti dizisi oluşturulamadı."
     },
     {
-      "id": "native.apple.8ec708a3605a2cc3",
-      "source": "Search sessions",
-      "translated": "Oturumlarda ara"
+      "id": "native.apple.6bd91c435b69d638",
+      "source": "Search threads",
+      "translated": "İleti dizilerinde ara"
     },
     {
-      "id": "native.apple.23b069b4e7f97039",
-      "source": "No Sessions",
-      "translated": "Oturum Yok"
+      "id": "native.apple.6fde4bdf9d5b9191",
+      "source": "No Threads",
+      "translated": "İleti Dizisi Yok"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23779,29 +23899,29 @@
       "translated": "Sonuç Yok"
     },
     {
-      "id": "native.apple.0058923f2ce8a3ec",
-      "source": "New Session",
-      "translated": "Yeni Oturum"
+      "id": "native.apple.a02fd99740d29bd3",
+      "source": "New Thread",
+      "translated": "Yeni İleti Dizisi"
     },
     {
-      "id": "native.apple.66ba42960eb4135b",
-      "source": "New session",
-      "translated": "Yeni oturum"
+      "id": "native.apple.b625801dd04b09f2",
+      "source": "New thread",
+      "translated": "Yeni ileti dizisi"
     },
     {
-      "id": "native.apple.2ef0e34db02ad255",
-      "source": "New session options",
-      "translated": "Yeni oturum seçenekleri"
+      "id": "native.apple.851be81fcc933608",
+      "source": "New thread options",
+      "translated": "Yeni ileti dizisi seçenekleri"
     },
     {
-      "id": "native.apple.36753ef2f1ed4264",
-      "source": "Rename Session",
-      "translated": "Oturumu Yeniden Adlandır"
+      "id": "native.apple.9ce8a4aba7b444b2",
+      "source": "Rename Thread",
+      "translated": "İleti Dizisini Yeniden Adlandır"
     },
     {
-      "id": "native.apple.c9de0a1510ef475f",
-      "source": "Session name",
-      "translated": "Oturum adı"
+      "id": "native.apple.1dd067c44511c7f0",
+      "source": "Thread name",
+      "translated": "İleti dizisi adı"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23814,14 +23934,14 @@
       "translated": "İptal"
     },
     {
-      "id": "native.apple.afb4e6c99c63a28d",
-      "source": "Delete Session",
-      "translated": "Oturumu Sil"
+      "id": "native.apple.618073d6ab3f2721",
+      "source": "Delete Thread",
+      "translated": "İleti Dizisini Sil"
     },
     {
-      "id": "native.apple.3d4ef32e42f136a4",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "Oturum ve dökümü Gateway'den kaldırılır."
+      "id": "native.apple.10a5e72bba3cbccc",
+      "source": "The thread and its transcript are removed from the gateway.",
+      "translated": "İleti dizisi ve dökümü gateway'den kaldırılır."
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23829,14 +23949,14 @@
       "translated": "“%@” silinsin mi?"
     },
     {
-      "id": "native.apple.9a7dca238fba628d",
-      "source": "Session running",
-      "translated": "Oturum çalışıyor"
+      "id": "native.apple.ac71e3b2aa496a2c",
+      "source": "Thread running",
+      "translated": "İleti dizisi çalışıyor"
     },
     {
-      "id": "native.apple.fcfbfe5e97a95e9c",
-      "source": "Session failed",
-      "translated": "Oturum başarısız oldu"
+      "id": "native.apple.c775e87f997278b2",
+      "source": "Thread failed",
+      "translated": "İleti dizisi başarısız oldu"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23894,9 +24014,9 @@
       "translated": "Oturum Anahtarını Kopyala"
     },
     {
-      "id": "native.apple.4aeb7c14c26dabac",
-      "source": "Delete Session…",
-      "translated": "Oturumu Sil…"
+      "id": "native.apple.f4998cfb572f23ff",
+      "source": "Delete Thread…",
+      "translated": "İleti Dizisini Sil…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23909,9 +24029,9 @@
       "translated": "Bağlanıyor…"
     },
     {
-      "id": "native.apple.79f708b3bc1d3a6c",
-      "source": "Retry session groups",
-      "translated": "Oturum gruplarını yeniden dene"
+      "id": "native.apple.8802e9576ffd0f65",
+      "source": "Retry thread groups",
+      "translated": "İleti dizisi gruplarını yeniden dene"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23934,24 +24054,24 @@
       "translated": "Kapsam"
     },
     {
-      "id": "native.apple.2c37581c7b88f741",
-      "source": "Search sessions",
-      "translated": "Oturumlarda ara"
+      "id": "native.apple.b313b80def4bda52",
+      "source": "Search threads",
+      "translated": "İleti dizilerinde ara"
     },
     {
-      "id": "native.apple.43be8a2336e42faf",
-      "source": "Sessions",
-      "translated": "Oturumlar"
+      "id": "native.apple.c0cc6acc36f413ce",
+      "source": "Threads",
+      "translated": "İş Parçacıkları"
     },
     {
-      "id": "native.apple.0b379cdfcbd3247f",
-      "source": "Rename Session",
-      "translated": "Oturumu Yeniden Adlandır"
+      "id": "native.apple.854d3928fe5a557c",
+      "source": "Rename Thread",
+      "translated": "İş Parçacığını Yeniden Adlandır"
     },
     {
-      "id": "native.apple.54b6fbd9e41db009",
-      "source": "Session name",
-      "translated": "Oturum adı"
+      "id": "native.apple.9d0d3f20096cc4da",
+      "source": "Thread name",
+      "translated": "İş parçacığı adı"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -23959,19 +24079,19 @@
       "translated": "İptal"
     },
     {
-      "id": "native.apple.751e0f6b81cd374a",
-      "source": "Delete selected sessions?",
-      "translated": "Seçili oturumlar silinsin mi?"
+      "id": "native.apple.dc00eb94f33bae15",
+      "source": "Delete selected threads?",
+      "translated": "Seçili iş parçacıkları silinsin mi?"
     },
     {
-      "id": "native.apple.aa679276581b0058",
-      "source": "Delete Sessions",
-      "translated": "Oturumları Sil"
+      "id": "native.apple.2053fc9f74dc3158",
+      "source": "Delete Threads",
+      "translated": "İş Parçacıklarını Sil"
     },
     {
-      "id": "native.apple.f837129cbee23297",
-      "source": "Each selected session and its transcript will be removed from the gateway.",
-      "translated": "Seçili her oturum ve dökümü gateway'den kaldırılacaktır."
+      "id": "native.apple.0970247871a834a0",
+      "source": "Each selected thread and its transcript will be removed from the gateway.",
+      "translated": "Seçili her iş parçacığı ve dökümü gateway'den kaldırılacak."
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -23979,9 +24099,9 @@
       "translated": "Gruplar"
     },
     {
-      "id": "native.apple.64013cfee5e25305",
-      "source": "Manage session groups",
-      "translated": "Oturum gruplarını yönet"
+      "id": "native.apple.6f8acab2256728b5",
+      "source": "Manage thread groups",
+      "translated": "İş parçacığı gruplarını yönet"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -23994,14 +24114,14 @@
       "translated": "Seç"
     },
     {
-      "id": "native.apple.b67eaecec1b423ac",
-      "source": "No archived sessions",
-      "translated": "Arşivlenmiş oturum yok"
+      "id": "native.apple.692972314d04b184",
+      "source": "No archived threads",
+      "translated": "Arşivlenmiş iş parçacığı yok"
     },
     {
-      "id": "native.apple.b2435a79abf0c794",
-      "source": "No sessions found",
-      "translated": "Oturum bulunamadı"
+      "id": "native.apple.d6a4b5711dcd26e7",
+      "source": "No threads found",
+      "translated": "İş parçacığı bulunamadı"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24169,6 +24289,16 @@
       "translated": "Tam İletiyi Aç"
     },
     {
+      "id": "native.apple.002bfcede229ad4b",
+      "source": "Rewind to Here",
+      "translated": "Buraya Geri Sar"
+    },
+    {
+      "id": "native.apple.14df2e4997689fb3",
+      "source": "Fork from Here",
+      "translated": "Buradan Dallandır"
+    },
+    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "Yanıtla"
@@ -24254,9 +24384,9 @@
       "translated": "Yeni bir sohbet başlatmadan önce ekleri kaldırın veya teslimatın tamamlanmasını bekleyin."
     },
     {
-      "id": "native.apple.980f552bb0f96c0f",
-      "source": "Gateway changed before the session operation started.",
-      "translated": "Oturum işlemi başlamadan önce Gateway değişti."
+      "id": "native.apple.e0f045151c8d3137",
+      "source": "Gateway changed before the thread operation started.",
+      "translated": "İş parçacığı işlemi başlamadan önce Gateway değişti."
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24264,9 +24394,9 @@
       "translated": "Sohbetleri değiştirmeden önce ekleri kaldırın veya teslimatın tamamlanmasını bekleyin."
     },
     {
-      "id": "native.apple.87ba543b42696b92",
-      "source": "Clear this session's history?",
-      "translated": "Bu oturumun geçmişi temizlensin mi?"
+      "id": "native.apple.0a5c4e15466c3acc",
+      "source": "Clear this thread's history?",
+      "translated": "Bu iş parçacığının geçmişi temizlensin mi?"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24279,14 +24409,14 @@
       "translated": "Bu işlem, %@ için konuşmayı sıfırlar. Oturum anahtarı aynı kalır."
     },
     {
-      "id": "native.apple.a92e96bed98bd553",
-      "source": "Rename Session",
-      "translated": "Oturumu Yeniden Adlandır"
+      "id": "native.apple.67ac221dbe7179f0",
+      "source": "Rename Thread",
+      "translated": "İş Parçacığını Yeniden Adlandır"
     },
     {
-      "id": "native.apple.848e2388f3466f40",
-      "source": "Session name",
-      "translated": "Oturum adı"
+      "id": "native.apple.cf0f7e049603f518",
+      "source": "Thread name",
+      "translated": "İş parçacığı adı"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24304,9 +24434,9 @@
       "translated": "Dökümü Dışa Aktar"
     },
     {
-      "id": "native.apple.4af0f566d39d7041",
-      "source": "Sessions",
-      "translated": "Oturumlar"
+      "id": "native.apple.c0ada47504425f23",
+      "source": "Threads",
+      "translated": "İş Parçacıkları"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24379,14 +24509,14 @@
       "translated": "Varsayılan"
     },
     {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "Yeni Oturum"
+      "id": "native.apple.1a765291943599e5",
+      "source": "New Thread",
+      "translated": "Yeni İş Parçacığı"
     },
     {
-      "id": "native.apple.a7119fbf9d25df5e",
-      "source": "New Session Options…",
-      "translated": "Yeni Oturum Seçenekleri…"
+      "id": "native.apple.c7a3a6d5e43dd98f",
+      "source": "New Thread Options…",
+      "translated": "Yeni İş Parçacığı Seçenekleri…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24394,19 +24524,19 @@
       "translated": "Yenile"
     },
     {
-      "id": "native.apple.2bcff4a8fa503739",
-      "source": "Sessions…",
-      "translated": "Oturumlar…"
+      "id": "native.apple.0e710b81808e5dcf",
+      "source": "Threads…",
+      "translated": "İş Parçacıkları…"
     },
     {
-      "id": "native.apple.c36e008b051adb38",
-      "source": "Rename Session…",
-      "translated": "Oturumu Yeniden Adlandır…"
+      "id": "native.apple.faad8f92b6bef166",
+      "source": "Rename Thread…",
+      "translated": "İş Parçacığını Yeniden Adlandır…"
     },
     {
-      "id": "native.apple.ea0ef95a159bffe0",
-      "source": "Fork Session",
-      "translated": "Oturumu Çatalla"
+      "id": "native.apple.23b61d6cd26ac112",
+      "source": "Fork",
+      "translated": "Dallandır"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24464,24 +24594,24 @@
       "translated": "Geçmişi Temizle…"
     },
     {
-      "id": "native.apple.920fe8a7a33f9e92",
-      "source": "Session",
-      "translated": "Oturum"
+      "id": "native.apple.8b4f1c5107ea8a0e",
+      "source": "Thread",
+      "translated": "Konu"
     },
     {
-      "id": "native.apple.185a401f78328b0f",
-      "source": "Session actions",
-      "translated": "Oturum işlemleri"
+      "id": "native.apple.4d7750c9bf699469",
+      "source": "Thread actions",
+      "translated": "Konu eylemleri"
     },
     {
-      "id": "native.apple.9f9dedf599b2619b",
-      "source": "Session cost %@",
-      "translated": "Oturum maliyeti %@"
+      "id": "native.apple.bb2f22cc43c97f8e",
+      "source": "Thread cost %@",
+      "translated": "Konu maliyeti %@"
     },
     {
-      "id": "native.apple.f0a4720df5f5f403",
-      "source": "Compact Session",
-      "translated": "Oturumu Sıkıştır"
+      "id": "native.apple.6239ced0b86e86f8",
+      "source": "Compact Thread",
+      "translated": "Konuyu sıkıştır"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/tr.json
+++ b/apps/.i18n/native/tr.json
@@ -1429,9 +1429,9 @@
       "translated": "OpenClaw ile konuşun veya dikte edin"
     },
     {
-      "id": "native.android.e2cf5a38587382cb",
-      "source": "Browse Threads",
-      "translated": "Konulara Göz At"
+      "id": "native.android.5876e15e5e92fd45",
+      "source": "Browse Sessions",
+      "translated": "Oturumlara Göz At"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "İşlem bulunamadı"
     },
     {
-      "id": "native.android.bc70a4ac965b82ba",
-      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
-      "translated": "Sohbet, Ses, Konular, Sağlayıcılar veya Ayarlar'ı deneyin."
+      "id": "native.android.48ad0ae0e930e02b",
+      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
+      "translated": "Chat, Voice, Sessions, Providers veya Settings’i deneyin."
     },
     {
-      "id": "native.android.670121e54dbe286f",
-      "source": "Threads",
-      "translated": "Konular"
+      "id": "native.android.d4fbd1ee4f55a5db",
+      "source": "Sessions",
+      "translated": "Oturumlar"
     },
     {
-      "id": "native.android.d38be650b1bce4a0",
-      "source": "Connect the Gateway to search threads.",
-      "translated": "Konularda arama yapmak için Gateway'e bağlanın."
+      "id": "native.android.207c2170504e99e6",
+      "source": "Connect the Gateway to search sessions.",
+      "translated": "Oturumları aramak için Gateway'i bağlayın."
     },
     {
-      "id": "native.android.3d7754721f776ef8",
-      "source": "No matching threads yet.",
-      "translated": "Henüz eşleşen konu yok."
+      "id": "native.android.25d2c2d792c952fe",
+      "source": "No matching sessions yet.",
+      "translated": "Henüz eşleşen oturum yok."
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "Asistan çalışıyor"
     },
     {
-      "id": "native.android.9a839f6e3e05a744",
-      "source": "OpenClaw thread",
-      "translated": "OpenClaw konusu"
+      "id": "native.android.8f8384286317f5c9",
+      "source": "OpenClaw session",
+      "translated": "OpenClaw oturumu"
     },
     {
-      "id": "native.android.d83f82a1e4a5ed99",
-      "source": "Open thread",
-      "translated": "Konuyu aç"
+      "id": "native.android.15799e57704b20c6",
+      "source": "Open session",
+      "translated": "Oturumu aç"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "Hazır sağlayıcı yok"
     },
     {
-      "id": "native.android.8a1c5365c0538908",
-      "source": "Main thread",
-      "translated": "Ana konu"
+      "id": "native.android.73e6ab1a168fd381",
+      "source": "Main session",
+      "translated": "Ana oturum"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.a5845742daecb4ba",
-      "source": "Threads",
-      "translated": "Konular"
+      "id": "native.android.0e3157c15c56944f",
+      "source": "Sessions",
+      "translated": "Oturumlar"
     },
     {
-      "id": "native.android.439b324280869527",
-      "source": "Focus thread search",
-      "translated": "Konu aramasına odaklan"
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "Oturum aramasına odaklan"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "Arşivlendi"
     },
     {
-      "id": "native.android.03981341841b04ac",
-      "source": "Search threads",
-      "translated": "Konularda ara"
+      "id": "native.android.b9cf34c137e4cf03",
+      "source": "Search sessions",
+      "translated": "Oturumlarda ara"
     },
     {
-      "id": "native.android.99570c528a41fa72",
-      "source": "Clear thread search",
-      "translated": "Konu aramasını temizle"
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "Oturum aramasını temizle"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "Önce en eski"
     },
     {
-      "id": "native.android.fd67be543e321cc9",
-      "source": "Toggle thread layout",
-      "translated": "Konu düzenini değiştir"
+      "id": "native.android.c6bf8751e2a7f5c7",
+      "source": "Toggle session layout",
+      "translated": "Oturum düzenini değiştir"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "Düzen: Ayrıntılı"
     },
     {
-      "id": "native.android.ebd17565e0ffd8eb",
-      "source": "Searching threads",
-      "translated": "Konular aranıyor"
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "Oturumlar aranıyor"
     },
     {
-      "id": "native.android.472d46ae8669f860",
-      "source": "No matching threads",
-      "translated": "Eşleşen konu yok"
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "Eşleşen oturum yok"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "Sohbet Başlat"
     },
     {
-      "id": "native.android.ff81ad1bee00d384",
-      "source": "Current thread",
-      "translated": "Geçerli konu"
+      "id": "native.android.f10d4df7cbc6df4f",
+      "source": "Current session",
+      "translated": "Geçerli oturum"
     },
     {
-      "id": "native.android.fc145645b9620e57",
-      "source": "OpenClaw thread",
-      "translated": "OpenClaw konusu"
+      "id": "native.android.8f0482425838ae64",
+      "source": "OpenClaw session",
+      "translated": "OpenClaw oturumu"
     },
     {
-      "id": "native.android.71cbb8dde8bf138b",
-      "source": "Rename thread",
-      "translated": "Konuyu yeniden adlandır"
+      "id": "native.android.786774c8a76e50d7",
+      "source": "Rename session",
+      "translated": "Oturumu yeniden adlandır"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "Grup silinsin mi?"
     },
     {
-      "id": "native.android.691e92cfe5cf106e",
-      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "\"$group\" grubundaki konular korunur ve Gruplandırılmamış'a geri taşınır."
+      "id": "native.android.3455fc2f77d564e3",
+      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "\"$group\" içindeki oturumlar korunur ve Gruplanmamış'a geri taşınır."
     },
     {
-      "id": "native.android.d87a8217ab56999b",
-      "source": "Delete thread?",
-      "translated": "Konu silinsin mi?"
+      "id": "native.android.4805fb9d6623e8c0",
+      "source": "Delete session?",
+      "translated": "Oturum silinsin mi?"
     },
     {
-      "id": "native.android.930de97ff47113a8",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "Bu işlem, ileti dizisini ve dökümünü kalıcı olarak siler."
+      "id": "native.android.0c3283a2b2445eae",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "Bu işlem oturumu ve dökümünü kalıcı olarak siler."
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "Gruplandırılmamış"
     },
     {
-      "id": "native.android.8e21a70428def6e0",
-      "source": "No threads yet",
-      "translated": "Henüz ileti dizisi yok"
+      "id": "native.android.db243d71d056afa4",
+      "source": "No sessions yet",
+      "translated": "Henüz oturum yok"
     },
     {
-      "id": "native.android.cda4c5ad8b17e394",
-      "source": "No current thread",
-      "translated": "Geçerli ileti dizisi yok"
+      "id": "native.android.5b4eee6a8092925e",
+      "source": "No current session",
+      "translated": "Geçerli oturum yok"
     },
     {
-      "id": "native.android.be84f061047aa2da",
-      "source": "No archived threads",
-      "translated": "Arşivlenmiş ileti dizisi yok"
+      "id": "native.android.acbcc9c9ea53d8c0",
+      "source": "No archived sessions",
+      "translated": "Arşivlenmiş oturum yok"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "Yeni bir konuşma başlatın; burada görünecektir."
     },
     {
-      "id": "native.android.f289d03e1d3eee98",
-      "source": "Open Chat to start or resume the current thread.",
-      "translated": "Geçerli ileti dizisini başlatmak veya sürdürmek için Sohbet'i açın."
+      "id": "native.android.56fcd605dc7be3c0",
+      "source": "Open Chat to start or resume the current session.",
+      "translated": "Geçerli oturumu başlatmak veya sürdürmek için Sohbet’i açın."
     },
     {
-      "id": "native.android.504b71386e76c6ae",
-      "source": "Archived threads will show up here.",
-      "translated": "Arşivlenen ileti dizileri burada gösterilir."
+      "id": "native.android.085515989f8a2022",
+      "source": "Archived sessions will show up here.",
+      "translated": "Arşivlenmiş oturumlar burada görünecek."
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days} gün"
     },
     {
-      "id": "native.android.ee4c727cdafbe963",
-      "source": "Main thread",
-      "translated": "Ana ileti dizisi"
+      "id": "native.android.3d4fa07acbc015c5",
+      "source": "Main session",
+      "translated": "Ana oturum"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway Beklemede"
     },
     {
-      "id": "native.android.da78209effb11cfd",
-      "source": "Thread Activity",
-      "translated": "İleti Dizisi Etkinliği"
+      "id": "native.android.2d8d049afe99f751",
+      "source": "Session Activity",
+      "translated": "Oturum Etkinliği"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "Exec onay istekleri, bu telefon bağlıyken burada görünecek."
     },
     {
-      "id": "native.android.f615712dfb56319a",
-      "source": "Thread activity",
-      "translated": "İleti dizisi etkinliği"
+      "id": "native.android.dc3e7ca5a491103a",
+      "source": "Session activity",
+      "translated": "Oturum etkinliği"
     },
     {
-      "id": "native.android.6c93973c13db43ae",
-      "source": "Chat tool calls waiting in the active thread remain visible here.",
-      "translated": "Etkin ileti dizisinde bekleyen sohbet aracı çağrıları burada görünür durumda kalır."
+      "id": "native.android.8551e02b060bd7d8",
+      "source": "Chat tool calls waiting in the active session remain visible here.",
+      "translated": "Etkin oturumda bekleyen sohbet aracı çağrıları burada görünür kalır."
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,11 +4294,6 @@
       "translated": "Konuşma Sağlayıcısı Kurulumu"
     },
     {
-      "id": "native.android.23b638094c34b916",
-      "source": "Microphone",
-      "translated": "Mikrofon"
-    },
-    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "Ses Testi"
@@ -4342,66 +4337,6 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "Bitti"
-    },
-    {
-      "id": "native.android.8d9ecdfdd916b780",
-      "source": "Automatic",
-      "translated": "Otomatik"
-    },
-    {
-      "id": "native.android.c1626a6700a570f6",
-      "source": "Preferred microphone unavailable; using automatic routing.",
-      "translated": "Tercih edilen mikrofon kullanılamıyor; otomatik yönlendirme kullanılıyor."
-    },
-    {
-      "id": "native.android.820bc5d0ce571d8b",
-      "source": "Prioritizes connected Bluetooth microphones.",
-      "translated": "Bağlı Bluetooth mikrofonlarına öncelik verir."
-    },
-    {
-      "id": "native.android.11e48038d5e8bff6",
-      "source": "Preferred microphone",
-      "translated": "Tercih edilen mikrofon"
-    },
-    {
-      "id": "native.android.eaa4d7563a46d307",
-      "source": "Unavailable",
-      "translated": "Kullanılamıyor"
-    },
-    {
-      "id": "native.android.9f5ebf17eb405ba8",
-      "source": "Next session",
-      "translated": "Sonraki oturum"
-    },
-    {
-      "id": "native.android.8c4e91f53928efb2",
-      "source": "Built-in microphone",
-      "translated": "Dahili mikrofon"
-    },
-    {
-      "id": "native.android.14b613cb6e2446b4",
-      "source": "Bluetooth microphone",
-      "translated": "Bluetooth mikrofonu"
-    },
-    {
-      "id": "native.android.c885247b2d7ce271",
-      "source": "Bluetooth LE microphone",
-      "translated": "Bluetooth LE mikrofonu"
-    },
-    {
-      "id": "native.android.b6a4e674c5fb441a",
-      "source": "Wired headset microphone",
-      "translated": "Kablolu kulaklık mikrofonu"
-    },
-    {
-      "id": "native.android.9c8becb3b0fb5a90",
-      "source": "USB microphone",
-      "translated": "USB mikrofonu"
-    },
-    {
-      "id": "native.android.ba46258fadec7a39",
-      "source": "External microphone",
-      "translated": "Harici mikrofon"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5139,9 +5074,9 @@
       "translated": "Kontrol et"
     },
     {
-      "id": "native.android.c971506716c96e91",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
-      "translated": "OpenClaw, bu telefonu ileti dizileri, ses, sağlayıcılar ve Gateway için sade bir mobil komut arayüzüne dönüştürür."
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw, bu telefonu oturumlar, ses, sağlayıcılar ve Gateway için sade bir mobil komut arayüzüne dönüştürür."
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5689,9 +5624,9 @@
       "translated": "Talk ayarları"
     },
     {
-      "id": "native.android.36f78c8c85dc283f",
-      "source": "Recent Threads",
-      "translated": "Son İleti Dizileri"
+      "id": "native.android.73f07a5d54915259",
+      "source": "Recent Sessions",
+      "translated": "Son Oturumlar"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5749,14 +5684,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% çevrimiçi"
     },
     {
-      "id": "native.android.57177017a6a93826",
-      "source": "Threads",
-      "translated": "İleti Dizileri"
+      "id": "native.android.16c3425d3a594481",
+      "source": "Sessions",
+      "translated": "Oturumlar"
     },
     {
-      "id": "native.android.43320b54a68b00a1",
-      "source": "No recent threads",
-      "translated": "Yakın tarihli ileti dizisi yok"
+      "id": "native.android.a5c0f8b3112aa58c",
+      "source": "No recent sessions",
+      "translated": "Yakın zamanda oturum yok"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5794,14 +5729,14 @@
       "translated": "Çalışıyor · $pendingRunCount etkin çalıştırma"
     },
     {
-      "id": "native.android.e24db059480f1e6a",
-      "source": "Monitoring · 1 thread",
-      "translated": "İzleniyor · 1 ileti dizisi"
+      "id": "native.android.2c89da708b12a522",
+      "source": "Monitoring · 1 session",
+      "translated": "İzleniyor · 1 oturum"
     },
     {
-      "id": "native.android.5a475f37d80e02bc",
-      "source": "Monitoring · $sessionCount threads",
-      "translated": "İzleniyor · $sessionCount ileti dizisi"
+      "id": "native.android.8b6ee382dcb64e1f",
+      "source": "Monitoring · $sessionCount sessions",
+      "translated": "İzleniyor · $sessionCount oturum"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5834,9 +5769,9 @@
       "translated": "Sağlayıcılar"
     },
     {
-      "id": "native.android.358c5e0e838d5423",
-      "source": "Open thread",
-      "translated": "İleti dizisini aç"
+      "id": "native.android.a65477861c7203aa",
+      "source": "Open session",
+      "translated": "Oturumu aç"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6259,9 +6194,9 @@
       "translated": "${days} gün"
     },
     {
-      "id": "native.android.28a1a1acc5a0959f",
-      "source": "Main thread",
-      "translated": "Ana ileti dizisi"
+      "id": "native.android.22d755834386db07",
+      "source": "Main session",
+      "translated": "Ana oturum"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6942,16 +6877,6 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "Sessizden çıkar"
-    },
-    {
-      "id": "native.android.cb608d82c5b3352a",
-      "source": "Back camera",
-      "translated": "Arka kamera"
-    },
-    {
-      "id": "native.android.e89a0e780eed2e1e",
-      "source": "Front camera",
-      "translated": "Ön kamera"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7759,9 +7684,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.0c74bc30a994dd33",
-      "source": "Loading thread",
-      "translated": "İleti dizisi yükleniyor"
+      "id": "native.android.882cc14a58e7e105",
+      "source": "Loading session",
+      "translated": "Oturum yükleniyor"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7804,14 +7729,14 @@
       "translated": "Beni bilgilendir"
     },
     {
-      "id": "native.android.cf40df9739f78f27",
-      "source": "Summarize recent threads and next steps.",
-      "translated": "Son ileti dizilerini ve sonraki adımları özetle."
+      "id": "native.android.1e5add56e48c99f9",
+      "source": "Summarize recent sessions and next steps.",
+      "translated": "Son oturumları ve sonraki adımları özetleyin."
     },
     {
-      "id": "native.android.ebe49a8b8df80bd3",
-      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
-      "translated": "Son OpenClaw yazışmalarımı özetle ve sonraki adımları öner."
+      "id": "native.android.06d515351bb79576",
+      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
+      "translated": "Son OpenClaw oturumlarım hakkında beni bilgilendirin ve sonraki adımları önerin."
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8149,9 +8074,9 @@
       "translated": "Bağlandı"
     },
     {
-      "id": "native.android.6cf5d6fa8a4186d5",
-      "source": "Threads",
-      "translated": "Yazışmalar"
+      "id": "native.android.81931886b9caf3ab",
+      "source": "Sessions",
+      "translated": "Oturumlar"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,6 +10719,61 @@
       "translated": "Görev Ayrıntıları"
     },
     {
+      "id": "native.apple.29cacb53ea5e77fc",
+      "source": "Pinned",
+      "translated": "Sabitlenmiş"
+    },
+    {
+      "id": "native.apple.940062cfdce9211b",
+      "source": "Recent",
+      "translated": "Son Kullanılanlar"
+    },
+    {
+      "id": "native.apple.a0980128426308a9",
+      "source": "Model",
+      "translated": "Model"
+    },
+    {
+      "id": "native.apple.9520e60f21535dde",
+      "source": "Thinking",
+      "translated": "Düşünme"
+    },
+    {
+      "id": "native.apple.8b321f3ffce97429",
+      "source": "Fast",
+      "translated": "Hızlı"
+    },
+    {
+      "id": "native.apple.989b70d64e328d55",
+      "source": "Default (inherited)",
+      "translated": "Varsayılan (devralınan)"
+    },
+    {
+      "id": "native.apple.f4114e73b07eb9ae",
+      "source": "Off",
+      "translated": "Kapalı"
+    },
+    {
+      "id": "native.apple.7ed231b28d16312f",
+      "source": "On",
+      "translated": "Açık"
+    },
+    {
+      "id": "native.apple.412a74802320a037",
+      "source": "Full",
+      "translated": "Tam"
+    },
+    {
+      "id": "native.apple.299f21a2071ff9fc",
+      "source": "Verbosity",
+      "translated": "Ayrıntı Düzeyi"
+    },
+    {
+      "id": "native.apple.faf0ef05e1496de7",
+      "source": "Default",
+      "translated": "Varsayılan"
+    },
+    {
       "id": "native.apple.e5524d5756a62744",
       "source": "Unable to Export Transcript",
       "translated": "Döküm dışa aktarılamıyor"
@@ -10814,9 +10794,9 @@
       "translated": "Ne üzerinde çalışmak istersiniz?"
     },
     {
-      "id": "native.apple.4da775013ac9b123",
-      "source": "The thread attaches once the gateway is ready.",
-      "translated": "Gateway hazır olduğunda yazışma bağlanır."
+      "id": "native.apple.32179ce0b6d4543f",
+      "source": "The session attaches once the gateway is ready.",
+      "translated": "Gateway hazır olduğunda oturum bağlanır."
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10859,9 +10839,14 @@
       "translated": "Worktree'de Yeni Sohbet"
     },
     {
-      "id": "native.apple.003b25ddafeb18e9",
-      "source": "Threads…",
-      "translated": "Yazışmalar…"
+      "id": "native.apple.ce6ebe91fc597015",
+      "source": "New Session Options…",
+      "translated": "Yeni Oturum Seçenekleri…"
+    },
+    {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "Oturumlar…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11024,14 +11009,14 @@
       "translated": "Oluştur"
     },
     {
-      "id": "native.apple.31d5c7287cfb3abe",
-      "source": "Delete Thread?",
-      "translated": "Yazışma Silinsin mi?"
+      "id": "native.apple.f488b9caf6e51ac3",
+      "source": "Delete Session?",
+      "translated": "Oturum silinsin mi?"
     },
     {
-      "id": "native.apple.d3395564809f1120",
-      "source": "Delete Thread",
-      "translated": "Yazışmayı Sil"
+      "id": "native.apple.8634b17be9b111bc",
+      "source": "Delete Session",
+      "translated": "Oturumu Sil"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11039,9 +11024,9 @@
       "translated": "İptal"
     },
     {
-      "id": "native.apple.092659256d26cb03",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "Bu işlem, yazışmayı ve dökümünü kalıcı olarak siler."
+      "id": "native.apple.4a9568ac9b18d8d3",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "Bu işlem oturumu ve dökümünü kalıcı olarak siler."
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11069,9 +11054,9 @@
       "translated": "Yeni Grup"
     },
     {
-      "id": "native.apple.683032464c497bbd",
-      "source": "Rename Thread",
-      "translated": "Yazışmayı Yeniden Adlandır"
+      "id": "native.apple.5bccdc23a1640895",
+      "source": "Rename Session",
+      "translated": "Oturumu Yeniden Adlandır"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11079,9 +11064,9 @@
       "translated": "Grup adı"
     },
     {
-      "id": "native.apple.f887aa956588f237",
-      "source": "Thread name",
-      "translated": "Yazışma adı"
+      "id": "native.apple.af789b2d2fda0f67",
+      "source": "Session name",
+      "translated": "Oturum adı"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11119,14 +11104,14 @@
       "translated": "Aracılar"
     },
     {
-      "id": "native.apple.7c8231b7b1ca480f",
-      "source": "Agent thread",
-      "translated": "Aracı yazışması"
+      "id": "native.apple.a3bde8045fe9224a",
+      "source": "Agent session",
+      "translated": "Aracı oturumu"
     },
     {
-      "id": "native.apple.b3c553614f762a58",
-      "source": "Recent threads",
-      "translated": "Son yazışmalar"
+      "id": "native.apple.27f775de30b37ff8",
+      "source": "Recent sessions",
+      "translated": "Son oturumlar"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11134,9 +11119,9 @@
       "translated": "Gateway çevrimdışı"
     },
     {
-      "id": "native.apple.5aa32afda85064ea",
-      "source": "No recent threads",
-      "translated": "Son yazışma yok"
+      "id": "native.apple.28c97cf23665ee01",
+      "source": "No recent sessions",
+      "translated": "Son oturum yok"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11234,14 +11219,14 @@
       "translated": "İptal"
     },
     {
-      "id": "native.apple.b6855cf19a50f477",
-      "source": "Threads",
-      "translated": "Yazışmalar"
+      "id": "native.apple.9f2fd65953013b7c",
+      "source": "Sessions",
+      "translated": "Oturumlar"
     },
     {
-      "id": "native.apple.9b1d0ef27a1333b0",
-      "source": "Archived threads",
-      "translated": "Arşivlenmiş yazışmalar"
+      "id": "native.apple.0422818cc95d5071",
+      "source": "Archived sessions",
+      "translated": "Arşivlenmiş oturumlar"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11249,34 +11234,34 @@
       "translated": "Arşivlenenleri Göster"
     },
     {
-      "id": "native.apple.98167401c7267735",
-      "source": "Threads unavailable",
-      "translated": "Yazışmalar kullanılamıyor"
+      "id": "native.apple.b272115c83f7ef58",
+      "source": "Sessions unavailable",
+      "translated": "Oturumlar kullanılamıyor"
     },
     {
-      "id": "native.apple.4d28a7def2337b9f",
-      "source": "Loading archived threads",
-      "translated": "Arşivlenmiş yazışmalar yükleniyor"
+      "id": "native.apple.54f8260c9b863087",
+      "source": "Loading archived sessions",
+      "translated": "Arşivlenmiş oturumlar yükleniyor"
     },
     {
-      "id": "native.apple.777d7b706933bd7b",
-      "source": "Loading recent threads",
-      "translated": "Son yazışmalar yükleniyor"
+      "id": "native.apple.9b305868873dade2",
+      "source": "Loading recent sessions",
+      "translated": "Son oturumlar yükleniyor"
     },
     {
-      "id": "native.apple.22f81ea94bef8410",
-      "source": "^[\\(count) thread](inflect: true)",
-      "translated": "^[\\(count) yazışma](inflect: true)"
+      "id": "native.apple.207dad20d09f3160",
+      "source": "^[\\(count) session](inflect: true)",
+      "translated": "^[\\(count) oturum](inflect: true)"
     },
     {
-      "id": "native.apple.1cad51e14db59bf9",
-      "source": "No archived threads",
-      "translated": "Arşivlenmiş yazışma yok"
+      "id": "native.apple.1f4501a6bf2bae4c",
+      "source": "No archived sessions",
+      "translated": "Arşivlenmiş oturum yok"
     },
     {
-      "id": "native.apple.18ef832d3a7ddcf8",
-      "source": "Archived threads will appear here.",
-      "translated": "Arşivlenmiş yazışmalar burada görünür."
+      "id": "native.apple.2a1ba7a5e1979c9e",
+      "source": "Archived sessions will appear here.",
+      "translated": "Arşivlenen oturumlar burada görünecek."
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11359,9 +11344,9 @@
       "translated": "Paylaşım alımı"
     },
     {
-      "id": "native.apple.21d9208d86a4d1fe",
-      "source": "Loading threads",
-      "translated": "Konular yükleniyor"
+      "id": "native.apple.2360d25fe6ae9946",
+      "source": "Loading sessions",
+      "translated": "Oturumlar yükleniyor"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11369,19 +11354,19 @@
       "translated": "Gateway üzerinden son etkinlik alınıyor."
     },
     {
-      "id": "native.apple.4be1f79aa2b230ff",
-      "source": "Threads unavailable",
-      "translated": "Konular kullanılamıyor"
+      "id": "native.apple.c334f2e86702a7b8",
+      "source": "Sessions unavailable",
+      "translated": "Oturumlar kullanılamıyor"
     },
     {
-      "id": "native.apple.98b348873556bc46",
-      "source": "No recent threads",
-      "translated": "Yakın zamanda konu yok"
+      "id": "native.apple.6cc6efb7a03960b6",
+      "source": "No recent sessions",
+      "translated": "Yakın zamanda oturum yok"
     },
     {
-      "id": "native.apple.7396d205574d279f",
-      "source": "Thread activity offline",
-      "translated": "Konu etkinliği çevrimdışı"
+      "id": "native.apple.08483af2d043bee6",
+      "source": "Session activity offline",
+      "translated": "Oturum etkinliği çevrimdışı"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11839,9 +11824,9 @@
       "translated": "Kart"
     },
     {
-      "id": "native.apple.c9ec1b0e18074d8a",
-      "source": "Open Thread",
-      "translated": "Konuyu Aç"
+      "id": "native.apple.93eeaedb2ff61043",
+      "source": "Open Session",
+      "translated": "Oturumu Aç"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13329,9 +13314,9 @@
       "translated": "Varsayılan"
     },
     {
-      "id": "native.apple.f4ae5664c3eda95d",
-      "source": "Used for new Chat threads and Talk sessions.",
-      "translated": "Yeni Sohbet konuları ve Konuşma oturumları için kullanılır."
+      "id": "native.apple.3de045f17ea3c6d0",
+      "source": "Used for new Chat and Talk sessions.",
+      "translated": "Yeni Chat ve Talk oturumları için kullanılır."
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15734,9 +15719,9 @@
       "translated": "Örnekler"
     },
     {
-      "id": "native.apple.11fe8b9941954dfb",
-      "source": "Threads",
-      "translated": "Konular"
+      "id": "native.apple.3579cf2750470a22",
+      "source": "Sessions",
+      "translated": "Oturumlar"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19044,9 +19029,9 @@
       "translated": "Hızlı Sohbet kestirmesi"
     },
     {
-      "id": "native.apple.94dd793cd7d7d555",
-      "source": "Global shortcut that opens a floating chat bar for the main thread.",
-      "translated": "Ana konu için yüzen bir sohbet çubuğu açan genel kısayol."
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "Ana oturum için yüzen bir sohbet çubuğu açan genel kestirme."
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19624,9 +19609,9 @@
       "translated": "Kritik"
     },
     {
-      "id": "native.apple.13f96467014cf344",
-      "source": "New Thread",
-      "translated": "Yeni Konu"
+      "id": "native.apple.75102378a6775180",
+      "source": "New Session",
+      "translated": "Yeni Oturum"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21914,9 +21899,9 @@
       "translated": "Yakın zamanda mesaj yok"
     },
     {
-      "id": "native.apple.3ec2afcbc298c673",
-      "source": "Threads",
-      "translated": "Konular"
+      "id": "native.apple.1ff8aec0044934c3",
+      "source": "Sessions",
+      "translated": "Oturumlar"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21924,9 +21909,9 @@
       "translated": "CLI'ın bağlam ve hız sınırları için yeniden kullandığı depolanmış konuşma kümelerine göz atın."
     },
     {
-      "id": "native.apple.14ccb32cd8ed1c81",
-      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
-      "translated": "Henüz konu yok. İlk gelen mesaj veya durum sinyalinden sonra görünürler."
+      "id": "native.apple.bab897f3252b134c",
+      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
+      "translated": "Henüz oturum yok. İlk gelen mesaj veya heartbeat'ten sonra görünürler."
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -22009,9 +21994,9 @@
       "translated": "Yürütme Onayları"
     },
     {
-      "id": "native.apple.52e37e3a44ae516c",
-      "source": "Threads",
-      "translated": "Konular"
+      "id": "native.apple.64a6dc7d49e8fb57",
+      "source": "Sessions",
+      "translated": "Oturumlar"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -23014,9 +22999,9 @@
       "translated": "Beni bilgilendir"
     },
     {
-      "id": "native.apple.fc4ce810900ec0b6",
-      "source": "Summarize what happened in my threads since yesterday.",
-      "translated": "Dünden bu yana konularımda neler olduğunu özetle."
+      "id": "native.apple.234ec45f4231edc4",
+      "source": "Summarize what happened in my sessions since yesterday.",
+      "translated": "Dünden bu yana oturumlarımda neler olduğunu özetle."
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23194,9 +23179,9 @@
       "translated": "Modelin sabitlemesini kaldır"
     },
     {
-      "id": "native.apple.4edb66657f5aca1f",
-      "source": "Thread",
-      "translated": "Konu"
+      "id": "native.apple.5dfc0700d8dff8de",
+      "source": "Session",
+      "translated": "Oturum"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23359,51 +23344,6 @@
       "translated": "Widget kullanılamıyor"
     },
     {
-      "id": "native.apple.d640691fd196f338",
-      "source": "Widget export failed",
-      "translated": "Widget dışa aktarılamadı"
-    },
-    {
-      "id": "native.apple.533c6e22a11e88de",
-      "source": "OK",
-      "translated": "Tamam"
-    },
-    {
-      "id": "native.apple.e1fb28a2a9756402",
-      "source": "Copy image",
-      "translated": "Görseli kopyala"
-    },
-    {
-      "id": "native.apple.ebd7bc92e1b12235",
-      "source": "Save image…",
-      "translated": "Görseli kaydet…"
-    },
-    {
-      "id": "native.apple.742c46d4cf2db134",
-      "source": "Save image",
-      "translated": "Görseli kaydet"
-    },
-    {
-      "id": "native.apple.0589cce608418f90",
-      "source": "The widget image could not be captured.",
-      "translated": "Widget görüntüsü yakalanamadı."
-    },
-    {
-      "id": "native.apple.dfe24e827fdbe9c5",
-      "source": "The widget image could not be copied.",
-      "translated": "Widget görüntüsü kopyalanamadı."
-    },
-    {
-      "id": "native.apple.9e611e3a80e71408",
-      "source": "The widget image could not be encoded as PNG.",
-      "translated": "Widget görüntüsü PNG olarak kodlanamadı."
-    },
-    {
-      "id": "native.apple.9a6e8afbe24a262b",
-      "source": "The widget image could not be saved.",
-      "translated": "Widget görüntüsü kaydedilemedi."
-    },
-    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23544,19 +23484,19 @@
       "translated": "Kullanıcı"
     },
     {
-      "id": "native.apple.9d0cba09d92ee669",
-      "source": "This thread cannot be archived while it is active or running.",
-      "translated": "Bu konu etkinken veya çalışırken arşivlenemez."
+      "id": "native.apple.b1cdcb906a43d5d6",
+      "source": "This session cannot be archived while it is active or running.",
+      "translated": "Bu oturum etkinken veya çalışırken arşivlenemez."
     },
     {
-      "id": "native.apple.8952a111a1075051",
-      "source": "The main thread cannot be deleted.",
-      "translated": "Ana konu silinemez."
+      "id": "native.apple.5817e3f3dab1ee19",
+      "source": "The main session cannot be deleted.",
+      "translated": "Ana oturum silinemez."
     },
     {
-      "id": "native.apple.90d0ccf80ca28717",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
-      "translated": "Bu konuyu arşivlemeden veya silmeden önce ekleri kaldırın ya da teslim edilmelerini bekleyin."
+      "id": "native.apple.a6b8df3f18171c91",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
+      "translated": "Bu oturumu arşivlemeden veya silmeden önce ekleri kaldırın ya da teslim edilmelerini bekleyin."
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23694,9 +23634,9 @@
       "translated": "Çalıştırma sona erdi"
     },
     {
-      "id": "native.apple.bbccb4c8db5cac12",
-      "source": "Thread Info",
-      "translated": "Konu Bilgileri"
+      "id": "native.apple.cd7c3095a22f80a9",
+      "source": "Session Info",
+      "translated": "Oturum Bilgileri"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23729,9 +23669,9 @@
       "translated": "Grup Ekle"
     },
     {
-      "id": "native.apple.7b641fed5bace855",
-      "source": "Thread Groups",
-      "translated": "Konu Grupları"
+      "id": "native.apple.23d628606fe0734f",
+      "source": "Session Groups",
+      "translated": "Oturum Grupları"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23774,9 +23714,9 @@
       "translated": "Grubu Sil"
     },
     {
-      "id": "native.apple.56401c79410a310d",
-      "source": "Threads in this group become ungrouped.",
-      "translated": "Bu gruptaki konular gruptan çıkarılır."
+      "id": "native.apple.b049c8a4d2805e08",
+      "source": "Sessions in this group become ungrouped.",
+      "translated": "Bu gruptaki oturumlar gruptan çıkarılır."
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23789,9 +23729,9 @@
       "translated": "Bu Gateway'de kullanılabilir aracı yok."
     },
     {
-      "id": "native.apple.2d96aa7d3d12f85b",
-      "source": "New Thread Options",
-      "translated": "Yeni Konu Seçenekleri"
+      "id": "native.apple.6c89f35d53506406",
+      "source": "New Session Options",
+      "translated": "Yeni Oturum Seçenekleri"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23819,19 +23759,19 @@
       "translated": "Oluştur"
     },
     {
-      "id": "native.apple.87ef57319d1ddc85",
-      "source": "The thread could not be created.",
-      "translated": "Konu oluşturulamadı."
+      "id": "native.apple.795ba37f6782cf28",
+      "source": "The session could not be created.",
+      "translated": "Oturum oluşturulamadı."
     },
     {
-      "id": "native.apple.6bd91c435b69d638",
-      "source": "Search threads",
-      "translated": "Konularda ara"
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "Oturumlarda ara"
     },
     {
-      "id": "native.apple.6fde4bdf9d5b9191",
-      "source": "No Threads",
-      "translated": "Konu Yok"
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "Oturum Yok"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23839,29 +23779,29 @@
       "translated": "Sonuç Yok"
     },
     {
-      "id": "native.apple.a02fd99740d29bd3",
-      "source": "New Thread",
-      "translated": "Yeni Konu"
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "Yeni Oturum"
     },
     {
-      "id": "native.apple.b625801dd04b09f2",
-      "source": "New thread",
-      "translated": "Yeni konu"
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "Yeni oturum"
     },
     {
-      "id": "native.apple.851be81fcc933608",
-      "source": "New thread options",
-      "translated": "Yeni konu seçenekleri"
+      "id": "native.apple.2ef0e34db02ad255",
+      "source": "New session options",
+      "translated": "Yeni oturum seçenekleri"
     },
     {
-      "id": "native.apple.9ce8a4aba7b444b2",
-      "source": "Rename Thread",
-      "translated": "Konuyu Yeniden Adlandır"
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "Oturumu Yeniden Adlandır"
     },
     {
-      "id": "native.apple.1dd067c44511c7f0",
-      "source": "Thread name",
-      "translated": "Konu adı"
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "Oturum adı"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23874,14 +23814,14 @@
       "translated": "İptal"
     },
     {
-      "id": "native.apple.618073d6ab3f2721",
-      "source": "Delete Thread",
-      "translated": "Konuyu Sil"
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "Oturumu Sil"
     },
     {
-      "id": "native.apple.10a5e72bba3cbccc",
-      "source": "The thread and its transcript are removed from the gateway.",
-      "translated": "Konu ve dökümü gateway'den kaldırılır."
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "Oturum ve dökümü Gateway'den kaldırılır."
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23889,14 +23829,14 @@
       "translated": "“%@” silinsin mi?"
     },
     {
-      "id": "native.apple.ac71e3b2aa496a2c",
-      "source": "Thread running",
-      "translated": "Konu çalışıyor"
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "Oturum çalışıyor"
     },
     {
-      "id": "native.apple.c775e87f997278b2",
-      "source": "Thread failed",
-      "translated": "Konu başarısız oldu"
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "Oturum başarısız oldu"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23954,9 +23894,9 @@
       "translated": "Oturum Anahtarını Kopyala"
     },
     {
-      "id": "native.apple.f4998cfb572f23ff",
-      "source": "Delete Thread…",
-      "translated": "Konuyu Sil…"
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "Oturumu Sil…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23969,9 +23909,9 @@
       "translated": "Bağlanıyor…"
     },
     {
-      "id": "native.apple.8802e9576ffd0f65",
-      "source": "Retry thread groups",
-      "translated": "Konu gruplarını yeniden dene"
+      "id": "native.apple.79f708b3bc1d3a6c",
+      "source": "Retry session groups",
+      "translated": "Oturum gruplarını yeniden dene"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23994,24 +23934,24 @@
       "translated": "Kapsam"
     },
     {
-      "id": "native.apple.b313b80def4bda52",
-      "source": "Search threads",
-      "translated": "Konularda ara"
+      "id": "native.apple.2c37581c7b88f741",
+      "source": "Search sessions",
+      "translated": "Oturumlarda ara"
     },
     {
-      "id": "native.apple.c0cc6acc36f413ce",
-      "source": "Threads",
-      "translated": "Konular"
+      "id": "native.apple.43be8a2336e42faf",
+      "source": "Sessions",
+      "translated": "Oturumlar"
     },
     {
-      "id": "native.apple.854d3928fe5a557c",
-      "source": "Rename Thread",
-      "translated": "Konuyu Yeniden Adlandır"
+      "id": "native.apple.0b379cdfcbd3247f",
+      "source": "Rename Session",
+      "translated": "Oturumu Yeniden Adlandır"
     },
     {
-      "id": "native.apple.9d0d3f20096cc4da",
-      "source": "Thread name",
-      "translated": "Konu adı"
+      "id": "native.apple.54b6fbd9e41db009",
+      "source": "Session name",
+      "translated": "Oturum adı"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -24019,19 +23959,19 @@
       "translated": "İptal"
     },
     {
-      "id": "native.apple.dc00eb94f33bae15",
-      "source": "Delete selected threads?",
-      "translated": "Seçili konular silinsin mi?"
+      "id": "native.apple.751e0f6b81cd374a",
+      "source": "Delete selected sessions?",
+      "translated": "Seçili oturumlar silinsin mi?"
     },
     {
-      "id": "native.apple.2053fc9f74dc3158",
-      "source": "Delete Threads",
-      "translated": "Konuları Sil"
+      "id": "native.apple.aa679276581b0058",
+      "source": "Delete Sessions",
+      "translated": "Oturumları Sil"
     },
     {
-      "id": "native.apple.0970247871a834a0",
-      "source": "Each selected thread and its transcript will be removed from the gateway.",
-      "translated": "Seçilen her konu ve dökümü gateway'den kaldırılacak."
+      "id": "native.apple.f837129cbee23297",
+      "source": "Each selected session and its transcript will be removed from the gateway.",
+      "translated": "Seçili her oturum ve dökümü gateway'den kaldırılacaktır."
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -24039,9 +23979,9 @@
       "translated": "Gruplar"
     },
     {
-      "id": "native.apple.6f8acab2256728b5",
-      "source": "Manage thread groups",
-      "translated": "Konu gruplarını yönet"
+      "id": "native.apple.64013cfee5e25305",
+      "source": "Manage session groups",
+      "translated": "Oturum gruplarını yönet"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -24054,14 +23994,14 @@
       "translated": "Seç"
     },
     {
-      "id": "native.apple.692972314d04b184",
-      "source": "No archived threads",
-      "translated": "Arşivlenmiş konu yok"
+      "id": "native.apple.b67eaecec1b423ac",
+      "source": "No archived sessions",
+      "translated": "Arşivlenmiş oturum yok"
     },
     {
-      "id": "native.apple.d6a4b5711dcd26e7",
-      "source": "No threads found",
-      "translated": "Konu bulunamadı"
+      "id": "native.apple.b2435a79abf0c794",
+      "source": "No sessions found",
+      "translated": "Oturum bulunamadı"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24229,16 +24169,6 @@
       "translated": "Tam İletiyi Aç"
     },
     {
-      "id": "native.apple.002bfcede229ad4b",
-      "source": "Rewind to Here",
-      "translated": "Buraya Geri Sar"
-    },
-    {
-      "id": "native.apple.14df2e4997689fb3",
-      "source": "Fork from Here",
-      "translated": "Buradan Çatallandır"
-    },
-    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "Yanıtla"
@@ -24324,9 +24254,9 @@
       "translated": "Yeni bir sohbet başlatmadan önce ekleri kaldırın veya teslimatın tamamlanmasını bekleyin."
     },
     {
-      "id": "native.apple.e0f045151c8d3137",
-      "source": "Gateway changed before the thread operation started.",
-      "translated": "Konu işlemi başlamadan önce Gateway değişti."
+      "id": "native.apple.980f552bb0f96c0f",
+      "source": "Gateway changed before the session operation started.",
+      "translated": "Oturum işlemi başlamadan önce Gateway değişti."
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24334,9 +24264,9 @@
       "translated": "Sohbetleri değiştirmeden önce ekleri kaldırın veya teslimatın tamamlanmasını bekleyin."
     },
     {
-      "id": "native.apple.0a5c4e15466c3acc",
-      "source": "Clear this thread's history?",
-      "translated": "Bu konunun geçmişi temizlensin mi?"
+      "id": "native.apple.87ba543b42696b92",
+      "source": "Clear this session's history?",
+      "translated": "Bu oturumun geçmişi temizlensin mi?"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24349,14 +24279,14 @@
       "translated": "Bu işlem, %@ için konuşmayı sıfırlar. Oturum anahtarı aynı kalır."
     },
     {
-      "id": "native.apple.67ac221dbe7179f0",
-      "source": "Rename Thread",
-      "translated": "Konuyu Yeniden Adlandır"
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "Oturumu Yeniden Adlandır"
     },
     {
-      "id": "native.apple.cf0f7e049603f518",
-      "source": "Thread name",
-      "translated": "Konu adı"
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "Oturum adı"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24374,9 +24304,9 @@
       "translated": "Dökümü Dışa Aktar"
     },
     {
-      "id": "native.apple.c0ada47504425f23",
-      "source": "Threads",
-      "translated": "Konular"
+      "id": "native.apple.4af0f566d39d7041",
+      "source": "Sessions",
+      "translated": "Oturumlar"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24449,14 +24379,14 @@
       "translated": "Varsayılan"
     },
     {
-      "id": "native.apple.1a765291943599e5",
-      "source": "New Thread",
-      "translated": "Yeni Konu"
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "Yeni Oturum"
     },
     {
-      "id": "native.apple.c7a3a6d5e43dd98f",
-      "source": "New Thread Options…",
-      "translated": "Yeni Konu Seçenekleri…"
+      "id": "native.apple.a7119fbf9d25df5e",
+      "source": "New Session Options…",
+      "translated": "Yeni Oturum Seçenekleri…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24464,19 +24394,19 @@
       "translated": "Yenile"
     },
     {
-      "id": "native.apple.0e710b81808e5dcf",
-      "source": "Threads…",
-      "translated": "Konular…"
+      "id": "native.apple.2bcff4a8fa503739",
+      "source": "Sessions…",
+      "translated": "Oturumlar…"
     },
     {
-      "id": "native.apple.faad8f92b6bef166",
-      "source": "Rename Thread…",
-      "translated": "Konuyu Yeniden Adlandır…"
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "Oturumu Yeniden Adlandır…"
     },
     {
-      "id": "native.apple.23b61d6cd26ac112",
-      "source": "Fork",
-      "translated": "Çatalla"
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "Oturumu Çatalla"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24534,24 +24464,24 @@
       "translated": "Geçmişi Temizle…"
     },
     {
-      "id": "native.apple.8b4f1c5107ea8a0e",
-      "source": "Thread",
-      "translated": "Konu"
+      "id": "native.apple.920fe8a7a33f9e92",
+      "source": "Session",
+      "translated": "Oturum"
     },
     {
-      "id": "native.apple.4d7750c9bf699469",
-      "source": "Thread actions",
-      "translated": "Konu eylemleri"
+      "id": "native.apple.185a401f78328b0f",
+      "source": "Session actions",
+      "translated": "Oturum işlemleri"
     },
     {
-      "id": "native.apple.bb2f22cc43c97f8e",
-      "source": "Thread cost %@",
-      "translated": "Konu maliyeti %@"
+      "id": "native.apple.9f9dedf599b2619b",
+      "source": "Session cost %@",
+      "translated": "Oturum maliyeti %@"
     },
     {
-      "id": "native.apple.6239ced0b86e86f8",
-      "source": "Compact Thread",
-      "translated": "Konuyu Sıkıştır"
+      "id": "native.apple.f0a4720df5f5f403",
+      "source": "Compact Session",
+      "translated": "Oturumu Sıkıştır"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/uk.json
+++ b/apps/.i18n/native/uk.json
@@ -1429,9 +1429,9 @@
       "translated": "Говоріть або диктуйте за допомогою OpenClaw"
     },
     {
-      "id": "native.android.5876e15e5e92fd45",
-      "source": "Browse Sessions",
-      "translated": "Переглянути сеанси"
+      "id": "native.android.e2cf5a38587382cb",
+      "source": "Browse Threads",
+      "translated": "Переглянути гілки"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "Дій не знайдено"
     },
     {
-      "id": "native.android.48ad0ae0e930e02b",
-      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
-      "translated": "Спробуйте Chat, Voice, Sessions, Providers або Settings."
+      "id": "native.android.bc70a4ac965b82ba",
+      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
+      "translated": "Спробуйте чат, голос, гілки, постачальників або налаштування."
     },
     {
-      "id": "native.android.d4fbd1ee4f55a5db",
-      "source": "Sessions",
-      "translated": "Сеанси"
+      "id": "native.android.670121e54dbe286f",
+      "source": "Threads",
+      "translated": "Гілки"
     },
     {
-      "id": "native.android.207c2170504e99e6",
-      "source": "Connect the Gateway to search sessions.",
-      "translated": "Підключіть Gateway, щоб шукати сеанси."
+      "id": "native.android.d38be650b1bce4a0",
+      "source": "Connect the Gateway to search threads.",
+      "translated": "Підключіть Gateway, щоб шукати гілки."
     },
     {
-      "id": "native.android.25d2c2d792c952fe",
-      "source": "No matching sessions yet.",
-      "translated": "Відповідних сеансів поки немає."
+      "id": "native.android.3d7754721f776ef8",
+      "source": "No matching threads yet.",
+      "translated": "Поки немає відповідних гілок."
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "Асистент працює"
     },
     {
-      "id": "native.android.8f8384286317f5c9",
-      "source": "OpenClaw session",
-      "translated": "Сеанс OpenClaw"
+      "id": "native.android.9a839f6e3e05a744",
+      "source": "OpenClaw thread",
+      "translated": "Гілка OpenClaw"
     },
     {
-      "id": "native.android.15799e57704b20c6",
-      "source": "Open session",
-      "translated": "Відкрити сеанс"
+      "id": "native.android.d83f82a1e4a5ed99",
+      "source": "Open thread",
+      "translated": "Відкрити гілку"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "Немає готових провайдерів"
     },
     {
-      "id": "native.android.73e6ab1a168fd381",
-      "source": "Main session",
-      "translated": "Основний сеанс"
+      "id": "native.android.8a1c5365c0538908",
+      "source": "Main thread",
+      "translated": "Основна гілка"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.0e3157c15c56944f",
-      "source": "Sessions",
-      "translated": "Сеанси"
+      "id": "native.android.a5845742daecb4ba",
+      "source": "Threads",
+      "translated": "Гілки"
     },
     {
-      "id": "native.android.70f5d0507d34b5c8",
-      "source": "Focus session search",
-      "translated": "Перейти до пошуку сеансів"
+      "id": "native.android.439b324280869527",
+      "source": "Focus thread search",
+      "translated": "Перейти до пошуку гілок"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "Заархівовано"
     },
     {
-      "id": "native.android.b9cf34c137e4cf03",
-      "source": "Search sessions",
-      "translated": "Пошук сеансів"
+      "id": "native.android.03981341841b04ac",
+      "source": "Search threads",
+      "translated": "Шукати гілки"
     },
     {
-      "id": "native.android.10cb26723e9990fc",
-      "source": "Clear session search",
-      "translated": "Очистити пошук сеансів"
+      "id": "native.android.99570c528a41fa72",
+      "source": "Clear thread search",
+      "translated": "Очистити пошук гілок"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "Спочатку найстаріші"
     },
     {
-      "id": "native.android.c6bf8751e2a7f5c7",
-      "source": "Toggle session layout",
-      "translated": "Перемкнути макет сеансів"
+      "id": "native.android.fd67be543e321cc9",
+      "source": "Toggle thread layout",
+      "translated": "Змінити компонування гілок"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "Макет: докладний"
     },
     {
-      "id": "native.android.69b79a3c2c987cd4",
-      "source": "Searching sessions",
-      "translated": "Пошук сеансів"
+      "id": "native.android.ebd17565e0ffd8eb",
+      "source": "Searching threads",
+      "translated": "Пошук гілок"
     },
     {
-      "id": "native.android.dd587d341af44212",
-      "source": "No matching sessions",
-      "translated": "Відповідних сеансів не знайдено"
+      "id": "native.android.472d46ae8669f860",
+      "source": "No matching threads",
+      "translated": "Немає відповідних гілок"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "Почати чат"
     },
     {
-      "id": "native.android.f10d4df7cbc6df4f",
-      "source": "Current session",
-      "translated": "Поточний сеанс"
+      "id": "native.android.ff81ad1bee00d384",
+      "source": "Current thread",
+      "translated": "Поточна гілка"
     },
     {
-      "id": "native.android.8f0482425838ae64",
-      "source": "OpenClaw session",
-      "translated": "Сеанс OpenClaw"
+      "id": "native.android.fc145645b9620e57",
+      "source": "OpenClaw thread",
+      "translated": "Гілка OpenClaw"
     },
     {
-      "id": "native.android.786774c8a76e50d7",
-      "source": "Rename session",
-      "translated": "Перейменувати сеанс"
+      "id": "native.android.71cbb8dde8bf138b",
+      "source": "Rename thread",
+      "translated": "Перейменувати гілку"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "Видалити групу?"
     },
     {
-      "id": "native.android.3455fc2f77d564e3",
-      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "Сесії у групі \"$group\" зберігаються та повертаються до Без групи."
+      "id": "native.android.691e92cfe5cf106e",
+      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "Гілки в групі \"$group\" буде збережено й переміщено назад до розділу «Без групи»."
     },
     {
-      "id": "native.android.4805fb9d6623e8c0",
-      "source": "Delete session?",
-      "translated": "Видалити сеанс?"
+      "id": "native.android.d87a8217ab56999b",
+      "source": "Delete thread?",
+      "translated": "Видалити гілку?"
     },
     {
-      "id": "native.android.0c3283a2b2445eae",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "Це назавжди видалить сеанс і його стенограму."
+      "id": "native.android.930de97ff47113a8",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "Це назавжди видалить гілку та її журнал."
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "Без групи"
     },
     {
-      "id": "native.android.db243d71d056afa4",
-      "source": "No sessions yet",
-      "translated": "Сеансів поки немає"
+      "id": "native.android.8e21a70428def6e0",
+      "source": "No threads yet",
+      "translated": "Гілок ще немає"
     },
     {
-      "id": "native.android.5b4eee6a8092925e",
-      "source": "No current session",
-      "translated": "Немає поточного сеансу"
+      "id": "native.android.cda4c5ad8b17e394",
+      "source": "No current thread",
+      "translated": "Немає поточної гілки"
     },
     {
-      "id": "native.android.acbcc9c9ea53d8c0",
-      "source": "No archived sessions",
-      "translated": "Немає архівованих сеансів"
+      "id": "native.android.be84f061047aa2da",
+      "source": "No archived threads",
+      "translated": "Немає архівованих гілок"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "Почніть нову розмову, і вона з’явиться тут."
     },
     {
-      "id": "native.android.56fcd605dc7be3c0",
-      "source": "Open Chat to start or resume the current session.",
-      "translated": "Відкрийте чат, щоб почати або продовжити поточний сеанс."
+      "id": "native.android.f289d03e1d3eee98",
+      "source": "Open Chat to start or resume the current thread.",
+      "translated": "Відкрийте чат, щоб почати або продовжити поточну гілку."
     },
     {
-      "id": "native.android.085515989f8a2022",
-      "source": "Archived sessions will show up here.",
-      "translated": "Архівовані сеанси з’являтимуться тут."
+      "id": "native.android.504b71386e76c6ae",
+      "source": "Archived threads will show up here.",
+      "translated": "Тут відображатимуться архівовані гілки."
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days} дн"
     },
     {
-      "id": "native.android.3d4fa07acbc015c5",
-      "source": "Main session",
-      "translated": "Основний сеанс"
+      "id": "native.android.ee4c727cdafbe963",
+      "source": "Main thread",
+      "translated": "Основна гілка"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Очікування Gateway"
     },
     {
-      "id": "native.android.2d8d049afe99f751",
-      "source": "Session Activity",
-      "translated": "Активність сеансу"
+      "id": "native.android.da78209effb11cfd",
+      "source": "Thread Activity",
+      "translated": "Активність гілки"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "Запити на схвалення виконання з’являтимуться тут, поки цей телефон підключено."
     },
     {
-      "id": "native.android.dc3e7ca5a491103a",
-      "source": "Session activity",
-      "translated": "Активність сеансу"
+      "id": "native.android.f615712dfb56319a",
+      "source": "Thread activity",
+      "translated": "Активність гілки"
     },
     {
-      "id": "native.android.8551e02b060bd7d8",
-      "source": "Chat tool calls waiting in the active session remain visible here.",
-      "translated": "Виклики інструментів чату, що очікують в активному сеансі, залишатимуться видимими тут."
+      "id": "native.android.6c93973c13db43ae",
+      "source": "Chat tool calls waiting in the active thread remain visible here.",
+      "translated": "Виклики інструментів чату, що очікують в активній гілці, залишаються видимими тут."
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,6 +4294,11 @@
       "translated": "Налаштування постачальника розмов"
     },
     {
+      "id": "native.android.23b638094c34b916",
+      "source": "Microphone",
+      "translated": "Мікрофон"
+    },
+    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "Тест аудіо"
@@ -4337,6 +4342,66 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "Готово"
+    },
+    {
+      "id": "native.android.8d9ecdfdd916b780",
+      "source": "Automatic",
+      "translated": "Автоматично"
+    },
+    {
+      "id": "native.android.c1626a6700a570f6",
+      "source": "Preferred microphone unavailable; using automatic routing.",
+      "translated": "Бажаний мікрофон недоступний; використовується автоматичне маршрутизування."
+    },
+    {
+      "id": "native.android.820bc5d0ce571d8b",
+      "source": "Prioritizes connected Bluetooth microphones.",
+      "translated": "Надає пріоритет підключеним мікрофонам Bluetooth."
+    },
+    {
+      "id": "native.android.11e48038d5e8bff6",
+      "source": "Preferred microphone",
+      "translated": "Бажаний мікрофон"
+    },
+    {
+      "id": "native.android.eaa4d7563a46d307",
+      "source": "Unavailable",
+      "translated": "Недоступно"
+    },
+    {
+      "id": "native.android.9f5ebf17eb405ba8",
+      "source": "Next session",
+      "translated": "Наступний сеанс"
+    },
+    {
+      "id": "native.android.8c4e91f53928efb2",
+      "source": "Built-in microphone",
+      "translated": "Вбудований мікрофон"
+    },
+    {
+      "id": "native.android.14b613cb6e2446b4",
+      "source": "Bluetooth microphone",
+      "translated": "Мікрофон Bluetooth"
+    },
+    {
+      "id": "native.android.c885247b2d7ce271",
+      "source": "Bluetooth LE microphone",
+      "translated": "Мікрофон Bluetooth LE"
+    },
+    {
+      "id": "native.android.b6a4e674c5fb441a",
+      "source": "Wired headset microphone",
+      "translated": "Мікрофон дротової гарнітури"
+    },
+    {
+      "id": "native.android.9c8becb3b0fb5a90",
+      "source": "USB microphone",
+      "translated": "USB-мікрофон"
+    },
+    {
+      "id": "native.android.ba46258fadec7a39",
+      "source": "External microphone",
+      "translated": "Зовнішній мікрофон"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5074,9 +5139,9 @@
       "translated": "Перевірити"
     },
     {
-      "id": "native.android.5a540761383fa474",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
-      "translated": "OpenClaw перетворює цей телефон на зручний мобільний інтерфейс керування сеансами, голосовими функціями, постачальниками та Gateway."
+      "id": "native.android.c971506716c96e91",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
+      "translated": "OpenClaw перетворює цей телефон на зручний мобільний інтерфейс керування гілками, голосом, постачальниками та Gateway."
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5624,9 +5689,9 @@
       "translated": "Налаштування Розмови"
     },
     {
-      "id": "native.android.73f07a5d54915259",
-      "source": "Recent Sessions",
-      "translated": "Нещодавні сеанси"
+      "id": "native.android.36f78c8c85dc283f",
+      "source": "Recent Threads",
+      "translated": "Нещодавні гілки"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5684,14 +5749,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% у мережі"
     },
     {
-      "id": "native.android.16c3425d3a594481",
-      "source": "Sessions",
-      "translated": "Сеанси"
+      "id": "native.android.57177017a6a93826",
+      "source": "Threads",
+      "translated": "Гілки"
     },
     {
-      "id": "native.android.a5c0f8b3112aa58c",
-      "source": "No recent sessions",
-      "translated": "Немає нещодавніх сеансів"
+      "id": "native.android.43320b54a68b00a1",
+      "source": "No recent threads",
+      "translated": "Немає нещодавніх гілок"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5729,14 +5794,14 @@
       "translated": "Виконується · $pendingRunCount активних запусків"
     },
     {
-      "id": "native.android.2c89da708b12a522",
-      "source": "Monitoring · 1 session",
-      "translated": "Відстеження · 1 сеанс"
+      "id": "native.android.e24db059480f1e6a",
+      "source": "Monitoring · 1 thread",
+      "translated": "Моніторинг · 1 гілка"
     },
     {
-      "id": "native.android.8b6ee382dcb64e1f",
-      "source": "Monitoring · $sessionCount sessions",
-      "translated": "Відстеження · $sessionCount сеансів"
+      "id": "native.android.5a475f37d80e02bc",
+      "source": "Monitoring · $sessionCount threads",
+      "translated": "Моніторинг · гілок: $sessionCount"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5769,9 +5834,9 @@
       "translated": "Провайдери"
     },
     {
-      "id": "native.android.a65477861c7203aa",
-      "source": "Open session",
-      "translated": "Відкрити сеанс"
+      "id": "native.android.358c5e0e838d5423",
+      "source": "Open thread",
+      "translated": "Відкрити гілку"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6194,9 +6259,9 @@
       "translated": "${days} дн"
     },
     {
-      "id": "native.android.22d755834386db07",
-      "source": "Main session",
-      "translated": "Основний сеанс"
+      "id": "native.android.28a1a1acc5a0959f",
+      "source": "Main thread",
+      "translated": "Основна гілка"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6877,6 +6942,16 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "Увімкнути мікрофон"
+    },
+    {
+      "id": "native.android.cb608d82c5b3352a",
+      "source": "Back camera",
+      "translated": "Задня камера"
+    },
+    {
+      "id": "native.android.e89a0e780eed2e1e",
+      "source": "Front camera",
+      "translated": "Передня камера"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7684,9 +7759,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.882cc14a58e7e105",
-      "source": "Loading session",
-      "translated": "Завантаження сеансу"
+      "id": "native.android.0c74bc30a994dd33",
+      "source": "Loading thread",
+      "translated": "Завантаження гілки"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7729,14 +7804,14 @@
       "translated": "Введіть мене в курс справ"
     },
     {
-      "id": "native.android.1e5add56e48c99f9",
-      "source": "Summarize recent sessions and next steps.",
-      "translated": "Підсумуйте нещодавні сеанси та подальші кроки."
+      "id": "native.android.cf40df9739f78f27",
+      "source": "Summarize recent threads and next steps.",
+      "translated": "Підсумувати нещодавні гілки та наступні кроки."
     },
     {
-      "id": "native.android.06d515351bb79576",
-      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
-      "translated": "Введіть мене в курс моїх нещодавніх сеансів OpenClaw і запропонуйте подальші кроки."
+      "id": "native.android.ebe49a8b8df80bd3",
+      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
+      "translated": "Ознайом мене з моїми нещодавніми гілками OpenClaw і запропонуй наступні кроки."
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8074,9 +8149,9 @@
       "translated": "Підключено"
     },
     {
-      "id": "native.android.81931886b9caf3ab",
-      "source": "Sessions",
-      "translated": "Сесії"
+      "id": "native.android.6cf5d6fa8a4186d5",
+      "source": "Threads",
+      "translated": "Гілки"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,9 +10869,9 @@
       "translated": "Над чим ви хотіли б попрацювати?"
     },
     {
-      "id": "native.apple.32179ce0b6d4543f",
-      "source": "The session attaches once the gateway is ready.",
-      "translated": "Сеанс під’єднається, щойно Gateway буде готовий."
+      "id": "native.apple.4da775013ac9b123",
+      "source": "The thread attaches once the gateway is ready.",
+      "translated": "Гілку буде підключено, щойно Gateway буде готовий."
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10844,9 +10919,9 @@
       "translated": "Параметри нового сеансу…"
     },
     {
-      "id": "native.apple.a1b0d289758e2213",
-      "source": "Sessions…",
-      "translated": "Сеанси…"
+      "id": "native.apple.003b25ddafeb18e9",
+      "source": "Threads…",
+      "translated": "Гілки…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11009,14 +11084,14 @@
       "translated": "Створити"
     },
     {
-      "id": "native.apple.f488b9caf6e51ac3",
-      "source": "Delete Session?",
-      "translated": "Видалити сеанс?"
+      "id": "native.apple.31d5c7287cfb3abe",
+      "source": "Delete Thread?",
+      "translated": "Видалити гілку?"
     },
     {
-      "id": "native.apple.8634b17be9b111bc",
-      "source": "Delete Session",
-      "translated": "Видалити сеанс"
+      "id": "native.apple.d3395564809f1120",
+      "source": "Delete Thread",
+      "translated": "Видалити гілку"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11024,9 +11099,9 @@
       "translated": "Скасувати"
     },
     {
-      "id": "native.apple.4a9568ac9b18d8d3",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "Це назавжди видалить сеанс і його стенограму."
+      "id": "native.apple.092659256d26cb03",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "Це назавжди видалить гілку та її розшифрування."
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11054,9 +11129,9 @@
       "translated": "Нова група"
     },
     {
-      "id": "native.apple.5bccdc23a1640895",
-      "source": "Rename Session",
-      "translated": "Перейменувати сеанс"
+      "id": "native.apple.683032464c497bbd",
+      "source": "Rename Thread",
+      "translated": "Перейменувати гілку"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11064,9 +11139,9 @@
       "translated": "Назва групи"
     },
     {
-      "id": "native.apple.af789b2d2fda0f67",
-      "source": "Session name",
-      "translated": "Назва сеансу"
+      "id": "native.apple.f887aa956588f237",
+      "source": "Thread name",
+      "translated": "Назва гілки"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11104,14 +11179,14 @@
       "translated": "Агенти"
     },
     {
-      "id": "native.apple.a3bde8045fe9224a",
-      "source": "Agent session",
-      "translated": "Сеанс агента"
+      "id": "native.apple.7c8231b7b1ca480f",
+      "source": "Agent thread",
+      "translated": "Гілка агента"
     },
     {
-      "id": "native.apple.27f775de30b37ff8",
-      "source": "Recent sessions",
-      "translated": "Нещодавні сеанси"
+      "id": "native.apple.b3c553614f762a58",
+      "source": "Recent threads",
+      "translated": "Недавні гілки"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11119,9 +11194,9 @@
       "translated": "Gateway офлайн"
     },
     {
-      "id": "native.apple.28c97cf23665ee01",
-      "source": "No recent sessions",
-      "translated": "Немає нещодавніх сеансів"
+      "id": "native.apple.5aa32afda85064ea",
+      "source": "No recent threads",
+      "translated": "Немає недавніх гілок"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11219,14 +11294,14 @@
       "translated": "Скасувати"
     },
     {
-      "id": "native.apple.9f2fd65953013b7c",
-      "source": "Sessions",
-      "translated": "Сеанси"
+      "id": "native.apple.b6855cf19a50f477",
+      "source": "Threads",
+      "translated": "Гілки"
     },
     {
-      "id": "native.apple.0422818cc95d5071",
-      "source": "Archived sessions",
-      "translated": "Архівовані сеанси"
+      "id": "native.apple.9b1d0ef27a1333b0",
+      "source": "Archived threads",
+      "translated": "Архівні гілки"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11234,34 +11309,34 @@
       "translated": "Показати архівовані"
     },
     {
-      "id": "native.apple.b272115c83f7ef58",
-      "source": "Sessions unavailable",
-      "translated": "Сеанси недоступні"
+      "id": "native.apple.98167401c7267735",
+      "source": "Threads unavailable",
+      "translated": "Гілки недоступні"
     },
     {
-      "id": "native.apple.54f8260c9b863087",
-      "source": "Loading archived sessions",
-      "translated": "Завантаження архівованих сеансів"
+      "id": "native.apple.4d28a7def2337b9f",
+      "source": "Loading archived threads",
+      "translated": "Завантаження архівних гілок"
     },
     {
-      "id": "native.apple.9b305868873dade2",
-      "source": "Loading recent sessions",
-      "translated": "Завантаження нещодавніх сеансів"
+      "id": "native.apple.777d7b706933bd7b",
+      "source": "Loading recent threads",
+      "translated": "Завантаження недавніх гілок"
     },
     {
-      "id": "native.apple.207dad20d09f3160",
-      "source": "^[\\(count) session](inflect: true)",
-      "translated": "^[\\(count) сеанс](inflect: true)"
+      "id": "native.apple.22f81ea94bef8410",
+      "source": "^[\\(count) thread](inflect: true)",
+      "translated": "^[\\(count) гілка](inflect: true)"
     },
     {
-      "id": "native.apple.1f4501a6bf2bae4c",
-      "source": "No archived sessions",
-      "translated": "Немає архівованих сеансів"
+      "id": "native.apple.1cad51e14db59bf9",
+      "source": "No archived threads",
+      "translated": "Немає архівних гілок"
     },
     {
-      "id": "native.apple.2a1ba7a5e1979c9e",
-      "source": "Archived sessions will appear here.",
-      "translated": "Архівовані сеанси з’являться тут."
+      "id": "native.apple.18ef832d3a7ddcf8",
+      "source": "Archived threads will appear here.",
+      "translated": "Архівні гілки з’являться тут."
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11344,9 +11419,9 @@
       "translated": "Поділитися надходженням"
     },
     {
-      "id": "native.apple.2360d25fe6ae9946",
-      "source": "Loading sessions",
-      "translated": "Завантаження сеансів"
+      "id": "native.apple.21d9208d86a4d1fe",
+      "source": "Loading threads",
+      "translated": "Завантаження гілок"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11354,19 +11429,19 @@
       "translated": "Отримання нещодавньої активності з Gateway."
     },
     {
-      "id": "native.apple.c334f2e86702a7b8",
-      "source": "Sessions unavailable",
-      "translated": "Сеанси недоступні"
+      "id": "native.apple.4be1f79aa2b230ff",
+      "source": "Threads unavailable",
+      "translated": "Гілки недоступні"
     },
     {
-      "id": "native.apple.6cc6efb7a03960b6",
-      "source": "No recent sessions",
-      "translated": "Немає нещодавніх сеансів"
+      "id": "native.apple.98b348873556bc46",
+      "source": "No recent threads",
+      "translated": "Немає недавніх гілок"
     },
     {
-      "id": "native.apple.08483af2d043bee6",
-      "source": "Session activity offline",
-      "translated": "Активність сеансів офлайн"
+      "id": "native.apple.7396d205574d279f",
+      "source": "Thread activity offline",
+      "translated": "Активність гілок офлайн"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11824,9 +11899,9 @@
       "translated": "Картка"
     },
     {
-      "id": "native.apple.93eeaedb2ff61043",
-      "source": "Open Session",
-      "translated": "Відкрити сесію"
+      "id": "native.apple.c9ec1b0e18074d8a",
+      "source": "Open Thread",
+      "translated": "Відкрити гілку"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13314,9 +13389,9 @@
       "translated": "За замовчуванням"
     },
     {
-      "id": "native.apple.3de045f17ea3c6d0",
-      "source": "Used for new Chat and Talk sessions.",
-      "translated": "Використовується для нових сеансів Chat і Talk."
+      "id": "native.apple.f4ae5664c3eda95d",
+      "source": "Used for new Chat threads and Talk sessions.",
+      "translated": "Використовується для нових гілок чату та сеансів розмови."
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15719,9 +15794,9 @@
       "translated": "Екземпляри"
     },
     {
-      "id": "native.apple.3579cf2750470a22",
-      "source": "Sessions",
-      "translated": "Сеанси"
+      "id": "native.apple.11fe8b9941954dfb",
+      "source": "Threads",
+      "translated": "Гілки"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19029,9 +19104,9 @@
       "translated": "Швидка команда Quick Chat"
     },
     {
-      "id": "native.apple.6ae77665b5f4490f",
-      "source": "Global shortcut that opens a floating chat bar for the main session.",
-      "translated": "Глобальна швидка команда, що відкриває плаваючу панель чату для основного сеансу."
+      "id": "native.apple.94dd793cd7d7d555",
+      "source": "Global shortcut that opens a floating chat bar for the main thread.",
+      "translated": "Глобальне сполучення клавіш, яке відкриває плавучу панель чату для основної гілки."
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19609,9 +19684,9 @@
       "translated": "Критично"
     },
     {
-      "id": "native.apple.75102378a6775180",
-      "source": "New Session",
-      "translated": "Новий сеанс"
+      "id": "native.apple.13f96467014cf344",
+      "source": "New Thread",
+      "translated": "Нова гілка"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21899,9 +21974,9 @@
       "translated": "Немає нещодавніх повідомлень"
     },
     {
-      "id": "native.apple.1ff8aec0044934c3",
-      "source": "Sessions",
-      "translated": "Сеанси"
+      "id": "native.apple.3ec2afcbc298c673",
+      "source": "Threads",
+      "translated": "Гілки"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21909,9 +21984,9 @@
       "translated": "Перегляньте збережені кошики розмов, які CLI повторно використовує для контексту та лімітів частоти."
     },
     {
-      "id": "native.apple.bab897f3252b134c",
-      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
-      "translated": "Сеансів ще немає. Вони з’являться після першого вхідного повідомлення або heartbeat."
+      "id": "native.apple.14ccb32cd8ed1c81",
+      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
+      "translated": "Гілок ще немає. Вони з’являться після першого вхідного повідомлення або сигналу активності."
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -21994,9 +22069,9 @@
       "translated": "Схвалення виконання"
     },
     {
-      "id": "native.apple.64a6dc7d49e8fb57",
-      "source": "Sessions",
-      "translated": "Сеанси"
+      "id": "native.apple.52e37e3a44ae516c",
+      "source": "Threads",
+      "translated": "Гілки"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -22999,9 +23074,9 @@
       "translated": "Введи мене в курс справ"
     },
     {
-      "id": "native.apple.234ec45f4231edc4",
-      "source": "Summarize what happened in my sessions since yesterday.",
-      "translated": "Підсумуй, що відбулося в моїх сеансах від учора."
+      "id": "native.apple.fc4ce810900ec0b6",
+      "source": "Summarize what happened in my threads since yesterday.",
+      "translated": "Підсумуй, що відбулося в моїх гілках від учора."
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23179,9 +23254,9 @@
       "translated": "Відкріпити модель"
     },
     {
-      "id": "native.apple.5dfc0700d8dff8de",
-      "source": "Session",
-      "translated": "Сеанс"
+      "id": "native.apple.4edb66657f5aca1f",
+      "source": "Thread",
+      "translated": "Гілка"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23344,6 +23419,51 @@
       "translated": "Віджет недоступний"
     },
     {
+      "id": "native.apple.d640691fd196f338",
+      "source": "Widget export failed",
+      "translated": "Не вдалося експортувати віджет"
+    },
+    {
+      "id": "native.apple.533c6e22a11e88de",
+      "source": "OK",
+      "translated": "OK"
+    },
+    {
+      "id": "native.apple.e1fb28a2a9756402",
+      "source": "Copy image",
+      "translated": "Копіювати зображення"
+    },
+    {
+      "id": "native.apple.ebd7bc92e1b12235",
+      "source": "Save image…",
+      "translated": "Зберегти зображення…"
+    },
+    {
+      "id": "native.apple.742c46d4cf2db134",
+      "source": "Save image",
+      "translated": "Зберегти зображення"
+    },
+    {
+      "id": "native.apple.0589cce608418f90",
+      "source": "The widget image could not be captured.",
+      "translated": "Не вдалося захопити зображення віджета."
+    },
+    {
+      "id": "native.apple.dfe24e827fdbe9c5",
+      "source": "The widget image could not be copied.",
+      "translated": "Не вдалося скопіювати зображення віджета."
+    },
+    {
+      "id": "native.apple.9e611e3a80e71408",
+      "source": "The widget image could not be encoded as PNG.",
+      "translated": "Не вдалося закодувати зображення віджета у форматі PNG."
+    },
+    {
+      "id": "native.apple.9a6e8afbe24a262b",
+      "source": "The widget image could not be saved.",
+      "translated": "Не вдалося зберегти зображення віджета."
+    },
+    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23484,19 +23604,19 @@
       "translated": "Користувач"
     },
     {
-      "id": "native.apple.b1cdcb906a43d5d6",
-      "source": "This session cannot be archived while it is active or running.",
-      "translated": "Цей сеанс не можна архівувати, доки він активний або виконується."
+      "id": "native.apple.9d0cba09d92ee669",
+      "source": "This thread cannot be archived while it is active or running.",
+      "translated": "Цю гілку не можна архівувати, доки вона активна або виконується."
     },
     {
-      "id": "native.apple.5817e3f3dab1ee19",
-      "source": "The main session cannot be deleted.",
-      "translated": "Основний сеанс не можна видалити."
+      "id": "native.apple.8952a111a1075051",
+      "source": "The main thread cannot be deleted.",
+      "translated": "Основну гілку не можна видалити."
     },
     {
-      "id": "native.apple.a6b8df3f18171c91",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
-      "translated": "Видаліть вкладення або дочекайтеся їх доставлення, перш ніж архівувати чи видаляти цей сеанс."
+      "id": "native.apple.90d0ccf80ca28717",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
+      "translated": "Видаліть вкладення або дочекайтеся їх доставки, перш ніж архівувати чи видаляти цю гілку."
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23634,9 +23754,9 @@
       "translated": "Запуск завершено"
     },
     {
-      "id": "native.apple.cd7c3095a22f80a9",
-      "source": "Session Info",
-      "translated": "Відомості про сеанс"
+      "id": "native.apple.bbccb4c8db5cac12",
+      "source": "Thread Info",
+      "translated": "Інформація про гілку"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23669,9 +23789,9 @@
       "translated": "Додати групу"
     },
     {
-      "id": "native.apple.23d628606fe0734f",
-      "source": "Session Groups",
-      "translated": "Групи сеансів"
+      "id": "native.apple.7b641fed5bace855",
+      "source": "Thread Groups",
+      "translated": "Групи гілок"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23714,9 +23834,9 @@
       "translated": "Видалити групу"
     },
     {
-      "id": "native.apple.b049c8a4d2805e08",
-      "source": "Sessions in this group become ungrouped.",
-      "translated": "Сеанси в цій групі більше не будуть згруповані."
+      "id": "native.apple.56401c79410a310d",
+      "source": "Threads in this group become ungrouped.",
+      "translated": "Гілки в цій групі буде розгруповано."
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23729,9 +23849,9 @@
       "translated": "На цьому шлюзі немає доступних агентів."
     },
     {
-      "id": "native.apple.6c89f35d53506406",
-      "source": "New Session Options",
-      "translated": "Параметри нового сеансу"
+      "id": "native.apple.2d96aa7d3d12f85b",
+      "source": "New Thread Options",
+      "translated": "Параметри нової гілки"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23759,19 +23879,19 @@
       "translated": "Створити"
     },
     {
-      "id": "native.apple.795ba37f6782cf28",
-      "source": "The session could not be created.",
-      "translated": "Не вдалося створити сеанс."
+      "id": "native.apple.87ef57319d1ddc85",
+      "source": "The thread could not be created.",
+      "translated": "Не вдалося створити гілку."
     },
     {
-      "id": "native.apple.8ec708a3605a2cc3",
-      "source": "Search sessions",
-      "translated": "Пошук сеансів"
+      "id": "native.apple.6bd91c435b69d638",
+      "source": "Search threads",
+      "translated": "Пошук гілок"
     },
     {
-      "id": "native.apple.23b069b4e7f97039",
-      "source": "No Sessions",
-      "translated": "Немає сеансів"
+      "id": "native.apple.6fde4bdf9d5b9191",
+      "source": "No Threads",
+      "translated": "Немає гілок"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23779,29 +23899,29 @@
       "translated": "Немає результатів"
     },
     {
-      "id": "native.apple.0058923f2ce8a3ec",
-      "source": "New Session",
-      "translated": "Новий сеанс"
+      "id": "native.apple.a02fd99740d29bd3",
+      "source": "New Thread",
+      "translated": "Нова гілка"
     },
     {
-      "id": "native.apple.66ba42960eb4135b",
-      "source": "New session",
-      "translated": "Новий сеанс"
+      "id": "native.apple.b625801dd04b09f2",
+      "source": "New thread",
+      "translated": "Нова гілка"
     },
     {
-      "id": "native.apple.2ef0e34db02ad255",
-      "source": "New session options",
-      "translated": "Параметри нового сеансу"
+      "id": "native.apple.851be81fcc933608",
+      "source": "New thread options",
+      "translated": "Параметри нової гілки"
     },
     {
-      "id": "native.apple.36753ef2f1ed4264",
-      "source": "Rename Session",
-      "translated": "Перейменувати сеанс"
+      "id": "native.apple.9ce8a4aba7b444b2",
+      "source": "Rename Thread",
+      "translated": "Перейменувати гілку"
     },
     {
-      "id": "native.apple.c9de0a1510ef475f",
-      "source": "Session name",
-      "translated": "Назва сеансу"
+      "id": "native.apple.1dd067c44511c7f0",
+      "source": "Thread name",
+      "translated": "Назва гілки"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23814,14 +23934,14 @@
       "translated": "Скасувати"
     },
     {
-      "id": "native.apple.afb4e6c99c63a28d",
-      "source": "Delete Session",
-      "translated": "Видалити сеанс"
+      "id": "native.apple.618073d6ab3f2721",
+      "source": "Delete Thread",
+      "translated": "Видалити гілку"
     },
     {
-      "id": "native.apple.3d4ef32e42f136a4",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "Сеанс і його розшифровку буде видалено з Gateway."
+      "id": "native.apple.10a5e72bba3cbccc",
+      "source": "The thread and its transcript are removed from the gateway.",
+      "translated": "Гілку та її стенограму буде видалено з Gateway."
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23829,14 +23949,14 @@
       "translated": "Видалити «%@»?"
     },
     {
-      "id": "native.apple.9a7dca238fba628d",
-      "source": "Session running",
-      "translated": "Сеанс виконується"
+      "id": "native.apple.ac71e3b2aa496a2c",
+      "source": "Thread running",
+      "translated": "Гілка виконується"
     },
     {
-      "id": "native.apple.fcfbfe5e97a95e9c",
-      "source": "Session failed",
-      "translated": "Помилка сеансу"
+      "id": "native.apple.c775e87f997278b2",
+      "source": "Thread failed",
+      "translated": "Помилка гілки"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23894,9 +24014,9 @@
       "translated": "Копіювати ключ сесії"
     },
     {
-      "id": "native.apple.4aeb7c14c26dabac",
-      "source": "Delete Session…",
-      "translated": "Видалити сесію…"
+      "id": "native.apple.f4998cfb572f23ff",
+      "source": "Delete Thread…",
+      "translated": "Видалити гілку…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23909,9 +24029,9 @@
       "translated": "Підключення…"
     },
     {
-      "id": "native.apple.79f708b3bc1d3a6c",
-      "source": "Retry session groups",
-      "translated": "Повторити завантаження груп сеансів"
+      "id": "native.apple.8802e9576ffd0f65",
+      "source": "Retry thread groups",
+      "translated": "Повторити завантаження груп гілок"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23934,24 +24054,24 @@
       "translated": "Область"
     },
     {
-      "id": "native.apple.2c37581c7b88f741",
-      "source": "Search sessions",
-      "translated": "Пошук сеансів"
+      "id": "native.apple.b313b80def4bda52",
+      "source": "Search threads",
+      "translated": "Пошук гілок"
     },
     {
-      "id": "native.apple.43be8a2336e42faf",
-      "source": "Sessions",
-      "translated": "Сесії"
+      "id": "native.apple.c0cc6acc36f413ce",
+      "source": "Threads",
+      "translated": "Гілки"
     },
     {
-      "id": "native.apple.0b379cdfcbd3247f",
-      "source": "Rename Session",
-      "translated": "Перейменувати сеанс"
+      "id": "native.apple.854d3928fe5a557c",
+      "source": "Rename Thread",
+      "translated": "Перейменувати гілку"
     },
     {
-      "id": "native.apple.54b6fbd9e41db009",
-      "source": "Session name",
-      "translated": "Назва сеансу"
+      "id": "native.apple.9d0d3f20096cc4da",
+      "source": "Thread name",
+      "translated": "Назва гілки"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -23959,19 +24079,19 @@
       "translated": "Скасувати"
     },
     {
-      "id": "native.apple.751e0f6b81cd374a",
-      "source": "Delete selected sessions?",
-      "translated": "Видалити вибрані сеанси?"
+      "id": "native.apple.dc00eb94f33bae15",
+      "source": "Delete selected threads?",
+      "translated": "Видалити вибрані гілки?"
     },
     {
-      "id": "native.apple.aa679276581b0058",
-      "source": "Delete Sessions",
-      "translated": "Видалити сеанси"
+      "id": "native.apple.2053fc9f74dc3158",
+      "source": "Delete Threads",
+      "translated": "Видалити гілки"
     },
     {
-      "id": "native.apple.f837129cbee23297",
-      "source": "Each selected session and its transcript will be removed from the gateway.",
-      "translated": "Кожен вибраний сеанс і його стенограму буде видалено з Gateway."
+      "id": "native.apple.0970247871a834a0",
+      "source": "Each selected thread and its transcript will be removed from the gateway.",
+      "translated": "Кожну вибрану гілку та її стенограму буде видалено з Gateway."
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -23979,9 +24099,9 @@
       "translated": "Групи"
     },
     {
-      "id": "native.apple.64013cfee5e25305",
-      "source": "Manage session groups",
-      "translated": "Керувати групами сеансів"
+      "id": "native.apple.6f8acab2256728b5",
+      "source": "Manage thread groups",
+      "translated": "Керувати групами гілок"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -23994,14 +24114,14 @@
       "translated": "Вибрати"
     },
     {
-      "id": "native.apple.b67eaecec1b423ac",
-      "source": "No archived sessions",
-      "translated": "Немає заархівованих сеансів"
+      "id": "native.apple.692972314d04b184",
+      "source": "No archived threads",
+      "translated": "Немає архівованих гілок"
     },
     {
-      "id": "native.apple.b2435a79abf0c794",
-      "source": "No sessions found",
-      "translated": "Сеансів не знайдено"
+      "id": "native.apple.d6a4b5711dcd26e7",
+      "source": "No threads found",
+      "translated": "Гілок не знайдено"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24169,6 +24289,16 @@
       "translated": "Відкрити повне повідомлення"
     },
     {
+      "id": "native.apple.002bfcede229ad4b",
+      "source": "Rewind to Here",
+      "translated": "Відкотити до цього місця"
+    },
+    {
+      "id": "native.apple.14df2e4997689fb3",
+      "source": "Fork from Here",
+      "translated": "Створити відгалуження звідси"
+    },
+    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "Відповісти"
@@ -24254,9 +24384,9 @@
       "translated": "Видаліть вкладення або дочекайтеся завершення доставки, перш ніж починати новий чат."
     },
     {
-      "id": "native.apple.980f552bb0f96c0f",
-      "source": "Gateway changed before the session operation started.",
-      "translated": "Gateway змінився до початку операції із сеансом."
+      "id": "native.apple.e0f045151c8d3137",
+      "source": "Gateway changed before the thread operation started.",
+      "translated": "Gateway змінився до початку операції з гілкою."
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24264,9 +24394,9 @@
       "translated": "Видаліть вкладення або зачекайте на завершення доставлення, перш ніж перемикати чати."
     },
     {
-      "id": "native.apple.87ba543b42696b92",
-      "source": "Clear this session's history?",
-      "translated": "Очистити історію цього сеансу?"
+      "id": "native.apple.0a5c4e15466c3acc",
+      "source": "Clear this thread's history?",
+      "translated": "Очистити історію цієї гілки?"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24279,14 +24409,14 @@
       "translated": "Це скине розмову для %@. Ключ сеансу залишиться незмінним."
     },
     {
-      "id": "native.apple.a92e96bed98bd553",
-      "source": "Rename Session",
-      "translated": "Перейменувати сесію"
+      "id": "native.apple.67ac221dbe7179f0",
+      "source": "Rename Thread",
+      "translated": "Перейменувати гілку"
     },
     {
-      "id": "native.apple.848e2388f3466f40",
-      "source": "Session name",
-      "translated": "Назва сесії"
+      "id": "native.apple.cf0f7e049603f518",
+      "source": "Thread name",
+      "translated": "Назва гілки"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24304,9 +24434,9 @@
       "translated": "Експортувати стенограму"
     },
     {
-      "id": "native.apple.4af0f566d39d7041",
-      "source": "Sessions",
-      "translated": "Сеанси"
+      "id": "native.apple.c0ada47504425f23",
+      "source": "Threads",
+      "translated": "Гілки"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24379,14 +24509,14 @@
       "translated": "За замовчуванням"
     },
     {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "Нова сесія"
+      "id": "native.apple.1a765291943599e5",
+      "source": "New Thread",
+      "translated": "Нова гілка"
     },
     {
-      "id": "native.apple.a7119fbf9d25df5e",
-      "source": "New Session Options…",
-      "translated": "Параметри нового сеансу…"
+      "id": "native.apple.c7a3a6d5e43dd98f",
+      "source": "New Thread Options…",
+      "translated": "Параметри нової гілки…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24394,19 +24524,19 @@
       "translated": "Оновити"
     },
     {
-      "id": "native.apple.2bcff4a8fa503739",
-      "source": "Sessions…",
-      "translated": "Сеанси…"
+      "id": "native.apple.0e710b81808e5dcf",
+      "source": "Threads…",
+      "translated": "Гілки…"
     },
     {
-      "id": "native.apple.c36e008b051adb38",
-      "source": "Rename Session…",
-      "translated": "Перейменувати сесію…"
+      "id": "native.apple.faad8f92b6bef166",
+      "source": "Rename Thread…",
+      "translated": "Перейменувати гілку…"
     },
     {
-      "id": "native.apple.ea0ef95a159bffe0",
-      "source": "Fork Session",
-      "translated": "Створити відгалуження сесії"
+      "id": "native.apple.23b61d6cd26ac112",
+      "source": "Fork",
+      "translated": "Відгалузити"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24464,24 +24594,24 @@
       "translated": "Очистити історію…"
     },
     {
-      "id": "native.apple.920fe8a7a33f9e92",
-      "source": "Session",
-      "translated": "Сесія"
+      "id": "native.apple.8b4f1c5107ea8a0e",
+      "source": "Thread",
+      "translated": "Гілка"
     },
     {
-      "id": "native.apple.185a401f78328b0f",
-      "source": "Session actions",
-      "translated": "Дії сесії"
+      "id": "native.apple.4d7750c9bf699469",
+      "source": "Thread actions",
+      "translated": "Дії з гілкою"
     },
     {
-      "id": "native.apple.9f9dedf599b2619b",
-      "source": "Session cost %@",
-      "translated": "Вартість сеансу: %@"
+      "id": "native.apple.bb2f22cc43c97f8e",
+      "source": "Thread cost %@",
+      "translated": "Вартість гілки %@"
     },
     {
-      "id": "native.apple.f0a4720df5f5f403",
-      "source": "Compact Session",
-      "translated": "Стиснути сесію"
+      "id": "native.apple.6239ced0b86e86f8",
+      "source": "Compact Thread",
+      "translated": "Стиснути гілку"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/uk.json
+++ b/apps/.i18n/native/uk.json
@@ -1429,9 +1429,9 @@
       "translated": "Говоріть або диктуйте за допомогою OpenClaw"
     },
     {
-      "id": "native.android.e2cf5a38587382cb",
-      "source": "Browse Threads",
-      "translated": "Переглянути гілки"
+      "id": "native.android.5876e15e5e92fd45",
+      "source": "Browse Sessions",
+      "translated": "Переглянути сеанси"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "Дій не знайдено"
     },
     {
-      "id": "native.android.bc70a4ac965b82ba",
-      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
-      "translated": "Спробуйте чат, голос, гілки, провайдерів або налаштування."
+      "id": "native.android.48ad0ae0e930e02b",
+      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
+      "translated": "Спробуйте Chat, Voice, Sessions, Providers або Settings."
     },
     {
-      "id": "native.android.670121e54dbe286f",
-      "source": "Threads",
-      "translated": "Гілки"
+      "id": "native.android.d4fbd1ee4f55a5db",
+      "source": "Sessions",
+      "translated": "Сеанси"
     },
     {
-      "id": "native.android.d38be650b1bce4a0",
-      "source": "Connect the Gateway to search threads.",
-      "translated": "Підключіть Gateway, щоб шукати гілки."
+      "id": "native.android.207c2170504e99e6",
+      "source": "Connect the Gateway to search sessions.",
+      "translated": "Підключіть Gateway, щоб шукати сеанси."
     },
     {
-      "id": "native.android.3d7754721f776ef8",
-      "source": "No matching threads yet.",
-      "translated": "Відповідних гілок поки немає."
+      "id": "native.android.25d2c2d792c952fe",
+      "source": "No matching sessions yet.",
+      "translated": "Відповідних сеансів поки немає."
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "Асистент працює"
     },
     {
-      "id": "native.android.9a839f6e3e05a744",
-      "source": "OpenClaw thread",
-      "translated": "Гілка OpenClaw"
+      "id": "native.android.8f8384286317f5c9",
+      "source": "OpenClaw session",
+      "translated": "Сеанс OpenClaw"
     },
     {
-      "id": "native.android.d83f82a1e4a5ed99",
-      "source": "Open thread",
-      "translated": "Відкрити гілку"
+      "id": "native.android.15799e57704b20c6",
+      "source": "Open session",
+      "translated": "Відкрити сеанс"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "Немає готових провайдерів"
     },
     {
-      "id": "native.android.8a1c5365c0538908",
-      "source": "Main thread",
-      "translated": "Основна гілка"
+      "id": "native.android.73e6ab1a168fd381",
+      "source": "Main session",
+      "translated": "Основний сеанс"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.a5845742daecb4ba",
-      "source": "Threads",
-      "translated": "Гілки"
+      "id": "native.android.0e3157c15c56944f",
+      "source": "Sessions",
+      "translated": "Сеанси"
     },
     {
-      "id": "native.android.439b324280869527",
-      "source": "Focus thread search",
-      "translated": "Перейти до пошуку гілок"
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "Перейти до пошуку сеансів"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "Заархівовано"
     },
     {
-      "id": "native.android.03981341841b04ac",
-      "source": "Search threads",
-      "translated": "Пошук гілок"
+      "id": "native.android.b9cf34c137e4cf03",
+      "source": "Search sessions",
+      "translated": "Пошук сеансів"
     },
     {
-      "id": "native.android.99570c528a41fa72",
-      "source": "Clear thread search",
-      "translated": "Очистити пошук гілок"
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "Очистити пошук сеансів"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "Спочатку найстаріші"
     },
     {
-      "id": "native.android.fd67be543e321cc9",
-      "source": "Toggle thread layout",
-      "translated": "Змінити вигляд гілок"
+      "id": "native.android.c6bf8751e2a7f5c7",
+      "source": "Toggle session layout",
+      "translated": "Перемкнути макет сеансів"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "Макет: докладний"
     },
     {
-      "id": "native.android.ebd17565e0ffd8eb",
-      "source": "Searching threads",
-      "translated": "Пошук гілок"
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "Пошук сеансів"
     },
     {
-      "id": "native.android.472d46ae8669f860",
-      "source": "No matching threads",
-      "translated": "Відповідних гілок немає"
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "Відповідних сеансів не знайдено"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "Почати чат"
     },
     {
-      "id": "native.android.ff81ad1bee00d384",
-      "source": "Current thread",
-      "translated": "Поточна гілка"
+      "id": "native.android.f10d4df7cbc6df4f",
+      "source": "Current session",
+      "translated": "Поточний сеанс"
     },
     {
-      "id": "native.android.fc145645b9620e57",
-      "source": "OpenClaw thread",
-      "translated": "Гілка OpenClaw"
+      "id": "native.android.8f0482425838ae64",
+      "source": "OpenClaw session",
+      "translated": "Сеанс OpenClaw"
     },
     {
-      "id": "native.android.71cbb8dde8bf138b",
-      "source": "Rename thread",
-      "translated": "Перейменувати гілку"
+      "id": "native.android.786774c8a76e50d7",
+      "source": "Rename session",
+      "translated": "Перейменувати сеанс"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "Видалити групу?"
     },
     {
-      "id": "native.android.691e92cfe5cf106e",
-      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "Гілки в групі \"$group\" буде збережено й переміщено назад до розділу «Без групи»."
+      "id": "native.android.3455fc2f77d564e3",
+      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "Сесії у групі \"$group\" зберігаються та повертаються до Без групи."
     },
     {
-      "id": "native.android.d87a8217ab56999b",
-      "source": "Delete thread?",
-      "translated": "Видалити гілку?"
+      "id": "native.android.4805fb9d6623e8c0",
+      "source": "Delete session?",
+      "translated": "Видалити сеанс?"
     },
     {
-      "id": "native.android.930de97ff47113a8",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "Це назавжди видалить гілку та її стенограму."
+      "id": "native.android.0c3283a2b2445eae",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "Це назавжди видалить сеанс і його стенограму."
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "Без групи"
     },
     {
-      "id": "native.android.8e21a70428def6e0",
-      "source": "No threads yet",
-      "translated": "Гілок ще немає"
+      "id": "native.android.db243d71d056afa4",
+      "source": "No sessions yet",
+      "translated": "Сеансів поки немає"
     },
     {
-      "id": "native.android.cda4c5ad8b17e394",
-      "source": "No current thread",
-      "translated": "Немає поточної гілки"
+      "id": "native.android.5b4eee6a8092925e",
+      "source": "No current session",
+      "translated": "Немає поточного сеансу"
     },
     {
-      "id": "native.android.be84f061047aa2da",
-      "source": "No archived threads",
-      "translated": "Немає архівованих гілок"
+      "id": "native.android.acbcc9c9ea53d8c0",
+      "source": "No archived sessions",
+      "translated": "Немає архівованих сеансів"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "Почніть нову розмову, і вона з’явиться тут."
     },
     {
-      "id": "native.android.f289d03e1d3eee98",
-      "source": "Open Chat to start or resume the current thread.",
-      "translated": "Відкрийте чат, щоб почати або продовжити поточну гілку."
+      "id": "native.android.56fcd605dc7be3c0",
+      "source": "Open Chat to start or resume the current session.",
+      "translated": "Відкрийте чат, щоб почати або продовжити поточний сеанс."
     },
     {
-      "id": "native.android.504b71386e76c6ae",
-      "source": "Archived threads will show up here.",
-      "translated": "Архівовані гілки з’являться тут."
+      "id": "native.android.085515989f8a2022",
+      "source": "Archived sessions will show up here.",
+      "translated": "Архівовані сеанси з’являтимуться тут."
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days} дн"
     },
     {
-      "id": "native.android.ee4c727cdafbe963",
-      "source": "Main thread",
-      "translated": "Головна гілка"
+      "id": "native.android.3d4fa07acbc015c5",
+      "source": "Main session",
+      "translated": "Основний сеанс"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Очікування Gateway"
     },
     {
-      "id": "native.android.da78209effb11cfd",
-      "source": "Thread Activity",
-      "translated": "Активність гілки"
+      "id": "native.android.2d8d049afe99f751",
+      "source": "Session Activity",
+      "translated": "Активність сеансу"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "Запити на схвалення виконання з’являтимуться тут, поки цей телефон підключено."
     },
     {
-      "id": "native.android.f615712dfb56319a",
-      "source": "Thread activity",
-      "translated": "Активність гілки"
+      "id": "native.android.dc3e7ca5a491103a",
+      "source": "Session activity",
+      "translated": "Активність сеансу"
     },
     {
-      "id": "native.android.6c93973c13db43ae",
-      "source": "Chat tool calls waiting in the active thread remain visible here.",
-      "translated": "Виклики інструментів чату, що очікують в активній гілці, залишаються видимими тут."
+      "id": "native.android.8551e02b060bd7d8",
+      "source": "Chat tool calls waiting in the active session remain visible here.",
+      "translated": "Виклики інструментів чату, що очікують в активному сеансі, залишатимуться видимими тут."
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,11 +4294,6 @@
       "translated": "Налаштування постачальника розмов"
     },
     {
-      "id": "native.android.23b638094c34b916",
-      "source": "Microphone",
-      "translated": "Мікрофон"
-    },
-    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "Тест аудіо"
@@ -4342,66 +4337,6 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "Готово"
-    },
-    {
-      "id": "native.android.8d9ecdfdd916b780",
-      "source": "Automatic",
-      "translated": "Автоматично"
-    },
-    {
-      "id": "native.android.c1626a6700a570f6",
-      "source": "Preferred microphone unavailable; using automatic routing.",
-      "translated": "Бажаний мікрофон недоступний; використовується автоматична маршрутизація."
-    },
-    {
-      "id": "native.android.820bc5d0ce571d8b",
-      "source": "Prioritizes connected Bluetooth microphones.",
-      "translated": "Надає пріоритет підключеним Bluetooth-мікрофонам."
-    },
-    {
-      "id": "native.android.11e48038d5e8bff6",
-      "source": "Preferred microphone",
-      "translated": "Бажаний мікрофон"
-    },
-    {
-      "id": "native.android.eaa4d7563a46d307",
-      "source": "Unavailable",
-      "translated": "Недоступний"
-    },
-    {
-      "id": "native.android.9f5ebf17eb405ba8",
-      "source": "Next session",
-      "translated": "Наступний сеанс"
-    },
-    {
-      "id": "native.android.8c4e91f53928efb2",
-      "source": "Built-in microphone",
-      "translated": "Вбудований мікрофон"
-    },
-    {
-      "id": "native.android.14b613cb6e2446b4",
-      "source": "Bluetooth microphone",
-      "translated": "Bluetooth-мікрофон"
-    },
-    {
-      "id": "native.android.c885247b2d7ce271",
-      "source": "Bluetooth LE microphone",
-      "translated": "Мікрофон Bluetooth LE"
-    },
-    {
-      "id": "native.android.b6a4e674c5fb441a",
-      "source": "Wired headset microphone",
-      "translated": "Мікрофон дротової гарнітури"
-    },
-    {
-      "id": "native.android.9c8becb3b0fb5a90",
-      "source": "USB microphone",
-      "translated": "USB-мікрофон"
-    },
-    {
-      "id": "native.android.ba46258fadec7a39",
-      "source": "External microphone",
-      "translated": "Зовнішній мікрофон"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5139,9 +5074,9 @@
       "translated": "Перевірити"
     },
     {
-      "id": "native.android.c971506716c96e91",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
-      "translated": "OpenClaw перетворює цей телефон на зручний мобільний інтерфейс керування гілками, голосом, постачальниками та Gateway."
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw перетворює цей телефон на зручний мобільний інтерфейс керування сеансами, голосовими функціями, постачальниками та Gateway."
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5689,9 +5624,9 @@
       "translated": "Налаштування Розмови"
     },
     {
-      "id": "native.android.36f78c8c85dc283f",
-      "source": "Recent Threads",
-      "translated": "Останні гілки"
+      "id": "native.android.73f07a5d54915259",
+      "source": "Recent Sessions",
+      "translated": "Нещодавні сеанси"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5749,14 +5684,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% у мережі"
     },
     {
-      "id": "native.android.57177017a6a93826",
-      "source": "Threads",
-      "translated": "Гілки"
+      "id": "native.android.16c3425d3a594481",
+      "source": "Sessions",
+      "translated": "Сеанси"
     },
     {
-      "id": "native.android.43320b54a68b00a1",
-      "source": "No recent threads",
-      "translated": "Немає останніх гілок"
+      "id": "native.android.a5c0f8b3112aa58c",
+      "source": "No recent sessions",
+      "translated": "Немає нещодавніх сеансів"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5794,14 +5729,14 @@
       "translated": "Виконується · $pendingRunCount активних запусків"
     },
     {
-      "id": "native.android.e24db059480f1e6a",
-      "source": "Monitoring · 1 thread",
-      "translated": "Моніторинг · 1 гілка"
+      "id": "native.android.2c89da708b12a522",
+      "source": "Monitoring · 1 session",
+      "translated": "Відстеження · 1 сеанс"
     },
     {
-      "id": "native.android.5a475f37d80e02bc",
-      "source": "Monitoring · $sessionCount threads",
-      "translated": "Моніторинг · $sessionCount гілок"
+      "id": "native.android.8b6ee382dcb64e1f",
+      "source": "Monitoring · $sessionCount sessions",
+      "translated": "Відстеження · $sessionCount сеансів"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5834,9 +5769,9 @@
       "translated": "Провайдери"
     },
     {
-      "id": "native.android.358c5e0e838d5423",
-      "source": "Open thread",
-      "translated": "Відкрити гілку"
+      "id": "native.android.a65477861c7203aa",
+      "source": "Open session",
+      "translated": "Відкрити сеанс"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6259,9 +6194,9 @@
       "translated": "${days} дн"
     },
     {
-      "id": "native.android.28a1a1acc5a0959f",
-      "source": "Main thread",
-      "translated": "Головна гілка"
+      "id": "native.android.22d755834386db07",
+      "source": "Main session",
+      "translated": "Основний сеанс"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6942,16 +6877,6 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "Увімкнути мікрофон"
-    },
-    {
-      "id": "native.android.cb608d82c5b3352a",
-      "source": "Back camera",
-      "translated": "Задня камера"
-    },
-    {
-      "id": "native.android.e89a0e780eed2e1e",
-      "source": "Front camera",
-      "translated": "Фронтальна камера"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7759,9 +7684,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.0c74bc30a994dd33",
-      "source": "Loading thread",
-      "translated": "Завантаження гілки"
+      "id": "native.android.882cc14a58e7e105",
+      "source": "Loading session",
+      "translated": "Завантаження сеансу"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7804,14 +7729,14 @@
       "translated": "Введіть мене в курс справ"
     },
     {
-      "id": "native.android.cf40df9739f78f27",
-      "source": "Summarize recent threads and next steps.",
-      "translated": "Підсумуйте останні гілки та наступні кроки."
+      "id": "native.android.1e5add56e48c99f9",
+      "source": "Summarize recent sessions and next steps.",
+      "translated": "Підсумуйте нещодавні сеанси та подальші кроки."
     },
     {
-      "id": "native.android.ebe49a8b8df80bd3",
-      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
-      "translated": "Ознайом мене з останніми гілками OpenClaw і запропонуй подальші кроки."
+      "id": "native.android.06d515351bb79576",
+      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
+      "translated": "Введіть мене в курс моїх нещодавніх сеансів OpenClaw і запропонуйте подальші кроки."
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8149,9 +8074,9 @@
       "translated": "Підключено"
     },
     {
-      "id": "native.android.6cf5d6fa8a4186d5",
-      "source": "Threads",
-      "translated": "Гілки"
+      "id": "native.android.81931886b9caf3ab",
+      "source": "Sessions",
+      "translated": "Сесії"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,6 +10719,61 @@
       "translated": "Відомості про завдання"
     },
     {
+      "id": "native.apple.29cacb53ea5e77fc",
+      "source": "Pinned",
+      "translated": "Закріплені"
+    },
+    {
+      "id": "native.apple.940062cfdce9211b",
+      "source": "Recent",
+      "translated": "Останні"
+    },
+    {
+      "id": "native.apple.a0980128426308a9",
+      "source": "Model",
+      "translated": "Модель"
+    },
+    {
+      "id": "native.apple.9520e60f21535dde",
+      "source": "Thinking",
+      "translated": "Міркування"
+    },
+    {
+      "id": "native.apple.8b321f3ffce97429",
+      "source": "Fast",
+      "translated": "Швидко"
+    },
+    {
+      "id": "native.apple.989b70d64e328d55",
+      "source": "Default (inherited)",
+      "translated": "За замовчуванням (успадковано)"
+    },
+    {
+      "id": "native.apple.f4114e73b07eb9ae",
+      "source": "Off",
+      "translated": "Вимк."
+    },
+    {
+      "id": "native.apple.7ed231b28d16312f",
+      "source": "On",
+      "translated": "Увімк."
+    },
+    {
+      "id": "native.apple.412a74802320a037",
+      "source": "Full",
+      "translated": "Повне"
+    },
+    {
+      "id": "native.apple.299f21a2071ff9fc",
+      "source": "Verbosity",
+      "translated": "Докладність"
+    },
+    {
+      "id": "native.apple.faf0ef05e1496de7",
+      "source": "Default",
+      "translated": "За замовчуванням"
+    },
+    {
       "id": "native.apple.e5524d5756a62744",
       "source": "Unable to Export Transcript",
       "translated": "Не вдалося експортувати транскрипт"
@@ -10814,9 +10794,9 @@
       "translated": "Над чим ви хотіли б попрацювати?"
     },
     {
-      "id": "native.apple.4da775013ac9b123",
-      "source": "The thread attaches once the gateway is ready.",
-      "translated": "Гілку буде підключено, щойно Gateway буде готовий."
+      "id": "native.apple.32179ce0b6d4543f",
+      "source": "The session attaches once the gateway is ready.",
+      "translated": "Сеанс під’єднається, щойно Gateway буде готовий."
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10859,9 +10839,14 @@
       "translated": "Новий чат у Worktree"
     },
     {
-      "id": "native.apple.003b25ddafeb18e9",
-      "source": "Threads…",
-      "translated": "Гілки…"
+      "id": "native.apple.ce6ebe91fc597015",
+      "source": "New Session Options…",
+      "translated": "Параметри нового сеансу…"
+    },
+    {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "Сеанси…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11024,14 +11009,14 @@
       "translated": "Створити"
     },
     {
-      "id": "native.apple.31d5c7287cfb3abe",
-      "source": "Delete Thread?",
-      "translated": "Видалити гілку?"
+      "id": "native.apple.f488b9caf6e51ac3",
+      "source": "Delete Session?",
+      "translated": "Видалити сеанс?"
     },
     {
-      "id": "native.apple.d3395564809f1120",
-      "source": "Delete Thread",
-      "translated": "Видалити гілку"
+      "id": "native.apple.8634b17be9b111bc",
+      "source": "Delete Session",
+      "translated": "Видалити сеанс"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11039,9 +11024,9 @@
       "translated": "Скасувати"
     },
     {
-      "id": "native.apple.092659256d26cb03",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "Це назавжди видалить гілку та її розшифрування."
+      "id": "native.apple.4a9568ac9b18d8d3",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "Це назавжди видалить сеанс і його стенограму."
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11069,9 +11054,9 @@
       "translated": "Нова група"
     },
     {
-      "id": "native.apple.683032464c497bbd",
-      "source": "Rename Thread",
-      "translated": "Перейменувати гілку"
+      "id": "native.apple.5bccdc23a1640895",
+      "source": "Rename Session",
+      "translated": "Перейменувати сеанс"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11079,9 +11064,9 @@
       "translated": "Назва групи"
     },
     {
-      "id": "native.apple.f887aa956588f237",
-      "source": "Thread name",
-      "translated": "Назва гілки"
+      "id": "native.apple.af789b2d2fda0f67",
+      "source": "Session name",
+      "translated": "Назва сеансу"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11119,14 +11104,14 @@
       "translated": "Агенти"
     },
     {
-      "id": "native.apple.7c8231b7b1ca480f",
-      "source": "Agent thread",
-      "translated": "Гілка агента"
+      "id": "native.apple.a3bde8045fe9224a",
+      "source": "Agent session",
+      "translated": "Сеанс агента"
     },
     {
-      "id": "native.apple.b3c553614f762a58",
-      "source": "Recent threads",
-      "translated": "Останні гілки"
+      "id": "native.apple.27f775de30b37ff8",
+      "source": "Recent sessions",
+      "translated": "Нещодавні сеанси"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11134,9 +11119,9 @@
       "translated": "Gateway офлайн"
     },
     {
-      "id": "native.apple.5aa32afda85064ea",
-      "source": "No recent threads",
-      "translated": "Немає останніх гілок"
+      "id": "native.apple.28c97cf23665ee01",
+      "source": "No recent sessions",
+      "translated": "Немає нещодавніх сеансів"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11234,14 +11219,14 @@
       "translated": "Скасувати"
     },
     {
-      "id": "native.apple.b6855cf19a50f477",
-      "source": "Threads",
-      "translated": "Гілки"
+      "id": "native.apple.9f2fd65953013b7c",
+      "source": "Sessions",
+      "translated": "Сеанси"
     },
     {
-      "id": "native.apple.9b1d0ef27a1333b0",
-      "source": "Archived threads",
-      "translated": "Архівовані гілки"
+      "id": "native.apple.0422818cc95d5071",
+      "source": "Archived sessions",
+      "translated": "Архівовані сеанси"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11249,34 +11234,34 @@
       "translated": "Показати архівовані"
     },
     {
-      "id": "native.apple.98167401c7267735",
-      "source": "Threads unavailable",
-      "translated": "Гілки недоступні"
+      "id": "native.apple.b272115c83f7ef58",
+      "source": "Sessions unavailable",
+      "translated": "Сеанси недоступні"
     },
     {
-      "id": "native.apple.4d28a7def2337b9f",
-      "source": "Loading archived threads",
-      "translated": "Завантаження архівованих гілок"
+      "id": "native.apple.54f8260c9b863087",
+      "source": "Loading archived sessions",
+      "translated": "Завантаження архівованих сеансів"
     },
     {
-      "id": "native.apple.777d7b706933bd7b",
-      "source": "Loading recent threads",
-      "translated": "Завантаження останніх гілок"
+      "id": "native.apple.9b305868873dade2",
+      "source": "Loading recent sessions",
+      "translated": "Завантаження нещодавніх сеансів"
     },
     {
-      "id": "native.apple.22f81ea94bef8410",
-      "source": "^[\\(count) thread](inflect: true)",
-      "translated": "^[\\(count) гілка](inflect: true)"
+      "id": "native.apple.207dad20d09f3160",
+      "source": "^[\\(count) session](inflect: true)",
+      "translated": "^[\\(count) сеанс](inflect: true)"
     },
     {
-      "id": "native.apple.1cad51e14db59bf9",
-      "source": "No archived threads",
-      "translated": "Немає архівованих гілок"
+      "id": "native.apple.1f4501a6bf2bae4c",
+      "source": "No archived sessions",
+      "translated": "Немає архівованих сеансів"
     },
     {
-      "id": "native.apple.18ef832d3a7ddcf8",
-      "source": "Archived threads will appear here.",
-      "translated": "Архівовані гілки з’являться тут."
+      "id": "native.apple.2a1ba7a5e1979c9e",
+      "source": "Archived sessions will appear here.",
+      "translated": "Архівовані сеанси з’являться тут."
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11359,9 +11344,9 @@
       "translated": "Поділитися надходженням"
     },
     {
-      "id": "native.apple.21d9208d86a4d1fe",
-      "source": "Loading threads",
-      "translated": "Завантаження гілок"
+      "id": "native.apple.2360d25fe6ae9946",
+      "source": "Loading sessions",
+      "translated": "Завантаження сеансів"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11369,19 +11354,19 @@
       "translated": "Отримання нещодавньої активності з Gateway."
     },
     {
-      "id": "native.apple.4be1f79aa2b230ff",
-      "source": "Threads unavailable",
-      "translated": "Гілки недоступні"
+      "id": "native.apple.c334f2e86702a7b8",
+      "source": "Sessions unavailable",
+      "translated": "Сеанси недоступні"
     },
     {
-      "id": "native.apple.98b348873556bc46",
-      "source": "No recent threads",
-      "translated": "Немає нещодавніх гілок"
+      "id": "native.apple.6cc6efb7a03960b6",
+      "source": "No recent sessions",
+      "translated": "Немає нещодавніх сеансів"
     },
     {
-      "id": "native.apple.7396d205574d279f",
-      "source": "Thread activity offline",
-      "translated": "Активність гілок офлайн"
+      "id": "native.apple.08483af2d043bee6",
+      "source": "Session activity offline",
+      "translated": "Активність сеансів офлайн"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11839,9 +11824,9 @@
       "translated": "Картка"
     },
     {
-      "id": "native.apple.c9ec1b0e18074d8a",
-      "source": "Open Thread",
-      "translated": "Відкрити гілку"
+      "id": "native.apple.93eeaedb2ff61043",
+      "source": "Open Session",
+      "translated": "Відкрити сесію"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13329,9 +13314,9 @@
       "translated": "За замовчуванням"
     },
     {
-      "id": "native.apple.f4ae5664c3eda95d",
-      "source": "Used for new Chat threads and Talk sessions.",
-      "translated": "Використовується для нових гілок чату та сеансів розмови."
+      "id": "native.apple.3de045f17ea3c6d0",
+      "source": "Used for new Chat and Talk sessions.",
+      "translated": "Використовується для нових сеансів Chat і Talk."
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15734,9 +15719,9 @@
       "translated": "Екземпляри"
     },
     {
-      "id": "native.apple.11fe8b9941954dfb",
-      "source": "Threads",
-      "translated": "Гілки"
+      "id": "native.apple.3579cf2750470a22",
+      "source": "Sessions",
+      "translated": "Сеанси"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19044,9 +19029,9 @@
       "translated": "Швидка команда Quick Chat"
     },
     {
-      "id": "native.apple.94dd793cd7d7d555",
-      "source": "Global shortcut that opens a floating chat bar for the main thread.",
-      "translated": "Глобальне скорочення, яке відкриває плаваючу панель чату для головної гілки."
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "Глобальна швидка команда, що відкриває плаваючу панель чату для основного сеансу."
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19624,9 +19609,9 @@
       "translated": "Критично"
     },
     {
-      "id": "native.apple.13f96467014cf344",
-      "source": "New Thread",
-      "translated": "Нова гілка"
+      "id": "native.apple.75102378a6775180",
+      "source": "New Session",
+      "translated": "Новий сеанс"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21914,9 +21899,9 @@
       "translated": "Немає нещодавніх повідомлень"
     },
     {
-      "id": "native.apple.3ec2afcbc298c673",
-      "source": "Threads",
-      "translated": "Гілки"
+      "id": "native.apple.1ff8aec0044934c3",
+      "source": "Sessions",
+      "translated": "Сеанси"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21924,9 +21909,9 @@
       "translated": "Перегляньте збережені кошики розмов, які CLI повторно використовує для контексту та лімітів частоти."
     },
     {
-      "id": "native.apple.14ccb32cd8ed1c81",
-      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
-      "translated": "Гілок ще немає. Вони з’являться після першого вхідного повідомлення або сигналу активності."
+      "id": "native.apple.bab897f3252b134c",
+      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
+      "translated": "Сеансів ще немає. Вони з’являться після першого вхідного повідомлення або heartbeat."
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -22009,9 +21994,9 @@
       "translated": "Схвалення виконання"
     },
     {
-      "id": "native.apple.52e37e3a44ae516c",
-      "source": "Threads",
-      "translated": "Гілки"
+      "id": "native.apple.64a6dc7d49e8fb57",
+      "source": "Sessions",
+      "translated": "Сеанси"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -23014,9 +22999,9 @@
       "translated": "Введи мене в курс справ"
     },
     {
-      "id": "native.apple.fc4ce810900ec0b6",
-      "source": "Summarize what happened in my threads since yesterday.",
-      "translated": "Підсумуй, що відбулося в моїх гілках із учорашнього дня."
+      "id": "native.apple.234ec45f4231edc4",
+      "source": "Summarize what happened in my sessions since yesterday.",
+      "translated": "Підсумуй, що відбулося в моїх сеансах від учора."
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23194,9 +23179,9 @@
       "translated": "Відкріпити модель"
     },
     {
-      "id": "native.apple.4edb66657f5aca1f",
-      "source": "Thread",
-      "translated": "Гілка"
+      "id": "native.apple.5dfc0700d8dff8de",
+      "source": "Session",
+      "translated": "Сеанс"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23359,51 +23344,6 @@
       "translated": "Віджет недоступний"
     },
     {
-      "id": "native.apple.d640691fd196f338",
-      "source": "Widget export failed",
-      "translated": "Не вдалося експортувати віджет"
-    },
-    {
-      "id": "native.apple.533c6e22a11e88de",
-      "source": "OK",
-      "translated": "ОК"
-    },
-    {
-      "id": "native.apple.e1fb28a2a9756402",
-      "source": "Copy image",
-      "translated": "Копіювати зображення"
-    },
-    {
-      "id": "native.apple.ebd7bc92e1b12235",
-      "source": "Save image…",
-      "translated": "Зберегти зображення…"
-    },
-    {
-      "id": "native.apple.742c46d4cf2db134",
-      "source": "Save image",
-      "translated": "Зберегти зображення"
-    },
-    {
-      "id": "native.apple.0589cce608418f90",
-      "source": "The widget image could not be captured.",
-      "translated": "Не вдалося зробити знімок віджета."
-    },
-    {
-      "id": "native.apple.dfe24e827fdbe9c5",
-      "source": "The widget image could not be copied.",
-      "translated": "Не вдалося скопіювати зображення віджета."
-    },
-    {
-      "id": "native.apple.9e611e3a80e71408",
-      "source": "The widget image could not be encoded as PNG.",
-      "translated": "Не вдалося закодувати зображення віджета у форматі PNG."
-    },
-    {
-      "id": "native.apple.9a6e8afbe24a262b",
-      "source": "The widget image could not be saved.",
-      "translated": "Не вдалося зберегти зображення віджета."
-    },
-    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23544,19 +23484,19 @@
       "translated": "Користувач"
     },
     {
-      "id": "native.apple.9d0cba09d92ee669",
-      "source": "This thread cannot be archived while it is active or running.",
-      "translated": "Цю гілку не можна архівувати, доки вона активна або виконується."
+      "id": "native.apple.b1cdcb906a43d5d6",
+      "source": "This session cannot be archived while it is active or running.",
+      "translated": "Цей сеанс не можна архівувати, доки він активний або виконується."
     },
     {
-      "id": "native.apple.8952a111a1075051",
-      "source": "The main thread cannot be deleted.",
-      "translated": "Головну гілку не можна видалити."
+      "id": "native.apple.5817e3f3dab1ee19",
+      "source": "The main session cannot be deleted.",
+      "translated": "Основний сеанс не можна видалити."
     },
     {
-      "id": "native.apple.90d0ccf80ca28717",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
-      "translated": "Видаліть вкладення або дочекайтеся доставки, перш ніж архівувати чи видаляти цю гілку."
+      "id": "native.apple.a6b8df3f18171c91",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
+      "translated": "Видаліть вкладення або дочекайтеся їх доставлення, перш ніж архівувати чи видаляти цей сеанс."
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23694,9 +23634,9 @@
       "translated": "Запуск завершено"
     },
     {
-      "id": "native.apple.bbccb4c8db5cac12",
-      "source": "Thread Info",
-      "translated": "Інформація про гілку"
+      "id": "native.apple.cd7c3095a22f80a9",
+      "source": "Session Info",
+      "translated": "Відомості про сеанс"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23729,9 +23669,9 @@
       "translated": "Додати групу"
     },
     {
-      "id": "native.apple.7b641fed5bace855",
-      "source": "Thread Groups",
-      "translated": "Групи гілок"
+      "id": "native.apple.23d628606fe0734f",
+      "source": "Session Groups",
+      "translated": "Групи сеансів"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23774,9 +23714,9 @@
       "translated": "Видалити групу"
     },
     {
-      "id": "native.apple.56401c79410a310d",
-      "source": "Threads in this group become ungrouped.",
-      "translated": "Гілки в цій групі буде вилучено з групи."
+      "id": "native.apple.b049c8a4d2805e08",
+      "source": "Sessions in this group become ungrouped.",
+      "translated": "Сеанси в цій групі більше не будуть згруповані."
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23789,9 +23729,9 @@
       "translated": "На цьому шлюзі немає доступних агентів."
     },
     {
-      "id": "native.apple.2d96aa7d3d12f85b",
-      "source": "New Thread Options",
-      "translated": "Параметри нової гілки"
+      "id": "native.apple.6c89f35d53506406",
+      "source": "New Session Options",
+      "translated": "Параметри нового сеансу"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23819,19 +23759,19 @@
       "translated": "Створити"
     },
     {
-      "id": "native.apple.87ef57319d1ddc85",
-      "source": "The thread could not be created.",
-      "translated": "Не вдалося створити гілку."
+      "id": "native.apple.795ba37f6782cf28",
+      "source": "The session could not be created.",
+      "translated": "Не вдалося створити сеанс."
     },
     {
-      "id": "native.apple.6bd91c435b69d638",
-      "source": "Search threads",
-      "translated": "Пошук гілок"
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "Пошук сеансів"
     },
     {
-      "id": "native.apple.6fde4bdf9d5b9191",
-      "source": "No Threads",
-      "translated": "Немає гілок"
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "Немає сеансів"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23839,29 +23779,29 @@
       "translated": "Немає результатів"
     },
     {
-      "id": "native.apple.a02fd99740d29bd3",
-      "source": "New Thread",
-      "translated": "Нова гілка"
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "Новий сеанс"
     },
     {
-      "id": "native.apple.b625801dd04b09f2",
-      "source": "New thread",
-      "translated": "Нова гілка"
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "Новий сеанс"
     },
     {
-      "id": "native.apple.851be81fcc933608",
-      "source": "New thread options",
-      "translated": "Параметри нової гілки"
+      "id": "native.apple.2ef0e34db02ad255",
+      "source": "New session options",
+      "translated": "Параметри нового сеансу"
     },
     {
-      "id": "native.apple.9ce8a4aba7b444b2",
-      "source": "Rename Thread",
-      "translated": "Перейменувати гілку"
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "Перейменувати сеанс"
     },
     {
-      "id": "native.apple.1dd067c44511c7f0",
-      "source": "Thread name",
-      "translated": "Назва гілки"
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "Назва сеансу"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23874,14 +23814,14 @@
       "translated": "Скасувати"
     },
     {
-      "id": "native.apple.618073d6ab3f2721",
-      "source": "Delete Thread",
-      "translated": "Видалити гілку"
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "Видалити сеанс"
     },
     {
-      "id": "native.apple.10a5e72bba3cbccc",
-      "source": "The thread and its transcript are removed from the gateway.",
-      "translated": "Гілку та її стенограму буде видалено з Gateway."
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "Сеанс і його розшифровку буде видалено з Gateway."
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23889,14 +23829,14 @@
       "translated": "Видалити «%@»?"
     },
     {
-      "id": "native.apple.ac71e3b2aa496a2c",
-      "source": "Thread running",
-      "translated": "Гілка виконується"
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "Сеанс виконується"
     },
     {
-      "id": "native.apple.c775e87f997278b2",
-      "source": "Thread failed",
-      "translated": "Помилка гілки"
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "Помилка сеансу"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23954,9 +23894,9 @@
       "translated": "Копіювати ключ сесії"
     },
     {
-      "id": "native.apple.f4998cfb572f23ff",
-      "source": "Delete Thread…",
-      "translated": "Видалити гілку…"
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "Видалити сесію…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23969,9 +23909,9 @@
       "translated": "Підключення…"
     },
     {
-      "id": "native.apple.8802e9576ffd0f65",
-      "source": "Retry thread groups",
-      "translated": "Повторити завантаження груп гілок"
+      "id": "native.apple.79f708b3bc1d3a6c",
+      "source": "Retry session groups",
+      "translated": "Повторити завантаження груп сеансів"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23994,24 +23934,24 @@
       "translated": "Область"
     },
     {
-      "id": "native.apple.b313b80def4bda52",
-      "source": "Search threads",
-      "translated": "Пошук гілок"
+      "id": "native.apple.2c37581c7b88f741",
+      "source": "Search sessions",
+      "translated": "Пошук сеансів"
     },
     {
-      "id": "native.apple.c0cc6acc36f413ce",
-      "source": "Threads",
-      "translated": "Гілки"
+      "id": "native.apple.43be8a2336e42faf",
+      "source": "Sessions",
+      "translated": "Сесії"
     },
     {
-      "id": "native.apple.854d3928fe5a557c",
-      "source": "Rename Thread",
-      "translated": "Перейменувати гілку"
+      "id": "native.apple.0b379cdfcbd3247f",
+      "source": "Rename Session",
+      "translated": "Перейменувати сеанс"
     },
     {
-      "id": "native.apple.9d0d3f20096cc4da",
-      "source": "Thread name",
-      "translated": "Назва гілки"
+      "id": "native.apple.54b6fbd9e41db009",
+      "source": "Session name",
+      "translated": "Назва сеансу"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -24019,19 +23959,19 @@
       "translated": "Скасувати"
     },
     {
-      "id": "native.apple.dc00eb94f33bae15",
-      "source": "Delete selected threads?",
-      "translated": "Видалити вибрані гілки?"
+      "id": "native.apple.751e0f6b81cd374a",
+      "source": "Delete selected sessions?",
+      "translated": "Видалити вибрані сеанси?"
     },
     {
-      "id": "native.apple.2053fc9f74dc3158",
-      "source": "Delete Threads",
-      "translated": "Видалити гілки"
+      "id": "native.apple.aa679276581b0058",
+      "source": "Delete Sessions",
+      "translated": "Видалити сеанси"
     },
     {
-      "id": "native.apple.0970247871a834a0",
-      "source": "Each selected thread and its transcript will be removed from the gateway.",
-      "translated": "Кожну вибрану гілку та її історію буде видалено з Gateway."
+      "id": "native.apple.f837129cbee23297",
+      "source": "Each selected session and its transcript will be removed from the gateway.",
+      "translated": "Кожен вибраний сеанс і його стенограму буде видалено з Gateway."
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -24039,9 +23979,9 @@
       "translated": "Групи"
     },
     {
-      "id": "native.apple.6f8acab2256728b5",
-      "source": "Manage thread groups",
-      "translated": "Керувати групами гілок"
+      "id": "native.apple.64013cfee5e25305",
+      "source": "Manage session groups",
+      "translated": "Керувати групами сеансів"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -24054,14 +23994,14 @@
       "translated": "Вибрати"
     },
     {
-      "id": "native.apple.692972314d04b184",
-      "source": "No archived threads",
-      "translated": "Немає архівованих гілок"
+      "id": "native.apple.b67eaecec1b423ac",
+      "source": "No archived sessions",
+      "translated": "Немає заархівованих сеансів"
     },
     {
-      "id": "native.apple.d6a4b5711dcd26e7",
-      "source": "No threads found",
-      "translated": "Гілок не знайдено"
+      "id": "native.apple.b2435a79abf0c794",
+      "source": "No sessions found",
+      "translated": "Сеансів не знайдено"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24229,16 +24169,6 @@
       "translated": "Відкрити повне повідомлення"
     },
     {
-      "id": "native.apple.002bfcede229ad4b",
-      "source": "Rewind to Here",
-      "translated": "Перемотати сюди"
-    },
-    {
-      "id": "native.apple.14df2e4997689fb3",
-      "source": "Fork from Here",
-      "translated": "Створити відгалуження звідси"
-    },
-    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "Відповісти"
@@ -24324,9 +24254,9 @@
       "translated": "Видаліть вкладення або дочекайтеся завершення доставки, перш ніж починати новий чат."
     },
     {
-      "id": "native.apple.e0f045151c8d3137",
-      "source": "Gateway changed before the thread operation started.",
-      "translated": "Gateway змінився до початку операції з гілкою."
+      "id": "native.apple.980f552bb0f96c0f",
+      "source": "Gateway changed before the session operation started.",
+      "translated": "Gateway змінився до початку операції із сеансом."
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24334,9 +24264,9 @@
       "translated": "Видаліть вкладення або зачекайте на завершення доставлення, перш ніж перемикати чати."
     },
     {
-      "id": "native.apple.0a5c4e15466c3acc",
-      "source": "Clear this thread's history?",
-      "translated": "Очистити історію цієї гілки?"
+      "id": "native.apple.87ba543b42696b92",
+      "source": "Clear this session's history?",
+      "translated": "Очистити історію цього сеансу?"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24349,14 +24279,14 @@
       "translated": "Це скине розмову для %@. Ключ сеансу залишиться незмінним."
     },
     {
-      "id": "native.apple.67ac221dbe7179f0",
-      "source": "Rename Thread",
-      "translated": "Перейменувати гілку"
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "Перейменувати сесію"
     },
     {
-      "id": "native.apple.cf0f7e049603f518",
-      "source": "Thread name",
-      "translated": "Назва гілки"
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "Назва сесії"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24374,9 +24304,9 @@
       "translated": "Експортувати стенограму"
     },
     {
-      "id": "native.apple.c0ada47504425f23",
-      "source": "Threads",
-      "translated": "Гілки"
+      "id": "native.apple.4af0f566d39d7041",
+      "source": "Sessions",
+      "translated": "Сеанси"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24449,14 +24379,14 @@
       "translated": "За замовчуванням"
     },
     {
-      "id": "native.apple.1a765291943599e5",
-      "source": "New Thread",
-      "translated": "Нова гілка"
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "Нова сесія"
     },
     {
-      "id": "native.apple.c7a3a6d5e43dd98f",
-      "source": "New Thread Options…",
-      "translated": "Параметри нової гілки…"
+      "id": "native.apple.a7119fbf9d25df5e",
+      "source": "New Session Options…",
+      "translated": "Параметри нового сеансу…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24464,19 +24394,19 @@
       "translated": "Оновити"
     },
     {
-      "id": "native.apple.0e710b81808e5dcf",
-      "source": "Threads…",
-      "translated": "Гілки…"
+      "id": "native.apple.2bcff4a8fa503739",
+      "source": "Sessions…",
+      "translated": "Сеанси…"
     },
     {
-      "id": "native.apple.faad8f92b6bef166",
-      "source": "Rename Thread…",
-      "translated": "Перейменувати гілку…"
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "Перейменувати сесію…"
     },
     {
-      "id": "native.apple.23b61d6cd26ac112",
-      "source": "Fork",
-      "translated": "Відгалузити"
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "Створити відгалуження сесії"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24534,24 +24464,24 @@
       "translated": "Очистити історію…"
     },
     {
-      "id": "native.apple.8b4f1c5107ea8a0e",
-      "source": "Thread",
-      "translated": "Гілка"
+      "id": "native.apple.920fe8a7a33f9e92",
+      "source": "Session",
+      "translated": "Сесія"
     },
     {
-      "id": "native.apple.4d7750c9bf699469",
-      "source": "Thread actions",
-      "translated": "Дії з гілкою"
+      "id": "native.apple.185a401f78328b0f",
+      "source": "Session actions",
+      "translated": "Дії сесії"
     },
     {
-      "id": "native.apple.bb2f22cc43c97f8e",
-      "source": "Thread cost %@",
-      "translated": "Вартість гілки %@"
+      "id": "native.apple.9f9dedf599b2619b",
+      "source": "Session cost %@",
+      "translated": "Вартість сеансу: %@"
     },
     {
-      "id": "native.apple.6239ced0b86e86f8",
-      "source": "Compact Thread",
-      "translated": "Стиснути гілку"
+      "id": "native.apple.f0a4720df5f5f403",
+      "source": "Compact Session",
+      "translated": "Стиснути сесію"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/vi.json
+++ b/apps/.i18n/native/vi.json
@@ -1429,9 +1429,9 @@
       "translated": "Trò chuyện hoặc đọc chính tả với OpenClaw"
     },
     {
-      "id": "native.android.e2cf5a38587382cb",
-      "source": "Browse Threads",
-      "translated": "Duyệt luồng"
+      "id": "native.android.5876e15e5e92fd45",
+      "source": "Browse Sessions",
+      "translated": "Duyệt các phiên"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "Không tìm thấy tác vụ nào"
     },
     {
-      "id": "native.android.bc70a4ac965b82ba",
-      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
-      "translated": "Hãy thử Trò chuyện, Giọng nói, Luồng, Nhà cung cấp hoặc Cài đặt."
+      "id": "native.android.48ad0ae0e930e02b",
+      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
+      "translated": "Thử Chat, Voice, Sessions, Providers hoặc Settings."
     },
     {
-      "id": "native.android.670121e54dbe286f",
-      "source": "Threads",
-      "translated": "Luồng"
+      "id": "native.android.d4fbd1ee4f55a5db",
+      "source": "Sessions",
+      "translated": "Phiên"
     },
     {
-      "id": "native.android.d38be650b1bce4a0",
-      "source": "Connect the Gateway to search threads.",
-      "translated": "Kết nối Gateway để tìm kiếm luồng."
+      "id": "native.android.207c2170504e99e6",
+      "source": "Connect the Gateway to search sessions.",
+      "translated": "Kết nối Gateway để tìm kiếm phiên."
     },
     {
-      "id": "native.android.3d7754721f776ef8",
-      "source": "No matching threads yet.",
-      "translated": "Chưa có luồng phù hợp."
+      "id": "native.android.25d2c2d792c952fe",
+      "source": "No matching sessions yet.",
+      "translated": "Chưa có phiên phù hợp."
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "Trợ lý đang làm việc"
     },
     {
-      "id": "native.android.9a839f6e3e05a744",
-      "source": "OpenClaw thread",
-      "translated": "Luồng OpenClaw"
+      "id": "native.android.8f8384286317f5c9",
+      "source": "OpenClaw session",
+      "translated": "Phiên OpenClaw"
     },
     {
-      "id": "native.android.d83f82a1e4a5ed99",
-      "source": "Open thread",
-      "translated": "Mở luồng"
+      "id": "native.android.15799e57704b20c6",
+      "source": "Open session",
+      "translated": "Mở phiên"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "Không có nhà cung cấp nào sẵn sàng"
     },
     {
-      "id": "native.android.8a1c5365c0538908",
-      "source": "Main thread",
-      "translated": "Luồng chính"
+      "id": "native.android.73e6ab1a168fd381",
+      "source": "Main session",
+      "translated": "Phiên chính"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.a5845742daecb4ba",
-      "source": "Threads",
-      "translated": "Luồng"
+      "id": "native.android.0e3157c15c56944f",
+      "source": "Sessions",
+      "translated": "Phiên"
     },
     {
-      "id": "native.android.439b324280869527",
-      "source": "Focus thread search",
-      "translated": "Tập trung vào ô tìm kiếm luồng"
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "Tập trung vào ô tìm kiếm phiên"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "Đã lưu trữ"
     },
     {
-      "id": "native.android.03981341841b04ac",
-      "source": "Search threads",
-      "translated": "Tìm kiếm luồng"
+      "id": "native.android.b9cf34c137e4cf03",
+      "source": "Search sessions",
+      "translated": "Tìm kiếm phiên"
     },
     {
-      "id": "native.android.99570c528a41fa72",
-      "source": "Clear thread search",
-      "translated": "Xóa nội dung tìm kiếm luồng"
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "Xóa nội dung tìm kiếm phiên"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "Cũ nhất trước"
     },
     {
-      "id": "native.android.fd67be543e321cc9",
-      "source": "Toggle thread layout",
-      "translated": "Chuyển đổi bố cục luồng"
+      "id": "native.android.c6bf8751e2a7f5c7",
+      "source": "Toggle session layout",
+      "translated": "Chuyển đổi bố cục phiên"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "Bố cục: Chi tiết"
     },
     {
-      "id": "native.android.ebd17565e0ffd8eb",
-      "source": "Searching threads",
-      "translated": "Đang tìm kiếm luồng"
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "Đang tìm kiếm phiên"
     },
     {
-      "id": "native.android.472d46ae8669f860",
-      "source": "No matching threads",
-      "translated": "Không có luồng phù hợp"
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "Không có phiên phù hợp"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "Bắt đầu trò chuyện"
     },
     {
-      "id": "native.android.ff81ad1bee00d384",
-      "source": "Current thread",
-      "translated": "Luồng hiện tại"
+      "id": "native.android.f10d4df7cbc6df4f",
+      "source": "Current session",
+      "translated": "Phiên hiện tại"
     },
     {
-      "id": "native.android.fc145645b9620e57",
-      "source": "OpenClaw thread",
-      "translated": "Luồng OpenClaw"
+      "id": "native.android.8f0482425838ae64",
+      "source": "OpenClaw session",
+      "translated": "Phiên OpenClaw"
     },
     {
-      "id": "native.android.71cbb8dde8bf138b",
-      "source": "Rename thread",
-      "translated": "Đổi tên luồng"
+      "id": "native.android.786774c8a76e50d7",
+      "source": "Rename session",
+      "translated": "Đổi tên phiên"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "Xóa nhóm?"
     },
     {
-      "id": "native.android.691e92cfe5cf106e",
-      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "Các luồng trong \"$group\" được giữ lại và chuyển về Chưa nhóm."
+      "id": "native.android.3455fc2f77d564e3",
+      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "Các phiên trong \"$group\" được giữ lại và chuyển về Chưa nhóm."
     },
     {
-      "id": "native.android.d87a8217ab56999b",
-      "source": "Delete thread?",
-      "translated": "Xóa luồng?"
+      "id": "native.android.4805fb9d6623e8c0",
+      "source": "Delete session?",
+      "translated": "Xóa phiên?"
     },
     {
-      "id": "native.android.930de97ff47113a8",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "Thao tác này sẽ xóa vĩnh viễn luồng và bản ghi của luồng."
+      "id": "native.android.0c3283a2b2445eae",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "Thao tác này sẽ xóa vĩnh viễn phiên và bản ghi cuộc trò chuyện của phiên đó."
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "Chưa phân nhóm"
     },
     {
-      "id": "native.android.8e21a70428def6e0",
-      "source": "No threads yet",
-      "translated": "Chưa có luồng nào"
+      "id": "native.android.db243d71d056afa4",
+      "source": "No sessions yet",
+      "translated": "Chưa có phiên nào"
     },
     {
-      "id": "native.android.cda4c5ad8b17e394",
-      "source": "No current thread",
-      "translated": "Không có luồng hiện tại"
+      "id": "native.android.5b4eee6a8092925e",
+      "source": "No current session",
+      "translated": "Không có phiên hiện tại"
     },
     {
-      "id": "native.android.be84f061047aa2da",
-      "source": "No archived threads",
-      "translated": "Không có luồng đã lưu trữ"
+      "id": "native.android.acbcc9c9ea53d8c0",
+      "source": "No archived sessions",
+      "translated": "Không có phiên đã lưu trữ"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "Bắt đầu một cuộc trò chuyện mới và cuộc trò chuyện đó sẽ hiển thị ở đây."
     },
     {
-      "id": "native.android.f289d03e1d3eee98",
-      "source": "Open Chat to start or resume the current thread.",
-      "translated": "Mở Chat để bắt đầu hoặc tiếp tục luồng hiện tại."
+      "id": "native.android.56fcd605dc7be3c0",
+      "source": "Open Chat to start or resume the current session.",
+      "translated": "Mở Trò chuyện để bắt đầu hoặc tiếp tục phiên hiện tại."
     },
     {
-      "id": "native.android.504b71386e76c6ae",
-      "source": "Archived threads will show up here.",
-      "translated": "Các luồng đã lưu trữ sẽ xuất hiện tại đây."
+      "id": "native.android.085515989f8a2022",
+      "source": "Archived sessions will show up here.",
+      "translated": "Các phiên đã lưu trữ sẽ xuất hiện tại đây."
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days} ngày"
     },
     {
-      "id": "native.android.ee4c727cdafbe963",
-      "source": "Main thread",
-      "translated": "Luồng chính"
+      "id": "native.android.3d4fa07acbc015c5",
+      "source": "Main session",
+      "translated": "Phiên chính"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway đang chờ xử lý"
     },
     {
-      "id": "native.android.da78209effb11cfd",
-      "source": "Thread Activity",
-      "translated": "Hoạt động của luồng"
+      "id": "native.android.2d8d049afe99f751",
+      "source": "Session Activity",
+      "translated": "Hoạt động phiên"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "Các yêu cầu phê duyệt exec sẽ xuất hiện tại đây khi điện thoại này được kết nối."
     },
     {
-      "id": "native.android.f615712dfb56319a",
-      "source": "Thread activity",
-      "translated": "Hoạt động của luồng"
+      "id": "native.android.dc3e7ca5a491103a",
+      "source": "Session activity",
+      "translated": "Hoạt động phiên"
     },
     {
-      "id": "native.android.6c93973c13db43ae",
-      "source": "Chat tool calls waiting in the active thread remain visible here.",
-      "translated": "Các lệnh gọi công cụ Chat đang chờ trong luồng hoạt động vẫn hiển thị tại đây."
+      "id": "native.android.8551e02b060bd7d8",
+      "source": "Chat tool calls waiting in the active session remain visible here.",
+      "translated": "Các lệnh gọi công cụ trò chuyện đang chờ trong phiên đang hoạt động vẫn hiển thị tại đây."
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,11 +4294,6 @@
       "translated": "Thiết lập nhà cung cấp Talk"
     },
     {
-      "id": "native.android.23b638094c34b916",
-      "source": "Microphone",
-      "translated": "Micrô"
-    },
-    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "Kiểm tra âm thanh"
@@ -4342,66 +4337,6 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "Xong"
-    },
-    {
-      "id": "native.android.8d9ecdfdd916b780",
-      "source": "Automatic",
-      "translated": "Tự động"
-    },
-    {
-      "id": "native.android.c1626a6700a570f6",
-      "source": "Preferred microphone unavailable; using automatic routing.",
-      "translated": "Micrô ưu tiên không khả dụng; đang sử dụng định tuyến tự động."
-    },
-    {
-      "id": "native.android.820bc5d0ce571d8b",
-      "source": "Prioritizes connected Bluetooth microphones.",
-      "translated": "Ưu tiên micrô Bluetooth đã kết nối."
-    },
-    {
-      "id": "native.android.11e48038d5e8bff6",
-      "source": "Preferred microphone",
-      "translated": "Micrô ưu tiên"
-    },
-    {
-      "id": "native.android.eaa4d7563a46d307",
-      "source": "Unavailable",
-      "translated": "Không khả dụng"
-    },
-    {
-      "id": "native.android.9f5ebf17eb405ba8",
-      "source": "Next session",
-      "translated": "Phiên tiếp theo"
-    },
-    {
-      "id": "native.android.8c4e91f53928efb2",
-      "source": "Built-in microphone",
-      "translated": "Micrô tích hợp"
-    },
-    {
-      "id": "native.android.14b613cb6e2446b4",
-      "source": "Bluetooth microphone",
-      "translated": "Micrô Bluetooth"
-    },
-    {
-      "id": "native.android.c885247b2d7ce271",
-      "source": "Bluetooth LE microphone",
-      "translated": "Micrô Bluetooth LE"
-    },
-    {
-      "id": "native.android.b6a4e674c5fb441a",
-      "source": "Wired headset microphone",
-      "translated": "Micrô tai nghe có dây"
-    },
-    {
-      "id": "native.android.9c8becb3b0fb5a90",
-      "source": "USB microphone",
-      "translated": "Micrô USB"
-    },
-    {
-      "id": "native.android.ba46258fadec7a39",
-      "source": "External microphone",
-      "translated": "Micrô ngoài"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5139,9 +5074,9 @@
       "translated": "Kiểm tra"
     },
     {
-      "id": "native.android.c971506716c96e91",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
-      "translated": "OpenClaw biến điện thoại này thành một giao diện điều khiển di động gọn gàng cho các luồng, giọng nói, nhà cung cấp và Gateway."
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw biến điện thoại này thành một giao diện lệnh di động gọn gàng cho các phiên, giọng nói, nhà cung cấp và Gateway."
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5689,9 +5624,9 @@
       "translated": "Cài đặt Talk"
     },
     {
-      "id": "native.android.36f78c8c85dc283f",
-      "source": "Recent Threads",
-      "translated": "Luồng gần đây"
+      "id": "native.android.73f07a5d54915259",
+      "source": "Recent Sessions",
+      "translated": "Phiên gần đây"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5749,14 +5684,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% đang trực tuyến"
     },
     {
-      "id": "native.android.57177017a6a93826",
-      "source": "Threads",
-      "translated": "Luồng"
+      "id": "native.android.16c3425d3a594481",
+      "source": "Sessions",
+      "translated": "Phiên"
     },
     {
-      "id": "native.android.43320b54a68b00a1",
-      "source": "No recent threads",
-      "translated": "Không có luồng gần đây"
+      "id": "native.android.a5c0f8b3112aa58c",
+      "source": "No recent sessions",
+      "translated": "Không có phiên gần đây"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5794,14 +5729,14 @@
       "translated": "Đang hoạt động · $pendingRunCount lượt chạy đang hoạt động"
     },
     {
-      "id": "native.android.e24db059480f1e6a",
-      "source": "Monitoring · 1 thread",
-      "translated": "Đang giám sát · 1 luồng"
+      "id": "native.android.2c89da708b12a522",
+      "source": "Monitoring · 1 session",
+      "translated": "Đang giám sát · 1 phiên"
     },
     {
-      "id": "native.android.5a475f37d80e02bc",
-      "source": "Monitoring · $sessionCount threads",
-      "translated": "Đang giám sát · $sessionCount luồng"
+      "id": "native.android.8b6ee382dcb64e1f",
+      "source": "Monitoring · $sessionCount sessions",
+      "translated": "Đang giám sát · $sessionCount phiên"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5834,9 +5769,9 @@
       "translated": "Nhà cung cấp"
     },
     {
-      "id": "native.android.358c5e0e838d5423",
-      "source": "Open thread",
-      "translated": "Mở luồng"
+      "id": "native.android.a65477861c7203aa",
+      "source": "Open session",
+      "translated": "Mở phiên"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6259,9 +6194,9 @@
       "translated": "${days} ngày"
     },
     {
-      "id": "native.android.28a1a1acc5a0959f",
-      "source": "Main thread",
-      "translated": "Luồng chính"
+      "id": "native.android.22d755834386db07",
+      "source": "Main session",
+      "translated": "Phiên chính"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6942,16 +6877,6 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "Bật tiếng"
-    },
-    {
-      "id": "native.android.cb608d82c5b3352a",
-      "source": "Back camera",
-      "translated": "Camera sau"
-    },
-    {
-      "id": "native.android.e89a0e780eed2e1e",
-      "source": "Front camera",
-      "translated": "Camera trước"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7759,9 +7684,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.0c74bc30a994dd33",
-      "source": "Loading thread",
-      "translated": "Đang tải luồng"
+      "id": "native.android.882cc14a58e7e105",
+      "source": "Loading session",
+      "translated": "Đang tải phiên"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7804,14 +7729,14 @@
       "translated": "Cập nhật thông tin cho tôi"
     },
     {
-      "id": "native.android.cf40df9739f78f27",
-      "source": "Summarize recent threads and next steps.",
-      "translated": "Tóm tắt các luồng gần đây và các bước tiếp theo."
+      "id": "native.android.1e5add56e48c99f9",
+      "source": "Summarize recent sessions and next steps.",
+      "translated": "Tóm tắt các phiên gần đây và những bước tiếp theo."
     },
     {
-      "id": "native.android.ebe49a8b8df80bd3",
-      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
-      "translated": "Tóm tắt cho tôi các luồng OpenClaw gần đây và đề xuất các bước tiếp theo."
+      "id": "native.android.06d515351bb79576",
+      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
+      "translated": "Cập nhật cho tôi về các phiên OpenClaw gần đây và đề xuất những bước tiếp theo."
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8149,9 +8074,9 @@
       "translated": "Đã kết nối"
     },
     {
-      "id": "native.android.6cf5d6fa8a4186d5",
-      "source": "Threads",
-      "translated": "Luồng"
+      "id": "native.android.81931886b9caf3ab",
+      "source": "Sessions",
+      "translated": "Phiên"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,6 +10719,61 @@
       "translated": "Chi tiết tác vụ"
     },
     {
+      "id": "native.apple.29cacb53ea5e77fc",
+      "source": "Pinned",
+      "translated": "Đã ghim"
+    },
+    {
+      "id": "native.apple.940062cfdce9211b",
+      "source": "Recent",
+      "translated": "Gần đây"
+    },
+    {
+      "id": "native.apple.a0980128426308a9",
+      "source": "Model",
+      "translated": "Mô hình"
+    },
+    {
+      "id": "native.apple.9520e60f21535dde",
+      "source": "Thinking",
+      "translated": "Suy luận"
+    },
+    {
+      "id": "native.apple.8b321f3ffce97429",
+      "source": "Fast",
+      "translated": "Nhanh"
+    },
+    {
+      "id": "native.apple.989b70d64e328d55",
+      "source": "Default (inherited)",
+      "translated": "Mặc định (kế thừa)"
+    },
+    {
+      "id": "native.apple.f4114e73b07eb9ae",
+      "source": "Off",
+      "translated": "Tắt"
+    },
+    {
+      "id": "native.apple.7ed231b28d16312f",
+      "source": "On",
+      "translated": "Bật"
+    },
+    {
+      "id": "native.apple.412a74802320a037",
+      "source": "Full",
+      "translated": "Đầy đủ"
+    },
+    {
+      "id": "native.apple.299f21a2071ff9fc",
+      "source": "Verbosity",
+      "translated": "Mức độ chi tiết"
+    },
+    {
+      "id": "native.apple.faf0ef05e1496de7",
+      "source": "Default",
+      "translated": "Mặc định"
+    },
+    {
       "id": "native.apple.e5524d5756a62744",
       "source": "Unable to Export Transcript",
       "translated": "Không thể xuất bản ghi cuộc trò chuyện"
@@ -10814,9 +10794,9 @@
       "translated": "Bạn muốn làm việc gì?"
     },
     {
-      "id": "native.apple.4da775013ac9b123",
-      "source": "The thread attaches once the gateway is ready.",
-      "translated": "Luồng sẽ được đính kèm khi Gateway sẵn sàng."
+      "id": "native.apple.32179ce0b6d4543f",
+      "source": "The session attaches once the gateway is ready.",
+      "translated": "Phiên sẽ được đính kèm khi gateway sẵn sàng."
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10859,9 +10839,14 @@
       "translated": "Trò chuyện mới trong Worktree"
     },
     {
-      "id": "native.apple.003b25ddafeb18e9",
-      "source": "Threads…",
-      "translated": "Luồng…"
+      "id": "native.apple.ce6ebe91fc597015",
+      "source": "New Session Options…",
+      "translated": "Tùy chọn phiên mới…"
+    },
+    {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "Phiên…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11024,14 +11009,14 @@
       "translated": "Tạo"
     },
     {
-      "id": "native.apple.31d5c7287cfb3abe",
-      "source": "Delete Thread?",
-      "translated": "Xóa luồng?"
+      "id": "native.apple.f488b9caf6e51ac3",
+      "source": "Delete Session?",
+      "translated": "Xóa phiên?"
     },
     {
-      "id": "native.apple.d3395564809f1120",
-      "source": "Delete Thread",
-      "translated": "Xóa luồng"
+      "id": "native.apple.8634b17be9b111bc",
+      "source": "Delete Session",
+      "translated": "Xóa phiên"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11039,9 +11024,9 @@
       "translated": "Hủy"
     },
     {
-      "id": "native.apple.092659256d26cb03",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "Thao tác này sẽ xóa vĩnh viễn luồng và bản ghi của luồng."
+      "id": "native.apple.4a9568ac9b18d8d3",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "Thao tác này sẽ xóa vĩnh viễn phiên và bản ghi của phiên đó."
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11069,9 +11054,9 @@
       "translated": "Nhóm mới"
     },
     {
-      "id": "native.apple.683032464c497bbd",
-      "source": "Rename Thread",
-      "translated": "Đổi tên luồng"
+      "id": "native.apple.5bccdc23a1640895",
+      "source": "Rename Session",
+      "translated": "Đổi tên phiên"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11079,9 +11064,9 @@
       "translated": "Tên nhóm"
     },
     {
-      "id": "native.apple.f887aa956588f237",
-      "source": "Thread name",
-      "translated": "Tên luồng"
+      "id": "native.apple.af789b2d2fda0f67",
+      "source": "Session name",
+      "translated": "Tên phiên"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11119,14 +11104,14 @@
       "translated": "Tác tử"
     },
     {
-      "id": "native.apple.7c8231b7b1ca480f",
-      "source": "Agent thread",
-      "translated": "Luồng tác nhân"
+      "id": "native.apple.a3bde8045fe9224a",
+      "source": "Agent session",
+      "translated": "Phiên tác tử"
     },
     {
-      "id": "native.apple.b3c553614f762a58",
-      "source": "Recent threads",
-      "translated": "Luồng gần đây"
+      "id": "native.apple.27f775de30b37ff8",
+      "source": "Recent sessions",
+      "translated": "Phiên gần đây"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11134,9 +11119,9 @@
       "translated": "Gateway ngoại tuyến"
     },
     {
-      "id": "native.apple.5aa32afda85064ea",
-      "source": "No recent threads",
-      "translated": "Không có luồng gần đây"
+      "id": "native.apple.28c97cf23665ee01",
+      "source": "No recent sessions",
+      "translated": "Không có phiên gần đây"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11234,14 +11219,14 @@
       "translated": "Hủy"
     },
     {
-      "id": "native.apple.b6855cf19a50f477",
-      "source": "Threads",
-      "translated": "Luồng"
+      "id": "native.apple.9f2fd65953013b7c",
+      "source": "Sessions",
+      "translated": "Phiên"
     },
     {
-      "id": "native.apple.9b1d0ef27a1333b0",
-      "source": "Archived threads",
-      "translated": "Luồng đã lưu trữ"
+      "id": "native.apple.0422818cc95d5071",
+      "source": "Archived sessions",
+      "translated": "Các phiên đã lưu trữ"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11249,34 +11234,34 @@
       "translated": "Hiển thị mục đã lưu trữ"
     },
     {
-      "id": "native.apple.98167401c7267735",
-      "source": "Threads unavailable",
-      "translated": "Không thể truy cập các luồng"
+      "id": "native.apple.b272115c83f7ef58",
+      "source": "Sessions unavailable",
+      "translated": "Phiên không khả dụng"
     },
     {
-      "id": "native.apple.4d28a7def2337b9f",
-      "source": "Loading archived threads",
-      "translated": "Đang tải các luồng đã lưu trữ"
+      "id": "native.apple.54f8260c9b863087",
+      "source": "Loading archived sessions",
+      "translated": "Đang tải các phiên đã lưu trữ"
     },
     {
-      "id": "native.apple.777d7b706933bd7b",
-      "source": "Loading recent threads",
-      "translated": "Đang tải các luồng gần đây"
+      "id": "native.apple.9b305868873dade2",
+      "source": "Loading recent sessions",
+      "translated": "Đang tải các phiên gần đây"
     },
     {
-      "id": "native.apple.22f81ea94bef8410",
-      "source": "^[\\(count) thread](inflect: true)",
-      "translated": "^[\\(count) luồng](inflect: true)"
+      "id": "native.apple.207dad20d09f3160",
+      "source": "^[\\(count) session](inflect: true)",
+      "translated": "^[\\(count) phiên](inflect: true)"
     },
     {
-      "id": "native.apple.1cad51e14db59bf9",
-      "source": "No archived threads",
-      "translated": "Không có luồng đã lưu trữ"
+      "id": "native.apple.1f4501a6bf2bae4c",
+      "source": "No archived sessions",
+      "translated": "Không có phiên nào đã lưu trữ"
     },
     {
-      "id": "native.apple.18ef832d3a7ddcf8",
-      "source": "Archived threads will appear here.",
-      "translated": "Các luồng đã lưu trữ sẽ xuất hiện tại đây."
+      "id": "native.apple.2a1ba7a5e1979c9e",
+      "source": "Archived sessions will appear here.",
+      "translated": "Các phiên đã lưu trữ sẽ xuất hiện tại đây."
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11359,9 +11344,9 @@
       "translated": "Chia sẻ đầu vào"
     },
     {
-      "id": "native.apple.21d9208d86a4d1fe",
-      "source": "Loading threads",
-      "translated": "Đang tải các luồng"
+      "id": "native.apple.2360d25fe6ae9946",
+      "source": "Loading sessions",
+      "translated": "Đang tải phiên"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11369,19 +11354,19 @@
       "translated": "Đang lấy hoạt động gần đây từ gateway."
     },
     {
-      "id": "native.apple.4be1f79aa2b230ff",
-      "source": "Threads unavailable",
-      "translated": "Không thể truy cập các luồng"
+      "id": "native.apple.c334f2e86702a7b8",
+      "source": "Sessions unavailable",
+      "translated": "Phiên không khả dụng"
     },
     {
-      "id": "native.apple.98b348873556bc46",
-      "source": "No recent threads",
-      "translated": "Không có luồng gần đây"
+      "id": "native.apple.6cc6efb7a03960b6",
+      "source": "No recent sessions",
+      "translated": "Không có phiên gần đây"
     },
     {
-      "id": "native.apple.7396d205574d279f",
-      "source": "Thread activity offline",
-      "translated": "Hoạt động của luồng đang ngoại tuyến"
+      "id": "native.apple.08483af2d043bee6",
+      "source": "Session activity offline",
+      "translated": "Hoạt động phiên ngoại tuyến"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11839,9 +11824,9 @@
       "translated": "Thẻ"
     },
     {
-      "id": "native.apple.c9ec1b0e18074d8a",
-      "source": "Open Thread",
-      "translated": "Mở luồng"
+      "id": "native.apple.93eeaedb2ff61043",
+      "source": "Open Session",
+      "translated": "Mở phiên"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13329,9 +13314,9 @@
       "translated": "Mặc định"
     },
     {
-      "id": "native.apple.f4ae5664c3eda95d",
-      "source": "Used for new Chat threads and Talk sessions.",
-      "translated": "Dùng cho các luồng Trò chuyện và phiên Trò chuyện thoại mới."
+      "id": "native.apple.3de045f17ea3c6d0",
+      "source": "Used for new Chat and Talk sessions.",
+      "translated": "Được dùng cho các phiên Chat và Talk mới."
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15734,9 +15719,9 @@
       "translated": "Phiên bản"
     },
     {
-      "id": "native.apple.11fe8b9941954dfb",
-      "source": "Threads",
-      "translated": "Luồng"
+      "id": "native.apple.3579cf2750470a22",
+      "source": "Sessions",
+      "translated": "Phiên"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19044,9 +19029,9 @@
       "translated": "Phím tắt Trò chuyện nhanh"
     },
     {
-      "id": "native.apple.94dd793cd7d7d555",
-      "source": "Global shortcut that opens a floating chat bar for the main thread.",
-      "translated": "Phím tắt toàn cục để mở thanh trò chuyện nổi cho luồng chính."
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "Phím tắt toàn cục để mở thanh trò chuyện nổi cho phiên chính."
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19624,9 +19609,9 @@
       "translated": "Nghiêm trọng"
     },
     {
-      "id": "native.apple.13f96467014cf344",
-      "source": "New Thread",
-      "translated": "Luồng mới"
+      "id": "native.apple.75102378a6775180",
+      "source": "New Session",
+      "translated": "Phiên mới"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21914,9 +21899,9 @@
       "translated": "Không có tin nhắn gần đây"
     },
     {
-      "id": "native.apple.3ec2afcbc298c673",
-      "source": "Threads",
-      "translated": "Luồng"
+      "id": "native.apple.1ff8aec0044934c3",
+      "source": "Sessions",
+      "translated": "Phiên"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21924,9 +21909,9 @@
       "translated": "Xem nhanh các nhóm hội thoại đã lưu mà CLI tái sử dụng cho ngữ cảnh và giới hạn tốc độ."
     },
     {
-      "id": "native.apple.14ccb32cd8ed1c81",
-      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
-      "translated": "Chưa có luồng nào. Các luồng sẽ xuất hiện sau tin nhắn đến hoặc tín hiệu duy trì kết nối đầu tiên."
+      "id": "native.apple.bab897f3252b134c",
+      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
+      "translated": "Chưa có phiên nào. Chúng xuất hiện sau tin nhắn đến hoặc nhịp tim đầu tiên."
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -22009,9 +21994,9 @@
       "translated": "Phê duyệt thực thi"
     },
     {
-      "id": "native.apple.52e37e3a44ae516c",
-      "source": "Threads",
-      "translated": "Luồng"
+      "id": "native.apple.64a6dc7d49e8fb57",
+      "source": "Sessions",
+      "translated": "Phiên"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -23014,9 +22999,9 @@
       "translated": "Cập nhật tình hình cho tôi"
     },
     {
-      "id": "native.apple.fc4ce810900ec0b6",
-      "source": "Summarize what happened in my threads since yesterday.",
-      "translated": "Tóm tắt những gì đã xảy ra trong các luồng của tôi kể từ hôm qua."
+      "id": "native.apple.234ec45f4231edc4",
+      "source": "Summarize what happened in my sessions since yesterday.",
+      "translated": "Tóm tắt những gì đã xảy ra trong các phiên của tôi kể từ hôm qua."
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23194,9 +23179,9 @@
       "translated": "Bỏ ghim mô hình"
     },
     {
-      "id": "native.apple.4edb66657f5aca1f",
-      "source": "Thread",
-      "translated": "Luồng"
+      "id": "native.apple.5dfc0700d8dff8de",
+      "source": "Session",
+      "translated": "Phiên"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23359,51 +23344,6 @@
       "translated": "Tiện ích không khả dụng"
     },
     {
-      "id": "native.apple.d640691fd196f338",
-      "source": "Widget export failed",
-      "translated": "Xuất tiện ích không thành công"
-    },
-    {
-      "id": "native.apple.533c6e22a11e88de",
-      "source": "OK",
-      "translated": "OK"
-    },
-    {
-      "id": "native.apple.e1fb28a2a9756402",
-      "source": "Copy image",
-      "translated": "Sao chép hình ảnh"
-    },
-    {
-      "id": "native.apple.ebd7bc92e1b12235",
-      "source": "Save image…",
-      "translated": "Lưu hình ảnh…"
-    },
-    {
-      "id": "native.apple.742c46d4cf2db134",
-      "source": "Save image",
-      "translated": "Lưu hình ảnh"
-    },
-    {
-      "id": "native.apple.0589cce608418f90",
-      "source": "The widget image could not be captured.",
-      "translated": "Không thể chụp ảnh tiện ích."
-    },
-    {
-      "id": "native.apple.dfe24e827fdbe9c5",
-      "source": "The widget image could not be copied.",
-      "translated": "Không thể sao chép ảnh tiện ích."
-    },
-    {
-      "id": "native.apple.9e611e3a80e71408",
-      "source": "The widget image could not be encoded as PNG.",
-      "translated": "Không thể mã hóa ảnh tiện ích dưới dạng PNG."
-    },
-    {
-      "id": "native.apple.9a6e8afbe24a262b",
-      "source": "The widget image could not be saved.",
-      "translated": "Không thể lưu ảnh tiện ích."
-    },
-    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23544,19 +23484,19 @@
       "translated": "Người dùng"
     },
     {
-      "id": "native.apple.9d0cba09d92ee669",
-      "source": "This thread cannot be archived while it is active or running.",
-      "translated": "Không thể lưu trữ luồng này khi luồng đang hoạt động hoặc đang chạy."
+      "id": "native.apple.b1cdcb906a43d5d6",
+      "source": "This session cannot be archived while it is active or running.",
+      "translated": "Không thể lưu trữ phiên này khi phiên đang hoạt động hoặc đang chạy."
     },
     {
-      "id": "native.apple.8952a111a1075051",
-      "source": "The main thread cannot be deleted.",
-      "translated": "Không thể xóa luồng chính."
+      "id": "native.apple.5817e3f3dab1ee19",
+      "source": "The main session cannot be deleted.",
+      "translated": "Không thể xóa phiên chính."
     },
     {
-      "id": "native.apple.90d0ccf80ca28717",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
-      "translated": "Xóa tệp đính kèm hoặc chờ gửi xong trước khi lưu trữ hoặc xóa luồng này."
+      "id": "native.apple.a6b8df3f18171c91",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
+      "translated": "Hãy xóa tệp đính kèm hoặc chờ gửi xong trước khi lưu trữ hoặc xóa phiên này."
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23694,9 +23634,9 @@
       "translated": "Lượt chạy đã kết thúc"
     },
     {
-      "id": "native.apple.bbccb4c8db5cac12",
-      "source": "Thread Info",
-      "translated": "Thông tin luồng"
+      "id": "native.apple.cd7c3095a22f80a9",
+      "source": "Session Info",
+      "translated": "Thông tin phiên"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23729,9 +23669,9 @@
       "translated": "Thêm nhóm"
     },
     {
-      "id": "native.apple.7b641fed5bace855",
-      "source": "Thread Groups",
-      "translated": "Nhóm luồng"
+      "id": "native.apple.23d628606fe0734f",
+      "source": "Session Groups",
+      "translated": "Nhóm phiên"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23774,9 +23714,9 @@
       "translated": "Xóa nhóm"
     },
     {
-      "id": "native.apple.56401c79410a310d",
-      "source": "Threads in this group become ungrouped.",
-      "translated": "Các luồng trong nhóm này sẽ không còn thuộc nhóm nào."
+      "id": "native.apple.b049c8a4d2805e08",
+      "source": "Sessions in this group become ungrouped.",
+      "translated": "Các phiên trong nhóm này sẽ không còn thuộc nhóm nào."
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23789,9 +23729,9 @@
       "translated": "Không có tác nhân nào khả dụng trên gateway này."
     },
     {
-      "id": "native.apple.2d96aa7d3d12f85b",
-      "source": "New Thread Options",
-      "translated": "Tùy chọn cuộc trò chuyện mới"
+      "id": "native.apple.6c89f35d53506406",
+      "source": "New Session Options",
+      "translated": "Tùy chọn phiên mới"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23819,19 +23759,19 @@
       "translated": "Tạo"
     },
     {
-      "id": "native.apple.87ef57319d1ddc85",
-      "source": "The thread could not be created.",
-      "translated": "Không thể tạo cuộc trò chuyện."
+      "id": "native.apple.795ba37f6782cf28",
+      "source": "The session could not be created.",
+      "translated": "Không thể tạo phiên."
     },
     {
-      "id": "native.apple.6bd91c435b69d638",
-      "source": "Search threads",
-      "translated": "Tìm kiếm cuộc trò chuyện"
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "Tìm kiếm phiên"
     },
     {
-      "id": "native.apple.6fde4bdf9d5b9191",
-      "source": "No Threads",
-      "translated": "Không có cuộc trò chuyện"
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "Không có phiên nào"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23839,29 +23779,29 @@
       "translated": "Không có kết quả"
     },
     {
-      "id": "native.apple.a02fd99740d29bd3",
-      "source": "New Thread",
-      "translated": "Cuộc trò chuyện mới"
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "Phiên mới"
     },
     {
-      "id": "native.apple.b625801dd04b09f2",
-      "source": "New thread",
-      "translated": "Cuộc trò chuyện mới"
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "Phiên mới"
     },
     {
-      "id": "native.apple.851be81fcc933608",
-      "source": "New thread options",
-      "translated": "Tùy chọn cuộc trò chuyện mới"
+      "id": "native.apple.2ef0e34db02ad255",
+      "source": "New session options",
+      "translated": "Tùy chọn phiên mới"
     },
     {
-      "id": "native.apple.9ce8a4aba7b444b2",
-      "source": "Rename Thread",
-      "translated": "Đổi tên cuộc trò chuyện"
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "Đổi tên phiên"
     },
     {
-      "id": "native.apple.1dd067c44511c7f0",
-      "source": "Thread name",
-      "translated": "Tên cuộc trò chuyện"
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "Tên phiên"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23874,14 +23814,14 @@
       "translated": "Hủy"
     },
     {
-      "id": "native.apple.618073d6ab3f2721",
-      "source": "Delete Thread",
-      "translated": "Xóa cuộc trò chuyện"
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "Xóa phiên"
     },
     {
-      "id": "native.apple.10a5e72bba3cbccc",
-      "source": "The thread and its transcript are removed from the gateway.",
-      "translated": "Cuộc trò chuyện và bản ghi của cuộc trò chuyện đó sẽ bị xóa khỏi Gateway."
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "Phiên và bản ghi của phiên sẽ bị xóa khỏi Gateway."
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23889,14 +23829,14 @@
       "translated": "Xóa “%@”?"
     },
     {
-      "id": "native.apple.ac71e3b2aa496a2c",
-      "source": "Thread running",
-      "translated": "Cuộc trò chuyện đang chạy"
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "Phiên đang chạy"
     },
     {
-      "id": "native.apple.c775e87f997278b2",
-      "source": "Thread failed",
-      "translated": "Cuộc trò chuyện thất bại"
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "Phiên không thành công"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23954,9 +23894,9 @@
       "translated": "Sao chép khóa phiên"
     },
     {
-      "id": "native.apple.f4998cfb572f23ff",
-      "source": "Delete Thread…",
-      "translated": "Xóa cuộc trò chuyện…"
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "Xóa phiên…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23969,9 +23909,9 @@
       "translated": "Đang kết nối…"
     },
     {
-      "id": "native.apple.8802e9576ffd0f65",
-      "source": "Retry thread groups",
-      "translated": "Thử lại các nhóm cuộc trò chuyện"
+      "id": "native.apple.79f708b3bc1d3a6c",
+      "source": "Retry session groups",
+      "translated": "Thử tải lại các nhóm phiên"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23994,24 +23934,24 @@
       "translated": "Phạm vi"
     },
     {
-      "id": "native.apple.b313b80def4bda52",
-      "source": "Search threads",
-      "translated": "Tìm kiếm cuộc trò chuyện"
+      "id": "native.apple.2c37581c7b88f741",
+      "source": "Search sessions",
+      "translated": "Tìm phiên"
     },
     {
-      "id": "native.apple.c0cc6acc36f413ce",
-      "source": "Threads",
-      "translated": "Cuộc trò chuyện"
+      "id": "native.apple.43be8a2336e42faf",
+      "source": "Sessions",
+      "translated": "Phiên"
     },
     {
-      "id": "native.apple.854d3928fe5a557c",
-      "source": "Rename Thread",
-      "translated": "Đổi tên cuộc trò chuyện"
+      "id": "native.apple.0b379cdfcbd3247f",
+      "source": "Rename Session",
+      "translated": "Đổi tên phiên"
     },
     {
-      "id": "native.apple.9d0d3f20096cc4da",
-      "source": "Thread name",
-      "translated": "Tên cuộc trò chuyện"
+      "id": "native.apple.54b6fbd9e41db009",
+      "source": "Session name",
+      "translated": "Tên phiên"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -24019,19 +23959,19 @@
       "translated": "Hủy"
     },
     {
-      "id": "native.apple.dc00eb94f33bae15",
-      "source": "Delete selected threads?",
-      "translated": "Xóa các cuộc trò chuyện đã chọn?"
+      "id": "native.apple.751e0f6b81cd374a",
+      "source": "Delete selected sessions?",
+      "translated": "Xóa các phiên đã chọn?"
     },
     {
-      "id": "native.apple.2053fc9f74dc3158",
-      "source": "Delete Threads",
-      "translated": "Xóa các luồng"
+      "id": "native.apple.aa679276581b0058",
+      "source": "Delete Sessions",
+      "translated": "Xóa các phiên"
     },
     {
-      "id": "native.apple.0970247871a834a0",
-      "source": "Each selected thread and its transcript will be removed from the gateway.",
-      "translated": "Mỗi luồng được chọn và bản ghi hội thoại của luồng đó sẽ bị xóa khỏi Gateway."
+      "id": "native.apple.f837129cbee23297",
+      "source": "Each selected session and its transcript will be removed from the gateway.",
+      "translated": "Mỗi phiên đã chọn và bản ghi của phiên đó sẽ bị xóa khỏi gateway."
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -24039,9 +23979,9 @@
       "translated": "Nhóm"
     },
     {
-      "id": "native.apple.6f8acab2256728b5",
-      "source": "Manage thread groups",
-      "translated": "Quản lý nhóm luồng"
+      "id": "native.apple.64013cfee5e25305",
+      "source": "Manage session groups",
+      "translated": "Quản lý nhóm phiên"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -24054,14 +23994,14 @@
       "translated": "Chọn"
     },
     {
-      "id": "native.apple.692972314d04b184",
-      "source": "No archived threads",
-      "translated": "Không có luồng nào đã lưu trữ"
+      "id": "native.apple.b67eaecec1b423ac",
+      "source": "No archived sessions",
+      "translated": "Không có phiên đã lưu trữ"
     },
     {
-      "id": "native.apple.d6a4b5711dcd26e7",
-      "source": "No threads found",
-      "translated": "Không tìm thấy luồng nào"
+      "id": "native.apple.b2435a79abf0c794",
+      "source": "No sessions found",
+      "translated": "Không tìm thấy phiên nào"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24229,16 +24169,6 @@
       "translated": "Mở toàn bộ tin nhắn"
     },
     {
-      "id": "native.apple.002bfcede229ad4b",
-      "source": "Rewind to Here",
-      "translated": "Tua lại đến đây"
-    },
-    {
-      "id": "native.apple.14df2e4997689fb3",
-      "source": "Fork from Here",
-      "translated": "Tạo nhánh từ đây"
-    },
-    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "Trả lời"
@@ -24324,9 +24254,9 @@
       "translated": "Xóa tệp đính kèm hoặc chờ quá trình gửi hoàn tất trước khi bắt đầu cuộc trò chuyện mới."
     },
     {
-      "id": "native.apple.e0f045151c8d3137",
-      "source": "Gateway changed before the thread operation started.",
-      "translated": "Gateway đã thay đổi trước khi thao tác với luồng bắt đầu."
+      "id": "native.apple.980f552bb0f96c0f",
+      "source": "Gateway changed before the session operation started.",
+      "translated": "Gateway đã thay đổi trước khi thao tác phiên bắt đầu."
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24334,9 +24264,9 @@
       "translated": "Gỡ tệp đính kèm hoặc chờ gửi xong trước khi chuyển cuộc trò chuyện."
     },
     {
-      "id": "native.apple.0a5c4e15466c3acc",
-      "source": "Clear this thread's history?",
-      "translated": "Xóa lịch sử của luồng này?"
+      "id": "native.apple.87ba543b42696b92",
+      "source": "Clear this session's history?",
+      "translated": "Xóa lịch sử của phiên này?"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24349,14 +24279,14 @@
       "translated": "Thao tác này sẽ đặt lại cuộc trò chuyện cho %@. Khóa phiên vẫn giữ nguyên."
     },
     {
-      "id": "native.apple.67ac221dbe7179f0",
-      "source": "Rename Thread",
-      "translated": "Đổi tên luồng"
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "Đổi tên phiên"
     },
     {
-      "id": "native.apple.cf0f7e049603f518",
-      "source": "Thread name",
-      "translated": "Tên luồng"
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "Tên phiên"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24374,9 +24304,9 @@
       "translated": "Xuất Bản ghi"
     },
     {
-      "id": "native.apple.c0ada47504425f23",
-      "source": "Threads",
-      "translated": "Các luồng"
+      "id": "native.apple.4af0f566d39d7041",
+      "source": "Sessions",
+      "translated": "Phiên"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24449,14 +24379,14 @@
       "translated": "Mặc định"
     },
     {
-      "id": "native.apple.1a765291943599e5",
-      "source": "New Thread",
-      "translated": "Luồng mới"
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "Phiên Mới"
     },
     {
-      "id": "native.apple.c7a3a6d5e43dd98f",
-      "source": "New Thread Options…",
-      "translated": "Tùy chọn luồng mới…"
+      "id": "native.apple.a7119fbf9d25df5e",
+      "source": "New Session Options…",
+      "translated": "Tùy chọn phiên mới…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24464,19 +24394,19 @@
       "translated": "Làm mới"
     },
     {
-      "id": "native.apple.0e710b81808e5dcf",
-      "source": "Threads…",
-      "translated": "Các luồng…"
+      "id": "native.apple.2bcff4a8fa503739",
+      "source": "Sessions…",
+      "translated": "Phiên…"
     },
     {
-      "id": "native.apple.faad8f92b6bef166",
-      "source": "Rename Thread…",
-      "translated": "Đổi tên luồng…"
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "Đổi tên phiên…"
     },
     {
-      "id": "native.apple.23b61d6cd26ac112",
-      "source": "Fork",
-      "translated": "Phân nhánh"
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "Phân nhánh phiên"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24534,24 +24464,24 @@
       "translated": "Xóa Lịch sử…"
     },
     {
-      "id": "native.apple.8b4f1c5107ea8a0e",
-      "source": "Thread",
-      "translated": "Luồng"
+      "id": "native.apple.920fe8a7a33f9e92",
+      "source": "Session",
+      "translated": "Phiên"
     },
     {
-      "id": "native.apple.4d7750c9bf699469",
-      "source": "Thread actions",
-      "translated": "Thao tác với luồng"
+      "id": "native.apple.185a401f78328b0f",
+      "source": "Session actions",
+      "translated": "Thao tác phiên"
     },
     {
-      "id": "native.apple.bb2f22cc43c97f8e",
-      "source": "Thread cost %@",
-      "translated": "Chi phí luồng %@"
+      "id": "native.apple.9f9dedf599b2619b",
+      "source": "Session cost %@",
+      "translated": "Chi phí phiên %@"
     },
     {
-      "id": "native.apple.6239ced0b86e86f8",
-      "source": "Compact Thread",
-      "translated": "Thu gọn luồng"
+      "id": "native.apple.f0a4720df5f5f403",
+      "source": "Compact Session",
+      "translated": "Thu gọn Phiên"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/vi.json
+++ b/apps/.i18n/native/vi.json
@@ -1429,9 +1429,9 @@
       "translated": "Trò chuyện hoặc đọc chính tả với OpenClaw"
     },
     {
-      "id": "native.android.5876e15e5e92fd45",
-      "source": "Browse Sessions",
-      "translated": "Duyệt các phiên"
+      "id": "native.android.e2cf5a38587382cb",
+      "source": "Browse Threads",
+      "translated": "Duyệt luồng"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "Không tìm thấy tác vụ nào"
     },
     {
-      "id": "native.android.48ad0ae0e930e02b",
-      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
-      "translated": "Thử Chat, Voice, Sessions, Providers hoặc Settings."
+      "id": "native.android.bc70a4ac965b82ba",
+      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
+      "translated": "Thử Trò chuyện, Giọng nói, Luồng, Nhà cung cấp hoặc Cài đặt."
     },
     {
-      "id": "native.android.d4fbd1ee4f55a5db",
-      "source": "Sessions",
-      "translated": "Phiên"
+      "id": "native.android.670121e54dbe286f",
+      "source": "Threads",
+      "translated": "Luồng"
     },
     {
-      "id": "native.android.207c2170504e99e6",
-      "source": "Connect the Gateway to search sessions.",
-      "translated": "Kết nối Gateway để tìm kiếm phiên."
+      "id": "native.android.d38be650b1bce4a0",
+      "source": "Connect the Gateway to search threads.",
+      "translated": "Kết nối Gateway để tìm kiếm luồng."
     },
     {
-      "id": "native.android.25d2c2d792c952fe",
-      "source": "No matching sessions yet.",
-      "translated": "Chưa có phiên phù hợp."
+      "id": "native.android.3d7754721f776ef8",
+      "source": "No matching threads yet.",
+      "translated": "Chưa có luồng phù hợp."
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "Trợ lý đang làm việc"
     },
     {
-      "id": "native.android.8f8384286317f5c9",
-      "source": "OpenClaw session",
-      "translated": "Phiên OpenClaw"
+      "id": "native.android.9a839f6e3e05a744",
+      "source": "OpenClaw thread",
+      "translated": "Luồng OpenClaw"
     },
     {
-      "id": "native.android.15799e57704b20c6",
-      "source": "Open session",
-      "translated": "Mở phiên"
+      "id": "native.android.d83f82a1e4a5ed99",
+      "source": "Open thread",
+      "translated": "Mở luồng"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "Không có nhà cung cấp nào sẵn sàng"
     },
     {
-      "id": "native.android.73e6ab1a168fd381",
-      "source": "Main session",
-      "translated": "Phiên chính"
+      "id": "native.android.8a1c5365c0538908",
+      "source": "Main thread",
+      "translated": "Luồng chính"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.0e3157c15c56944f",
-      "source": "Sessions",
-      "translated": "Phiên"
+      "id": "native.android.a5845742daecb4ba",
+      "source": "Threads",
+      "translated": "Luồng"
     },
     {
-      "id": "native.android.70f5d0507d34b5c8",
-      "source": "Focus session search",
-      "translated": "Tập trung vào ô tìm kiếm phiên"
+      "id": "native.android.439b324280869527",
+      "source": "Focus thread search",
+      "translated": "Đưa con trỏ vào ô tìm kiếm luồng"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "Đã lưu trữ"
     },
     {
-      "id": "native.android.b9cf34c137e4cf03",
-      "source": "Search sessions",
-      "translated": "Tìm kiếm phiên"
+      "id": "native.android.03981341841b04ac",
+      "source": "Search threads",
+      "translated": "Tìm kiếm luồng"
     },
     {
-      "id": "native.android.10cb26723e9990fc",
-      "source": "Clear session search",
-      "translated": "Xóa nội dung tìm kiếm phiên"
+      "id": "native.android.99570c528a41fa72",
+      "source": "Clear thread search",
+      "translated": "Xóa nội dung tìm kiếm luồng"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "Cũ nhất trước"
     },
     {
-      "id": "native.android.c6bf8751e2a7f5c7",
-      "source": "Toggle session layout",
-      "translated": "Chuyển đổi bố cục phiên"
+      "id": "native.android.fd67be543e321cc9",
+      "source": "Toggle thread layout",
+      "translated": "Chuyển đổi bố cục luồng"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "Bố cục: Chi tiết"
     },
     {
-      "id": "native.android.69b79a3c2c987cd4",
-      "source": "Searching sessions",
-      "translated": "Đang tìm kiếm phiên"
+      "id": "native.android.ebd17565e0ffd8eb",
+      "source": "Searching threads",
+      "translated": "Đang tìm kiếm luồng"
     },
     {
-      "id": "native.android.dd587d341af44212",
-      "source": "No matching sessions",
-      "translated": "Không có phiên phù hợp"
+      "id": "native.android.472d46ae8669f860",
+      "source": "No matching threads",
+      "translated": "Không có luồng phù hợp"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "Bắt đầu trò chuyện"
     },
     {
-      "id": "native.android.f10d4df7cbc6df4f",
-      "source": "Current session",
-      "translated": "Phiên hiện tại"
+      "id": "native.android.ff81ad1bee00d384",
+      "source": "Current thread",
+      "translated": "Luồng hiện tại"
     },
     {
-      "id": "native.android.8f0482425838ae64",
-      "source": "OpenClaw session",
-      "translated": "Phiên OpenClaw"
+      "id": "native.android.fc145645b9620e57",
+      "source": "OpenClaw thread",
+      "translated": "Luồng OpenClaw"
     },
     {
-      "id": "native.android.786774c8a76e50d7",
-      "source": "Rename session",
-      "translated": "Đổi tên phiên"
+      "id": "native.android.71cbb8dde8bf138b",
+      "source": "Rename thread",
+      "translated": "Đổi tên luồng"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "Xóa nhóm?"
     },
     {
-      "id": "native.android.3455fc2f77d564e3",
-      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "Các phiên trong \"$group\" được giữ lại và chuyển về Chưa nhóm."
+      "id": "native.android.691e92cfe5cf106e",
+      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "Các luồng trong \"$group\" được giữ lại và chuyển về Chưa nhóm."
     },
     {
-      "id": "native.android.4805fb9d6623e8c0",
-      "source": "Delete session?",
-      "translated": "Xóa phiên?"
+      "id": "native.android.d87a8217ab56999b",
+      "source": "Delete thread?",
+      "translated": "Xóa luồng?"
     },
     {
-      "id": "native.android.0c3283a2b2445eae",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "Thao tác này sẽ xóa vĩnh viễn phiên và bản ghi cuộc trò chuyện của phiên đó."
+      "id": "native.android.930de97ff47113a8",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "Thao tác này sẽ xóa vĩnh viễn luồng và bản ghi của luồng."
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "Chưa phân nhóm"
     },
     {
-      "id": "native.android.db243d71d056afa4",
-      "source": "No sessions yet",
-      "translated": "Chưa có phiên nào"
+      "id": "native.android.8e21a70428def6e0",
+      "source": "No threads yet",
+      "translated": "Chưa có luồng nào"
     },
     {
-      "id": "native.android.5b4eee6a8092925e",
-      "source": "No current session",
-      "translated": "Không có phiên hiện tại"
+      "id": "native.android.cda4c5ad8b17e394",
+      "source": "No current thread",
+      "translated": "Không có luồng hiện tại"
     },
     {
-      "id": "native.android.acbcc9c9ea53d8c0",
-      "source": "No archived sessions",
-      "translated": "Không có phiên đã lưu trữ"
+      "id": "native.android.be84f061047aa2da",
+      "source": "No archived threads",
+      "translated": "Không có luồng đã lưu trữ"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "Bắt đầu một cuộc trò chuyện mới và cuộc trò chuyện đó sẽ hiển thị ở đây."
     },
     {
-      "id": "native.android.56fcd605dc7be3c0",
-      "source": "Open Chat to start or resume the current session.",
-      "translated": "Mở Trò chuyện để bắt đầu hoặc tiếp tục phiên hiện tại."
+      "id": "native.android.f289d03e1d3eee98",
+      "source": "Open Chat to start or resume the current thread.",
+      "translated": "Mở Chat để bắt đầu hoặc tiếp tục luồng hiện tại."
     },
     {
-      "id": "native.android.085515989f8a2022",
-      "source": "Archived sessions will show up here.",
-      "translated": "Các phiên đã lưu trữ sẽ xuất hiện tại đây."
+      "id": "native.android.504b71386e76c6ae",
+      "source": "Archived threads will show up here.",
+      "translated": "Các luồng đã lưu trữ sẽ xuất hiện tại đây."
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days} ngày"
     },
     {
-      "id": "native.android.3d4fa07acbc015c5",
-      "source": "Main session",
-      "translated": "Phiên chính"
+      "id": "native.android.ee4c727cdafbe963",
+      "source": "Main thread",
+      "translated": "Luồng chính"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway đang chờ xử lý"
     },
     {
-      "id": "native.android.2d8d049afe99f751",
-      "source": "Session Activity",
-      "translated": "Hoạt động phiên"
+      "id": "native.android.da78209effb11cfd",
+      "source": "Thread Activity",
+      "translated": "Hoạt động của luồng"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "Các yêu cầu phê duyệt exec sẽ xuất hiện tại đây khi điện thoại này được kết nối."
     },
     {
-      "id": "native.android.dc3e7ca5a491103a",
-      "source": "Session activity",
-      "translated": "Hoạt động phiên"
+      "id": "native.android.f615712dfb56319a",
+      "source": "Thread activity",
+      "translated": "Hoạt động của luồng"
     },
     {
-      "id": "native.android.8551e02b060bd7d8",
-      "source": "Chat tool calls waiting in the active session remain visible here.",
-      "translated": "Các lệnh gọi công cụ trò chuyện đang chờ trong phiên đang hoạt động vẫn hiển thị tại đây."
+      "id": "native.android.6c93973c13db43ae",
+      "source": "Chat tool calls waiting in the active thread remain visible here.",
+      "translated": "Các lệnh gọi công cụ Chat đang chờ trong luồng đang hoạt động vẫn hiển thị tại đây."
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,6 +4294,11 @@
       "translated": "Thiết lập nhà cung cấp Talk"
     },
     {
+      "id": "native.android.23b638094c34b916",
+      "source": "Microphone",
+      "translated": "Micrô"
+    },
+    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "Kiểm tra âm thanh"
@@ -4337,6 +4342,66 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "Xong"
+    },
+    {
+      "id": "native.android.8d9ecdfdd916b780",
+      "source": "Automatic",
+      "translated": "Tự động"
+    },
+    {
+      "id": "native.android.c1626a6700a570f6",
+      "source": "Preferred microphone unavailable; using automatic routing.",
+      "translated": "Micrô ưu tiên không khả dụng; đang sử dụng định tuyến tự động."
+    },
+    {
+      "id": "native.android.820bc5d0ce571d8b",
+      "source": "Prioritizes connected Bluetooth microphones.",
+      "translated": "Ưu tiên các micrô Bluetooth đã kết nối."
+    },
+    {
+      "id": "native.android.11e48038d5e8bff6",
+      "source": "Preferred microphone",
+      "translated": "Micrô ưu tiên"
+    },
+    {
+      "id": "native.android.eaa4d7563a46d307",
+      "source": "Unavailable",
+      "translated": "Không khả dụng"
+    },
+    {
+      "id": "native.android.9f5ebf17eb405ba8",
+      "source": "Next session",
+      "translated": "Phiên tiếp theo"
+    },
+    {
+      "id": "native.android.8c4e91f53928efb2",
+      "source": "Built-in microphone",
+      "translated": "Micrô tích hợp"
+    },
+    {
+      "id": "native.android.14b613cb6e2446b4",
+      "source": "Bluetooth microphone",
+      "translated": "Micrô Bluetooth"
+    },
+    {
+      "id": "native.android.c885247b2d7ce271",
+      "source": "Bluetooth LE microphone",
+      "translated": "Micrô Bluetooth LE"
+    },
+    {
+      "id": "native.android.b6a4e674c5fb441a",
+      "source": "Wired headset microphone",
+      "translated": "Micrô tai nghe có dây"
+    },
+    {
+      "id": "native.android.9c8becb3b0fb5a90",
+      "source": "USB microphone",
+      "translated": "Micrô USB"
+    },
+    {
+      "id": "native.android.ba46258fadec7a39",
+      "source": "External microphone",
+      "translated": "Micrô ngoài"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5074,9 +5139,9 @@
       "translated": "Kiểm tra"
     },
     {
-      "id": "native.android.5a540761383fa474",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
-      "translated": "OpenClaw biến điện thoại này thành một giao diện lệnh di động gọn gàng cho các phiên, giọng nói, nhà cung cấp và Gateway."
+      "id": "native.android.c971506716c96e91",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
+      "translated": "OpenClaw biến điện thoại này thành một giao diện lệnh di động gọn gàng cho các luồng, giọng nói, nhà cung cấp và Gateway."
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5624,9 +5689,9 @@
       "translated": "Cài đặt Talk"
     },
     {
-      "id": "native.android.73f07a5d54915259",
-      "source": "Recent Sessions",
-      "translated": "Phiên gần đây"
+      "id": "native.android.36f78c8c85dc283f",
+      "source": "Recent Threads",
+      "translated": "Luồng gần đây"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5684,14 +5749,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% đang trực tuyến"
     },
     {
-      "id": "native.android.16c3425d3a594481",
-      "source": "Sessions",
-      "translated": "Phiên"
+      "id": "native.android.57177017a6a93826",
+      "source": "Threads",
+      "translated": "Luồng"
     },
     {
-      "id": "native.android.a5c0f8b3112aa58c",
-      "source": "No recent sessions",
-      "translated": "Không có phiên gần đây"
+      "id": "native.android.43320b54a68b00a1",
+      "source": "No recent threads",
+      "translated": "Không có luồng gần đây"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5729,14 +5794,14 @@
       "translated": "Đang hoạt động · $pendingRunCount lượt chạy đang hoạt động"
     },
     {
-      "id": "native.android.2c89da708b12a522",
-      "source": "Monitoring · 1 session",
-      "translated": "Đang giám sát · 1 phiên"
+      "id": "native.android.e24db059480f1e6a",
+      "source": "Monitoring · 1 thread",
+      "translated": "Đang theo dõi · 1 luồng"
     },
     {
-      "id": "native.android.8b6ee382dcb64e1f",
-      "source": "Monitoring · $sessionCount sessions",
-      "translated": "Đang giám sát · $sessionCount phiên"
+      "id": "native.android.5a475f37d80e02bc",
+      "source": "Monitoring · $sessionCount threads",
+      "translated": "Đang theo dõi · $sessionCount luồng"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5769,9 +5834,9 @@
       "translated": "Nhà cung cấp"
     },
     {
-      "id": "native.android.a65477861c7203aa",
-      "source": "Open session",
-      "translated": "Mở phiên"
+      "id": "native.android.358c5e0e838d5423",
+      "source": "Open thread",
+      "translated": "Mở luồng"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6194,9 +6259,9 @@
       "translated": "${days} ngày"
     },
     {
-      "id": "native.android.22d755834386db07",
-      "source": "Main session",
-      "translated": "Phiên chính"
+      "id": "native.android.28a1a1acc5a0959f",
+      "source": "Main thread",
+      "translated": "Luồng chính"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6877,6 +6942,16 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "Bật tiếng"
+    },
+    {
+      "id": "native.android.cb608d82c5b3352a",
+      "source": "Back camera",
+      "translated": "Camera sau"
+    },
+    {
+      "id": "native.android.e89a0e780eed2e1e",
+      "source": "Front camera",
+      "translated": "Camera trước"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7684,9 +7759,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.882cc14a58e7e105",
-      "source": "Loading session",
-      "translated": "Đang tải phiên"
+      "id": "native.android.0c74bc30a994dd33",
+      "source": "Loading thread",
+      "translated": "Đang tải luồng"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7729,14 +7804,14 @@
       "translated": "Cập nhật thông tin cho tôi"
     },
     {
-      "id": "native.android.1e5add56e48c99f9",
-      "source": "Summarize recent sessions and next steps.",
-      "translated": "Tóm tắt các phiên gần đây và những bước tiếp theo."
+      "id": "native.android.cf40df9739f78f27",
+      "source": "Summarize recent threads and next steps.",
+      "translated": "Tóm tắt các luồng gần đây và các bước tiếp theo."
     },
     {
-      "id": "native.android.06d515351bb79576",
-      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
-      "translated": "Cập nhật cho tôi về các phiên OpenClaw gần đây và đề xuất những bước tiếp theo."
+      "id": "native.android.ebe49a8b8df80bd3",
+      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
+      "translated": "Cập nhật cho tôi về các luồng OpenClaw gần đây và đề xuất các bước tiếp theo."
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8074,9 +8149,9 @@
       "translated": "Đã kết nối"
     },
     {
-      "id": "native.android.81931886b9caf3ab",
-      "source": "Sessions",
-      "translated": "Phiên"
+      "id": "native.android.6cf5d6fa8a4186d5",
+      "source": "Threads",
+      "translated": "Luồng"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,9 +10869,9 @@
       "translated": "Bạn muốn làm việc gì?"
     },
     {
-      "id": "native.apple.32179ce0b6d4543f",
-      "source": "The session attaches once the gateway is ready.",
-      "translated": "Phiên sẽ được đính kèm khi gateway sẵn sàng."
+      "id": "native.apple.4da775013ac9b123",
+      "source": "The thread attaches once the gateway is ready.",
+      "translated": "Luồng sẽ được đính kèm khi Gateway sẵn sàng."
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10844,9 +10919,9 @@
       "translated": "Tùy chọn phiên mới…"
     },
     {
-      "id": "native.apple.a1b0d289758e2213",
-      "source": "Sessions…",
-      "translated": "Phiên…"
+      "id": "native.apple.003b25ddafeb18e9",
+      "source": "Threads…",
+      "translated": "Luồng…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11009,14 +11084,14 @@
       "translated": "Tạo"
     },
     {
-      "id": "native.apple.f488b9caf6e51ac3",
-      "source": "Delete Session?",
-      "translated": "Xóa phiên?"
+      "id": "native.apple.31d5c7287cfb3abe",
+      "source": "Delete Thread?",
+      "translated": "Xóa luồng?"
     },
     {
-      "id": "native.apple.8634b17be9b111bc",
-      "source": "Delete Session",
-      "translated": "Xóa phiên"
+      "id": "native.apple.d3395564809f1120",
+      "source": "Delete Thread",
+      "translated": "Xóa luồng"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11024,9 +11099,9 @@
       "translated": "Hủy"
     },
     {
-      "id": "native.apple.4a9568ac9b18d8d3",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "Thao tác này sẽ xóa vĩnh viễn phiên và bản ghi của phiên đó."
+      "id": "native.apple.092659256d26cb03",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "Thao tác này sẽ xóa vĩnh viễn luồng và bản ghi của luồng."
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11054,9 +11129,9 @@
       "translated": "Nhóm mới"
     },
     {
-      "id": "native.apple.5bccdc23a1640895",
-      "source": "Rename Session",
-      "translated": "Đổi tên phiên"
+      "id": "native.apple.683032464c497bbd",
+      "source": "Rename Thread",
+      "translated": "Đổi tên luồng"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11064,9 +11139,9 @@
       "translated": "Tên nhóm"
     },
     {
-      "id": "native.apple.af789b2d2fda0f67",
-      "source": "Session name",
-      "translated": "Tên phiên"
+      "id": "native.apple.f887aa956588f237",
+      "source": "Thread name",
+      "translated": "Tên luồng"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11104,14 +11179,14 @@
       "translated": "Tác tử"
     },
     {
-      "id": "native.apple.a3bde8045fe9224a",
-      "source": "Agent session",
-      "translated": "Phiên tác tử"
+      "id": "native.apple.7c8231b7b1ca480f",
+      "source": "Agent thread",
+      "translated": "Luồng tác nhân"
     },
     {
-      "id": "native.apple.27f775de30b37ff8",
-      "source": "Recent sessions",
-      "translated": "Phiên gần đây"
+      "id": "native.apple.b3c553614f762a58",
+      "source": "Recent threads",
+      "translated": "Luồng gần đây"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11119,9 +11194,9 @@
       "translated": "Gateway ngoại tuyến"
     },
     {
-      "id": "native.apple.28c97cf23665ee01",
-      "source": "No recent sessions",
-      "translated": "Không có phiên gần đây"
+      "id": "native.apple.5aa32afda85064ea",
+      "source": "No recent threads",
+      "translated": "Không có luồng nào gần đây"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11219,14 +11294,14 @@
       "translated": "Hủy"
     },
     {
-      "id": "native.apple.9f2fd65953013b7c",
-      "source": "Sessions",
-      "translated": "Phiên"
+      "id": "native.apple.b6855cf19a50f477",
+      "source": "Threads",
+      "translated": "Luồng"
     },
     {
-      "id": "native.apple.0422818cc95d5071",
-      "source": "Archived sessions",
-      "translated": "Các phiên đã lưu trữ"
+      "id": "native.apple.9b1d0ef27a1333b0",
+      "source": "Archived threads",
+      "translated": "Luồng đã lưu trữ"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11234,34 +11309,34 @@
       "translated": "Hiển thị mục đã lưu trữ"
     },
     {
-      "id": "native.apple.b272115c83f7ef58",
-      "source": "Sessions unavailable",
-      "translated": "Phiên không khả dụng"
+      "id": "native.apple.98167401c7267735",
+      "source": "Threads unavailable",
+      "translated": "Không thể truy cập các luồng"
     },
     {
-      "id": "native.apple.54f8260c9b863087",
-      "source": "Loading archived sessions",
-      "translated": "Đang tải các phiên đã lưu trữ"
+      "id": "native.apple.4d28a7def2337b9f",
+      "source": "Loading archived threads",
+      "translated": "Đang tải các luồng đã lưu trữ"
     },
     {
-      "id": "native.apple.9b305868873dade2",
-      "source": "Loading recent sessions",
-      "translated": "Đang tải các phiên gần đây"
+      "id": "native.apple.777d7b706933bd7b",
+      "source": "Loading recent threads",
+      "translated": "Đang tải các luồng gần đây"
     },
     {
-      "id": "native.apple.207dad20d09f3160",
-      "source": "^[\\(count) session](inflect: true)",
-      "translated": "^[\\(count) phiên](inflect: true)"
+      "id": "native.apple.22f81ea94bef8410",
+      "source": "^[\\(count) thread](inflect: true)",
+      "translated": "^[\\(count) luồng](inflect: true)"
     },
     {
-      "id": "native.apple.1f4501a6bf2bae4c",
-      "source": "No archived sessions",
-      "translated": "Không có phiên nào đã lưu trữ"
+      "id": "native.apple.1cad51e14db59bf9",
+      "source": "No archived threads",
+      "translated": "Không có luồng nào đã lưu trữ"
     },
     {
-      "id": "native.apple.2a1ba7a5e1979c9e",
-      "source": "Archived sessions will appear here.",
-      "translated": "Các phiên đã lưu trữ sẽ xuất hiện tại đây."
+      "id": "native.apple.18ef832d3a7ddcf8",
+      "source": "Archived threads will appear here.",
+      "translated": "Các luồng đã lưu trữ sẽ xuất hiện tại đây."
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11344,9 +11419,9 @@
       "translated": "Chia sẻ đầu vào"
     },
     {
-      "id": "native.apple.2360d25fe6ae9946",
-      "source": "Loading sessions",
-      "translated": "Đang tải phiên"
+      "id": "native.apple.21d9208d86a4d1fe",
+      "source": "Loading threads",
+      "translated": "Đang tải các luồng"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11354,19 +11429,19 @@
       "translated": "Đang lấy hoạt động gần đây từ gateway."
     },
     {
-      "id": "native.apple.c334f2e86702a7b8",
-      "source": "Sessions unavailable",
-      "translated": "Phiên không khả dụng"
+      "id": "native.apple.4be1f79aa2b230ff",
+      "source": "Threads unavailable",
+      "translated": "Không thể truy cập các luồng"
     },
     {
-      "id": "native.apple.6cc6efb7a03960b6",
-      "source": "No recent sessions",
-      "translated": "Không có phiên gần đây"
+      "id": "native.apple.98b348873556bc46",
+      "source": "No recent threads",
+      "translated": "Không có luồng nào gần đây"
     },
     {
-      "id": "native.apple.08483af2d043bee6",
-      "source": "Session activity offline",
-      "translated": "Hoạt động phiên ngoại tuyến"
+      "id": "native.apple.7396d205574d279f",
+      "source": "Thread activity offline",
+      "translated": "Hoạt động của luồng đang ngoại tuyến"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11824,9 +11899,9 @@
       "translated": "Thẻ"
     },
     {
-      "id": "native.apple.93eeaedb2ff61043",
-      "source": "Open Session",
-      "translated": "Mở phiên"
+      "id": "native.apple.c9ec1b0e18074d8a",
+      "source": "Open Thread",
+      "translated": "Mở luồng"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13314,9 +13389,9 @@
       "translated": "Mặc định"
     },
     {
-      "id": "native.apple.3de045f17ea3c6d0",
-      "source": "Used for new Chat and Talk sessions.",
-      "translated": "Được dùng cho các phiên Chat và Talk mới."
+      "id": "native.apple.f4ae5664c3eda95d",
+      "source": "Used for new Chat threads and Talk sessions.",
+      "translated": "Được dùng cho các chuỗi Chat và phiên Talk mới."
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15719,9 +15794,9 @@
       "translated": "Phiên bản"
     },
     {
-      "id": "native.apple.3579cf2750470a22",
-      "source": "Sessions",
-      "translated": "Phiên"
+      "id": "native.apple.11fe8b9941954dfb",
+      "source": "Threads",
+      "translated": "Chuỗi"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19029,9 +19104,9 @@
       "translated": "Phím tắt Trò chuyện nhanh"
     },
     {
-      "id": "native.apple.6ae77665b5f4490f",
-      "source": "Global shortcut that opens a floating chat bar for the main session.",
-      "translated": "Phím tắt toàn cục để mở thanh trò chuyện nổi cho phiên chính."
+      "id": "native.apple.94dd793cd7d7d555",
+      "source": "Global shortcut that opens a floating chat bar for the main thread.",
+      "translated": "Phím tắt toàn cục mở thanh trò chuyện nổi cho chuỗi chính."
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19609,9 +19684,9 @@
       "translated": "Nghiêm trọng"
     },
     {
-      "id": "native.apple.75102378a6775180",
-      "source": "New Session",
-      "translated": "Phiên mới"
+      "id": "native.apple.13f96467014cf344",
+      "source": "New Thread",
+      "translated": "Chuỗi mới"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21899,9 +21974,9 @@
       "translated": "Không có tin nhắn gần đây"
     },
     {
-      "id": "native.apple.1ff8aec0044934c3",
-      "source": "Sessions",
-      "translated": "Phiên"
+      "id": "native.apple.3ec2afcbc298c673",
+      "source": "Threads",
+      "translated": "Chuỗi"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21909,9 +21984,9 @@
       "translated": "Xem nhanh các nhóm hội thoại đã lưu mà CLI tái sử dụng cho ngữ cảnh và giới hạn tốc độ."
     },
     {
-      "id": "native.apple.bab897f3252b134c",
-      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
-      "translated": "Chưa có phiên nào. Chúng xuất hiện sau tin nhắn đến hoặc nhịp tim đầu tiên."
+      "id": "native.apple.14ccb32cd8ed1c81",
+      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
+      "translated": "Chưa có chuỗi nào. Các chuỗi sẽ xuất hiện sau tin nhắn đến hoặc tín hiệu heartbeat đầu tiên."
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -21994,9 +22069,9 @@
       "translated": "Phê duyệt thực thi"
     },
     {
-      "id": "native.apple.64a6dc7d49e8fb57",
-      "source": "Sessions",
-      "translated": "Phiên"
+      "id": "native.apple.52e37e3a44ae516c",
+      "source": "Threads",
+      "translated": "Chuỗi"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -22999,9 +23074,9 @@
       "translated": "Cập nhật tình hình cho tôi"
     },
     {
-      "id": "native.apple.234ec45f4231edc4",
-      "source": "Summarize what happened in my sessions since yesterday.",
-      "translated": "Tóm tắt những gì đã xảy ra trong các phiên của tôi kể từ hôm qua."
+      "id": "native.apple.fc4ce810900ec0b6",
+      "source": "Summarize what happened in my threads since yesterday.",
+      "translated": "Tóm tắt những gì đã xảy ra trong các chuỗi của tôi kể từ hôm qua."
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23179,9 +23254,9 @@
       "translated": "Bỏ ghim mô hình"
     },
     {
-      "id": "native.apple.5dfc0700d8dff8de",
-      "source": "Session",
-      "translated": "Phiên"
+      "id": "native.apple.4edb66657f5aca1f",
+      "source": "Thread",
+      "translated": "Chuỗi"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23344,6 +23419,51 @@
       "translated": "Tiện ích không khả dụng"
     },
     {
+      "id": "native.apple.d640691fd196f338",
+      "source": "Widget export failed",
+      "translated": "Xuất tiện ích không thành công"
+    },
+    {
+      "id": "native.apple.533c6e22a11e88de",
+      "source": "OK",
+      "translated": "OK"
+    },
+    {
+      "id": "native.apple.e1fb28a2a9756402",
+      "source": "Copy image",
+      "translated": "Sao chép hình ảnh"
+    },
+    {
+      "id": "native.apple.ebd7bc92e1b12235",
+      "source": "Save image…",
+      "translated": "Lưu hình ảnh…"
+    },
+    {
+      "id": "native.apple.742c46d4cf2db134",
+      "source": "Save image",
+      "translated": "Lưu hình ảnh"
+    },
+    {
+      "id": "native.apple.0589cce608418f90",
+      "source": "The widget image could not be captured.",
+      "translated": "Không thể chụp hình ảnh tiện ích."
+    },
+    {
+      "id": "native.apple.dfe24e827fdbe9c5",
+      "source": "The widget image could not be copied.",
+      "translated": "Không thể sao chép hình ảnh tiện ích."
+    },
+    {
+      "id": "native.apple.9e611e3a80e71408",
+      "source": "The widget image could not be encoded as PNG.",
+      "translated": "Không thể mã hóa hình ảnh tiện ích thành PNG."
+    },
+    {
+      "id": "native.apple.9a6e8afbe24a262b",
+      "source": "The widget image could not be saved.",
+      "translated": "Không thể lưu hình ảnh tiện ích."
+    },
+    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23484,19 +23604,19 @@
       "translated": "Người dùng"
     },
     {
-      "id": "native.apple.b1cdcb906a43d5d6",
-      "source": "This session cannot be archived while it is active or running.",
-      "translated": "Không thể lưu trữ phiên này khi phiên đang hoạt động hoặc đang chạy."
+      "id": "native.apple.9d0cba09d92ee669",
+      "source": "This thread cannot be archived while it is active or running.",
+      "translated": "Không thể lưu trữ chuỗi này khi chuỗi đang hoạt động hoặc đang chạy."
     },
     {
-      "id": "native.apple.5817e3f3dab1ee19",
-      "source": "The main session cannot be deleted.",
-      "translated": "Không thể xóa phiên chính."
+      "id": "native.apple.8952a111a1075051",
+      "source": "The main thread cannot be deleted.",
+      "translated": "Không thể xóa chuỗi chính."
     },
     {
-      "id": "native.apple.a6b8df3f18171c91",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
-      "translated": "Hãy xóa tệp đính kèm hoặc chờ gửi xong trước khi lưu trữ hoặc xóa phiên này."
+      "id": "native.apple.90d0ccf80ca28717",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
+      "translated": "Xóa tệp đính kèm hoặc chờ gửi xong trước khi lưu trữ hay xóa luồng này."
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23634,9 +23754,9 @@
       "translated": "Lượt chạy đã kết thúc"
     },
     {
-      "id": "native.apple.cd7c3095a22f80a9",
-      "source": "Session Info",
-      "translated": "Thông tin phiên"
+      "id": "native.apple.bbccb4c8db5cac12",
+      "source": "Thread Info",
+      "translated": "Thông tin luồng"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23669,9 +23789,9 @@
       "translated": "Thêm nhóm"
     },
     {
-      "id": "native.apple.23d628606fe0734f",
-      "source": "Session Groups",
-      "translated": "Nhóm phiên"
+      "id": "native.apple.7b641fed5bace855",
+      "source": "Thread Groups",
+      "translated": "Nhóm luồng"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23714,9 +23834,9 @@
       "translated": "Xóa nhóm"
     },
     {
-      "id": "native.apple.b049c8a4d2805e08",
-      "source": "Sessions in this group become ungrouped.",
-      "translated": "Các phiên trong nhóm này sẽ không còn thuộc nhóm nào."
+      "id": "native.apple.56401c79410a310d",
+      "source": "Threads in this group become ungrouped.",
+      "translated": "Các luồng trong nhóm này sẽ được bỏ nhóm."
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23729,9 +23849,9 @@
       "translated": "Không có tác nhân nào khả dụng trên gateway này."
     },
     {
-      "id": "native.apple.6c89f35d53506406",
-      "source": "New Session Options",
-      "translated": "Tùy chọn phiên mới"
+      "id": "native.apple.2d96aa7d3d12f85b",
+      "source": "New Thread Options",
+      "translated": "Tùy chọn luồng mới"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23759,19 +23879,19 @@
       "translated": "Tạo"
     },
     {
-      "id": "native.apple.795ba37f6782cf28",
-      "source": "The session could not be created.",
-      "translated": "Không thể tạo phiên."
+      "id": "native.apple.87ef57319d1ddc85",
+      "source": "The thread could not be created.",
+      "translated": "Không thể tạo luồng."
     },
     {
-      "id": "native.apple.8ec708a3605a2cc3",
-      "source": "Search sessions",
-      "translated": "Tìm kiếm phiên"
+      "id": "native.apple.6bd91c435b69d638",
+      "source": "Search threads",
+      "translated": "Tìm kiếm luồng"
     },
     {
-      "id": "native.apple.23b069b4e7f97039",
-      "source": "No Sessions",
-      "translated": "Không có phiên nào"
+      "id": "native.apple.6fde4bdf9d5b9191",
+      "source": "No Threads",
+      "translated": "Không có luồng"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23779,29 +23899,29 @@
       "translated": "Không có kết quả"
     },
     {
-      "id": "native.apple.0058923f2ce8a3ec",
-      "source": "New Session",
-      "translated": "Phiên mới"
+      "id": "native.apple.a02fd99740d29bd3",
+      "source": "New Thread",
+      "translated": "Luồng mới"
     },
     {
-      "id": "native.apple.66ba42960eb4135b",
-      "source": "New session",
-      "translated": "Phiên mới"
+      "id": "native.apple.b625801dd04b09f2",
+      "source": "New thread",
+      "translated": "Luồng mới"
     },
     {
-      "id": "native.apple.2ef0e34db02ad255",
-      "source": "New session options",
-      "translated": "Tùy chọn phiên mới"
+      "id": "native.apple.851be81fcc933608",
+      "source": "New thread options",
+      "translated": "Tùy chọn luồng mới"
     },
     {
-      "id": "native.apple.36753ef2f1ed4264",
-      "source": "Rename Session",
-      "translated": "Đổi tên phiên"
+      "id": "native.apple.9ce8a4aba7b444b2",
+      "source": "Rename Thread",
+      "translated": "Đổi tên luồng"
     },
     {
-      "id": "native.apple.c9de0a1510ef475f",
-      "source": "Session name",
-      "translated": "Tên phiên"
+      "id": "native.apple.1dd067c44511c7f0",
+      "source": "Thread name",
+      "translated": "Tên luồng"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23814,14 +23934,14 @@
       "translated": "Hủy"
     },
     {
-      "id": "native.apple.afb4e6c99c63a28d",
-      "source": "Delete Session",
-      "translated": "Xóa phiên"
+      "id": "native.apple.618073d6ab3f2721",
+      "source": "Delete Thread",
+      "translated": "Xóa luồng"
     },
     {
-      "id": "native.apple.3d4ef32e42f136a4",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "Phiên và bản ghi của phiên sẽ bị xóa khỏi Gateway."
+      "id": "native.apple.10a5e72bba3cbccc",
+      "source": "The thread and its transcript are removed from the gateway.",
+      "translated": "Luồng và bản ghi của luồng sẽ bị xóa khỏi gateway."
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23829,14 +23949,14 @@
       "translated": "Xóa “%@”?"
     },
     {
-      "id": "native.apple.9a7dca238fba628d",
-      "source": "Session running",
-      "translated": "Phiên đang chạy"
+      "id": "native.apple.ac71e3b2aa496a2c",
+      "source": "Thread running",
+      "translated": "Luồng đang chạy"
     },
     {
-      "id": "native.apple.fcfbfe5e97a95e9c",
-      "source": "Session failed",
-      "translated": "Phiên không thành công"
+      "id": "native.apple.c775e87f997278b2",
+      "source": "Thread failed",
+      "translated": "Luồng gặp lỗi"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23894,9 +24014,9 @@
       "translated": "Sao chép khóa phiên"
     },
     {
-      "id": "native.apple.4aeb7c14c26dabac",
-      "source": "Delete Session…",
-      "translated": "Xóa phiên…"
+      "id": "native.apple.f4998cfb572f23ff",
+      "source": "Delete Thread…",
+      "translated": "Xóa luồng…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23909,9 +24029,9 @@
       "translated": "Đang kết nối…"
     },
     {
-      "id": "native.apple.79f708b3bc1d3a6c",
-      "source": "Retry session groups",
-      "translated": "Thử tải lại các nhóm phiên"
+      "id": "native.apple.8802e9576ffd0f65",
+      "source": "Retry thread groups",
+      "translated": "Thử tải lại nhóm luồng"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23934,24 +24054,24 @@
       "translated": "Phạm vi"
     },
     {
-      "id": "native.apple.2c37581c7b88f741",
-      "source": "Search sessions",
-      "translated": "Tìm phiên"
+      "id": "native.apple.b313b80def4bda52",
+      "source": "Search threads",
+      "translated": "Tìm kiếm luồng"
     },
     {
-      "id": "native.apple.43be8a2336e42faf",
-      "source": "Sessions",
-      "translated": "Phiên"
+      "id": "native.apple.c0cc6acc36f413ce",
+      "source": "Threads",
+      "translated": "Luồng"
     },
     {
-      "id": "native.apple.0b379cdfcbd3247f",
-      "source": "Rename Session",
-      "translated": "Đổi tên phiên"
+      "id": "native.apple.854d3928fe5a557c",
+      "source": "Rename Thread",
+      "translated": "Đổi tên luồng"
     },
     {
-      "id": "native.apple.54b6fbd9e41db009",
-      "source": "Session name",
-      "translated": "Tên phiên"
+      "id": "native.apple.9d0d3f20096cc4da",
+      "source": "Thread name",
+      "translated": "Tên luồng"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -23959,19 +24079,19 @@
       "translated": "Hủy"
     },
     {
-      "id": "native.apple.751e0f6b81cd374a",
-      "source": "Delete selected sessions?",
-      "translated": "Xóa các phiên đã chọn?"
+      "id": "native.apple.dc00eb94f33bae15",
+      "source": "Delete selected threads?",
+      "translated": "Xóa các luồng đã chọn?"
     },
     {
-      "id": "native.apple.aa679276581b0058",
-      "source": "Delete Sessions",
-      "translated": "Xóa các phiên"
+      "id": "native.apple.2053fc9f74dc3158",
+      "source": "Delete Threads",
+      "translated": "Xóa luồng"
     },
     {
-      "id": "native.apple.f837129cbee23297",
-      "source": "Each selected session and its transcript will be removed from the gateway.",
-      "translated": "Mỗi phiên đã chọn và bản ghi của phiên đó sẽ bị xóa khỏi gateway."
+      "id": "native.apple.0970247871a834a0",
+      "source": "Each selected thread and its transcript will be removed from the gateway.",
+      "translated": "Mỗi luồng đã chọn và bản ghi của luồng đó sẽ bị xóa khỏi Gateway."
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -23979,9 +24099,9 @@
       "translated": "Nhóm"
     },
     {
-      "id": "native.apple.64013cfee5e25305",
-      "source": "Manage session groups",
-      "translated": "Quản lý nhóm phiên"
+      "id": "native.apple.6f8acab2256728b5",
+      "source": "Manage thread groups",
+      "translated": "Quản lý nhóm luồng"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -23994,14 +24114,14 @@
       "translated": "Chọn"
     },
     {
-      "id": "native.apple.b67eaecec1b423ac",
-      "source": "No archived sessions",
-      "translated": "Không có phiên đã lưu trữ"
+      "id": "native.apple.692972314d04b184",
+      "source": "No archived threads",
+      "translated": "Không có luồng nào được lưu trữ"
     },
     {
-      "id": "native.apple.b2435a79abf0c794",
-      "source": "No sessions found",
-      "translated": "Không tìm thấy phiên nào"
+      "id": "native.apple.d6a4b5711dcd26e7",
+      "source": "No threads found",
+      "translated": "Không tìm thấy luồng nào"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24169,6 +24289,16 @@
       "translated": "Mở toàn bộ tin nhắn"
     },
     {
+      "id": "native.apple.002bfcede229ad4b",
+      "source": "Rewind to Here",
+      "translated": "Quay lại đây"
+    },
+    {
+      "id": "native.apple.14df2e4997689fb3",
+      "source": "Fork from Here",
+      "translated": "Tạo nhánh từ đây"
+    },
+    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "Trả lời"
@@ -24254,9 +24384,9 @@
       "translated": "Xóa tệp đính kèm hoặc chờ quá trình gửi hoàn tất trước khi bắt đầu cuộc trò chuyện mới."
     },
     {
-      "id": "native.apple.980f552bb0f96c0f",
-      "source": "Gateway changed before the session operation started.",
-      "translated": "Gateway đã thay đổi trước khi thao tác phiên bắt đầu."
+      "id": "native.apple.e0f045151c8d3137",
+      "source": "Gateway changed before the thread operation started.",
+      "translated": "Gateway đã thay đổi trước khi thao tác với luồng bắt đầu."
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24264,9 +24394,9 @@
       "translated": "Gỡ tệp đính kèm hoặc chờ gửi xong trước khi chuyển cuộc trò chuyện."
     },
     {
-      "id": "native.apple.87ba543b42696b92",
-      "source": "Clear this session's history?",
-      "translated": "Xóa lịch sử của phiên này?"
+      "id": "native.apple.0a5c4e15466c3acc",
+      "source": "Clear this thread's history?",
+      "translated": "Xóa lịch sử của luồng này?"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24279,14 +24409,14 @@
       "translated": "Thao tác này sẽ đặt lại cuộc trò chuyện cho %@. Khóa phiên vẫn giữ nguyên."
     },
     {
-      "id": "native.apple.a92e96bed98bd553",
-      "source": "Rename Session",
-      "translated": "Đổi tên phiên"
+      "id": "native.apple.67ac221dbe7179f0",
+      "source": "Rename Thread",
+      "translated": "Đổi tên luồng"
     },
     {
-      "id": "native.apple.848e2388f3466f40",
-      "source": "Session name",
-      "translated": "Tên phiên"
+      "id": "native.apple.cf0f7e049603f518",
+      "source": "Thread name",
+      "translated": "Tên luồng"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24304,9 +24434,9 @@
       "translated": "Xuất Bản ghi"
     },
     {
-      "id": "native.apple.4af0f566d39d7041",
-      "source": "Sessions",
-      "translated": "Phiên"
+      "id": "native.apple.c0ada47504425f23",
+      "source": "Threads",
+      "translated": "Luồng"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24379,14 +24509,14 @@
       "translated": "Mặc định"
     },
     {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "Phiên Mới"
+      "id": "native.apple.1a765291943599e5",
+      "source": "New Thread",
+      "translated": "Luồng mới"
     },
     {
-      "id": "native.apple.a7119fbf9d25df5e",
-      "source": "New Session Options…",
-      "translated": "Tùy chọn phiên mới…"
+      "id": "native.apple.c7a3a6d5e43dd98f",
+      "source": "New Thread Options…",
+      "translated": "Tùy chọn luồng mới…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24394,19 +24524,19 @@
       "translated": "Làm mới"
     },
     {
-      "id": "native.apple.2bcff4a8fa503739",
-      "source": "Sessions…",
-      "translated": "Phiên…"
+      "id": "native.apple.0e710b81808e5dcf",
+      "source": "Threads…",
+      "translated": "Luồng…"
     },
     {
-      "id": "native.apple.c36e008b051adb38",
-      "source": "Rename Session…",
-      "translated": "Đổi tên phiên…"
+      "id": "native.apple.faad8f92b6bef166",
+      "source": "Rename Thread…",
+      "translated": "Đổi tên luồng…"
     },
     {
-      "id": "native.apple.ea0ef95a159bffe0",
-      "source": "Fork Session",
-      "translated": "Phân nhánh phiên"
+      "id": "native.apple.23b61d6cd26ac112",
+      "source": "Fork",
+      "translated": "Phân nhánh"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24464,24 +24594,24 @@
       "translated": "Xóa Lịch sử…"
     },
     {
-      "id": "native.apple.920fe8a7a33f9e92",
-      "source": "Session",
-      "translated": "Phiên"
+      "id": "native.apple.8b4f1c5107ea8a0e",
+      "source": "Thread",
+      "translated": "Luồng"
     },
     {
-      "id": "native.apple.185a401f78328b0f",
-      "source": "Session actions",
-      "translated": "Thao tác phiên"
+      "id": "native.apple.4d7750c9bf699469",
+      "source": "Thread actions",
+      "translated": "Thao tác với luồng"
     },
     {
-      "id": "native.apple.9f9dedf599b2619b",
-      "source": "Session cost %@",
-      "translated": "Chi phí phiên %@"
+      "id": "native.apple.bb2f22cc43c97f8e",
+      "source": "Thread cost %@",
+      "translated": "Chi phí luồng %@"
     },
     {
-      "id": "native.apple.f0a4720df5f5f403",
-      "source": "Compact Session",
-      "translated": "Thu gọn Phiên"
+      "id": "native.apple.6239ced0b86e86f8",
+      "source": "Compact Thread",
+      "translated": "Thu gọn luồng"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/zh-CN.json
+++ b/apps/.i18n/native/zh-CN.json
@@ -1429,8 +1429,8 @@
       "translated": "与 OpenClaw 交谈或向其听写"
     },
     {
-      "id": "native.android.5876e15e5e92fd45",
-      "source": "Browse Sessions",
+      "id": "native.android.e2cf5a38587382cb",
+      "source": "Browse Threads",
       "translated": "浏览会话"
     },
     {
@@ -1484,24 +1484,24 @@
       "translated": "未找到操作"
     },
     {
-      "id": "native.android.48ad0ae0e930e02b",
-      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
-      "translated": "尝试聊天、语音、会话、提供商或设置。"
+      "id": "native.android.bc70a4ac965b82ba",
+      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
+      "translated": "试试聊天、语音、会话、提供商或设置。"
     },
     {
-      "id": "native.android.d4fbd1ee4f55a5db",
-      "source": "Sessions",
+      "id": "native.android.670121e54dbe286f",
+      "source": "Threads",
       "translated": "会话"
     },
     {
-      "id": "native.android.207c2170504e99e6",
-      "source": "Connect the Gateway to search sessions.",
+      "id": "native.android.d38be650b1bce4a0",
+      "source": "Connect the Gateway to search threads.",
       "translated": "连接 Gateway 以搜索会话。"
     },
     {
-      "id": "native.android.25d2c2d792c952fe",
-      "source": "No matching sessions yet.",
-      "translated": "尚无匹配的会话。"
+      "id": "native.android.3d7754721f776ef8",
+      "source": "No matching threads yet.",
+      "translated": "暂无匹配的会话。"
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,13 +1509,13 @@
       "translated": "助手正在工作"
     },
     {
-      "id": "native.android.8f8384286317f5c9",
-      "source": "OpenClaw session",
+      "id": "native.android.9a839f6e3e05a744",
+      "source": "OpenClaw thread",
       "translated": "OpenClaw 会话"
     },
     {
-      "id": "native.android.15799e57704b20c6",
-      "source": "Open session",
+      "id": "native.android.d83f82a1e4a5ed99",
+      "source": "Open thread",
       "translated": "打开会话"
     },
     {
@@ -1539,8 +1539,8 @@
       "translated": "没有就绪的提供方"
     },
     {
-      "id": "native.android.73e6ab1a168fd381",
-      "source": "Main session",
+      "id": "native.android.8a1c5365c0538908",
+      "source": "Main thread",
       "translated": "主会话"
     },
     {
@@ -3679,13 +3679,13 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.0e3157c15c56944f",
-      "source": "Sessions",
+      "id": "native.android.a5845742daecb4ba",
+      "source": "Threads",
       "translated": "会话"
     },
     {
-      "id": "native.android.70f5d0507d34b5c8",
-      "source": "Focus session search",
+      "id": "native.android.439b324280869527",
+      "source": "Focus thread search",
       "translated": "聚焦会话搜索"
     },
     {
@@ -3699,13 +3699,13 @@
       "translated": "已归档"
     },
     {
-      "id": "native.android.b9cf34c137e4cf03",
-      "source": "Search sessions",
+      "id": "native.android.03981341841b04ac",
+      "source": "Search threads",
       "translated": "搜索会话"
     },
     {
-      "id": "native.android.10cb26723e9990fc",
-      "source": "Clear session search",
+      "id": "native.android.99570c528a41fa72",
+      "source": "Clear thread search",
       "translated": "清除会话搜索"
     },
     {
@@ -3724,8 +3724,8 @@
       "translated": "最早优先"
     },
     {
-      "id": "native.android.c6bf8751e2a7f5c7",
-      "source": "Toggle session layout",
+      "id": "native.android.fd67be543e321cc9",
+      "source": "Toggle thread layout",
       "translated": "切换会话布局"
     },
     {
@@ -3739,13 +3739,13 @@
       "translated": "布局：详细"
     },
     {
-      "id": "native.android.69b79a3c2c987cd4",
-      "source": "Searching sessions",
+      "id": "native.android.ebd17565e0ffd8eb",
+      "source": "Searching threads",
       "translated": "正在搜索会话"
     },
     {
-      "id": "native.android.dd587d341af44212",
-      "source": "No matching sessions",
+      "id": "native.android.472d46ae8669f860",
+      "source": "No matching threads",
       "translated": "没有匹配的会话"
     },
     {
@@ -3764,18 +3764,18 @@
       "translated": "开始聊天"
     },
     {
-      "id": "native.android.f10d4df7cbc6df4f",
-      "source": "Current session",
+      "id": "native.android.ff81ad1bee00d384",
+      "source": "Current thread",
       "translated": "当前会话"
     },
     {
-      "id": "native.android.8f0482425838ae64",
-      "source": "OpenClaw session",
+      "id": "native.android.fc145645b9620e57",
+      "source": "OpenClaw thread",
       "translated": "OpenClaw 会话"
     },
     {
-      "id": "native.android.786774c8a76e50d7",
-      "source": "Rename session",
+      "id": "native.android.71cbb8dde8bf138b",
+      "source": "Rename thread",
       "translated": "重命名会话"
     },
     {
@@ -3804,19 +3804,19 @@
       "translated": "删除分组？"
     },
     {
-      "id": "native.android.3455fc2f77d564e3",
-      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "“$group”中的会话将被保留并移回未分组。"
+      "id": "native.android.691e92cfe5cf106e",
+      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "“$group”中的会话将被保留并移回“未分组”。"
     },
     {
-      "id": "native.android.4805fb9d6623e8c0",
-      "source": "Delete session?",
+      "id": "native.android.d87a8217ab56999b",
+      "source": "Delete thread?",
       "translated": "删除会话？"
     },
     {
-      "id": "native.android.0c3283a2b2445eae",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "这将永久删除该会话及其转录内容。"
+      "id": "native.android.930de97ff47113a8",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "这将永久删除该对话线程及其记录。"
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "未分组"
     },
     {
-      "id": "native.android.db243d71d056afa4",
-      "source": "No sessions yet",
-      "translated": "还没有会话"
+      "id": "native.android.8e21a70428def6e0",
+      "source": "No threads yet",
+      "translated": "暂无对话线程"
     },
     {
-      "id": "native.android.5b4eee6a8092925e",
-      "source": "No current session",
-      "translated": "没有当前会话"
+      "id": "native.android.cda4c5ad8b17e394",
+      "source": "No current thread",
+      "translated": "暂无当前对话线程"
     },
     {
-      "id": "native.android.acbcc9c9ea53d8c0",
-      "source": "No archived sessions",
-      "translated": "没有已归档会话"
+      "id": "native.android.be84f061047aa2da",
+      "source": "No archived threads",
+      "translated": "暂无已归档的对话线程"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "开始新的对话后，它会显示在这里。"
     },
     {
-      "id": "native.android.56fcd605dc7be3c0",
-      "source": "Open Chat to start or resume the current session.",
-      "translated": "打开聊天以开始或继续当前会话。"
+      "id": "native.android.f289d03e1d3eee98",
+      "source": "Open Chat to start or resume the current thread.",
+      "translated": "打开聊天以开始或继续当前对话线程。"
     },
     {
-      "id": "native.android.085515989f8a2022",
-      "source": "Archived sessions will show up here.",
-      "translated": "已归档的会话将显示在这里。"
+      "id": "native.android.504b71386e76c6ae",
+      "source": "Archived threads will show up here.",
+      "translated": "已归档的对话线程将显示在此处。"
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days}天"
     },
     {
-      "id": "native.android.3d4fa07acbc015c5",
-      "source": "Main session",
-      "translated": "主会话"
+      "id": "native.android.ee4c727cdafbe963",
+      "source": "Main thread",
+      "translated": "主对话线程"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway 待处理"
     },
     {
-      "id": "native.android.2d8d049afe99f751",
-      "source": "Session Activity",
-      "translated": "会话活动"
+      "id": "native.android.da78209effb11cfd",
+      "source": "Thread Activity",
+      "translated": "对话线程活动"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "当此手机连接时，Exec 批准请求将显示在此处。"
     },
     {
-      "id": "native.android.dc3e7ca5a491103a",
-      "source": "Session activity",
-      "translated": "会话活动"
+      "id": "native.android.f615712dfb56319a",
+      "source": "Thread activity",
+      "translated": "对话线程活动"
     },
     {
-      "id": "native.android.8551e02b060bd7d8",
-      "source": "Chat tool calls waiting in the active session remain visible here.",
-      "translated": "活动会话中等待处理的聊天工具调用会保留显示在此处。"
+      "id": "native.android.6c93973c13db43ae",
+      "source": "Chat tool calls waiting in the active thread remain visible here.",
+      "translated": "当前对话线程中等待处理的聊天工具调用仍会显示在此处。"
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,6 +4294,11 @@
       "translated": "Talk Provider 设置"
     },
     {
+      "id": "native.android.23b638094c34b916",
+      "source": "Microphone",
+      "translated": "麦克风"
+    },
+    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "音频测试"
@@ -4337,6 +4342,66 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "完成"
+    },
+    {
+      "id": "native.android.8d9ecdfdd916b780",
+      "source": "Automatic",
+      "translated": "自动"
+    },
+    {
+      "id": "native.android.c1626a6700a570f6",
+      "source": "Preferred microphone unavailable; using automatic routing.",
+      "translated": "首选麦克风不可用；正在使用自动路由。"
+    },
+    {
+      "id": "native.android.820bc5d0ce571d8b",
+      "source": "Prioritizes connected Bluetooth microphones.",
+      "translated": "优先使用已连接的蓝牙麦克风。"
+    },
+    {
+      "id": "native.android.11e48038d5e8bff6",
+      "source": "Preferred microphone",
+      "translated": "首选麦克风"
+    },
+    {
+      "id": "native.android.eaa4d7563a46d307",
+      "source": "Unavailable",
+      "translated": "不可用"
+    },
+    {
+      "id": "native.android.9f5ebf17eb405ba8",
+      "source": "Next session",
+      "translated": "下次会话"
+    },
+    {
+      "id": "native.android.8c4e91f53928efb2",
+      "source": "Built-in microphone",
+      "translated": "内置麦克风"
+    },
+    {
+      "id": "native.android.14b613cb6e2446b4",
+      "source": "Bluetooth microphone",
+      "translated": "蓝牙麦克风"
+    },
+    {
+      "id": "native.android.c885247b2d7ce271",
+      "source": "Bluetooth LE microphone",
+      "translated": "Bluetooth LE 麦克风"
+    },
+    {
+      "id": "native.android.b6a4e674c5fb441a",
+      "source": "Wired headset microphone",
+      "translated": "有线耳机麦克风"
+    },
+    {
+      "id": "native.android.9c8becb3b0fb5a90",
+      "source": "USB microphone",
+      "translated": "USB 麦克风"
+    },
+    {
+      "id": "native.android.ba46258fadec7a39",
+      "source": "External microphone",
+      "translated": "外接麦克风"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5074,9 +5139,9 @@
       "translated": "检查"
     },
     {
-      "id": "native.android.5a540761383fa474",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
-      "translated": "OpenClaw 将此手机变成一个简洁的移动命令界面，用于管理会话、语音、提供商和 Gateway。"
+      "id": "native.android.c971506716c96e91",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
+      "translated": "OpenClaw 将此手机变成简洁的移动命令界面，用于管理会话、语音、提供商和 Gateway。"
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5624,9 +5689,9 @@
       "translated": "对话设置"
     },
     {
-      "id": "native.android.73f07a5d54915259",
-      "source": "Recent Sessions",
-      "translated": "最近会话"
+      "id": "native.android.36f78c8c85dc283f",
+      "source": "Recent Threads",
+      "translated": "最近的会话"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5684,14 +5749,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% 在线"
     },
     {
-      "id": "native.android.16c3425d3a594481",
-      "source": "Sessions",
+      "id": "native.android.57177017a6a93826",
+      "source": "Threads",
       "translated": "会话"
     },
     {
-      "id": "native.android.a5c0f8b3112aa58c",
-      "source": "No recent sessions",
-      "translated": "没有最近会话"
+      "id": "native.android.43320b54a68b00a1",
+      "source": "No recent threads",
+      "translated": "没有最近的会话"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5729,14 +5794,14 @@
       "translated": "工作中 · $pendingRunCount 个活跃运行"
     },
     {
-      "id": "native.android.2c89da708b12a522",
-      "source": "Monitoring · 1 session",
-      "translated": "监控中 · 1 个会话"
+      "id": "native.android.e24db059480f1e6a",
+      "source": "Monitoring · 1 thread",
+      "translated": "正在监控 · 1 个会话"
     },
     {
-      "id": "native.android.8b6ee382dcb64e1f",
-      "source": "Monitoring · $sessionCount sessions",
-      "translated": "监控中 · $sessionCount 个会话"
+      "id": "native.android.5a475f37d80e02bc",
+      "source": "Monitoring · $sessionCount threads",
+      "translated": "正在监控 · $sessionCount 个会话"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5769,8 +5834,8 @@
       "translated": "提供商"
     },
     {
-      "id": "native.android.a65477861c7203aa",
-      "source": "Open session",
+      "id": "native.android.358c5e0e838d5423",
+      "source": "Open thread",
       "translated": "打开会话"
     },
     {
@@ -6194,8 +6259,8 @@
       "translated": "${days}天"
     },
     {
-      "id": "native.android.22d755834386db07",
-      "source": "Main session",
+      "id": "native.android.28a1a1acc5a0959f",
+      "source": "Main thread",
       "translated": "主会话"
     },
     {
@@ -6877,6 +6942,16 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "取消静音"
+    },
+    {
+      "id": "native.android.cb608d82c5b3352a",
+      "source": "Back camera",
+      "translated": "后置摄像头"
+    },
+    {
+      "id": "native.android.e89a0e780eed2e1e",
+      "source": "Front camera",
+      "translated": "前置摄像头"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7684,8 +7759,8 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.882cc14a58e7e105",
-      "source": "Loading session",
+      "id": "native.android.0c74bc30a994dd33",
+      "source": "Loading thread",
       "translated": "正在加载会话"
     },
     {
@@ -7729,14 +7804,14 @@
       "translated": "帮我了解最新进展"
     },
     {
-      "id": "native.android.1e5add56e48c99f9",
-      "source": "Summarize recent sessions and next steps.",
+      "id": "native.android.cf40df9739f78f27",
+      "source": "Summarize recent threads and next steps.",
       "translated": "总结最近的会话和后续步骤。"
     },
     {
-      "id": "native.android.06d515351bb79576",
-      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
-      "translated": "帮我了解最近 OpenClaw 会话的最新进展，并建议后续步骤。"
+      "id": "native.android.ebe49a8b8df80bd3",
+      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
+      "translated": "帮我了解最近的 OpenClaw 会话，并建议后续步骤。"
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8074,8 +8149,8 @@
       "translated": "已连接"
     },
     {
-      "id": "native.android.81931886b9caf3ab",
-      "source": "Sessions",
+      "id": "native.android.6cf5d6fa8a4186d5",
+      "source": "Threads",
       "translated": "会话"
     },
     {
@@ -10794,9 +10869,9 @@
       "translated": "你想处理什么？"
     },
     {
-      "id": "native.apple.32179ce0b6d4543f",
-      "source": "The session attaches once the gateway is ready.",
-      "translated": "Gateway 准备就绪后，会话将会附加。"
+      "id": "native.apple.4da775013ac9b123",
+      "source": "The thread attaches once the gateway is ready.",
+      "translated": "Gateway 准备就绪后将连接该会话。"
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10844,8 +10919,8 @@
       "translated": "新会话选项…"
     },
     {
-      "id": "native.apple.a1b0d289758e2213",
-      "source": "Sessions…",
+      "id": "native.apple.003b25ddafeb18e9",
+      "source": "Threads…",
       "translated": "会话…"
     },
     {
@@ -11009,14 +11084,14 @@
       "translated": "创建"
     },
     {
-      "id": "native.apple.f488b9caf6e51ac3",
-      "source": "Delete Session?",
+      "id": "native.apple.31d5c7287cfb3abe",
+      "source": "Delete Thread?",
       "translated": "删除会话？"
     },
     {
-      "id": "native.apple.8634b17be9b111bc",
-      "source": "Delete Session",
-      "translated": "删除会话"
+      "id": "native.apple.d3395564809f1120",
+      "source": "Delete Thread",
+      "translated": "删除对话"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11024,9 +11099,9 @@
       "translated": "取消"
     },
     {
-      "id": "native.apple.4a9568ac9b18d8d3",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "这将永久删除该会话及其转录内容。"
+      "id": "native.apple.092659256d26cb03",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "这将永久删除该对话及其对话记录。"
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11054,9 +11129,9 @@
       "translated": "新建组"
     },
     {
-      "id": "native.apple.5bccdc23a1640895",
-      "source": "Rename Session",
-      "translated": "重命名会话"
+      "id": "native.apple.683032464c497bbd",
+      "source": "Rename Thread",
+      "translated": "重命名对话"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11064,9 +11139,9 @@
       "translated": "组名称"
     },
     {
-      "id": "native.apple.af789b2d2fda0f67",
-      "source": "Session name",
-      "translated": "会话名称"
+      "id": "native.apple.f887aa956588f237",
+      "source": "Thread name",
+      "translated": "对话名称"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11104,14 +11179,14 @@
       "translated": "智能体"
     },
     {
-      "id": "native.apple.a3bde8045fe9224a",
-      "source": "Agent session",
-      "translated": "智能体会话"
+      "id": "native.apple.7c8231b7b1ca480f",
+      "source": "Agent thread",
+      "translated": "智能体对话"
     },
     {
-      "id": "native.apple.27f775de30b37ff8",
-      "source": "Recent sessions",
-      "translated": "最近会话"
+      "id": "native.apple.b3c553614f762a58",
+      "source": "Recent threads",
+      "translated": "最近的对话"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11119,9 +11194,9 @@
       "translated": "Gateway 离线"
     },
     {
-      "id": "native.apple.28c97cf23665ee01",
-      "source": "No recent sessions",
-      "translated": "没有最近会话"
+      "id": "native.apple.5aa32afda85064ea",
+      "source": "No recent threads",
+      "translated": "没有最近的对话"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11219,14 +11294,14 @@
       "translated": "取消"
     },
     {
-      "id": "native.apple.9f2fd65953013b7c",
-      "source": "Sessions",
-      "translated": "会话"
+      "id": "native.apple.b6855cf19a50f477",
+      "source": "Threads",
+      "translated": "对话"
     },
     {
-      "id": "native.apple.0422818cc95d5071",
-      "source": "Archived sessions",
-      "translated": "已归档的会话"
+      "id": "native.apple.9b1d0ef27a1333b0",
+      "source": "Archived threads",
+      "translated": "已归档的对话"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11234,34 +11309,34 @@
       "translated": "显示已归档"
     },
     {
-      "id": "native.apple.b272115c83f7ef58",
-      "source": "Sessions unavailable",
-      "translated": "会话不可用"
+      "id": "native.apple.98167401c7267735",
+      "source": "Threads unavailable",
+      "translated": "对话不可用"
     },
     {
-      "id": "native.apple.54f8260c9b863087",
-      "source": "Loading archived sessions",
-      "translated": "正在加载已归档的会话"
+      "id": "native.apple.4d28a7def2337b9f",
+      "source": "Loading archived threads",
+      "translated": "正在加载已归档的对话"
     },
     {
-      "id": "native.apple.9b305868873dade2",
-      "source": "Loading recent sessions",
-      "translated": "正在加载最近的会话"
+      "id": "native.apple.777d7b706933bd7b",
+      "source": "Loading recent threads",
+      "translated": "正在加载最近的对话"
     },
     {
-      "id": "native.apple.207dad20d09f3160",
-      "source": "^[\\(count) session](inflect: true)",
-      "translated": "^[\\(count) 个会话](inflect: true)"
+      "id": "native.apple.22f81ea94bef8410",
+      "source": "^[\\(count) thread](inflect: true)",
+      "translated": "^[\\(count) 个对话](inflect: true)"
     },
     {
-      "id": "native.apple.1f4501a6bf2bae4c",
-      "source": "No archived sessions",
-      "translated": "没有已归档的会话"
+      "id": "native.apple.1cad51e14db59bf9",
+      "source": "No archived threads",
+      "translated": "没有已归档的对话"
     },
     {
-      "id": "native.apple.2a1ba7a5e1979c9e",
-      "source": "Archived sessions will appear here.",
-      "translated": "已归档的会话将显示在此处。"
+      "id": "native.apple.18ef832d3a7ddcf8",
+      "source": "Archived threads will appear here.",
+      "translated": "已归档的对话将显示在此处。"
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11344,9 +11419,9 @@
       "translated": "共享入口"
     },
     {
-      "id": "native.apple.2360d25fe6ae9946",
-      "source": "Loading sessions",
-      "translated": "正在加载会话"
+      "id": "native.apple.21d9208d86a4d1fe",
+      "source": "Loading threads",
+      "translated": "正在加载对话"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11354,19 +11429,19 @@
       "translated": "正在从 Gateway 获取最近活动。"
     },
     {
-      "id": "native.apple.c334f2e86702a7b8",
-      "source": "Sessions unavailable",
-      "translated": "会话不可用"
+      "id": "native.apple.4be1f79aa2b230ff",
+      "source": "Threads unavailable",
+      "translated": "对话不可用"
     },
     {
-      "id": "native.apple.6cc6efb7a03960b6",
-      "source": "No recent sessions",
-      "translated": "没有最近会话"
+      "id": "native.apple.98b348873556bc46",
+      "source": "No recent threads",
+      "translated": "没有最近的对话"
     },
     {
-      "id": "native.apple.08483af2d043bee6",
-      "source": "Session activity offline",
-      "translated": "会话活动离线"
+      "id": "native.apple.7396d205574d279f",
+      "source": "Thread activity offline",
+      "translated": "对话活动已离线"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11824,9 +11899,9 @@
       "translated": "卡片"
     },
     {
-      "id": "native.apple.93eeaedb2ff61043",
-      "source": "Open Session",
-      "translated": "打开会话"
+      "id": "native.apple.c9ec1b0e18074d8a",
+      "source": "Open Thread",
+      "translated": "打开对话"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13314,9 +13389,9 @@
       "translated": "默认"
     },
     {
-      "id": "native.apple.3de045f17ea3c6d0",
-      "source": "Used for new Chat and Talk sessions.",
-      "translated": "用于新的聊天和通话会话。"
+      "id": "native.apple.f4ae5664c3eda95d",
+      "source": "Used for new Chat threads and Talk sessions.",
+      "translated": "用于新的聊天话题串和通话会话。"
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15719,9 +15794,9 @@
       "translated": "实例"
     },
     {
-      "id": "native.apple.3579cf2750470a22",
-      "source": "Sessions",
-      "translated": "会话"
+      "id": "native.apple.11fe8b9941954dfb",
+      "source": "Threads",
+      "translated": "话题串"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19029,9 +19104,9 @@
       "translated": "快速聊天快捷键"
     },
     {
-      "id": "native.apple.6ae77665b5f4490f",
-      "source": "Global shortcut that opens a floating chat bar for the main session.",
-      "translated": "用于为主会话打开浮动聊天栏的全局快捷键。"
+      "id": "native.apple.94dd793cd7d7d555",
+      "source": "Global shortcut that opens a floating chat bar for the main thread.",
+      "translated": "用于打开主话题串浮动聊天栏的全局快捷键。"
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19609,9 +19684,9 @@
       "translated": "严重"
     },
     {
-      "id": "native.apple.75102378a6775180",
-      "source": "New Session",
-      "translated": "新建会话"
+      "id": "native.apple.13f96467014cf344",
+      "source": "New Thread",
+      "translated": "新建话题串"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21899,9 +21974,9 @@
       "translated": "没有最近消息"
     },
     {
-      "id": "native.apple.1ff8aec0044934c3",
-      "source": "Sessions",
-      "translated": "会话"
+      "id": "native.apple.3ec2afcbc298c673",
+      "source": "Threads",
+      "translated": "话题串"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21909,9 +21984,9 @@
       "translated": "查看 CLI 为上下文和速率限制复用的已存储对话桶。"
     },
     {
-      "id": "native.apple.bab897f3252b134c",
-      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
-      "translated": "还没有会话。它们会在第一条入站消息或心跳之后显示。"
+      "id": "native.apple.14ccb32cd8ed1c81",
+      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
+      "translated": "暂无话题串。收到第一条传入消息或心跳后，话题串将显示在此处。"
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -21994,9 +22069,9 @@
       "translated": "执行审批"
     },
     {
-      "id": "native.apple.64a6dc7d49e8fb57",
-      "source": "Sessions",
-      "translated": "会话"
+      "id": "native.apple.52e37e3a44ae516c",
+      "source": "Threads",
+      "translated": "话题串"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -22999,9 +23074,9 @@
       "translated": "帮我了解最新情况"
     },
     {
-      "id": "native.apple.234ec45f4231edc4",
-      "source": "Summarize what happened in my sessions since yesterday.",
-      "translated": "总结从昨天起我的会话中发生的事情。"
+      "id": "native.apple.fc4ce810900ec0b6",
+      "source": "Summarize what happened in my threads since yesterday.",
+      "translated": "总结自昨天以来我的话题串中发生的事情。"
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23179,9 +23254,9 @@
       "translated": "取消固定模型"
     },
     {
-      "id": "native.apple.5dfc0700d8dff8de",
-      "source": "Session",
-      "translated": "会话"
+      "id": "native.apple.4edb66657f5aca1f",
+      "source": "Thread",
+      "translated": "话题串"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23344,6 +23419,51 @@
       "translated": "小组件不可用"
     },
     {
+      "id": "native.apple.d640691fd196f338",
+      "source": "Widget export failed",
+      "translated": "小组件导出失败"
+    },
+    {
+      "id": "native.apple.533c6e22a11e88de",
+      "source": "OK",
+      "translated": "好"
+    },
+    {
+      "id": "native.apple.e1fb28a2a9756402",
+      "source": "Copy image",
+      "translated": "复制图像"
+    },
+    {
+      "id": "native.apple.ebd7bc92e1b12235",
+      "source": "Save image…",
+      "translated": "存储图像…"
+    },
+    {
+      "id": "native.apple.742c46d4cf2db134",
+      "source": "Save image",
+      "translated": "存储图像"
+    },
+    {
+      "id": "native.apple.0589cce608418f90",
+      "source": "The widget image could not be captured.",
+      "translated": "无法截取小组件图像。"
+    },
+    {
+      "id": "native.apple.dfe24e827fdbe9c5",
+      "source": "The widget image could not be copied.",
+      "translated": "无法复制小组件图像。"
+    },
+    {
+      "id": "native.apple.9e611e3a80e71408",
+      "source": "The widget image could not be encoded as PNG.",
+      "translated": "无法将小组件图像编码为 PNG。"
+    },
+    {
+      "id": "native.apple.9a6e8afbe24a262b",
+      "source": "The widget image could not be saved.",
+      "translated": "无法存储小组件图像。"
+    },
+    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23484,19 +23604,19 @@
       "translated": "用户"
     },
     {
-      "id": "native.apple.b1cdcb906a43d5d6",
-      "source": "This session cannot be archived while it is active or running.",
-      "translated": "此会话处于活动或运行状态时无法归档。"
+      "id": "native.apple.9d0cba09d92ee669",
+      "source": "This thread cannot be archived while it is active or running.",
+      "translated": "此话题串处于活动或运行状态时无法归档。"
     },
     {
-      "id": "native.apple.5817e3f3dab1ee19",
-      "source": "The main session cannot be deleted.",
-      "translated": "无法删除主会话。"
+      "id": "native.apple.8952a111a1075051",
+      "source": "The main thread cannot be deleted.",
+      "translated": "无法删除主话题串。"
     },
     {
-      "id": "native.apple.a6b8df3f18171c91",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
-      "translated": "请移除附件或等待其发送完成，然后再归档或删除此会话。"
+      "id": "native.apple.90d0ccf80ca28717",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
+      "translated": "请移除附件或等待附件发送完毕，然后再归档或删除此话题。"
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23634,9 +23754,9 @@
       "translated": "运行结束时间"
     },
     {
-      "id": "native.apple.cd7c3095a22f80a9",
-      "source": "Session Info",
-      "translated": "会话信息"
+      "id": "native.apple.bbccb4c8db5cac12",
+      "source": "Thread Info",
+      "translated": "话题信息"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23669,9 +23789,9 @@
       "translated": "添加群组"
     },
     {
-      "id": "native.apple.23d628606fe0734f",
-      "source": "Session Groups",
-      "translated": "会话群组"
+      "id": "native.apple.7b641fed5bace855",
+      "source": "Thread Groups",
+      "translated": "话题组"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23714,9 +23834,9 @@
       "translated": "删除群组"
     },
     {
-      "id": "native.apple.b049c8a4d2805e08",
-      "source": "Sessions in this group become ungrouped.",
-      "translated": "此群组中的会话将变为未分组状态。"
+      "id": "native.apple.56401c79410a310d",
+      "source": "Threads in this group become ungrouped.",
+      "translated": "此组中的话题将变为未分组状态。"
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23729,9 +23849,9 @@
       "translated": "此 Gateway 上没有可用的代理。"
     },
     {
-      "id": "native.apple.6c89f35d53506406",
-      "source": "New Session Options",
-      "translated": "新建会话选项"
+      "id": "native.apple.2d96aa7d3d12f85b",
+      "source": "New Thread Options",
+      "translated": "新建话题选项"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23759,19 +23879,19 @@
       "translated": "创建"
     },
     {
-      "id": "native.apple.795ba37f6782cf28",
-      "source": "The session could not be created.",
-      "translated": "无法创建会话。"
+      "id": "native.apple.87ef57319d1ddc85",
+      "source": "The thread could not be created.",
+      "translated": "无法创建话题。"
     },
     {
-      "id": "native.apple.8ec708a3605a2cc3",
-      "source": "Search sessions",
-      "translated": "搜索会话"
+      "id": "native.apple.6bd91c435b69d638",
+      "source": "Search threads",
+      "translated": "搜索话题"
     },
     {
-      "id": "native.apple.23b069b4e7f97039",
-      "source": "No Sessions",
-      "translated": "没有会话"
+      "id": "native.apple.6fde4bdf9d5b9191",
+      "source": "No Threads",
+      "translated": "没有话题"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23779,29 +23899,29 @@
       "translated": "没有结果"
     },
     {
-      "id": "native.apple.0058923f2ce8a3ec",
-      "source": "New Session",
-      "translated": "新建会话"
+      "id": "native.apple.a02fd99740d29bd3",
+      "source": "New Thread",
+      "translated": "新建话题"
     },
     {
-      "id": "native.apple.66ba42960eb4135b",
-      "source": "New session",
-      "translated": "新建会话"
+      "id": "native.apple.b625801dd04b09f2",
+      "source": "New thread",
+      "translated": "新建话题"
     },
     {
-      "id": "native.apple.2ef0e34db02ad255",
-      "source": "New session options",
-      "translated": "新建会话选项"
+      "id": "native.apple.851be81fcc933608",
+      "source": "New thread options",
+      "translated": "新建话题选项"
     },
     {
-      "id": "native.apple.36753ef2f1ed4264",
-      "source": "Rename Session",
-      "translated": "重命名会话"
+      "id": "native.apple.9ce8a4aba7b444b2",
+      "source": "Rename Thread",
+      "translated": "重命名话题"
     },
     {
-      "id": "native.apple.c9de0a1510ef475f",
-      "source": "Session name",
-      "translated": "会话名称"
+      "id": "native.apple.1dd067c44511c7f0",
+      "source": "Thread name",
+      "translated": "话题名称"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23814,14 +23934,14 @@
       "translated": "取消"
     },
     {
-      "id": "native.apple.afb4e6c99c63a28d",
-      "source": "Delete Session",
-      "translated": "删除会话"
+      "id": "native.apple.618073d6ab3f2721",
+      "source": "Delete Thread",
+      "translated": "删除话题"
     },
     {
-      "id": "native.apple.3d4ef32e42f136a4",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "该会话及其转录内容将从 Gateway 中移除。"
+      "id": "native.apple.10a5e72bba3cbccc",
+      "source": "The thread and its transcript are removed from the gateway.",
+      "translated": "该话题及其对话记录将从 Gateway 中移除。"
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23829,14 +23949,14 @@
       "translated": "删除“%@”？"
     },
     {
-      "id": "native.apple.9a7dca238fba628d",
-      "source": "Session running",
-      "translated": "会话正在运行"
+      "id": "native.apple.ac71e3b2aa496a2c",
+      "source": "Thread running",
+      "translated": "话题正在运行"
     },
     {
-      "id": "native.apple.fcfbfe5e97a95e9c",
-      "source": "Session failed",
-      "translated": "会话失败"
+      "id": "native.apple.c775e87f997278b2",
+      "source": "Thread failed",
+      "translated": "话题运行失败"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23894,9 +24014,9 @@
       "translated": "复制会话密钥"
     },
     {
-      "id": "native.apple.4aeb7c14c26dabac",
-      "source": "Delete Session…",
-      "translated": "删除会话…"
+      "id": "native.apple.f4998cfb572f23ff",
+      "source": "Delete Thread…",
+      "translated": "删除话题…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23909,9 +24029,9 @@
       "translated": "正在连接…"
     },
     {
-      "id": "native.apple.79f708b3bc1d3a6c",
-      "source": "Retry session groups",
-      "translated": "重试加载会话群组"
+      "id": "native.apple.8802e9576ffd0f65",
+      "source": "Retry thread groups",
+      "translated": "重试加载话题组"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23934,24 +24054,24 @@
       "translated": "范围"
     },
     {
-      "id": "native.apple.2c37581c7b88f741",
-      "source": "Search sessions",
-      "translated": "搜索会话"
+      "id": "native.apple.b313b80def4bda52",
+      "source": "Search threads",
+      "translated": "搜索话题"
     },
     {
-      "id": "native.apple.43be8a2336e42faf",
-      "source": "Sessions",
-      "translated": "会话"
+      "id": "native.apple.c0cc6acc36f413ce",
+      "source": "Threads",
+      "translated": "对话"
     },
     {
-      "id": "native.apple.0b379cdfcbd3247f",
-      "source": "Rename Session",
-      "translated": "重命名会话"
+      "id": "native.apple.854d3928fe5a557c",
+      "source": "Rename Thread",
+      "translated": "重命名对话"
     },
     {
-      "id": "native.apple.54b6fbd9e41db009",
-      "source": "Session name",
-      "translated": "会话名称"
+      "id": "native.apple.9d0d3f20096cc4da",
+      "source": "Thread name",
+      "translated": "对话名称"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -23959,19 +24079,19 @@
       "translated": "取消"
     },
     {
-      "id": "native.apple.751e0f6b81cd374a",
-      "source": "Delete selected sessions?",
-      "translated": "删除所选会话？"
+      "id": "native.apple.dc00eb94f33bae15",
+      "source": "Delete selected threads?",
+      "translated": "删除所选对话？"
     },
     {
-      "id": "native.apple.aa679276581b0058",
-      "source": "Delete Sessions",
-      "translated": "删除会话"
+      "id": "native.apple.2053fc9f74dc3158",
+      "source": "Delete Threads",
+      "translated": "删除对话"
     },
     {
-      "id": "native.apple.f837129cbee23297",
-      "source": "Each selected session and its transcript will be removed from the gateway.",
-      "translated": "每个所选会话及其转录记录都将从 Gateway 中移除。"
+      "id": "native.apple.0970247871a834a0",
+      "source": "Each selected thread and its transcript will be removed from the gateway.",
+      "translated": "每个所选对话及其记录都将从 Gateway 中移除。"
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -23979,9 +24099,9 @@
       "translated": "群组"
     },
     {
-      "id": "native.apple.64013cfee5e25305",
-      "source": "Manage session groups",
-      "translated": "管理会话分组"
+      "id": "native.apple.6f8acab2256728b5",
+      "source": "Manage thread groups",
+      "translated": "管理对话分组"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -23994,14 +24114,14 @@
       "translated": "选择"
     },
     {
-      "id": "native.apple.b67eaecec1b423ac",
-      "source": "No archived sessions",
-      "translated": "没有已归档的会话"
+      "id": "native.apple.692972314d04b184",
+      "source": "No archived threads",
+      "translated": "没有已归档的对话"
     },
     {
-      "id": "native.apple.b2435a79abf0c794",
-      "source": "No sessions found",
-      "translated": "未找到会话"
+      "id": "native.apple.d6a4b5711dcd26e7",
+      "source": "No threads found",
+      "translated": "未找到对话"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24169,6 +24289,16 @@
       "translated": "打开完整消息"
     },
     {
+      "id": "native.apple.002bfcede229ad4b",
+      "source": "Rewind to Here",
+      "translated": "回退到此处"
+    },
+    {
+      "id": "native.apple.14df2e4997689fb3",
+      "source": "Fork from Here",
+      "translated": "从此处分支"
+    },
+    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "回复"
@@ -24254,9 +24384,9 @@
       "translated": "请移除附件或等待发送完成后，再开始新聊天。"
     },
     {
-      "id": "native.apple.980f552bb0f96c0f",
-      "source": "Gateway changed before the session operation started.",
-      "translated": "Gateway 在会话操作开始前已更改。"
+      "id": "native.apple.e0f045151c8d3137",
+      "source": "Gateway changed before the thread operation started.",
+      "translated": "Gateway 在对话操作开始前已发生更改。"
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24264,9 +24394,9 @@
       "translated": "请移除附件或等待发送完成后再切换聊天。"
     },
     {
-      "id": "native.apple.87ba543b42696b92",
-      "source": "Clear this session's history?",
-      "translated": "清除此会话的历史记录？"
+      "id": "native.apple.0a5c4e15466c3acc",
+      "source": "Clear this thread's history?",
+      "translated": "清除此对话的历史记录？"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24279,14 +24409,14 @@
       "translated": "这将重置与 %@ 的对话。会话密钥保持不变。"
     },
     {
-      "id": "native.apple.a92e96bed98bd553",
-      "source": "Rename Session",
-      "translated": "重命名会话"
+      "id": "native.apple.67ac221dbe7179f0",
+      "source": "Rename Thread",
+      "translated": "重命名对话"
     },
     {
-      "id": "native.apple.848e2388f3466f40",
-      "source": "Session name",
-      "translated": "会话名称"
+      "id": "native.apple.cf0f7e049603f518",
+      "source": "Thread name",
+      "translated": "对话名称"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24304,9 +24434,9 @@
       "translated": "导出对话记录"
     },
     {
-      "id": "native.apple.4af0f566d39d7041",
-      "source": "Sessions",
-      "translated": "会话"
+      "id": "native.apple.c0ada47504425f23",
+      "source": "Threads",
+      "translated": "对话"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24379,14 +24509,14 @@
       "translated": "默认"
     },
     {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "新建会话"
+      "id": "native.apple.1a765291943599e5",
+      "source": "New Thread",
+      "translated": "新建对话"
     },
     {
-      "id": "native.apple.a7119fbf9d25df5e",
-      "source": "New Session Options…",
-      "translated": "新建会话选项…"
+      "id": "native.apple.c7a3a6d5e43dd98f",
+      "source": "New Thread Options…",
+      "translated": "新建对话选项…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24394,19 +24524,19 @@
       "translated": "刷新"
     },
     {
-      "id": "native.apple.2bcff4a8fa503739",
-      "source": "Sessions…",
-      "translated": "会话…"
+      "id": "native.apple.0e710b81808e5dcf",
+      "source": "Threads…",
+      "translated": "对话…"
     },
     {
-      "id": "native.apple.c36e008b051adb38",
-      "source": "Rename Session…",
-      "translated": "重命名会话…"
+      "id": "native.apple.faad8f92b6bef166",
+      "source": "Rename Thread…",
+      "translated": "重命名对话…"
     },
     {
-      "id": "native.apple.ea0ef95a159bffe0",
-      "source": "Fork Session",
-      "translated": "为会话创建分支"
+      "id": "native.apple.23b61d6cd26ac112",
+      "source": "Fork",
+      "translated": "创建分支"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24464,24 +24594,24 @@
       "translated": "清除历史记录…"
     },
     {
-      "id": "native.apple.920fe8a7a33f9e92",
-      "source": "Session",
-      "translated": "会话"
+      "id": "native.apple.8b4f1c5107ea8a0e",
+      "source": "Thread",
+      "translated": "对话串"
     },
     {
-      "id": "native.apple.185a401f78328b0f",
-      "source": "Session actions",
-      "translated": "会话操作"
+      "id": "native.apple.4d7750c9bf699469",
+      "source": "Thread actions",
+      "translated": "对话串操作"
     },
     {
-      "id": "native.apple.9f9dedf599b2619b",
-      "source": "Session cost %@",
-      "translated": "会话费用 %@"
+      "id": "native.apple.bb2f22cc43c97f8e",
+      "source": "Thread cost %@",
+      "translated": "对话串费用 %@"
     },
     {
-      "id": "native.apple.f0a4720df5f5f403",
-      "source": "Compact Session",
-      "translated": "压缩会话"
+      "id": "native.apple.6239ced0b86e86f8",
+      "source": "Compact Thread",
+      "translated": "压缩对话串"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/zh-CN.json
+++ b/apps/.i18n/native/zh-CN.json
@@ -1429,9 +1429,9 @@
       "translated": "与 OpenClaw 交谈或向其听写"
     },
     {
-      "id": "native.android.e2cf5a38587382cb",
-      "source": "Browse Threads",
-      "translated": "浏览对话"
+      "id": "native.android.5876e15e5e92fd45",
+      "source": "Browse Sessions",
+      "translated": "浏览会话"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "未找到操作"
     },
     {
-      "id": "native.android.bc70a4ac965b82ba",
-      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
-      "translated": "试试聊天、语音、对话、提供商或设置。"
+      "id": "native.android.48ad0ae0e930e02b",
+      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
+      "translated": "尝试聊天、语音、会话、提供商或设置。"
     },
     {
-      "id": "native.android.670121e54dbe286f",
-      "source": "Threads",
-      "translated": "对话"
+      "id": "native.android.d4fbd1ee4f55a5db",
+      "source": "Sessions",
+      "translated": "会话"
     },
     {
-      "id": "native.android.d38be650b1bce4a0",
-      "source": "Connect the Gateway to search threads.",
-      "translated": "连接 Gateway 以搜索对话。"
+      "id": "native.android.207c2170504e99e6",
+      "source": "Connect the Gateway to search sessions.",
+      "translated": "连接 Gateway 以搜索会话。"
     },
     {
-      "id": "native.android.3d7754721f776ef8",
-      "source": "No matching threads yet.",
-      "translated": "暂无匹配的对话。"
+      "id": "native.android.25d2c2d792c952fe",
+      "source": "No matching sessions yet.",
+      "translated": "尚无匹配的会话。"
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "助手正在工作"
     },
     {
-      "id": "native.android.9a839f6e3e05a744",
-      "source": "OpenClaw thread",
-      "translated": "OpenClaw 对话"
+      "id": "native.android.8f8384286317f5c9",
+      "source": "OpenClaw session",
+      "translated": "OpenClaw 会话"
     },
     {
-      "id": "native.android.d83f82a1e4a5ed99",
-      "source": "Open thread",
-      "translated": "打开对话"
+      "id": "native.android.15799e57704b20c6",
+      "source": "Open session",
+      "translated": "打开会话"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "没有就绪的提供方"
     },
     {
-      "id": "native.android.8a1c5365c0538908",
-      "source": "Main thread",
-      "translated": "主对话"
+      "id": "native.android.73e6ab1a168fd381",
+      "source": "Main session",
+      "translated": "主会话"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.a5845742daecb4ba",
-      "source": "Threads",
-      "translated": "对话"
+      "id": "native.android.0e3157c15c56944f",
+      "source": "Sessions",
+      "translated": "会话"
     },
     {
-      "id": "native.android.439b324280869527",
-      "source": "Focus thread search",
-      "translated": "聚焦对话搜索"
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "聚焦会话搜索"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "已归档"
     },
     {
-      "id": "native.android.03981341841b04ac",
-      "source": "Search threads",
-      "translated": "搜索对话"
+      "id": "native.android.b9cf34c137e4cf03",
+      "source": "Search sessions",
+      "translated": "搜索会话"
     },
     {
-      "id": "native.android.99570c528a41fa72",
-      "source": "Clear thread search",
-      "translated": "清除对话搜索"
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "清除会话搜索"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "最早优先"
     },
     {
-      "id": "native.android.fd67be543e321cc9",
-      "source": "Toggle thread layout",
-      "translated": "切换对话布局"
+      "id": "native.android.c6bf8751e2a7f5c7",
+      "source": "Toggle session layout",
+      "translated": "切换会话布局"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "布局：详细"
     },
     {
-      "id": "native.android.ebd17565e0ffd8eb",
-      "source": "Searching threads",
-      "translated": "正在搜索对话"
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "正在搜索会话"
     },
     {
-      "id": "native.android.472d46ae8669f860",
-      "source": "No matching threads",
-      "translated": "没有匹配的对话"
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "没有匹配的会话"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "开始聊天"
     },
     {
-      "id": "native.android.ff81ad1bee00d384",
-      "source": "Current thread",
-      "translated": "当前对话"
+      "id": "native.android.f10d4df7cbc6df4f",
+      "source": "Current session",
+      "translated": "当前会话"
     },
     {
-      "id": "native.android.fc145645b9620e57",
-      "source": "OpenClaw thread",
-      "translated": "OpenClaw 对话"
+      "id": "native.android.8f0482425838ae64",
+      "source": "OpenClaw session",
+      "translated": "OpenClaw 会话"
     },
     {
-      "id": "native.android.71cbb8dde8bf138b",
-      "source": "Rename thread",
-      "translated": "重命名对话"
+      "id": "native.android.786774c8a76e50d7",
+      "source": "Rename session",
+      "translated": "重命名会话"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "删除分组？"
     },
     {
-      "id": "native.android.691e92cfe5cf106e",
-      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "“$group”中的对话将被保留并移回未分组。"
+      "id": "native.android.3455fc2f77d564e3",
+      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "“$group”中的会话将被保留并移回未分组。"
     },
     {
-      "id": "native.android.d87a8217ab56999b",
-      "source": "Delete thread?",
-      "translated": "删除对话？"
+      "id": "native.android.4805fb9d6623e8c0",
+      "source": "Delete session?",
+      "translated": "删除会话？"
     },
     {
-      "id": "native.android.930de97ff47113a8",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "这将永久删除该对话及其记录。"
+      "id": "native.android.0c3283a2b2445eae",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "这将永久删除该会话及其转录内容。"
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "未分组"
     },
     {
-      "id": "native.android.8e21a70428def6e0",
-      "source": "No threads yet",
-      "translated": "暂无对话"
+      "id": "native.android.db243d71d056afa4",
+      "source": "No sessions yet",
+      "translated": "还没有会话"
     },
     {
-      "id": "native.android.cda4c5ad8b17e394",
-      "source": "No current thread",
-      "translated": "当前无对话"
+      "id": "native.android.5b4eee6a8092925e",
+      "source": "No current session",
+      "translated": "没有当前会话"
     },
     {
-      "id": "native.android.be84f061047aa2da",
-      "source": "No archived threads",
-      "translated": "暂无已归档的对话"
+      "id": "native.android.acbcc9c9ea53d8c0",
+      "source": "No archived sessions",
+      "translated": "没有已归档会话"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "开始新的对话后，它会显示在这里。"
     },
     {
-      "id": "native.android.f289d03e1d3eee98",
-      "source": "Open Chat to start or resume the current thread.",
-      "translated": "打开聊天以开始或继续当前对话。"
+      "id": "native.android.56fcd605dc7be3c0",
+      "source": "Open Chat to start or resume the current session.",
+      "translated": "打开聊天以开始或继续当前会话。"
     },
     {
-      "id": "native.android.504b71386e76c6ae",
-      "source": "Archived threads will show up here.",
-      "translated": "已归档的对话将显示在此处。"
+      "id": "native.android.085515989f8a2022",
+      "source": "Archived sessions will show up here.",
+      "translated": "已归档的会话将显示在这里。"
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days}天"
     },
     {
-      "id": "native.android.ee4c727cdafbe963",
-      "source": "Main thread",
-      "translated": "主对话"
+      "id": "native.android.3d4fa07acbc015c5",
+      "source": "Main session",
+      "translated": "主会话"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway 待处理"
     },
     {
-      "id": "native.android.da78209effb11cfd",
-      "source": "Thread Activity",
-      "translated": "对话活动"
+      "id": "native.android.2d8d049afe99f751",
+      "source": "Session Activity",
+      "translated": "会话活动"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "当此手机连接时，Exec 批准请求将显示在此处。"
     },
     {
-      "id": "native.android.f615712dfb56319a",
-      "source": "Thread activity",
-      "translated": "对话活动"
+      "id": "native.android.dc3e7ca5a491103a",
+      "source": "Session activity",
+      "translated": "会话活动"
     },
     {
-      "id": "native.android.6c93973c13db43ae",
-      "source": "Chat tool calls waiting in the active thread remain visible here.",
-      "translated": "活动对话中等待处理的聊天工具调用仍会显示在此处。"
+      "id": "native.android.8551e02b060bd7d8",
+      "source": "Chat tool calls waiting in the active session remain visible here.",
+      "translated": "活动会话中等待处理的聊天工具调用会保留显示在此处。"
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,11 +4294,6 @@
       "translated": "Talk Provider 设置"
     },
     {
-      "id": "native.android.23b638094c34b916",
-      "source": "Microphone",
-      "translated": "麦克风"
-    },
-    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "音频测试"
@@ -4342,66 +4337,6 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "完成"
-    },
-    {
-      "id": "native.android.8d9ecdfdd916b780",
-      "source": "Automatic",
-      "translated": "自动"
-    },
-    {
-      "id": "native.android.c1626a6700a570f6",
-      "source": "Preferred microphone unavailable; using automatic routing.",
-      "translated": "首选麦克风不可用；正在使用自动路由。"
-    },
-    {
-      "id": "native.android.820bc5d0ce571d8b",
-      "source": "Prioritizes connected Bluetooth microphones.",
-      "translated": "优先使用已连接的蓝牙麦克风。"
-    },
-    {
-      "id": "native.android.11e48038d5e8bff6",
-      "source": "Preferred microphone",
-      "translated": "首选麦克风"
-    },
-    {
-      "id": "native.android.eaa4d7563a46d307",
-      "source": "Unavailable",
-      "translated": "不可用"
-    },
-    {
-      "id": "native.android.9f5ebf17eb405ba8",
-      "source": "Next session",
-      "translated": "下次会话"
-    },
-    {
-      "id": "native.android.8c4e91f53928efb2",
-      "source": "Built-in microphone",
-      "translated": "内置麦克风"
-    },
-    {
-      "id": "native.android.14b613cb6e2446b4",
-      "source": "Bluetooth microphone",
-      "translated": "蓝牙麦克风"
-    },
-    {
-      "id": "native.android.c885247b2d7ce271",
-      "source": "Bluetooth LE microphone",
-      "translated": "低功耗蓝牙麦克风"
-    },
-    {
-      "id": "native.android.b6a4e674c5fb441a",
-      "source": "Wired headset microphone",
-      "translated": "有线耳机麦克风"
-    },
-    {
-      "id": "native.android.9c8becb3b0fb5a90",
-      "source": "USB microphone",
-      "translated": "USB 麦克风"
-    },
-    {
-      "id": "native.android.ba46258fadec7a39",
-      "source": "External microphone",
-      "translated": "外接麦克风"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5139,9 +5074,9 @@
       "translated": "检查"
     },
     {
-      "id": "native.android.c971506716c96e91",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
-      "translated": "OpenClaw 将这部手机变成简洁的移动命令界面，用于管理对话、语音、提供商和 Gateway。"
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw 将此手机变成一个简洁的移动命令界面，用于管理会话、语音、提供商和 Gateway。"
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5689,9 +5624,9 @@
       "translated": "对话设置"
     },
     {
-      "id": "native.android.36f78c8c85dc283f",
-      "source": "Recent Threads",
-      "translated": "最近的对话"
+      "id": "native.android.73f07a5d54915259",
+      "source": "Recent Sessions",
+      "translated": "最近会话"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5749,14 +5684,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% 在线"
     },
     {
-      "id": "native.android.57177017a6a93826",
-      "source": "Threads",
-      "translated": "对话"
+      "id": "native.android.16c3425d3a594481",
+      "source": "Sessions",
+      "translated": "会话"
     },
     {
-      "id": "native.android.43320b54a68b00a1",
-      "source": "No recent threads",
-      "translated": "暂无最近的对话"
+      "id": "native.android.a5c0f8b3112aa58c",
+      "source": "No recent sessions",
+      "translated": "没有最近会话"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5794,14 +5729,14 @@
       "translated": "工作中 · $pendingRunCount 个活跃运行"
     },
     {
-      "id": "native.android.e24db059480f1e6a",
-      "source": "Monitoring · 1 thread",
-      "translated": "正在监控 · 1 个对话"
+      "id": "native.android.2c89da708b12a522",
+      "source": "Monitoring · 1 session",
+      "translated": "监控中 · 1 个会话"
     },
     {
-      "id": "native.android.5a475f37d80e02bc",
-      "source": "Monitoring · $sessionCount threads",
-      "translated": "正在监控 · $sessionCount 个对话"
+      "id": "native.android.8b6ee382dcb64e1f",
+      "source": "Monitoring · $sessionCount sessions",
+      "translated": "监控中 · $sessionCount 个会话"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5834,9 +5769,9 @@
       "translated": "提供商"
     },
     {
-      "id": "native.android.358c5e0e838d5423",
-      "source": "Open thread",
-      "translated": "打开对话"
+      "id": "native.android.a65477861c7203aa",
+      "source": "Open session",
+      "translated": "打开会话"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6259,9 +6194,9 @@
       "translated": "${days}天"
     },
     {
-      "id": "native.android.28a1a1acc5a0959f",
-      "source": "Main thread",
-      "translated": "主对话"
+      "id": "native.android.22d755834386db07",
+      "source": "Main session",
+      "translated": "主会话"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6942,16 +6877,6 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "取消静音"
-    },
-    {
-      "id": "native.android.cb608d82c5b3352a",
-      "source": "Back camera",
-      "translated": "后置摄像头"
-    },
-    {
-      "id": "native.android.e89a0e780eed2e1e",
-      "source": "Front camera",
-      "translated": "前置摄像头"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7759,9 +7684,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.0c74bc30a994dd33",
-      "source": "Loading thread",
-      "translated": "正在加载对话"
+      "id": "native.android.882cc14a58e7e105",
+      "source": "Loading session",
+      "translated": "正在加载会话"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7804,14 +7729,14 @@
       "translated": "帮我了解最新进展"
     },
     {
-      "id": "native.android.cf40df9739f78f27",
-      "source": "Summarize recent threads and next steps.",
-      "translated": "总结最近的对话和后续步骤。"
+      "id": "native.android.1e5add56e48c99f9",
+      "source": "Summarize recent sessions and next steps.",
+      "translated": "总结最近的会话和后续步骤。"
     },
     {
-      "id": "native.android.ebe49a8b8df80bd3",
-      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
-      "translated": "帮我了解最近的 OpenClaw 对话，并建议后续步骤。"
+      "id": "native.android.06d515351bb79576",
+      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
+      "translated": "帮我了解最近 OpenClaw 会话的最新进展，并建议后续步骤。"
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8149,9 +8074,9 @@
       "translated": "已连接"
     },
     {
-      "id": "native.android.6cf5d6fa8a4186d5",
-      "source": "Threads",
-      "translated": "对话"
+      "id": "native.android.81931886b9caf3ab",
+      "source": "Sessions",
+      "translated": "会话"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,6 +10719,61 @@
       "translated": "任务详情"
     },
     {
+      "id": "native.apple.29cacb53ea5e77fc",
+      "source": "Pinned",
+      "translated": "已固定"
+    },
+    {
+      "id": "native.apple.940062cfdce9211b",
+      "source": "Recent",
+      "translated": "最近"
+    },
+    {
+      "id": "native.apple.a0980128426308a9",
+      "source": "Model",
+      "translated": "模型"
+    },
+    {
+      "id": "native.apple.9520e60f21535dde",
+      "source": "Thinking",
+      "translated": "思考"
+    },
+    {
+      "id": "native.apple.8b321f3ffce97429",
+      "source": "Fast",
+      "translated": "快速"
+    },
+    {
+      "id": "native.apple.989b70d64e328d55",
+      "source": "Default (inherited)",
+      "translated": "默认（继承）"
+    },
+    {
+      "id": "native.apple.f4114e73b07eb9ae",
+      "source": "Off",
+      "translated": "关闭"
+    },
+    {
+      "id": "native.apple.7ed231b28d16312f",
+      "source": "On",
+      "translated": "开启"
+    },
+    {
+      "id": "native.apple.412a74802320a037",
+      "source": "Full",
+      "translated": "完整"
+    },
+    {
+      "id": "native.apple.299f21a2071ff9fc",
+      "source": "Verbosity",
+      "translated": "详细程度"
+    },
+    {
+      "id": "native.apple.faf0ef05e1496de7",
+      "source": "Default",
+      "translated": "默认"
+    },
+    {
       "id": "native.apple.e5524d5756a62744",
       "source": "Unable to Export Transcript",
       "translated": "无法导出转录"
@@ -10814,9 +10794,9 @@
       "translated": "你想处理什么？"
     },
     {
-      "id": "native.apple.4da775013ac9b123",
-      "source": "The thread attaches once the gateway is ready.",
-      "translated": "Gateway 准备就绪后将连接对话。"
+      "id": "native.apple.32179ce0b6d4543f",
+      "source": "The session attaches once the gateway is ready.",
+      "translated": "Gateway 准备就绪后，会话将会附加。"
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10859,9 +10839,14 @@
       "translated": "在 Worktree 中新建聊天"
     },
     {
-      "id": "native.apple.003b25ddafeb18e9",
-      "source": "Threads…",
-      "translated": "对话…"
+      "id": "native.apple.ce6ebe91fc597015",
+      "source": "New Session Options…",
+      "translated": "新会话选项…"
+    },
+    {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "会话…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11024,14 +11009,14 @@
       "translated": "创建"
     },
     {
-      "id": "native.apple.31d5c7287cfb3abe",
-      "source": "Delete Thread?",
-      "translated": "删除对话？"
+      "id": "native.apple.f488b9caf6e51ac3",
+      "source": "Delete Session?",
+      "translated": "删除会话？"
     },
     {
-      "id": "native.apple.d3395564809f1120",
-      "source": "Delete Thread",
-      "translated": "删除对话"
+      "id": "native.apple.8634b17be9b111bc",
+      "source": "Delete Session",
+      "translated": "删除会话"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11039,9 +11024,9 @@
       "translated": "取消"
     },
     {
-      "id": "native.apple.092659256d26cb03",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "这将永久删除该对话及其记录。"
+      "id": "native.apple.4a9568ac9b18d8d3",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "这将永久删除该会话及其转录内容。"
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11069,9 +11054,9 @@
       "translated": "新建组"
     },
     {
-      "id": "native.apple.683032464c497bbd",
-      "source": "Rename Thread",
-      "translated": "重命名对话"
+      "id": "native.apple.5bccdc23a1640895",
+      "source": "Rename Session",
+      "translated": "重命名会话"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11079,9 +11064,9 @@
       "translated": "组名称"
     },
     {
-      "id": "native.apple.f887aa956588f237",
-      "source": "Thread name",
-      "translated": "对话名称"
+      "id": "native.apple.af789b2d2fda0f67",
+      "source": "Session name",
+      "translated": "会话名称"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11119,14 +11104,14 @@
       "translated": "智能体"
     },
     {
-      "id": "native.apple.7c8231b7b1ca480f",
-      "source": "Agent thread",
-      "translated": "智能体对话"
+      "id": "native.apple.a3bde8045fe9224a",
+      "source": "Agent session",
+      "translated": "智能体会话"
     },
     {
-      "id": "native.apple.b3c553614f762a58",
-      "source": "Recent threads",
-      "translated": "最近的对话"
+      "id": "native.apple.27f775de30b37ff8",
+      "source": "Recent sessions",
+      "translated": "最近会话"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11134,9 +11119,9 @@
       "translated": "Gateway 离线"
     },
     {
-      "id": "native.apple.5aa32afda85064ea",
-      "source": "No recent threads",
-      "translated": "没有最近的对话"
+      "id": "native.apple.28c97cf23665ee01",
+      "source": "No recent sessions",
+      "translated": "没有最近会话"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11234,14 +11219,14 @@
       "translated": "取消"
     },
     {
-      "id": "native.apple.b6855cf19a50f477",
-      "source": "Threads",
-      "translated": "对话"
+      "id": "native.apple.9f2fd65953013b7c",
+      "source": "Sessions",
+      "translated": "会话"
     },
     {
-      "id": "native.apple.9b1d0ef27a1333b0",
-      "source": "Archived threads",
-      "translated": "已归档的对话"
+      "id": "native.apple.0422818cc95d5071",
+      "source": "Archived sessions",
+      "translated": "已归档的会话"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11249,34 +11234,34 @@
       "translated": "显示已归档"
     },
     {
-      "id": "native.apple.98167401c7267735",
-      "source": "Threads unavailable",
-      "translated": "对话不可用"
+      "id": "native.apple.b272115c83f7ef58",
+      "source": "Sessions unavailable",
+      "translated": "会话不可用"
     },
     {
-      "id": "native.apple.4d28a7def2337b9f",
-      "source": "Loading archived threads",
-      "translated": "正在加载已归档的对话"
+      "id": "native.apple.54f8260c9b863087",
+      "source": "Loading archived sessions",
+      "translated": "正在加载已归档的会话"
     },
     {
-      "id": "native.apple.777d7b706933bd7b",
-      "source": "Loading recent threads",
-      "translated": "正在加载最近的对话"
+      "id": "native.apple.9b305868873dade2",
+      "source": "Loading recent sessions",
+      "translated": "正在加载最近的会话"
     },
     {
-      "id": "native.apple.22f81ea94bef8410",
-      "source": "^[\\(count) thread](inflect: true)",
-      "translated": "^[\\(count) 个对话](inflect: true)"
+      "id": "native.apple.207dad20d09f3160",
+      "source": "^[\\(count) session](inflect: true)",
+      "translated": "^[\\(count) 个会话](inflect: true)"
     },
     {
-      "id": "native.apple.1cad51e14db59bf9",
-      "source": "No archived threads",
-      "translated": "没有已归档的对话"
+      "id": "native.apple.1f4501a6bf2bae4c",
+      "source": "No archived sessions",
+      "translated": "没有已归档的会话"
     },
     {
-      "id": "native.apple.18ef832d3a7ddcf8",
-      "source": "Archived threads will appear here.",
-      "translated": "已归档的对话将显示在此处。"
+      "id": "native.apple.2a1ba7a5e1979c9e",
+      "source": "Archived sessions will appear here.",
+      "translated": "已归档的会话将显示在此处。"
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11359,9 +11344,9 @@
       "translated": "共享入口"
     },
     {
-      "id": "native.apple.21d9208d86a4d1fe",
-      "source": "Loading threads",
-      "translated": "正在加载对话"
+      "id": "native.apple.2360d25fe6ae9946",
+      "source": "Loading sessions",
+      "translated": "正在加载会话"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11369,19 +11354,19 @@
       "translated": "正在从 Gateway 获取最近活动。"
     },
     {
-      "id": "native.apple.4be1f79aa2b230ff",
-      "source": "Threads unavailable",
-      "translated": "对话不可用"
+      "id": "native.apple.c334f2e86702a7b8",
+      "source": "Sessions unavailable",
+      "translated": "会话不可用"
     },
     {
-      "id": "native.apple.98b348873556bc46",
-      "source": "No recent threads",
-      "translated": "没有最近的对话"
+      "id": "native.apple.6cc6efb7a03960b6",
+      "source": "No recent sessions",
+      "translated": "没有最近会话"
     },
     {
-      "id": "native.apple.7396d205574d279f",
-      "source": "Thread activity offline",
-      "translated": "对话活动处于离线状态"
+      "id": "native.apple.08483af2d043bee6",
+      "source": "Session activity offline",
+      "translated": "会话活动离线"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11839,9 +11824,9 @@
       "translated": "卡片"
     },
     {
-      "id": "native.apple.c9ec1b0e18074d8a",
-      "source": "Open Thread",
-      "translated": "打开对话"
+      "id": "native.apple.93eeaedb2ff61043",
+      "source": "Open Session",
+      "translated": "打开会话"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13329,9 +13314,9 @@
       "translated": "默认"
     },
     {
-      "id": "native.apple.f4ae5664c3eda95d",
-      "source": "Used for new Chat threads and Talk sessions.",
-      "translated": "用于新的聊天对话和通话会话。"
+      "id": "native.apple.3de045f17ea3c6d0",
+      "source": "Used for new Chat and Talk sessions.",
+      "translated": "用于新的聊天和通话会话。"
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15734,9 +15719,9 @@
       "translated": "实例"
     },
     {
-      "id": "native.apple.11fe8b9941954dfb",
-      "source": "Threads",
-      "translated": "对话"
+      "id": "native.apple.3579cf2750470a22",
+      "source": "Sessions",
+      "translated": "会话"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19044,9 +19029,9 @@
       "translated": "快速聊天快捷键"
     },
     {
-      "id": "native.apple.94dd793cd7d7d555",
-      "source": "Global shortcut that opens a floating chat bar for the main thread.",
-      "translated": "用于打开主对话悬浮聊天栏的全局快捷键。"
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "用于为主会话打开浮动聊天栏的全局快捷键。"
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19624,9 +19609,9 @@
       "translated": "严重"
     },
     {
-      "id": "native.apple.13f96467014cf344",
-      "source": "New Thread",
-      "translated": "新建对话"
+      "id": "native.apple.75102378a6775180",
+      "source": "New Session",
+      "translated": "新建会话"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21914,9 +21899,9 @@
       "translated": "没有最近消息"
     },
     {
-      "id": "native.apple.3ec2afcbc298c673",
-      "source": "Threads",
-      "translated": "对话"
+      "id": "native.apple.1ff8aec0044934c3",
+      "source": "Sessions",
+      "translated": "会话"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21924,9 +21909,9 @@
       "translated": "查看 CLI 为上下文和速率限制复用的已存储对话桶。"
     },
     {
-      "id": "native.apple.14ccb32cd8ed1c81",
-      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
-      "translated": "暂无对话。首次收到消息或心跳后，对话将显示在此处。"
+      "id": "native.apple.bab897f3252b134c",
+      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
+      "translated": "还没有会话。它们会在第一条入站消息或心跳之后显示。"
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -22009,9 +21994,9 @@
       "translated": "执行审批"
     },
     {
-      "id": "native.apple.52e37e3a44ae516c",
-      "source": "Threads",
-      "translated": "对话"
+      "id": "native.apple.64a6dc7d49e8fb57",
+      "source": "Sessions",
+      "translated": "会话"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -23014,9 +22999,9 @@
       "translated": "帮我了解最新情况"
     },
     {
-      "id": "native.apple.fc4ce810900ec0b6",
-      "source": "Summarize what happened in my threads since yesterday.",
-      "translated": "总结一下从昨天到现在我的对话中发生了什么。"
+      "id": "native.apple.234ec45f4231edc4",
+      "source": "Summarize what happened in my sessions since yesterday.",
+      "translated": "总结从昨天起我的会话中发生的事情。"
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23194,9 +23179,9 @@
       "translated": "取消固定模型"
     },
     {
-      "id": "native.apple.4edb66657f5aca1f",
-      "source": "Thread",
-      "translated": "对话"
+      "id": "native.apple.5dfc0700d8dff8de",
+      "source": "Session",
+      "translated": "会话"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23359,51 +23344,6 @@
       "translated": "小组件不可用"
     },
     {
-      "id": "native.apple.d640691fd196f338",
-      "source": "Widget export failed",
-      "translated": "小组件导出失败"
-    },
-    {
-      "id": "native.apple.533c6e22a11e88de",
-      "source": "OK",
-      "translated": "好"
-    },
-    {
-      "id": "native.apple.e1fb28a2a9756402",
-      "source": "Copy image",
-      "translated": "拷贝图像"
-    },
-    {
-      "id": "native.apple.ebd7bc92e1b12235",
-      "source": "Save image…",
-      "translated": "存储图像…"
-    },
-    {
-      "id": "native.apple.742c46d4cf2db134",
-      "source": "Save image",
-      "translated": "存储图像"
-    },
-    {
-      "id": "native.apple.0589cce608418f90",
-      "source": "The widget image could not be captured.",
-      "translated": "无法捕捉小组件图像。"
-    },
-    {
-      "id": "native.apple.dfe24e827fdbe9c5",
-      "source": "The widget image could not be copied.",
-      "translated": "无法拷贝小组件图像。"
-    },
-    {
-      "id": "native.apple.9e611e3a80e71408",
-      "source": "The widget image could not be encoded as PNG.",
-      "translated": "无法将小组件图像编码为 PNG。"
-    },
-    {
-      "id": "native.apple.9a6e8afbe24a262b",
-      "source": "The widget image could not be saved.",
-      "translated": "无法存储小组件图像。"
-    },
-    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23544,19 +23484,19 @@
       "translated": "用户"
     },
     {
-      "id": "native.apple.9d0cba09d92ee669",
-      "source": "This thread cannot be archived while it is active or running.",
-      "translated": "此对话处于活跃或运行状态时无法归档。"
+      "id": "native.apple.b1cdcb906a43d5d6",
+      "source": "This session cannot be archived while it is active or running.",
+      "translated": "此会话处于活动或运行状态时无法归档。"
     },
     {
-      "id": "native.apple.8952a111a1075051",
-      "source": "The main thread cannot be deleted.",
-      "translated": "无法删除主对话。"
+      "id": "native.apple.5817e3f3dab1ee19",
+      "source": "The main session cannot be deleted.",
+      "translated": "无法删除主会话。"
     },
     {
-      "id": "native.apple.90d0ccf80ca28717",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
-      "translated": "请移除附件或等待传送完成后，再归档或删除此对话。"
+      "id": "native.apple.a6b8df3f18171c91",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
+      "translated": "请移除附件或等待其发送完成，然后再归档或删除此会话。"
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23694,9 +23634,9 @@
       "translated": "运行结束时间"
     },
     {
-      "id": "native.apple.bbccb4c8db5cac12",
-      "source": "Thread Info",
-      "translated": "对话信息"
+      "id": "native.apple.cd7c3095a22f80a9",
+      "source": "Session Info",
+      "translated": "会话信息"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23729,9 +23669,9 @@
       "translated": "添加群组"
     },
     {
-      "id": "native.apple.7b641fed5bace855",
-      "source": "Thread Groups",
-      "translated": "对话分组"
+      "id": "native.apple.23d628606fe0734f",
+      "source": "Session Groups",
+      "translated": "会话群组"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23774,9 +23714,9 @@
       "translated": "删除群组"
     },
     {
-      "id": "native.apple.56401c79410a310d",
-      "source": "Threads in this group become ungrouped.",
-      "translated": "此分组中的对话将被取消分组。"
+      "id": "native.apple.b049c8a4d2805e08",
+      "source": "Sessions in this group become ungrouped.",
+      "translated": "此群组中的会话将变为未分组状态。"
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23789,9 +23729,9 @@
       "translated": "此 Gateway 上没有可用的代理。"
     },
     {
-      "id": "native.apple.2d96aa7d3d12f85b",
-      "source": "New Thread Options",
-      "translated": "新建对话选项"
+      "id": "native.apple.6c89f35d53506406",
+      "source": "New Session Options",
+      "translated": "新建会话选项"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23819,19 +23759,19 @@
       "translated": "创建"
     },
     {
-      "id": "native.apple.87ef57319d1ddc85",
-      "source": "The thread could not be created.",
-      "translated": "无法创建对话。"
+      "id": "native.apple.795ba37f6782cf28",
+      "source": "The session could not be created.",
+      "translated": "无法创建会话。"
     },
     {
-      "id": "native.apple.6bd91c435b69d638",
-      "source": "Search threads",
-      "translated": "搜索对话"
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "搜索会话"
     },
     {
-      "id": "native.apple.6fde4bdf9d5b9191",
-      "source": "No Threads",
-      "translated": "无对话"
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "没有会话"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23839,29 +23779,29 @@
       "translated": "没有结果"
     },
     {
-      "id": "native.apple.a02fd99740d29bd3",
-      "source": "New Thread",
-      "translated": "新建对话"
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "新建会话"
     },
     {
-      "id": "native.apple.b625801dd04b09f2",
-      "source": "New thread",
-      "translated": "新建对话"
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "新建会话"
     },
     {
-      "id": "native.apple.851be81fcc933608",
-      "source": "New thread options",
-      "translated": "新建对话选项"
+      "id": "native.apple.2ef0e34db02ad255",
+      "source": "New session options",
+      "translated": "新建会话选项"
     },
     {
-      "id": "native.apple.9ce8a4aba7b444b2",
-      "source": "Rename Thread",
-      "translated": "重命名对话"
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "重命名会话"
     },
     {
-      "id": "native.apple.1dd067c44511c7f0",
-      "source": "Thread name",
-      "translated": "对话名称"
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "会话名称"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23874,14 +23814,14 @@
       "translated": "取消"
     },
     {
-      "id": "native.apple.618073d6ab3f2721",
-      "source": "Delete Thread",
-      "translated": "删除对话"
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "删除会话"
     },
     {
-      "id": "native.apple.10a5e72bba3cbccc",
-      "source": "The thread and its transcript are removed from the gateway.",
-      "translated": "该对话及其对话记录将从 Gateway 中移除。"
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "该会话及其转录内容将从 Gateway 中移除。"
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23889,14 +23829,14 @@
       "translated": "删除“%@”？"
     },
     {
-      "id": "native.apple.ac71e3b2aa496a2c",
-      "source": "Thread running",
-      "translated": "对话正在运行"
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "会话正在运行"
     },
     {
-      "id": "native.apple.c775e87f997278b2",
-      "source": "Thread failed",
-      "translated": "对话运行失败"
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "会话失败"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23954,9 +23894,9 @@
       "translated": "复制会话密钥"
     },
     {
-      "id": "native.apple.f4998cfb572f23ff",
-      "source": "Delete Thread…",
-      "translated": "删除对话…"
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "删除会话…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23969,9 +23909,9 @@
       "translated": "正在连接…"
     },
     {
-      "id": "native.apple.8802e9576ffd0f65",
-      "source": "Retry thread groups",
-      "translated": "重试对话组"
+      "id": "native.apple.79f708b3bc1d3a6c",
+      "source": "Retry session groups",
+      "translated": "重试加载会话群组"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23994,24 +23934,24 @@
       "translated": "范围"
     },
     {
-      "id": "native.apple.b313b80def4bda52",
-      "source": "Search threads",
-      "translated": "搜索对话"
+      "id": "native.apple.2c37581c7b88f741",
+      "source": "Search sessions",
+      "translated": "搜索会话"
     },
     {
-      "id": "native.apple.c0cc6acc36f413ce",
-      "source": "Threads",
-      "translated": "对话"
+      "id": "native.apple.43be8a2336e42faf",
+      "source": "Sessions",
+      "translated": "会话"
     },
     {
-      "id": "native.apple.854d3928fe5a557c",
-      "source": "Rename Thread",
-      "translated": "重命名对话"
+      "id": "native.apple.0b379cdfcbd3247f",
+      "source": "Rename Session",
+      "translated": "重命名会话"
     },
     {
-      "id": "native.apple.9d0d3f20096cc4da",
-      "source": "Thread name",
-      "translated": "对话名称"
+      "id": "native.apple.54b6fbd9e41db009",
+      "source": "Session name",
+      "translated": "会话名称"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -24019,19 +23959,19 @@
       "translated": "取消"
     },
     {
-      "id": "native.apple.dc00eb94f33bae15",
-      "source": "Delete selected threads?",
-      "translated": "删除所选对话？"
+      "id": "native.apple.751e0f6b81cd374a",
+      "source": "Delete selected sessions?",
+      "translated": "删除所选会话？"
     },
     {
-      "id": "native.apple.2053fc9f74dc3158",
-      "source": "Delete Threads",
-      "translated": "删除对话"
+      "id": "native.apple.aa679276581b0058",
+      "source": "Delete Sessions",
+      "translated": "删除会话"
     },
     {
-      "id": "native.apple.0970247871a834a0",
-      "source": "Each selected thread and its transcript will be removed from the gateway.",
-      "translated": "每个所选对话及其对话记录都将从 Gateway 中移除。"
+      "id": "native.apple.f837129cbee23297",
+      "source": "Each selected session and its transcript will be removed from the gateway.",
+      "translated": "每个所选会话及其转录记录都将从 Gateway 中移除。"
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -24039,9 +23979,9 @@
       "translated": "群组"
     },
     {
-      "id": "native.apple.6f8acab2256728b5",
-      "source": "Manage thread groups",
-      "translated": "管理对话组"
+      "id": "native.apple.64013cfee5e25305",
+      "source": "Manage session groups",
+      "translated": "管理会话分组"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -24054,14 +23994,14 @@
       "translated": "选择"
     },
     {
-      "id": "native.apple.692972314d04b184",
-      "source": "No archived threads",
-      "translated": "没有已归档的对话"
+      "id": "native.apple.b67eaecec1b423ac",
+      "source": "No archived sessions",
+      "translated": "没有已归档的会话"
     },
     {
-      "id": "native.apple.d6a4b5711dcd26e7",
-      "source": "No threads found",
-      "translated": "未找到对话"
+      "id": "native.apple.b2435a79abf0c794",
+      "source": "No sessions found",
+      "translated": "未找到会话"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24229,16 +24169,6 @@
       "translated": "打开完整消息"
     },
     {
-      "id": "native.apple.002bfcede229ad4b",
-      "source": "Rewind to Here",
-      "translated": "回退到此处"
-    },
-    {
-      "id": "native.apple.14df2e4997689fb3",
-      "source": "Fork from Here",
-      "translated": "从此处分叉"
-    },
-    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "回复"
@@ -24324,9 +24254,9 @@
       "translated": "请移除附件或等待发送完成后，再开始新聊天。"
     },
     {
-      "id": "native.apple.e0f045151c8d3137",
-      "source": "Gateway changed before the thread operation started.",
-      "translated": "对话操作开始前 Gateway 已更改。"
+      "id": "native.apple.980f552bb0f96c0f",
+      "source": "Gateway changed before the session operation started.",
+      "translated": "Gateway 在会话操作开始前已更改。"
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24334,9 +24264,9 @@
       "translated": "请移除附件或等待发送完成后再切换聊天。"
     },
     {
-      "id": "native.apple.0a5c4e15466c3acc",
-      "source": "Clear this thread's history?",
-      "translated": "要清除此对话的历史记录吗？"
+      "id": "native.apple.87ba543b42696b92",
+      "source": "Clear this session's history?",
+      "translated": "清除此会话的历史记录？"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24349,14 +24279,14 @@
       "translated": "这将重置与 %@ 的对话。会话密钥保持不变。"
     },
     {
-      "id": "native.apple.67ac221dbe7179f0",
-      "source": "Rename Thread",
-      "translated": "重命名对话"
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "重命名会话"
     },
     {
-      "id": "native.apple.cf0f7e049603f518",
-      "source": "Thread name",
-      "translated": "对话名称"
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "会话名称"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24374,9 +24304,9 @@
       "translated": "导出对话记录"
     },
     {
-      "id": "native.apple.c0ada47504425f23",
-      "source": "Threads",
-      "translated": "对话"
+      "id": "native.apple.4af0f566d39d7041",
+      "source": "Sessions",
+      "translated": "会话"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24449,14 +24379,14 @@
       "translated": "默认"
     },
     {
-      "id": "native.apple.1a765291943599e5",
-      "source": "New Thread",
-      "translated": "新建对话"
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "新建会话"
     },
     {
-      "id": "native.apple.c7a3a6d5e43dd98f",
-      "source": "New Thread Options…",
-      "translated": "新建对话选项…"
+      "id": "native.apple.a7119fbf9d25df5e",
+      "source": "New Session Options…",
+      "translated": "新建会话选项…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24464,19 +24394,19 @@
       "translated": "刷新"
     },
     {
-      "id": "native.apple.0e710b81808e5dcf",
-      "source": "Threads…",
-      "translated": "对话…"
+      "id": "native.apple.2bcff4a8fa503739",
+      "source": "Sessions…",
+      "translated": "会话…"
     },
     {
-      "id": "native.apple.faad8f92b6bef166",
-      "source": "Rename Thread…",
-      "translated": "重命名对话…"
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "重命名会话…"
     },
     {
-      "id": "native.apple.23b61d6cd26ac112",
-      "source": "Fork",
-      "translated": "分支"
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "为会话创建分支"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24534,24 +24464,24 @@
       "translated": "清除历史记录…"
     },
     {
-      "id": "native.apple.8b4f1c5107ea8a0e",
-      "source": "Thread",
-      "translated": "对话"
+      "id": "native.apple.920fe8a7a33f9e92",
+      "source": "Session",
+      "translated": "会话"
     },
     {
-      "id": "native.apple.4d7750c9bf699469",
-      "source": "Thread actions",
-      "translated": "对话操作"
+      "id": "native.apple.185a401f78328b0f",
+      "source": "Session actions",
+      "translated": "会话操作"
     },
     {
-      "id": "native.apple.bb2f22cc43c97f8e",
-      "source": "Thread cost %@",
-      "translated": "对话费用 %@"
+      "id": "native.apple.9f9dedf599b2619b",
+      "source": "Session cost %@",
+      "translated": "会话费用 %@"
     },
     {
-      "id": "native.apple.6239ced0b86e86f8",
-      "source": "Compact Thread",
-      "translated": "压缩对话"
+      "id": "native.apple.f0a4720df5f5f403",
+      "source": "Compact Session",
+      "translated": "压缩会话"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/zh-TW.json
+++ b/apps/.i18n/native/zh-TW.json
@@ -1429,9 +1429,9 @@
       "translated": "與 OpenClaw 對話或使用語音輸入"
     },
     {
-      "id": "native.android.e2cf5a38587382cb",
-      "source": "Browse Threads",
-      "translated": "瀏覽對話串"
+      "id": "native.android.5876e15e5e92fd45",
+      "source": "Browse Sessions",
+      "translated": "瀏覽工作階段"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "找不到動作"
     },
     {
-      "id": "native.android.bc70a4ac965b82ba",
-      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
-      "translated": "試試聊天、語音、對話串、供應商或設定。"
+      "id": "native.android.48ad0ae0e930e02b",
+      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
+      "translated": "試試 Chat、Voice、Sessions、Providers 或 Settings。"
     },
     {
-      "id": "native.android.670121e54dbe286f",
-      "source": "Threads",
-      "translated": "對話串"
+      "id": "native.android.d4fbd1ee4f55a5db",
+      "source": "Sessions",
+      "translated": "工作階段"
     },
     {
-      "id": "native.android.d38be650b1bce4a0",
-      "source": "Connect the Gateway to search threads.",
-      "translated": "連線至 Gateway 以搜尋對話串。"
+      "id": "native.android.207c2170504e99e6",
+      "source": "Connect the Gateway to search sessions.",
+      "translated": "連接 Gateway 以搜尋工作階段。"
     },
     {
-      "id": "native.android.3d7754721f776ef8",
-      "source": "No matching threads yet.",
-      "translated": "尚無相符的對話串。"
+      "id": "native.android.25d2c2d792c952fe",
+      "source": "No matching sessions yet.",
+      "translated": "尚無相符的工作階段。"
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "助理正在處理"
     },
     {
-      "id": "native.android.9a839f6e3e05a744",
-      "source": "OpenClaw thread",
-      "translated": "OpenClaw 對話串"
+      "id": "native.android.8f8384286317f5c9",
+      "source": "OpenClaw session",
+      "translated": "OpenClaw 工作階段"
     },
     {
-      "id": "native.android.d83f82a1e4a5ed99",
-      "source": "Open thread",
-      "translated": "開啟對話串"
+      "id": "native.android.15799e57704b20c6",
+      "source": "Open session",
+      "translated": "開啟工作階段"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "沒有已就緒的提供者"
     },
     {
-      "id": "native.android.8a1c5365c0538908",
-      "source": "Main thread",
-      "translated": "主要對話串"
+      "id": "native.android.73e6ab1a168fd381",
+      "source": "Main session",
+      "translated": "主要工作階段"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.a5845742daecb4ba",
-      "source": "Threads",
-      "translated": "對話串"
+      "id": "native.android.0e3157c15c56944f",
+      "source": "Sessions",
+      "translated": "工作階段"
     },
     {
-      "id": "native.android.439b324280869527",
-      "source": "Focus thread search",
-      "translated": "聚焦對話串搜尋"
+      "id": "native.android.70f5d0507d34b5c8",
+      "source": "Focus session search",
+      "translated": "聚焦工作階段搜尋"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "已封存"
     },
     {
-      "id": "native.android.03981341841b04ac",
-      "source": "Search threads",
-      "translated": "搜尋對話串"
+      "id": "native.android.b9cf34c137e4cf03",
+      "source": "Search sessions",
+      "translated": "搜尋工作階段"
     },
     {
-      "id": "native.android.99570c528a41fa72",
-      "source": "Clear thread search",
-      "translated": "清除對話串搜尋"
+      "id": "native.android.10cb26723e9990fc",
+      "source": "Clear session search",
+      "translated": "清除工作階段搜尋"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "最舊優先"
     },
     {
-      "id": "native.android.fd67be543e321cc9",
-      "source": "Toggle thread layout",
-      "translated": "切換對話串版面配置"
+      "id": "native.android.c6bf8751e2a7f5c7",
+      "source": "Toggle session layout",
+      "translated": "切換工作階段版面配置"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "版面配置：詳細"
     },
     {
-      "id": "native.android.ebd17565e0ffd8eb",
-      "source": "Searching threads",
-      "translated": "正在搜尋對話串"
+      "id": "native.android.69b79a3c2c987cd4",
+      "source": "Searching sessions",
+      "translated": "正在搜尋工作階段"
     },
     {
-      "id": "native.android.472d46ae8669f860",
-      "source": "No matching threads",
-      "translated": "沒有相符的對話串"
+      "id": "native.android.dd587d341af44212",
+      "source": "No matching sessions",
+      "translated": "沒有相符的工作階段"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "開始聊天"
     },
     {
-      "id": "native.android.ff81ad1bee00d384",
-      "source": "Current thread",
-      "translated": "目前的對話串"
+      "id": "native.android.f10d4df7cbc6df4f",
+      "source": "Current session",
+      "translated": "目前工作階段"
     },
     {
-      "id": "native.android.fc145645b9620e57",
-      "source": "OpenClaw thread",
-      "translated": "OpenClaw 對話串"
+      "id": "native.android.8f0482425838ae64",
+      "source": "OpenClaw session",
+      "translated": "OpenClaw 工作階段"
     },
     {
-      "id": "native.android.71cbb8dde8bf138b",
-      "source": "Rename thread",
-      "translated": "重新命名對話串"
+      "id": "native.android.786774c8a76e50d7",
+      "source": "Rename session",
+      "translated": "重新命名工作階段"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "刪除群組？"
     },
     {
-      "id": "native.android.691e92cfe5cf106e",
-      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "「$group」中的對話串會保留並移回「未分組」。"
+      "id": "native.android.3455fc2f77d564e3",
+      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "「$group」中的工作階段會保留並移回未分組。"
     },
     {
-      "id": "native.android.d87a8217ab56999b",
-      "source": "Delete thread?",
-      "translated": "要刪除對話串嗎？"
+      "id": "native.android.4805fb9d6623e8c0",
+      "source": "Delete session?",
+      "translated": "要刪除工作階段嗎？"
     },
     {
-      "id": "native.android.930de97ff47113a8",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "這將永久刪除此對話串及其逐字稿。"
+      "id": "native.android.0c3283a2b2445eae",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "這會永久刪除此工作階段及其逐字稿。"
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "未分組"
     },
     {
-      "id": "native.android.8e21a70428def6e0",
-      "source": "No threads yet",
-      "translated": "尚無對話串"
+      "id": "native.android.db243d71d056afa4",
+      "source": "No sessions yet",
+      "translated": "尚無工作階段"
     },
     {
-      "id": "native.android.cda4c5ad8b17e394",
-      "source": "No current thread",
-      "translated": "目前沒有對話串"
+      "id": "native.android.5b4eee6a8092925e",
+      "source": "No current session",
+      "translated": "沒有目前工作階段"
     },
     {
-      "id": "native.android.be84f061047aa2da",
-      "source": "No archived threads",
-      "translated": "沒有已封存的對話串"
+      "id": "native.android.acbcc9c9ea53d8c0",
+      "source": "No archived sessions",
+      "translated": "沒有封存的工作階段"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "開始新的對話後，就會顯示在這裡。"
     },
     {
-      "id": "native.android.f289d03e1d3eee98",
-      "source": "Open Chat to start or resume the current thread.",
-      "translated": "開啟聊天以開始或繼續目前的對話串。"
+      "id": "native.android.56fcd605dc7be3c0",
+      "source": "Open Chat to start or resume the current session.",
+      "translated": "開啟聊天以開始或繼續目前工作階段。"
     },
     {
-      "id": "native.android.504b71386e76c6ae",
-      "source": "Archived threads will show up here.",
-      "translated": "已封存的對話串會顯示在這裡。"
+      "id": "native.android.085515989f8a2022",
+      "source": "Archived sessions will show up here.",
+      "translated": "封存的工作階段會顯示在這裡。"
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days}天"
     },
     {
-      "id": "native.android.ee4c727cdafbe963",
-      "source": "Main thread",
-      "translated": "主要對話串"
+      "id": "native.android.3d4fa07acbc015c5",
+      "source": "Main session",
+      "translated": "主要工作階段"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway 待處理"
     },
     {
-      "id": "native.android.da78209effb11cfd",
-      "source": "Thread Activity",
-      "translated": "對話串活動"
+      "id": "native.android.2d8d049afe99f751",
+      "source": "Session Activity",
+      "translated": "工作階段活動"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "當這支手機連線時，Exec 核准請求會顯示在這裡。"
     },
     {
-      "id": "native.android.f615712dfb56319a",
-      "source": "Thread activity",
-      "translated": "對話串活動"
+      "id": "native.android.dc3e7ca5a491103a",
+      "source": "Session activity",
+      "translated": "工作階段活動"
     },
     {
-      "id": "native.android.6c93973c13db43ae",
-      "source": "Chat tool calls waiting in the active thread remain visible here.",
-      "translated": "使用中對話串內等待中的聊天工具呼叫會繼續顯示在這裡。"
+      "id": "native.android.8551e02b060bd7d8",
+      "source": "Chat tool calls waiting in the active session remain visible here.",
+      "translated": "作用中工作階段中等待的聊天工具呼叫會持續顯示在這裡。"
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,11 +4294,6 @@
       "translated": "Talk Provider 設定"
     },
     {
-      "id": "native.android.23b638094c34b916",
-      "source": "Microphone",
-      "translated": "麥克風"
-    },
-    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "音訊測試"
@@ -4342,66 +4337,6 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "完成"
-    },
-    {
-      "id": "native.android.8d9ecdfdd916b780",
-      "source": "Automatic",
-      "translated": "自動"
-    },
-    {
-      "id": "native.android.c1626a6700a570f6",
-      "source": "Preferred microphone unavailable; using automatic routing.",
-      "translated": "偏好的麥克風無法使用；目前使用自動路由。"
-    },
-    {
-      "id": "native.android.820bc5d0ce571d8b",
-      "source": "Prioritizes connected Bluetooth microphones.",
-      "translated": "優先使用已連線的 Bluetooth 麥克風。"
-    },
-    {
-      "id": "native.android.11e48038d5e8bff6",
-      "source": "Preferred microphone",
-      "translated": "偏好的麥克風"
-    },
-    {
-      "id": "native.android.eaa4d7563a46d307",
-      "source": "Unavailable",
-      "translated": "無法使用"
-    },
-    {
-      "id": "native.android.9f5ebf17eb405ba8",
-      "source": "Next session",
-      "translated": "下次工作階段"
-    },
-    {
-      "id": "native.android.8c4e91f53928efb2",
-      "source": "Built-in microphone",
-      "translated": "內建麥克風"
-    },
-    {
-      "id": "native.android.14b613cb6e2446b4",
-      "source": "Bluetooth microphone",
-      "translated": "Bluetooth 麥克風"
-    },
-    {
-      "id": "native.android.c885247b2d7ce271",
-      "source": "Bluetooth LE microphone",
-      "translated": "Bluetooth LE 麥克風"
-    },
-    {
-      "id": "native.android.b6a4e674c5fb441a",
-      "source": "Wired headset microphone",
-      "translated": "有線耳機麥克風"
-    },
-    {
-      "id": "native.android.9c8becb3b0fb5a90",
-      "source": "USB microphone",
-      "translated": "USB 麥克風"
-    },
-    {
-      "id": "native.android.ba46258fadec7a39",
-      "source": "External microphone",
-      "translated": "外接麥克風"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5139,9 +5074,9 @@
       "translated": "檢查"
     },
     {
-      "id": "native.android.c971506716c96e91",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
-      "translated": "OpenClaw 將此手機化為簡潔的行動指令介面，可管理對話串、語音、供應商和 Gateway。"
+      "id": "native.android.5a540761383fa474",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
+      "translated": "OpenClaw 可將此手機變成簡潔的行動指令介面，用於工作階段、語音、提供者及 Gateway。"
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5689,9 +5624,9 @@
       "translated": "Talk 設定"
     },
     {
-      "id": "native.android.36f78c8c85dc283f",
-      "source": "Recent Threads",
-      "translated": "最近的對話串"
+      "id": "native.android.73f07a5d54915259",
+      "source": "Recent Sessions",
+      "translated": "最近的工作階段"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5749,14 +5684,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% 在線"
     },
     {
-      "id": "native.android.57177017a6a93826",
-      "source": "Threads",
-      "translated": "對話串"
+      "id": "native.android.16c3425d3a594481",
+      "source": "Sessions",
+      "translated": "工作階段"
     },
     {
-      "id": "native.android.43320b54a68b00a1",
-      "source": "No recent threads",
-      "translated": "沒有最近的對話串"
+      "id": "native.android.a5c0f8b3112aa58c",
+      "source": "No recent sessions",
+      "translated": "沒有最近的工作階段"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5794,14 +5729,14 @@
       "translated": "運作中 · $pendingRunCount 個執行項目進行中"
     },
     {
-      "id": "native.android.e24db059480f1e6a",
-      "source": "Monitoring · 1 thread",
-      "translated": "監控中 · 1 個對話串"
+      "id": "native.android.2c89da708b12a522",
+      "source": "Monitoring · 1 session",
+      "translated": "監控中 · 1 個工作階段"
     },
     {
-      "id": "native.android.5a475f37d80e02bc",
-      "source": "Monitoring · $sessionCount threads",
-      "translated": "監控中 · $sessionCount 個對話串"
+      "id": "native.android.8b6ee382dcb64e1f",
+      "source": "Monitoring · $sessionCount sessions",
+      "translated": "監控中 · $sessionCount 個工作階段"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5834,9 +5769,9 @@
       "translated": "提供者"
     },
     {
-      "id": "native.android.358c5e0e838d5423",
-      "source": "Open thread",
-      "translated": "開啟對話串"
+      "id": "native.android.a65477861c7203aa",
+      "source": "Open session",
+      "translated": "開啟工作階段"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6259,9 +6194,9 @@
       "translated": "${days} 天"
     },
     {
-      "id": "native.android.28a1a1acc5a0959f",
-      "source": "Main thread",
-      "translated": "主要對話串"
+      "id": "native.android.22d755834386db07",
+      "source": "Main session",
+      "translated": "主要工作階段"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6942,16 +6877,6 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "取消靜音"
-    },
-    {
-      "id": "native.android.cb608d82c5b3352a",
-      "source": "Back camera",
-      "translated": "後置相機"
-    },
-    {
-      "id": "native.android.e89a0e780eed2e1e",
-      "source": "Front camera",
-      "translated": "前置相機"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7759,9 +7684,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.0c74bc30a994dd33",
-      "source": "Loading thread",
-      "translated": "正在載入對話串"
+      "id": "native.android.882cc14a58e7e105",
+      "source": "Loading session",
+      "translated": "正在載入工作階段"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7804,14 +7729,14 @@
       "translated": "掌握最新進度"
     },
     {
-      "id": "native.android.cf40df9739f78f27",
-      "source": "Summarize recent threads and next steps.",
-      "translated": "摘要最近的對話串和後續步驟。"
+      "id": "native.android.1e5add56e48c99f9",
+      "source": "Summarize recent sessions and next steps.",
+      "translated": "摘要近期工作階段並列出後續步驟。"
     },
     {
-      "id": "native.android.ebe49a8b8df80bd3",
-      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
-      "translated": "整理我最近的 OpenClaw 對話串，並建議後續步驟。"
+      "id": "native.android.06d515351bb79576",
+      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
+      "translated": "協助我掌握近期 OpenClaw 工作階段的進度，並建議後續步驟。"
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8149,9 +8074,9 @@
       "translated": "已連線"
     },
     {
-      "id": "native.android.6cf5d6fa8a4186d5",
-      "source": "Threads",
-      "translated": "對話串"
+      "id": "native.android.81931886b9caf3ab",
+      "source": "Sessions",
+      "translated": "工作階段"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,6 +10719,61 @@
       "translated": "任務詳細資料"
     },
     {
+      "id": "native.apple.29cacb53ea5e77fc",
+      "source": "Pinned",
+      "translated": "已釘選"
+    },
+    {
+      "id": "native.apple.940062cfdce9211b",
+      "source": "Recent",
+      "translated": "最近使用"
+    },
+    {
+      "id": "native.apple.a0980128426308a9",
+      "source": "Model",
+      "translated": "模型"
+    },
+    {
+      "id": "native.apple.9520e60f21535dde",
+      "source": "Thinking",
+      "translated": "思考"
+    },
+    {
+      "id": "native.apple.8b321f3ffce97429",
+      "source": "Fast",
+      "translated": "快速"
+    },
+    {
+      "id": "native.apple.989b70d64e328d55",
+      "source": "Default (inherited)",
+      "translated": "預設（繼承）"
+    },
+    {
+      "id": "native.apple.f4114e73b07eb9ae",
+      "source": "Off",
+      "translated": "關閉"
+    },
+    {
+      "id": "native.apple.7ed231b28d16312f",
+      "source": "On",
+      "translated": "開啟"
+    },
+    {
+      "id": "native.apple.412a74802320a037",
+      "source": "Full",
+      "translated": "完整"
+    },
+    {
+      "id": "native.apple.299f21a2071ff9fc",
+      "source": "Verbosity",
+      "translated": "詳細程度"
+    },
+    {
+      "id": "native.apple.faf0ef05e1496de7",
+      "source": "Default",
+      "translated": "預設"
+    },
+    {
       "id": "native.apple.e5524d5756a62744",
       "source": "Unable to Export Transcript",
       "translated": "無法匯出逐字稿"
@@ -10814,9 +10794,9 @@
       "translated": "你想要處理什麼？"
     },
     {
-      "id": "native.apple.4da775013ac9b123",
-      "source": "The thread attaches once the gateway is ready.",
-      "translated": "Gateway 準備就緒後，將會連結對話串。"
+      "id": "native.apple.32179ce0b6d4543f",
+      "source": "The session attaches once the gateway is ready.",
+      "translated": "Gateway 準備就緒後，工作階段會連接。"
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10859,9 +10839,14 @@
       "translated": "在 Worktree 中新增聊天"
     },
     {
-      "id": "native.apple.003b25ddafeb18e9",
-      "source": "Threads…",
-      "translated": "對話串…"
+      "id": "native.apple.ce6ebe91fc597015",
+      "source": "New Session Options…",
+      "translated": "新增工作階段選項…"
+    },
+    {
+      "id": "native.apple.a1b0d289758e2213",
+      "source": "Sessions…",
+      "translated": "工作階段…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11024,14 +11009,14 @@
       "translated": "建立"
     },
     {
-      "id": "native.apple.31d5c7287cfb3abe",
-      "source": "Delete Thread?",
-      "translated": "要刪除對話串嗎？"
+      "id": "native.apple.f488b9caf6e51ac3",
+      "source": "Delete Session?",
+      "translated": "刪除工作階段？"
     },
     {
-      "id": "native.apple.d3395564809f1120",
-      "source": "Delete Thread",
-      "translated": "刪除對話串"
+      "id": "native.apple.8634b17be9b111bc",
+      "source": "Delete Session",
+      "translated": "刪除工作階段"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11039,9 +11024,9 @@
       "translated": "取消"
     },
     {
-      "id": "native.apple.092659256d26cb03",
-      "source": "This permanently deletes the thread and its transcript.",
-      "translated": "這將永久刪除對話串及其文字記錄。"
+      "id": "native.apple.4a9568ac9b18d8d3",
+      "source": "This permanently deletes the session and its transcript.",
+      "translated": "這會永久刪除此工作階段及其文字記錄。"
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11069,9 +11054,9 @@
       "translated": "新增群組"
     },
     {
-      "id": "native.apple.683032464c497bbd",
-      "source": "Rename Thread",
-      "translated": "重新命名對話串"
+      "id": "native.apple.5bccdc23a1640895",
+      "source": "Rename Session",
+      "translated": "重新命名工作階段"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11079,9 +11064,9 @@
       "translated": "群組名稱"
     },
     {
-      "id": "native.apple.f887aa956588f237",
-      "source": "Thread name",
-      "translated": "對話串名稱"
+      "id": "native.apple.af789b2d2fda0f67",
+      "source": "Session name",
+      "translated": "工作階段名稱"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11119,14 +11104,14 @@
       "translated": "代理程式"
     },
     {
-      "id": "native.apple.7c8231b7b1ca480f",
-      "source": "Agent thread",
-      "translated": "代理程式對話串"
+      "id": "native.apple.a3bde8045fe9224a",
+      "source": "Agent session",
+      "translated": "代理程式工作階段"
     },
     {
-      "id": "native.apple.b3c553614f762a58",
-      "source": "Recent threads",
-      "translated": "最近的對話串"
+      "id": "native.apple.27f775de30b37ff8",
+      "source": "Recent sessions",
+      "translated": "最近的工作階段"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11134,9 +11119,9 @@
       "translated": "Gateway 離線"
     },
     {
-      "id": "native.apple.5aa32afda85064ea",
-      "source": "No recent threads",
-      "translated": "沒有最近的對話串"
+      "id": "native.apple.28c97cf23665ee01",
+      "source": "No recent sessions",
+      "translated": "沒有最近的工作階段"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11234,14 +11219,14 @@
       "translated": "取消"
     },
     {
-      "id": "native.apple.b6855cf19a50f477",
-      "source": "Threads",
-      "translated": "對話串"
+      "id": "native.apple.9f2fd65953013b7c",
+      "source": "Sessions",
+      "translated": "工作階段"
     },
     {
-      "id": "native.apple.9b1d0ef27a1333b0",
-      "source": "Archived threads",
-      "translated": "已封存的對話串"
+      "id": "native.apple.0422818cc95d5071",
+      "source": "Archived sessions",
+      "translated": "已封存的工作階段"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11249,34 +11234,34 @@
       "translated": "顯示已封存"
     },
     {
-      "id": "native.apple.98167401c7267735",
-      "source": "Threads unavailable",
-      "translated": "無法使用對話串"
+      "id": "native.apple.b272115c83f7ef58",
+      "source": "Sessions unavailable",
+      "translated": "工作階段無法使用"
     },
     {
-      "id": "native.apple.4d28a7def2337b9f",
-      "source": "Loading archived threads",
-      "translated": "正在載入已封存的對話串"
+      "id": "native.apple.54f8260c9b863087",
+      "source": "Loading archived sessions",
+      "translated": "正在載入已封存的工作階段"
     },
     {
-      "id": "native.apple.777d7b706933bd7b",
-      "source": "Loading recent threads",
-      "translated": "正在載入最近的對話串"
+      "id": "native.apple.9b305868873dade2",
+      "source": "Loading recent sessions",
+      "translated": "正在載入最近的工作階段"
     },
     {
-      "id": "native.apple.22f81ea94bef8410",
-      "source": "^[\\(count) thread](inflect: true)",
-      "translated": "^[\\(count) 個對話串](inflect: true)"
+      "id": "native.apple.207dad20d09f3160",
+      "source": "^[\\(count) session](inflect: true)",
+      "translated": "^[\\(count) 個工作階段](inflect: true)"
     },
     {
-      "id": "native.apple.1cad51e14db59bf9",
-      "source": "No archived threads",
-      "translated": "沒有已封存的對話串"
+      "id": "native.apple.1f4501a6bf2bae4c",
+      "source": "No archived sessions",
+      "translated": "沒有已封存的工作階段"
     },
     {
-      "id": "native.apple.18ef832d3a7ddcf8",
-      "source": "Archived threads will appear here.",
-      "translated": "已封存的對話串將顯示在這裡。"
+      "id": "native.apple.2a1ba7a5e1979c9e",
+      "source": "Archived sessions will appear here.",
+      "translated": "已封存的工作階段會顯示在這裡。"
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11359,9 +11344,9 @@
       "translated": "分享接收"
     },
     {
-      "id": "native.apple.21d9208d86a4d1fe",
-      "source": "Loading threads",
-      "translated": "正在載入討論串"
+      "id": "native.apple.2360d25fe6ae9946",
+      "source": "Loading sessions",
+      "translated": "正在載入工作階段"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11369,19 +11354,19 @@
       "translated": "正在從 Gateway 擷取最近活動。"
     },
     {
-      "id": "native.apple.4be1f79aa2b230ff",
-      "source": "Threads unavailable",
-      "translated": "討論串無法使用"
+      "id": "native.apple.c334f2e86702a7b8",
+      "source": "Sessions unavailable",
+      "translated": "工作階段無法使用"
     },
     {
-      "id": "native.apple.98b348873556bc46",
-      "source": "No recent threads",
-      "translated": "沒有最近的討論串"
+      "id": "native.apple.6cc6efb7a03960b6",
+      "source": "No recent sessions",
+      "translated": "沒有最近工作階段"
     },
     {
-      "id": "native.apple.7396d205574d279f",
-      "source": "Thread activity offline",
-      "translated": "討論串活動已離線"
+      "id": "native.apple.08483af2d043bee6",
+      "source": "Session activity offline",
+      "translated": "工作階段活動離線"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11839,9 +11824,9 @@
       "translated": "卡片"
     },
     {
-      "id": "native.apple.c9ec1b0e18074d8a",
-      "source": "Open Thread",
-      "translated": "開啟討論串"
+      "id": "native.apple.93eeaedb2ff61043",
+      "source": "Open Session",
+      "translated": "開啟工作階段"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13329,9 +13314,9 @@
       "translated": "預設"
     },
     {
-      "id": "native.apple.f4ae5664c3eda95d",
-      "source": "Used for new Chat threads and Talk sessions.",
-      "translated": "用於新的聊天討論串和通話工作階段。"
+      "id": "native.apple.3de045f17ea3c6d0",
+      "source": "Used for new Chat and Talk sessions.",
+      "translated": "用於新的 Chat 和 Talk 工作階段。"
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15734,9 +15719,9 @@
       "translated": "執行個體"
     },
     {
-      "id": "native.apple.11fe8b9941954dfb",
-      "source": "Threads",
-      "translated": "討論串"
+      "id": "native.apple.3579cf2750470a22",
+      "source": "Sessions",
+      "translated": "工作階段"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19044,9 +19029,9 @@
       "translated": "快速聊天快捷鍵"
     },
     {
-      "id": "native.apple.94dd793cd7d7d555",
-      "source": "Global shortcut that opens a floating chat bar for the main thread.",
-      "translated": "用於開啟主要討論串浮動聊天列的全域快速鍵。"
+      "id": "native.apple.6ae77665b5f4490f",
+      "source": "Global shortcut that opens a floating chat bar for the main session.",
+      "translated": "可開啟主工作階段浮動聊天列的全域快捷鍵。"
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19624,9 +19609,9 @@
       "translated": "嚴重"
     },
     {
-      "id": "native.apple.13f96467014cf344",
-      "source": "New Thread",
-      "translated": "新增討論串"
+      "id": "native.apple.75102378a6775180",
+      "source": "New Session",
+      "translated": "新增工作階段"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21914,9 +21899,9 @@
       "translated": "沒有最近的訊息"
     },
     {
-      "id": "native.apple.3ec2afcbc298c673",
-      "source": "Threads",
-      "translated": "對話串"
+      "id": "native.apple.1ff8aec0044934c3",
+      "source": "Sessions",
+      "translated": "工作階段"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21924,9 +21909,9 @@
       "translated": "查看 CLI 針對上下文和速率限制重複使用的已儲存對話儲存桶。"
     },
     {
-      "id": "native.apple.14ccb32cd8ed1c81",
-      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
-      "translated": "目前尚無對話串。收到第一則傳入訊息或心跳訊號後，對話串就會顯示在這裡。"
+      "id": "native.apple.bab897f3252b134c",
+      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
+      "translated": "尚無工作階段。它們會在收到第一則傳入訊息或心跳後出現。"
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -22009,9 +21994,9 @@
       "translated": "Exec Approvals"
     },
     {
-      "id": "native.apple.52e37e3a44ae516c",
-      "source": "Threads",
-      "translated": "對話串"
+      "id": "native.apple.64a6dc7d49e8fb57",
+      "source": "Sessions",
+      "translated": "工作階段"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -23014,9 +22999,9 @@
       "translated": "讓我掌握近況"
     },
     {
-      "id": "native.apple.fc4ce810900ec0b6",
-      "source": "Summarize what happened in my threads since yesterday.",
-      "translated": "摘要說明自昨天以來我的討論串中發生的事情。"
+      "id": "native.apple.234ec45f4231edc4",
+      "source": "Summarize what happened in my sessions since yesterday.",
+      "translated": "摘要說明自昨天以來我的工作階段中發生了什麼事。"
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23194,9 +23179,9 @@
       "translated": "取消釘選模型"
     },
     {
-      "id": "native.apple.4edb66657f5aca1f",
-      "source": "Thread",
-      "translated": "討論串"
+      "id": "native.apple.5dfc0700d8dff8de",
+      "source": "Session",
+      "translated": "工作階段"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23359,51 +23344,6 @@
       "translated": "小工具無法使用"
     },
     {
-      "id": "native.apple.d640691fd196f338",
-      "source": "Widget export failed",
-      "translated": "小工具匯出失敗"
-    },
-    {
-      "id": "native.apple.533c6e22a11e88de",
-      "source": "OK",
-      "translated": "確定"
-    },
-    {
-      "id": "native.apple.e1fb28a2a9756402",
-      "source": "Copy image",
-      "translated": "複製圖片"
-    },
-    {
-      "id": "native.apple.ebd7bc92e1b12235",
-      "source": "Save image…",
-      "translated": "儲存圖片…"
-    },
-    {
-      "id": "native.apple.742c46d4cf2db134",
-      "source": "Save image",
-      "translated": "儲存圖片"
-    },
-    {
-      "id": "native.apple.0589cce608418f90",
-      "source": "The widget image could not be captured.",
-      "translated": "無法擷取小工具圖片。"
-    },
-    {
-      "id": "native.apple.dfe24e827fdbe9c5",
-      "source": "The widget image could not be copied.",
-      "translated": "無法複製小工具圖片。"
-    },
-    {
-      "id": "native.apple.9e611e3a80e71408",
-      "source": "The widget image could not be encoded as PNG.",
-      "translated": "無法將小工具圖片編碼為 PNG。"
-    },
-    {
-      "id": "native.apple.9a6e8afbe24a262b",
-      "source": "The widget image could not be saved.",
-      "translated": "無法儲存小工具圖片。"
-    },
-    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23544,19 +23484,19 @@
       "translated": "使用者"
     },
     {
-      "id": "native.apple.9d0cba09d92ee669",
-      "source": "This thread cannot be archived while it is active or running.",
-      "translated": "此討論串仍在活動或執行中，無法封存。"
+      "id": "native.apple.b1cdcb906a43d5d6",
+      "source": "This session cannot be archived while it is active or running.",
+      "translated": "此工作階段在作用中或執行中時無法封存。"
     },
     {
-      "id": "native.apple.8952a111a1075051",
-      "source": "The main thread cannot be deleted.",
-      "translated": "無法刪除主要討論串。"
+      "id": "native.apple.5817e3f3dab1ee19",
+      "source": "The main session cannot be deleted.",
+      "translated": "無法刪除主要工作階段。"
     },
     {
-      "id": "native.apple.90d0ccf80ca28717",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
-      "translated": "請先移除附件或等待傳送完成，再封存或刪除此討論串。"
+      "id": "native.apple.a6b8df3f18171c91",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
+      "translated": "請先移除附件或等待傳送完成，再封存或刪除此工作階段。"
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23694,9 +23634,9 @@
       "translated": "執行結束時間"
     },
     {
-      "id": "native.apple.bbccb4c8db5cac12",
-      "source": "Thread Info",
-      "translated": "討論串資訊"
+      "id": "native.apple.cd7c3095a22f80a9",
+      "source": "Session Info",
+      "translated": "工作階段資訊"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23729,9 +23669,9 @@
       "translated": "加入群組"
     },
     {
-      "id": "native.apple.7b641fed5bace855",
-      "source": "Thread Groups",
-      "translated": "討論串群組"
+      "id": "native.apple.23d628606fe0734f",
+      "source": "Session Groups",
+      "translated": "工作階段群組"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23774,9 +23714,9 @@
       "translated": "刪除群組"
     },
     {
-      "id": "native.apple.56401c79410a310d",
-      "source": "Threads in this group become ungrouped.",
-      "translated": "此群組中的討論串將取消分組。"
+      "id": "native.apple.b049c8a4d2805e08",
+      "source": "Sessions in this group become ungrouped.",
+      "translated": "此群組中的工作階段將變為未分組。"
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23789,9 +23729,9 @@
       "translated": "此 Gateway 上沒有可用的代理程式。"
     },
     {
-      "id": "native.apple.2d96aa7d3d12f85b",
-      "source": "New Thread Options",
-      "translated": "新增討論串選項"
+      "id": "native.apple.6c89f35d53506406",
+      "source": "New Session Options",
+      "translated": "新工作階段選項"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23819,19 +23759,19 @@
       "translated": "建立"
     },
     {
-      "id": "native.apple.87ef57319d1ddc85",
-      "source": "The thread could not be created.",
-      "translated": "無法建立討論串。"
+      "id": "native.apple.795ba37f6782cf28",
+      "source": "The session could not be created.",
+      "translated": "無法建立工作階段。"
     },
     {
-      "id": "native.apple.6bd91c435b69d638",
-      "source": "Search threads",
-      "translated": "搜尋討論串"
+      "id": "native.apple.8ec708a3605a2cc3",
+      "source": "Search sessions",
+      "translated": "搜尋工作階段"
     },
     {
-      "id": "native.apple.6fde4bdf9d5b9191",
-      "source": "No Threads",
-      "translated": "沒有對話串"
+      "id": "native.apple.23b069b4e7f97039",
+      "source": "No Sessions",
+      "translated": "沒有工作階段"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23839,29 +23779,29 @@
       "translated": "沒有結果"
     },
     {
-      "id": "native.apple.a02fd99740d29bd3",
-      "source": "New Thread",
-      "translated": "新增對話串"
+      "id": "native.apple.0058923f2ce8a3ec",
+      "source": "New Session",
+      "translated": "新增工作階段"
     },
     {
-      "id": "native.apple.b625801dd04b09f2",
-      "source": "New thread",
-      "translated": "新增對話串"
+      "id": "native.apple.66ba42960eb4135b",
+      "source": "New session",
+      "translated": "新增工作階段"
     },
     {
-      "id": "native.apple.851be81fcc933608",
-      "source": "New thread options",
-      "translated": "新增對話串選項"
+      "id": "native.apple.2ef0e34db02ad255",
+      "source": "New session options",
+      "translated": "新工作階段選項"
     },
     {
-      "id": "native.apple.9ce8a4aba7b444b2",
-      "source": "Rename Thread",
-      "translated": "重新命名對話串"
+      "id": "native.apple.36753ef2f1ed4264",
+      "source": "Rename Session",
+      "translated": "重新命名工作階段"
     },
     {
-      "id": "native.apple.1dd067c44511c7f0",
-      "source": "Thread name",
-      "translated": "對話串名稱"
+      "id": "native.apple.c9de0a1510ef475f",
+      "source": "Session name",
+      "translated": "工作階段名稱"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23874,14 +23814,14 @@
       "translated": "取消"
     },
     {
-      "id": "native.apple.618073d6ab3f2721",
-      "source": "Delete Thread",
-      "translated": "刪除對話串"
+      "id": "native.apple.afb4e6c99c63a28d",
+      "source": "Delete Session",
+      "translated": "刪除工作階段"
     },
     {
-      "id": "native.apple.10a5e72bba3cbccc",
-      "source": "The thread and its transcript are removed from the gateway.",
-      "translated": "此對話串及其文字記錄將從 Gateway 移除。"
+      "id": "native.apple.3d4ef32e42f136a4",
+      "source": "The session and its transcript are removed from the gateway.",
+      "translated": "工作階段及其逐字記錄將從 Gateway 中移除。"
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23889,14 +23829,14 @@
       "translated": "刪除「%@」？"
     },
     {
-      "id": "native.apple.ac71e3b2aa496a2c",
-      "source": "Thread running",
-      "translated": "對話串執行中"
+      "id": "native.apple.9a7dca238fba628d",
+      "source": "Session running",
+      "translated": "工作階段執行中"
     },
     {
-      "id": "native.apple.c775e87f997278b2",
-      "source": "Thread failed",
-      "translated": "對話串執行失敗"
+      "id": "native.apple.fcfbfe5e97a95e9c",
+      "source": "Session failed",
+      "translated": "工作階段失敗"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23954,9 +23894,9 @@
       "translated": "複製工作階段金鑰"
     },
     {
-      "id": "native.apple.f4998cfb572f23ff",
-      "source": "Delete Thread…",
-      "translated": "刪除對話串…"
+      "id": "native.apple.4aeb7c14c26dabac",
+      "source": "Delete Session…",
+      "translated": "刪除工作階段…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23969,9 +23909,9 @@
       "translated": "連線中…"
     },
     {
-      "id": "native.apple.8802e9576ffd0f65",
-      "source": "Retry thread groups",
-      "translated": "重試對話串群組"
+      "id": "native.apple.79f708b3bc1d3a6c",
+      "source": "Retry session groups",
+      "translated": "重試工作階段群組"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23994,24 +23934,24 @@
       "translated": "範圍"
     },
     {
-      "id": "native.apple.b313b80def4bda52",
-      "source": "Search threads",
-      "translated": "搜尋對話串"
+      "id": "native.apple.2c37581c7b88f741",
+      "source": "Search sessions",
+      "translated": "搜尋工作階段"
     },
     {
-      "id": "native.apple.c0cc6acc36f413ce",
-      "source": "Threads",
-      "translated": "對話串"
+      "id": "native.apple.43be8a2336e42faf",
+      "source": "Sessions",
+      "translated": "工作階段"
     },
     {
-      "id": "native.apple.854d3928fe5a557c",
-      "source": "Rename Thread",
-      "translated": "重新命名對話串"
+      "id": "native.apple.0b379cdfcbd3247f",
+      "source": "Rename Session",
+      "translated": "重新命名工作階段"
     },
     {
-      "id": "native.apple.9d0d3f20096cc4da",
-      "source": "Thread name",
-      "translated": "對話串名稱"
+      "id": "native.apple.54b6fbd9e41db009",
+      "source": "Session name",
+      "translated": "工作階段名稱"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -24019,19 +23959,19 @@
       "translated": "取消"
     },
     {
-      "id": "native.apple.dc00eb94f33bae15",
-      "source": "Delete selected threads?",
-      "translated": "要刪除所選的對話串嗎？"
+      "id": "native.apple.751e0f6b81cd374a",
+      "source": "Delete selected sessions?",
+      "translated": "刪除所選的工作階段？"
     },
     {
-      "id": "native.apple.2053fc9f74dc3158",
-      "source": "Delete Threads",
-      "translated": "刪除對話串"
+      "id": "native.apple.aa679276581b0058",
+      "source": "Delete Sessions",
+      "translated": "刪除工作階段"
     },
     {
-      "id": "native.apple.0970247871a834a0",
-      "source": "Each selected thread and its transcript will be removed from the gateway.",
-      "translated": "每個所選的對話串及其文字記錄都將從 Gateway 移除。"
+      "id": "native.apple.f837129cbee23297",
+      "source": "Each selected session and its transcript will be removed from the gateway.",
+      "translated": "每個所選的工作階段及其逐字稿都將從 Gateway 中移除。"
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -24039,9 +23979,9 @@
       "translated": "群組"
     },
     {
-      "id": "native.apple.6f8acab2256728b5",
-      "source": "Manage thread groups",
-      "translated": "管理對話串群組"
+      "id": "native.apple.64013cfee5e25305",
+      "source": "Manage session groups",
+      "translated": "管理工作階段群組"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -24054,14 +23994,14 @@
       "translated": "選取"
     },
     {
-      "id": "native.apple.692972314d04b184",
-      "source": "No archived threads",
-      "translated": "沒有已封存的對話串"
+      "id": "native.apple.b67eaecec1b423ac",
+      "source": "No archived sessions",
+      "translated": "沒有已封存的工作階段"
     },
     {
-      "id": "native.apple.d6a4b5711dcd26e7",
-      "source": "No threads found",
-      "translated": "找不到對話串"
+      "id": "native.apple.b2435a79abf0c794",
+      "source": "No sessions found",
+      "translated": "找不到工作階段"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24229,16 +24169,6 @@
       "translated": "開啟完整訊息"
     },
     {
-      "id": "native.apple.002bfcede229ad4b",
-      "source": "Rewind to Here",
-      "translated": "倒回此處"
-    },
-    {
-      "id": "native.apple.14df2e4997689fb3",
-      "source": "Fork from Here",
-      "translated": "從這裡分支"
-    },
-    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "回覆"
@@ -24324,9 +24254,9 @@
       "translated": "請移除附件，或等待傳送問題解決後再開始新的聊天。"
     },
     {
-      "id": "native.apple.e0f045151c8d3137",
-      "source": "Gateway changed before the thread operation started.",
-      "translated": "Gateway 已在對話串操作開始前變更。"
+      "id": "native.apple.980f552bb0f96c0f",
+      "source": "Gateway changed before the session operation started.",
+      "translated": "Gateway 在工作階段操作開始前已變更。"
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24334,9 +24264,9 @@
       "translated": "請先移除附件或等待傳送完成，再切換聊天。"
     },
     {
-      "id": "native.apple.0a5c4e15466c3acc",
-      "source": "Clear this thread's history?",
-      "translated": "要清除此對話串的歷史記錄嗎？"
+      "id": "native.apple.87ba543b42696b92",
+      "source": "Clear this session's history?",
+      "translated": "要清除此工作階段的歷史記錄嗎？"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24349,14 +24279,14 @@
       "translated": "這會重設與 %@ 的對話。工作階段金鑰將維持不變。"
     },
     {
-      "id": "native.apple.67ac221dbe7179f0",
-      "source": "Rename Thread",
-      "translated": "重新命名對話串"
+      "id": "native.apple.a92e96bed98bd553",
+      "source": "Rename Session",
+      "translated": "重新命名工作階段"
     },
     {
-      "id": "native.apple.cf0f7e049603f518",
-      "source": "Thread name",
-      "translated": "對話串名稱"
+      "id": "native.apple.848e2388f3466f40",
+      "source": "Session name",
+      "translated": "工作階段名稱"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24374,9 +24304,9 @@
       "translated": "匯出對話紀錄"
     },
     {
-      "id": "native.apple.c0ada47504425f23",
-      "source": "Threads",
-      "translated": "對話串"
+      "id": "native.apple.4af0f566d39d7041",
+      "source": "Sessions",
+      "translated": "工作階段"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24449,14 +24379,14 @@
       "translated": "預設"
     },
     {
-      "id": "native.apple.1a765291943599e5",
-      "source": "New Thread",
-      "translated": "新增對話串"
+      "id": "native.apple.eb58552e43c8dde2",
+      "source": "New Session",
+      "translated": "新增工作階段"
     },
     {
-      "id": "native.apple.c7a3a6d5e43dd98f",
-      "source": "New Thread Options…",
-      "translated": "新增對話串選項…"
+      "id": "native.apple.a7119fbf9d25df5e",
+      "source": "New Session Options…",
+      "translated": "新增工作階段選項…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24464,19 +24394,19 @@
       "translated": "重新整理"
     },
     {
-      "id": "native.apple.0e710b81808e5dcf",
-      "source": "Threads…",
-      "translated": "對話串…"
+      "id": "native.apple.2bcff4a8fa503739",
+      "source": "Sessions…",
+      "translated": "工作階段…"
     },
     {
-      "id": "native.apple.faad8f92b6bef166",
-      "source": "Rename Thread…",
-      "translated": "重新命名對話串…"
+      "id": "native.apple.c36e008b051adb38",
+      "source": "Rename Session…",
+      "translated": "重新命名工作階段…"
     },
     {
-      "id": "native.apple.23b61d6cd26ac112",
-      "source": "Fork",
-      "translated": "分支"
+      "id": "native.apple.ea0ef95a159bffe0",
+      "source": "Fork Session",
+      "translated": "分支工作階段"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24534,24 +24464,24 @@
       "translated": "清除歷史記錄…"
     },
     {
-      "id": "native.apple.8b4f1c5107ea8a0e",
-      "source": "Thread",
-      "translated": "對話串"
+      "id": "native.apple.920fe8a7a33f9e92",
+      "source": "Session",
+      "translated": "工作階段"
     },
     {
-      "id": "native.apple.4d7750c9bf699469",
-      "source": "Thread actions",
-      "translated": "對話串操作"
+      "id": "native.apple.185a401f78328b0f",
+      "source": "Session actions",
+      "translated": "工作階段動作"
     },
     {
-      "id": "native.apple.bb2f22cc43c97f8e",
-      "source": "Thread cost %@",
-      "translated": "對話串費用 %@"
+      "id": "native.apple.9f9dedf599b2619b",
+      "source": "Session cost %@",
+      "translated": "工作階段費用 %@"
     },
     {
-      "id": "native.apple.6239ced0b86e86f8",
-      "source": "Compact Thread",
-      "translated": "壓縮對話串"
+      "id": "native.apple.f0a4720df5f5f403",
+      "source": "Compact Session",
+      "translated": "精簡工作階段"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/.i18n/native/zh-TW.json
+++ b/apps/.i18n/native/zh-TW.json
@@ -1429,9 +1429,9 @@
       "translated": "與 OpenClaw 對話或使用語音輸入"
     },
     {
-      "id": "native.android.5876e15e5e92fd45",
-      "source": "Browse Sessions",
-      "translated": "瀏覽工作階段"
+      "id": "native.android.e2cf5a38587382cb",
+      "source": "Browse Threads",
+      "translated": "瀏覽討論串"
     },
     {
       "id": "native.android.9052827e69dafbdc",
@@ -1484,24 +1484,24 @@
       "translated": "找不到動作"
     },
     {
-      "id": "native.android.48ad0ae0e930e02b",
-      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
-      "translated": "試試 Chat、Voice、Sessions、Providers 或 Settings。"
+      "id": "native.android.bc70a4ac965b82ba",
+      "source": "Try Chat, Voice, Threads, Providers, or Settings.",
+      "translated": "試試聊天、語音、討論串、提供者或設定。"
     },
     {
-      "id": "native.android.d4fbd1ee4f55a5db",
-      "source": "Sessions",
-      "translated": "工作階段"
+      "id": "native.android.670121e54dbe286f",
+      "source": "Threads",
+      "translated": "討論串"
     },
     {
-      "id": "native.android.207c2170504e99e6",
-      "source": "Connect the Gateway to search sessions.",
-      "translated": "連接 Gateway 以搜尋工作階段。"
+      "id": "native.android.d38be650b1bce4a0",
+      "source": "Connect the Gateway to search threads.",
+      "translated": "連線至 Gateway 以搜尋討論串。"
     },
     {
-      "id": "native.android.25d2c2d792c952fe",
-      "source": "No matching sessions yet.",
-      "translated": "尚無相符的工作階段。"
+      "id": "native.android.3d7754721f776ef8",
+      "source": "No matching threads yet.",
+      "translated": "目前沒有相符的討論串。"
     },
     {
       "id": "native.android.1d009aa9b54d689d",
@@ -1509,14 +1509,14 @@
       "translated": "助理正在處理"
     },
     {
-      "id": "native.android.8f8384286317f5c9",
-      "source": "OpenClaw session",
-      "translated": "OpenClaw 工作階段"
+      "id": "native.android.9a839f6e3e05a744",
+      "source": "OpenClaw thread",
+      "translated": "OpenClaw 討論串"
     },
     {
-      "id": "native.android.15799e57704b20c6",
-      "source": "Open session",
-      "translated": "開啟工作階段"
+      "id": "native.android.d83f82a1e4a5ed99",
+      "source": "Open thread",
+      "translated": "開啟討論串"
     },
     {
       "id": "native.android.42fd88c3d0418a4a",
@@ -1539,9 +1539,9 @@
       "translated": "沒有已就緒的提供者"
     },
     {
-      "id": "native.android.73e6ab1a168fd381",
-      "source": "Main session",
-      "translated": "主要工作階段"
+      "id": "native.android.8a1c5365c0538908",
+      "source": "Main thread",
+      "translated": "主要討論串"
     },
     {
       "id": "native.android.5f06e4d6a59f7a59",
@@ -3679,14 +3679,14 @@
       "translated": "${tokens / 1_000}k"
     },
     {
-      "id": "native.android.0e3157c15c56944f",
-      "source": "Sessions",
-      "translated": "工作階段"
+      "id": "native.android.a5845742daecb4ba",
+      "source": "Threads",
+      "translated": "討論串"
     },
     {
-      "id": "native.android.70f5d0507d34b5c8",
-      "source": "Focus session search",
-      "translated": "聚焦工作階段搜尋"
+      "id": "native.android.439b324280869527",
+      "source": "Focus thread search",
+      "translated": "聚焦討論串搜尋"
     },
     {
       "id": "native.android.e0f10db479f627eb",
@@ -3699,14 +3699,14 @@
       "translated": "已封存"
     },
     {
-      "id": "native.android.b9cf34c137e4cf03",
-      "source": "Search sessions",
-      "translated": "搜尋工作階段"
+      "id": "native.android.03981341841b04ac",
+      "source": "Search threads",
+      "translated": "搜尋討論串"
     },
     {
-      "id": "native.android.10cb26723e9990fc",
-      "source": "Clear session search",
-      "translated": "清除工作階段搜尋"
+      "id": "native.android.99570c528a41fa72",
+      "source": "Clear thread search",
+      "translated": "清除討論串搜尋"
     },
     {
       "id": "native.android.784ecdd6ea2ec5f0",
@@ -3724,9 +3724,9 @@
       "translated": "最舊優先"
     },
     {
-      "id": "native.android.c6bf8751e2a7f5c7",
-      "source": "Toggle session layout",
-      "translated": "切換工作階段版面配置"
+      "id": "native.android.fd67be543e321cc9",
+      "source": "Toggle thread layout",
+      "translated": "切換討論串版面配置"
     },
     {
       "id": "native.android.49db3101cf9c806c",
@@ -3739,14 +3739,14 @@
       "translated": "版面配置：詳細"
     },
     {
-      "id": "native.android.69b79a3c2c987cd4",
-      "source": "Searching sessions",
-      "translated": "正在搜尋工作階段"
+      "id": "native.android.ebd17565e0ffd8eb",
+      "source": "Searching threads",
+      "translated": "正在搜尋討論串"
     },
     {
-      "id": "native.android.dd587d341af44212",
-      "source": "No matching sessions",
-      "translated": "沒有相符的工作階段"
+      "id": "native.android.472d46ae8669f860",
+      "source": "No matching threads",
+      "translated": "沒有相符的討論串"
     },
     {
       "id": "native.android.11c1a8c944bea0ae",
@@ -3764,19 +3764,19 @@
       "translated": "開始聊天"
     },
     {
-      "id": "native.android.f10d4df7cbc6df4f",
-      "source": "Current session",
-      "translated": "目前工作階段"
+      "id": "native.android.ff81ad1bee00d384",
+      "source": "Current thread",
+      "translated": "目前的討論串"
     },
     {
-      "id": "native.android.8f0482425838ae64",
-      "source": "OpenClaw session",
-      "translated": "OpenClaw 工作階段"
+      "id": "native.android.fc145645b9620e57",
+      "source": "OpenClaw thread",
+      "translated": "OpenClaw 討論串"
     },
     {
-      "id": "native.android.786774c8a76e50d7",
-      "source": "Rename session",
-      "translated": "重新命名工作階段"
+      "id": "native.android.71cbb8dde8bf138b",
+      "source": "Rename thread",
+      "translated": "重新命名討論串"
     },
     {
       "id": "native.android.fa420bc51ff675a1",
@@ -3804,19 +3804,19 @@
       "translated": "刪除群組？"
     },
     {
-      "id": "native.android.3455fc2f77d564e3",
-      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
-      "translated": "「$group」中的工作階段會保留並移回未分組。"
+      "id": "native.android.691e92cfe5cf106e",
+      "source": "Threads in \"$group\" are kept and move back to Ungrouped.",
+      "translated": "「$group」中的討論串會被保留並移回「未分組」。"
     },
     {
-      "id": "native.android.4805fb9d6623e8c0",
-      "source": "Delete session?",
-      "translated": "要刪除工作階段嗎？"
+      "id": "native.android.d87a8217ab56999b",
+      "source": "Delete thread?",
+      "translated": "要刪除討論串嗎？"
     },
     {
-      "id": "native.android.0c3283a2b2445eae",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "這會永久刪除此工作階段及其逐字稿。"
+      "id": "native.android.930de97ff47113a8",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "這會永久刪除此對話串及其文字記錄。"
     },
     {
       "id": "native.android.807ba5c6699af2f1",
@@ -3939,19 +3939,19 @@
       "translated": "未分組"
     },
     {
-      "id": "native.android.db243d71d056afa4",
-      "source": "No sessions yet",
-      "translated": "尚無工作階段"
+      "id": "native.android.8e21a70428def6e0",
+      "source": "No threads yet",
+      "translated": "尚無對話串"
     },
     {
-      "id": "native.android.5b4eee6a8092925e",
-      "source": "No current session",
-      "translated": "沒有目前工作階段"
+      "id": "native.android.cda4c5ad8b17e394",
+      "source": "No current thread",
+      "translated": "目前沒有對話串"
     },
     {
-      "id": "native.android.acbcc9c9ea53d8c0",
-      "source": "No archived sessions",
-      "translated": "沒有封存的工作階段"
+      "id": "native.android.be84f061047aa2da",
+      "source": "No archived threads",
+      "translated": "沒有已封存的對話串"
     },
     {
       "id": "native.android.0a38a1167c6b6941",
@@ -3959,14 +3959,14 @@
       "translated": "開始新的對話後，就會顯示在這裡。"
     },
     {
-      "id": "native.android.56fcd605dc7be3c0",
-      "source": "Open Chat to start or resume the current session.",
-      "translated": "開啟聊天以開始或繼續目前工作階段。"
+      "id": "native.android.f289d03e1d3eee98",
+      "source": "Open Chat to start or resume the current thread.",
+      "translated": "開啟聊天以開始或繼續目前的對話串。"
     },
     {
-      "id": "native.android.085515989f8a2022",
-      "source": "Archived sessions will show up here.",
-      "translated": "封存的工作階段會顯示在這裡。"
+      "id": "native.android.504b71386e76c6ae",
+      "source": "Archived threads will show up here.",
+      "translated": "已封存的對話串會顯示在這裡。"
     },
     {
       "id": "native.android.2261a31153cec409",
@@ -3989,9 +3989,9 @@
       "translated": "${days}天"
     },
     {
-      "id": "native.android.3d4fa07acbc015c5",
-      "source": "Main session",
-      "translated": "主要工作階段"
+      "id": "native.android.ee4c727cdafbe963",
+      "source": "Main thread",
+      "translated": "主要對話串"
     },
     {
       "id": "native.android.dcb7d5956029bbc4",
@@ -4129,9 +4129,9 @@
       "translated": "Gateway 待處理"
     },
     {
-      "id": "native.android.2d8d049afe99f751",
-      "source": "Session Activity",
-      "translated": "工作階段活動"
+      "id": "native.android.da78209effb11cfd",
+      "source": "Thread Activity",
+      "translated": "對話串活動"
     },
     {
       "id": "native.android.5d53e328e4deb444",
@@ -4174,14 +4174,14 @@
       "translated": "當這支手機連線時，Exec 核准請求會顯示在這裡。"
     },
     {
-      "id": "native.android.dc3e7ca5a491103a",
-      "source": "Session activity",
-      "translated": "工作階段活動"
+      "id": "native.android.f615712dfb56319a",
+      "source": "Thread activity",
+      "translated": "對話串活動"
     },
     {
-      "id": "native.android.8551e02b060bd7d8",
-      "source": "Chat tool calls waiting in the active session remain visible here.",
-      "translated": "作用中工作階段中等待的聊天工具呼叫會持續顯示在這裡。"
+      "id": "native.android.6c93973c13db43ae",
+      "source": "Chat tool calls waiting in the active thread remain visible here.",
+      "translated": "使用中對話串內等待中的聊天工具呼叫仍會顯示在這裡。"
     },
     {
       "id": "native.android.fea93eda5bf97d9e",
@@ -4294,6 +4294,11 @@
       "translated": "Talk Provider 設定"
     },
     {
+      "id": "native.android.23b638094c34b916",
+      "source": "Microphone",
+      "translated": "麥克風"
+    },
+    {
       "id": "native.android.98a8bbb2b1f382e6",
       "source": "Audio Test",
       "translated": "音訊測試"
@@ -4337,6 +4342,66 @@
       "id": "native.android.05bd460309ac6db6",
       "source": "Done",
       "translated": "完成"
+    },
+    {
+      "id": "native.android.8d9ecdfdd916b780",
+      "source": "Automatic",
+      "translated": "自動"
+    },
+    {
+      "id": "native.android.c1626a6700a570f6",
+      "source": "Preferred microphone unavailable; using automatic routing.",
+      "translated": "偏好的麥克風無法使用；正在使用自動路由。"
+    },
+    {
+      "id": "native.android.820bc5d0ce571d8b",
+      "source": "Prioritizes connected Bluetooth microphones.",
+      "translated": "優先使用已連線的藍牙麥克風。"
+    },
+    {
+      "id": "native.android.11e48038d5e8bff6",
+      "source": "Preferred microphone",
+      "translated": "偏好的麥克風"
+    },
+    {
+      "id": "native.android.eaa4d7563a46d307",
+      "source": "Unavailable",
+      "translated": "無法使用"
+    },
+    {
+      "id": "native.android.9f5ebf17eb405ba8",
+      "source": "Next session",
+      "translated": "下次工作階段"
+    },
+    {
+      "id": "native.android.8c4e91f53928efb2",
+      "source": "Built-in microphone",
+      "translated": "內建麥克風"
+    },
+    {
+      "id": "native.android.14b613cb6e2446b4",
+      "source": "Bluetooth microphone",
+      "translated": "藍牙麥克風"
+    },
+    {
+      "id": "native.android.c885247b2d7ce271",
+      "source": "Bluetooth LE microphone",
+      "translated": "Bluetooth LE 麥克風"
+    },
+    {
+      "id": "native.android.b6a4e674c5fb441a",
+      "source": "Wired headset microphone",
+      "translated": "有線耳機麥克風"
+    },
+    {
+      "id": "native.android.9c8becb3b0fb5a90",
+      "source": "USB microphone",
+      "translated": "USB 麥克風"
+    },
+    {
+      "id": "native.android.ba46258fadec7a39",
+      "source": "External microphone",
+      "translated": "外接麥克風"
     },
     {
       "id": "native.android.60cf67eb5ec46ea0",
@@ -5074,9 +5139,9 @@
       "translated": "檢查"
     },
     {
-      "id": "native.android.5a540761383fa474",
-      "source": "OpenClaw turns this phone into a clean mobile command surface for sessions, voice, providers, and Gateway.",
-      "translated": "OpenClaw 可將此手機變成簡潔的行動指令介面，用於工作階段、語音、提供者及 Gateway。"
+      "id": "native.android.c971506716c96e91",
+      "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
+      "translated": "OpenClaw 將這支手機化為簡潔的行動指令介面，用於討論串、語音、提供者和 Gateway。"
     },
     {
       "id": "native.android.3a3bea53e6a6ada7",
@@ -5624,9 +5689,9 @@
       "translated": "Talk 設定"
     },
     {
-      "id": "native.android.73f07a5d54915259",
-      "source": "Recent Sessions",
-      "translated": "最近的工作階段"
+      "id": "native.android.36f78c8c85dc283f",
+      "source": "Recent Threads",
+      "translated": "最近的討論串"
     },
     {
       "id": "native.android.e7e2862bffbd0706",
@@ -5684,14 +5749,14 @@
       "translated": "${nodeOnlinePercent(onlineNodes = onlineNodes, nodeCount = nodeCount)}% 在線"
     },
     {
-      "id": "native.android.16c3425d3a594481",
-      "source": "Sessions",
-      "translated": "工作階段"
+      "id": "native.android.57177017a6a93826",
+      "source": "Threads",
+      "translated": "討論串"
     },
     {
-      "id": "native.android.a5c0f8b3112aa58c",
-      "source": "No recent sessions",
-      "translated": "沒有最近的工作階段"
+      "id": "native.android.43320b54a68b00a1",
+      "source": "No recent threads",
+      "translated": "沒有最近的討論串"
     },
     {
       "id": "native.android.7178756ffe9e4c72",
@@ -5729,14 +5794,14 @@
       "translated": "運作中 · $pendingRunCount 個執行項目進行中"
     },
     {
-      "id": "native.android.2c89da708b12a522",
-      "source": "Monitoring · 1 session",
-      "translated": "監控中 · 1 個工作階段"
+      "id": "native.android.e24db059480f1e6a",
+      "source": "Monitoring · 1 thread",
+      "translated": "監控中 · 1 個討論串"
     },
     {
-      "id": "native.android.8b6ee382dcb64e1f",
-      "source": "Monitoring · $sessionCount sessions",
-      "translated": "監控中 · $sessionCount 個工作階段"
+      "id": "native.android.5a475f37d80e02bc",
+      "source": "Monitoring · $sessionCount threads",
+      "translated": "監控中 · $sessionCount 個討論串"
     },
     {
       "id": "native.android.50f3b7af0428311c",
@@ -5769,9 +5834,9 @@
       "translated": "提供者"
     },
     {
-      "id": "native.android.a65477861c7203aa",
-      "source": "Open session",
-      "translated": "開啟工作階段"
+      "id": "native.android.358c5e0e838d5423",
+      "source": "Open thread",
+      "translated": "開啟討論串"
     },
     {
       "id": "native.android.ede6f2717ca8e267",
@@ -6194,9 +6259,9 @@
       "translated": "${days} 天"
     },
     {
-      "id": "native.android.22d755834386db07",
-      "source": "Main session",
-      "translated": "主要工作階段"
+      "id": "native.android.28a1a1acc5a0959f",
+      "source": "Main thread",
+      "translated": "主要討論串"
     },
     {
       "id": "native.android.b1f9c790e2dbac1b",
@@ -6877,6 +6942,16 @@
       "id": "native.android.5d4f2992e2320c3e",
       "source": "Unmute",
       "translated": "取消靜音"
+    },
+    {
+      "id": "native.android.cb608d82c5b3352a",
+      "source": "Back camera",
+      "translated": "後置相機"
+    },
+    {
+      "id": "native.android.e89a0e780eed2e1e",
+      "source": "Front camera",
+      "translated": "前置相機"
     },
     {
       "id": "native.android.d7ffaa41c514ba38",
@@ -7684,9 +7759,9 @@
       "translated": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows."
     },
     {
-      "id": "native.android.882cc14a58e7e105",
-      "source": "Loading session",
-      "translated": "正在載入工作階段"
+      "id": "native.android.0c74bc30a994dd33",
+      "source": "Loading thread",
+      "translated": "正在載入討論串"
     },
     {
       "id": "native.android.2c1106e1687ab258",
@@ -7729,14 +7804,14 @@
       "translated": "掌握最新進度"
     },
     {
-      "id": "native.android.1e5add56e48c99f9",
-      "source": "Summarize recent sessions and next steps.",
-      "translated": "摘要近期工作階段並列出後續步驟。"
+      "id": "native.android.cf40df9739f78f27",
+      "source": "Summarize recent threads and next steps.",
+      "translated": "摘要最近的討論串和後續步驟。"
     },
     {
-      "id": "native.android.06d515351bb79576",
-      "source": "Catch me up on my recent OpenClaw sessions and suggest next steps.",
-      "translated": "協助我掌握近期 OpenClaw 工作階段的進度，並建議後續步驟。"
+      "id": "native.android.ebe49a8b8df80bd3",
+      "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
+      "translated": "讓我掌握最近的 OpenClaw 討論串，並建議後續步驟。"
     },
     {
       "id": "native.android.79f64f0b5ecaa07c",
@@ -8074,9 +8149,9 @@
       "translated": "已連線"
     },
     {
-      "id": "native.android.81931886b9caf3ab",
-      "source": "Sessions",
-      "translated": "工作階段"
+      "id": "native.android.6cf5d6fa8a4186d5",
+      "source": "Threads",
+      "translated": "討論串"
     },
     {
       "id": "native.android.e4dc7610b0898e37",
@@ -10794,9 +10869,9 @@
       "translated": "你想要處理什麼？"
     },
     {
-      "id": "native.apple.32179ce0b6d4543f",
-      "source": "The session attaches once the gateway is ready.",
-      "translated": "Gateway 準備就緒後，工作階段會連接。"
+      "id": "native.apple.4da775013ac9b123",
+      "source": "The thread attaches once the gateway is ready.",
+      "translated": "Gateway 準備就緒後，將連結此討論串。"
     },
     {
       "id": "native.apple.02611ddddef7295a",
@@ -10844,9 +10919,9 @@
       "translated": "新增工作階段選項…"
     },
     {
-      "id": "native.apple.a1b0d289758e2213",
-      "source": "Sessions…",
-      "translated": "工作階段…"
+      "id": "native.apple.003b25ddafeb18e9",
+      "source": "Threads…",
+      "translated": "討論串…"
     },
     {
       "id": "native.apple.17c13312e7532c89",
@@ -11009,14 +11084,14 @@
       "translated": "建立"
     },
     {
-      "id": "native.apple.f488b9caf6e51ac3",
-      "source": "Delete Session?",
-      "translated": "刪除工作階段？"
+      "id": "native.apple.31d5c7287cfb3abe",
+      "source": "Delete Thread?",
+      "translated": "要刪除討論串嗎？"
     },
     {
-      "id": "native.apple.8634b17be9b111bc",
-      "source": "Delete Session",
-      "translated": "刪除工作階段"
+      "id": "native.apple.d3395564809f1120",
+      "source": "Delete Thread",
+      "translated": "刪除討論串"
     },
     {
       "id": "native.apple.9b1aed19568a048e",
@@ -11024,9 +11099,9 @@
       "translated": "取消"
     },
     {
-      "id": "native.apple.4a9568ac9b18d8d3",
-      "source": "This permanently deletes the session and its transcript.",
-      "translated": "這會永久刪除此工作階段及其文字記錄。"
+      "id": "native.apple.092659256d26cb03",
+      "source": "This permanently deletes the thread and its transcript.",
+      "translated": "這會永久刪除討論串及其對話記錄。"
     },
     {
       "id": "native.apple.0965d8d2429c3b9f",
@@ -11054,9 +11129,9 @@
       "translated": "新增群組"
     },
     {
-      "id": "native.apple.5bccdc23a1640895",
-      "source": "Rename Session",
-      "translated": "重新命名工作階段"
+      "id": "native.apple.683032464c497bbd",
+      "source": "Rename Thread",
+      "translated": "重新命名討論串"
     },
     {
       "id": "native.apple.31424500c53d6c32",
@@ -11064,9 +11139,9 @@
       "translated": "群組名稱"
     },
     {
-      "id": "native.apple.af789b2d2fda0f67",
-      "source": "Session name",
-      "translated": "工作階段名稱"
+      "id": "native.apple.f887aa956588f237",
+      "source": "Thread name",
+      "translated": "討論串名稱"
     },
     {
       "id": "native.apple.e8018adcccaa2a4d",
@@ -11104,14 +11179,14 @@
       "translated": "代理程式"
     },
     {
-      "id": "native.apple.a3bde8045fe9224a",
-      "source": "Agent session",
-      "translated": "代理程式工作階段"
+      "id": "native.apple.7c8231b7b1ca480f",
+      "source": "Agent thread",
+      "translated": "代理程式討論串"
     },
     {
-      "id": "native.apple.27f775de30b37ff8",
-      "source": "Recent sessions",
-      "translated": "最近的工作階段"
+      "id": "native.apple.b3c553614f762a58",
+      "source": "Recent threads",
+      "translated": "最近的討論串"
     },
     {
       "id": "native.apple.9161ca3c61de6cc7",
@@ -11119,9 +11194,9 @@
       "translated": "Gateway 離線"
     },
     {
-      "id": "native.apple.28c97cf23665ee01",
-      "source": "No recent sessions",
-      "translated": "沒有最近的工作階段"
+      "id": "native.apple.5aa32afda85064ea",
+      "source": "No recent threads",
+      "translated": "沒有最近的討論串"
     },
     {
       "id": "native.apple.79937d7781fb65ae",
@@ -11219,14 +11294,14 @@
       "translated": "取消"
     },
     {
-      "id": "native.apple.9f2fd65953013b7c",
-      "source": "Sessions",
-      "translated": "工作階段"
+      "id": "native.apple.b6855cf19a50f477",
+      "source": "Threads",
+      "translated": "討論串"
     },
     {
-      "id": "native.apple.0422818cc95d5071",
-      "source": "Archived sessions",
-      "translated": "已封存的工作階段"
+      "id": "native.apple.9b1d0ef27a1333b0",
+      "source": "Archived threads",
+      "translated": "已封存的討論串"
     },
     {
       "id": "native.apple.bc8e64efb095a625",
@@ -11234,34 +11309,34 @@
       "translated": "顯示已封存"
     },
     {
-      "id": "native.apple.b272115c83f7ef58",
-      "source": "Sessions unavailable",
-      "translated": "工作階段無法使用"
+      "id": "native.apple.98167401c7267735",
+      "source": "Threads unavailable",
+      "translated": "無法使用討論串"
     },
     {
-      "id": "native.apple.54f8260c9b863087",
-      "source": "Loading archived sessions",
-      "translated": "正在載入已封存的工作階段"
+      "id": "native.apple.4d28a7def2337b9f",
+      "source": "Loading archived threads",
+      "translated": "正在載入已封存的討論串"
     },
     {
-      "id": "native.apple.9b305868873dade2",
-      "source": "Loading recent sessions",
-      "translated": "正在載入最近的工作階段"
+      "id": "native.apple.777d7b706933bd7b",
+      "source": "Loading recent threads",
+      "translated": "正在載入最近的討論串"
     },
     {
-      "id": "native.apple.207dad20d09f3160",
-      "source": "^[\\(count) session](inflect: true)",
-      "translated": "^[\\(count) 個工作階段](inflect: true)"
+      "id": "native.apple.22f81ea94bef8410",
+      "source": "^[\\(count) thread](inflect: true)",
+      "translated": "^[\\(count) 個討論串](inflect: true)"
     },
     {
-      "id": "native.apple.1f4501a6bf2bae4c",
-      "source": "No archived sessions",
-      "translated": "沒有已封存的工作階段"
+      "id": "native.apple.1cad51e14db59bf9",
+      "source": "No archived threads",
+      "translated": "沒有已封存的討論串"
     },
     {
-      "id": "native.apple.2a1ba7a5e1979c9e",
-      "source": "Archived sessions will appear here.",
-      "translated": "已封存的工作階段會顯示在這裡。"
+      "id": "native.apple.18ef832d3a7ddcf8",
+      "source": "Archived threads will appear here.",
+      "translated": "已封存的討論串會顯示在這裡。"
     },
     {
       "id": "native.apple.e8e8cea7ec44fe08",
@@ -11344,9 +11419,9 @@
       "translated": "分享接收"
     },
     {
-      "id": "native.apple.2360d25fe6ae9946",
-      "source": "Loading sessions",
-      "translated": "正在載入工作階段"
+      "id": "native.apple.21d9208d86a4d1fe",
+      "source": "Loading threads",
+      "translated": "正在載入討論串"
     },
     {
       "id": "native.apple.48655128d0a34e44",
@@ -11354,19 +11429,19 @@
       "translated": "正在從 Gateway 擷取最近活動。"
     },
     {
-      "id": "native.apple.c334f2e86702a7b8",
-      "source": "Sessions unavailable",
-      "translated": "工作階段無法使用"
+      "id": "native.apple.4be1f79aa2b230ff",
+      "source": "Threads unavailable",
+      "translated": "無法使用討論串"
     },
     {
-      "id": "native.apple.6cc6efb7a03960b6",
-      "source": "No recent sessions",
-      "translated": "沒有最近工作階段"
+      "id": "native.apple.98b348873556bc46",
+      "source": "No recent threads",
+      "translated": "沒有最近的討論串"
     },
     {
-      "id": "native.apple.08483af2d043bee6",
-      "source": "Session activity offline",
-      "translated": "工作階段活動離線"
+      "id": "native.apple.7396d205574d279f",
+      "source": "Thread activity offline",
+      "translated": "討論串活動已離線"
     },
     {
       "id": "native.apple.e3586d8a603f67e0",
@@ -11824,9 +11899,9 @@
       "translated": "卡片"
     },
     {
-      "id": "native.apple.93eeaedb2ff61043",
-      "source": "Open Session",
-      "translated": "開啟工作階段"
+      "id": "native.apple.c9ec1b0e18074d8a",
+      "source": "Open Thread",
+      "translated": "開啟討論串"
     },
     {
       "id": "native.apple.a2732e4ff77a201b",
@@ -13314,9 +13389,9 @@
       "translated": "預設"
     },
     {
-      "id": "native.apple.3de045f17ea3c6d0",
-      "source": "Used for new Chat and Talk sessions.",
-      "translated": "用於新的 Chat 和 Talk 工作階段。"
+      "id": "native.apple.f4ae5664c3eda95d",
+      "source": "Used for new Chat threads and Talk sessions.",
+      "translated": "用於新的聊天討論串和對話工作階段。"
     },
     {
       "id": "native.apple.19552e71de246322",
@@ -15719,9 +15794,9 @@
       "translated": "執行個體"
     },
     {
-      "id": "native.apple.3579cf2750470a22",
-      "source": "Sessions",
-      "translated": "工作階段"
+      "id": "native.apple.11fe8b9941954dfb",
+      "source": "Threads",
+      "translated": "討論串"
     },
     {
       "id": "native.apple.253cb2debeb51859",
@@ -19029,9 +19104,9 @@
       "translated": "快速聊天快捷鍵"
     },
     {
-      "id": "native.apple.6ae77665b5f4490f",
-      "source": "Global shortcut that opens a floating chat bar for the main session.",
-      "translated": "可開啟主工作階段浮動聊天列的全域快捷鍵。"
+      "id": "native.apple.94dd793cd7d7d555",
+      "source": "Global shortcut that opens a floating chat bar for the main thread.",
+      "translated": "開啟主要討論串浮動聊天列的全域快捷鍵。"
     },
     {
       "id": "native.apple.a66c725f98bfa823",
@@ -19609,9 +19684,9 @@
       "translated": "嚴重"
     },
     {
-      "id": "native.apple.75102378a6775180",
-      "source": "New Session",
-      "translated": "新增工作階段"
+      "id": "native.apple.13f96467014cf344",
+      "source": "New Thread",
+      "translated": "新增討論串"
     },
     {
       "id": "native.apple.185a1b27c9859cc0",
@@ -21899,9 +21974,9 @@
       "translated": "沒有最近的訊息"
     },
     {
-      "id": "native.apple.1ff8aec0044934c3",
-      "source": "Sessions",
-      "translated": "工作階段"
+      "id": "native.apple.3ec2afcbc298c673",
+      "source": "Threads",
+      "translated": "討論串"
     },
     {
       "id": "native.apple.74f66e96c112c3fa",
@@ -21909,9 +21984,9 @@
       "translated": "查看 CLI 針對上下文和速率限制重複使用的已儲存對話儲存桶。"
     },
     {
-      "id": "native.apple.bab897f3252b134c",
-      "source": "No sessions yet. They appear after the first inbound message or heartbeat.",
-      "translated": "尚無工作階段。它們會在收到第一則傳入訊息或心跳後出現。"
+      "id": "native.apple.14ccb32cd8ed1c81",
+      "source": "No threads yet. They appear after the first inbound message or heartbeat.",
+      "translated": "目前尚無討論串。收到第一則傳入訊息或活動訊號後，討論串便會顯示於此。"
     },
     {
       "id": "native.apple.cebd5d2895976bee",
@@ -21994,9 +22069,9 @@
       "translated": "Exec Approvals"
     },
     {
-      "id": "native.apple.64a6dc7d49e8fb57",
-      "source": "Sessions",
-      "translated": "工作階段"
+      "id": "native.apple.52e37e3a44ae516c",
+      "source": "Threads",
+      "translated": "討論串"
     },
     {
       "id": "native.apple.704924cd0704b5b5",
@@ -22999,9 +23074,9 @@
       "translated": "讓我掌握近況"
     },
     {
-      "id": "native.apple.234ec45f4231edc4",
-      "source": "Summarize what happened in my sessions since yesterday.",
-      "translated": "摘要說明自昨天以來我的工作階段中發生了什麼事。"
+      "id": "native.apple.fc4ce810900ec0b6",
+      "source": "Summarize what happened in my threads since yesterday.",
+      "translated": "摘要說明自昨天起我的討論串中發生的事情。"
     },
     {
       "id": "native.apple.c5d8bca2d78e1b9b",
@@ -23179,9 +23254,9 @@
       "translated": "取消釘選模型"
     },
     {
-      "id": "native.apple.5dfc0700d8dff8de",
-      "source": "Session",
-      "translated": "工作階段"
+      "id": "native.apple.4edb66657f5aca1f",
+      "source": "Thread",
+      "translated": "討論串"
     },
     {
       "id": "native.apple.284b2b94c272591d",
@@ -23344,6 +23419,51 @@
       "translated": "小工具無法使用"
     },
     {
+      "id": "native.apple.d640691fd196f338",
+      "source": "Widget export failed",
+      "translated": "小工具匯出失敗"
+    },
+    {
+      "id": "native.apple.533c6e22a11e88de",
+      "source": "OK",
+      "translated": "好"
+    },
+    {
+      "id": "native.apple.e1fb28a2a9756402",
+      "source": "Copy image",
+      "translated": "拷貝影像"
+    },
+    {
+      "id": "native.apple.ebd7bc92e1b12235",
+      "source": "Save image…",
+      "translated": "儲存影像…"
+    },
+    {
+      "id": "native.apple.742c46d4cf2db134",
+      "source": "Save image",
+      "translated": "儲存影像"
+    },
+    {
+      "id": "native.apple.0589cce608418f90",
+      "source": "The widget image could not be captured.",
+      "translated": "無法擷取小工具影像。"
+    },
+    {
+      "id": "native.apple.dfe24e827fdbe9c5",
+      "source": "The widget image could not be copied.",
+      "translated": "無法拷貝小工具影像。"
+    },
+    {
+      "id": "native.apple.9e611e3a80e71408",
+      "source": "The widget image could not be encoded as PNG.",
+      "translated": "無法將小工具影像編碼為 PNG。"
+    },
+    {
+      "id": "native.apple.9a6e8afbe24a262b",
+      "source": "The widget image could not be saved.",
+      "translated": "無法儲存小工具影像。"
+    },
+    {
       "id": "native.apple.769b7dcea4708c40",
       "source": "Image",
       "translated": "Image"
@@ -23484,19 +23604,19 @@
       "translated": "使用者"
     },
     {
-      "id": "native.apple.b1cdcb906a43d5d6",
-      "source": "This session cannot be archived while it is active or running.",
-      "translated": "此工作階段在作用中或執行中時無法封存。"
+      "id": "native.apple.9d0cba09d92ee669",
+      "source": "This thread cannot be archived while it is active or running.",
+      "translated": "此討論串仍在使用或執行中，因此無法封存。"
     },
     {
-      "id": "native.apple.5817e3f3dab1ee19",
-      "source": "The main session cannot be deleted.",
-      "translated": "無法刪除主要工作階段。"
+      "id": "native.apple.8952a111a1075051",
+      "source": "The main thread cannot be deleted.",
+      "translated": "無法刪除主要討論串。"
     },
     {
-      "id": "native.apple.a6b8df3f18171c91",
-      "source": "Remove attachments or wait for delivery before archiving or deleting this session.",
-      "translated": "請先移除附件或等待傳送完成，再封存或刪除此工作階段。"
+      "id": "native.apple.90d0ccf80ca28717",
+      "source": "Remove attachments or wait for delivery before archiving or deleting this thread.",
+      "translated": "請先移除附件或等待傳送完成，再封存或刪除此對話串。"
     },
     {
       "id": "native.apple.476b3862e0449857",
@@ -23634,9 +23754,9 @@
       "translated": "執行結束時間"
     },
     {
-      "id": "native.apple.cd7c3095a22f80a9",
-      "source": "Session Info",
-      "translated": "工作階段資訊"
+      "id": "native.apple.bbccb4c8db5cac12",
+      "source": "Thread Info",
+      "translated": "對話串資訊"
     },
     {
       "id": "native.apple.e308b012d84b3b3e",
@@ -23669,9 +23789,9 @@
       "translated": "加入群組"
     },
     {
-      "id": "native.apple.23d628606fe0734f",
-      "source": "Session Groups",
-      "translated": "工作階段群組"
+      "id": "native.apple.7b641fed5bace855",
+      "source": "Thread Groups",
+      "translated": "對話串群組"
     },
     {
       "id": "native.apple.7777b2d2ec43ed59",
@@ -23714,9 +23834,9 @@
       "translated": "刪除群組"
     },
     {
-      "id": "native.apple.b049c8a4d2805e08",
-      "source": "Sessions in this group become ungrouped.",
-      "translated": "此群組中的工作階段將變為未分組。"
+      "id": "native.apple.56401c79410a310d",
+      "source": "Threads in this group become ungrouped.",
+      "translated": "此群組中的對話串將取消群組。"
     },
     {
       "id": "native.apple.5aa6082d78027c5f",
@@ -23729,9 +23849,9 @@
       "translated": "此 Gateway 上沒有可用的代理程式。"
     },
     {
-      "id": "native.apple.6c89f35d53506406",
-      "source": "New Session Options",
-      "translated": "新工作階段選項"
+      "id": "native.apple.2d96aa7d3d12f85b",
+      "source": "New Thread Options",
+      "translated": "新增對話串選項"
     },
     {
       "id": "native.apple.5b0cde807ccb4241",
@@ -23759,19 +23879,19 @@
       "translated": "建立"
     },
     {
-      "id": "native.apple.795ba37f6782cf28",
-      "source": "The session could not be created.",
-      "translated": "無法建立工作階段。"
+      "id": "native.apple.87ef57319d1ddc85",
+      "source": "The thread could not be created.",
+      "translated": "無法建立對話串。"
     },
     {
-      "id": "native.apple.8ec708a3605a2cc3",
-      "source": "Search sessions",
-      "translated": "搜尋工作階段"
+      "id": "native.apple.6bd91c435b69d638",
+      "source": "Search threads",
+      "translated": "搜尋對話串"
     },
     {
-      "id": "native.apple.23b069b4e7f97039",
-      "source": "No Sessions",
-      "translated": "沒有工作階段"
+      "id": "native.apple.6fde4bdf9d5b9191",
+      "source": "No Threads",
+      "translated": "沒有對話串"
     },
     {
       "id": "native.apple.2d4ee298bdd1c05d",
@@ -23779,29 +23899,29 @@
       "translated": "沒有結果"
     },
     {
-      "id": "native.apple.0058923f2ce8a3ec",
-      "source": "New Session",
-      "translated": "新增工作階段"
+      "id": "native.apple.a02fd99740d29bd3",
+      "source": "New Thread",
+      "translated": "新增對話串"
     },
     {
-      "id": "native.apple.66ba42960eb4135b",
-      "source": "New session",
-      "translated": "新增工作階段"
+      "id": "native.apple.b625801dd04b09f2",
+      "source": "New thread",
+      "translated": "新增對話串"
     },
     {
-      "id": "native.apple.2ef0e34db02ad255",
-      "source": "New session options",
-      "translated": "新工作階段選項"
+      "id": "native.apple.851be81fcc933608",
+      "source": "New thread options",
+      "translated": "新增對話串選項"
     },
     {
-      "id": "native.apple.36753ef2f1ed4264",
-      "source": "Rename Session",
-      "translated": "重新命名工作階段"
+      "id": "native.apple.9ce8a4aba7b444b2",
+      "source": "Rename Thread",
+      "translated": "重新命名對話串"
     },
     {
-      "id": "native.apple.c9de0a1510ef475f",
-      "source": "Session name",
-      "translated": "工作階段名稱"
+      "id": "native.apple.1dd067c44511c7f0",
+      "source": "Thread name",
+      "translated": "對話串名稱"
     },
     {
       "id": "native.apple.6ec5a13c0e6c20d9",
@@ -23814,14 +23934,14 @@
       "translated": "取消"
     },
     {
-      "id": "native.apple.afb4e6c99c63a28d",
-      "source": "Delete Session",
-      "translated": "刪除工作階段"
+      "id": "native.apple.618073d6ab3f2721",
+      "source": "Delete Thread",
+      "translated": "刪除對話串"
     },
     {
-      "id": "native.apple.3d4ef32e42f136a4",
-      "source": "The session and its transcript are removed from the gateway.",
-      "translated": "工作階段及其逐字記錄將從 Gateway 中移除。"
+      "id": "native.apple.10a5e72bba3cbccc",
+      "source": "The thread and its transcript are removed from the gateway.",
+      "translated": "對話串及其文字記錄將從 Gateway 中移除。"
     },
     {
       "id": "native.apple.90bcad5f067b4be1",
@@ -23829,14 +23949,14 @@
       "translated": "刪除「%@」？"
     },
     {
-      "id": "native.apple.9a7dca238fba628d",
-      "source": "Session running",
-      "translated": "工作階段執行中"
+      "id": "native.apple.ac71e3b2aa496a2c",
+      "source": "Thread running",
+      "translated": "對話串執行中"
     },
     {
-      "id": "native.apple.fcfbfe5e97a95e9c",
-      "source": "Session failed",
-      "translated": "工作階段失敗"
+      "id": "native.apple.c775e87f997278b2",
+      "source": "Thread failed",
+      "translated": "對話串執行失敗"
     },
     {
       "id": "native.apple.ac85292b16a7465f",
@@ -23894,9 +24014,9 @@
       "translated": "複製工作階段金鑰"
     },
     {
-      "id": "native.apple.4aeb7c14c26dabac",
-      "source": "Delete Session…",
-      "translated": "刪除工作階段…"
+      "id": "native.apple.f4998cfb572f23ff",
+      "source": "Delete Thread…",
+      "translated": "刪除對話串…"
     },
     {
       "id": "native.apple.6a3425ea2811ff88",
@@ -23909,9 +24029,9 @@
       "translated": "連線中…"
     },
     {
-      "id": "native.apple.79f708b3bc1d3a6c",
-      "source": "Retry session groups",
-      "translated": "重試工作階段群組"
+      "id": "native.apple.8802e9576ffd0f65",
+      "source": "Retry thread groups",
+      "translated": "重試載入對話串群組"
     },
     {
       "id": "native.apple.63320b6d5138c0db",
@@ -23934,24 +24054,24 @@
       "translated": "範圍"
     },
     {
-      "id": "native.apple.2c37581c7b88f741",
-      "source": "Search sessions",
-      "translated": "搜尋工作階段"
+      "id": "native.apple.b313b80def4bda52",
+      "source": "Search threads",
+      "translated": "搜尋對話串"
     },
     {
-      "id": "native.apple.43be8a2336e42faf",
-      "source": "Sessions",
-      "translated": "工作階段"
+      "id": "native.apple.c0cc6acc36f413ce",
+      "source": "Threads",
+      "translated": "對話串"
     },
     {
-      "id": "native.apple.0b379cdfcbd3247f",
-      "source": "Rename Session",
-      "translated": "重新命名工作階段"
+      "id": "native.apple.854d3928fe5a557c",
+      "source": "Rename Thread",
+      "translated": "重新命名對話串"
     },
     {
-      "id": "native.apple.54b6fbd9e41db009",
-      "source": "Session name",
-      "translated": "工作階段名稱"
+      "id": "native.apple.9d0d3f20096cc4da",
+      "source": "Thread name",
+      "translated": "對話串名稱"
     },
     {
       "id": "native.apple.833fe2915430c89d",
@@ -23959,19 +24079,19 @@
       "translated": "取消"
     },
     {
-      "id": "native.apple.751e0f6b81cd374a",
-      "source": "Delete selected sessions?",
-      "translated": "刪除所選的工作階段？"
+      "id": "native.apple.dc00eb94f33bae15",
+      "source": "Delete selected threads?",
+      "translated": "要刪除所選的對話串嗎？"
     },
     {
-      "id": "native.apple.aa679276581b0058",
-      "source": "Delete Sessions",
-      "translated": "刪除工作階段"
+      "id": "native.apple.2053fc9f74dc3158",
+      "source": "Delete Threads",
+      "translated": "刪除對話串"
     },
     {
-      "id": "native.apple.f837129cbee23297",
-      "source": "Each selected session and its transcript will be removed from the gateway.",
-      "translated": "每個所選的工作階段及其逐字稿都將從 Gateway 中移除。"
+      "id": "native.apple.0970247871a834a0",
+      "source": "Each selected thread and its transcript will be removed from the gateway.",
+      "translated": "每個所選的對話串及其文字記錄都將從 Gateway 中移除。"
     },
     {
       "id": "native.apple.bf09df5e38a7a950",
@@ -23979,9 +24099,9 @@
       "translated": "群組"
     },
     {
-      "id": "native.apple.64013cfee5e25305",
-      "source": "Manage session groups",
-      "translated": "管理工作階段群組"
+      "id": "native.apple.6f8acab2256728b5",
+      "source": "Manage thread groups",
+      "translated": "管理對話串群組"
     },
     {
       "id": "native.apple.185f4688f98e244e",
@@ -23994,14 +24114,14 @@
       "translated": "選取"
     },
     {
-      "id": "native.apple.b67eaecec1b423ac",
-      "source": "No archived sessions",
-      "translated": "沒有已封存的工作階段"
+      "id": "native.apple.692972314d04b184",
+      "source": "No archived threads",
+      "translated": "沒有已封存的對話串"
     },
     {
-      "id": "native.apple.b2435a79abf0c794",
-      "source": "No sessions found",
-      "translated": "找不到工作階段"
+      "id": "native.apple.d6a4b5711dcd26e7",
+      "source": "No threads found",
+      "translated": "找不到對話串"
     },
     {
       "id": "native.apple.f0e9d8f69c1d9190",
@@ -24169,6 +24289,16 @@
       "translated": "開啟完整訊息"
     },
     {
+      "id": "native.apple.002bfcede229ad4b",
+      "source": "Rewind to Here",
+      "translated": "倒回此處"
+    },
+    {
+      "id": "native.apple.14df2e4997689fb3",
+      "source": "Fork from Here",
+      "translated": "從此處分支"
+    },
+    {
       "id": "native.apple.b37ec7bd7dc1579a",
       "source": "Reply",
       "translated": "回覆"
@@ -24254,9 +24384,9 @@
       "translated": "請移除附件，或等待傳送問題解決後再開始新的聊天。"
     },
     {
-      "id": "native.apple.980f552bb0f96c0f",
-      "source": "Gateway changed before the session operation started.",
-      "translated": "Gateway 在工作階段操作開始前已變更。"
+      "id": "native.apple.e0f045151c8d3137",
+      "source": "Gateway changed before the thread operation started.",
+      "translated": "Gateway 在對話串操作開始前已變更。"
     },
     {
       "id": "native.apple.710c7bd117a7cc12",
@@ -24264,9 +24394,9 @@
       "translated": "請先移除附件或等待傳送完成，再切換聊天。"
     },
     {
-      "id": "native.apple.87ba543b42696b92",
-      "source": "Clear this session's history?",
-      "translated": "要清除此工作階段的歷史記錄嗎？"
+      "id": "native.apple.0a5c4e15466c3acc",
+      "source": "Clear this thread's history?",
+      "translated": "要清除此對話串的記錄嗎？"
     },
     {
       "id": "native.apple.6192578088f1b100",
@@ -24279,14 +24409,14 @@
       "translated": "這會重設與 %@ 的對話。工作階段金鑰將維持不變。"
     },
     {
-      "id": "native.apple.a92e96bed98bd553",
-      "source": "Rename Session",
-      "translated": "重新命名工作階段"
+      "id": "native.apple.67ac221dbe7179f0",
+      "source": "Rename Thread",
+      "translated": "重新命名對話串"
     },
     {
-      "id": "native.apple.848e2388f3466f40",
-      "source": "Session name",
-      "translated": "工作階段名稱"
+      "id": "native.apple.cf0f7e049603f518",
+      "source": "Thread name",
+      "translated": "對話串名稱"
     },
     {
       "id": "native.apple.8d636ca6b4764418",
@@ -24304,9 +24434,9 @@
       "translated": "匯出對話紀錄"
     },
     {
-      "id": "native.apple.4af0f566d39d7041",
-      "source": "Sessions",
-      "translated": "工作階段"
+      "id": "native.apple.c0ada47504425f23",
+      "source": "Threads",
+      "translated": "對話串"
     },
     {
       "id": "native.apple.c13dbe6b5c01e9bd",
@@ -24379,14 +24509,14 @@
       "translated": "預設"
     },
     {
-      "id": "native.apple.eb58552e43c8dde2",
-      "source": "New Session",
-      "translated": "新增工作階段"
+      "id": "native.apple.1a765291943599e5",
+      "source": "New Thread",
+      "translated": "新增對話串"
     },
     {
-      "id": "native.apple.a7119fbf9d25df5e",
-      "source": "New Session Options…",
-      "translated": "新增工作階段選項…"
+      "id": "native.apple.c7a3a6d5e43dd98f",
+      "source": "New Thread Options…",
+      "translated": "新增對話串選項…"
     },
     {
       "id": "native.apple.5361129a24118af6",
@@ -24394,19 +24524,19 @@
       "translated": "重新整理"
     },
     {
-      "id": "native.apple.2bcff4a8fa503739",
-      "source": "Sessions…",
-      "translated": "工作階段…"
+      "id": "native.apple.0e710b81808e5dcf",
+      "source": "Threads…",
+      "translated": "對話串…"
     },
     {
-      "id": "native.apple.c36e008b051adb38",
-      "source": "Rename Session…",
-      "translated": "重新命名工作階段…"
+      "id": "native.apple.faad8f92b6bef166",
+      "source": "Rename Thread…",
+      "translated": "重新命名對話串…"
     },
     {
-      "id": "native.apple.ea0ef95a159bffe0",
-      "source": "Fork Session",
-      "translated": "分支工作階段"
+      "id": "native.apple.23b61d6cd26ac112",
+      "source": "Fork",
+      "translated": "建立分支"
     },
     {
       "id": "native.apple.8768f9ed198edc54",
@@ -24464,24 +24594,24 @@
       "translated": "清除歷史記錄…"
     },
     {
-      "id": "native.apple.920fe8a7a33f9e92",
-      "source": "Session",
-      "translated": "工作階段"
+      "id": "native.apple.8b4f1c5107ea8a0e",
+      "source": "Thread",
+      "translated": "對話串"
     },
     {
-      "id": "native.apple.185a401f78328b0f",
-      "source": "Session actions",
-      "translated": "工作階段動作"
+      "id": "native.apple.4d7750c9bf699469",
+      "source": "Thread actions",
+      "translated": "對話串操作"
     },
     {
-      "id": "native.apple.9f9dedf599b2619b",
-      "source": "Session cost %@",
-      "translated": "工作階段費用 %@"
+      "id": "native.apple.bb2f22cc43c97f8e",
+      "source": "Thread cost %@",
+      "translated": "對話串費用 %@"
     },
     {
-      "id": "native.apple.f0a4720df5f5f403",
-      "source": "Compact Session",
-      "translated": "精簡工作階段"
+      "id": "native.apple.6239ced0b86e86f8",
+      "source": "Compact Thread",
+      "translated": "壓縮對話串"
     },
     {
       "id": "native.apple.fa10740f9e272e83",

--- a/apps/android/app/src/main/res/values-ar/strings.xml
+++ b/apps/android/app/src/main/res/values-ar/strings.xml
@@ -494,7 +494,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"التسليم"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"كتم مكبر الصوت"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"جارٍ فتح اتصال Gateway"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"المراقبة · %1$s من سلاسل المحادثات"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"اكتمل تشغيل المهمة الآلية."</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"لا توجد تطبيقات مطابقة."</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"إرسال إلى الدردشة"</string>
@@ -860,7 +860,7 @@
     <string name="native_8e19f962b0cd6587" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ابدأ محادثة جديدة وستظهر هنا."</string>
     <string name="native_8e20431e6645ccdd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مشكلة في الاتصال"</string>
     <string name="native_8e588cd187741f1c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"متوسط"</string>
-    <string name="native_8e5b1a73152cf01c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"إنشاء فرع"</string>
+    <string name="native_8e5b1a73152cf01c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"إنشاء نسخة متفرعة"</string>
     <string name="native_8e6feeb36a83a707" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تفعيل مكبر الصوت"</string>
     <string name="native_8e803d361324b459" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"نص حدث النظام"</string>
     <string name="native_8eb626078c16c726" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الترتيب: %1$s"</string>
@@ -1277,7 +1277,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الملف الشخصي"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ستظهر حدود المزوّد هنا عندما يبلّغ عنها Gateway."</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مشكلة واحدة"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"سيتم الاحتفاظ بالمحادثات في \"%1$s\" ونقلها مجددًا إلى غير المجمّعة."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تاريخ الإنشاء"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s رموز مميزة نشطة"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>

--- a/apps/android/app/src/main/res/values-ar/strings.xml
+++ b/apps/android/app/src/main/res/values-ar/strings.xml
@@ -24,14 +24,14 @@
     <string name="native_002a6fcb30b2def4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تعذّر تجهيز مرفق للإرسال."</string>
     <string name="native_003aaf9e0a0e6b9f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الميكروفون متوقف"</string>
     <string name="native_0060cbfdd3cf13ba" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"عرض تنبيهات OpenClaw"</string>
-    <string name="native_0077032d7e9f9cbe" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"نشاط سلسلة المحادثة"</string>
+    <string name="native_0077032d7e9f9cbe" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"نشاط المحادثة"</string>
     <string name="native_008dacb6d1e85bd8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"كامل"</string>
     <string name="native_009506aeb0484b2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تمت الموافقة والحفظ."</string>
     <string name="native_00d108e2e6466940" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"عرض سجل المكالمات الأخيرة"</string>
     <string name="native_00e8aeba41d79ce3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 قيد الانتظار"</string>
     <string name="native_010f6550a1c8f554" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مرفق غير مدعوم"</string>
     <string name="native_01267be21eb77392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"0 = دقيق"</string>
-    <string name="native_0171e3d4e07f1861" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"صِل Gateway للبحث في المحادثات."</string>
+    <string name="native_0171e3d4e07f1861" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"اتصل بـ Gateway للبحث في المحادثات."</string>
     <string name="native_0174f83136630e7e" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s حسابات"</string>
     <string name="native_01ac1c298e0cbd9a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تتطلب تغييرات Cron الإذن operator.admin. لا تمنحه رموز الإعداد عمدًا. أعد الاتصال باستخدام الرمز المميز المشترك أو كلمة المرور الخاصة بـ Gateway لطلب وصول المسؤول. إذا ظل هذا الجهاز يفتقر إليه، فوافق على ترقية النطاق المعلّقة من عميل مسؤول حالي."</string>
     <string name="native_01bcfe7a9296b6d6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Apply Patch"</string>
@@ -73,9 +73,8 @@
     <string name="native_08ea63ee26954dca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الميكروفون المدمج"</string>
     <string name="native_0905f7f59021c2a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الواجهة"</string>
     <string name="native_0929c9dc7f794852" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"لا توجد مقترحات"</string>
-    <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"سلسلة المحادثة الرئيسية"</string>
+    <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"المحادثة الرئيسية"</string>
     <string name="native_0979c6fdbdca1675" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"فتح الدردشة"</string>
-    <string name="native_09ce95090659d069" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"إجراءات إقران الأجهزة غير متاحة في جلسة Gateway هذه. شغّل openclaw devices list على مضيف Gateway وأدِر الطلب من هناك. الموافقة على إمكانات العقدة منفصلة، ولا تزال تستخدم nodes approve &lt;request id&gt;."</string>
     <string name="native_0a0b7cf7c428c703" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"طلب إجراء"</string>
     <string name="native_0a708e7b03aaf1fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list pins"</string>
     <string name="native_0ab0e1629576aecf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"اتصل بـ Gateway لتحميل مقترحات ورشة Skills."</string>
@@ -88,12 +87,10 @@
     <string name="native_0c3845dcd2f0f683" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"افحص هذا المقترح لتحميل محتواه بتنسيق Markdown."</string>
     <string name="native_0c3ea4e2f12153e7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"افتح OpenClaw واسأل %1$s"</string>
     <string name="native_0c4d01e81bb3d1fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الاستدلال"</string>
-    <string name="native_0c77fe09ab336a3e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"العميل"</string>
     <string name="native_0c79a9c222840ed0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مطبق"</string>
     <string name="native_0cab1c9617404faf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"فيديو"</string>
     <string name="native_0cf04463c4276a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تمت ترقيته"</string>
     <string name="native_0d21bd52022ca7f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"متصل"</string>
-    <string name="native_0d5644ff52ce2ba3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"النطاقات"</string>
     <string name="native_0d5efd432e4fedf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"موفر الصوت في الوقت الفعلي غير مهيأ."</string>
     <string name="native_0d8ca811c3744a6d" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s · %2$s"</string>
     <string name="native_0db10f2c2f332cd2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"kick"</string>
@@ -104,7 +101,7 @@
     <string name="native_0e91610117029a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تحديث"</string>
     <string name="native_0ee30822ed35a792" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s في قائمة الانتظار"</string>
     <string name="native_0f4c8529742b31ea" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"بدء الدردشة"</string>
-    <string name="native_0f559ff270904904" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تظل استدعاءات أدوات الدردشة المنتظرة في سلسلة المحادثة النشطة مرئية هنا."</string>
+    <string name="native_0f559ff270904904" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تظل استدعاءات أدوات الدردشة المنتظرة في المحادثة النشطة ظاهرة هنا."</string>
     <string name="native_0f56cc286a4f23d8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مراجعة الشهادة مطلوبة"</string>
     <string name="native_0f8fe3a9688138a1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"افتح سطح Canvas الحالي لفحصه أو التفاعل معه."</string>
     <string name="native_0ff98f05be01ce5e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تم تحديث التشغيل الآلي."</string>
@@ -141,7 +138,6 @@
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الجلسة المستهدفة"</string>
     <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مراجعة مهارة ClawHub"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
-    <string name="native_16a5b7ad567a8093" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"هل تريد رفض طلب الاقتران من هذا الجهاز؟"</string>
     <string name="native_16b1a05e1d987ed1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الميكروفون المفضل"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مضيف العقدة"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"المستوى"</string>
@@ -187,7 +183,6 @@
     <string name="native_1d91629837639a5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تغيّرت عملية الأتمتة هذه أثناء تعديلك لها. ارجع إلى أحدث إصدار في Gateway قبل الحفظ."</string>
     <string name="native_1dbf9d5979606697" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"عند الاتصال، يمكن لـ Gateway تنشيط الهاتف بإشعار صامت بدلًا من إبقاء جلسة دائمة التشغيل."</string>
     <string name="native_1e432ea5425e4a3a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"وضع التنبيه"</string>
-    <string name="native_1e595a107c78b957" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"هل تريد إزالة الجهاز المقترن؟"</string>
     <string name="native_1e955a58278623a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"نص حدث النظام"</string>
     <string name="native_1ea44149be42d970" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تعذّر نسخ صورة الأداة"</string>
     <string name="native_1ea442a134b2a184" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"لا"</string>
@@ -202,7 +197,6 @@
     <string name="native_2065cc867eba1b39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تعذّر تحميل إعدادات نماذج موفّر الخدمة."</string>
     <string name="native_207ccb22d618db05" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"يُسمح لـ %1$s تطبيق بإعادة التوجيه."</string>
     <string name="native_209b9e597963e7e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"إعداد الصوت"</string>
-    <string name="native_211988ba9dd0570a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"هل تريد رفض طلب الاقتران؟"</string>
     <string name="native_2132066dc9475cb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"This skill is installed but not available to the current agent. Agent filters stay on desktop or CLI."</string>
     <string name="native_21378545892f1fe2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الناشر"</string>
     <string name="native_214d4932fc767e8f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">" · المحادثة: جارٍ التحدث"</string>
@@ -244,7 +238,6 @@
     <string name="native_2682bd813a3bccbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"أدخل رمز الإعداد من openclaw qr."</string>
     <string name="native_268f14bbfe119c1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"التشخيصات"</string>
     <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"يؤدي هذا إلى حذف المحادثة ونصها نهائيًا."</string>
-    <string name="native_26e47d73a55d7fa7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تمت الموافقة على الجهاز."</string>
     <string name="native_26f0dd993530eb2d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تجري إعادة المحاولة تلقائيًا"</string>
     <string name="native_270ff82f36da987f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تم نسخ صورة الأداة"</string>
     <string name="native_2728740a95d465c6" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s أدوار"</string>
@@ -260,7 +253,7 @@
     <string name="native_27d773b934ed324f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"التحقق والتثبيت"</string>
     <string name="native_2821f0168d6dd9df" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"حوّل هذا الجهاز إلى عقدة OpenClaw آمنة للدردشة والصوت والكاميرا وأدوات الجهاز."</string>
     <string name="native_2831546121359362" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"إعداد يدوي"</string>
-    <string name="native_287c4b113aafc215" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"افتح الدردشة لبدء سلسلة المحادثة الحالية أو استئنافها."</string>
+    <string name="native_287c4b113aafc215" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"افتح الدردشة لبدء المحادثة الحالية أو استئنافها."</string>
     <string name="native_28bb849671cab958" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تلميح: أوقف الاستماع لإرسال الجزء الملتقط."</string>
     <string name="native_28d03596d24eeb4e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تخطي"</string>
     <string name="native_28d55ec6974d84e8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"فشل الطلب الصوتي"</string>
@@ -283,7 +276,7 @@
     <string name="native_2cd62f7a670b2819" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"محادثة OpenClaw"</string>
     <string name="native_2d4dfe885f84629e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"السماح بالوصول إلى مكتبة الصور."</string>
     <string name="native_2d6416405eb44982" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"حلّ رد سابق هذه الموافقة بالفعل."</string>
-    <string name="native_2d85de9d56c226e4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"لا توجد سلاسل محادثات حديثة"</string>
+    <string name="native_2d85de9d56c226e4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"لا توجد محادثات أخيرة"</string>
     <string name="native_2df01a03ff43400b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"لا توجد نتائج مطابقة"</string>
     <string name="native_2df30b117ad829ab" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"قراءة إشعارات التطبيقات المحددة"</string>
     <string name="native_2e0078a8322d6f1f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"التوفر غير معروف"</string>
@@ -345,7 +338,7 @@
     <string name="native_36c725ddb20f8bd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"إعداد مزوّد المحادثة"</string>
     <string name="native_36d88ed6cc91d2b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Music Generation"</string>
     <string name="native_36e8d5e94219dc37" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"إعدادات Talk"</string>
-    <string name="native_36f1fac278711470" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"المراقبة · سلسلة محادثة واحدة"</string>
+    <string name="native_36f1fac278711470" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"المراقبة · سلسلة محادثات واحدة"</string>
     <string name="native_37053dc1f680546b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"نص الحمولة"</string>
     <string name="native_37582309e7a1dbe5" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الموافقة %1$s"</string>
     <string name="native_379ce0aacf46c35f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"لم يُرجع Gateway جاهزية %1$s"</string>
@@ -353,7 +346,6 @@
     <string name="native_381428f5f251a764" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Conversation Send"</string>
     <string name="native_3824a9f4dafe92c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"اللوحة"</string>
     <string name="native_384ae4ab1a2830f9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مزوّد واحد"</string>
-    <string name="native_385001409de8562a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تعذّرت قراءة شهادة Gateway تلقائيًا. الصق بصمة SHA-256 التي حصلت عليها من مضيف Gateway."</string>
     <string name="native_387b2569e440838c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"فشل الإرسال: %1$s"</string>
     <string name="native_3892e10346fd2012" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الجسر"</string>
     <string name="native_38d198cd5303680f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"خطأ في التسليم"</string>
@@ -410,8 +402,7 @@
     <string name="native_4287d54ad5e78985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"أعمال OpenClaw المجدولة من Gateway لديك."</string>
     <string name="native_429f6057535c1ea3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sub-agent"</string>
     <string name="native_42e3a99c21767def" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"في انتظار الموافقة على الجهاز"</string>
-    <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"جارٍ تحميل سلسلة المحادثة"</string>
-    <string name="native_430df68ec29a85a2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"يقدّم Gateway هذا الآن شهادة موثوقة من هذا الجهاز."</string>
+    <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"جارٍ تحميل سلسلة المحادثات"</string>
     <string name="native_43905968a540af6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"التداخل بالميلي ثانية"</string>
     <string name="native_43988c156beabf7d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"event create"</string>
     <string name="native_43cc23fa52b87b4c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مستند"</string>
@@ -421,7 +412,7 @@
     <string name="native_4441146b0fe1d5c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screenshot"</string>
     <string name="native_4481c2190a1b4bca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تعبير Cron، مثل 0 9 * * *"</string>
     <string name="native_4499e7b7e1c9ddbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"العودة إلى الصوت"</string>
-    <string name="native_449f5a775762cdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تحدّث"</string>
+    <string name="native_449f5a775762cdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تحدث"</string>
     <string name="native_45a64dc17588f2ca" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s متصلة"</string>
     <string name="native_45a8847c4a6b2c81" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"يُسمح لـ %1$s تطبيقات بإعادة التوجيه."</string>
     <string name="native_460b3a7da007b7af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الدردشة"</string>
@@ -473,7 +464,6 @@
     <string name="native_4e8c72cab82e0711" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"إعدادات التشغيل الآلي غير صالحة."</string>
     <string name="native_4ec30e9d85725d41" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"قائمة السماح"</string>
     <string name="native_4ed379d418bb8629" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"groups"</string>
-    <string name="native_4ee252fb736effa2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"المفتاح العام"</string>
     <string name="native_4efca0d10c5feb8e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"حول"</string>
     <string name="native_4f1bc100d1dccc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"لم يتم العثور على رمز QR للإعداد في هذه الصورة. اختر رمز QR الذي أنشأه openclaw qr، أو أدخل رمز الإعداد يدويًا."</string>
     <string name="native_4fe3cdd404ea0290" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"permissions"</string>
@@ -494,7 +484,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"التسليم"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"كتم مكبر الصوت"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"جارٍ فتح اتصال Gateway"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"المراقبة · %1$s من سلاسل المحادثات"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"اكتمل تشغيل المهمة الآلية."</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"لا توجد تطبيقات مطابقة."</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"إرسال إلى الدردشة"</string>
@@ -519,7 +509,7 @@
     <string name="native_55898449eb74fb2e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الحالة"</string>
     <string name="native_55a12cbe0995e214" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مستمع الإشعارات"</string>
     <string name="native_55d8e7da6d0a752c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مكبر الصوت مكتوم"</string>
-    <string name="native_560d3e826c413dc9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"البحث في المحادثات"</string>
+    <string name="native_560d3e826c413dc9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"البحث في سلاسل المحادثات"</string>
     <string name="native_565339bc4d33d728" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"حسنًا"</string>
     <string name="native_56a508f3f2bf424a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تعذّر فتح دليل الإعداد."</string>
     <string name="native_56c41c606c44f3fc" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"اسأل OpenClaw %1$s"</string>
@@ -560,7 +550,6 @@
     <string name="native_5c0c8c9aa658f4a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OPENCLAW"</string>
     <string name="native_5c1acea9c9b0e704" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Fetch"</string>
     <string name="native_5c39123805ffb4e2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الموجّه"</string>
-    <string name="native_5c944156b5353428" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"هل تريد الموافقة على الجهاز؟"</string>
     <string name="native_5d410adb9576e266" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"هل تريد إزالة %1$s وبيانات الاعتماد المحفوظة الخاصة به من هذا الهاتف؟"</string>
     <string name="native_5d6c41a67139ee26" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"يشير رمز QR إلى Gateway بعيد غير آمن. %1$s %2$s"</string>
     <string name="native_5d6cbac59f87e78d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"سطح الشاشة جاهز"</string>
@@ -578,7 +567,6 @@
     <string name="native_5fa1d457ddfcd26c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"rename group"</string>
     <string name="native_5fa7aac5375c5815" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"جاهز"</string>
     <string name="native_5fc1927ca948f31c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تنتظر المذكّرات أول إدخال لها."</string>
-    <string name="native_6007acbe30b2cd98" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"موافقة"</string>
     <string name="native_600c9c27960112a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الصفحة المباشرة"</string>
     <string name="native_6030d1f6340776d2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"التشغيل الآلي قيد التشغيل بالفعل."</string>
     <string name="native_604e6d6faf8d0295" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"إزالة عملية الأتمتة هذه بعد تشغيل ناجح لمرة واحدة."</string>
@@ -618,14 +606,12 @@
     <string name="native_6657cc73af00feac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"السماح بأدوات الكاميرا عند طلبها."</string>
     <string name="native_666067dd376e5d45" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"المشكلات"</string>
     <string name="native_666c8bc0319f3b54" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"التنبيه الصوتي"</string>
-    <string name="native_66713d713e3a41c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تم رفض طلب الاقتران."</string>
     <string name="native_66b23bae66fc0d79" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"قبل %1$s ي"</string>
     <string name="native_66cf5513b37462be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"roles"</string>
     <string name="native_66d0f523a379b2de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skills"</string>
     <string name="native_66f4804ee23ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"أرشفة"</string>
     <string name="native_66fab2875ee427f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"العقدة غير متصلة. أعد الاتصال وحاول مجددًا."</string>
     <string name="native_6725e7bbcd28f3a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"النظام"</string>
-    <string name="native_672f3453e1dd571b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"عنوان IP البعيد"</string>
     <string name="native_674b38cae72bb0c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"غير مصنّف"</string>
     <string name="native_674eb55d9c353900" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تفاصيل الجدول"</string>
     <string name="native_67528858c36397f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"إمكانات الهاتف"</string>
@@ -633,8 +619,7 @@
     <string name="native_67b696468610b879" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dashboard"</string>
     <string name="native_67fa416afa64d304" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"لصق الرمز المميز"</string>
     <string name="native_6827238fea72c88b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"لا يوجد موفرون"</string>
-    <string name="native_684889f0079cc145" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"بصمة SHA-256"</string>
-    <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"لا توجد سلاسل محادثات بعد"</string>
+    <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"لا توجد محادثات بعد"</string>
     <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ميكروفون Bluetooth"</string>
     <string name="native_690dbe9dc0993c42" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الأخيرة"</string>
     <string name="native_6930c8d1fc4f01d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"إعادة تسمية المحادثة"</string>
@@ -668,7 +653,6 @@
     <string name="native_6d5d9004797377e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"التراخيص"</string>
     <string name="native_6d7c95a353d873cd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"اتصل بـ Gateway للبحث عن مهارات ClawHub."</string>
     <string name="native_6df1bb18a59ab97d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مهارة"</string>
-    <string name="native_6e0a0b9d8c5ee4d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"معرّف الجهاز"</string>
     <string name="native_6e117ba97cbfb6f0" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"لم يحدّد Gateway موفّر %1$s النشط"</string>
     <string name="native_6e293a8c009e0011" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"قيد الانتظار"</string>
     <string name="native_6e2c0963d056e104" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تم حفظ كلمات التنبيه"</string>
@@ -792,7 +776,7 @@
     <string name="native_8193ee8a22d25208" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تثبيت النموذج"</string>
     <string name="native_81c2c4f30a4bec68" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مسح البحث"</string>
     <string name="native_81d38aca5306940b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ممكّنة للوكلاء المؤهلين."</string>
-    <string name="native_820d08e12968baff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"لا توجد سلسلة محادثة حالية"</string>
+    <string name="native_820d08e12968baff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"لا توجد محادثة حالية"</string>
     <string name="native_82250171708918de" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"بعد %1$s"</string>
     <string name="native_825b9c75d7fed691" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"السماح للمجدول بتشغيل عملية الأتمتة هذه."</string>
     <string name="native_82990a093599a9bb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s مطبّق"</string>
@@ -845,7 +829,6 @@
     <string name="native_8bb7ec15b1e350a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"جارٍ الفحص"</string>
     <string name="native_8bf253a125f66985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"امسح رمز الإعداد ضوئيًا أو الصقه لإضافة Gateway آخر."</string>
     <string name="native_8c4a3896e8f06d27" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"انتهت مهلة TLS"</string>
-    <string name="native_8c55387fb6c584c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تمت إزالة الجهاز المقترن."</string>
     <string name="native_8c93c68056cde54d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تم إقران Gateway. جارٍ التحقق من الموافقة على إمكانات العقدة."</string>
     <string name="native_8ca344247c18317e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الحركة"</string>
     <string name="native_8cac4b77b9c54695" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"فشل إجراء cron."</string>
@@ -860,7 +843,7 @@
     <string name="native_8e19f962b0cd6587" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ابدأ محادثة جديدة وستظهر هنا."</string>
     <string name="native_8e20431e6645ccdd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مشكلة في الاتصال"</string>
     <string name="native_8e588cd187741f1c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"متوسط"</string>
-    <string name="native_8e5b1a73152cf01c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"إنشاء نسخة متفرعة"</string>
+    <string name="native_8e5b1a73152cf01c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تفريع"</string>
     <string name="native_8e6feeb36a83a707" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تفعيل مكبر الصوت"</string>
     <string name="native_8e803d361324b459" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"نص حدث النظام"</string>
     <string name="native_8eb626078c16c726" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الترتيب: %1$s"</string>
@@ -1038,6 +1021,7 @@
     <string name="native_ad1c341c65f84ede" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"شغّل أمر الموافقة على كمبيوتر Gateway، ثم تحقّق مرة أخرى."</string>
     <string name="native_ad1fb9ec0cb3c7a4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"عمليات الأتمتة"</string>
     <string name="native_adb7eb8a03ad699c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$sد"</string>
+    <string name="native_adca3171c270301a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"يمكن لتسجيل الدخول إلى Gateway هذا عرض العقد المتصلة، لكنه لا يستطيع الموافقة على إقران هواتف جديدة. أقرن الهواتف الجديدة من جلسة مسؤول Gateway. موافقة إمكانات العقدة منفصلة، ولا تزال تستخدم nodes approve &lt;request id&gt;."</string>
     <string name="native_ade9248e0132b411" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الوثوق"</string>
     <string name="native_ae27fa789a03c1db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"رمز QR هذا ليس رمز إعداد QR خاصًا بـ OpenClaw. أنشئ رمزًا جديدًا باستخدام openclaw qr، ثم حاول مرة أخرى."</string>
     <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الميكروفون المفضل غير متاح؛ جارٍ استخدام التوجيه التلقائي."</string>
@@ -1107,7 +1091,6 @@
     <string name="native_bb4f2558e4333834" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تم حفظ صورة الأداة في التنزيلات"</string>
     <string name="native_bbe5fc3b9ef39f99" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"جارٍ البدء…"</string>
     <string name="native_bc19cec293228fb8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"خطأ في العميل"</string>
-    <string name="native_bc1c94a6dfce1058" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تحقق من الجهاز الذي يطلب الوصول قبل منحه الإذن."</string>
     <string name="native_bc6618670f3e8a17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ميكروفون Bluetooth LE"</string>
     <string name="native_bcb06651437caa15" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
     <string name="native_bd08450d63406844" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تم تفعيل التشغيل الآلي."</string>
@@ -1116,7 +1099,6 @@
     <string name="native_bdc090ec61e3fcfc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"إعادة التحميل"</string>
     <string name="native_bdff71b20b9cf392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"البحث في عمليات الأتمتة"</string>
     <string name="native_be969becb173e0c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ستظهر الهواتف المرتبطة ومضيفو العُقد هنا بعد الاقتران."</string>
-    <string name="native_bf1870ff5c6322fb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s: %2$s"</string>
     <string name="native_bf350e6a0ed60b7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تم تغيير هذه المهمة الآلية على Gateway. راجع أحدث إصدار قبل الحفظ مرة أخرى."</string>
     <string name="native_bf399ffa03617a96" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"إيقاف الإملاء"</string>
     <string name="native_bf56ee2fe3345ce1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"سهل القراءة"</string>
@@ -1140,7 +1122,6 @@
     <string name="native_c1c224b03cd9bc7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"المشرف"</string>
     <string name="native_c1ebc7817870e5be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"يتطلب الانتباه"</string>
     <string name="native_c22d5e02fbec7d65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"اقرن هذا الجهاز بـ Gateway لتنشيطه فقط عند وجود عمل فعلي، والاحتفاظ بنظرة عامة مباشرة على الوكلاء في متناولك، وتجنب حلقات الخلفية التي تستنزف البطارية."</string>
-    <string name="native_c25337055464f8d3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الأدوار"</string>
     <string name="native_c253f451bdd56431" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"رد"</string>
     <string name="native_c26225b6c16a4bc7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"دليل المزوّدين"</string>
     <string name="native_c272b225cf5bd643" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"فعّل الإذن في الإعدادات"</string>
@@ -1154,7 +1135,6 @@
     <string name="native_c34dd5eb8b0af56e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"من أين أحصل على رمز الإعداد؟"</string>
     <string name="native_c3546b39ecbbed8a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تعذّر تمكين المهارة."</string>
     <string name="native_c35b21d6ca39aa7c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"pdf"</string>
-    <string name="native_c3812fc4acb861d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"إزالة"</string>
     <string name="native_c382566dbe2ea49f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s%% متصلة"</string>
     <string name="native_c385951198c45d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"لا توجد قنوات"</string>
     <string name="native_c41ad84496b53420" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"صوت في الوقت الفعلي"</string>
@@ -1183,7 +1163,6 @@
     <string name="native_c6d5ed757b66bfd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"حلم"</string>
     <string name="native_c6dd061350fc69b8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"لا توجد تطبيقات محظورة. يمكن للتطبيقات إعادة التوجيه ما لم تضف عمليات حظر."</string>
     <string name="native_c753cdf0c19f1e38" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"أداة التعرّف على الكلام غير متاحة"</string>
-    <string name="native_c78ffe19571018fb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"المنصة"</string>
     <string name="native_c7985fa72daa6ea4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"لم يُرجع Gateway إعداد %1$s"</string>
     <string name="native_c7b6dfd5c3a183c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"هل تريد نسيان Gateway؟"</string>
     <string name="native_c7b7b7f01360f6a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"وصف اختياري"</string>
@@ -1212,7 +1191,7 @@
     <string name="native_cc721e25d73938a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway المنزلي"</string>
     <string name="native_cc7a9a5cf8c4bc9d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"شغّل أمر الموافقة على Gateway"</string>
     <string name="native_cc925e3c97ac7a35" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تعذر تحميل مقترحات ورشة عمل Skills."</string>
-    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"أطلعني على أحدث محادثاتي في OpenClaw واقترح الخطوات التالية."</string>
+    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"أطلعني على آخر مستجدات سلاسل محادثاتي الأخيرة في OpenClaw واقترح الخطوات التالية."</string>
     <string name="native_ccb4c324f516c633" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ليس الآن"</string>
     <string name="native_cced0b0d83a9e400" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"رمز QR لـ OpenClaw"</string>
     <string name="native_cced28c6dc3f99c2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"start"</string>
@@ -1235,7 +1214,7 @@
     <string name="native_ceb6931ea57cc999" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تكيفي"</string>
     <string name="native_cf0ee3547a4e51a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"قريبًا"</string>
     <string name="native_d04fc7d7e19702f8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Search"</string>
-    <string name="native_d053ba98d8bbcec1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"جرّب الدردشة أو الصوت أو المحادثات أو موفري الخدمة أو الإعدادات."</string>
+    <string name="native_d053ba98d8bbcec1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"جرّب الدردشة أو الصوت أو المحادثات أو المزوّدين أو الإعدادات."</string>
     <string name="native_d056177742e27cf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw نشط"</string>
     <string name="native_d0cda6559bb347db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"navigate"</string>
     <string name="native_d0d0de0039c7990b" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"طُلب %1$s"</string>
@@ -1246,7 +1225,6 @@
     <string name="native_d17d2d78d76e6a6c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"النماذج"</string>
     <string name="native_d19c2dd2fb598b93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw سلبي"</string>
     <string name="native_d1a574e23344c407" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"كلمة مرور Gateway غير صالحة"</string>
-    <string name="native_d1af697abaff485f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تعذر التحقق من تغيير اقتران الجهاز. حدّث الصفحة وحاول مرة أخرى."</string>
     <string name="native_d1bf045bb524dae5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"عرض التفاصيل"</string>
     <string name="native_d1e9567da9a8a4b0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bash"</string>
     <string name="native_d2089be672953d11" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الرمز المميز"</string>
@@ -1261,7 +1239,6 @@
     <string name="native_d31de1a5c5c8ba2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"المتصفح"</string>
     <string name="native_d354ee936f59115e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screen record"</string>
     <string name="native_d3974fd6d3b6c81f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"التشغيل معلّق"</string>
-    <string name="native_d3e1c5f8a6e240fc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"المصدر"</string>
     <string name="native_d3f75e24411053c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ذكاء اصطناعي شخصي على أجهزتك"</string>
     <string name="native_d406ade2958cb5b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attach"</string>
     <string name="native_d461a493a3753877" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تلقائي"</string>
@@ -1277,7 +1254,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الملف الشخصي"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ستظهر حدود المزوّد هنا عندما يبلّغ عنها Gateway."</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مشكلة واحدة"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"يتم الاحتفاظ بالمحادثات في \"%1$s\" ونقلها مجددًا إلى غير مجمّعة."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تاريخ الإنشاء"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s رموز مميزة نشطة"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>
@@ -1369,13 +1346,13 @@
     <string name="native_e52b3044724b9f4d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"إلغاء تثبيت النموذج"</string>
     <string name="native_e5584bc5057284ae" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"أسطح المراسلة المتصلة بهذا Gateway."</string>
     <string name="native_e595f17fac1d8384" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"جارٍ الإرسال"</string>
-    <string name="native_e5b87192a9e6321f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ستظهر سلاسل المحادثات المؤرشفة هنا."</string>
+    <string name="native_e5b87192a9e6321f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ستظهر المحادثات المؤرشفة هنا."</string>
     <string name="native_e5c02424e511e1ef" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تم نسخ الأمر"</string>
     <string name="native_e5c083cf41ff6472" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"لا تتوفر معاينة"</string>
     <string name="native_e5c3e7b8110e7087" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"وافق على هذا الهاتف في Gateway.\nثم أعد محاولة الاتصال."</string>
     <string name="native_e5c7478bbce26eb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مسح رمز QR ضوئيًا"</string>
     <string name="native_e5e4f854dcd3ffc6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"دليل عمل الأمر · لا يمكن مسحه"</string>
-    <string name="native_e614ccf26ec5d312" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"نشاط سلسلة المحادثة"</string>
+    <string name="native_e614ccf26ec5d312" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"نشاط المحادثة"</string>
     <string name="native_e674447337e83c13" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"متاح"</string>
     <string name="native_e68e23dc04b0f986" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"حذف عملية الأتمتة؟"</string>
     <string name="native_e7053d96b6704dbb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s اليوم · %2$s إجمالًا"</string>
@@ -1450,7 +1427,6 @@
     <string name="native_f2da2e47cd31a5dd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تعذر فك ترميز هذه الصورة."</string>
     <string name="native_f3753c0fe29b88db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway والصوت والإشعارات والخصوصية"</string>
     <string name="native_f386c32c1bf437d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ملفات مساحة عمل الوكيل"</string>
-    <string name="native_f418bf0894a1806a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"سيفقد هذا الجهاز وصوله الموثوق إلى Gateway."</string>
     <string name="native_f41d9e8b7e09aa24" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"استخدم requestId من الأمر المعلّق في أمر الموافقة."</string>
     <string name="native_f4830a1dae298044" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الجدول الزمني"</string>
     <string name="native_f493f0ce7a52a8aa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"حد المعدل"</string>
@@ -1458,7 +1434,6 @@
     <string name="native_f4cc820d308495c4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الحمولة · %1$s"</string>
     <string name="native_f4ccae29e1bb0c20" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"قيد التشغيل"</string>
     <string name="native_f4db1e48476f6075" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"إنهاء"</string>
-    <string name="native_f4e2076014711222" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"استخدام ثقة النظام"</string>
     <string name="native_f4ef7a41caa88dd1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"لا يوجد مزوّدون جاهزون"</string>
     <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"يعطي الأولوية لميكروفونات Bluetooth المتصلة."</string>
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تم حظر %1$s تطبيق من إعادة التوجيه."</string>
@@ -1486,7 +1461,7 @@
     <string name="native_f8b32f4e92bd84ce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"المثبتة"</string>
     <string name="native_f8c2745155505d39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"انتهت مهلة انتظار الرد؛ حاول مجددًا أو حدّث الصفحة."</string>
     <string name="native_f8cd133f0ea1031b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"العثور على المحادثات السابقة"</string>
-    <string name="native_f90f3791049b995d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تصفح المحادثات"</string>
+    <string name="native_f90f3791049b995d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تصفّح المحادثات"</string>
     <string name="native_f92e2ad582c0e13f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"جارٍ التحديث"</string>
     <string name="native_f991ae9cb081e1f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"افتح الكاميرا وضع الرمز من openclaw qr داخل الإطار."</string>
     <string name="native_f9ea3f1540eaa584" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"لا توجد أجهزة"</string>
@@ -1522,7 +1497,7 @@
     <string name="native_ff716fc4735e067f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"إعدادات الإملاء"</string>
     <string name="native_ff9dbbdfb84ddab2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تم تحميل نماذج موفّر الخدمة، لكن حالة الجاهزية غير متاحة."</string>
     <string name="native_ffa7aa557b547a79" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"حذف المحادثة؟"</string>
-    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"يحوّل OpenClaw هذا الهاتف إلى واجهة أوامر محمولة ومنظمة لسلاسل المحادثات والصوت ومزوّدي الخدمة وGateway."</string>
+    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"يحوّل OpenClaw هذا الهاتف إلى واجهة أوامر محمولة ومنظّمة لسلاسل المحادثات والصوت ومزوّدي الخدمة وGateway."</string>
     <string name="native_ffb6f5764bddb68c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الأحدث أولاً"</string>
     <string name="native_ffcf16006c652ee3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الدورة التالية"</string>
 </resources>

--- a/apps/android/app/src/main/res/values-ar/strings.xml
+++ b/apps/android/app/src/main/res/values-ar/strings.xml
@@ -75,6 +75,7 @@
     <string name="native_0929c9dc7f794852" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"لا توجد مقترحات"</string>
     <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"المحادثة الرئيسية"</string>
     <string name="native_0979c6fdbdca1675" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"فتح الدردشة"</string>
+    <string name="native_09ce95090659d069" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"إجراءات إقران الأجهزة غير متاحة في جلسة Gateway هذه. شغّل openclaw devices list على مضيف Gateway وأدِر الطلب من هناك. الموافقة على إمكانات العقدة منفصلة، ولا تزال تستخدم nodes approve &lt;request id&gt;."</string>
     <string name="native_0a0b7cf7c428c703" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"طلب إجراء"</string>
     <string name="native_0a708e7b03aaf1fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list pins"</string>
     <string name="native_0ab0e1629576aecf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"اتصل بـ Gateway لتحميل مقترحات ورشة Skills."</string>
@@ -87,10 +88,12 @@
     <string name="native_0c3845dcd2f0f683" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"افحص هذا المقترح لتحميل محتواه بتنسيق Markdown."</string>
     <string name="native_0c3ea4e2f12153e7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"افتح OpenClaw واسأل %1$s"</string>
     <string name="native_0c4d01e81bb3d1fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الاستدلال"</string>
+    <string name="native_0c77fe09ab336a3e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"العميل"</string>
     <string name="native_0c79a9c222840ed0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مطبق"</string>
     <string name="native_0cab1c9617404faf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"فيديو"</string>
     <string name="native_0cf04463c4276a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تمت ترقيته"</string>
     <string name="native_0d21bd52022ca7f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"متصل"</string>
+    <string name="native_0d5644ff52ce2ba3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"النطاقات"</string>
     <string name="native_0d5efd432e4fedf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"موفر الصوت في الوقت الفعلي غير مهيأ."</string>
     <string name="native_0d8ca811c3744a6d" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s · %2$s"</string>
     <string name="native_0db10f2c2f332cd2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"kick"</string>
@@ -138,6 +141,7 @@
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الجلسة المستهدفة"</string>
     <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مراجعة مهارة ClawHub"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
+    <string name="native_16a5b7ad567a8093" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"هل تريد رفض طلب الاقتران من هذا الجهاز؟"</string>
     <string name="native_16b1a05e1d987ed1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الميكروفون المفضل"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مضيف العقدة"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"المستوى"</string>
@@ -183,6 +187,7 @@
     <string name="native_1d91629837639a5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تغيّرت عملية الأتمتة هذه أثناء تعديلك لها. ارجع إلى أحدث إصدار في Gateway قبل الحفظ."</string>
     <string name="native_1dbf9d5979606697" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"عند الاتصال، يمكن لـ Gateway تنشيط الهاتف بإشعار صامت بدلًا من إبقاء جلسة دائمة التشغيل."</string>
     <string name="native_1e432ea5425e4a3a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"وضع التنبيه"</string>
+    <string name="native_1e595a107c78b957" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"هل تريد إزالة الجهاز المقترن؟"</string>
     <string name="native_1e955a58278623a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"نص حدث النظام"</string>
     <string name="native_1ea44149be42d970" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تعذّر نسخ صورة الأداة"</string>
     <string name="native_1ea442a134b2a184" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"لا"</string>
@@ -197,6 +202,7 @@
     <string name="native_2065cc867eba1b39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تعذّر تحميل إعدادات نماذج موفّر الخدمة."</string>
     <string name="native_207ccb22d618db05" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"يُسمح لـ %1$s تطبيق بإعادة التوجيه."</string>
     <string name="native_209b9e597963e7e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"إعداد الصوت"</string>
+    <string name="native_211988ba9dd0570a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"هل تريد رفض طلب الاقتران؟"</string>
     <string name="native_2132066dc9475cb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"This skill is installed but not available to the current agent. Agent filters stay on desktop or CLI."</string>
     <string name="native_21378545892f1fe2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الناشر"</string>
     <string name="native_214d4932fc767e8f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">" · المحادثة: جارٍ التحدث"</string>
@@ -238,6 +244,7 @@
     <string name="native_2682bd813a3bccbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"أدخل رمز الإعداد من openclaw qr."</string>
     <string name="native_268f14bbfe119c1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"التشخيصات"</string>
     <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"يؤدي هذا إلى حذف المحادثة ونصها نهائيًا."</string>
+    <string name="native_26e47d73a55d7fa7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تمت الموافقة على الجهاز."</string>
     <string name="native_26f0dd993530eb2d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تجري إعادة المحاولة تلقائيًا"</string>
     <string name="native_270ff82f36da987f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تم نسخ صورة الأداة"</string>
     <string name="native_2728740a95d465c6" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s أدوار"</string>
@@ -346,6 +353,7 @@
     <string name="native_381428f5f251a764" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Conversation Send"</string>
     <string name="native_3824a9f4dafe92c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"اللوحة"</string>
     <string name="native_384ae4ab1a2830f9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مزوّد واحد"</string>
+    <string name="native_385001409de8562a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تعذّرت قراءة شهادة Gateway تلقائيًا. الصق بصمة SHA-256 التي حصلت عليها من مضيف Gateway."</string>
     <string name="native_387b2569e440838c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"فشل الإرسال: %1$s"</string>
     <string name="native_3892e10346fd2012" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الجسر"</string>
     <string name="native_38d198cd5303680f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"خطأ في التسليم"</string>
@@ -403,6 +411,7 @@
     <string name="native_429f6057535c1ea3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sub-agent"</string>
     <string name="native_42e3a99c21767def" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"في انتظار الموافقة على الجهاز"</string>
     <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"جارٍ تحميل سلسلة المحادثات"</string>
+    <string name="native_430df68ec29a85a2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"يقدّم Gateway هذا الآن شهادة موثوقة من هذا الجهاز."</string>
     <string name="native_43905968a540af6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"التداخل بالميلي ثانية"</string>
     <string name="native_43988c156beabf7d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"event create"</string>
     <string name="native_43cc23fa52b87b4c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مستند"</string>
@@ -412,7 +421,7 @@
     <string name="native_4441146b0fe1d5c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screenshot"</string>
     <string name="native_4481c2190a1b4bca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تعبير Cron، مثل 0 9 * * *"</string>
     <string name="native_4499e7b7e1c9ddbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"العودة إلى الصوت"</string>
-    <string name="native_449f5a775762cdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تحدث"</string>
+    <string name="native_449f5a775762cdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تحدّث"</string>
     <string name="native_45a64dc17588f2ca" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s متصلة"</string>
     <string name="native_45a8847c4a6b2c81" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"يُسمح لـ %1$s تطبيقات بإعادة التوجيه."</string>
     <string name="native_460b3a7da007b7af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الدردشة"</string>
@@ -464,6 +473,7 @@
     <string name="native_4e8c72cab82e0711" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"إعدادات التشغيل الآلي غير صالحة."</string>
     <string name="native_4ec30e9d85725d41" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"قائمة السماح"</string>
     <string name="native_4ed379d418bb8629" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"groups"</string>
+    <string name="native_4ee252fb736effa2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"المفتاح العام"</string>
     <string name="native_4efca0d10c5feb8e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"حول"</string>
     <string name="native_4f1bc100d1dccc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"لم يتم العثور على رمز QR للإعداد في هذه الصورة. اختر رمز QR الذي أنشأه openclaw qr، أو أدخل رمز الإعداد يدويًا."</string>
     <string name="native_4fe3cdd404ea0290" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"permissions"</string>
@@ -550,6 +560,7 @@
     <string name="native_5c0c8c9aa658f4a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OPENCLAW"</string>
     <string name="native_5c1acea9c9b0e704" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Fetch"</string>
     <string name="native_5c39123805ffb4e2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الموجّه"</string>
+    <string name="native_5c944156b5353428" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"هل تريد الموافقة على الجهاز؟"</string>
     <string name="native_5d410adb9576e266" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"هل تريد إزالة %1$s وبيانات الاعتماد المحفوظة الخاصة به من هذا الهاتف؟"</string>
     <string name="native_5d6c41a67139ee26" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"يشير رمز QR إلى Gateway بعيد غير آمن. %1$s %2$s"</string>
     <string name="native_5d6cbac59f87e78d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"سطح الشاشة جاهز"</string>
@@ -567,6 +578,7 @@
     <string name="native_5fa1d457ddfcd26c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"rename group"</string>
     <string name="native_5fa7aac5375c5815" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"جاهز"</string>
     <string name="native_5fc1927ca948f31c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تنتظر المذكّرات أول إدخال لها."</string>
+    <string name="native_6007acbe30b2cd98" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"موافقة"</string>
     <string name="native_600c9c27960112a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الصفحة المباشرة"</string>
     <string name="native_6030d1f6340776d2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"التشغيل الآلي قيد التشغيل بالفعل."</string>
     <string name="native_604e6d6faf8d0295" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"إزالة عملية الأتمتة هذه بعد تشغيل ناجح لمرة واحدة."</string>
@@ -606,12 +618,14 @@
     <string name="native_6657cc73af00feac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"السماح بأدوات الكاميرا عند طلبها."</string>
     <string name="native_666067dd376e5d45" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"المشكلات"</string>
     <string name="native_666c8bc0319f3b54" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"التنبيه الصوتي"</string>
+    <string name="native_66713d713e3a41c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تم رفض طلب الاقتران."</string>
     <string name="native_66b23bae66fc0d79" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"قبل %1$s ي"</string>
     <string name="native_66cf5513b37462be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"roles"</string>
     <string name="native_66d0f523a379b2de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skills"</string>
     <string name="native_66f4804ee23ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"أرشفة"</string>
     <string name="native_66fab2875ee427f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"العقدة غير متصلة. أعد الاتصال وحاول مجددًا."</string>
     <string name="native_6725e7bbcd28f3a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"النظام"</string>
+    <string name="native_672f3453e1dd571b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"عنوان IP البعيد"</string>
     <string name="native_674b38cae72bb0c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"غير مصنّف"</string>
     <string name="native_674eb55d9c353900" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تفاصيل الجدول"</string>
     <string name="native_67528858c36397f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"إمكانات الهاتف"</string>
@@ -619,6 +633,7 @@
     <string name="native_67b696468610b879" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dashboard"</string>
     <string name="native_67fa416afa64d304" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"لصق الرمز المميز"</string>
     <string name="native_6827238fea72c88b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"لا يوجد موفرون"</string>
+    <string name="native_684889f0079cc145" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"بصمة SHA-256"</string>
     <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"لا توجد محادثات بعد"</string>
     <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ميكروفون Bluetooth"</string>
     <string name="native_690dbe9dc0993c42" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الأخيرة"</string>
@@ -653,6 +668,7 @@
     <string name="native_6d5d9004797377e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"التراخيص"</string>
     <string name="native_6d7c95a353d873cd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"اتصل بـ Gateway للبحث عن مهارات ClawHub."</string>
     <string name="native_6df1bb18a59ab97d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مهارة"</string>
+    <string name="native_6e0a0b9d8c5ee4d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"معرّف الجهاز"</string>
     <string name="native_6e117ba97cbfb6f0" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"لم يحدّد Gateway موفّر %1$s النشط"</string>
     <string name="native_6e293a8c009e0011" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"قيد الانتظار"</string>
     <string name="native_6e2c0963d056e104" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تم حفظ كلمات التنبيه"</string>
@@ -829,6 +845,7 @@
     <string name="native_8bb7ec15b1e350a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"جارٍ الفحص"</string>
     <string name="native_8bf253a125f66985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"امسح رمز الإعداد ضوئيًا أو الصقه لإضافة Gateway آخر."</string>
     <string name="native_8c4a3896e8f06d27" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"انتهت مهلة TLS"</string>
+    <string name="native_8c55387fb6c584c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تمت إزالة الجهاز المقترن."</string>
     <string name="native_8c93c68056cde54d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تم إقران Gateway. جارٍ التحقق من الموافقة على إمكانات العقدة."</string>
     <string name="native_8ca344247c18317e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الحركة"</string>
     <string name="native_8cac4b77b9c54695" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"فشل إجراء cron."</string>
@@ -1021,7 +1038,6 @@
     <string name="native_ad1c341c65f84ede" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"شغّل أمر الموافقة على كمبيوتر Gateway، ثم تحقّق مرة أخرى."</string>
     <string name="native_ad1fb9ec0cb3c7a4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"عمليات الأتمتة"</string>
     <string name="native_adb7eb8a03ad699c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$sد"</string>
-    <string name="native_adca3171c270301a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"يمكن لتسجيل الدخول إلى Gateway هذا عرض العقد المتصلة، لكنه لا يستطيع الموافقة على إقران هواتف جديدة. أقرن الهواتف الجديدة من جلسة مسؤول Gateway. موافقة إمكانات العقدة منفصلة، ولا تزال تستخدم nodes approve &lt;request id&gt;."</string>
     <string name="native_ade9248e0132b411" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الوثوق"</string>
     <string name="native_ae27fa789a03c1db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"رمز QR هذا ليس رمز إعداد QR خاصًا بـ OpenClaw. أنشئ رمزًا جديدًا باستخدام openclaw qr، ثم حاول مرة أخرى."</string>
     <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الميكروفون المفضل غير متاح؛ جارٍ استخدام التوجيه التلقائي."</string>
@@ -1091,6 +1107,7 @@
     <string name="native_bb4f2558e4333834" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تم حفظ صورة الأداة في التنزيلات"</string>
     <string name="native_bbe5fc3b9ef39f99" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"جارٍ البدء…"</string>
     <string name="native_bc19cec293228fb8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"خطأ في العميل"</string>
+    <string name="native_bc1c94a6dfce1058" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تحقق من الجهاز الذي يطلب الوصول قبل منحه الإذن."</string>
     <string name="native_bc6618670f3e8a17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ميكروفون Bluetooth LE"</string>
     <string name="native_bcb06651437caa15" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
     <string name="native_bd08450d63406844" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تم تفعيل التشغيل الآلي."</string>
@@ -1099,6 +1116,7 @@
     <string name="native_bdc090ec61e3fcfc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"إعادة التحميل"</string>
     <string name="native_bdff71b20b9cf392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"البحث في عمليات الأتمتة"</string>
     <string name="native_be969becb173e0c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ستظهر الهواتف المرتبطة ومضيفو العُقد هنا بعد الاقتران."</string>
+    <string name="native_bf1870ff5c6322fb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s: %2$s"</string>
     <string name="native_bf350e6a0ed60b7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تم تغيير هذه المهمة الآلية على Gateway. راجع أحدث إصدار قبل الحفظ مرة أخرى."</string>
     <string name="native_bf399ffa03617a96" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"إيقاف الإملاء"</string>
     <string name="native_bf56ee2fe3345ce1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"سهل القراءة"</string>
@@ -1122,6 +1140,7 @@
     <string name="native_c1c224b03cd9bc7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"المشرف"</string>
     <string name="native_c1ebc7817870e5be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"يتطلب الانتباه"</string>
     <string name="native_c22d5e02fbec7d65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"اقرن هذا الجهاز بـ Gateway لتنشيطه فقط عند وجود عمل فعلي، والاحتفاظ بنظرة عامة مباشرة على الوكلاء في متناولك، وتجنب حلقات الخلفية التي تستنزف البطارية."</string>
+    <string name="native_c25337055464f8d3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الأدوار"</string>
     <string name="native_c253f451bdd56431" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"رد"</string>
     <string name="native_c26225b6c16a4bc7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"دليل المزوّدين"</string>
     <string name="native_c272b225cf5bd643" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"فعّل الإذن في الإعدادات"</string>
@@ -1135,6 +1154,7 @@
     <string name="native_c34dd5eb8b0af56e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"من أين أحصل على رمز الإعداد؟"</string>
     <string name="native_c3546b39ecbbed8a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تعذّر تمكين المهارة."</string>
     <string name="native_c35b21d6ca39aa7c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"pdf"</string>
+    <string name="native_c3812fc4acb861d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"إزالة"</string>
     <string name="native_c382566dbe2ea49f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s%% متصلة"</string>
     <string name="native_c385951198c45d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"لا توجد قنوات"</string>
     <string name="native_c41ad84496b53420" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"صوت في الوقت الفعلي"</string>
@@ -1163,6 +1183,7 @@
     <string name="native_c6d5ed757b66bfd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"حلم"</string>
     <string name="native_c6dd061350fc69b8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"لا توجد تطبيقات محظورة. يمكن للتطبيقات إعادة التوجيه ما لم تضف عمليات حظر."</string>
     <string name="native_c753cdf0c19f1e38" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"أداة التعرّف على الكلام غير متاحة"</string>
+    <string name="native_c78ffe19571018fb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"المنصة"</string>
     <string name="native_c7985fa72daa6ea4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"لم يُرجع Gateway إعداد %1$s"</string>
     <string name="native_c7b6dfd5c3a183c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"هل تريد نسيان Gateway؟"</string>
     <string name="native_c7b7b7f01360f6a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"وصف اختياري"</string>
@@ -1225,6 +1246,7 @@
     <string name="native_d17d2d78d76e6a6c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"النماذج"</string>
     <string name="native_d19c2dd2fb598b93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw سلبي"</string>
     <string name="native_d1a574e23344c407" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"كلمة مرور Gateway غير صالحة"</string>
+    <string name="native_d1af697abaff485f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تعذر التحقق من تغيير اقتران الجهاز. حدّث الصفحة وحاول مرة أخرى."</string>
     <string name="native_d1bf045bb524dae5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"عرض التفاصيل"</string>
     <string name="native_d1e9567da9a8a4b0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bash"</string>
     <string name="native_d2089be672953d11" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الرمز المميز"</string>
@@ -1239,6 +1261,7 @@
     <string name="native_d31de1a5c5c8ba2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"المتصفح"</string>
     <string name="native_d354ee936f59115e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screen record"</string>
     <string name="native_d3974fd6d3b6c81f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"التشغيل معلّق"</string>
+    <string name="native_d3e1c5f8a6e240fc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"المصدر"</string>
     <string name="native_d3f75e24411053c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ذكاء اصطناعي شخصي على أجهزتك"</string>
     <string name="native_d406ade2958cb5b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attach"</string>
     <string name="native_d461a493a3753877" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تلقائي"</string>
@@ -1427,6 +1450,7 @@
     <string name="native_f2da2e47cd31a5dd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تعذر فك ترميز هذه الصورة."</string>
     <string name="native_f3753c0fe29b88db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway والصوت والإشعارات والخصوصية"</string>
     <string name="native_f386c32c1bf437d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ملفات مساحة عمل الوكيل"</string>
+    <string name="native_f418bf0894a1806a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"سيفقد هذا الجهاز وصوله الموثوق إلى Gateway."</string>
     <string name="native_f41d9e8b7e09aa24" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"استخدم requestId من الأمر المعلّق في أمر الموافقة."</string>
     <string name="native_f4830a1dae298044" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الجدول الزمني"</string>
     <string name="native_f493f0ce7a52a8aa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"حد المعدل"</string>
@@ -1434,6 +1458,7 @@
     <string name="native_f4cc820d308495c4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الحمولة · %1$s"</string>
     <string name="native_f4ccae29e1bb0c20" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"قيد التشغيل"</string>
     <string name="native_f4db1e48476f6075" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"إنهاء"</string>
+    <string name="native_f4e2076014711222" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"استخدام ثقة النظام"</string>
     <string name="native_f4ef7a41caa88dd1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"لا يوجد مزوّدون جاهزون"</string>
     <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"يعطي الأولوية لميكروفونات Bluetooth المتصلة."</string>
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تم حظر %1$s تطبيق من إعادة التوجيه."</string>

--- a/apps/android/app/src/main/res/values-de/strings.xml
+++ b/apps/android/app/src/main/res/values-de/strings.xml
@@ -104,7 +104,7 @@
     <string name="native_0e91610117029a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aktualisieren"</string>
     <string name="native_0ee30822ed35a792" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s in der Warteschlange"</string>
     <string name="native_0f4c8529742b31ea" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Chat starten"</string>
-    <string name="native_0f559ff270904904" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aufrufe von Chat-Tools, die im aktiven Thread ausstehen, bleiben hier sichtbar."</string>
+    <string name="native_0f559ff270904904" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aufrufe von Chat-Tools, die im aktiven Thread warten, bleiben hier sichtbar."</string>
     <string name="native_0f56cc286a4f23d8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zertifikatsprüfung erforderlich"</string>
     <string name="native_0f8fe3a9688138a1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Öffne die aktuelle Canvas-Oberfläche, um sie zu untersuchen oder mit ihr zu interagieren."</string>
     <string name="native_0ff98f05be01ce5e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Die Automation wurde aktualisiert."</string>
@@ -283,7 +283,7 @@
     <string name="native_2cd62f7a670b2819" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw-Thread"</string>
     <string name="native_2d4dfe885f84629e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zugriff auf die Fotomediathek erlauben."</string>
     <string name="native_2d6416405eb44982" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Eine frühere Antwort hat diese Genehmigung bereits bearbeitet."</string>
-    <string name="native_2d85de9d56c226e4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Keine aktuellen Threads"</string>
+    <string name="native_2d85de9d56c226e4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Keine kürzlich verwendeten Threads"</string>
     <string name="native_2df01a03ff43400b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Keine Übereinstimmungen"</string>
     <string name="native_2df30b117ad829ab" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Benachrichtigungen ausgewählter Apps lesen"</string>
     <string name="native_2e0078a8322d6f1f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Verfügbarkeit unbekannt"</string>
@@ -494,7 +494,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zustellung"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Lautsprecher stummschalten"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway-Verbindung wird geöffnet"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Überwachung · %1$s Threads"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Die Automation wurde ausgeführt."</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Keine passenden Apps."</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"An Chat senden"</string>
@@ -1040,7 +1040,7 @@
     <string name="native_adb7eb8a03ad699c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s Min."</string>
     <string name="native_ade9248e0132b411" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Vertrauen"</string>
     <string name="native_ae27fa789a03c1db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dieser QR-Code ist kein OpenClaw-Einrichtungs-QR-Code. Generiere mit openclaw qr einen neuen Code und versuche es erneut."</string>
-    <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bevorzugtes Mikrofon nicht verfügbar; automatische Audioausgabe wird verwendet."</string>
+    <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Das bevorzugte Mikrofon ist nicht verfügbar; die automatische Auswahl wird verwendet."</string>
     <string name="native_aea4a04a80426ed8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Abgelehnt"</string>
     <string name="native_aed306fbb63c0c68" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Android- und Hintergrundpakete einschließen."</string>
     <string name="native_aedf1cf58372f943" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ihr Gateway ist bereit."</string>
@@ -1212,7 +1212,7 @@
     <string name="native_cc721e25d73938a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Home-Gateway"</string>
     <string name="native_cc7a9a5cf8c4bc9d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Führen Sie den Freigabebefehl auf dem Gateway aus"</string>
     <string name="native_cc925e3c97ac7a35" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Vorschläge aus Skill Workshop konnten nicht geladen werden."</string>
-    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bring mich bei meinen neuesten OpenClaw-Threads auf den aktuellen Stand und schlage nächste Schritte vor."</string>
+    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bring mich bei meinen letzten OpenClaw-Threads auf den neuesten Stand und schlage nächste Schritte vor."</string>
     <string name="native_ccb4c324f516c633" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nicht jetzt"</string>
     <string name="native_cced0b0d83a9e400" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw qr"</string>
     <string name="native_cced28c6dc3f99c2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"start"</string>
@@ -1277,7 +1277,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Profil"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Anbieterlimits werden hier angezeigt, wenn Ihr Gateway sie meldet."</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 Problem"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" bleiben erhalten und werden zurück nach „Nicht gruppiert“ verschoben."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Erstellt"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s aktive Token"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>
@@ -1340,7 +1340,7 @@
     <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Installierte Skills durchsuchen"</string>
     <string name="native_e0723a86a5b9408a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Prüfen"</string>
     <string name="native_e083bd83e9d3e97e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Process"</string>
-    <string name="native_e08a8fc53e29e5c9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kürzlich verwendete Threads"</string>
+    <string name="native_e08a8fc53e29e5c9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Letzte Threads"</string>
     <string name="native_e0926fdac700b094" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Terminal"</string>
     <string name="native_e0d1b68224bf0b31" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aktuell"</string>
     <string name="native_e10435f6306b06d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 Konto"</string>
@@ -1522,7 +1522,7 @@
     <string name="native_ff716fc4735e067f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Diktateinstellungen"</string>
     <string name="native_ff9dbbdfb84ddab2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Anbietermodelle wurden geladen, aber die Bereitschaft ist nicht verfügbar."</string>
     <string name="native_ffa7aa557b547a79" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Thread löschen?"</string>
-    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw macht dieses Smartphone zu einer übersichtlichen mobilen Steuerungsoberfläche für Threads, Sprache, Anbieter und Gateway."</string>
+    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw verwandelt dieses Smartphone in eine übersichtliche mobile Bedienoberfläche für Threads, Sprache, Anbieter und Gateway."</string>
     <string name="native_ffb6f5764bddb68c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Neueste zuerst"</string>
     <string name="native_ffcf16006c652ee3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nächster Zyklus"</string>
 </resources>

--- a/apps/android/app/src/main/res/values-de/strings.xml
+++ b/apps/android/app/src/main/res/values-de/strings.xml
@@ -494,7 +494,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zustellung"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Lautsprecher stummschalten"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway-Verbindung wird geöffnet"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Überwachung · %1$s Threads"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Die Automation wurde ausgeführt."</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Keine passenden Apps."</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"An Chat senden"</string>
@@ -1277,7 +1277,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Profil"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Anbieterlimits werden hier angezeigt, wenn Ihr Gateway sie meldet."</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 Problem"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" bleiben erhalten und werden zurück nach „Nicht gruppiert“ verschoben."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Erstellt"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s aktive Token"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>

--- a/apps/android/app/src/main/res/values-es/strings.xml
+++ b/apps/android/app/src/main/res/values-es/strings.xml
@@ -104,7 +104,7 @@
     <string name="native_0e91610117029a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Actualizar"</string>
     <string name="native_0ee30822ed35a792" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s en cola"</string>
     <string name="native_0f4c8529742b31ea" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Iniciar chat"</string>
-    <string name="native_0f559ff270904904" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Las llamadas a herramientas del chat que estén en espera en el hilo activo seguirán visibles aquí."</string>
+    <string name="native_0f559ff270904904" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Las llamadas a herramientas del chat que esperan en el hilo activo siguen visibles aquí."</string>
     <string name="native_0f56cc286a4f23d8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Se necesita revisar el certificado"</string>
     <string name="native_0f8fe3a9688138a1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Abre la superficie actual de Canvas para inspeccionarla o interactuar con ella."</string>
     <string name="native_0ff98f05be01ce5e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatización actualizada."</string>
@@ -494,7 +494,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Entrega"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Silenciar altavoz"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Abriendo la conexión con el Gateway"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Supervisión · %1$s hilos"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"La ejecución de la automatización ha finalizado."</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"No hay apps coincidentes."</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Enviar al chat"</string>
@@ -1235,7 +1235,7 @@
     <string name="native_ceb6931ea57cc999" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Adaptativo"</string>
     <string name="native_cf0ee3547a4e51a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Pronto"</string>
     <string name="native_d04fc7d7e19702f8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Search"</string>
-    <string name="native_d053ba98d8bbcec1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Prueba Chat, Voz, Hilos, Proveedores o Ajustes."</string>
+    <string name="native_d053ba98d8bbcec1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Prueba Chat, Voz, Hilos, Proveedores o Configuración."</string>
     <string name="native_d056177742e27cf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw activo"</string>
     <string name="native_d0cda6559bb347db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"navigate"</string>
     <string name="native_d0d0de0039c7990b" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"solicitado %1$s"</string>
@@ -1277,7 +1277,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Perfil"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Los límites del proveedor aparecerán aquí cuando tu Gateway los informe."</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 problema"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Los hilos de \"%1$s\" se conservan y vuelven a Sin agrupar."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Creado"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s tokens activos"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>
@@ -1522,7 +1522,7 @@
     <string name="native_ff716fc4735e067f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Configuración de dictado"</string>
     <string name="native_ff9dbbdfb84ddab2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Se cargaron los modelos del proveedor, pero la disponibilidad no está disponible."</string>
     <string name="native_ffa7aa557b547a79" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"¿Eliminar el hilo?"</string>
-    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw convierte este teléfono en una interfaz móvil despejada para gestionar hilos, voz, proveedores y Gateway."</string>
+    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw convierte este teléfono en una interfaz móvil sencilla para hilos, voz, proveedores y Gateway."</string>
     <string name="native_ffb6f5764bddb68c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Más recientes primero"</string>
     <string name="native_ffcf16006c652ee3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Próximo ciclo"</string>
 </resources>

--- a/apps/android/app/src/main/res/values-es/strings.xml
+++ b/apps/android/app/src/main/res/values-es/strings.xml
@@ -494,7 +494,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Entrega"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Silenciar altavoz"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Abriendo la conexión con el Gateway"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Supervisión · %1$s hilos"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"La ejecución de la automatización ha finalizado."</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"No hay apps coincidentes."</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Enviar al chat"</string>
@@ -1277,7 +1277,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Perfil"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Los límites del proveedor aparecerán aquí cuando tu Gateway los informe."</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 problema"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Los hilos de \"%1$s\" se conservan y vuelven a Sin agrupar."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Creado"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s tokens activos"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>

--- a/apps/android/app/src/main/res/values-fa/strings.xml
+++ b/apps/android/app/src/main/res/values-fa/strings.xml
@@ -494,7 +494,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تحویل"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"بی‌صدا کردن بلندگو"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"در حال باز کردن اتصال Gateway"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"در حال پایش · %1$s رشته"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"اجرای خودکار به پایان رسید."</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"برنامه مطابقی یافت نشد."</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ارسال به چت"</string>
@@ -1277,7 +1277,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"پروفایل"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"وقتی Gateway شما آن‌ها را گزارش کند، محدودیت‌های ارائه‌دهنده اینجا نمایش داده می‌شوند."</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"۱ مشکل"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"رشته‌های موجود در \"%1$s\" حفظ می‌شوند و به «بدون گروه» بازمی‌گردند."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ایجادشده"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s توکن فعال"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>

--- a/apps/android/app/src/main/res/values-fa/strings.xml
+++ b/apps/android/app/src/main/res/values-fa/strings.xml
@@ -31,7 +31,7 @@
     <string name="native_00e8aeba41d79ce3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"۱ در انتظار"</string>
     <string name="native_010f6550a1c8f554" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"پیوست پشتیبانی‌نشده"</string>
     <string name="native_01267be21eb77392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"0 = دقیق"</string>
-    <string name="native_0171e3d4e07f1861" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"برای جست‌وجوی رشته‌ها، به Gateway متصل شوید."</string>
+    <string name="native_0171e3d4e07f1861" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"برای جستجوی گفتگوها، به Gateway متصل شوید."</string>
     <string name="native_0174f83136630e7e" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s حساب"</string>
     <string name="native_01ac1c298e0cbd9a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تغییرات Cron به operator.admin نیاز دارند. کدهای راه‌اندازی عمداً این دسترسی را اعطا نمی‌کنند. برای درخواست دسترسی مدیر، با توکن مشترک یا گذرواژه Gateway دوباره متصل شوید. اگر این دستگاه همچنان فاقد این دسترسی است، ارتقای محدوده در انتظار را از یک کلاینت مدیر موجود تأیید کنید."</string>
     <string name="native_01bcfe7a9296b6d6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Apply Patch"</string>
@@ -75,7 +75,6 @@
     <string name="native_0929c9dc7f794852" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"هیچ پیشنهادی نیست"</string>
     <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"رشته اصلی"</string>
     <string name="native_0979c6fdbdca1675" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"باز کردن چت"</string>
-    <string name="native_09ce95090659d069" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"اقدامات جفت‌سازی دستگاه در این نشست Gateway در دسترس نیست. دستور openclaw devices list را روی میزبان Gateway اجرا کنید و درخواست را در آنجا مدیریت کنید. تأیید قابلیت گره جداگانه است و همچنان از nodes approve &lt;request id&gt; استفاده می‌کند."</string>
     <string name="native_0a0b7cf7c428c703" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"درخواست اقدام"</string>
     <string name="native_0a708e7b03aaf1fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list pins"</string>
     <string name="native_0ab0e1629576aecf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"برای بارگذاری پیشنهادهای کارگاه Skill به یک Gateway متصل شوید."</string>
@@ -88,12 +87,10 @@
     <string name="native_0c3845dcd2f0f683" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"برای بارگذاری Markdown این پیشنهاد، آن را بررسی کنید."</string>
     <string name="native_0c3ea4e2f12153e7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw را باز کن و بپرس %1$s"</string>
     <string name="native_0c4d01e81bb3d1fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"استدلال"</string>
-    <string name="native_0c77fe09ab336a3e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"کلاینت"</string>
     <string name="native_0c79a9c222840ed0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"اعمال‌شده"</string>
     <string name="native_0cab1c9617404faf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ویدئو"</string>
     <string name="native_0cf04463c4276a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ارتقایافته"</string>
     <string name="native_0d21bd52022ca7f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"آنلاین"</string>
-    <string name="native_0d5644ff52ce2ba3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"دامنه‌ها"</string>
     <string name="native_0d5efd432e4fedf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ارائه‌دهنده صدای بلادرنگ پیکربندی نشده است."</string>
     <string name="native_0d8ca811c3744a6d" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s · %2$s"</string>
     <string name="native_0db10f2c2f332cd2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"kick"</string>
@@ -104,7 +101,7 @@
     <string name="native_0e91610117029a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تازه‌سازی"</string>
     <string name="native_0ee30822ed35a792" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s در صف"</string>
     <string name="native_0f4c8529742b31ea" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"شروع گفتگو"</string>
-    <string name="native_0f559ff270904904" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"فراخوانی‌های ابزار گپ که در رشته فعال منتظر هستند، اینجا قابل مشاهده می‌مانند."</string>
+    <string name="native_0f559ff270904904" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"فراخوانی‌های ابزار Chat که در رشته فعال منتظر هستند، اینجا قابل مشاهده می‌مانند."</string>
     <string name="native_0f56cc286a4f23d8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"بازبینی گواهی لازم است"</string>
     <string name="native_0f8fe3a9688138a1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"سطح Canvas فعلی را برای بررسی یا تعامل با آن باز کنید."</string>
     <string name="native_0ff98f05be01ce5e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"اجرای خودکار به‌روزرسانی شد."</string>
@@ -125,7 +122,7 @@
     <string name="native_12698ce1ea5cd4ab" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"رد شد"</string>
     <string name="native_1291833ee42d8143" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"از نشانی LAN رایانه Gateway یا نام میزبان راه دور امن استفاده کنید."</string>
     <string name="native_130011756125313c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"روشن"</string>
-    <string name="native_133f293961d7aa43" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"در حال جست‌وجوی رشته‌ها"</string>
+    <string name="native_133f293961d7aa43" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"در حال جستجوی گفتگوها"</string>
     <string name="native_13798c3256e792c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"گفت‌وگوی بلادرنگ"</string>
     <string name="native_13b588109e423636" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw در حال آماده‌سازی پاسخ است."</string>
     <string name="native_13ba4cde12390943" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تأیید یک‌بار اجازه داده شد."</string>
@@ -141,7 +138,6 @@
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مقصد نشست"</string>
     <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"بررسی Skill در ClawHub"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
-    <string name="native_16a5b7ad567a8093" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"درخواست جفت‌سازی این دستگاه رد شود؟"</string>
     <string name="native_16b1a05e1d987ed1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"میکروفون ترجیحی"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"میزبان گره"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"سطح"</string>
@@ -187,7 +183,6 @@
     <string name="native_1d91629837639a5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"این خودکارسازی هنگام ویرایش شما تغییر کرده است. پیش از ذخیره، آن را به آخرین نسخه Gateway بازگردانید."</string>
     <string name="native_1dbf9d5979606697" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"پس از اتصال، Gateway می‌تواند به‌جای حفظ یک نشست همیشه‌فعال، گوشی را با یک اعلان بی‌صدا بیدار کند."</string>
     <string name="native_1e432ea5425e4a3a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"حالت بیدارباش"</string>
-    <string name="native_1e595a107c78b957" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"دستگاه جفت‌شده حذف شود؟"</string>
     <string name="native_1e955a58278623a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"متن رویداد سیستم"</string>
     <string name="native_1ea44149be42d970" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تصویر ویجت کپی نشد"</string>
     <string name="native_1ea442a134b2a184" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"خیر"</string>
@@ -202,7 +197,6 @@
     <string name="native_2065cc867eba1b39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"پیکربندی مدل ارائه‌دهنده بارگیری نشد."</string>
     <string name="native_207ccb22d618db05" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s برنامه مجاز به بازارسال است."</string>
     <string name="native_209b9e597963e7e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"راه‌اندازی صدا"</string>
-    <string name="native_211988ba9dd0570a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"درخواست جفت‌سازی رد شود؟"</string>
     <string name="native_2132066dc9475cb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"This skill is installed but not available to the current agent. Agent filters stay on desktop or CLI."</string>
     <string name="native_21378545892f1fe2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ناشر"</string>
     <string name="native_214d4932fc767e8f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">" · گفت‌وگو: در حال صحبت"</string>
@@ -216,7 +210,7 @@
     <string name="native_22965568d22a14ee" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"متصل"</string>
     <string name="native_22a970d2e5b1cc23" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تکمیل‌شده"</string>
     <string name="native_22b8da9e693e94eb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تلفن شما با %1$s جفت شده است. برای تکمیل دسترسی گره ادامه دهید."</string>
-    <string name="native_22f19ab686639b9a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"رشته فعلی"</string>
+    <string name="native_22f19ab686639b9a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"گفتگوی فعلی"</string>
     <string name="native_23246d9852fed325" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تفکر %1$s"</string>
     <string name="native_2346f214ad56b180" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"بی‌صدا"</string>
     <string name="native_2347fc06da5f60de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw از شرکای خود در جامعهٔ متن‌باز قدردانی می‌کند."</string>
@@ -244,7 +238,6 @@
     <string name="native_2682bd813a3bccbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"کد راه‌اندازی را از openclaw qr وارد کنید."</string>
     <string name="native_268f14bbfe119c1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"عیب‌یابی"</string>
     <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"این کار رشته و رونوشت آن را برای همیشه حذف می‌کند."</string>
-    <string name="native_26e47d73a55d7fa7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"دستگاه تأیید شد."</string>
     <string name="native_26f0dd993530eb2d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تلاش مجدد به‌صورت خودکار"</string>
     <string name="native_270ff82f36da987f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تصویر ویجت کپی شد"</string>
     <string name="native_2728740a95d465c6" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s نقش"</string>
@@ -260,7 +253,7 @@
     <string name="native_27d773b934ed324f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تأیید و نصب"</string>
     <string name="native_2821f0168d6dd9df" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"این دستگاه را به یک گره امن OpenClaw برای چت، صدا، دوربین و ابزارهای دستگاه تبدیل کنید."</string>
     <string name="native_2831546121359362" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"راه‌اندازی دستی"</string>
-    <string name="native_287c4b113aafc215" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"برای شروع یا ازسرگیری رشته فعلی، گپ را باز کنید."</string>
+    <string name="native_287c4b113aafc215" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"برای شروع یا ازسرگیری رشته فعلی، Chat را باز کنید."</string>
     <string name="native_28bb849671cab958" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"نکته: برای ارسال نوبت ضبط‌شده، گوش دادن را متوقف کنید."</string>
     <string name="native_28d03596d24eeb4e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"رد کردن"</string>
     <string name="native_28d55ec6974d84e8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"درخواست صوتی ناموفق بود"</string>
@@ -280,10 +273,10 @@
     <string name="native_2c19d584bf8ad518" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"علامت‌گذاری به‌عنوان خوانده‌نشده"</string>
     <string name="native_2c75802a5f8df5f8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"یافتن افراد و اطلاعات تماس"</string>
     <string name="native_2c9cce8250d746e3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"هویت دستگاه لازم است"</string>
-    <string name="native_2cd62f7a670b2819" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"رشته OpenClaw"</string>
+    <string name="native_2cd62f7a670b2819" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"گفتگوی OpenClaw"</string>
     <string name="native_2d4dfe885f84629e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"اجازه دسترسی به کتابخانه عکس را بدهید."</string>
     <string name="native_2d6416405eb44982" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"پاسخ قبلی این تأیید را حل کرده است."</string>
-    <string name="native_2d85de9d56c226e4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"رشته اخیری وجود ندارد"</string>
+    <string name="native_2d85de9d56c226e4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"هیچ رشته اخیری وجود ندارد"</string>
     <string name="native_2df01a03ff43400b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"موردی یافت نشد"</string>
     <string name="native_2df30b117ad829ab" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"خواندن اعلان‌های برنامه‌های انتخاب‌شده"</string>
     <string name="native_2e0078a8322d6f1f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"وضعیت دسترسی نامشخص است"</string>
@@ -345,7 +338,7 @@
     <string name="native_36c725ddb20f8bd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"راه‌اندازی ارائه‌دهنده گفتار"</string>
     <string name="native_36d88ed6cc91d2b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Music Generation"</string>
     <string name="native_36e8d5e94219dc37" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تنظیمات Talk"</string>
-    <string name="native_36f1fac278711470" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"در حال پایش · ۱ رشته"</string>
+    <string name="native_36f1fac278711470" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"در حال نظارت · ۱ رشته"</string>
     <string name="native_37053dc1f680546b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"متن Payload"</string>
     <string name="native_37582309e7a1dbe5" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تأیید %1$s"</string>
     <string name="native_379ce0aacf46c35f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway وضعیت آمادگی %1$s را برنگرداند"</string>
@@ -353,7 +346,6 @@
     <string name="native_381428f5f251a764" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Conversation Send"</string>
     <string name="native_3824a9f4dafe92c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"بوم"</string>
     <string name="native_384ae4ab1a2830f9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"۱ ارائه‌دهنده"</string>
-    <string name="native_385001409de8562a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"گواهی Gateway به‌طور خودکار قابل خواندن نبود. اثر انگشت SHA-256 دریافت‌شده در میزبان Gateway را جای‌گذاری کنید."</string>
     <string name="native_387b2569e440838c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ارسال ناموفق بود: %1$s"</string>
     <string name="native_3892e10346fd2012" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"پل ارتباطی"</string>
     <string name="native_38d198cd5303680f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"خطای تحویل"</string>
@@ -371,7 +363,7 @@
     <string name="native_3a65cf1204f18864" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"متصل (گره آفلاین است)"</string>
     <string name="native_3a78695388b38b5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"خانه"</string>
     <string name="native_3b28b535950f8175" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"دیکته در حال شنیدن است"</string>
-    <string name="native_3b46b7912670bfb0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"رشته بایگانی‌شده‌ای وجود ندارد"</string>
+    <string name="native_3b46b7912670bfb0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"هیچ رشته بایگانی‌شده‌ای وجود ندارد"</string>
     <string name="native_3b851469ea31d489" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"دستیارهای موجود در این Gateway را انتخاب و بررسی کنید."</string>
     <string name="native_3be0085a6bd88cdd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"حالت گفت‌وگو فعال است"</string>
     <string name="native_3bee4ede6bf4436c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"در حال کار · ۱ اجرای فعال"</string>
@@ -410,8 +402,7 @@
     <string name="native_4287d54ad5e78985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"کارهای زمان‌بندی‌شده OpenClaw از Gateway شما."</string>
     <string name="native_429f6057535c1ea3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sub-agent"</string>
     <string name="native_42e3a99c21767def" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"در انتظار تأیید دستگاه"</string>
-    <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"در حال بارگیری رشته"</string>
-    <string name="native_430df68ec29a85a2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"این Gateway اکنون گواهی‌ای ارائه می‌کند که مورد اعتماد این دستگاه است."</string>
+    <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"در حال بارگذاری رشته"</string>
     <string name="native_43905968a540af6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"میلی‌ثانیه پراکندگی"</string>
     <string name="native_43988c156beabf7d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"event create"</string>
     <string name="native_43cc23fa52b87b4c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"سند"</string>
@@ -421,7 +412,7 @@
     <string name="native_4441146b0fe1d5c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screenshot"</string>
     <string name="native_4481c2190a1b4bca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"عبارت cron، مثلاً 0 9 * * *"</string>
     <string name="native_4499e7b7e1c9ddbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"بازگشت به صدا"</string>
-    <string name="native_449f5a775762cdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"صحبت"</string>
+    <string name="native_449f5a775762cdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"گفتگو"</string>
     <string name="native_45a64dc17588f2ca" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s آنلاین"</string>
     <string name="native_45a8847c4a6b2c81" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s برنامه مجاز به بازارسال."</string>
     <string name="native_460b3a7da007b7af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"گفت‌وگو"</string>
@@ -473,7 +464,6 @@
     <string name="native_4e8c72cab82e0711" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"پیکربندی اجرای خودکار نامعتبر است."</string>
     <string name="native_4ec30e9d85725d41" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"فهرست مجاز"</string>
     <string name="native_4ed379d418bb8629" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"groups"</string>
-    <string name="native_4ee252fb736effa2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"کلید عمومی"</string>
     <string name="native_4efca0d10c5feb8e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"درباره"</string>
     <string name="native_4f1bc100d1dccc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"هیچ کد QR راه‌اندازی در این تصویر پیدا نشد. کد QR ایجادشده با openclaw qr را انتخاب کنید، یا کد راه‌اندازی را به‌صورت دستی وارد کنید."</string>
     <string name="native_4fe3cdd404ea0290" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"permissions"</string>
@@ -494,7 +484,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تحویل"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"بی‌صدا کردن بلندگو"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"در حال باز کردن اتصال Gateway"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"در حال نظارت · %1$s رشته"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"اجرای خودکار به پایان رسید."</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"برنامه مطابقی یافت نشد."</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ارسال به چت"</string>
@@ -519,7 +509,7 @@
     <string name="native_55898449eb74fb2e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"سلامت"</string>
     <string name="native_55a12cbe0995e214" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"شنود اعلان‌ها"</string>
     <string name="native_55d8e7da6d0a752c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"بلندگو بی‌صدا شد"</string>
-    <string name="native_560d3e826c413dc9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"جست‌وجوی گفت‌وگوها"</string>
+    <string name="native_560d3e826c413dc9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"جستجوی رشته‌ها"</string>
     <string name="native_565339bc4d33d728" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تأیید"</string>
     <string name="native_56a508f3f2bf424a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"راهنمای راه‌اندازی باز نشد."</string>
     <string name="native_56c41c606c44f3fc" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"از OpenClaw بپرس %1$s"</string>
@@ -560,7 +550,6 @@
     <string name="native_5c0c8c9aa658f4a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OPENCLAW"</string>
     <string name="native_5c1acea9c9b0e704" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Fetch"</string>
     <string name="native_5c39123805ffb4e2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"درخواست"</string>
-    <string name="native_5c944156b5353428" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"دستگاه تأیید شود؟"</string>
     <string name="native_5d410adb9576e266" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s و اطلاعات ورود ذخیره‌شده آن از این تلفن حذف شوند؟"</string>
     <string name="native_5d6c41a67139ee26" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"کد QR به یک gateway راه‌دور ناامن اشاره دارد. %1$s %2$s"</string>
     <string name="native_5d6cbac59f87e78d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"سطح صفحه آماده است"</string>
@@ -578,7 +567,6 @@
     <string name="native_5fa1d457ddfcd26c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"rename group"</string>
     <string name="native_5fa7aac5375c5815" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"آماده"</string>
     <string name="native_5fc1927ca948f31c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"دفترچه منتظر نخستین ورودی خود است."</string>
-    <string name="native_6007acbe30b2cd98" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تأیید کردن"</string>
     <string name="native_600c9c27960112a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"صفحه زنده"</string>
     <string name="native_6030d1f6340776d2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"اجرای خودکار در حال حاضر فعال است."</string>
     <string name="native_604e6d6faf8d0295" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"این خودکارسازی پس از یک اجرای یک‌باره موفق حذف شود."</string>
@@ -588,7 +576,7 @@
     <string name="native_60ea1847c2ba5446" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"پاسخ لغو شد"</string>
     <string name="native_6105d6cc76af4003" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تصویر"</string>
     <string name="native_614b8348a2dbe46b" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s نگه‌داشته‌شده"</string>
-    <string name="native_614e83ef17c13f3c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"هیچ رشته منطبقی وجود ندارد"</string>
+    <string name="native_614e83ef17c13f3c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"هیچ گفتگوی منطبقی وجود ندارد"</string>
     <string name="native_6197595503f01ee2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"delete"</string>
     <string name="native_619837a134285528" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"چیدمان: فشرده"</string>
     <string name="native_61ffa9c8c703dd5e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"channels"</string>
@@ -618,14 +606,12 @@
     <string name="native_6657cc73af00feac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"در صورت درخواست، ابزارهای دوربین را مجاز کنید."</string>
     <string name="native_666067dd376e5d45" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مشکلات"</string>
     <string name="native_666c8bc0319f3b54" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"بیدارباش صوتی"</string>
-    <string name="native_66713d713e3a41c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"درخواست جفت‌سازی رد شد."</string>
     <string name="native_66b23bae66fc0d79" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s روز پیش"</string>
     <string name="native_66cf5513b37462be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"roles"</string>
     <string name="native_66d0f523a379b2de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skills"</string>
     <string name="native_66f4804ee23ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"بایگانی"</string>
     <string name="native_66fab2875ee427f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"گره آفلاین است. دوباره متصل شوید و مجدداً تلاش کنید."</string>
     <string name="native_6725e7bbcd28f3a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"سیستم"</string>
-    <string name="native_672f3453e1dd571b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"IP راه دور"</string>
     <string name="native_674b38cae72bb0c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"گروه‌بندی‌نشده"</string>
     <string name="native_674eb55d9c353900" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"جزئیات زمان‌بندی"</string>
     <string name="native_67528858c36397f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"قابلیت‌های تلفن"</string>
@@ -633,11 +619,10 @@
     <string name="native_67b696468610b879" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dashboard"</string>
     <string name="native_67fa416afa64d304" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"چسباندن توکن"</string>
     <string name="native_6827238fea72c88b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ارائه‌دهنده‌ای وجود ندارد"</string>
-    <string name="native_684889f0079cc145" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"اثر انگشت SHA-256"</string>
     <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"هنوز رشته‌ای وجود ندارد"</string>
     <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"میکروفون Bluetooth"</string>
     <string name="native_690dbe9dc0993c42" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"اخیر"</string>
-    <string name="native_6930c8d1fc4f01d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تغییر نام رشته"</string>
+    <string name="native_6930c8d1fc4f01d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تغییر نام گفتگو"</string>
     <string name="native_69384c1c4d99f6eb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"نتیجه تعیین تکلیف نامشخص است. تا زمانی که رکورد Gateway تأیید نشود، اقدامات غیرفعال می‌مانند."</string>
     <string name="native_6940189433657105" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"dialog"</string>
     <string name="native_695c03727ff0251f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"گوش‌دادن به واژه‌های بیدارباش"</string>
@@ -668,7 +653,6 @@
     <string name="native_6d5d9004797377e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مجوزها"</string>
     <string name="native_6d7c95a353d873cd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"برای جست‌وجوی Skills در ClawHub، Gateway را متصل کنید."</string>
     <string name="native_6df1bb18a59ab97d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مهارت"</string>
-    <string name="native_6e0a0b9d8c5ee4d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"شناسه دستگاه"</string>
     <string name="native_6e117ba97cbfb6f0" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway ارائه‌دهنده فعال %1$s را شناسایی نکرد"</string>
     <string name="native_6e293a8c009e0011" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"در انتظار"</string>
     <string name="native_6e2c0963d056e104" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"واژه‌های بیدارباش ذخیره شدند"</string>
@@ -798,7 +782,7 @@
     <string name="native_82990a093599a9bb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s اعمال‌شده"</string>
     <string name="native_8340dad4f3be30a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"هنوز دفترچهٔ رؤیایی وجود ندارد."</string>
     <string name="native_837e39f46163ffb4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تازه‌سازی وظایف پس‌زمینه"</string>
-    <string name="native_838337fd9ab30454" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"رشته‌های اخیر و گام‌های بعدی را خلاصه کنید."</string>
+    <string name="native_838337fd9ab30454" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"رشته‌های اخیر و گام‌های بعدی را خلاصه کن."</string>
     <string name="native_83e2faed20a3cda4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تا زمانی که OpenClaw قابل مشاهده است، روی دستگاه اجرا می‌شود."</string>
     <string name="native_844e5b02f3ef05ca" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s در حال کار است"</string>
     <string name="native_846c75dca0b71591" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
@@ -845,7 +829,6 @@
     <string name="native_8bb7ec15b1e350a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"در حال بازرسی"</string>
     <string name="native_8bf253a125f66985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"برای افزودن Gateway دیگر، کد راه‌اندازی را اسکن یا جای‌گذاری کنید."</string>
     <string name="native_8c4a3896e8f06d27" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مهلت TLS به پایان رسید"</string>
-    <string name="native_8c55387fb6c584c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"دستگاه جفت‌شده حذف شد."</string>
     <string name="native_8c93c68056cde54d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway جفت شد. در حال بررسی تأیید قابلیت گره."</string>
     <string name="native_8ca344247c18317e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"حرکت"</string>
     <string name="native_8cac4b77b9c54695" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"عملیات cron ناموفق بود."</string>
@@ -958,7 +941,7 @@
     <string name="native_9e37aa0704a3cf44" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s نصب شد."</string>
     <string name="native_9e4635769f0aaf0d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gatewayها"</string>
     <string name="native_9e9bef85bb320b81" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"حالت بازارسال"</string>
-    <string name="native_9f6e180ff696bec5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تغییر چیدمان رشته‌ها"</string>
+    <string name="native_9f6e180ff696bec5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تغییر چیدمان گفتگوها"</string>
     <string name="native_9fb7c4ebcbc3e558" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"نقطه پایانی TLS موجود نیست"</string>
     <string name="native_9fe101a0ec7ef416" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway OpenClaw"</string>
     <string name="native_9ffc843f501acdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"راه‌اندازی دستی"</string>
@@ -1038,6 +1021,7 @@
     <string name="native_ad1c341c65f84ede" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"فرمان approve را روی رایانه Gateway اجرا کنید، سپس دوباره بررسی کنید."</string>
     <string name="native_ad1fb9ec0cb3c7a4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"خودکارسازی‌ها"</string>
     <string name="native_adb7eb8a03ad699c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s دقیقه"</string>
+    <string name="native_adca3171c270301a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"این ورود به Gateway می‌تواند گره‌های متصل را فهرست کند، اما نمی‌تواند جفت‌سازی تلفن جدید را تأیید کند. تلفن‌های جدید را از یک نشست مدیر Gateway جفت کنید. تأیید قابلیت گره جداگانه است و همچنان از nodes approve &lt;request id&gt; استفاده می‌کند."</string>
     <string name="native_ade9248e0132b411" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"اعتماد"</string>
     <string name="native_ae27fa789a03c1db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"این کد QR، کد QR راه‌اندازی OpenClaw نیست. با openclaw qr یک کد جدید ایجاد کنید، سپس دوباره امتحان کنید."</string>
     <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"میکروفون ترجیحی در دسترس نیست؛ از مسیریابی خودکار استفاده می‌شود."</string>
@@ -1107,7 +1091,6 @@
     <string name="native_bb4f2558e4333834" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تصویر ویجت در Downloads ذخیره شد"</string>
     <string name="native_bbe5fc3b9ef39f99" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"در حال شروع…"</string>
     <string name="native_bc19cec293228fb8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"خطای کلاینت"</string>
-    <string name="native_bc1c94a6dfce1058" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"پیش از اعطای دسترسی، این دستگاه درخواست‌کننده را بررسی کنید."</string>
     <string name="native_bc6618670f3e8a17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"میکروفون Bluetooth LE"</string>
     <string name="native_bcb06651437caa15" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
     <string name="native_bd08450d63406844" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"اجرای خودکار فعال شد."</string>
@@ -1116,7 +1099,6 @@
     <string name="native_bdc090ec61e3fcfc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"بارگذاری مجدد"</string>
     <string name="native_bdff71b20b9cf392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"جستجوی خودکارسازی‌ها"</string>
     <string name="native_be969becb173e0c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تلفن‌های پیوندشده و میزبان‌های گره پس از جفت‌سازی اینجا نمایش داده می‌شوند."</string>
-    <string name="native_bf1870ff5c6322fb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s: %2$s"</string>
     <string name="native_bf350e6a0ed60b7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"این اجرای خودکار در Gateway تغییر کرده است. پیش از ذخیره مجدد، آخرین نسخه را بررسی کنید."</string>
     <string name="native_bf399ffa03617a96" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"توقف دیکته"</string>
     <string name="native_bf56ee2fe3345ce1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"خوانا"</string>
@@ -1134,13 +1116,12 @@
     <string name="native_c12a06263b75eb23" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"برای بارگذاری جزئیات Skill، Gateway را متصل کنید."</string>
     <string name="native_c156b9eaf502aabc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"شنونده بیدارباش"</string>
     <string name="native_c184b2ada7abc688" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"گسترش پیش‌نمایش پیوند"</string>
-    <string name="native_c18ee03d3906a488" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"پاک کردن جست‌وجوی رشته‌ها"</string>
+    <string name="native_c18ee03d3906a488" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"پاک کردن جستجوی گفتگو"</string>
     <string name="native_c1970bb2cdf299b7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"NULL (ناموفق)"</string>
     <string name="native_c1c1009d3f37ec05" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"به‌روزرسانی"</string>
     <string name="native_c1c224b03cd9bc7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مدیر"</string>
     <string name="native_c1ebc7817870e5be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"نیازمند توجه"</string>
     <string name="native_c22d5e02fbec7d65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"این دستگاه را با Gateway خود جفت کنید تا فقط برای کار واقعی بیدار شود، نمای کلی زنده‌ای از عامل‌ها در دسترس داشته باشید و از چرخه‌های پس‌زمینه‌ای پرمصرف جلوگیری کنید."</string>
-    <string name="native_c25337055464f8d3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"نقش‌ها"</string>
     <string name="native_c253f451bdd56431" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"پاسخ"</string>
     <string name="native_c26225b6c16a4bc7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"فهرست ارائه‌دهندگان"</string>
     <string name="native_c272b225cf5bd643" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"فعال کردن مجوز در تنظیمات"</string>
@@ -1154,7 +1135,6 @@
     <string name="native_c34dd5eb8b0af56e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"کد راه‌اندازی را از کجا دریافت کنم؟"</string>
     <string name="native_c3546b39ecbbed8a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"فعال‌کردن مهارت ممکن نبود."</string>
     <string name="native_c35b21d6ca39aa7c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"pdf"</string>
-    <string name="native_c3812fc4acb861d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"حذف"</string>
     <string name="native_c382566dbe2ea49f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s٪ آنلاین"</string>
     <string name="native_c385951198c45d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"هیچ کانالی وجود ندارد"</string>
     <string name="native_c41ad84496b53420" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"صدای هم‌زمان"</string>
@@ -1183,7 +1163,6 @@
     <string name="native_c6d5ed757b66bfd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"رؤیا"</string>
     <string name="native_c6dd061350fc69b8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"هیچ برنامه‌ای مسدود نشده است. برنامه‌ها می‌توانند ارسال کنند، مگر اینکه مواردی را مسدود کنید."</string>
     <string name="native_c753cdf0c19f1e38" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تشخیص‌دهنده گفتار در دسترس نیست"</string>
-    <string name="native_c78ffe19571018fb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"پلتفرم"</string>
     <string name="native_c7985fa72daa6ea4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway تنظیمات %1$s را برنگرداند"</string>
     <string name="native_c7b6dfd5c3a183c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway فراموش شود؟"</string>
     <string name="native_c7b7b7f01360f6a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"توضیح اختیاری"</string>
@@ -1205,14 +1184,14 @@
     <string name="native_ca7981b46ecf2c17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"خاموش"</string>
     <string name="native_cab94aba84f97f7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تایپوگرافی"</string>
     <string name="native_cae7d57bc067a514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"توقف"</string>
-    <string name="native_cae98462b30650eb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"هنوز رشته منطبقی وجود ندارد."</string>
+    <string name="native_cae98462b30650eb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"هنوز گفتگوی منطبقی وجود ندارد."</string>
     <string name="native_cba62d81f910c7f0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"جفت‌سازی Gateway موفق بود.\nقابلیت‌های گره این تلفن را از طریق رابط کاربری اپراتور تأیید کنید."</string>
     <string name="native_cc4b66e7e22230c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"این Skills نصب شده است، اما در حال حاضر شرایط اجرا را ندارد. برای تغییرات پیکربندی از دسکتاپ یا CLI استفاده کنید."</string>
     <string name="native_cc5f45fb30a26e07" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تشخیص‌دهنده مشغول است"</string>
     <string name="native_cc721e25d73938a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway خانگی"</string>
     <string name="native_cc7a9a5cf8c4bc9d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"فرمان تأیید را در Gateway اجرا کنید"</string>
     <string name="native_cc925e3c97ac7a35" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"پیشنهادهای Skill Workshop بارگیری نشدند."</string>
-    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"خلاصه‌ای از رشته‌های اخیر OpenClaw من ارائه کن و گام‌های بعدی را پیشنهاد بده."</string>
+    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"من را در جریان رشته‌های اخیر OpenClaw بگذار و گام‌های بعدی را پیشنهاد کن."</string>
     <string name="native_ccb4c324f516c633" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"فعلاً نه"</string>
     <string name="native_cced0b0d83a9e400" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw qr"</string>
     <string name="native_cced28c6dc3f99c2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"start"</string>
@@ -1235,7 +1214,7 @@
     <string name="native_ceb6931ea57cc999" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تطبیقی"</string>
     <string name="native_cf0ee3547a4e51a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"به‌زودی"</string>
     <string name="native_d04fc7d7e19702f8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Search"</string>
-    <string name="native_d053ba98d8bbcec1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"گفت‌وگو، صدا، رشته‌ها، ارائه‌دهندگان یا تنظیمات را امتحان کنید."</string>
+    <string name="native_d053ba98d8bbcec1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"گفتگو، صدا، گفتگوها، ارائه‌دهندگان یا تنظیمات را امتحان کنید."</string>
     <string name="native_d056177742e27cf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw فعال"</string>
     <string name="native_d0cda6559bb347db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"navigate"</string>
     <string name="native_d0d0de0039c7990b" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"درخواست‌شده %1$s"</string>
@@ -1246,7 +1225,6 @@
     <string name="native_d17d2d78d76e6a6c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مدل‌ها"</string>
     <string name="native_d19c2dd2fb598b93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw غیرفعال"</string>
     <string name="native_d1a574e23344c407" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"رمز عبور Gateway نامعتبر است"</string>
-    <string name="native_d1af697abaff485f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تأیید تغییر جفت‌سازی دستگاه ممکن نشد. صفحه را تازه‌سازی کنید و دوباره تلاش کنید."</string>
     <string name="native_d1bf045bb524dae5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مشاهده جزئیات"</string>
     <string name="native_d1e9567da9a8a4b0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bash"</string>
     <string name="native_d2089be672953d11" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"توکن"</string>
@@ -1261,7 +1239,6 @@
     <string name="native_d31de1a5c5c8ba2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مرورگر"</string>
     <string name="native_d354ee936f59115e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screen record"</string>
     <string name="native_d3974fd6d3b6c81f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"اجرای در انتظار"</string>
-    <string name="native_d3e1c5f8a6e240fc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مبدأ"</string>
     <string name="native_d3f75e24411053c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"هوش مصنوعی شخصی روی دستگاه‌های شما"</string>
     <string name="native_d406ade2958cb5b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attach"</string>
     <string name="native_d461a493a3753877" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"خودکار"</string>
@@ -1277,7 +1254,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"پروفایل"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"وقتی Gateway شما آن‌ها را گزارش کند، محدودیت‌های ارائه‌دهنده اینجا نمایش داده می‌شوند."</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"۱ مشکل"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"گفتگوهای موجود در «%1$s» حفظ می‌شوند و به بخش بدون گروه بازمی‌گردند."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ایجادشده"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s توکن فعال"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>
@@ -1294,7 +1271,7 @@
     <string name="native_d93e2b7a15efbc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تأیید تعیین تکلیف نشد. صفحه را تازه‌سازی و دوباره تلاش کنید."</string>
     <string name="native_d942f64886578d87" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"import"</string>
     <string name="native_d94cfb21b67ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"این تلفن چگونه برای OpenClaw نمایش داده می‌شود."</string>
-    <string name="native_d96f2b0eab4e67b7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تمرکز روی جست‌وجوی رشته‌ها"</string>
+    <string name="native_d96f2b0eab4e67b7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تمرکز روی جستجوی گفتگو"</string>
     <string name="native_d975ca28a64f8850" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"اتصال Gateway"</string>
     <string name="native_d9be42d9b30ce057" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"خواندن تقویم"</string>
     <string name="native_d9f641e1a02807cb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"نمای کلی هنگام اتصال مجدد و باز شدن این صفحه تازه‌سازی می‌شود."</string>
@@ -1450,7 +1427,6 @@
     <string name="native_f2da2e47cd31a5dd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"این تصویر قابل رمزگشایی نبود."</string>
     <string name="native_f3753c0fe29b88db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway، صدا، اعلان‌ها، حریم خصوصی"</string>
     <string name="native_f386c32c1bf437d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"فایل‌های فضای کاری عامل"</string>
-    <string name="native_f418bf0894a1806a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"این دستگاه دسترسی مورد اعتماد خود به Gateway را از دست خواهد داد."</string>
     <string name="native_f41d9e8b7e09aa24" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"از requestId مربوط به فرمان در انتظار، در فرمان approve استفاده کنید."</string>
     <string name="native_f4830a1dae298044" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"زمان‌بندی"</string>
     <string name="native_f493f0ce7a52a8aa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"محدودیت نرخ"</string>
@@ -1458,7 +1434,6 @@
     <string name="native_f4cc820d308495c4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"بار داده · %1$s"</string>
     <string name="native_f4ccae29e1bb0c20" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"در حال اجرا"</string>
     <string name="native_f4db1e48476f6075" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"پایان"</string>
-    <string name="native_f4e2076014711222" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"استفاده از اعتماد سیستم"</string>
     <string name="native_f4ef7a41caa88dd1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"هیچ ارائه‌دهنده آماده‌ای وجود ندارد"</string>
     <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"میکروفون‌های Bluetooth متصل را در اولویت قرار می‌دهد."</string>
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s برنامه از بازارسال مسدود شده است."</string>
@@ -1486,7 +1461,7 @@
     <string name="native_f8b32f4e92bd84ce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"نصب‌شده"</string>
     <string name="native_f8c2745155505d39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"زمان انتظار برای پاسخ به پایان رسید؛ دوباره تلاش کنید یا صفحه را تازه‌سازی کنید."</string>
     <string name="native_f8cd133f0ea1031b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"یافتن گفت‌وگوهای قبلی"</string>
-    <string name="native_f90f3791049b995d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مرور رشته‌ها"</string>
+    <string name="native_f90f3791049b995d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مرور گفتگوها"</string>
     <string name="native_f92e2ad582c0e13f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"در حال تازه‌سازی"</string>
     <string name="native_f991ae9cb081e1f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"دوربین را باز کنید و کد openclaw qr را در کادر قرار دهید."</string>
     <string name="native_f9ea3f1540eaa584" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"هیچ دستگاهی وجود ندارد"</string>
@@ -1521,8 +1496,8 @@
     <string name="native_ff52188203241c29" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"رمز عبور Gateway پیکربندی نشده است"</string>
     <string name="native_ff716fc4735e067f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تنظیمات دیکته"</string>
     <string name="native_ff9dbbdfb84ddab2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مدل‌های ارائه‌دهنده بارگیری شدند، اما وضعیت آمادگی در دسترس نیست."</string>
-    <string name="native_ffa7aa557b547a79" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"رشته حذف شود؟"</string>
-    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw این تلفن را به یک رابط فرمان همراه و ساده برای رشته‌ها، صدا، ارائه‌دهندگان و Gateway تبدیل می‌کند."</string>
+    <string name="native_ffa7aa557b547a79" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"گفتگو حذف شود؟"</string>
+    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw این تلفن را به یک رابط فرمان موبایل ساده برای رشته‌ها، صدا، ارائه‌دهندگان و Gateway تبدیل می‌کند."</string>
     <string name="native_ffb6f5764bddb68c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ابتدا جدیدترین"</string>
     <string name="native_ffcf16006c652ee3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"چرخه بعدی"</string>
 </resources>

--- a/apps/android/app/src/main/res/values-fa/strings.xml
+++ b/apps/android/app/src/main/res/values-fa/strings.xml
@@ -75,6 +75,7 @@
     <string name="native_0929c9dc7f794852" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"هیچ پیشنهادی نیست"</string>
     <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"رشته اصلی"</string>
     <string name="native_0979c6fdbdca1675" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"باز کردن چت"</string>
+    <string name="native_09ce95090659d069" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"اقدامات جفت‌سازی دستگاه در این نشست Gateway در دسترس نیست. دستور openclaw devices list را روی میزبان Gateway اجرا کنید و درخواست را در آنجا مدیریت کنید. تأیید قابلیت گره جداگانه است و همچنان از nodes approve &lt;request id&gt; استفاده می‌کند."</string>
     <string name="native_0a0b7cf7c428c703" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"درخواست اقدام"</string>
     <string name="native_0a708e7b03aaf1fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list pins"</string>
     <string name="native_0ab0e1629576aecf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"برای بارگذاری پیشنهادهای کارگاه Skill به یک Gateway متصل شوید."</string>
@@ -87,10 +88,12 @@
     <string name="native_0c3845dcd2f0f683" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"برای بارگذاری Markdown این پیشنهاد، آن را بررسی کنید."</string>
     <string name="native_0c3ea4e2f12153e7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw را باز کن و بپرس %1$s"</string>
     <string name="native_0c4d01e81bb3d1fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"استدلال"</string>
+    <string name="native_0c77fe09ab336a3e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"کلاینت"</string>
     <string name="native_0c79a9c222840ed0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"اعمال‌شده"</string>
     <string name="native_0cab1c9617404faf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ویدئو"</string>
     <string name="native_0cf04463c4276a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ارتقایافته"</string>
     <string name="native_0d21bd52022ca7f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"آنلاین"</string>
+    <string name="native_0d5644ff52ce2ba3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"دامنه‌ها"</string>
     <string name="native_0d5efd432e4fedf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ارائه‌دهنده صدای بلادرنگ پیکربندی نشده است."</string>
     <string name="native_0d8ca811c3744a6d" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s · %2$s"</string>
     <string name="native_0db10f2c2f332cd2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"kick"</string>
@@ -138,6 +141,7 @@
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مقصد نشست"</string>
     <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"بررسی Skill در ClawHub"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
+    <string name="native_16a5b7ad567a8093" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"درخواست جفت‌سازی این دستگاه رد شود؟"</string>
     <string name="native_16b1a05e1d987ed1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"میکروفون ترجیحی"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"میزبان گره"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"سطح"</string>
@@ -183,6 +187,7 @@
     <string name="native_1d91629837639a5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"این خودکارسازی هنگام ویرایش شما تغییر کرده است. پیش از ذخیره، آن را به آخرین نسخه Gateway بازگردانید."</string>
     <string name="native_1dbf9d5979606697" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"پس از اتصال، Gateway می‌تواند به‌جای حفظ یک نشست همیشه‌فعال، گوشی را با یک اعلان بی‌صدا بیدار کند."</string>
     <string name="native_1e432ea5425e4a3a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"حالت بیدارباش"</string>
+    <string name="native_1e595a107c78b957" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"دستگاه جفت‌شده حذف شود؟"</string>
     <string name="native_1e955a58278623a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"متن رویداد سیستم"</string>
     <string name="native_1ea44149be42d970" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تصویر ویجت کپی نشد"</string>
     <string name="native_1ea442a134b2a184" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"خیر"</string>
@@ -197,6 +202,7 @@
     <string name="native_2065cc867eba1b39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"پیکربندی مدل ارائه‌دهنده بارگیری نشد."</string>
     <string name="native_207ccb22d618db05" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s برنامه مجاز به بازارسال است."</string>
     <string name="native_209b9e597963e7e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"راه‌اندازی صدا"</string>
+    <string name="native_211988ba9dd0570a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"درخواست جفت‌سازی رد شود؟"</string>
     <string name="native_2132066dc9475cb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"This skill is installed but not available to the current agent. Agent filters stay on desktop or CLI."</string>
     <string name="native_21378545892f1fe2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ناشر"</string>
     <string name="native_214d4932fc767e8f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">" · گفت‌وگو: در حال صحبت"</string>
@@ -238,6 +244,7 @@
     <string name="native_2682bd813a3bccbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"کد راه‌اندازی را از openclaw qr وارد کنید."</string>
     <string name="native_268f14bbfe119c1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"عیب‌یابی"</string>
     <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"این کار رشته و رونوشت آن را برای همیشه حذف می‌کند."</string>
+    <string name="native_26e47d73a55d7fa7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"دستگاه تأیید شد."</string>
     <string name="native_26f0dd993530eb2d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تلاش مجدد به‌صورت خودکار"</string>
     <string name="native_270ff82f36da987f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تصویر ویجت کپی شد"</string>
     <string name="native_2728740a95d465c6" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s نقش"</string>
@@ -346,6 +353,7 @@
     <string name="native_381428f5f251a764" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Conversation Send"</string>
     <string name="native_3824a9f4dafe92c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"بوم"</string>
     <string name="native_384ae4ab1a2830f9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"۱ ارائه‌دهنده"</string>
+    <string name="native_385001409de8562a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"گواهی Gateway به‌طور خودکار قابل خواندن نبود. اثر انگشت SHA-256 دریافت‌شده در میزبان Gateway را جای‌گذاری کنید."</string>
     <string name="native_387b2569e440838c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ارسال ناموفق بود: %1$s"</string>
     <string name="native_3892e10346fd2012" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"پل ارتباطی"</string>
     <string name="native_38d198cd5303680f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"خطای تحویل"</string>
@@ -403,6 +411,7 @@
     <string name="native_429f6057535c1ea3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sub-agent"</string>
     <string name="native_42e3a99c21767def" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"در انتظار تأیید دستگاه"</string>
     <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"در حال بارگذاری رشته"</string>
+    <string name="native_430df68ec29a85a2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"این Gateway اکنون گواهی‌ای ارائه می‌کند که مورد اعتماد این دستگاه است."</string>
     <string name="native_43905968a540af6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"میلی‌ثانیه پراکندگی"</string>
     <string name="native_43988c156beabf7d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"event create"</string>
     <string name="native_43cc23fa52b87b4c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"سند"</string>
@@ -412,7 +421,7 @@
     <string name="native_4441146b0fe1d5c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screenshot"</string>
     <string name="native_4481c2190a1b4bca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"عبارت cron، مثلاً 0 9 * * *"</string>
     <string name="native_4499e7b7e1c9ddbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"بازگشت به صدا"</string>
-    <string name="native_449f5a775762cdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"گفتگو"</string>
+    <string name="native_449f5a775762cdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"صحبت"</string>
     <string name="native_45a64dc17588f2ca" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s آنلاین"</string>
     <string name="native_45a8847c4a6b2c81" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s برنامه مجاز به بازارسال."</string>
     <string name="native_460b3a7da007b7af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"گفت‌وگو"</string>
@@ -464,6 +473,7 @@
     <string name="native_4e8c72cab82e0711" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"پیکربندی اجرای خودکار نامعتبر است."</string>
     <string name="native_4ec30e9d85725d41" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"فهرست مجاز"</string>
     <string name="native_4ed379d418bb8629" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"groups"</string>
+    <string name="native_4ee252fb736effa2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"کلید عمومی"</string>
     <string name="native_4efca0d10c5feb8e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"درباره"</string>
     <string name="native_4f1bc100d1dccc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"هیچ کد QR راه‌اندازی در این تصویر پیدا نشد. کد QR ایجادشده با openclaw qr را انتخاب کنید، یا کد راه‌اندازی را به‌صورت دستی وارد کنید."</string>
     <string name="native_4fe3cdd404ea0290" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"permissions"</string>
@@ -550,6 +560,7 @@
     <string name="native_5c0c8c9aa658f4a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OPENCLAW"</string>
     <string name="native_5c1acea9c9b0e704" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Fetch"</string>
     <string name="native_5c39123805ffb4e2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"درخواست"</string>
+    <string name="native_5c944156b5353428" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"دستگاه تأیید شود؟"</string>
     <string name="native_5d410adb9576e266" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s و اطلاعات ورود ذخیره‌شده آن از این تلفن حذف شوند؟"</string>
     <string name="native_5d6c41a67139ee26" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"کد QR به یک gateway راه‌دور ناامن اشاره دارد. %1$s %2$s"</string>
     <string name="native_5d6cbac59f87e78d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"سطح صفحه آماده است"</string>
@@ -567,6 +578,7 @@
     <string name="native_5fa1d457ddfcd26c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"rename group"</string>
     <string name="native_5fa7aac5375c5815" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"آماده"</string>
     <string name="native_5fc1927ca948f31c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"دفترچه منتظر نخستین ورودی خود است."</string>
+    <string name="native_6007acbe30b2cd98" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تأیید کردن"</string>
     <string name="native_600c9c27960112a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"صفحه زنده"</string>
     <string name="native_6030d1f6340776d2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"اجرای خودکار در حال حاضر فعال است."</string>
     <string name="native_604e6d6faf8d0295" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"این خودکارسازی پس از یک اجرای یک‌باره موفق حذف شود."</string>
@@ -606,12 +618,14 @@
     <string name="native_6657cc73af00feac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"در صورت درخواست، ابزارهای دوربین را مجاز کنید."</string>
     <string name="native_666067dd376e5d45" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مشکلات"</string>
     <string name="native_666c8bc0319f3b54" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"بیدارباش صوتی"</string>
+    <string name="native_66713d713e3a41c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"درخواست جفت‌سازی رد شد."</string>
     <string name="native_66b23bae66fc0d79" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s روز پیش"</string>
     <string name="native_66cf5513b37462be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"roles"</string>
     <string name="native_66d0f523a379b2de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skills"</string>
     <string name="native_66f4804ee23ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"بایگانی"</string>
     <string name="native_66fab2875ee427f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"گره آفلاین است. دوباره متصل شوید و مجدداً تلاش کنید."</string>
     <string name="native_6725e7bbcd28f3a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"سیستم"</string>
+    <string name="native_672f3453e1dd571b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"IP راه دور"</string>
     <string name="native_674b38cae72bb0c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"گروه‌بندی‌نشده"</string>
     <string name="native_674eb55d9c353900" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"جزئیات زمان‌بندی"</string>
     <string name="native_67528858c36397f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"قابلیت‌های تلفن"</string>
@@ -619,6 +633,7 @@
     <string name="native_67b696468610b879" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dashboard"</string>
     <string name="native_67fa416afa64d304" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"چسباندن توکن"</string>
     <string name="native_6827238fea72c88b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ارائه‌دهنده‌ای وجود ندارد"</string>
+    <string name="native_684889f0079cc145" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"اثر انگشت SHA-256"</string>
     <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"هنوز رشته‌ای وجود ندارد"</string>
     <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"میکروفون Bluetooth"</string>
     <string name="native_690dbe9dc0993c42" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"اخیر"</string>
@@ -653,6 +668,7 @@
     <string name="native_6d5d9004797377e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مجوزها"</string>
     <string name="native_6d7c95a353d873cd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"برای جست‌وجوی Skills در ClawHub، Gateway را متصل کنید."</string>
     <string name="native_6df1bb18a59ab97d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مهارت"</string>
+    <string name="native_6e0a0b9d8c5ee4d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"شناسه دستگاه"</string>
     <string name="native_6e117ba97cbfb6f0" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway ارائه‌دهنده فعال %1$s را شناسایی نکرد"</string>
     <string name="native_6e293a8c009e0011" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"در انتظار"</string>
     <string name="native_6e2c0963d056e104" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"واژه‌های بیدارباش ذخیره شدند"</string>
@@ -829,6 +845,7 @@
     <string name="native_8bb7ec15b1e350a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"در حال بازرسی"</string>
     <string name="native_8bf253a125f66985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"برای افزودن Gateway دیگر، کد راه‌اندازی را اسکن یا جای‌گذاری کنید."</string>
     <string name="native_8c4a3896e8f06d27" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مهلت TLS به پایان رسید"</string>
+    <string name="native_8c55387fb6c584c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"دستگاه جفت‌شده حذف شد."</string>
     <string name="native_8c93c68056cde54d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway جفت شد. در حال بررسی تأیید قابلیت گره."</string>
     <string name="native_8ca344247c18317e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"حرکت"</string>
     <string name="native_8cac4b77b9c54695" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"عملیات cron ناموفق بود."</string>
@@ -1021,7 +1038,6 @@
     <string name="native_ad1c341c65f84ede" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"فرمان approve را روی رایانه Gateway اجرا کنید، سپس دوباره بررسی کنید."</string>
     <string name="native_ad1fb9ec0cb3c7a4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"خودکارسازی‌ها"</string>
     <string name="native_adb7eb8a03ad699c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s دقیقه"</string>
-    <string name="native_adca3171c270301a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"این ورود به Gateway می‌تواند گره‌های متصل را فهرست کند، اما نمی‌تواند جفت‌سازی تلفن جدید را تأیید کند. تلفن‌های جدید را از یک نشست مدیر Gateway جفت کنید. تأیید قابلیت گره جداگانه است و همچنان از nodes approve &lt;request id&gt; استفاده می‌کند."</string>
     <string name="native_ade9248e0132b411" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"اعتماد"</string>
     <string name="native_ae27fa789a03c1db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"این کد QR، کد QR راه‌اندازی OpenClaw نیست. با openclaw qr یک کد جدید ایجاد کنید، سپس دوباره امتحان کنید."</string>
     <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"میکروفون ترجیحی در دسترس نیست؛ از مسیریابی خودکار استفاده می‌شود."</string>
@@ -1091,6 +1107,7 @@
     <string name="native_bb4f2558e4333834" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تصویر ویجت در Downloads ذخیره شد"</string>
     <string name="native_bbe5fc3b9ef39f99" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"در حال شروع…"</string>
     <string name="native_bc19cec293228fb8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"خطای کلاینت"</string>
+    <string name="native_bc1c94a6dfce1058" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"پیش از اعطای دسترسی، این دستگاه درخواست‌کننده را بررسی کنید."</string>
     <string name="native_bc6618670f3e8a17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"میکروفون Bluetooth LE"</string>
     <string name="native_bcb06651437caa15" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
     <string name="native_bd08450d63406844" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"اجرای خودکار فعال شد."</string>
@@ -1099,6 +1116,7 @@
     <string name="native_bdc090ec61e3fcfc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"بارگذاری مجدد"</string>
     <string name="native_bdff71b20b9cf392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"جستجوی خودکارسازی‌ها"</string>
     <string name="native_be969becb173e0c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تلفن‌های پیوندشده و میزبان‌های گره پس از جفت‌سازی اینجا نمایش داده می‌شوند."</string>
+    <string name="native_bf1870ff5c6322fb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s: %2$s"</string>
     <string name="native_bf350e6a0ed60b7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"این اجرای خودکار در Gateway تغییر کرده است. پیش از ذخیره مجدد، آخرین نسخه را بررسی کنید."</string>
     <string name="native_bf399ffa03617a96" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"توقف دیکته"</string>
     <string name="native_bf56ee2fe3345ce1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"خوانا"</string>
@@ -1122,6 +1140,7 @@
     <string name="native_c1c224b03cd9bc7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مدیر"</string>
     <string name="native_c1ebc7817870e5be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"نیازمند توجه"</string>
     <string name="native_c22d5e02fbec7d65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"این دستگاه را با Gateway خود جفت کنید تا فقط برای کار واقعی بیدار شود، نمای کلی زنده‌ای از عامل‌ها در دسترس داشته باشید و از چرخه‌های پس‌زمینه‌ای پرمصرف جلوگیری کنید."</string>
+    <string name="native_c25337055464f8d3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"نقش‌ها"</string>
     <string name="native_c253f451bdd56431" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"پاسخ"</string>
     <string name="native_c26225b6c16a4bc7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"فهرست ارائه‌دهندگان"</string>
     <string name="native_c272b225cf5bd643" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"فعال کردن مجوز در تنظیمات"</string>
@@ -1135,6 +1154,7 @@
     <string name="native_c34dd5eb8b0af56e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"کد راه‌اندازی را از کجا دریافت کنم؟"</string>
     <string name="native_c3546b39ecbbed8a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"فعال‌کردن مهارت ممکن نبود."</string>
     <string name="native_c35b21d6ca39aa7c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"pdf"</string>
+    <string name="native_c3812fc4acb861d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"حذف"</string>
     <string name="native_c382566dbe2ea49f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s٪ آنلاین"</string>
     <string name="native_c385951198c45d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"هیچ کانالی وجود ندارد"</string>
     <string name="native_c41ad84496b53420" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"صدای هم‌زمان"</string>
@@ -1163,6 +1183,7 @@
     <string name="native_c6d5ed757b66bfd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"رؤیا"</string>
     <string name="native_c6dd061350fc69b8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"هیچ برنامه‌ای مسدود نشده است. برنامه‌ها می‌توانند ارسال کنند، مگر اینکه مواردی را مسدود کنید."</string>
     <string name="native_c753cdf0c19f1e38" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تشخیص‌دهنده گفتار در دسترس نیست"</string>
+    <string name="native_c78ffe19571018fb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"پلتفرم"</string>
     <string name="native_c7985fa72daa6ea4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway تنظیمات %1$s را برنگرداند"</string>
     <string name="native_c7b6dfd5c3a183c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway فراموش شود؟"</string>
     <string name="native_c7b7b7f01360f6a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"توضیح اختیاری"</string>
@@ -1225,6 +1246,7 @@
     <string name="native_d17d2d78d76e6a6c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مدل‌ها"</string>
     <string name="native_d19c2dd2fb598b93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw غیرفعال"</string>
     <string name="native_d1a574e23344c407" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"رمز عبور Gateway نامعتبر است"</string>
+    <string name="native_d1af697abaff485f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تأیید تغییر جفت‌سازی دستگاه ممکن نشد. صفحه را تازه‌سازی کنید و دوباره تلاش کنید."</string>
     <string name="native_d1bf045bb524dae5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مشاهده جزئیات"</string>
     <string name="native_d1e9567da9a8a4b0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bash"</string>
     <string name="native_d2089be672953d11" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"توکن"</string>
@@ -1239,6 +1261,7 @@
     <string name="native_d31de1a5c5c8ba2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مرورگر"</string>
     <string name="native_d354ee936f59115e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screen record"</string>
     <string name="native_d3974fd6d3b6c81f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"اجرای در انتظار"</string>
+    <string name="native_d3e1c5f8a6e240fc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"مبدأ"</string>
     <string name="native_d3f75e24411053c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"هوش مصنوعی شخصی روی دستگاه‌های شما"</string>
     <string name="native_d406ade2958cb5b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attach"</string>
     <string name="native_d461a493a3753877" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"خودکار"</string>
@@ -1427,6 +1450,7 @@
     <string name="native_f2da2e47cd31a5dd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"این تصویر قابل رمزگشایی نبود."</string>
     <string name="native_f3753c0fe29b88db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway، صدا، اعلان‌ها، حریم خصوصی"</string>
     <string name="native_f386c32c1bf437d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"فایل‌های فضای کاری عامل"</string>
+    <string name="native_f418bf0894a1806a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"این دستگاه دسترسی مورد اعتماد خود به Gateway را از دست خواهد داد."</string>
     <string name="native_f41d9e8b7e09aa24" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"از requestId مربوط به فرمان در انتظار، در فرمان approve استفاده کنید."</string>
     <string name="native_f4830a1dae298044" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"زمان‌بندی"</string>
     <string name="native_f493f0ce7a52a8aa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"محدودیت نرخ"</string>
@@ -1434,6 +1458,7 @@
     <string name="native_f4cc820d308495c4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"بار داده · %1$s"</string>
     <string name="native_f4ccae29e1bb0c20" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"در حال اجرا"</string>
     <string name="native_f4db1e48476f6075" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"پایان"</string>
+    <string name="native_f4e2076014711222" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"استفاده از اعتماد سیستم"</string>
     <string name="native_f4ef7a41caa88dd1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"هیچ ارائه‌دهنده آماده‌ای وجود ندارد"</string>
     <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"میکروفون‌های Bluetooth متصل را در اولویت قرار می‌دهد."</string>
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s برنامه از بازارسال مسدود شده است."</string>

--- a/apps/android/app/src/main/res/values-fr/strings.xml
+++ b/apps/android/app/src/main/res/values-fr/strings.xml
@@ -494,7 +494,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Livraison"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Couper le haut-parleur"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ouverture de la connexion à la Gateway"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Surveillance · %1$s fils"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"L’exécution de l’automatisation est terminée."</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aucune application correspondante."</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Envoyer au chat"</string>
@@ -1277,7 +1277,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Profil"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Les limites du fournisseur s’afficheront ici lorsque votre Gateway les signalera."</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 problème"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Les fils de \"%1$s\" sont conservés et replacés dans Non groupés."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Créé"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s jetons actifs"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>

--- a/apps/android/app/src/main/res/values-fr/strings.xml
+++ b/apps/android/app/src/main/res/values-fr/strings.xml
@@ -75,7 +75,6 @@
     <string name="native_0929c9dc7f794852" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aucune proposition"</string>
     <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Fil principal"</string>
     <string name="native_0979c6fdbdca1675" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ouvrir le chat"</string>
-    <string name="native_09ce95090659d069" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Les actions d’association d’appareils ne sont pas disponibles dans cette session Gateway. Exécutez openclaw devices list sur l’hôte Gateway et gérez-y la demande. L’approbation des capacités du nœud est distincte et utilise toujours nodes approve &lt;request id&gt;."</string>
     <string name="native_0a0b7cf7c428c703" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Demande d’action"</string>
     <string name="native_0a708e7b03aaf1fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list pins"</string>
     <string name="native_0ab0e1629576aecf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Connectez-vous à un Gateway pour charger les propositions de l\'Atelier de Skills."</string>
@@ -88,12 +87,10 @@
     <string name="native_0c3845dcd2f0f683" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Inspectez cette proposition pour charger son contenu Markdown."</string>
     <string name="native_0c3ea4e2f12153e7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ouvrir OpenClaw et demander %1$s"</string>
     <string name="native_0c4d01e81bb3d1fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"raisonnement"</string>
-    <string name="native_0c77fe09ab336a3e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Client"</string>
     <string name="native_0c79a9c222840ed0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Appliqué"</string>
     <string name="native_0cab1c9617404faf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"vidéo"</string>
     <string name="native_0cf04463c4276a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Promu"</string>
     <string name="native_0d21bd52022ca7f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"En ligne"</string>
-    <string name="native_0d5644ff52ce2ba3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Portées"</string>
     <string name="native_0d5efd432e4fedf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Le fournisseur vocal en temps réel n’est pas configuré."</string>
     <string name="native_0d8ca811c3744a6d" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s · %2$s"</string>
     <string name="native_0db10f2c2f332cd2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"kick"</string>
@@ -141,7 +138,6 @@
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cible de session"</string>
     <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Examiner la skill ClawHub"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
-    <string name="native_16a5b7ad567a8093" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rejeter la demande d’appairage de cet appareil ?"</string>
     <string name="native_16b1a05e1d987ed1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Microphone préféré"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Hôte du nœud"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Niveau"</string>
@@ -187,7 +183,6 @@
     <string name="native_1d91629837639a5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cette automatisation a été modifiée pendant que vous la modifiiez. Rétablissez la dernière version du Gateway avant d’enregistrer."</string>
     <string name="native_1dbf9d5979606697" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Une fois connecté, le Gateway peut réveiller le téléphone à l’aide d’une notification push silencieuse au lieu de maintenir une session toujours active."</string>
     <string name="native_1e432ea5425e4a3a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Mode de réveil"</string>
-    <string name="native_1e595a107c78b957" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Supprimer l’appareil appairé ?"</string>
     <string name="native_1e955a58278623a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Texte de l\'événement système"</string>
     <string name="native_1ea44149be42d970" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Impossible de copier l’image du widget"</string>
     <string name="native_1ea442a134b2a184" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Non"</string>
@@ -202,7 +197,6 @@
     <string name="native_2065cc867eba1b39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Impossible de charger la configuration des modèles du fournisseur."</string>
     <string name="native_207ccb22d618db05" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s application autorisée à transférer."</string>
     <string name="native_209b9e597963e7e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Configuration vocale"</string>
-    <string name="native_211988ba9dd0570a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rejeter la demande d’appairage ?"</string>
     <string name="native_2132066dc9475cb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"This skill is installed but not available to the current agent. Agent filters stay on desktop or CLI."</string>
     <string name="native_21378545892f1fe2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Éditeur"</string>
     <string name="native_214d4932fc767e8f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">" · Conversation : parole"</string>
@@ -243,8 +237,7 @@
     <string name="native_262c897a1f408b0b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Connectez-vous à votre Gateway"</string>
     <string name="native_2682bd813a3bccbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Saisissez le code de configuration fourni par openclaw qr."</string>
     <string name="native_268f14bbfe119c1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Diagnostics"</string>
-    <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cette action supprime définitivement la discussion et sa transcription."</string>
-    <string name="native_26e47d73a55d7fa7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Appareil approuvé."</string>
+    <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cette action supprime définitivement le fil et sa transcription."</string>
     <string name="native_26f0dd993530eb2d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nouvelle tentative automatique"</string>
     <string name="native_270ff82f36da987f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Image du widget copiée"</string>
     <string name="native_2728740a95d465c6" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s rôles"</string>
@@ -283,7 +276,7 @@
     <string name="native_2cd62f7a670b2819" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Fil OpenClaw"</string>
     <string name="native_2d4dfe885f84629e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Autoriser l’accès à la photothèque."</string>
     <string name="native_2d6416405eb44982" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Une réponse précédente a déjà résolu cette approbation."</string>
-    <string name="native_2d85de9d56c226e4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aucun fil de discussion récent"</string>
+    <string name="native_2d85de9d56c226e4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aucun fil récent"</string>
     <string name="native_2df01a03ff43400b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aucun résultat"</string>
     <string name="native_2df30b117ad829ab" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Lire les notifications des applications sélectionnées"</string>
     <string name="native_2e0078a8322d6f1f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Disponibilité inconnue"</string>
@@ -345,7 +338,7 @@
     <string name="native_36c725ddb20f8bd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Configuration du fournisseur de conversation"</string>
     <string name="native_36d88ed6cc91d2b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Music Generation"</string>
     <string name="native_36e8d5e94219dc37" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Paramètres de Talk"</string>
-    <string name="native_36f1fac278711470" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Surveillance · 1 fil"</string>
+    <string name="native_36f1fac278711470" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Surveillance · 1 fil de discussion"</string>
     <string name="native_37053dc1f680546b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Texte de la charge utile"</string>
     <string name="native_37582309e7a1dbe5" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Approbation %1$s"</string>
     <string name="native_379ce0aacf46c35f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway n’a pas renvoyé l’état de préparation de %1$s"</string>
@@ -353,7 +346,6 @@
     <string name="native_381428f5f251a764" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Conversation Send"</string>
     <string name="native_3824a9f4dafe92c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Canevas"</string>
     <string name="native_384ae4ab1a2830f9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 fournisseur"</string>
-    <string name="native_385001409de8562a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Le certificat du Gateway n’a pas pu être lu automatiquement. Collez l’empreinte SHA-256 obtenue sur l’hôte du Gateway."</string>
     <string name="native_387b2569e440838c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Échec de l’envoi : %1$s"</string>
     <string name="native_3892e10346fd2012" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Pont"</string>
     <string name="native_38d198cd5303680f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Erreur de livraison"</string>
@@ -383,7 +375,7 @@
     <string name="native_3da4811eafea080a" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s://%2$s:%3$s"</string>
     <string name="native_3de3d401128d4395" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Impossible de charger les détails de l\'approbation. Actualisez et réessayez."</string>
     <string name="native_3e398e6fb979557a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tool Call"</string>
-    <string name="native_3e42e385075b9b56" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Fils"</string>
+    <string name="native_3e42e385075b9b56" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Fils de discussion"</string>
     <string name="native_3f00927a719345ed" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Write"</string>
     <string name="native_3f25ccebfa99dcf3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Commencez par une invite ou utilisez la voix."</string>
     <string name="native_3f39d5c348e5b79d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"J"</string>
@@ -410,8 +402,7 @@
     <string name="native_4287d54ad5e78985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Travail OpenClaw planifié depuis votre Gateway."</string>
     <string name="native_429f6057535c1ea3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sub-agent"</string>
     <string name="native_42e3a99c21767def" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"En attente de l’approbation de l’appareil"</string>
-    <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Chargement du fil"</string>
-    <string name="native_430df68ec29a85a2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ce Gateway présente désormais un certificat approuvé par cet appareil."</string>
+    <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Chargement du fil de discussion"</string>
     <string name="native_43905968a540af6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Décalage ms"</string>
     <string name="native_43988c156beabf7d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"event create"</string>
     <string name="native_43cc23fa52b87b4c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"document"</string>
@@ -473,7 +464,6 @@
     <string name="native_4e8c72cab82e0711" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"La configuration de l’automatisation n’est pas valide."</string>
     <string name="native_4ec30e9d85725d41" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Liste d’autorisation"</string>
     <string name="native_4ed379d418bb8629" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"groups"</string>
-    <string name="native_4ee252fb736effa2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Clé publique"</string>
     <string name="native_4efca0d10c5feb8e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"À propos"</string>
     <string name="native_4f1bc100d1dccc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aucun code QR de configuration n’a été trouvé dans cette image. Choisissez le code QR généré par openclaw qr ou saisissez manuellement le code de configuration."</string>
     <string name="native_4fe3cdd404ea0290" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"permissions"</string>
@@ -494,7 +484,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Livraison"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Couper le haut-parleur"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ouverture de la connexion à la Gateway"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Surveillance · %1$s fils de discussion"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"L’exécution de l’automatisation est terminée."</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aucune application correspondante."</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Envoyer au chat"</string>
@@ -560,7 +550,6 @@
     <string name="native_5c0c8c9aa658f4a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OPENCLAW"</string>
     <string name="native_5c1acea9c9b0e704" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Fetch"</string>
     <string name="native_5c39123805ffb4e2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Invite"</string>
-    <string name="native_5c944156b5353428" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Approuver l’appareil ?"</string>
     <string name="native_5d410adb9576e266" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Supprimer %1$s et ses identifiants enregistrés de ce téléphone ?"</string>
     <string name="native_5d6c41a67139ee26" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Le code QR pointe vers une Gateway distante non sécurisée. %1$s %2$s"</string>
     <string name="native_5d6cbac59f87e78d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Surface d’écran prête"</string>
@@ -578,7 +567,6 @@
     <string name="native_5fa1d457ddfcd26c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"rename group"</string>
     <string name="native_5fa7aac5375c5815" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Prêt"</string>
     <string name="native_5fc1927ca948f31c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Le journal attend sa première entrée."</string>
-    <string name="native_6007acbe30b2cd98" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Approuver"</string>
     <string name="native_600c9c27960112a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Page en direct"</string>
     <string name="native_6030d1f6340776d2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"L’automatisation est déjà en cours d’exécution."</string>
     <string name="native_604e6d6faf8d0295" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Supprimer cette automatisation après une exécution ponctuelle réussie."</string>
@@ -618,14 +606,12 @@
     <string name="native_6657cc73af00feac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Autoriser les outils de caméra sur demande."</string>
     <string name="native_666067dd376e5d45" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Problèmes"</string>
     <string name="native_666c8bc0319f3b54" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Réveil vocal"</string>
-    <string name="native_66713d713e3a41c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Demande d’appairage rejetée."</string>
     <string name="native_66b23bae66fc0d79" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"il y a %1$s j"</string>
     <string name="native_66cf5513b37462be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"roles"</string>
     <string name="native_66d0f523a379b2de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skills"</string>
     <string name="native_66f4804ee23ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Archiver"</string>
     <string name="native_66fab2875ee427f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nœud hors ligne. Reconnectez-vous et réessayez."</string>
     <string name="native_6725e7bbcd28f3a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Système"</string>
-    <string name="native_672f3453e1dd571b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Adresse IP distante"</string>
     <string name="native_674b38cae72bb0c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Non regroupé"</string>
     <string name="native_674eb55d9c353900" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Détails de la planification"</string>
     <string name="native_67528858c36397f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Fonctionnalités du téléphone"</string>
@@ -633,7 +619,6 @@
     <string name="native_67b696468610b879" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dashboard"</string>
     <string name="native_67fa416afa64d304" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Coller le jeton"</string>
     <string name="native_6827238fea72c88b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aucun fournisseur"</string>
-    <string name="native_684889f0079cc145" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Empreinte SHA-256"</string>
     <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aucun fil pour le moment"</string>
     <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Microphone Bluetooth"</string>
     <string name="native_690dbe9dc0993c42" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Récent"</string>
@@ -668,7 +653,6 @@
     <string name="native_6d5d9004797377e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Licences"</string>
     <string name="native_6d7c95a353d873cd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Connectez le Gateway pour rechercher des Skills ClawHub."</string>
     <string name="native_6df1bb18a59ab97d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skill"</string>
-    <string name="native_6e0a0b9d8c5ee4d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ID de l’appareil"</string>
     <string name="native_6e117ba97cbfb6f0" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway n’a pas identifié le fournisseur %1$s actif"</string>
     <string name="native_6e293a8c009e0011" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"En attente"</string>
     <string name="native_6e2c0963d056e104" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Mots d’activation enregistrés"</string>
@@ -798,7 +782,7 @@
     <string name="native_82990a093599a9bb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s appliqués"</string>
     <string name="native_8340dad4f3be30a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aucun journal de rêves pour le moment."</string>
     <string name="native_837e39f46163ffb4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Actualiser les tâches en arrière-plan"</string>
-    <string name="native_838337fd9ab30454" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Résumez les fils récents et les prochaines étapes."</string>
+    <string name="native_838337fd9ab30454" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Résumer les fils de discussion récents et les prochaines étapes."</string>
     <string name="native_83e2faed20a3cda4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"S’exécute sur l’appareil tant qu’OpenClaw est visible."</string>
     <string name="native_844e5b02f3ef05ca" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s travaille"</string>
     <string name="native_846c75dca0b71591" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
@@ -845,7 +829,6 @@
     <string name="native_8bb7ec15b1e350a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Inspection"</string>
     <string name="native_8bf253a125f66985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Scannez ou collez un code de configuration pour ajouter un autre Gateway."</string>
     <string name="native_8c4a3896e8f06d27" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Délai d’attente TLS dépassé"</string>
-    <string name="native_8c55387fb6c584c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Appareil appairé supprimé."</string>
     <string name="native_8c93c68056cde54d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway appairé. Vérification de l’approbation des fonctionnalités du nœud."</string>
     <string name="native_8ca344247c18317e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Mouvement"</string>
     <string name="native_8cac4b77b9c54695" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Échec de l’action cron."</string>
@@ -869,7 +852,7 @@
     <string name="native_8f54b0d1e30092d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Note vocale"</string>
     <string name="native_8fa196125b734940" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rien ne nécessite votre attention"</string>
     <string name="native_8fce9ec6fd5432df" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw a besoin des autorisations %1$s pour continuer."</string>
-    <string name="native_8fe42acb8573244e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Microphone de casque filaire"</string>
+    <string name="native_8fe42acb8573244e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Microphone du casque filaire"</string>
     <string name="native_906115657390f367" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Distribué"</string>
     <string name="native_9071738f145962a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Échéance"</string>
     <string name="native_90bf81305006e6ed" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Les détails du Skill ne sont pas disponibles dans l’état actuel des Skills."</string>
@@ -1038,6 +1021,7 @@
     <string name="native_ad1c341c65f84ede" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Exécutez la commande d’approbation sur l’ordinateur Gateway, puis vérifiez à nouveau."</string>
     <string name="native_ad1fb9ec0cb3c7a4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatisations"</string>
     <string name="native_adb7eb8a03ad699c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s min"</string>
+    <string name="native_adca3171c270301a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cette connexion au Gateway permet d’afficher la liste des nœuds connectés, mais pas d’approuver l’association d’un nouveau téléphone. Associez les nouveaux téléphones depuis une session administrateur du Gateway. L’approbation des capacités des nœuds est distincte et utilise toujours nodes approve &lt;request id&gt;."</string>
     <string name="native_ade9248e0132b411" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Faire confiance"</string>
     <string name="native_ae27fa789a03c1db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ce code QR n’est pas un code QR de configuration OpenClaw. Générez un nouveau code avec openclaw qr, puis réessayez."</string>
     <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Le microphone préféré n’est pas disponible ; utilisation du routage automatique."</string>
@@ -1076,7 +1060,7 @@
     <string name="native_b4aca584eecea590" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Impossible de charger les détails de la tâche"</string>
     <string name="native_b51702b087112113" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Message de l\'agent"</string>
     <string name="native_b538b9d40695a6fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Le Gateway requiert l’identité de cet appareil. Authentifiez-vous à nouveau ou réinitialisez cette connexion au Gateway."</string>
-    <string name="native_b53b35163f7588c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Session suivante"</string>
+    <string name="native_b53b35163f7588c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Prochaine session"</string>
     <string name="native_b55dae19fcb48a4d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sécurité de la connexion"</string>
     <string name="native_b5a229ac8becc603" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Site web"</string>
     <string name="native_b5af0517c02601fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Connectez le Gateway pour charger les demandes d’approbation dans l’application."</string>
@@ -1107,7 +1091,6 @@
     <string name="native_bb4f2558e4333834" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Image du widget enregistrée dans Téléchargements"</string>
     <string name="native_bbe5fc3b9ef39f99" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Démarrage…"</string>
     <string name="native_bc19cec293228fb8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Erreur du client"</string>
-    <string name="native_bc1c94a6dfce1058" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Vérifiez l’appareil à l’origine de cette demande avant d’accorder l’accès."</string>
     <string name="native_bc6618670f3e8a17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Microphone Bluetooth LE"</string>
     <string name="native_bcb06651437caa15" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
     <string name="native_bd08450d63406844" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatisation activée."</string>
@@ -1116,7 +1099,6 @@
     <string name="native_bdc090ec61e3fcfc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Recharger"</string>
     <string name="native_bdff71b20b9cf392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rechercher des automatisations"</string>
     <string name="native_be969becb173e0c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Les téléphones liés et les hôtes de nœud apparaîtront ici après l’association."</string>
-    <string name="native_bf1870ff5c6322fb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s : %2$s"</string>
     <string name="native_bf350e6a0ed60b7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cette automatisation a été modifiée sur Gateway. Vérifiez la dernière version avant de l’enregistrer à nouveau."</string>
     <string name="native_bf399ffa03617a96" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Arrêter la dictée"</string>
     <string name="native_bf56ee2fe3345ce1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Lisible"</string>
@@ -1140,7 +1122,6 @@
     <string name="native_c1c224b03cd9bc7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Administration"</string>
     <string name="native_c1ebc7817870e5be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nécessite une attention"</string>
     <string name="native_c22d5e02fbec7d65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Associez cet appareil à votre Gateway pour ne le réveiller que pour des tâches réelles, garder à portée de main une vue d’ensemble actualisée des agents et éviter les boucles en arrière-plan qui épuisent la batterie."</string>
-    <string name="native_c25337055464f8d3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rôles"</string>
     <string name="native_c253f451bdd56431" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Répondre"</string>
     <string name="native_c26225b6c16a4bc7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Catalogue des fournisseurs"</string>
     <string name="native_c272b225cf5bd643" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Activer l’autorisation dans les paramètres"</string>
@@ -1154,7 +1135,6 @@
     <string name="native_c34dd5eb8b0af56e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Où puis-je obtenir un code de configuration ?"</string>
     <string name="native_c3546b39ecbbed8a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Impossible d’activer la compétence."</string>
     <string name="native_c35b21d6ca39aa7c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"pdf"</string>
-    <string name="native_c3812fc4acb861d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Supprimer"</string>
     <string name="native_c382566dbe2ea49f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s%% en ligne"</string>
     <string name="native_c385951198c45d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aucun canal"</string>
     <string name="native_c41ad84496b53420" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Voix en temps réel"</string>
@@ -1183,7 +1163,6 @@
     <string name="native_c6d5ed757b66bfd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rêver"</string>
     <string name="native_c6dd061350fc69b8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aucune application bloquée. Les applications peuvent transférer des données tant que vous n’ajoutez pas de blocages."</string>
     <string name="native_c753cdf0c19f1e38" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Reconnaissance vocale indisponible"</string>
-    <string name="native_c78ffe19571018fb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Plateforme"</string>
     <string name="native_c7985fa72daa6ea4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway n’a pas renvoyé la configuration de %1$s"</string>
     <string name="native_c7b6dfd5c3a183c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Oublier le Gateway ?"</string>
     <string name="native_c7b7b7f01360f6a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Description facultative"</string>
@@ -1212,7 +1191,7 @@
     <string name="native_cc721e25d73938a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway domestique"</string>
     <string name="native_cc7a9a5cf8c4bc9d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Exécutez la commande d’approbation sur Gateway"</string>
     <string name="native_cc925e3c97ac7a35" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Impossible de charger les propositions de Skill Workshop."</string>
-    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Résume mes discussions OpenClaw récentes et suggère les prochaines étapes."</string>
+    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Fais-moi un récapitulatif de mes fils de discussion OpenClaw récents et suggère les prochaines étapes."</string>
     <string name="native_ccb4c324f516c633" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Pas maintenant"</string>
     <string name="native_cced0b0d83a9e400" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw qr"</string>
     <string name="native_cced28c6dc3f99c2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"start"</string>
@@ -1246,7 +1225,6 @@
     <string name="native_d17d2d78d76e6a6c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Modèles"</string>
     <string name="native_d19c2dd2fb598b93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw passif"</string>
     <string name="native_d1a574e23344c407" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Mot de passe Gateway invalide"</string>
-    <string name="native_d1af697abaff485f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Impossible de vérifier la modification de l’appairage de l’appareil. Actualisez et réessayez."</string>
     <string name="native_d1bf045bb524dae5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Afficher les détails"</string>
     <string name="native_d1e9567da9a8a4b0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bash"</string>
     <string name="native_d2089be672953d11" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Jeton"</string>
@@ -1261,7 +1239,6 @@
     <string name="native_d31de1a5c5c8ba2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Navigateur"</string>
     <string name="native_d354ee936f59115e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screen record"</string>
     <string name="native_d3974fd6d3b6c81f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Exécution en attente"</string>
-    <string name="native_d3e1c5f8a6e240fc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Origine"</string>
     <string name="native_d3f75e24411053c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"IA personnelle sur vos appareils"</string>
     <string name="native_d406ade2958cb5b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attach"</string>
     <string name="native_d461a493a3753877" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatique"</string>
@@ -1277,7 +1254,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Profil"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Les limites du fournisseur s’afficheront ici lorsque votre Gateway les signalera."</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 problème"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Les fils de \"%1$s\" sont conservés et replacés dans Non groupés."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Créé"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s jetons actifs"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>
@@ -1340,7 +1317,7 @@
     <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rechercher dans les Skills installés"</string>
     <string name="native_e0723a86a5b9408a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Inspecter"</string>
     <string name="native_e083bd83e9d3e97e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Process"</string>
-    <string name="native_e08a8fc53e29e5c9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Fils récents"</string>
+    <string name="native_e08a8fc53e29e5c9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Fils de discussion récents"</string>
     <string name="native_e0926fdac700b094" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Terminal"</string>
     <string name="native_e0d1b68224bf0b31" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Actuel"</string>
     <string name="native_e10435f6306b06d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 compte"</string>
@@ -1450,7 +1427,6 @@
     <string name="native_f2da2e47cd31a5dd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cette image n’a pas pu être décodée."</string>
     <string name="native_f3753c0fe29b88db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway, voix, notifications, confidentialité"</string>
     <string name="native_f386c32c1bf437d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Fichiers de l’espace de travail de l’agent"</string>
-    <string name="native_f418bf0894a1806a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cet appareil perdra son accès approuvé au Gateway."</string>
     <string name="native_f41d9e8b7e09aa24" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Utilisez le requestId de la commande en attente dans la commande d’approbation."</string>
     <string name="native_f4830a1dae298044" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Planification"</string>
     <string name="native_f493f0ce7a52a8aa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Limite de débit"</string>
@@ -1458,7 +1434,6 @@
     <string name="native_f4cc820d308495c4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Charge utile · %1$s"</string>
     <string name="native_f4ccae29e1bb0c20" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"En cours"</string>
     <string name="native_f4db1e48476f6075" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Terminer"</string>
-    <string name="native_f4e2076014711222" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Utiliser la confiance du système"</string>
     <string name="native_f4ef7a41caa88dd1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aucun fournisseur prêt"</string>
     <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Donne la priorité aux microphones Bluetooth connectés."</string>
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s application empêchée de transférer."</string>
@@ -1522,7 +1497,7 @@
     <string name="native_ff716fc4735e067f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Paramètres de dictée"</string>
     <string name="native_ff9dbbdfb84ddab2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Les modèles du fournisseur sont chargés, mais leur disponibilité est inconnue."</string>
     <string name="native_ffa7aa557b547a79" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Supprimer le fil ?"</string>
-    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw transforme ce téléphone en une interface de commande mobile épurée pour les fils, la voix, les fournisseurs et Gateway."</string>
+    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw transforme ce téléphone en une interface de commande mobile épurée pour les fils de discussion, la voix, les fournisseurs et Gateway."</string>
     <string name="native_ffb6f5764bddb68c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Plus récents d\'abord"</string>
     <string name="native_ffcf16006c652ee3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Prochain cycle"</string>
 </resources>

--- a/apps/android/app/src/main/res/values-fr/strings.xml
+++ b/apps/android/app/src/main/res/values-fr/strings.xml
@@ -75,6 +75,7 @@
     <string name="native_0929c9dc7f794852" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aucune proposition"</string>
     <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Fil principal"</string>
     <string name="native_0979c6fdbdca1675" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ouvrir le chat"</string>
+    <string name="native_09ce95090659d069" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Les actions d’association d’appareils ne sont pas disponibles dans cette session Gateway. Exécutez openclaw devices list sur l’hôte Gateway et gérez-y la demande. L’approbation des capacités du nœud est distincte et utilise toujours nodes approve &lt;request id&gt;."</string>
     <string name="native_0a0b7cf7c428c703" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Demande d’action"</string>
     <string name="native_0a708e7b03aaf1fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list pins"</string>
     <string name="native_0ab0e1629576aecf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Connectez-vous à un Gateway pour charger les propositions de l\'Atelier de Skills."</string>
@@ -87,10 +88,12 @@
     <string name="native_0c3845dcd2f0f683" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Inspectez cette proposition pour charger son contenu Markdown."</string>
     <string name="native_0c3ea4e2f12153e7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ouvrir OpenClaw et demander %1$s"</string>
     <string name="native_0c4d01e81bb3d1fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"raisonnement"</string>
+    <string name="native_0c77fe09ab336a3e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Client"</string>
     <string name="native_0c79a9c222840ed0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Appliqué"</string>
     <string name="native_0cab1c9617404faf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"vidéo"</string>
     <string name="native_0cf04463c4276a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Promu"</string>
     <string name="native_0d21bd52022ca7f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"En ligne"</string>
+    <string name="native_0d5644ff52ce2ba3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Portées"</string>
     <string name="native_0d5efd432e4fedf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Le fournisseur vocal en temps réel n’est pas configuré."</string>
     <string name="native_0d8ca811c3744a6d" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s · %2$s"</string>
     <string name="native_0db10f2c2f332cd2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"kick"</string>
@@ -138,6 +141,7 @@
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cible de session"</string>
     <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Examiner la skill ClawHub"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
+    <string name="native_16a5b7ad567a8093" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rejeter la demande d’appairage de cet appareil ?"</string>
     <string name="native_16b1a05e1d987ed1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Microphone préféré"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Hôte du nœud"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Niveau"</string>
@@ -183,6 +187,7 @@
     <string name="native_1d91629837639a5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cette automatisation a été modifiée pendant que vous la modifiiez. Rétablissez la dernière version du Gateway avant d’enregistrer."</string>
     <string name="native_1dbf9d5979606697" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Une fois connecté, le Gateway peut réveiller le téléphone à l’aide d’une notification push silencieuse au lieu de maintenir une session toujours active."</string>
     <string name="native_1e432ea5425e4a3a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Mode de réveil"</string>
+    <string name="native_1e595a107c78b957" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Supprimer l’appareil appairé ?"</string>
     <string name="native_1e955a58278623a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Texte de l\'événement système"</string>
     <string name="native_1ea44149be42d970" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Impossible de copier l’image du widget"</string>
     <string name="native_1ea442a134b2a184" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Non"</string>
@@ -197,6 +202,7 @@
     <string name="native_2065cc867eba1b39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Impossible de charger la configuration des modèles du fournisseur."</string>
     <string name="native_207ccb22d618db05" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s application autorisée à transférer."</string>
     <string name="native_209b9e597963e7e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Configuration vocale"</string>
+    <string name="native_211988ba9dd0570a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rejeter la demande d’appairage ?"</string>
     <string name="native_2132066dc9475cb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"This skill is installed but not available to the current agent. Agent filters stay on desktop or CLI."</string>
     <string name="native_21378545892f1fe2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Éditeur"</string>
     <string name="native_214d4932fc767e8f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">" · Conversation : parole"</string>
@@ -238,6 +244,7 @@
     <string name="native_2682bd813a3bccbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Saisissez le code de configuration fourni par openclaw qr."</string>
     <string name="native_268f14bbfe119c1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Diagnostics"</string>
     <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cette action supprime définitivement le fil et sa transcription."</string>
+    <string name="native_26e47d73a55d7fa7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Appareil approuvé."</string>
     <string name="native_26f0dd993530eb2d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nouvelle tentative automatique"</string>
     <string name="native_270ff82f36da987f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Image du widget copiée"</string>
     <string name="native_2728740a95d465c6" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s rôles"</string>
@@ -346,6 +353,7 @@
     <string name="native_381428f5f251a764" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Conversation Send"</string>
     <string name="native_3824a9f4dafe92c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Canevas"</string>
     <string name="native_384ae4ab1a2830f9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 fournisseur"</string>
+    <string name="native_385001409de8562a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Le certificat du Gateway n’a pas pu être lu automatiquement. Collez l’empreinte SHA-256 obtenue sur l’hôte du Gateway."</string>
     <string name="native_387b2569e440838c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Échec de l’envoi : %1$s"</string>
     <string name="native_3892e10346fd2012" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Pont"</string>
     <string name="native_38d198cd5303680f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Erreur de livraison"</string>
@@ -403,6 +411,7 @@
     <string name="native_429f6057535c1ea3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sub-agent"</string>
     <string name="native_42e3a99c21767def" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"En attente de l’approbation de l’appareil"</string>
     <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Chargement du fil de discussion"</string>
+    <string name="native_430df68ec29a85a2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ce Gateway présente désormais un certificat approuvé par cet appareil."</string>
     <string name="native_43905968a540af6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Décalage ms"</string>
     <string name="native_43988c156beabf7d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"event create"</string>
     <string name="native_43cc23fa52b87b4c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"document"</string>
@@ -464,6 +473,7 @@
     <string name="native_4e8c72cab82e0711" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"La configuration de l’automatisation n’est pas valide."</string>
     <string name="native_4ec30e9d85725d41" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Liste d’autorisation"</string>
     <string name="native_4ed379d418bb8629" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"groups"</string>
+    <string name="native_4ee252fb736effa2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Clé publique"</string>
     <string name="native_4efca0d10c5feb8e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"À propos"</string>
     <string name="native_4f1bc100d1dccc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aucun code QR de configuration n’a été trouvé dans cette image. Choisissez le code QR généré par openclaw qr ou saisissez manuellement le code de configuration."</string>
     <string name="native_4fe3cdd404ea0290" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"permissions"</string>
@@ -550,6 +560,7 @@
     <string name="native_5c0c8c9aa658f4a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OPENCLAW"</string>
     <string name="native_5c1acea9c9b0e704" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Fetch"</string>
     <string name="native_5c39123805ffb4e2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Invite"</string>
+    <string name="native_5c944156b5353428" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Approuver l’appareil ?"</string>
     <string name="native_5d410adb9576e266" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Supprimer %1$s et ses identifiants enregistrés de ce téléphone ?"</string>
     <string name="native_5d6c41a67139ee26" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Le code QR pointe vers une Gateway distante non sécurisée. %1$s %2$s"</string>
     <string name="native_5d6cbac59f87e78d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Surface d’écran prête"</string>
@@ -567,6 +578,7 @@
     <string name="native_5fa1d457ddfcd26c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"rename group"</string>
     <string name="native_5fa7aac5375c5815" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Prêt"</string>
     <string name="native_5fc1927ca948f31c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Le journal attend sa première entrée."</string>
+    <string name="native_6007acbe30b2cd98" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Approuver"</string>
     <string name="native_600c9c27960112a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Page en direct"</string>
     <string name="native_6030d1f6340776d2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"L’automatisation est déjà en cours d’exécution."</string>
     <string name="native_604e6d6faf8d0295" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Supprimer cette automatisation après une exécution ponctuelle réussie."</string>
@@ -606,12 +618,14 @@
     <string name="native_6657cc73af00feac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Autoriser les outils de caméra sur demande."</string>
     <string name="native_666067dd376e5d45" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Problèmes"</string>
     <string name="native_666c8bc0319f3b54" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Réveil vocal"</string>
+    <string name="native_66713d713e3a41c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Demande d’appairage rejetée."</string>
     <string name="native_66b23bae66fc0d79" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"il y a %1$s j"</string>
     <string name="native_66cf5513b37462be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"roles"</string>
     <string name="native_66d0f523a379b2de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skills"</string>
     <string name="native_66f4804ee23ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Archiver"</string>
     <string name="native_66fab2875ee427f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nœud hors ligne. Reconnectez-vous et réessayez."</string>
     <string name="native_6725e7bbcd28f3a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Système"</string>
+    <string name="native_672f3453e1dd571b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Adresse IP distante"</string>
     <string name="native_674b38cae72bb0c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Non regroupé"</string>
     <string name="native_674eb55d9c353900" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Détails de la planification"</string>
     <string name="native_67528858c36397f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Fonctionnalités du téléphone"</string>
@@ -619,6 +633,7 @@
     <string name="native_67b696468610b879" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dashboard"</string>
     <string name="native_67fa416afa64d304" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Coller le jeton"</string>
     <string name="native_6827238fea72c88b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aucun fournisseur"</string>
+    <string name="native_684889f0079cc145" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Empreinte SHA-256"</string>
     <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aucun fil pour le moment"</string>
     <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Microphone Bluetooth"</string>
     <string name="native_690dbe9dc0993c42" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Récent"</string>
@@ -653,6 +668,7 @@
     <string name="native_6d5d9004797377e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Licences"</string>
     <string name="native_6d7c95a353d873cd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Connectez le Gateway pour rechercher des Skills ClawHub."</string>
     <string name="native_6df1bb18a59ab97d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skill"</string>
+    <string name="native_6e0a0b9d8c5ee4d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ID de l’appareil"</string>
     <string name="native_6e117ba97cbfb6f0" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway n’a pas identifié le fournisseur %1$s actif"</string>
     <string name="native_6e293a8c009e0011" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"En attente"</string>
     <string name="native_6e2c0963d056e104" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Mots d’activation enregistrés"</string>
@@ -829,6 +845,7 @@
     <string name="native_8bb7ec15b1e350a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Inspection"</string>
     <string name="native_8bf253a125f66985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Scannez ou collez un code de configuration pour ajouter un autre Gateway."</string>
     <string name="native_8c4a3896e8f06d27" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Délai d’attente TLS dépassé"</string>
+    <string name="native_8c55387fb6c584c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Appareil appairé supprimé."</string>
     <string name="native_8c93c68056cde54d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway appairé. Vérification de l’approbation des fonctionnalités du nœud."</string>
     <string name="native_8ca344247c18317e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Mouvement"</string>
     <string name="native_8cac4b77b9c54695" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Échec de l’action cron."</string>
@@ -1021,7 +1038,6 @@
     <string name="native_ad1c341c65f84ede" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Exécutez la commande d’approbation sur l’ordinateur Gateway, puis vérifiez à nouveau."</string>
     <string name="native_ad1fb9ec0cb3c7a4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatisations"</string>
     <string name="native_adb7eb8a03ad699c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s min"</string>
-    <string name="native_adca3171c270301a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cette connexion au Gateway permet d’afficher la liste des nœuds connectés, mais pas d’approuver l’association d’un nouveau téléphone. Associez les nouveaux téléphones depuis une session administrateur du Gateway. L’approbation des capacités des nœuds est distincte et utilise toujours nodes approve &lt;request id&gt;."</string>
     <string name="native_ade9248e0132b411" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Faire confiance"</string>
     <string name="native_ae27fa789a03c1db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ce code QR n’est pas un code QR de configuration OpenClaw. Générez un nouveau code avec openclaw qr, puis réessayez."</string>
     <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Le microphone préféré n’est pas disponible ; utilisation du routage automatique."</string>
@@ -1091,6 +1107,7 @@
     <string name="native_bb4f2558e4333834" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Image du widget enregistrée dans Téléchargements"</string>
     <string name="native_bbe5fc3b9ef39f99" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Démarrage…"</string>
     <string name="native_bc19cec293228fb8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Erreur du client"</string>
+    <string name="native_bc1c94a6dfce1058" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Vérifiez l’appareil à l’origine de cette demande avant d’accorder l’accès."</string>
     <string name="native_bc6618670f3e8a17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Microphone Bluetooth LE"</string>
     <string name="native_bcb06651437caa15" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
     <string name="native_bd08450d63406844" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatisation activée."</string>
@@ -1099,6 +1116,7 @@
     <string name="native_bdc090ec61e3fcfc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Recharger"</string>
     <string name="native_bdff71b20b9cf392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rechercher des automatisations"</string>
     <string name="native_be969becb173e0c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Les téléphones liés et les hôtes de nœud apparaîtront ici après l’association."</string>
+    <string name="native_bf1870ff5c6322fb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s : %2$s"</string>
     <string name="native_bf350e6a0ed60b7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cette automatisation a été modifiée sur Gateway. Vérifiez la dernière version avant de l’enregistrer à nouveau."</string>
     <string name="native_bf399ffa03617a96" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Arrêter la dictée"</string>
     <string name="native_bf56ee2fe3345ce1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Lisible"</string>
@@ -1122,6 +1140,7 @@
     <string name="native_c1c224b03cd9bc7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Administration"</string>
     <string name="native_c1ebc7817870e5be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nécessite une attention"</string>
     <string name="native_c22d5e02fbec7d65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Associez cet appareil à votre Gateway pour ne le réveiller que pour des tâches réelles, garder à portée de main une vue d’ensemble actualisée des agents et éviter les boucles en arrière-plan qui épuisent la batterie."</string>
+    <string name="native_c25337055464f8d3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rôles"</string>
     <string name="native_c253f451bdd56431" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Répondre"</string>
     <string name="native_c26225b6c16a4bc7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Catalogue des fournisseurs"</string>
     <string name="native_c272b225cf5bd643" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Activer l’autorisation dans les paramètres"</string>
@@ -1135,6 +1154,7 @@
     <string name="native_c34dd5eb8b0af56e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Où puis-je obtenir un code de configuration ?"</string>
     <string name="native_c3546b39ecbbed8a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Impossible d’activer la compétence."</string>
     <string name="native_c35b21d6ca39aa7c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"pdf"</string>
+    <string name="native_c3812fc4acb861d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Supprimer"</string>
     <string name="native_c382566dbe2ea49f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s%% en ligne"</string>
     <string name="native_c385951198c45d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aucun canal"</string>
     <string name="native_c41ad84496b53420" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Voix en temps réel"</string>
@@ -1163,6 +1183,7 @@
     <string name="native_c6d5ed757b66bfd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rêver"</string>
     <string name="native_c6dd061350fc69b8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aucune application bloquée. Les applications peuvent transférer des données tant que vous n’ajoutez pas de blocages."</string>
     <string name="native_c753cdf0c19f1e38" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Reconnaissance vocale indisponible"</string>
+    <string name="native_c78ffe19571018fb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Plateforme"</string>
     <string name="native_c7985fa72daa6ea4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway n’a pas renvoyé la configuration de %1$s"</string>
     <string name="native_c7b6dfd5c3a183c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Oublier le Gateway ?"</string>
     <string name="native_c7b7b7f01360f6a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Description facultative"</string>
@@ -1225,6 +1246,7 @@
     <string name="native_d17d2d78d76e6a6c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Modèles"</string>
     <string name="native_d19c2dd2fb598b93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw passif"</string>
     <string name="native_d1a574e23344c407" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Mot de passe Gateway invalide"</string>
+    <string name="native_d1af697abaff485f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Impossible de vérifier la modification de l’appairage de l’appareil. Actualisez et réessayez."</string>
     <string name="native_d1bf045bb524dae5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Afficher les détails"</string>
     <string name="native_d1e9567da9a8a4b0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bash"</string>
     <string name="native_d2089be672953d11" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Jeton"</string>
@@ -1239,6 +1261,7 @@
     <string name="native_d31de1a5c5c8ba2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Navigateur"</string>
     <string name="native_d354ee936f59115e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screen record"</string>
     <string name="native_d3974fd6d3b6c81f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Exécution en attente"</string>
+    <string name="native_d3e1c5f8a6e240fc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Origine"</string>
     <string name="native_d3f75e24411053c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"IA personnelle sur vos appareils"</string>
     <string name="native_d406ade2958cb5b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attach"</string>
     <string name="native_d461a493a3753877" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatique"</string>
@@ -1427,6 +1450,7 @@
     <string name="native_f2da2e47cd31a5dd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cette image n’a pas pu être décodée."</string>
     <string name="native_f3753c0fe29b88db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway, voix, notifications, confidentialité"</string>
     <string name="native_f386c32c1bf437d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Fichiers de l’espace de travail de l’agent"</string>
+    <string name="native_f418bf0894a1806a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cet appareil perdra son accès approuvé au Gateway."</string>
     <string name="native_f41d9e8b7e09aa24" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Utilisez le requestId de la commande en attente dans la commande d’approbation."</string>
     <string name="native_f4830a1dae298044" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Planification"</string>
     <string name="native_f493f0ce7a52a8aa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Limite de débit"</string>
@@ -1434,6 +1458,7 @@
     <string name="native_f4cc820d308495c4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Charge utile · %1$s"</string>
     <string name="native_f4ccae29e1bb0c20" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"En cours"</string>
     <string name="native_f4db1e48476f6075" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Terminer"</string>
+    <string name="native_f4e2076014711222" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Utiliser la confiance du système"</string>
     <string name="native_f4ef7a41caa88dd1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aucun fournisseur prêt"</string>
     <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Donne la priorité aux microphones Bluetooth connectés."</string>
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s application empêchée de transférer."</string>

--- a/apps/android/app/src/main/res/values-hi/strings.xml
+++ b/apps/android/app/src/main/res/values-hi/strings.xml
@@ -494,7 +494,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"डिलीवरी"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"स्पीकर म्यूट करें"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway कनेक्शन खोला जा रहा है"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"निगरानी · %1$s थ्रेड"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ऑटोमेशन रन पूरा हुआ।"</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"कोई मेल खाते ऐप्स नहीं।"</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Chat में भेजें"</string>
@@ -1277,7 +1277,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"प्रोफ़ाइल"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"जब आपका Gateway उन्हें रिपोर्ट करेगा, तो प्रदाता सीमाएँ यहाँ दिखाई देंगी।"</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 समस्या"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"\"%1$s\" के थ्रेड रखे जाते हैं और वापस असमूहीकृत में चले जाते हैं।"</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"बनाया गया"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s सक्रिय टोकन"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>

--- a/apps/android/app/src/main/res/values-hi/strings.xml
+++ b/apps/android/app/src/main/res/values-hi/strings.xml
@@ -75,6 +75,7 @@
     <string name="native_0929c9dc7f794852" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"कोई प्रस्ताव नहीं"</string>
     <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"मुख्य थ्रेड"</string>
     <string name="native_0979c6fdbdca1675" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Chat खोलें"</string>
+    <string name="native_09ce95090659d069" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"इस Gateway सत्र में डिवाइस पेयरिंग की कार्रवाइयाँ उपलब्ध नहीं हैं। Gateway होस्ट पर openclaw devices list चलाएँ और अनुरोध को वहीं प्रबंधित करें। नोड क्षमता की स्वीकृति अलग है और अब भी nodes approve &lt;request id&gt; का उपयोग करती है।"</string>
     <string name="native_0a0b7cf7c428c703" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"कार्रवाई का अनुरोध"</string>
     <string name="native_0a708e7b03aaf1fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list pins"</string>
     <string name="native_0ab0e1629576aecf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skill Workshop प्रस्ताव लोड करने के लिए किसी Gateway से कनेक्ट करें."</string>
@@ -87,10 +88,12 @@
     <string name="native_0c3845dcd2f0f683" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"इस प्रस्ताव का markdown लोड करने के लिए इसका निरीक्षण करें।"</string>
     <string name="native_0c3ea4e2f12153e7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw खोलें और %1$s पूछें"</string>
     <string name="native_0c4d01e81bb3d1fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"तर्क"</string>
+    <string name="native_0c77fe09ab336a3e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"क्लाइंट"</string>
     <string name="native_0c79a9c222840ed0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"लागू किया गया"</string>
     <string name="native_0cab1c9617404faf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"वीडियो"</string>
     <string name="native_0cf04463c4276a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"प्रमोट किया गया"</string>
     <string name="native_0d21bd52022ca7f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ऑनलाइन"</string>
+    <string name="native_0d5644ff52ce2ba3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"दायरे"</string>
     <string name="native_0d5efd432e4fedf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"रीयल-टाइम वॉइस प्रदाता कॉन्फ़िगर नहीं किया गया है।"</string>
     <string name="native_0d8ca811c3744a6d" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s · %2$s"</string>
     <string name="native_0db10f2c2f332cd2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"kick"</string>
@@ -138,6 +141,7 @@
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"सेशन लक्ष्य"</string>
     <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ClawHub Skill की समीक्षा करें"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
+    <string name="native_16a5b7ad567a8093" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"इस डिवाइस का पेयरिंग अनुरोध अस्वीकार करें?"</string>
     <string name="native_16b1a05e1d987ed1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"पसंदीदा माइक्रोफ़ोन"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"नोड होस्ट"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"स्तर"</string>
@@ -183,6 +187,7 @@
     <string name="native_1d91629837639a5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"आपके संपादन के दौरान यह ऑटोमेशन बदल गया। सेव करने से पहले Gateway के नवीनतम संस्करण पर वापस जाएँ।"</string>
     <string name="native_1dbf9d5979606697" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"कनेक्ट होने पर, Gateway हमेशा चालू रहने वाला सत्र बनाए रखने के बजाय साइलेंट पुश से फ़ोन को सक्रिय कर सकता है।"</string>
     <string name="native_1e432ea5425e4a3a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"वेक मोड"</string>
+    <string name="native_1e595a107c78b957" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"पेयर किया गया डिवाइस हटाएँ?"</string>
     <string name="native_1e955a58278623a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"सिस्टम इवेंट टेक्स्ट"</string>
     <string name="native_1ea44149be42d970" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"विजेट इमेज कॉपी नहीं की जा सकी"</string>
     <string name="native_1ea442a134b2a184" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"नहीं"</string>
@@ -197,6 +202,7 @@
     <string name="native_2065cc867eba1b39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"प्रदाता मॉडल कॉन्फ़िगरेशन लोड नहीं किया जा सका।"</string>
     <string name="native_207ccb22d618db05" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s ऐप को फ़ॉरवर्ड करने की अनुमति है।"</string>
     <string name="native_209b9e597963e7e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"वॉइस सेटअप"</string>
+    <string name="native_211988ba9dd0570a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"पेयरिंग अनुरोध अस्वीकार करें?"</string>
     <string name="native_2132066dc9475cb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"This skill is installed but not available to the current agent. Agent filters stay on desktop or CLI."</string>
     <string name="native_21378545892f1fe2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"प्रकाशक"</string>
     <string name="native_214d4932fc767e8f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">" · बातचीत: बोल रहा है"</string>
@@ -238,6 +244,7 @@
     <string name="native_2682bd813a3bccbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw qr से सेटअप कोड दर्ज करें।"</string>
     <string name="native_268f14bbfe119c1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"डायग्नोस्टिक्स"</string>
     <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"यह थ्रेड और इसकी ट्रांसक्रिप्ट को स्थायी रूप से हटा देता है।"</string>
+    <string name="native_26e47d73a55d7fa7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"डिवाइस स्वीकृत किया गया।"</string>
     <string name="native_26f0dd993530eb2d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"अपने-आप फिर से प्रयास किया जा रहा है"</string>
     <string name="native_270ff82f36da987f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"विजेट इमेज कॉपी की गई"</string>
     <string name="native_2728740a95d465c6" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s भूमिकाएँ"</string>
@@ -346,6 +353,7 @@
     <string name="native_381428f5f251a764" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Conversation Send"</string>
     <string name="native_3824a9f4dafe92c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"कैनवास"</string>
     <string name="native_384ae4ab1a2830f9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 प्रदाता"</string>
+    <string name="native_385001409de8562a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway प्रमाणपत्र को स्वचालित रूप से पढ़ा नहीं जा सका। Gateway होस्ट पर प्राप्त SHA-256 फ़िंगरप्रिंट पेस्ट करें।"</string>
     <string name="native_387b2569e440838c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"भेजना विफल रहा: %1$s"</string>
     <string name="native_3892e10346fd2012" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ब्रिज"</string>
     <string name="native_38d198cd5303680f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"डिलीवरी त्रुटि"</string>
@@ -403,6 +411,7 @@
     <string name="native_429f6057535c1ea3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sub-agent"</string>
     <string name="native_42e3a99c21767def" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"डिवाइस की स्वीकृति की प्रतीक्षा है"</string>
     <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"थ्रेड लोड हो रहा है"</string>
+    <string name="native_430df68ec29a85a2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"यह Gateway अब इस डिवाइस द्वारा विश्वसनीय प्रमाणपत्र प्रस्तुत करता है।"</string>
     <string name="native_43905968a540af6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"विलंब ms"</string>
     <string name="native_43988c156beabf7d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"event create"</string>
     <string name="native_43cc23fa52b87b4c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"दस्तावेज़"</string>
@@ -464,6 +473,7 @@
     <string name="native_4e8c72cab82e0711" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ऑटोमेशन का कॉन्फ़िगरेशन अमान्य है।"</string>
     <string name="native_4ec30e9d85725d41" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"अनुमति सूची"</string>
     <string name="native_4ed379d418bb8629" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"groups"</string>
+    <string name="native_4ee252fb736effa2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"सार्वजनिक कुंजी"</string>
     <string name="native_4efca0d10c5feb8e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"परिचय"</string>
     <string name="native_4f1bc100d1dccc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"उस इमेज में कोई सेटअप QR कोड नहीं मिला। openclaw qr से जनरेट किया गया QR चुनें या सेटअप कोड मैन्युअल रूप से दर्ज करें।"</string>
     <string name="native_4fe3cdd404ea0290" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"permissions"</string>
@@ -550,6 +560,7 @@
     <string name="native_5c0c8c9aa658f4a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OPENCLAW"</string>
     <string name="native_5c1acea9c9b0e704" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Fetch"</string>
     <string name="native_5c39123805ffb4e2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"प्रॉम्प्ट"</string>
+    <string name="native_5c944156b5353428" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"डिवाइस स्वीकृत करें?"</string>
     <string name="native_5d410adb9576e266" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"इस फ़ोन से %1$s और इसके सहेजे गए क्रेडेंशियल हटाएँ?"</string>
     <string name="native_5d6c41a67139ee26" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"QR कोड एक असुरक्षित रिमोट gateway की ओर इशारा करता है। %1$s %2$s"</string>
     <string name="native_5d6cbac59f87e78d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"स्क्रीन सतह तैयार है"</string>
@@ -567,6 +578,7 @@
     <string name="native_5fa1d457ddfcd26c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"rename group"</string>
     <string name="native_5fa7aac5375c5815" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"तैयार"</string>
     <string name="native_5fc1927ca948f31c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"डायरी अपनी पहली प्रविष्टि की प्रतीक्षा कर रही है।"</string>
+    <string name="native_6007acbe30b2cd98" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"स्वीकृत करें"</string>
     <string name="native_600c9c27960112a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"लाइव पेज"</string>
     <string name="native_6030d1f6340776d2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ऑटोमेशन पहले से चल रहा है।"</string>
     <string name="native_604e6d6faf8d0295" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"एक बार सफलतापूर्वक चलने के बाद इस ऑटोमेशन को हटा दें।"</string>
@@ -606,12 +618,14 @@
     <string name="native_6657cc73af00feac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"अनुरोध किए जाने पर कैमरा टूल्स की अनुमति दें।"</string>
     <string name="native_666067dd376e5d45" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"समस्याएँ"</string>
     <string name="native_666c8bc0319f3b54" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"वॉइस वेक"</string>
+    <string name="native_66713d713e3a41c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"पेयरिंग अनुरोध अस्वीकार किया गया।"</string>
     <string name="native_66b23bae66fc0d79" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$sदि. पहले"</string>
     <string name="native_66cf5513b37462be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"roles"</string>
     <string name="native_66d0f523a379b2de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skills"</string>
     <string name="native_66f4804ee23ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"आर्काइव करें"</string>
     <string name="native_66fab2875ee427f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"नोड ऑफ़लाइन है। दोबारा कनेक्ट करें और पुनः प्रयास करें।"</string>
     <string name="native_6725e7bbcd28f3a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"सिस्टम"</string>
+    <string name="native_672f3453e1dd571b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"रिमोट IP"</string>
     <string name="native_674b38cae72bb0c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"असमूहीकृत"</string>
     <string name="native_674eb55d9c353900" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"शेड्यूल का विवरण"</string>
     <string name="native_67528858c36397f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"फ़ोन की क्षमताएँ"</string>
@@ -619,6 +633,7 @@
     <string name="native_67b696468610b879" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dashboard"</string>
     <string name="native_67fa416afa64d304" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"टोकन पेस्ट करें"</string>
     <string name="native_6827238fea72c88b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"कोई प्रदाता नहीं"</string>
+    <string name="native_684889f0079cc145" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"SHA-256 फ़िंगरप्रिंट"</string>
     <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"अभी कोई थ्रेड नहीं है"</string>
     <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bluetooth माइक्रोफ़ोन"</string>
     <string name="native_690dbe9dc0993c42" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"हाल के"</string>
@@ -653,6 +668,7 @@
     <string name="native_6d5d9004797377e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"लाइसेंस"</string>
     <string name="native_6d7c95a353d873cd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ClawHub Skills खोजने के लिए Gateway कनेक्ट करें।"</string>
     <string name="native_6df1bb18a59ab97d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skill"</string>
+    <string name="native_6e0a0b9d8c5ee4d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"डिवाइस ID"</string>
     <string name="native_6e117ba97cbfb6f0" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway ने सक्रिय %1$s प्रदाता की पहचान नहीं की"</string>
     <string name="native_6e293a8c009e0011" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"प्रतीक्षा में"</string>
     <string name="native_6e2c0963d056e104" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"वेक वर्ड सहेजे गए"</string>
@@ -829,6 +845,7 @@
     <string name="native_8bb7ec15b1e350a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Inspect हो रहा है"</string>
     <string name="native_8bf253a125f66985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"कोई और gateway जोड़ने के लिए सेटअप कोड स्कैन करें या पेस्ट करें।"</string>
     <string name="native_8c4a3896e8f06d27" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"TLS का समय समाप्त हो गया"</string>
+    <string name="native_8c55387fb6c584c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"पेयर किया गया डिवाइस हटा दिया गया।"</string>
     <string name="native_8c93c68056cde54d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway पेयर हो गया। नोड क्षमता की स्वीकृति जाँची जा रही है।"</string>
     <string name="native_8ca344247c18317e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"गतिविधि"</string>
     <string name="native_8cac4b77b9c54695" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"क्रॉन कार्रवाई विफल रही।"</string>
@@ -1021,7 +1038,6 @@
     <string name="native_ad1c341c65f84ede" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway कंप्यूटर पर approve कमांड चलाएँ, फिर दोबारा जाँचें।"</string>
     <string name="native_ad1fb9ec0cb3c7a4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"स्वचालन"</string>
     <string name="native_adb7eb8a03ad699c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$sमि"</string>
-    <string name="native_adca3171c270301a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"यह Gateway साइन-इन कनेक्ट किए गए नोड सूचीबद्ध कर सकता है, लेकिन नए फ़ोन की पेयरिंग को स्वीकृति नहीं दे सकता। नए फ़ोन को Gateway एडमिन सत्र से पेयर करें। नोड क्षमता की स्वीकृति अलग है और इसके लिए अब भी nodes approve &lt;request id&gt; का उपयोग होता है।"</string>
     <string name="native_ade9248e0132b411" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"भरोसा करें"</string>
     <string name="native_ae27fa789a03c1db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"वह QR कोड OpenClaw सेटअप QR नहीं है। openclaw qr से नया कोड जनरेट करें, फिर दोबारा कोशिश करें।"</string>
     <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"पसंदीदा माइक्रोफ़ोन उपलब्ध नहीं है; स्वचालित रूटिंग का उपयोग किया जा रहा है।"</string>
@@ -1091,6 +1107,7 @@
     <string name="native_bb4f2558e4333834" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"विजेट इमेज Downloads में सेव की गई"</string>
     <string name="native_bbe5fc3b9ef39f99" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"शुरू हो रहा है…"</string>
     <string name="native_bc19cec293228fb8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"क्लाइंट त्रुटि"</string>
+    <string name="native_bc1c94a6dfce1058" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"पहुँच देने से पहले अनुरोध करने वाले इस डिवाइस को सत्यापित करें।"</string>
     <string name="native_bc6618670f3e8a17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bluetooth LE माइक्रोफ़ोन"</string>
     <string name="native_bcb06651437caa15" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
     <string name="native_bd08450d63406844" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ऑटोमेशन सक्षम किया गया।"</string>
@@ -1099,6 +1116,7 @@
     <string name="native_bdc090ec61e3fcfc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"रीलोड करें"</string>
     <string name="native_bdff71b20b9cf392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ऑटोमेशन खोजें"</string>
     <string name="native_be969becb173e0c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"पेयरिंग के बाद लिंक किए गए फ़ोन और नोड होस्ट यहाँ दिखाई देंगे।"</string>
+    <string name="native_bf1870ff5c6322fb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s: %2$s"</string>
     <string name="native_bf350e6a0ed60b7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"यह ऑटोमेशन Gateway पर बदल गया है। दोबारा सहेजने से पहले नवीनतम संस्करण की समीक्षा करें।"</string>
     <string name="native_bf399ffa03617a96" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"डिक्टेशन रोकें"</string>
     <string name="native_bf56ee2fe3345ce1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"पठनीय"</string>
@@ -1122,6 +1140,7 @@
     <string name="native_c1c224b03cd9bc7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"एडमिन"</string>
     <string name="native_c1ebc7817870e5be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ध्यान देने की आवश्यकता है"</string>
     <string name="native_c22d5e02fbec7d65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"इस डिवाइस को अपने Gateway से पेयर करें, ताकि यह केवल वास्तविक काम के लिए सक्रिय हो, एजेंट की लाइव जानकारी आसानी से उपलब्ध रहे और बैटरी खर्च करने वाले बैकग्राउंड लूप से बचा जा सके।"</string>
+    <string name="native_c25337055464f8d3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"भूमिकाएँ"</string>
     <string name="native_c253f451bdd56431" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"जवाब दें"</string>
     <string name="native_c26225b6c16a4bc7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"प्रोवाइडर कैटलॉग"</string>
     <string name="native_c272b225cf5bd643" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Settings में अनुमति सक्षम करें"</string>
@@ -1135,6 +1154,7 @@
     <string name="native_c34dd5eb8b0af56e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"मुझे सेटअप कोड कहाँ मिलेगा?"</string>
     <string name="native_c3546b39ecbbed8a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skill को सक्षम नहीं किया जा सका।"</string>
     <string name="native_c35b21d6ca39aa7c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"pdf"</string>
+    <string name="native_c3812fc4acb861d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"हटाएँ"</string>
     <string name="native_c382566dbe2ea49f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s%% ऑनलाइन"</string>
     <string name="native_c385951198c45d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"कोई चैनल नहीं है"</string>
     <string name="native_c41ad84496b53420" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"रीयल-टाइम वॉइस"</string>
@@ -1163,6 +1183,7 @@
     <string name="native_c6d5ed757b66bfd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"सपना"</string>
     <string name="native_c6dd061350fc69b8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"कोई ऐप ब्लॉक नहीं किया गया है। जब तक आप ब्लॉक नहीं जोड़ते, ऐप्स फ़ॉरवर्ड कर सकते हैं।"</string>
     <string name="native_c753cdf0c19f1e38" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"वाक् पहचानकर्ता उपलब्ध नहीं है"</string>
+    <string name="native_c78ffe19571018fb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"प्लेटफ़ॉर्म"</string>
     <string name="native_c7985fa72daa6ea4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway ने %1$s सेटअप नहीं लौटाया"</string>
     <string name="native_c7b6dfd5c3a183c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway भूलें?"</string>
     <string name="native_c7b7b7f01360f6a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"वैकल्पिक विवरण"</string>
@@ -1225,6 +1246,7 @@
     <string name="native_d17d2d78d76e6a6c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"मॉडल"</string>
     <string name="native_d19c2dd2fb598b93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw निष्क्रिय"</string>
     <string name="native_d1a574e23344c407" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway पासवर्ड अमान्य है"</string>
+    <string name="native_d1af697abaff485f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"डिवाइस पेयरिंग में बदलाव सत्यापित नहीं किया जा सका। रीफ़्रेश करके फिर से कोशिश करें।"</string>
     <string name="native_d1bf045bb524dae5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"विवरण देखें"</string>
     <string name="native_d1e9567da9a8a4b0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bash"</string>
     <string name="native_d2089be672953d11" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"टोकन"</string>
@@ -1239,6 +1261,7 @@
     <string name="native_d31de1a5c5c8ba2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Browser"</string>
     <string name="native_d354ee936f59115e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screen record"</string>
     <string name="native_d3974fd6d3b6c81f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"रन लंबित है"</string>
+    <string name="native_d3e1c5f8a6e240fc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"मूल"</string>
     <string name="native_d3f75e24411053c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"आपके डिवाइसों पर निजी AI"</string>
     <string name="native_d406ade2958cb5b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attach"</string>
     <string name="native_d461a493a3753877" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"स्वचालित"</string>
@@ -1427,6 +1450,7 @@
     <string name="native_f2da2e47cd31a5dd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"इस इमेज को डिकोड नहीं किया जा सका."</string>
     <string name="native_f3753c0fe29b88db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway, वॉइस, सूचनाएँ, गोपनीयता"</string>
     <string name="native_f386c32c1bf437d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"एजेंट वर्कस्पेस की फ़ाइलें"</string>
+    <string name="native_f418bf0894a1806a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"यह डिवाइस अपनी विश्वसनीय Gateway पहुँच खो देगा।"</string>
     <string name="native_f41d9e8b7e09aa24" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"approve कमांड में pending कमांड से requestId का उपयोग करें।"</string>
     <string name="native_f4830a1dae298044" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"शेड्यूल"</string>
     <string name="native_f493f0ce7a52a8aa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"दर सीमा"</string>
@@ -1434,6 +1458,7 @@
     <string name="native_f4cc820d308495c4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"पेलोड · %1$s"</string>
     <string name="native_f4ccae29e1bb0c20" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"चल रहा है"</string>
     <string name="native_f4db1e48476f6075" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"समाप्त करें"</string>
+    <string name="native_f4e2076014711222" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"सिस्टम विश्वसनीयता का उपयोग करें"</string>
     <string name="native_f4ef7a41caa88dd1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"कोई तैयार प्रोवाइडर नहीं"</string>
     <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"कनेक्ट किए गए Bluetooth माइक्रोफ़ोन को प्राथमिकता देता है।"</string>
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s ऐप को फ़ॉरवर्ड करने से ब्लॉक किया गया है।"</string>

--- a/apps/android/app/src/main/res/values-hi/strings.xml
+++ b/apps/android/app/src/main/res/values-hi/strings.xml
@@ -70,12 +70,11 @@
     <string name="native_088e0e5ebc96c6ac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway सेटअप बदलें?"</string>
     <string name="native_08a5391c1de3078a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ऑटोमेशन लोड नहीं किए जा सके।"</string>
     <string name="native_08b041935798fbf6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"आप"</string>
-    <string name="native_08ea63ee26954dca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"बिल्ट-इन माइक्रोफ़ोन"</string>
+    <string name="native_08ea63ee26954dca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"अंतर्निहित माइक्रोफ़ोन"</string>
     <string name="native_0905f7f59021c2a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"सतह"</string>
     <string name="native_0929c9dc7f794852" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"कोई प्रस्ताव नहीं"</string>
     <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"मुख्य थ्रेड"</string>
     <string name="native_0979c6fdbdca1675" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Chat खोलें"</string>
-    <string name="native_09ce95090659d069" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"इस Gateway सत्र में डिवाइस पेयरिंग की कार्रवाइयाँ उपलब्ध नहीं हैं। Gateway होस्ट पर openclaw devices list चलाएँ और अनुरोध को वहीं प्रबंधित करें। नोड क्षमता की स्वीकृति अलग है और अब भी nodes approve &lt;request id&gt; का उपयोग करती है।"</string>
     <string name="native_0a0b7cf7c428c703" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"कार्रवाई का अनुरोध"</string>
     <string name="native_0a708e7b03aaf1fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list pins"</string>
     <string name="native_0ab0e1629576aecf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skill Workshop प्रस्ताव लोड करने के लिए किसी Gateway से कनेक्ट करें."</string>
@@ -88,12 +87,10 @@
     <string name="native_0c3845dcd2f0f683" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"इस प्रस्ताव का markdown लोड करने के लिए इसका निरीक्षण करें।"</string>
     <string name="native_0c3ea4e2f12153e7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw खोलें और %1$s पूछें"</string>
     <string name="native_0c4d01e81bb3d1fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"तर्क"</string>
-    <string name="native_0c77fe09ab336a3e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"क्लाइंट"</string>
     <string name="native_0c79a9c222840ed0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"लागू किया गया"</string>
     <string name="native_0cab1c9617404faf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"वीडियो"</string>
     <string name="native_0cf04463c4276a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"प्रमोट किया गया"</string>
     <string name="native_0d21bd52022ca7f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ऑनलाइन"</string>
-    <string name="native_0d5644ff52ce2ba3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"दायरे"</string>
     <string name="native_0d5efd432e4fedf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"रीयल-टाइम वॉइस प्रदाता कॉन्फ़िगर नहीं किया गया है।"</string>
     <string name="native_0d8ca811c3744a6d" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s · %2$s"</string>
     <string name="native_0db10f2c2f332cd2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"kick"</string>
@@ -104,7 +101,7 @@
     <string name="native_0e91610117029a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"रीफ़्रेश करें"</string>
     <string name="native_0ee30822ed35a792" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s कतार में हैं"</string>
     <string name="native_0f4c8529742b31ea" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"चैट शुरू करें"</string>
-    <string name="native_0f559ff270904904" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"सक्रिय थ्रेड में प्रतीक्षारत Chat टूल कॉल यहाँ दिखाई देते रहेंगे।"</string>
+    <string name="native_0f559ff270904904" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"सक्रिय थ्रेड में प्रतीक्षारत चैट टूल कॉल यहाँ दिखाई देते रहेंगे।"</string>
     <string name="native_0f56cc286a4f23d8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"प्रमाणपत्र की समीक्षा आवश्यक है"</string>
     <string name="native_0f8fe3a9688138a1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"इसे जांचने या इससे इंटरैक्ट करने के लिए वर्तमान Canvas surface खोलें।"</string>
     <string name="native_0ff98f05be01ce5e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ऑटोमेशन अपडेट किया गया।"</string>
@@ -141,7 +138,6 @@
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"सेशन लक्ष्य"</string>
     <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ClawHub Skill की समीक्षा करें"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
-    <string name="native_16a5b7ad567a8093" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"इस डिवाइस का पेयरिंग अनुरोध अस्वीकार करें?"</string>
     <string name="native_16b1a05e1d987ed1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"पसंदीदा माइक्रोफ़ोन"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"नोड होस्ट"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"स्तर"</string>
@@ -187,7 +183,6 @@
     <string name="native_1d91629837639a5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"आपके संपादन के दौरान यह ऑटोमेशन बदल गया। सेव करने से पहले Gateway के नवीनतम संस्करण पर वापस जाएँ।"</string>
     <string name="native_1dbf9d5979606697" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"कनेक्ट होने पर, Gateway हमेशा चालू रहने वाला सत्र बनाए रखने के बजाय साइलेंट पुश से फ़ोन को सक्रिय कर सकता है।"</string>
     <string name="native_1e432ea5425e4a3a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"वेक मोड"</string>
-    <string name="native_1e595a107c78b957" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"पेयर किया गया डिवाइस हटाएँ?"</string>
     <string name="native_1e955a58278623a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"सिस्टम इवेंट टेक्स्ट"</string>
     <string name="native_1ea44149be42d970" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"विजेट इमेज कॉपी नहीं की जा सकी"</string>
     <string name="native_1ea442a134b2a184" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"नहीं"</string>
@@ -202,7 +197,6 @@
     <string name="native_2065cc867eba1b39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"प्रदाता मॉडल कॉन्फ़िगरेशन लोड नहीं किया जा सका।"</string>
     <string name="native_207ccb22d618db05" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s ऐप को फ़ॉरवर्ड करने की अनुमति है।"</string>
     <string name="native_209b9e597963e7e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"वॉइस सेटअप"</string>
-    <string name="native_211988ba9dd0570a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"पेयरिंग अनुरोध अस्वीकार करें?"</string>
     <string name="native_2132066dc9475cb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"This skill is installed but not available to the current agent. Agent filters stay on desktop or CLI."</string>
     <string name="native_21378545892f1fe2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"प्रकाशक"</string>
     <string name="native_214d4932fc767e8f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">" · बातचीत: बोल रहा है"</string>
@@ -243,8 +237,7 @@
     <string name="native_262c897a1f408b0b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"अपने Gateway से कनेक्ट करें"</string>
     <string name="native_2682bd813a3bccbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw qr से सेटअप कोड दर्ज करें।"</string>
     <string name="native_268f14bbfe119c1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"डायग्नोस्टिक्स"</string>
-    <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"इससे थ्रेड और उसका ट्रांसक्रिप्ट स्थायी रूप से हट जाएगा।"</string>
-    <string name="native_26e47d73a55d7fa7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"डिवाइस स्वीकृत किया गया।"</string>
+    <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"यह थ्रेड और इसकी ट्रांसक्रिप्ट को स्थायी रूप से हटा देता है।"</string>
     <string name="native_26f0dd993530eb2d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"अपने-आप फिर से प्रयास किया जा रहा है"</string>
     <string name="native_270ff82f36da987f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"विजेट इमेज कॉपी की गई"</string>
     <string name="native_2728740a95d465c6" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s भूमिकाएँ"</string>
@@ -260,7 +253,7 @@
     <string name="native_27d773b934ed324f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"सत्यापित करें और इंस्टॉल करें"</string>
     <string name="native_2821f0168d6dd9df" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"इस डिवाइस को chat, voice, camera, और device tools के लिए सुरक्षित OpenClaw नोड में बदलें।"</string>
     <string name="native_2831546121359362" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"मैनुअल सेटअप"</string>
-    <string name="native_287c4b113aafc215" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"मौजूदा थ्रेड शुरू करने या फिर से जारी रखने के लिए Chat खोलें।"</string>
+    <string name="native_287c4b113aafc215" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"मौजूदा थ्रेड शुरू करने या फिर से जारी रखने के लिए चैट खोलें।"</string>
     <string name="native_28bb849671cab958" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"सुझाव: कैप्चर किया गया टर्न भेजने के लिए सुनना बंद करें।"</string>
     <string name="native_28d03596d24eeb4e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"छोड़ें"</string>
     <string name="native_28d55ec6974d84e8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"वॉइस अनुरोध विफल रहा"</string>
@@ -283,7 +276,7 @@
     <string name="native_2cd62f7a670b2819" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw थ्रेड"</string>
     <string name="native_2d4dfe885f84629e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"फ़ोटो लाइब्रेरी एक्सेस की अनुमति दें।"</string>
     <string name="native_2d6416405eb44982" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"पिछले उत्तर में इस स्वीकृति को पहले ही हल कर दिया गया था।"</string>
-    <string name="native_2d85de9d56c226e4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"कोई हाल का थ्रेड नहीं"</string>
+    <string name="native_2d85de9d56c226e4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"कोई हालिया थ्रेड नहीं"</string>
     <string name="native_2df01a03ff43400b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"कोई मिलान नहीं"</string>
     <string name="native_2df30b117ad829ab" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"चुने गए ऐप की सूचनाएँ पढ़ें"</string>
     <string name="native_2e0078a8322d6f1f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"उपलब्धता अज्ञात"</string>
@@ -353,7 +346,6 @@
     <string name="native_381428f5f251a764" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Conversation Send"</string>
     <string name="native_3824a9f4dafe92c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"कैनवास"</string>
     <string name="native_384ae4ab1a2830f9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 प्रदाता"</string>
-    <string name="native_385001409de8562a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway प्रमाणपत्र को स्वचालित रूप से पढ़ा नहीं जा सका। Gateway होस्ट पर प्राप्त SHA-256 फ़िंगरप्रिंट पेस्ट करें।"</string>
     <string name="native_387b2569e440838c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"भेजना विफल रहा: %1$s"</string>
     <string name="native_3892e10346fd2012" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ब्रिज"</string>
     <string name="native_38d198cd5303680f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"डिलीवरी त्रुटि"</string>
@@ -411,7 +403,6 @@
     <string name="native_429f6057535c1ea3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sub-agent"</string>
     <string name="native_42e3a99c21767def" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"डिवाइस की स्वीकृति की प्रतीक्षा है"</string>
     <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"थ्रेड लोड हो रहा है"</string>
-    <string name="native_430df68ec29a85a2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"यह Gateway अब इस डिवाइस द्वारा विश्वसनीय प्रमाणपत्र प्रस्तुत करता है।"</string>
     <string name="native_43905968a540af6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"विलंब ms"</string>
     <string name="native_43988c156beabf7d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"event create"</string>
     <string name="native_43cc23fa52b87b4c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"दस्तावेज़"</string>
@@ -473,7 +464,6 @@
     <string name="native_4e8c72cab82e0711" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ऑटोमेशन का कॉन्फ़िगरेशन अमान्य है।"</string>
     <string name="native_4ec30e9d85725d41" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"अनुमति सूची"</string>
     <string name="native_4ed379d418bb8629" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"groups"</string>
-    <string name="native_4ee252fb736effa2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"सार्वजनिक कुंजी"</string>
     <string name="native_4efca0d10c5feb8e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"परिचय"</string>
     <string name="native_4f1bc100d1dccc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"उस इमेज में कोई सेटअप QR कोड नहीं मिला। openclaw qr से जनरेट किया गया QR चुनें या सेटअप कोड मैन्युअल रूप से दर्ज करें।"</string>
     <string name="native_4fe3cdd404ea0290" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"permissions"</string>
@@ -494,7 +484,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"डिलीवरी"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"स्पीकर म्यूट करें"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway कनेक्शन खोला जा रहा है"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"निगरानी · %1$s थ्रेड"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ऑटोमेशन रन पूरा हुआ।"</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"कोई मेल खाते ऐप्स नहीं।"</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Chat में भेजें"</string>
@@ -560,7 +550,6 @@
     <string name="native_5c0c8c9aa658f4a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OPENCLAW"</string>
     <string name="native_5c1acea9c9b0e704" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Fetch"</string>
     <string name="native_5c39123805ffb4e2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"प्रॉम्प्ट"</string>
-    <string name="native_5c944156b5353428" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"डिवाइस स्वीकृत करें?"</string>
     <string name="native_5d410adb9576e266" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"इस फ़ोन से %1$s और इसके सहेजे गए क्रेडेंशियल हटाएँ?"</string>
     <string name="native_5d6c41a67139ee26" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"QR कोड एक असुरक्षित रिमोट gateway की ओर इशारा करता है। %1$s %2$s"</string>
     <string name="native_5d6cbac59f87e78d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"स्क्रीन सतह तैयार है"</string>
@@ -578,7 +567,6 @@
     <string name="native_5fa1d457ddfcd26c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"rename group"</string>
     <string name="native_5fa7aac5375c5815" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"तैयार"</string>
     <string name="native_5fc1927ca948f31c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"डायरी अपनी पहली प्रविष्टि की प्रतीक्षा कर रही है।"</string>
-    <string name="native_6007acbe30b2cd98" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"स्वीकृत करें"</string>
     <string name="native_600c9c27960112a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"लाइव पेज"</string>
     <string name="native_6030d1f6340776d2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ऑटोमेशन पहले से चल रहा है।"</string>
     <string name="native_604e6d6faf8d0295" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"एक बार सफलतापूर्वक चलने के बाद इस ऑटोमेशन को हटा दें।"</string>
@@ -618,14 +606,12 @@
     <string name="native_6657cc73af00feac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"अनुरोध किए जाने पर कैमरा टूल्स की अनुमति दें।"</string>
     <string name="native_666067dd376e5d45" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"समस्याएँ"</string>
     <string name="native_666c8bc0319f3b54" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"वॉइस वेक"</string>
-    <string name="native_66713d713e3a41c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"पेयरिंग अनुरोध अस्वीकार किया गया।"</string>
     <string name="native_66b23bae66fc0d79" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$sदि. पहले"</string>
     <string name="native_66cf5513b37462be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"roles"</string>
     <string name="native_66d0f523a379b2de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skills"</string>
     <string name="native_66f4804ee23ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"आर्काइव करें"</string>
     <string name="native_66fab2875ee427f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"नोड ऑफ़लाइन है। दोबारा कनेक्ट करें और पुनः प्रयास करें।"</string>
     <string name="native_6725e7bbcd28f3a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"सिस्टम"</string>
-    <string name="native_672f3453e1dd571b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"रिमोट IP"</string>
     <string name="native_674b38cae72bb0c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"असमूहीकृत"</string>
     <string name="native_674eb55d9c353900" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"शेड्यूल का विवरण"</string>
     <string name="native_67528858c36397f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"फ़ोन की क्षमताएँ"</string>
@@ -633,8 +619,7 @@
     <string name="native_67b696468610b879" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dashboard"</string>
     <string name="native_67fa416afa64d304" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"टोकन पेस्ट करें"</string>
     <string name="native_6827238fea72c88b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"कोई प्रदाता नहीं"</string>
-    <string name="native_684889f0079cc145" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"SHA-256 फ़िंगरप्रिंट"</string>
-    <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"अभी तक कोई थ्रेड नहीं"</string>
+    <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"अभी कोई थ्रेड नहीं है"</string>
     <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bluetooth माइक्रोफ़ोन"</string>
     <string name="native_690dbe9dc0993c42" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"हाल के"</string>
     <string name="native_6930c8d1fc4f01d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"थ्रेड का नाम बदलें"</string>
@@ -668,7 +653,6 @@
     <string name="native_6d5d9004797377e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"लाइसेंस"</string>
     <string name="native_6d7c95a353d873cd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ClawHub Skills खोजने के लिए Gateway कनेक्ट करें।"</string>
     <string name="native_6df1bb18a59ab97d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skill"</string>
-    <string name="native_6e0a0b9d8c5ee4d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"डिवाइस ID"</string>
     <string name="native_6e117ba97cbfb6f0" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway ने सक्रिय %1$s प्रदाता की पहचान नहीं की"</string>
     <string name="native_6e293a8c009e0011" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"प्रतीक्षा में"</string>
     <string name="native_6e2c0963d056e104" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"वेक वर्ड सहेजे गए"</string>
@@ -792,7 +776,7 @@
     <string name="native_8193ee8a22d25208" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"मॉडल पिन करें"</string>
     <string name="native_81c2c4f30a4bec68" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"खोज साफ़ करें"</string>
     <string name="native_81d38aca5306940b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"पात्र एजेंट के लिए सक्षम।"</string>
-    <string name="native_820d08e12968baff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"कोई मौजूदा थ्रेड नहीं"</string>
+    <string name="native_820d08e12968baff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"कोई मौजूदा थ्रेड नहीं है"</string>
     <string name="native_82250171708918de" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s के बाद"</string>
     <string name="native_825b9c75d7fed691" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"शेड्यूलर को यह ऑटोमेशन चलाने की अनुमति दें।"</string>
     <string name="native_82990a093599a9bb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s लागू किए गए"</string>
@@ -845,7 +829,6 @@
     <string name="native_8bb7ec15b1e350a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Inspect हो रहा है"</string>
     <string name="native_8bf253a125f66985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"कोई और gateway जोड़ने के लिए सेटअप कोड स्कैन करें या पेस्ट करें।"</string>
     <string name="native_8c4a3896e8f06d27" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"TLS का समय समाप्त हो गया"</string>
-    <string name="native_8c55387fb6c584c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"पेयर किया गया डिवाइस हटा दिया गया।"</string>
     <string name="native_8c93c68056cde54d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway पेयर हो गया। नोड क्षमता की स्वीकृति जाँची जा रही है।"</string>
     <string name="native_8ca344247c18317e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"गतिविधि"</string>
     <string name="native_8cac4b77b9c54695" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"क्रॉन कार्रवाई विफल रही।"</string>
@@ -958,7 +941,7 @@
     <string name="native_9e37aa0704a3cf44" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s इंस्टॉल किया गया।"</string>
     <string name="native_9e4635769f0aaf0d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateways"</string>
     <string name="native_9e9bef85bb320b81" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"फ़ॉरवर्डिंग मोड"</string>
-    <string name="native_9f6e180ff696bec5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"थ्रेड लेआउट टॉगल करें"</string>
+    <string name="native_9f6e180ff696bec5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"थ्रेड लेआउट बदलें"</string>
     <string name="native_9fb7c4ebcbc3e558" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"कोई TLS एंडपॉइंट नहीं"</string>
     <string name="native_9fe101a0ec7ef416" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw Gateway"</string>
     <string name="native_9ffc843f501acdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"मैन्युअल रूप से सेट अप करें"</string>
@@ -1038,6 +1021,7 @@
     <string name="native_ad1c341c65f84ede" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway कंप्यूटर पर approve कमांड चलाएँ, फिर दोबारा जाँचें।"</string>
     <string name="native_ad1fb9ec0cb3c7a4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"स्वचालन"</string>
     <string name="native_adb7eb8a03ad699c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$sमि"</string>
+    <string name="native_adca3171c270301a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"यह Gateway साइन-इन कनेक्ट किए गए नोड सूचीबद्ध कर सकता है, लेकिन नए फ़ोन की पेयरिंग को स्वीकृति नहीं दे सकता। नए फ़ोन को Gateway एडमिन सत्र से पेयर करें। नोड क्षमता की स्वीकृति अलग है और इसके लिए अब भी nodes approve &lt;request id&gt; का उपयोग होता है।"</string>
     <string name="native_ade9248e0132b411" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"भरोसा करें"</string>
     <string name="native_ae27fa789a03c1db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"वह QR कोड OpenClaw सेटअप QR नहीं है। openclaw qr से नया कोड जनरेट करें, फिर दोबारा कोशिश करें।"</string>
     <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"पसंदीदा माइक्रोफ़ोन उपलब्ध नहीं है; स्वचालित रूटिंग का उपयोग किया जा रहा है।"</string>
@@ -1107,7 +1091,6 @@
     <string name="native_bb4f2558e4333834" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"विजेट इमेज Downloads में सेव की गई"</string>
     <string name="native_bbe5fc3b9ef39f99" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"शुरू हो रहा है…"</string>
     <string name="native_bc19cec293228fb8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"क्लाइंट त्रुटि"</string>
-    <string name="native_bc1c94a6dfce1058" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"पहुँच देने से पहले अनुरोध करने वाले इस डिवाइस को सत्यापित करें।"</string>
     <string name="native_bc6618670f3e8a17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bluetooth LE माइक्रोफ़ोन"</string>
     <string name="native_bcb06651437caa15" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
     <string name="native_bd08450d63406844" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ऑटोमेशन सक्षम किया गया।"</string>
@@ -1116,7 +1099,6 @@
     <string name="native_bdc090ec61e3fcfc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"रीलोड करें"</string>
     <string name="native_bdff71b20b9cf392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ऑटोमेशन खोजें"</string>
     <string name="native_be969becb173e0c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"पेयरिंग के बाद लिंक किए गए फ़ोन और नोड होस्ट यहाँ दिखाई देंगे।"</string>
-    <string name="native_bf1870ff5c6322fb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s: %2$s"</string>
     <string name="native_bf350e6a0ed60b7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"यह ऑटोमेशन Gateway पर बदल गया है। दोबारा सहेजने से पहले नवीनतम संस्करण की समीक्षा करें।"</string>
     <string name="native_bf399ffa03617a96" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"डिक्टेशन रोकें"</string>
     <string name="native_bf56ee2fe3345ce1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"पठनीय"</string>
@@ -1140,7 +1122,6 @@
     <string name="native_c1c224b03cd9bc7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"एडमिन"</string>
     <string name="native_c1ebc7817870e5be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ध्यान देने की आवश्यकता है"</string>
     <string name="native_c22d5e02fbec7d65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"इस डिवाइस को अपने Gateway से पेयर करें, ताकि यह केवल वास्तविक काम के लिए सक्रिय हो, एजेंट की लाइव जानकारी आसानी से उपलब्ध रहे और बैटरी खर्च करने वाले बैकग्राउंड लूप से बचा जा सके।"</string>
-    <string name="native_c25337055464f8d3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"भूमिकाएँ"</string>
     <string name="native_c253f451bdd56431" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"जवाब दें"</string>
     <string name="native_c26225b6c16a4bc7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"प्रोवाइडर कैटलॉग"</string>
     <string name="native_c272b225cf5bd643" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Settings में अनुमति सक्षम करें"</string>
@@ -1154,7 +1135,6 @@
     <string name="native_c34dd5eb8b0af56e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"मुझे सेटअप कोड कहाँ मिलेगा?"</string>
     <string name="native_c3546b39ecbbed8a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skill को सक्षम नहीं किया जा सका।"</string>
     <string name="native_c35b21d6ca39aa7c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"pdf"</string>
-    <string name="native_c3812fc4acb861d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"हटाएँ"</string>
     <string name="native_c382566dbe2ea49f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s%% ऑनलाइन"</string>
     <string name="native_c385951198c45d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"कोई चैनल नहीं है"</string>
     <string name="native_c41ad84496b53420" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"रीयल-टाइम वॉइस"</string>
@@ -1183,7 +1163,6 @@
     <string name="native_c6d5ed757b66bfd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"सपना"</string>
     <string name="native_c6dd061350fc69b8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"कोई ऐप ब्लॉक नहीं किया गया है। जब तक आप ब्लॉक नहीं जोड़ते, ऐप्स फ़ॉरवर्ड कर सकते हैं।"</string>
     <string name="native_c753cdf0c19f1e38" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"वाक् पहचानकर्ता उपलब्ध नहीं है"</string>
-    <string name="native_c78ffe19571018fb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"प्लेटफ़ॉर्म"</string>
     <string name="native_c7985fa72daa6ea4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway ने %1$s सेटअप नहीं लौटाया"</string>
     <string name="native_c7b6dfd5c3a183c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway भूलें?"</string>
     <string name="native_c7b7b7f01360f6a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"वैकल्पिक विवरण"</string>
@@ -1246,7 +1225,6 @@
     <string name="native_d17d2d78d76e6a6c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"मॉडल"</string>
     <string name="native_d19c2dd2fb598b93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw निष्क्रिय"</string>
     <string name="native_d1a574e23344c407" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway पासवर्ड अमान्य है"</string>
-    <string name="native_d1af697abaff485f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"डिवाइस पेयरिंग में बदलाव सत्यापित नहीं किया जा सका। रीफ़्रेश करके फिर से कोशिश करें।"</string>
     <string name="native_d1bf045bb524dae5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"विवरण देखें"</string>
     <string name="native_d1e9567da9a8a4b0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bash"</string>
     <string name="native_d2089be672953d11" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"टोकन"</string>
@@ -1261,7 +1239,6 @@
     <string name="native_d31de1a5c5c8ba2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Browser"</string>
     <string name="native_d354ee936f59115e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screen record"</string>
     <string name="native_d3974fd6d3b6c81f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"रन लंबित है"</string>
-    <string name="native_d3e1c5f8a6e240fc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"मूल"</string>
     <string name="native_d3f75e24411053c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"आपके डिवाइसों पर निजी AI"</string>
     <string name="native_d406ade2958cb5b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attach"</string>
     <string name="native_d461a493a3753877" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"स्वचालित"</string>
@@ -1277,7 +1254,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"प्रोफ़ाइल"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"जब आपका Gateway उन्हें रिपोर्ट करेगा, तो प्रदाता सीमाएँ यहाँ दिखाई देंगी।"</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 समस्या"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"\"%1$s\" के थ्रेड रखे जाते हैं और वापस अवर्गीकृत में चले जाते हैं।"</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"बनाया गया"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s सक्रिय टोकन"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>
@@ -1369,7 +1346,7 @@
     <string name="native_e52b3044724b9f4d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"मॉडल अनपिन करें"</string>
     <string name="native_e5584bc5057284ae" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"इस gateway से जुड़ी मैसेजिंग सतहें।"</string>
     <string name="native_e595f17fac1d8384" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"भेजा जा रहा है"</string>
-    <string name="native_e5b87192a9e6321f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"आर्काइव किए गए थ्रेड यहाँ दिखाई देंगे।"</string>
+    <string name="native_e5b87192a9e6321f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"संग्रहीत थ्रेड यहाँ दिखाई देंगे।"</string>
     <string name="native_e5c02424e511e1ef" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"कमांड कॉपी की गई"</string>
     <string name="native_e5c083cf41ff6472" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"कोई पूर्वावलोकन उपलब्ध नहीं है"</string>
     <string name="native_e5c3e7b8110e7087" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"इस फ़ोन को Gateway पर स्वीकृत करें।\nफिर कनेक्शन का दोबारा प्रयास करें।"</string>
@@ -1450,7 +1427,6 @@
     <string name="native_f2da2e47cd31a5dd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"इस इमेज को डिकोड नहीं किया जा सका."</string>
     <string name="native_f3753c0fe29b88db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway, वॉइस, सूचनाएँ, गोपनीयता"</string>
     <string name="native_f386c32c1bf437d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"एजेंट वर्कस्पेस की फ़ाइलें"</string>
-    <string name="native_f418bf0894a1806a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"यह डिवाइस अपनी विश्वसनीय Gateway पहुँच खो देगा।"</string>
     <string name="native_f41d9e8b7e09aa24" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"approve कमांड में pending कमांड से requestId का उपयोग करें।"</string>
     <string name="native_f4830a1dae298044" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"शेड्यूल"</string>
     <string name="native_f493f0ce7a52a8aa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"दर सीमा"</string>
@@ -1458,7 +1434,6 @@
     <string name="native_f4cc820d308495c4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"पेलोड · %1$s"</string>
     <string name="native_f4ccae29e1bb0c20" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"चल रहा है"</string>
     <string name="native_f4db1e48476f6075" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"समाप्त करें"</string>
-    <string name="native_f4e2076014711222" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"सिस्टम विश्वसनीयता का उपयोग करें"</string>
     <string name="native_f4ef7a41caa88dd1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"कोई तैयार प्रोवाइडर नहीं"</string>
     <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"कनेक्ट किए गए Bluetooth माइक्रोफ़ोन को प्राथमिकता देता है।"</string>
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s ऐप को फ़ॉरवर्ड करने से ब्लॉक किया गया है।"</string>

--- a/apps/android/app/src/main/res/values-in/strings.xml
+++ b/apps/android/app/src/main/res/values-in/strings.xml
@@ -494,7 +494,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Pengiriman"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bisukan speaker"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Membuka koneksi Gateway"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Memantau · %1$s utas"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Proses automasi selesai."</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tidak ada aplikasi yang cocok."</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kirim ke Chat"</string>
@@ -798,7 +798,7 @@
     <string name="native_82990a093599a9bb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s diterapkan"</string>
     <string name="native_8340dad4f3be30a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Belum ada diary mimpi."</string>
     <string name="native_837e39f46163ffb4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Segarkan tugas latar belakang"</string>
-    <string name="native_838337fd9ab30454" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rangkum utas terbaru dan langkah selanjutnya."</string>
+    <string name="native_838337fd9ab30454" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rangkum utas terbaru dan langkah berikutnya."</string>
     <string name="native_83e2faed20a3cda4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Berjalan di perangkat saat OpenClaw terlihat."</string>
     <string name="native_844e5b02f3ef05ca" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s sedang bekerja"</string>
     <string name="native_846c75dca0b71591" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
@@ -958,7 +958,7 @@
     <string name="native_9e37aa0704a3cf44" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s telah diinstal."</string>
     <string name="native_9e4635769f0aaf0d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway"</string>
     <string name="native_9e9bef85bb320b81" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Mode Penerusan"</string>
-    <string name="native_9f6e180ff696bec5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Alihkan tata letak utas"</string>
+    <string name="native_9f6e180ff696bec5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ubah tata letak utas"</string>
     <string name="native_9fb7c4ebcbc3e558" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tidak ada endpoint TLS"</string>
     <string name="native_9fe101a0ec7ef416" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway OpenClaw"</string>
     <string name="native_9ffc843f501acdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Siapkan secara manual"</string>
@@ -1212,7 +1212,7 @@
     <string name="native_cc721e25d73938a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway Rumah"</string>
     <string name="native_cc7a9a5cf8c4bc9d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Jalankan perintah persetujuan di Gateway"</string>
     <string name="native_cc925e3c97ac7a35" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tidak dapat memuat proposal Skill Workshop."</string>
-    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Berikan ringkasan tentang utas OpenClaw terbaru saya dan sarankan langkah berikutnya."</string>
+    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Beri saya ringkasan utas OpenClaw terbaru saya dan sarankan langkah berikutnya."</string>
     <string name="native_ccb4c324f516c633" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Jangan Sekarang"</string>
     <string name="native_cced0b0d83a9e400" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw qr"</string>
     <string name="native_cced28c6dc3f99c2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"start"</string>
@@ -1277,7 +1277,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Profil"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Batas penyedia akan muncul di sini saat gateway Anda melaporkannya."</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 masalah"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Utas di \"%1$s\" tetap dipertahankan dan dipindahkan kembali ke Tidak dikelompokkan."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dibuat"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s token aktif"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>
@@ -1522,7 +1522,7 @@
     <string name="native_ff716fc4735e067f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Pengaturan dikte"</string>
     <string name="native_ff9dbbdfb84ddab2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Model penyedia telah dimuat, tetapi status kesiapan tidak tersedia."</string>
     <string name="native_ffa7aa557b547a79" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Hapus utas?"</string>
-    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw mengubah ponsel ini menjadi antarmuka perintah seluler yang ringkas untuk utas, suara, penyedia, dan Gateway."</string>
+    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw mengubah ponsel ini menjadi antarmuka perintah seluler yang rapi untuk utas, suara, penyedia, dan Gateway."</string>
     <string name="native_ffb6f5764bddb68c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Terbaru dahulu"</string>
     <string name="native_ffcf16006c652ee3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Siklus Berikutnya"</string>
 </resources>

--- a/apps/android/app/src/main/res/values-in/strings.xml
+++ b/apps/android/app/src/main/res/values-in/strings.xml
@@ -494,7 +494,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Pengiriman"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bisukan speaker"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Membuka koneksi Gateway"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Memantau · %1$s utas"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Proses automasi selesai."</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tidak ada aplikasi yang cocok."</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kirim ke Chat"</string>
@@ -1277,7 +1277,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Profil"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Batas penyedia akan muncul di sini saat gateway Anda melaporkannya."</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 masalah"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Utas di \"%1$s\" tetap disimpan dan dipindahkan kembali ke Tanpa Grup."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dibuat"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s token aktif"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>

--- a/apps/android/app/src/main/res/values-it/strings.xml
+++ b/apps/android/app/src/main/res/values-it/strings.xml
@@ -494,7 +494,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Consegna"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Disattiva altoparlante"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Apertura della connessione al Gateway"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoraggio · %1$s conversazioni"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Esecuzione dell\'automazione completata."</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nessuna app corrispondente."</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Invia alla chat"</string>
@@ -1277,7 +1277,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Profilo"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"I limiti del provider appariranno qui quando il tuo Gateway li segnalerà."</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 problema"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"I thread in \"%1$s\" vengono mantenuti e spostati di nuovo in Non raggruppati."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Creato"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s token attivi"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>

--- a/apps/android/app/src/main/res/values-it/strings.xml
+++ b/apps/android/app/src/main/res/values-it/strings.xml
@@ -75,6 +75,7 @@
     <string name="native_0929c9dc7f794852" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nessuna proposta"</string>
     <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Thread principale"</string>
     <string name="native_0979c6fdbdca1675" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Apri Chat"</string>
+    <string name="native_09ce95090659d069" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Le azioni di associazione del dispositivo non sono disponibili in questa sessione del Gateway. Esegui openclaw devices list sull\'host del Gateway e gestisci lì la richiesta. L\'approvazione delle funzionalità del nodo è separata e continua a utilizzare nodes approve &lt;request id&gt;."</string>
     <string name="native_0a0b7cf7c428c703" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Richiesta di azione"</string>
     <string name="native_0a708e7b03aaf1fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list pins"</string>
     <string name="native_0ab0e1629576aecf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Connettiti a un Gateway per caricare le proposte di Skill Workshop."</string>
@@ -87,10 +88,12 @@
     <string name="native_0c3845dcd2f0f683" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Esamina questa proposta per caricarne il markdown."</string>
     <string name="native_0c3ea4e2f12153e7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"apri OpenClaw e chiedi %1$s"</string>
     <string name="native_0c4d01e81bb3d1fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ragionamento"</string>
+    <string name="native_0c77fe09ab336a3e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Client"</string>
     <string name="native_0c79a9c222840ed0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Applicato"</string>
     <string name="native_0cab1c9617404faf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"video"</string>
     <string name="native_0cf04463c4276a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Promosso"</string>
     <string name="native_0d21bd52022ca7f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Online"</string>
+    <string name="native_0d5644ff52ce2ba3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ambiti"</string>
     <string name="native_0d5efd432e4fedf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Il provider vocale in tempo reale non è configurato."</string>
     <string name="native_0d8ca811c3744a6d" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s · %2$s"</string>
     <string name="native_0db10f2c2f332cd2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"kick"</string>
@@ -138,6 +141,7 @@
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Destinazione della sessione"</string>
     <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Esamina la skill di ClawHub"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
+    <string name="native_16a5b7ad567a8093" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rifiutare la richiesta di associazione da questo dispositivo?"</string>
     <string name="native_16b1a05e1d987ed1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Microfono preferito"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Host del nodo"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Livello"</string>
@@ -183,6 +187,7 @@
     <string name="native_1d91629837639a5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Questa automazione è stata modificata durante la modifica. Ripristina la versione più recente del Gateway prima di salvare."</string>
     <string name="native_1dbf9d5979606697" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Quando è connesso, il Gateway può riattivare il telefono con una notifica push silenziosa anziché mantenere una sessione sempre attiva."</string>
     <string name="native_1e432ea5425e4a3a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Modalità di attivazione"</string>
+    <string name="native_1e595a107c78b957" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rimuovere il dispositivo associato?"</string>
     <string name="native_1e955a58278623a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Testo evento di sistema"</string>
     <string name="native_1ea44149be42d970" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Impossibile copiare l\'immagine del widget"</string>
     <string name="native_1ea442a134b2a184" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"No"</string>
@@ -197,6 +202,7 @@
     <string name="native_2065cc867eba1b39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Impossibile caricare la configurazione dei modelli del provider."</string>
     <string name="native_207ccb22d618db05" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s app autorizzata all\'inoltro."</string>
     <string name="native_209b9e597963e7e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Configurazione voce"</string>
+    <string name="native_211988ba9dd0570a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rifiutare la richiesta di associazione?"</string>
     <string name="native_2132066dc9475cb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"This skill is installed but not available to the current agent. Agent filters stay on desktop or CLI."</string>
     <string name="native_21378545892f1fe2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Editore"</string>
     <string name="native_214d4932fc767e8f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">" · Conversazione: sta parlando"</string>
@@ -238,6 +244,7 @@
     <string name="native_2682bd813a3bccbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Inserisci il codice di configurazione da openclaw qr."</string>
     <string name="native_268f14bbfe119c1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Diagnostica"</string>
     <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Questa operazione elimina definitivamente il thread e la relativa trascrizione."</string>
+    <string name="native_26e47d73a55d7fa7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dispositivo approvato."</string>
     <string name="native_26f0dd993530eb2d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nuovo tentativo automatico"</string>
     <string name="native_270ff82f36da987f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Immagine del widget copiata"</string>
     <string name="native_2728740a95d465c6" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s ruoli"</string>
@@ -346,6 +353,7 @@
     <string name="native_381428f5f251a764" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Conversation Send"</string>
     <string name="native_3824a9f4dafe92c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Canvas"</string>
     <string name="native_384ae4ab1a2830f9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 provider"</string>
+    <string name="native_385001409de8562a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Non è stato possibile leggere automaticamente il certificato del Gateway. Incolla l\'impronta digitale SHA-256 ottenuta sull\'host del Gateway."</string>
     <string name="native_387b2569e440838c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Invio non riuscito: %1$s"</string>
     <string name="native_3892e10346fd2012" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bridge"</string>
     <string name="native_38d198cd5303680f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Errore di consegna"</string>
@@ -403,6 +411,7 @@
     <string name="native_429f6057535c1ea3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sub-agent"</string>
     <string name="native_42e3a99c21767def" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"In attesa dell\'approvazione del dispositivo"</string>
     <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Caricamento del thread"</string>
+    <string name="native_430df68ec29a85a2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Questo Gateway ora presenta un certificato considerato attendibile da questo dispositivo."</string>
     <string name="native_43905968a540af6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sfalsamento ms"</string>
     <string name="native_43988c156beabf7d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"event create"</string>
     <string name="native_43cc23fa52b87b4c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"documento"</string>
@@ -464,6 +473,7 @@
     <string name="native_4e8c72cab82e0711" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"L\'automazione ha una configurazione non valida."</string>
     <string name="native_4ec30e9d85725d41" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Elenco consentiti"</string>
     <string name="native_4ed379d418bb8629" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"groups"</string>
+    <string name="native_4ee252fb736effa2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Chiave pubblica"</string>
     <string name="native_4efca0d10c5feb8e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Informazioni"</string>
     <string name="native_4f1bc100d1dccc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nell\'immagine non è stato trovato alcun codice QR di configurazione. Scegli il QR generato da openclaw qr oppure inserisci manualmente il codice di configurazione."</string>
     <string name="native_4fe3cdd404ea0290" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"permissions"</string>
@@ -550,6 +560,7 @@
     <string name="native_5c0c8c9aa658f4a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OPENCLAW"</string>
     <string name="native_5c1acea9c9b0e704" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Fetch"</string>
     <string name="native_5c39123805ffb4e2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Prompt"</string>
+    <string name="native_5c944156b5353428" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Approvare il dispositivo?"</string>
     <string name="native_5d410adb9576e266" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rimuovere %1$s e le relative credenziali salvate da questo telefono?"</string>
     <string name="native_5d6c41a67139ee26" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Il codice QR punta a un gateway remoto non sicuro. %1$s %2$s"</string>
     <string name="native_5d6cbac59f87e78d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Superficie dello schermo pronta"</string>
@@ -567,6 +578,7 @@
     <string name="native_5fa1d457ddfcd26c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"rename group"</string>
     <string name="native_5fa7aac5375c5815" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Pronto"</string>
     <string name="native_5fc1927ca948f31c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Il diario è in attesa della sua prima voce."</string>
+    <string name="native_6007acbe30b2cd98" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Approva"</string>
     <string name="native_600c9c27960112a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Pagina live"</string>
     <string name="native_6030d1f6340776d2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"L\'automazione è già in esecuzione."</string>
     <string name="native_604e6d6faf8d0295" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rimuovi questa automazione dopo un\'esecuzione singola completata correttamente."</string>
@@ -606,12 +618,14 @@
     <string name="native_6657cc73af00feac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Consenti gli strumenti della fotocamera quando richiesto."</string>
     <string name="native_666067dd376e5d45" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Problemi"</string>
     <string name="native_666c8bc0319f3b54" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attivazione vocale"</string>
+    <string name="native_66713d713e3a41c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Richiesta di associazione rifiutata."</string>
     <string name="native_66b23bae66fc0d79" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s g fa"</string>
     <string name="native_66cf5513b37462be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"roles"</string>
     <string name="native_66d0f523a379b2de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skills"</string>
     <string name="native_66f4804ee23ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Archivia"</string>
     <string name="native_66fab2875ee427f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nodo offline. Riconnettiti e riprova."</string>
     <string name="native_6725e7bbcd28f3a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sistema"</string>
+    <string name="native_672f3453e1dd571b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"IP remoto"</string>
     <string name="native_674b38cae72bb0c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Non raggruppati"</string>
     <string name="native_674eb55d9c353900" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dettagli pianificazione"</string>
     <string name="native_67528858c36397f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Funzionalità del telefono"</string>
@@ -619,6 +633,7 @@
     <string name="native_67b696468610b879" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dashboard"</string>
     <string name="native_67fa416afa64d304" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Incolla token"</string>
     <string name="native_6827238fea72c88b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nessun provider"</string>
+    <string name="native_684889f0079cc145" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Impronta digitale SHA-256"</string>
     <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nessun thread"</string>
     <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Microfono Bluetooth"</string>
     <string name="native_690dbe9dc0993c42" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Recenti"</string>
@@ -653,6 +668,7 @@
     <string name="native_6d5d9004797377e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Licenze"</string>
     <string name="native_6d7c95a353d873cd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Connetti il Gateway per cercare le Skills di ClawHub."</string>
     <string name="native_6df1bb18a59ab97d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skill"</string>
+    <string name="native_6e0a0b9d8c5ee4d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ID dispositivo"</string>
     <string name="native_6e117ba97cbfb6f0" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway non ha identificato il provider %1$s attivo"</string>
     <string name="native_6e293a8c009e0011" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"In attesa"</string>
     <string name="native_6e2c0963d056e104" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Parole di attivazione salvate"</string>
@@ -829,6 +845,7 @@
     <string name="native_8bb7ec15b1e350a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ispezione in corso"</string>
     <string name="native_8bf253a125f66985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Scansiona o incolla un codice di configurazione per aggiungere un altro gateway."</string>
     <string name="native_8c4a3896e8f06d27" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Timeout TLS"</string>
+    <string name="native_8c55387fb6c584c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dispositivo associato rimosso."</string>
     <string name="native_8c93c68056cde54d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway associato. Verifica dell\'approvazione delle funzionalità del nodo."</string>
     <string name="native_8ca344247c18317e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Movimento"</string>
     <string name="native_8cac4b77b9c54695" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Azione cron non riuscita."</string>
@@ -1021,7 +1038,6 @@
     <string name="native_ad1c341c65f84ede" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Esegui il comando approve sul computer Gateway, quindi controlla di nuovo."</string>
     <string name="native_ad1fb9ec0cb3c7a4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automazioni"</string>
     <string name="native_adb7eb8a03ad699c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s min"</string>
-    <string name="native_adca3171c270301a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Questo accesso al Gateway può elencare i nodi connessi, ma non può approvare l\'associazione di nuovi telefoni. Associa i nuovi telefoni da una sessione amministratore del Gateway. L\'approvazione delle funzionalità dei nodi è separata e continua a utilizzare nodes approve &lt;request id&gt;."</string>
     <string name="native_ade9248e0132b411" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Autorizza"</string>
     <string name="native_ae27fa789a03c1db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Quel codice QR non è un QR di configurazione di OpenClaw. Genera un nuovo codice con openclaw qr, quindi riprova."</string>
     <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Il microfono preferito non è disponibile; viene usato l\'instradamento automatico."</string>
@@ -1091,6 +1107,7 @@
     <string name="native_bb4f2558e4333834" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Immagine del widget salvata in Download"</string>
     <string name="native_bbe5fc3b9ef39f99" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Avvio…"</string>
     <string name="native_bc19cec293228fb8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Errore del client"</string>
+    <string name="native_bc1c94a6dfce1058" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Verifica il dispositivo che ha inviato la richiesta prima di concedere l\'accesso."</string>
     <string name="native_bc6618670f3e8a17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Microfono Bluetooth LE"</string>
     <string name="native_bcb06651437caa15" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
     <string name="native_bd08450d63406844" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automazione attivata."</string>
@@ -1099,6 +1116,7 @@
     <string name="native_bdc090ec61e3fcfc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ricarica"</string>
     <string name="native_bdff71b20b9cf392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cerca automazioni"</string>
     <string name="native_be969becb173e0c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"I telefoni collegati e gli host dei nodi appariranno qui dopo l\'associazione."</string>
+    <string name="native_bf1870ff5c6322fb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s: %2$s"</string>
     <string name="native_bf350e6a0ed60b7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Questa automazione è stata modificata sul Gateway. Controlla la versione più recente prima di salvarla di nuovo."</string>
     <string name="native_bf399ffa03617a96" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Interrompi dettatura"</string>
     <string name="native_bf56ee2fe3345ce1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Leggibile"</string>
@@ -1122,6 +1140,7 @@
     <string name="native_c1c224b03cd9bc7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Amministratore"</string>
     <string name="native_c1ebc7817870e5be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Richiede attenzione"</string>
     <string name="native_c22d5e02fbec7d65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Abbina questo dispositivo al tuo Gateway per riattivarlo solo quando c\'è davvero del lavoro da svolgere, tenere a portata di mano una panoramica in tempo reale degli agenti ed evitare cicli in background che consumano la batteria."</string>
+    <string name="native_c25337055464f8d3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ruoli"</string>
     <string name="native_c253f451bdd56431" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rispondi"</string>
     <string name="native_c26225b6c16a4bc7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Catalogo dei provider"</string>
     <string name="native_c272b225cf5bd643" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Abilita l\'autorizzazione in Impostazioni"</string>
@@ -1135,6 +1154,7 @@
     <string name="native_c34dd5eb8b0af56e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dove posso ottenere un codice di configurazione?"</string>
     <string name="native_c3546b39ecbbed8a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Impossibile abilitare la skill."</string>
     <string name="native_c35b21d6ca39aa7c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"pdf"</string>
+    <string name="native_c3812fc4acb861d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rimuovi"</string>
     <string name="native_c382566dbe2ea49f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s%% online"</string>
     <string name="native_c385951198c45d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nessun canale"</string>
     <string name="native_c41ad84496b53420" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Voce in tempo reale"</string>
@@ -1163,6 +1183,7 @@
     <string name="native_c6d5ed757b66bfd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sogno"</string>
     <string name="native_c6dd061350fc69b8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nessuna app bloccata. Le app possono inoltrare finché non aggiungi blocchi."</string>
     <string name="native_c753cdf0c19f1e38" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Riconoscimento vocale non disponibile"</string>
+    <string name="native_c78ffe19571018fb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Piattaforma"</string>
     <string name="native_c7985fa72daa6ea4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway non ha restituito la configurazione di %1$s"</string>
     <string name="native_c7b6dfd5c3a183c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dimenticare il gateway?"</string>
     <string name="native_c7b7b7f01360f6a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Descrizione facoltativa"</string>
@@ -1225,6 +1246,7 @@
     <string name="native_d17d2d78d76e6a6c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Modelli"</string>
     <string name="native_d19c2dd2fb598b93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw passivo"</string>
     <string name="native_d1a574e23344c407" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Password del Gateway non valida"</string>
+    <string name="native_d1af697abaff485f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Impossibile verificare la modifica all\'associazione del dispositivo. Aggiorna e riprova."</string>
     <string name="native_d1bf045bb524dae5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Visualizza dettagli"</string>
     <string name="native_d1e9567da9a8a4b0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bash"</string>
     <string name="native_d2089be672953d11" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Token"</string>
@@ -1239,6 +1261,7 @@
     <string name="native_d31de1a5c5c8ba2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Browser"</string>
     <string name="native_d354ee936f59115e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screen record"</string>
     <string name="native_d3974fd6d3b6c81f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Esecuzione in sospeso"</string>
+    <string name="native_d3e1c5f8a6e240fc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Origine"</string>
     <string name="native_d3f75e24411053c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"AI personale sui tuoi dispositivi"</string>
     <string name="native_d406ade2958cb5b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attach"</string>
     <string name="native_d461a493a3753877" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatico"</string>
@@ -1427,6 +1450,7 @@
     <string name="native_f2da2e47cd31a5dd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Impossibile decodificare questa immagine."</string>
     <string name="native_f3753c0fe29b88db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway, voce, notifiche, privacy"</string>
     <string name="native_f386c32c1bf437d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"File dell\'area di lavoro dell\'agente"</string>
+    <string name="native_f418bf0894a1806a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Questo dispositivo perderà l\'accesso attendibile al Gateway."</string>
     <string name="native_f41d9e8b7e09aa24" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Usa il requestId dal comando in sospeso nel comando approve."</string>
     <string name="native_f4830a1dae298044" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Pianificazione"</string>
     <string name="native_f493f0ce7a52a8aa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Limite di frequenza"</string>
@@ -1434,6 +1458,7 @@
     <string name="native_f4cc820d308495c4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Payload · %1$s"</string>
     <string name="native_f4ccae29e1bb0c20" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"In esecuzione"</string>
     <string name="native_f4db1e48476f6075" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Termina"</string>
+    <string name="native_f4e2076014711222" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Usa l\'attendibilità di sistema"</string>
     <string name="native_f4ef7a41caa88dd1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nessun provider pronto"</string>
     <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dà priorità ai microfoni Bluetooth connessi."</string>
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s app bloccata dall\'inoltro."</string>

--- a/apps/android/app/src/main/res/values-it/strings.xml
+++ b/apps/android/app/src/main/res/values-it/strings.xml
@@ -31,7 +31,7 @@
     <string name="native_00e8aeba41d79ce3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 in sospeso"</string>
     <string name="native_010f6550a1c8f554" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Allegato non supportato"</string>
     <string name="native_01267be21eb77392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"0 = esatto"</string>
-    <string name="native_0171e3d4e07f1861" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Connetti il Gateway per cercare i thread."</string>
+    <string name="native_0171e3d4e07f1861" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Connetti il Gateway per cercare le conversazioni."</string>
     <string name="native_0174f83136630e7e" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s account"</string>
     <string name="native_01ac1c298e0cbd9a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Le modifiche Cron richiedono operator.admin. I codici di configurazione non lo concedono intenzionalmente. Riconnettiti con il token condiviso o la password del Gateway per richiedere l\'accesso amministratore. Se questo dispositivo continua a non disporne, approva l\'aggiornamento dell\'ambito in sospeso da un client amministratore esistente."</string>
     <string name="native_01bcfe7a9296b6d6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Apply Patch"</string>
@@ -75,7 +75,6 @@
     <string name="native_0929c9dc7f794852" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nessuna proposta"</string>
     <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Thread principale"</string>
     <string name="native_0979c6fdbdca1675" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Apri Chat"</string>
-    <string name="native_09ce95090659d069" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Le azioni di associazione del dispositivo non sono disponibili in questa sessione del Gateway. Esegui openclaw devices list sull\'host del Gateway e gestisci lì la richiesta. L\'approvazione delle funzionalità del nodo è separata e continua a utilizzare nodes approve &lt;request id&gt;."</string>
     <string name="native_0a0b7cf7c428c703" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Richiesta di azione"</string>
     <string name="native_0a708e7b03aaf1fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list pins"</string>
     <string name="native_0ab0e1629576aecf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Connettiti a un Gateway per caricare le proposte di Skill Workshop."</string>
@@ -88,12 +87,10 @@
     <string name="native_0c3845dcd2f0f683" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Esamina questa proposta per caricarne il markdown."</string>
     <string name="native_0c3ea4e2f12153e7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"apri OpenClaw e chiedi %1$s"</string>
     <string name="native_0c4d01e81bb3d1fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ragionamento"</string>
-    <string name="native_0c77fe09ab336a3e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Client"</string>
     <string name="native_0c79a9c222840ed0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Applicato"</string>
     <string name="native_0cab1c9617404faf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"video"</string>
     <string name="native_0cf04463c4276a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Promosso"</string>
     <string name="native_0d21bd52022ca7f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Online"</string>
-    <string name="native_0d5644ff52ce2ba3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ambiti"</string>
     <string name="native_0d5efd432e4fedf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Il provider vocale in tempo reale non è configurato."</string>
     <string name="native_0d8ca811c3744a6d" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s · %2$s"</string>
     <string name="native_0db10f2c2f332cd2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"kick"</string>
@@ -104,7 +101,7 @@
     <string name="native_0e91610117029a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aggiorna"</string>
     <string name="native_0ee30822ed35a792" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s in coda"</string>
     <string name="native_0f4c8529742b31ea" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Avvia chat"</string>
-    <string name="native_0f559ff270904904" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Le chiamate agli strumenti della chat in attesa nel thread attivo rimangono visibili qui."</string>
+    <string name="native_0f559ff270904904" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Le chiamate agli strumenti di Chat in attesa nel thread attivo rimangono visibili qui."</string>
     <string name="native_0f56cc286a4f23d8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Revisione del certificato necessaria"</string>
     <string name="native_0f8fe3a9688138a1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Apri la superficie Canvas corrente per ispezionarla o interagirvi."</string>
     <string name="native_0ff98f05be01ce5e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automazione aggiornata."</string>
@@ -125,7 +122,7 @@
     <string name="native_12698ce1ea5cd4ab" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ignorato"</string>
     <string name="native_1291833ee42d8143" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Usa l\'indirizzo LAN del computer Gateway o il nome host remoto sicuro."</string>
     <string name="native_130011756125313c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attivato"</string>
-    <string name="native_133f293961d7aa43" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ricerca dei thread"</string>
+    <string name="native_133f293961d7aa43" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ricerca delle conversazioni"</string>
     <string name="native_13798c3256e792c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Conversazione in tempo reale"</string>
     <string name="native_13b588109e423636" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw sta preparando una risposta."</string>
     <string name="native_13ba4cde12390943" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Approvazione consentita una volta."</string>
@@ -141,7 +138,6 @@
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Destinazione della sessione"</string>
     <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Esamina la skill di ClawHub"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
-    <string name="native_16a5b7ad567a8093" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rifiutare la richiesta di associazione da questo dispositivo?"</string>
     <string name="native_16b1a05e1d987ed1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Microfono preferito"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Host del nodo"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Livello"</string>
@@ -187,7 +183,6 @@
     <string name="native_1d91629837639a5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Questa automazione è stata modificata durante la modifica. Ripristina la versione più recente del Gateway prima di salvare."</string>
     <string name="native_1dbf9d5979606697" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Quando è connesso, il Gateway può riattivare il telefono con una notifica push silenziosa anziché mantenere una sessione sempre attiva."</string>
     <string name="native_1e432ea5425e4a3a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Modalità di attivazione"</string>
-    <string name="native_1e595a107c78b957" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rimuovere il dispositivo associato?"</string>
     <string name="native_1e955a58278623a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Testo evento di sistema"</string>
     <string name="native_1ea44149be42d970" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Impossibile copiare l\'immagine del widget"</string>
     <string name="native_1ea442a134b2a184" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"No"</string>
@@ -202,7 +197,6 @@
     <string name="native_2065cc867eba1b39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Impossibile caricare la configurazione dei modelli del provider."</string>
     <string name="native_207ccb22d618db05" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s app autorizzata all\'inoltro."</string>
     <string name="native_209b9e597963e7e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Configurazione voce"</string>
-    <string name="native_211988ba9dd0570a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rifiutare la richiesta di associazione?"</string>
     <string name="native_2132066dc9475cb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"This skill is installed but not available to the current agent. Agent filters stay on desktop or CLI."</string>
     <string name="native_21378545892f1fe2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Editore"</string>
     <string name="native_214d4932fc767e8f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">" · Conversazione: sta parlando"</string>
@@ -216,7 +210,7 @@
     <string name="native_22965568d22a14ee" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Connesso"</string>
     <string name="native_22a970d2e5b1cc23" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Completata"</string>
     <string name="native_22b8da9e693e94eb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Il tuo telefono è associato a %1$s. Continua per completare l\'accesso al nodo."</string>
-    <string name="native_22f19ab686639b9a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Thread corrente"</string>
+    <string name="native_22f19ab686639b9a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Conversazione corrente"</string>
     <string name="native_23246d9852fed325" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Elaborazione %1$s"</string>
     <string name="native_2346f214ad56b180" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Disattivato"</string>
     <string name="native_2347fc06da5f60de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw apprezza i suoi partner nella community open-source."</string>
@@ -244,7 +238,6 @@
     <string name="native_2682bd813a3bccbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Inserisci il codice di configurazione da openclaw qr."</string>
     <string name="native_268f14bbfe119c1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Diagnostica"</string>
     <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Questa operazione elimina definitivamente il thread e la relativa trascrizione."</string>
-    <string name="native_26e47d73a55d7fa7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dispositivo approvato."</string>
     <string name="native_26f0dd993530eb2d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nuovo tentativo automatico"</string>
     <string name="native_270ff82f36da987f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Immagine del widget copiata"</string>
     <string name="native_2728740a95d465c6" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s ruoli"</string>
@@ -260,7 +253,7 @@
     <string name="native_27d773b934ed324f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Verifica e installa"</string>
     <string name="native_2821f0168d6dd9df" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Trasforma questo dispositivo in un nodo OpenClaw sicuro per chat, voce, fotocamera e strumenti del dispositivo."</string>
     <string name="native_2831546121359362" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Configurazione manuale"</string>
-    <string name="native_287c4b113aafc215" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Apri la chat per avviare o riprendere il thread corrente."</string>
+    <string name="native_287c4b113aafc215" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Apri Chat per avviare o riprendere il thread corrente."</string>
     <string name="native_28bb849671cab958" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Suggerimento: interrompi l\'ascolto per inviare il turno acquisito."</string>
     <string name="native_28d03596d24eeb4e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Salta"</string>
     <string name="native_28d55ec6974d84e8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Richiesta vocale non riuscita"</string>
@@ -280,7 +273,7 @@
     <string name="native_2c19d584bf8ad518" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Segna come non letto"</string>
     <string name="native_2c75802a5f8df5f8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Trova persone e dettagli di contatto"</string>
     <string name="native_2c9cce8250d746e3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Identità del dispositivo richiesta"</string>
-    <string name="native_2cd62f7a670b2819" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Thread OpenClaw"</string>
+    <string name="native_2cd62f7a670b2819" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Conversazione OpenClaw"</string>
     <string name="native_2d4dfe885f84629e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Consenti l\'accesso alla libreria foto."</string>
     <string name="native_2d6416405eb44982" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Una risposta precedente ha già risolto questa approvazione."</string>
     <string name="native_2d85de9d56c226e4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nessuna conversazione recente"</string>
@@ -345,7 +338,7 @@
     <string name="native_36c725ddb20f8bd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Configurazione del provider Talk"</string>
     <string name="native_36d88ed6cc91d2b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Music Generation"</string>
     <string name="native_36e8d5e94219dc37" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Impostazioni conversazione"</string>
-    <string name="native_36f1fac278711470" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoraggio · 1 conversazione"</string>
+    <string name="native_36f1fac278711470" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoraggio · 1 thread"</string>
     <string name="native_37053dc1f680546b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Testo del payload"</string>
     <string name="native_37582309e7a1dbe5" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Approvazione %1$s"</string>
     <string name="native_379ce0aacf46c35f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway non ha restituito lo stato di prontezza di %1$s"</string>
@@ -353,7 +346,6 @@
     <string name="native_381428f5f251a764" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Conversation Send"</string>
     <string name="native_3824a9f4dafe92c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Canvas"</string>
     <string name="native_384ae4ab1a2830f9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 provider"</string>
-    <string name="native_385001409de8562a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Non è stato possibile leggere automaticamente il certificato del Gateway. Incolla l\'impronta digitale SHA-256 ottenuta sull\'host del Gateway."</string>
     <string name="native_387b2569e440838c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Invio non riuscito: %1$s"</string>
     <string name="native_3892e10346fd2012" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bridge"</string>
     <string name="native_38d198cd5303680f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Errore di consegna"</string>
@@ -410,8 +402,7 @@
     <string name="native_4287d54ad5e78985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Lavoro OpenClaw pianificato dal tuo Gateway."</string>
     <string name="native_429f6057535c1ea3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sub-agent"</string>
     <string name="native_42e3a99c21767def" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"In attesa dell\'approvazione del dispositivo"</string>
-    <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Caricamento della conversazione"</string>
-    <string name="native_430df68ec29a85a2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Questo Gateway ora presenta un certificato considerato attendibile da questo dispositivo."</string>
+    <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Caricamento del thread"</string>
     <string name="native_43905968a540af6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sfalsamento ms"</string>
     <string name="native_43988c156beabf7d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"event create"</string>
     <string name="native_43cc23fa52b87b4c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"documento"</string>
@@ -473,7 +464,6 @@
     <string name="native_4e8c72cab82e0711" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"L\'automazione ha una configurazione non valida."</string>
     <string name="native_4ec30e9d85725d41" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Elenco consentiti"</string>
     <string name="native_4ed379d418bb8629" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"groups"</string>
-    <string name="native_4ee252fb736effa2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Chiave pubblica"</string>
     <string name="native_4efca0d10c5feb8e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Informazioni"</string>
     <string name="native_4f1bc100d1dccc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nell\'immagine non è stato trovato alcun codice QR di configurazione. Scegli il QR generato da openclaw qr oppure inserisci manualmente il codice di configurazione."</string>
     <string name="native_4fe3cdd404ea0290" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"permissions"</string>
@@ -494,7 +484,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Consegna"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Disattiva altoparlante"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Apertura della connessione al Gateway"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoraggio · %1$s thread"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Esecuzione dell\'automazione completata."</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nessuna app corrispondente."</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Invia alla chat"</string>
@@ -560,7 +550,6 @@
     <string name="native_5c0c8c9aa658f4a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OPENCLAW"</string>
     <string name="native_5c1acea9c9b0e704" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Fetch"</string>
     <string name="native_5c39123805ffb4e2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Prompt"</string>
-    <string name="native_5c944156b5353428" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Approvare il dispositivo?"</string>
     <string name="native_5d410adb9576e266" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rimuovere %1$s e le relative credenziali salvate da questo telefono?"</string>
     <string name="native_5d6c41a67139ee26" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Il codice QR punta a un gateway remoto non sicuro. %1$s %2$s"</string>
     <string name="native_5d6cbac59f87e78d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Superficie dello schermo pronta"</string>
@@ -578,7 +567,6 @@
     <string name="native_5fa1d457ddfcd26c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"rename group"</string>
     <string name="native_5fa7aac5375c5815" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Pronto"</string>
     <string name="native_5fc1927ca948f31c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Il diario è in attesa della sua prima voce."</string>
-    <string name="native_6007acbe30b2cd98" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Approva"</string>
     <string name="native_600c9c27960112a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Pagina live"</string>
     <string name="native_6030d1f6340776d2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"L\'automazione è già in esecuzione."</string>
     <string name="native_604e6d6faf8d0295" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rimuovi questa automazione dopo un\'esecuzione singola completata correttamente."</string>
@@ -588,7 +576,7 @@
     <string name="native_60ea1847c2ba5446" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Risposta interrotta"</string>
     <string name="native_6105d6cc76af4003" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"immagine"</string>
     <string name="native_614b8348a2dbe46b" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s in attesa"</string>
-    <string name="native_614e83ef17c13f3c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nessun thread corrispondente"</string>
+    <string name="native_614e83ef17c13f3c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nessuna conversazione corrispondente"</string>
     <string name="native_6197595503f01ee2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"delete"</string>
     <string name="native_619837a134285528" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Layout: compatto"</string>
     <string name="native_61ffa9c8c703dd5e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"channels"</string>
@@ -618,14 +606,12 @@
     <string name="native_6657cc73af00feac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Consenti gli strumenti della fotocamera quando richiesto."</string>
     <string name="native_666067dd376e5d45" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Problemi"</string>
     <string name="native_666c8bc0319f3b54" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attivazione vocale"</string>
-    <string name="native_66713d713e3a41c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Richiesta di associazione rifiutata."</string>
     <string name="native_66b23bae66fc0d79" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s g fa"</string>
     <string name="native_66cf5513b37462be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"roles"</string>
     <string name="native_66d0f523a379b2de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skills"</string>
     <string name="native_66f4804ee23ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Archivia"</string>
     <string name="native_66fab2875ee427f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nodo offline. Riconnettiti e riprova."</string>
     <string name="native_6725e7bbcd28f3a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sistema"</string>
-    <string name="native_672f3453e1dd571b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"IP remoto"</string>
     <string name="native_674b38cae72bb0c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Non raggruppati"</string>
     <string name="native_674eb55d9c353900" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dettagli pianificazione"</string>
     <string name="native_67528858c36397f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Funzionalità del telefono"</string>
@@ -633,11 +619,10 @@
     <string name="native_67b696468610b879" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dashboard"</string>
     <string name="native_67fa416afa64d304" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Incolla token"</string>
     <string name="native_6827238fea72c88b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nessun provider"</string>
-    <string name="native_684889f0079cc145" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Impronta digitale SHA-256"</string>
     <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nessun thread"</string>
     <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Microfono Bluetooth"</string>
     <string name="native_690dbe9dc0993c42" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Recenti"</string>
-    <string name="native_6930c8d1fc4f01d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rinomina thread"</string>
+    <string name="native_6930c8d1fc4f01d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rinomina conversazione"</string>
     <string name="native_69384c1c4d99f6eb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Esito della risoluzione sconosciuto. Le azioni restano disabilitate finché il record del Gateway non viene verificato."</string>
     <string name="native_6940189433657105" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"dialog"</string>
     <string name="native_695c03727ff0251f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ascolta le parole di attivazione"</string>
@@ -668,7 +653,6 @@
     <string name="native_6d5d9004797377e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Licenze"</string>
     <string name="native_6d7c95a353d873cd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Connetti il Gateway per cercare le Skills di ClawHub."</string>
     <string name="native_6df1bb18a59ab97d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skill"</string>
-    <string name="native_6e0a0b9d8c5ee4d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ID dispositivo"</string>
     <string name="native_6e117ba97cbfb6f0" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway non ha identificato il provider %1$s attivo"</string>
     <string name="native_6e293a8c009e0011" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"In attesa"</string>
     <string name="native_6e2c0963d056e104" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Parole di attivazione salvate"</string>
@@ -798,7 +782,7 @@
     <string name="native_82990a093599a9bb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s applicati"</string>
     <string name="native_8340dad4f3be30a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nessun diario dei sogni al momento."</string>
     <string name="native_837e39f46163ffb4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aggiorna le attività in background"</string>
-    <string name="native_838337fd9ab30454" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Riassumi le conversazioni recenti e i prossimi passaggi."</string>
+    <string name="native_838337fd9ab30454" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Riassumi i thread recenti e i prossimi passaggi."</string>
     <string name="native_83e2faed20a3cda4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Viene eseguito sul dispositivo mentre OpenClaw è visibile."</string>
     <string name="native_844e5b02f3ef05ca" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s è al lavoro"</string>
     <string name="native_846c75dca0b71591" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
@@ -845,7 +829,6 @@
     <string name="native_8bb7ec15b1e350a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ispezione in corso"</string>
     <string name="native_8bf253a125f66985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Scansiona o incolla un codice di configurazione per aggiungere un altro gateway."</string>
     <string name="native_8c4a3896e8f06d27" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Timeout TLS"</string>
-    <string name="native_8c55387fb6c584c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dispositivo associato rimosso."</string>
     <string name="native_8c93c68056cde54d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway associato. Verifica dell\'approvazione delle funzionalità del nodo."</string>
     <string name="native_8ca344247c18317e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Movimento"</string>
     <string name="native_8cac4b77b9c54695" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Azione cron non riuscita."</string>
@@ -958,7 +941,7 @@
     <string name="native_9e37aa0704a3cf44" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s installata."</string>
     <string name="native_9e4635769f0aaf0d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway"</string>
     <string name="native_9e9bef85bb320b81" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Modalità di inoltro"</string>
-    <string name="native_9f6e180ff696bec5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cambia layout dei thread"</string>
+    <string name="native_9f6e180ff696bec5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cambia layout delle conversazioni"</string>
     <string name="native_9fb7c4ebcbc3e558" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nessun endpoint TLS"</string>
     <string name="native_9fe101a0ec7ef416" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway OpenClaw"</string>
     <string name="native_9ffc843f501acdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Configura manualmente"</string>
@@ -1038,9 +1021,10 @@
     <string name="native_ad1c341c65f84ede" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Esegui il comando approve sul computer Gateway, quindi controlla di nuovo."</string>
     <string name="native_ad1fb9ec0cb3c7a4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automazioni"</string>
     <string name="native_adb7eb8a03ad699c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s min"</string>
+    <string name="native_adca3171c270301a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Questo accesso al Gateway può elencare i nodi connessi, ma non può approvare l\'associazione di nuovi telefoni. Associa i nuovi telefoni da una sessione amministratore del Gateway. L\'approvazione delle funzionalità dei nodi è separata e continua a utilizzare nodes approve &lt;request id&gt;."</string>
     <string name="native_ade9248e0132b411" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Autorizza"</string>
     <string name="native_ae27fa789a03c1db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Quel codice QR non è un QR di configurazione di OpenClaw. Genera un nuovo codice con openclaw qr, quindi riprova."</string>
-    <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Il microfono preferito non è disponibile; verrà usato l\'instradamento automatico."</string>
+    <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Il microfono preferito non è disponibile; viene usato l\'instradamento automatico."</string>
     <string name="native_aea4a04a80426ed8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rifiutato"</string>
     <string name="native_aed306fbb63c0c68" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Includi Android e i pacchetti in background."</string>
     <string name="native_aedf1cf58372f943" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Il tuo Gateway è pronto."</string>
@@ -1107,7 +1091,6 @@
     <string name="native_bb4f2558e4333834" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Immagine del widget salvata in Download"</string>
     <string name="native_bbe5fc3b9ef39f99" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Avvio…"</string>
     <string name="native_bc19cec293228fb8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Errore del client"</string>
-    <string name="native_bc1c94a6dfce1058" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Verifica il dispositivo che ha inviato la richiesta prima di concedere l\'accesso."</string>
     <string name="native_bc6618670f3e8a17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Microfono Bluetooth LE"</string>
     <string name="native_bcb06651437caa15" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
     <string name="native_bd08450d63406844" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automazione attivata."</string>
@@ -1116,7 +1099,6 @@
     <string name="native_bdc090ec61e3fcfc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ricarica"</string>
     <string name="native_bdff71b20b9cf392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cerca automazioni"</string>
     <string name="native_be969becb173e0c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"I telefoni collegati e gli host dei nodi appariranno qui dopo l\'associazione."</string>
-    <string name="native_bf1870ff5c6322fb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s: %2$s"</string>
     <string name="native_bf350e6a0ed60b7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Questa automazione è stata modificata sul Gateway. Controlla la versione più recente prima di salvarla di nuovo."</string>
     <string name="native_bf399ffa03617a96" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Interrompi dettatura"</string>
     <string name="native_bf56ee2fe3345ce1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Leggibile"</string>
@@ -1134,13 +1116,12 @@
     <string name="native_c12a06263b75eb23" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Connetti il gateway per caricare i dettagli della Skill."</string>
     <string name="native_c156b9eaf502aabc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rilevamento dell\'attivazione"</string>
     <string name="native_c184b2ada7abc688" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Espandi anteprima link"</string>
-    <string name="native_c18ee03d3906a488" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cancella la ricerca dei thread"</string>
+    <string name="native_c18ee03d3906a488" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cancella la ricerca delle conversazioni"</string>
     <string name="native_c1970bb2cdf299b7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"NULL (NON RIUSCITO)"</string>
     <string name="native_c1c1009d3f37ec05" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aggiorna"</string>
     <string name="native_c1c224b03cd9bc7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Amministratore"</string>
     <string name="native_c1ebc7817870e5be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Richiede attenzione"</string>
     <string name="native_c22d5e02fbec7d65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Abbina questo dispositivo al tuo Gateway per riattivarlo solo quando c\'è davvero del lavoro da svolgere, tenere a portata di mano una panoramica in tempo reale degli agenti ed evitare cicli in background che consumano la batteria."</string>
-    <string name="native_c25337055464f8d3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ruoli"</string>
     <string name="native_c253f451bdd56431" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rispondi"</string>
     <string name="native_c26225b6c16a4bc7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Catalogo dei provider"</string>
     <string name="native_c272b225cf5bd643" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Abilita l\'autorizzazione in Impostazioni"</string>
@@ -1154,7 +1135,6 @@
     <string name="native_c34dd5eb8b0af56e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dove posso ottenere un codice di configurazione?"</string>
     <string name="native_c3546b39ecbbed8a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Impossibile abilitare la skill."</string>
     <string name="native_c35b21d6ca39aa7c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"pdf"</string>
-    <string name="native_c3812fc4acb861d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rimuovi"</string>
     <string name="native_c382566dbe2ea49f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s%% online"</string>
     <string name="native_c385951198c45d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nessun canale"</string>
     <string name="native_c41ad84496b53420" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Voce in tempo reale"</string>
@@ -1183,7 +1163,6 @@
     <string name="native_c6d5ed757b66bfd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sogno"</string>
     <string name="native_c6dd061350fc69b8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nessuna app bloccata. Le app possono inoltrare finché non aggiungi blocchi."</string>
     <string name="native_c753cdf0c19f1e38" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Riconoscimento vocale non disponibile"</string>
-    <string name="native_c78ffe19571018fb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Piattaforma"</string>
     <string name="native_c7985fa72daa6ea4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway non ha restituito la configurazione di %1$s"</string>
     <string name="native_c7b6dfd5c3a183c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dimenticare il gateway?"</string>
     <string name="native_c7b7b7f01360f6a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Descrizione facoltativa"</string>
@@ -1205,14 +1184,14 @@
     <string name="native_ca7981b46ecf2c17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Disattivato"</string>
     <string name="native_cab94aba84f97f7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tipografia"</string>
     <string name="native_cae7d57bc067a514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Interrompi"</string>
-    <string name="native_cae98462b30650eb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nessun thread corrispondente per ora."</string>
+    <string name="native_cae98462b30650eb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Non ci sono ancora conversazioni corrispondenti."</string>
     <string name="native_cba62d81f910c7f0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"L\'associazione del Gateway è riuscita.\nApprova le funzionalità del nodo di questo telefono da un\'interfaccia operatore."</string>
     <string name="native_cc4b66e7e22230c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Questa skill è installata, ma al momento non può essere eseguita. Usa il desktop o la CLI per modificare la configurazione."</string>
     <string name="native_cc5f45fb30a26e07" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Riconoscitore occupato"</string>
     <string name="native_cc721e25d73938a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway domestico"</string>
     <string name="native_cc7a9a5cf8c4bc9d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Esegui il comando di approvazione sul Gateway"</string>
     <string name="native_cc925e3c97ac7a35" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Impossibile caricare le proposte di Skill Workshop."</string>
-    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aggiornami sulle mie conversazioni recenti in OpenClaw e suggerisci i prossimi passi."</string>
+    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aggiornami sui miei thread recenti di OpenClaw e suggerisci i prossimi passaggi."</string>
     <string name="native_ccb4c324f516c633" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Non ora"</string>
     <string name="native_cced0b0d83a9e400" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw qr"</string>
     <string name="native_cced28c6dc3f99c2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"start"</string>
@@ -1235,7 +1214,7 @@
     <string name="native_ceb6931ea57cc999" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Adattivo"</string>
     <string name="native_cf0ee3547a4e51a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"A breve"</string>
     <string name="native_d04fc7d7e19702f8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Search"</string>
-    <string name="native_d053ba98d8bbcec1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Prova Chat, Voce, Thread, Provider o Impostazioni."</string>
+    <string name="native_d053ba98d8bbcec1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Prova Chat, Voce, Conversazioni, Provider o Impostazioni."</string>
     <string name="native_d056177742e27cf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw attivo"</string>
     <string name="native_d0cda6559bb347db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"navigate"</string>
     <string name="native_d0d0de0039c7990b" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"richiesto %1$s"</string>
@@ -1246,7 +1225,6 @@
     <string name="native_d17d2d78d76e6a6c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Modelli"</string>
     <string name="native_d19c2dd2fb598b93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw passivo"</string>
     <string name="native_d1a574e23344c407" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Password del Gateway non valida"</string>
-    <string name="native_d1af697abaff485f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Impossibile verificare la modifica all\'associazione del dispositivo. Aggiorna e riprova."</string>
     <string name="native_d1bf045bb524dae5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Visualizza dettagli"</string>
     <string name="native_d1e9567da9a8a4b0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bash"</string>
     <string name="native_d2089be672953d11" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Token"</string>
@@ -1261,7 +1239,6 @@
     <string name="native_d31de1a5c5c8ba2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Browser"</string>
     <string name="native_d354ee936f59115e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screen record"</string>
     <string name="native_d3974fd6d3b6c81f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Esecuzione in sospeso"</string>
-    <string name="native_d3e1c5f8a6e240fc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Origine"</string>
     <string name="native_d3f75e24411053c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"AI personale sui tuoi dispositivi"</string>
     <string name="native_d406ade2958cb5b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attach"</string>
     <string name="native_d461a493a3753877" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatico"</string>
@@ -1277,7 +1254,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Profilo"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"I limiti del provider appariranno qui quando il tuo Gateway li segnalerà."</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 problema"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Le conversazioni in \"%1$s\" vengono mantenute e spostate nuovamente in Senza gruppo."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Creato"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s token attivi"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>
@@ -1294,7 +1271,7 @@
     <string name="native_d93e2b7a15efbc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Impossibile risolvere l\'approvazione. Aggiorna e riprova."</string>
     <string name="native_d942f64886578d87" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"import"</string>
     <string name="native_d94cfb21b67ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Come questo telefono appare a OpenClaw."</string>
-    <string name="native_d96f2b0eab4e67b7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Porta il cursore sulla ricerca dei thread"</string>
+    <string name="native_d96f2b0eab4e67b7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Vai alla ricerca delle conversazioni"</string>
     <string name="native_d975ca28a64f8850" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Connetti il gateway"</string>
     <string name="native_d9be42d9b30ce057" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Leggi calendario"</string>
     <string name="native_d9f641e1a02807cb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"La panoramica si aggiorna alla riconnessione e all\'apertura di questa schermata."</string>
@@ -1340,7 +1317,7 @@
     <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cerca nelle skill installate"</string>
     <string name="native_e0723a86a5b9408a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ispeziona"</string>
     <string name="native_e083bd83e9d3e97e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Process"</string>
-    <string name="native_e08a8fc53e29e5c9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Conversazioni recenti"</string>
+    <string name="native_e08a8fc53e29e5c9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Thread recenti"</string>
     <string name="native_e0926fdac700b094" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Terminale"</string>
     <string name="native_e0d1b68224bf0b31" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attuale"</string>
     <string name="native_e10435f6306b06d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 account"</string>
@@ -1450,7 +1427,6 @@
     <string name="native_f2da2e47cd31a5dd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Impossibile decodificare questa immagine."</string>
     <string name="native_f3753c0fe29b88db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway, voce, notifiche, privacy"</string>
     <string name="native_f386c32c1bf437d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"File dell\'area di lavoro dell\'agente"</string>
-    <string name="native_f418bf0894a1806a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Questo dispositivo perderà l\'accesso attendibile al Gateway."</string>
     <string name="native_f41d9e8b7e09aa24" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Usa il requestId dal comando in sospeso nel comando approve."</string>
     <string name="native_f4830a1dae298044" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Pianificazione"</string>
     <string name="native_f493f0ce7a52a8aa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Limite di frequenza"</string>
@@ -1458,7 +1434,6 @@
     <string name="native_f4cc820d308495c4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Payload · %1$s"</string>
     <string name="native_f4ccae29e1bb0c20" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"In esecuzione"</string>
     <string name="native_f4db1e48476f6075" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Termina"</string>
-    <string name="native_f4e2076014711222" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Usa l\'attendibilità di sistema"</string>
     <string name="native_f4ef7a41caa88dd1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nessun provider pronto"</string>
     <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dà priorità ai microfoni Bluetooth connessi."</string>
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s app bloccata dall\'inoltro."</string>
@@ -1486,7 +1461,7 @@
     <string name="native_f8b32f4e92bd84ce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Installata"</string>
     <string name="native_f8c2745155505d39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tempo scaduto in attesa di una risposta; riprova o aggiorna."</string>
     <string name="native_f8cd133f0ea1031b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Trova conversazioni precedenti"</string>
-    <string name="native_f90f3791049b995d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sfoglia i thread"</string>
+    <string name="native_f90f3791049b995d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sfoglia le conversazioni"</string>
     <string name="native_f92e2ad582c0e13f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aggiornamento"</string>
     <string name="native_f991ae9cb081e1f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Apri la fotocamera e inquadra il codice da openclaw qr."</string>
     <string name="native_f9ea3f1540eaa584" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nessun dispositivo"</string>
@@ -1521,8 +1496,8 @@
     <string name="native_ff52188203241c29" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Password del Gateway non configurata"</string>
     <string name="native_ff716fc4735e067f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Impostazioni dettatura"</string>
     <string name="native_ff9dbbdfb84ddab2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"I modelli dei provider sono stati caricati, ma lo stato di disponibilità non è accessibile."</string>
-    <string name="native_ffa7aa557b547a79" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Eliminare il thread?"</string>
-    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw trasforma questo telefono in un\'interfaccia di comando mobile essenziale per conversazioni, voce, provider e Gateway."</string>
+    <string name="native_ffa7aa557b547a79" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Eliminare la conversazione?"</string>
+    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw trasforma questo telefono in un\'interfaccia mobile essenziale per thread, voce, provider e Gateway."</string>
     <string name="native_ffb6f5764bddb68c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Prima i più recenti"</string>
     <string name="native_ffcf16006c652ee3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Prossimo ciclo"</string>
 </resources>

--- a/apps/android/app/src/main/res/values-ja/strings.xml
+++ b/apps/android/app/src/main/res/values-ja/strings.xml
@@ -494,7 +494,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"配信"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"スピーカーをミュート"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gatewayへの接続を開始中"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"監視中 · %1$s件のスレッド"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自動化の実行が完了しました。"</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"一致するアプリはありません。"</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"チャットに送信"</string>
@@ -1277,7 +1277,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"プロフィール"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway がプロバイダーの制限を報告すると、ここに表示されます。"</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1件の問題"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"「%1$s」内のスレッドは保持され、「未分類」に戻されます。"</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"作成日時"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s 個の有効なトークン"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>

--- a/apps/android/app/src/main/res/values-ja/strings.xml
+++ b/apps/android/app/src/main/res/values-ja/strings.xml
@@ -31,7 +31,7 @@
     <string name="native_00e8aeba41d79ce3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 件保留中"</string>
     <string name="native_010f6550a1c8f554" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"サポートされていない添付ファイル"</string>
     <string name="native_01267be21eb77392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"0 = 正確"</string>
-    <string name="native_0171e3d4e07f1861" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"スレッドを検索するには、Gatewayに接続してください。"</string>
+    <string name="native_0171e3d4e07f1861" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"スレッドを検索するにはGatewayに接続してください。"</string>
     <string name="native_0174f83136630e7e" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s件のアカウント"</string>
     <string name="native_01ac1c298e0cbd9a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cronの変更にはoperator.adminが必要です。セットアップコードでは意図的にこの権限は付与されません。管理者アクセスを要求するには、Gatewayの共有トークンまたはパスワードを使用して再接続してください。このデバイスにまだ権限がない場合は、既存の管理者クライアントから保留中のスコープ昇格を承認してください。"</string>
     <string name="native_01bcfe7a9296b6d6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Apply Patch"</string>
@@ -494,7 +494,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"配信"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"スピーカーをミュート"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gatewayへの接続を開始中"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"監視中 · %1$s件のスレッド"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自動化の実行が完了しました。"</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"一致するアプリはありません。"</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"チャットに送信"</string>
@@ -798,7 +798,7 @@
     <string name="native_82990a093599a9bb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 件適用済み"</string>
     <string name="native_8340dad4f3be30a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"夢日記はまだありません。"</string>
     <string name="native_837e39f46163ffb4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"バックグラウンドタスクを更新"</string>
-    <string name="native_838337fd9ab30454" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"最近のスレッドと次のステップを要約します。"</string>
+    <string name="native_838337fd9ab30454" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"最近のスレッドと次のステップを要約してください。"</string>
     <string name="native_83e2faed20a3cda4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw の表示中にデバイス上で動作します。"</string>
     <string name="native_844e5b02f3ef05ca" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s が作業中です"</string>
     <string name="native_846c75dca0b71591" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
@@ -1040,7 +1040,7 @@
     <string name="native_adb7eb8a03ad699c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s分"</string>
     <string name="native_ade9248e0132b411" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"信頼"</string>
     <string name="native_ae27fa789a03c1db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"このQRコードはOpenClawのセットアップQRではありません。openclaw qr で新しいコードを生成してから、もう一度お試しください。"</string>
-    <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"優先マイクを利用できないため、自動ルーティングを使用します。"</string>
+    <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"優先マイクを利用できないため、自動ルーティングを使用しています。"</string>
     <string name="native_aea4a04a80426ed8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"拒否済み"</string>
     <string name="native_aed306fbb63c0c68" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Android とバックグラウンドのパッケージを含めます。"</string>
     <string name="native_aedf1cf58372f943" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gatewayの準備ができました。"</string>
@@ -1212,7 +1212,7 @@
     <string name="native_cc721e25d73938a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ホームGateway"</string>
     <string name="native_cc7a9a5cf8c4bc9d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gatewayで承認コマンドを実行してください"</string>
     <string name="native_cc925e3c97ac7a35" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skill Workshopの提案を読み込めませんでした。"</string>
-    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"最近のOpenClawスレッドの概要と、次のステップを提案してください。"</string>
+    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"最近のOpenClawスレッドの内容をまとめ、次のステップを提案してください。"</string>
     <string name="native_ccb4c324f516c633" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"今はしない"</string>
     <string name="native_cced0b0d83a9e400" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw qr"</string>
     <string name="native_cced28c6dc3f99c2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"start"</string>
@@ -1235,7 +1235,7 @@
     <string name="native_ceb6931ea57cc999" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"適応"</string>
     <string name="native_cf0ee3547a4e51a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"まもなく"</string>
     <string name="native_d04fc7d7e19702f8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Search"</string>
-    <string name="native_d053ba98d8bbcec1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"チャット、音声、スレッド、プロバイダー、設定をお試しください。"</string>
+    <string name="native_d053ba98d8bbcec1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"チャット、音声、スレッド、プロバイダー、または設定をお試しください。"</string>
     <string name="native_d056177742e27cf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw がアクティブです"</string>
     <string name="native_d0cda6559bb347db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"navigate"</string>
     <string name="native_d0d0de0039c7990b" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$sにリクエスト"</string>
@@ -1277,7 +1277,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"プロフィール"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway がプロバイダーの制限を報告すると、ここに表示されます。"</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1件の問題"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"「%1$s」内のスレッドは保持され、未分類に戻ります。"</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"作成日時"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s 個の有効なトークン"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>
@@ -1460,7 +1460,7 @@
     <string name="native_f4db1e48476f6075" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"終了"</string>
     <string name="native_f4e2076014711222" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"システムの信頼設定を使用"</string>
     <string name="native_f4ef7a41caa88dd1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"準備完了のプロバイダーはありません"</string>
-    <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"接続されているBluetoothマイクを優先します。"</string>
+    <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"接続済みのBluetoothマイクを優先します。"</string>
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 個のアプリの転送をブロックしました。"</string>
     <string name="native_f532ee1f7288365e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"メッセージアクション"</string>
     <string name="native_f5387f9bb6ed7031" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"種類"</string>
@@ -1486,7 +1486,7 @@
     <string name="native_f8b32f4e92bd84ce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"インストール済み"</string>
     <string name="native_f8c2745155505d39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"返信の待機中にタイムアウトしました。もう一度試すか、再読み込みしてください。"</string>
     <string name="native_f8cd133f0ea1031b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"以前の会話を検索"</string>
-    <string name="native_f90f3791049b995d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"スレッドを閲覧"</string>
+    <string name="native_f90f3791049b995d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"スレッドを参照"</string>
     <string name="native_f92e2ad582c0e13f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"更新中"</string>
     <string name="native_f991ae9cb081e1f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"カメラを開き、openclaw qrのコードを枠内に収めてください。"</string>
     <string name="native_f9ea3f1540eaa584" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"デバイスはありません"</string>
@@ -1522,7 +1522,7 @@
     <string name="native_ff716fc4735e067f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"音声入力設定"</string>
     <string name="native_ff9dbbdfb84ddab2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"プロバイダーモデルは読み込まれましたが、準備状況を確認できません。"</string>
     <string name="native_ffa7aa557b547a79" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"スレッドを削除しますか？"</string>
-    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClawは、このスマートフォンをスレッド、音声、プロバイダー、Gateway向けのシンプルなモバイルコマンド画面に変えます。"</string>
+    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClawは、このスマートフォンをスレッド、音声、プロバイダー、Gatewayのためのシンプルなモバイルコマンド画面に変えます。"</string>
     <string name="native_ffb6f5764bddb68c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"新しい順"</string>
     <string name="native_ffcf16006c652ee3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"次のサイクル"</string>
 </resources>

--- a/apps/android/app/src/main/res/values-ko/strings.xml
+++ b/apps/android/app/src/main/res/values-ko/strings.xml
@@ -1522,7 +1522,7 @@
     <string name="native_ff716fc4735e067f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"받아쓰기 설정"</string>
     <string name="native_ff9dbbdfb84ddab2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"제공자 모델을 불러왔지만 준비 상태를 확인할 수 없습니다."</string>
     <string name="native_ffa7aa557b547a79" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"스레드를 삭제하시겠습니까?"</string>
-    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw은 이 휴대전화를 스레드, 음성, 제공업체 및 Gateway를 위한 깔끔한 모바일 명령 인터페이스로 바꿔 줍니다."</string>
+    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw는 이 휴대전화를 스레드, 음성, 제공업체 및 Gateway를 위한 깔끔한 모바일 명령 인터페이스로 바꿔 줍니다."</string>
     <string name="native_ffb6f5764bddb68c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"최신순"</string>
     <string name="native_ffcf16006c652ee3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"다음 주기"</string>
 </resources>

--- a/apps/android/app/src/main/res/values-ko/strings.xml
+++ b/apps/android/app/src/main/res/values-ko/strings.xml
@@ -104,7 +104,7 @@
     <string name="native_0e91610117029a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"새로 고침"</string>
     <string name="native_0ee30822ed35a792" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s개 대기 중"</string>
     <string name="native_0f4c8529742b31ea" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"채팅 시작"</string>
-    <string name="native_0f559ff270904904" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"활성 스레드에서 대기 중인 Chat 도구 호출이 여기에 계속 표시됩니다."</string>
+    <string name="native_0f559ff270904904" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"활성 스레드에서 대기 중인 채팅 도구 호출이 여기에 계속 표시됩니다."</string>
     <string name="native_0f56cc286a4f23d8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"인증서 검토 필요"</string>
     <string name="native_0f8fe3a9688138a1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"현재 Canvas 화면을 열어 확인하거나 상호작용합니다."</string>
     <string name="native_0ff98f05be01ce5e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"자동화가 업데이트되었습니다."</string>
@@ -260,7 +260,7 @@
     <string name="native_27d773b934ed324f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"확인 및 설치"</string>
     <string name="native_2821f0168d6dd9df" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"이 기기를 채팅, 음성, 카메라 및 기기 도구를 위한 안전한 OpenClaw 노드로 전환하세요."</string>
     <string name="native_2831546121359362" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"수동 설정"</string>
-    <string name="native_287c4b113aafc215" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Chat을 열어 현재 스레드를 시작하거나 재개하세요."</string>
+    <string name="native_287c4b113aafc215" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"현재 스레드를 시작하거나 재개하려면 채팅을 여세요."</string>
     <string name="native_28bb849671cab958" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"팁: 캡처된 턴을 보내려면 듣기를 중지하세요."</string>
     <string name="native_28d03596d24eeb4e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"건너뛰기"</string>
     <string name="native_28d55ec6974d84e8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"음성 요청 실패"</string>
@@ -494,7 +494,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"전달"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"스피커 음소거"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 연결 여는 중"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"모니터링 · 스레드 %1$s개"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"자동화 실행이 완료되었습니다."</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"일치하는 앱이 없습니다."</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"채팅으로 보내기"</string>
@@ -798,7 +798,7 @@
     <string name="native_82990a093599a9bb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s개 적용됨"</string>
     <string name="native_8340dad4f3be30a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"아직 꿈 일기가 없습니다."</string>
     <string name="native_837e39f46163ffb4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"백그라운드 작업 새로고침"</string>
-    <string name="native_838337fd9ab30454" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"최근 스레드와 다음 단계를 요약하세요."</string>
+    <string name="native_838337fd9ab30454" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"최근 스레드와 다음 단계를 요약해 주세요."</string>
     <string name="native_83e2faed20a3cda4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw가 표시되는 동안 기기에서 실행됩니다."</string>
     <string name="native_844e5b02f3ef05ca" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 작업 중"</string>
     <string name="native_846c75dca0b71591" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
@@ -1212,7 +1212,7 @@
     <string name="native_cc721e25d73938a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"홈 Gateway"</string>
     <string name="native_cc7a9a5cf8c4bc9d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway에서 승인 명령을 실행하세요"</string>
     <string name="native_cc925e3c97ac7a35" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skill Workshop 제안을 불러올 수 없습니다."</string>
-    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"최근 OpenClaw 스레드의 내용을 요약하고 다음 단계를 제안해 주세요."</string>
+    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"최근 OpenClaw 스레드의 내용을 알려 주고 다음 단계를 제안해 주세요."</string>
     <string name="native_ccb4c324f516c633" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"나중에"</string>
     <string name="native_cced0b0d83a9e400" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw qr"</string>
     <string name="native_cced28c6dc3f99c2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"start"</string>
@@ -1277,7 +1277,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"프로필"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway가 제공자 제한을 보고하면 여기에 표시됩니다."</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"문제 1개"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"\"%1$s\"의 스레드는 유지되며 그룹 미지정으로 다시 이동합니다."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"생성됨"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"활성 토큰 %1$s/%2$s개"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>
@@ -1486,7 +1486,7 @@
     <string name="native_f8b32f4e92bd84ce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"설치됨"</string>
     <string name="native_f8c2745155505d39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"응답 대기 시간이 초과되었습니다. 다시 시도하거나 새로고침하세요."</string>
     <string name="native_f8cd133f0ea1031b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"이전 대화 찾기"</string>
-    <string name="native_f90f3791049b995d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"스레드 찾아보기"</string>
+    <string name="native_f90f3791049b995d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"스레드 탐색"</string>
     <string name="native_f92e2ad582c0e13f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"새로 고치는 중"</string>
     <string name="native_f991ae9cb081e1f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"카메라를 열고 openclaw qr의 코드를 프레임 안에 맞추세요."</string>
     <string name="native_f9ea3f1540eaa584" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"기기가 없습니다"</string>
@@ -1522,7 +1522,7 @@
     <string name="native_ff716fc4735e067f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"받아쓰기 설정"</string>
     <string name="native_ff9dbbdfb84ddab2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"제공자 모델을 불러왔지만 준비 상태를 확인할 수 없습니다."</string>
     <string name="native_ffa7aa557b547a79" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"스레드를 삭제하시겠습니까?"</string>
-    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw는 이 휴대전화를 스레드, 음성, 제공업체 및 Gateway를 위한 깔끔한 모바일 명령 인터페이스로 바꿔 줍니다."</string>
+    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw은 이 휴대전화를 스레드, 음성, 제공업체 및 Gateway를 위한 깔끔한 모바일 명령 인터페이스로 바꿔 줍니다."</string>
     <string name="native_ffb6f5764bddb68c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"최신순"</string>
     <string name="native_ffcf16006c652ee3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"다음 주기"</string>
 </resources>

--- a/apps/android/app/src/main/res/values-ko/strings.xml
+++ b/apps/android/app/src/main/res/values-ko/strings.xml
@@ -494,7 +494,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"전달"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"스피커 음소거"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 연결 여는 중"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"모니터링 · 스레드 %1$s개"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"자동화 실행이 완료되었습니다."</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"일치하는 앱이 없습니다."</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"채팅으로 보내기"</string>
@@ -1277,7 +1277,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"프로필"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway가 제공자 제한을 보고하면 여기에 표시됩니다."</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"문제 1개"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"\"%1$s\"의 스레드는 유지되며 그룹 없음으로 다시 이동됩니다."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"생성됨"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"활성 토큰 %1$s/%2$s개"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>

--- a/apps/android/app/src/main/res/values-nl/strings.xml
+++ b/apps/android/app/src/main/res/values-nl/strings.xml
@@ -494,7 +494,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aflevering"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Luidspreker dempen"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway-verbinding openen"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bewaking · %1$s threads"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"De automatisering is voltooid."</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Geen overeenkomende apps."</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Naar chat verzenden"</string>
@@ -535,7 +535,7 @@
     <string name="native_58268edca12a81a1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Android kan een bestaande setupcode scannen of plakken, maar deze gateway biedt de app nog geen mogelijkheid om setupcodes te genereren. Genereer de QR/code op de gatewayhost met openclaw qr en scan deze vervolgens hier of plak de setupcode hieronder."</string>
     <string name="native_584162ac73e99ee6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Canvasstatus"</string>
     <string name="native_5855b3ac2fcc1b3e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Verbinding herstellen"</string>
-    <string name="native_58e909c0f4cc5723" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Afbeelding bewaren"</string>
+    <string name="native_58e909c0f4cc5723" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Afbeelding opslaan"</string>
     <string name="native_590b0003ccaad929" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Node %1$s"</string>
     <string name="native_59235e6ebfd03967" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway-wachtwoord vereist"</string>
     <string name="native_592acaa91843913b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Update Plan"</string>
@@ -1277,7 +1277,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Profiel"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Limieten van providers verschijnen hier wanneer je Gateway ze rapporteert."</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 probleem"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" blijven behouden en worden teruggeplaatst naar Niet gegroepeerd."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aangemaakt"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s actieve tokens"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>

--- a/apps/android/app/src/main/res/values-nl/strings.xml
+++ b/apps/android/app/src/main/res/values-nl/strings.xml
@@ -75,7 +75,6 @@
     <string name="native_0929c9dc7f794852" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Geen voorstellen"</string>
     <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Hoofdthread"</string>
     <string name="native_0979c6fdbdca1675" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Chat openen"</string>
-    <string name="native_09ce95090659d069" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Acties voor het koppelen van apparaten zijn niet beschikbaar in deze Gateway-sessie. Voer openclaw devices list uit op de Gateway-host en beheer het verzoek daar. Goedkeuring van nodefunctionaliteiten staat hier los van en gebruikt nog steeds nodes approve &lt;request id&gt;."</string>
     <string name="native_0a0b7cf7c428c703" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Actieverzoek"</string>
     <string name="native_0a708e7b03aaf1fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list pins"</string>
     <string name="native_0ab0e1629576aecf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Maak verbinding met een Gateway om Skills Workshop-voorstellen te laden."</string>
@@ -88,12 +87,10 @@
     <string name="native_0c3845dcd2f0f683" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Inspecteer dit voorstel om de markdown te laden."</string>
     <string name="native_0c3ea4e2f12153e7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"open OpenClaw en vraag %1$s"</string>
     <string name="native_0c4d01e81bb3d1fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"redenering"</string>
-    <string name="native_0c77fe09ab336a3e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Client"</string>
     <string name="native_0c79a9c222840ed0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Toegepast"</string>
     <string name="native_0cab1c9617404faf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"video"</string>
     <string name="native_0cf04463c4276a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gepromoot"</string>
     <string name="native_0d21bd52022ca7f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Online"</string>
-    <string name="native_0d5644ff52ce2ba3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bereiken"</string>
     <string name="native_0d5efd432e4fedf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Realtime-spraakprovider is niet geconfigureerd."</string>
     <string name="native_0d8ca811c3744a6d" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s · %2$s"</string>
     <string name="native_0db10f2c2f332cd2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"kick"</string>
@@ -141,7 +138,6 @@
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sessiedoel"</string>
     <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ClawHub-skill beoordelen"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
-    <string name="native_16a5b7ad567a8093" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Het koppelingsverzoek van dit apparaat afwijzen?"</string>
     <string name="native_16b1a05e1d987ed1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Voorkeursmicrofoon"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nodehost"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Niveau"</string>
@@ -187,7 +183,6 @@
     <string name="native_1d91629837639a5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Deze automatisering is gewijzigd terwijl u deze bewerkte. Herstel de nieuwste versie van de Gateway voordat u opslaat."</string>
     <string name="native_1dbf9d5979606697" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wanneer er verbinding is, kan de Gateway de telefoon met een stille pushmelding activeren in plaats van een permanente sessie open te houden."</string>
     <string name="native_1e432ea5425e4a3a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Activeringsmodus"</string>
-    <string name="native_1e595a107c78b957" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gekoppeld apparaat verwijderen?"</string>
     <string name="native_1e955a58278623a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Systeemgebeurtenistekst"</string>
     <string name="native_1ea44149be42d970" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kan widgetafbeelding niet kopiëren"</string>
     <string name="native_1ea442a134b2a184" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nee"</string>
@@ -202,7 +197,6 @@
     <string name="native_2065cc867eba1b39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kan de configuratie van providermodellen niet laden."</string>
     <string name="native_207ccb22d618db05" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s app mag doorsturen."</string>
     <string name="native_209b9e597963e7e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Spraakinstellingen"</string>
-    <string name="native_211988ba9dd0570a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Koppelingsverzoek afwijzen?"</string>
     <string name="native_2132066dc9475cb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"This skill is installed but not available to the current agent. Agent filters stay on desktop or CLI."</string>
     <string name="native_21378545892f1fe2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Uitgever"</string>
     <string name="native_214d4932fc767e8f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">" · Gesprek: Spreekt"</string>
@@ -243,8 +237,7 @@
     <string name="native_262c897a1f408b0b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Verbinding maken met je Gateway"</string>
     <string name="native_2682bd813a3bccbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Voer de installatiecode van openclaw qr in."</string>
     <string name="native_268f14bbfe119c1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Diagnostiek"</string>
-    <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Hiermee worden de thread en het transcript permanent verwijderd."</string>
-    <string name="native_26e47d73a55d7fa7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Apparaat goedgekeurd."</string>
+    <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Hiermee worden de thread en het transcript ervan permanent verwijderd."</string>
     <string name="native_26f0dd993530eb2d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatisch opnieuw proberen"</string>
     <string name="native_270ff82f36da987f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Widgetafbeelding gekopieerd"</string>
     <string name="native_2728740a95d465c6" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s rollen"</string>
@@ -283,7 +276,7 @@
     <string name="native_2cd62f7a670b2819" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw-thread"</string>
     <string name="native_2d4dfe885f84629e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Toegang tot fotobibliotheek toestaan."</string>
     <string name="native_2d6416405eb44982" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Een eerdere reactie heeft deze goedkeuring al afgehandeld."</string>
-    <string name="native_2d85de9d56c226e4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Geen recente gesprekken"</string>
+    <string name="native_2d85de9d56c226e4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Geen recente threads"</string>
     <string name="native_2df01a03ff43400b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Geen overeenkomsten"</string>
     <string name="native_2df30b117ad829ab" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Meldingen van geselecteerde apps lezen"</string>
     <string name="native_2e0078a8322d6f1f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Beschikbaarheid onbekend"</string>
@@ -345,7 +338,7 @@
     <string name="native_36c725ddb20f8bd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Talk Provider instellen"</string>
     <string name="native_36d88ed6cc91d2b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Music Generation"</string>
     <string name="native_36e8d5e94219dc37" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Praatinstellingen"</string>
-    <string name="native_36f1fac278711470" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bewaking · 1 thread"</string>
+    <string name="native_36f1fac278711470" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoren · 1 thread"</string>
     <string name="native_37053dc1f680546b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Payloadtekst"</string>
     <string name="native_37582309e7a1dbe5" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Goedkeuring %1$s"</string>
     <string name="native_379ce0aacf46c35f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway heeft de gereedheid van %1$s niet geretourneerd"</string>
@@ -353,7 +346,6 @@
     <string name="native_381428f5f251a764" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Conversation Send"</string>
     <string name="native_3824a9f4dafe92c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Canvas"</string>
     <string name="native_384ae4ab1a2830f9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 provider"</string>
-    <string name="native_385001409de8562a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Het Gateway-certificaat kon niet automatisch worden gelezen. Plak de SHA-256-vingerafdruk die op de Gateway-host is verkregen."</string>
     <string name="native_387b2569e440838c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Verzenden mislukt: %1$s"</string>
     <string name="native_3892e10346fd2012" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Brug"</string>
     <string name="native_38d198cd5303680f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bezorgfout"</string>
@@ -411,7 +403,6 @@
     <string name="native_429f6057535c1ea3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sub-agent"</string>
     <string name="native_42e3a99c21767def" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wachten op apparaatgoedkeuring"</string>
     <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Thread laden"</string>
-    <string name="native_430df68ec29a85a2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Deze Gateway gebruikt nu een certificaat dat door dit apparaat wordt vertrouwd."</string>
     <string name="native_43905968a540af6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Spreiding ms"</string>
     <string name="native_43988c156beabf7d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"event create"</string>
     <string name="native_43cc23fa52b87b4c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"document"</string>
@@ -473,7 +464,6 @@
     <string name="native_4e8c72cab82e0711" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"De automatisering heeft een ongeldige configuratie."</string>
     <string name="native_4ec30e9d85725d41" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Toegestaan-lijst"</string>
     <string name="native_4ed379d418bb8629" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"groups"</string>
-    <string name="native_4ee252fb736effa2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Openbare sleutel"</string>
     <string name="native_4efca0d10c5feb8e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Over"</string>
     <string name="native_4f1bc100d1dccc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Er is geen installatie-QR-code gevonden in die afbeelding. Kies de QR-code die is gegenereerd door openclaw qr of voer de installatiecode handmatig in."</string>
     <string name="native_4fe3cdd404ea0290" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"permissions"</string>
@@ -494,7 +484,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aflevering"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Luidspreker dempen"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway-verbinding openen"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoren · %1$s threads"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"De automatisering is voltooid."</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Geen overeenkomende apps."</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Naar chat verzenden"</string>
@@ -535,7 +525,7 @@
     <string name="native_58268edca12a81a1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Android kan een bestaande setupcode scannen of plakken, maar deze gateway biedt de app nog geen mogelijkheid om setupcodes te genereren. Genereer de QR/code op de gatewayhost met openclaw qr en scan deze vervolgens hier of plak de setupcode hieronder."</string>
     <string name="native_584162ac73e99ee6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Canvasstatus"</string>
     <string name="native_5855b3ac2fcc1b3e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Verbinding herstellen"</string>
-    <string name="native_58e909c0f4cc5723" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Afbeelding opslaan"</string>
+    <string name="native_58e909c0f4cc5723" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Afbeelding bewaren"</string>
     <string name="native_590b0003ccaad929" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Node %1$s"</string>
     <string name="native_59235e6ebfd03967" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway-wachtwoord vereist"</string>
     <string name="native_592acaa91843913b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Update Plan"</string>
@@ -560,7 +550,6 @@
     <string name="native_5c0c8c9aa658f4a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OPENCLAW"</string>
     <string name="native_5c1acea9c9b0e704" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Fetch"</string>
     <string name="native_5c39123805ffb4e2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Prompt"</string>
-    <string name="native_5c944156b5353428" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Apparaat goedkeuren?"</string>
     <string name="native_5d410adb9576e266" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s en de opgeslagen inloggegevens van deze telefoon verwijderen?"</string>
     <string name="native_5d6c41a67139ee26" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"De QR-code verwijst naar een onveilige externe Gateway. %1$s %2$s"</string>
     <string name="native_5d6cbac59f87e78d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Schermoppervlak gereed"</string>
@@ -578,7 +567,6 @@
     <string name="native_5fa1d457ddfcd26c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"rename group"</string>
     <string name="native_5fa7aac5375c5815" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gereed"</string>
     <string name="native_5fc1927ca948f31c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Het dagboek wacht op het eerste item."</string>
-    <string name="native_6007acbe30b2cd98" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Goedkeuren"</string>
     <string name="native_600c9c27960112a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Livepagina"</string>
     <string name="native_6030d1f6340776d2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"De automatisering wordt al uitgevoerd."</string>
     <string name="native_604e6d6faf8d0295" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Verwijder deze automatisering na een geslaagde eenmalige uitvoering."</string>
@@ -618,14 +606,12 @@
     <string name="native_6657cc73af00feac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cameratools toestaan wanneer daarom wordt gevraagd."</string>
     <string name="native_666067dd376e5d45" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Problemen"</string>
     <string name="native_666c8bc0319f3b54" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Spraakactivering"</string>
-    <string name="native_66713d713e3a41c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Koppelingsverzoek afgewezen."</string>
     <string name="native_66b23bae66fc0d79" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$sd geleden"</string>
     <string name="native_66cf5513b37462be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"roles"</string>
     <string name="native_66d0f523a379b2de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skills"</string>
     <string name="native_66f4804ee23ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Archiveren"</string>
     <string name="native_66fab2875ee427f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Node offline. Maak opnieuw verbinding en probeer het opnieuw."</string>
     <string name="native_6725e7bbcd28f3a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Systeem"</string>
-    <string name="native_672f3453e1dd571b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Extern IP-adres"</string>
     <string name="native_674b38cae72bb0c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Niet gegroepeerd"</string>
     <string name="native_674eb55d9c353900" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Planningsdetails"</string>
     <string name="native_67528858c36397f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Telefoonmogelijkheden"</string>
@@ -633,7 +619,6 @@
     <string name="native_67b696468610b879" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dashboard"</string>
     <string name="native_67fa416afa64d304" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Token plakken"</string>
     <string name="native_6827238fea72c88b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Geen providers"</string>
-    <string name="native_684889f0079cc145" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"SHA-256-vingerafdruk"</string>
     <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nog geen threads"</string>
     <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bluetooth-microfoon"</string>
     <string name="native_690dbe9dc0993c42" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Recent"</string>
@@ -668,7 +653,6 @@
     <string name="native_6d5d9004797377e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Licenties"</string>
     <string name="native_6d7c95a353d873cd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Verbind de gateway om ClawHub-skills te zoeken."</string>
     <string name="native_6df1bb18a59ab97d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skill"</string>
-    <string name="native_6e0a0b9d8c5ee4d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Apparaat-ID"</string>
     <string name="native_6e117ba97cbfb6f0" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway heeft de actieve %1$s-provider niet geïdentificeerd"</string>
     <string name="native_6e293a8c009e0011" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wachten"</string>
     <string name="native_6e2c0963d056e104" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Activeringswoorden opgeslagen"</string>
@@ -717,7 +701,7 @@
     <string name="native_746f71ec623adc37" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Epoch-milliseconden (optioneel)"</string>
     <string name="native_7491b353909c1147" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Geen geconfigureerde modellen. Vernieuw om de beschikbaarheid opnieuw te controleren."</string>
     <string name="native_74a883a037bc227f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Instellingen"</string>
-    <string name="native_74c372f29b83df94" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Achtercamera"</string>
+    <string name="native_74c372f29b83df94" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Camera aan de achterkant"</string>
     <string name="native_74e21680eac7385c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"approve"</string>
     <string name="native_74e492d5d0df0bab" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Voordat je begint"</string>
     <string name="native_74f0a5d234edc4af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kan Skills niet laden."</string>
@@ -845,7 +829,6 @@
     <string name="native_8bb7ec15b1e350a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Inspecteren"</string>
     <string name="native_8bf253a125f66985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Scan of plak een installatiecode om een andere gateway toe te voegen."</string>
     <string name="native_8c4a3896e8f06d27" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Time-out bij TLS"</string>
-    <string name="native_8c55387fb6c584c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gekoppeld apparaat verwijderd."</string>
     <string name="native_8c93c68056cde54d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway gekoppeld. De goedkeuring van knooppuntmogelijkheden wordt gecontroleerd."</string>
     <string name="native_8ca344247c18317e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Beweging"</string>
     <string name="native_8cac4b77b9c54695" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cronactie mislukt."</string>
@@ -958,7 +941,7 @@
     <string name="native_9e37aa0704a3cf44" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s is geïnstalleerd."</string>
     <string name="native_9e4635769f0aaf0d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateways"</string>
     <string name="native_9e9bef85bb320b81" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Doorstuurmodus"</string>
-    <string name="native_9f6e180ff696bec5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threadindeling wisselen"</string>
+    <string name="native_9f6e180ff696bec5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threadindeling wijzigen"</string>
     <string name="native_9fb7c4ebcbc3e558" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Geen TLS-eindpunt"</string>
     <string name="native_9fe101a0ec7ef416" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw-gateway"</string>
     <string name="native_9ffc843f501acdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Handmatig instellen"</string>
@@ -1038,6 +1021,7 @@
     <string name="native_ad1c341c65f84ede" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Voer de approve-opdracht uit op de Gateway-computer en controleer daarna opnieuw."</string>
     <string name="native_ad1fb9ec0cb3c7a4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatiseringen"</string>
     <string name="native_adb7eb8a03ad699c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s min."</string>
+    <string name="native_adca3171c270301a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Met deze Gateway-aanmelding kunt u verbonden knooppunten weergeven, maar geen nieuwe telefoonkoppelingen goedkeuren. Koppel nieuwe telefoons vanuit een Gateway-beheerderssessie. De goedkeuring van knooppuntmogelijkheden staat hiervan los en gebruikt nog steeds nodes approve &lt;request id&gt;."</string>
     <string name="native_ade9248e0132b411" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Vertrouwen"</string>
     <string name="native_ae27fa789a03c1db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Die QR-code is geen OpenClaw-installatie-QR. Genereer een nieuwe code met openclaw qr en probeer het opnieuw."</string>
     <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Voorkeursmicrofoon niet beschikbaar; automatische routering wordt gebruikt."</string>
@@ -1107,7 +1091,6 @@
     <string name="native_bb4f2558e4333834" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Widgetafbeelding opgeslagen in Downloads"</string>
     <string name="native_bbe5fc3b9ef39f99" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Starten…"</string>
     <string name="native_bc19cec293228fb8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Clientfout"</string>
-    <string name="native_bc1c94a6dfce1058" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Verifieer dit verzoekende apparaat voordat u toegang verleent."</string>
     <string name="native_bc6618670f3e8a17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bluetooth LE-microfoon"</string>
     <string name="native_bcb06651437caa15" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
     <string name="native_bd08450d63406844" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"De automatisering is ingeschakeld."</string>
@@ -1116,7 +1099,6 @@
     <string name="native_bdc090ec61e3fcfc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Opnieuw laden"</string>
     <string name="native_bdff71b20b9cf392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatiseringen zoeken"</string>
     <string name="native_be969becb173e0c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gekoppelde telefoons en nodehosts verschijnen hier na het koppelen."</string>
-    <string name="native_bf1870ff5c6322fb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s: %2$s"</string>
     <string name="native_bf350e6a0ed60b7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Deze automatisering is gewijzigd op de Gateway. Controleer de nieuwste versie voordat u opnieuw opslaat."</string>
     <string name="native_bf399ffa03617a96" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dicteren stoppen"</string>
     <string name="native_bf56ee2fe3345ce1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Leesbaar"</string>
@@ -1140,7 +1122,6 @@
     <string name="native_c1c224b03cd9bc7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Beheerder"</string>
     <string name="native_c1ebc7817870e5be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aandacht vereist"</string>
     <string name="native_c22d5e02fbec7d65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Koppel dit apparaat aan je Gateway om het alleen voor echt werk te activeren, een liveoverzicht van agents bij de hand te houden en batterijverslindende achtergrondlussen te voorkomen."</string>
-    <string name="native_c25337055464f8d3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rollen"</string>
     <string name="native_c253f451bdd56431" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Antwoorden"</string>
     <string name="native_c26225b6c16a4bc7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Providercatalogus"</string>
     <string name="native_c272b225cf5bd643" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Schakel toestemming in via Instellingen"</string>
@@ -1154,7 +1135,6 @@
     <string name="native_c34dd5eb8b0af56e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Waar vind ik een installatiecode?"</string>
     <string name="native_c3546b39ecbbed8a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kan skill niet inschakelen."</string>
     <string name="native_c35b21d6ca39aa7c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"pdf"</string>
-    <string name="native_c3812fc4acb861d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Verwijderen"</string>
     <string name="native_c382566dbe2ea49f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s%% online"</string>
     <string name="native_c385951198c45d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Geen kanalen"</string>
     <string name="native_c41ad84496b53420" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Realtime spraak"</string>
@@ -1183,7 +1163,6 @@
     <string name="native_c6d5ed757b66bfd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dromen"</string>
     <string name="native_c6dd061350fc69b8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Geen apps geblokkeerd. Apps kunnen doorsturen tenzij je blokkeringen toevoegt."</string>
     <string name="native_c753cdf0c19f1e38" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Spraakherkenning niet beschikbaar"</string>
-    <string name="native_c78ffe19571018fb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Platform"</string>
     <string name="native_c7985fa72daa6ea4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway heeft de installatie van %1$s niet geretourneerd"</string>
     <string name="native_c7b6dfd5c3a183c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway vergeten?"</string>
     <string name="native_c7b7b7f01360f6a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Optionele beschrijving"</string>
@@ -1212,7 +1191,7 @@
     <string name="native_cc721e25d73938a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway thuis"</string>
     <string name="native_cc7a9a5cf8c4bc9d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Voer de goedkeuringsopdracht uit op de Gateway"</string>
     <string name="native_cc925e3c97ac7a35" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kan voorstellen van Skill Workshop niet laden."</string>
-    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Praat me bij over mijn recente OpenClaw-gesprekken en stel vervolgstappen voor."</string>
+    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Praat me bij over mijn recente OpenClaw-threads en stel vervolgstappen voor."</string>
     <string name="native_ccb4c324f516c633" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Niet nu"</string>
     <string name="native_cced0b0d83a9e400" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw qr"</string>
     <string name="native_cced28c6dc3f99c2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"start"</string>
@@ -1246,7 +1225,6 @@
     <string name="native_d17d2d78d76e6a6c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Modellen"</string>
     <string name="native_d19c2dd2fb598b93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw Passief"</string>
     <string name="native_d1a574e23344c407" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway-wachtwoord ongeldig"</string>
-    <string name="native_d1af697abaff485f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"De wijziging in de apparaatkoppeling kon niet worden geverifieerd. Vernieuw en probeer het opnieuw."</string>
     <string name="native_d1bf045bb524dae5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Details bekijken"</string>
     <string name="native_d1e9567da9a8a4b0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bash"</string>
     <string name="native_d2089be672953d11" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Token"</string>
@@ -1261,7 +1239,6 @@
     <string name="native_d31de1a5c5c8ba2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Browser"</string>
     <string name="native_d354ee936f59115e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screen record"</string>
     <string name="native_d3974fd6d3b6c81f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Uitvoering in behandeling"</string>
-    <string name="native_d3e1c5f8a6e240fc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Herkomst"</string>
     <string name="native_d3f75e24411053c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Persoonlijke AI op je apparaten"</string>
     <string name="native_d406ade2958cb5b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attach"</string>
     <string name="native_d461a493a3753877" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatisch"</string>
@@ -1277,7 +1254,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Profiel"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Limieten van providers verschijnen hier wanneer je Gateway ze rapporteert."</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 probleem"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" worden behouden en teruggezet naar Niet gegroepeerd."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aangemaakt"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s actieve tokens"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>
@@ -1294,7 +1271,7 @@
     <string name="native_d93e2b7a15efbc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kan de goedkeuring niet afhandelen. Vernieuw en probeer het opnieuw."</string>
     <string name="native_d942f64886578d87" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"import"</string>
     <string name="native_d94cfb21b67ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Hoe deze telefoon wordt weergegeven voor OpenClaw."</string>
-    <string name="native_d96f2b0eab4e67b7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zoeken naar threads activeren"</string>
+    <string name="native_d96f2b0eab4e67b7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zoeken in threads activeren"</string>
     <string name="native_d975ca28a64f8850" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Verbind de Gateway"</string>
     <string name="native_d9be42d9b30ce057" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Agenda lezen"</string>
     <string name="native_d9f641e1a02807cb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Het overzicht wordt vernieuwd wanneer opnieuw verbinding wordt gemaakt en wanneer dit scherm wordt geopend."</string>
@@ -1450,7 +1427,6 @@
     <string name="native_f2da2e47cd31a5dd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Deze afbeelding kan niet worden gedecodeerd."</string>
     <string name="native_f3753c0fe29b88db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway, spraak, meldingen, privacy"</string>
     <string name="native_f386c32c1bf437d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Werkruimtebestanden van agent"</string>
-    <string name="native_f418bf0894a1806a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dit apparaat verliest zijn vertrouwde toegang tot de Gateway."</string>
     <string name="native_f41d9e8b7e09aa24" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gebruik de requestId uit de opdracht in behandeling in de approve-opdracht."</string>
     <string name="native_f4830a1dae298044" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Planning"</string>
     <string name="native_f493f0ce7a52a8aa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Frequentielimiet"</string>
@@ -1458,7 +1434,6 @@
     <string name="native_f4cc820d308495c4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Payload · %1$s"</string>
     <string name="native_f4ccae29e1bb0c20" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Actief"</string>
     <string name="native_f4db1e48476f6075" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Beëindigen"</string>
-    <string name="native_f4e2076014711222" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Systeemvertrouwen gebruiken"</string>
     <string name="native_f4ef7a41caa88dd1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Geen providers gereed"</string>
     <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Geeft prioriteit aan verbonden Bluetooth-microfoons."</string>
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s app is geblokkeerd voor doorsturen."</string>
@@ -1486,7 +1461,7 @@
     <string name="native_f8b32f4e92bd84ce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Geïnstalleerd"</string>
     <string name="native_f8c2745155505d39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Time-out tijdens het wachten op een antwoord; probeer het opnieuw of vernieuw."</string>
     <string name="native_f8cd133f0ea1031b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Eerdere gesprekken zoeken"</string>
-    <string name="native_f90f3791049b995d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads bekijken"</string>
+    <string name="native_f90f3791049b995d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Door threads bladeren"</string>
     <string name="native_f92e2ad582c0e13f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Vernieuwen"</string>
     <string name="native_f991ae9cb081e1f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Open de camera en richt op de code van openclaw qr."</string>
     <string name="native_f9ea3f1540eaa584" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Geen apparaten"</string>
@@ -1508,7 +1483,7 @@
     <string name="native_fcdeb9947bc94101" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Test test 1 2 3"</string>
     <string name="native_fcea13c79c2f85a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kan ClawHub-skills niet zoeken."</string>
     <string name="native_fd175ecd65f7353d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Geen prompt"</string>
-    <string name="native_fd301dc5d0e7ccf1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Frontcamera"</string>
+    <string name="native_fd301dc5d0e7ccf1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Camera aan de voorkant"</string>
     <string name="native_fda8fc3b85420d14" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Logboekvermelding openen"</string>
     <string name="native_fdd0d769c49517c2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Netwerktime-out"</string>
     <string name="native_fe18013d93d22f4f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nu"</string>

--- a/apps/android/app/src/main/res/values-nl/strings.xml
+++ b/apps/android/app/src/main/res/values-nl/strings.xml
@@ -75,6 +75,7 @@
     <string name="native_0929c9dc7f794852" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Geen voorstellen"</string>
     <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Hoofdthread"</string>
     <string name="native_0979c6fdbdca1675" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Chat openen"</string>
+    <string name="native_09ce95090659d069" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Acties voor het koppelen van apparaten zijn niet beschikbaar in deze Gateway-sessie. Voer openclaw devices list uit op de Gateway-host en beheer het verzoek daar. Goedkeuring van nodefunctionaliteiten staat hier los van en gebruikt nog steeds nodes approve &lt;request id&gt;."</string>
     <string name="native_0a0b7cf7c428c703" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Actieverzoek"</string>
     <string name="native_0a708e7b03aaf1fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list pins"</string>
     <string name="native_0ab0e1629576aecf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Maak verbinding met een Gateway om Skills Workshop-voorstellen te laden."</string>
@@ -87,10 +88,12 @@
     <string name="native_0c3845dcd2f0f683" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Inspecteer dit voorstel om de markdown te laden."</string>
     <string name="native_0c3ea4e2f12153e7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"open OpenClaw en vraag %1$s"</string>
     <string name="native_0c4d01e81bb3d1fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"redenering"</string>
+    <string name="native_0c77fe09ab336a3e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Client"</string>
     <string name="native_0c79a9c222840ed0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Toegepast"</string>
     <string name="native_0cab1c9617404faf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"video"</string>
     <string name="native_0cf04463c4276a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gepromoot"</string>
     <string name="native_0d21bd52022ca7f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Online"</string>
+    <string name="native_0d5644ff52ce2ba3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bereiken"</string>
     <string name="native_0d5efd432e4fedf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Realtime-spraakprovider is niet geconfigureerd."</string>
     <string name="native_0d8ca811c3744a6d" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s · %2$s"</string>
     <string name="native_0db10f2c2f332cd2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"kick"</string>
@@ -138,6 +141,7 @@
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sessiedoel"</string>
     <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ClawHub-skill beoordelen"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
+    <string name="native_16a5b7ad567a8093" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Het koppelingsverzoek van dit apparaat afwijzen?"</string>
     <string name="native_16b1a05e1d987ed1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Voorkeursmicrofoon"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nodehost"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Niveau"</string>
@@ -183,6 +187,7 @@
     <string name="native_1d91629837639a5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Deze automatisering is gewijzigd terwijl u deze bewerkte. Herstel de nieuwste versie van de Gateway voordat u opslaat."</string>
     <string name="native_1dbf9d5979606697" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wanneer er verbinding is, kan de Gateway de telefoon met een stille pushmelding activeren in plaats van een permanente sessie open te houden."</string>
     <string name="native_1e432ea5425e4a3a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Activeringsmodus"</string>
+    <string name="native_1e595a107c78b957" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gekoppeld apparaat verwijderen?"</string>
     <string name="native_1e955a58278623a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Systeemgebeurtenistekst"</string>
     <string name="native_1ea44149be42d970" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kan widgetafbeelding niet kopiëren"</string>
     <string name="native_1ea442a134b2a184" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nee"</string>
@@ -197,6 +202,7 @@
     <string name="native_2065cc867eba1b39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kan de configuratie van providermodellen niet laden."</string>
     <string name="native_207ccb22d618db05" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s app mag doorsturen."</string>
     <string name="native_209b9e597963e7e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Spraakinstellingen"</string>
+    <string name="native_211988ba9dd0570a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Koppelingsverzoek afwijzen?"</string>
     <string name="native_2132066dc9475cb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"This skill is installed but not available to the current agent. Agent filters stay on desktop or CLI."</string>
     <string name="native_21378545892f1fe2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Uitgever"</string>
     <string name="native_214d4932fc767e8f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">" · Gesprek: Spreekt"</string>
@@ -238,6 +244,7 @@
     <string name="native_2682bd813a3bccbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Voer de installatiecode van openclaw qr in."</string>
     <string name="native_268f14bbfe119c1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Diagnostiek"</string>
     <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Hiermee worden de thread en het transcript ervan permanent verwijderd."</string>
+    <string name="native_26e47d73a55d7fa7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Apparaat goedgekeurd."</string>
     <string name="native_26f0dd993530eb2d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatisch opnieuw proberen"</string>
     <string name="native_270ff82f36da987f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Widgetafbeelding gekopieerd"</string>
     <string name="native_2728740a95d465c6" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s rollen"</string>
@@ -346,6 +353,7 @@
     <string name="native_381428f5f251a764" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Conversation Send"</string>
     <string name="native_3824a9f4dafe92c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Canvas"</string>
     <string name="native_384ae4ab1a2830f9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 provider"</string>
+    <string name="native_385001409de8562a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Het Gateway-certificaat kon niet automatisch worden gelezen. Plak de SHA-256-vingerafdruk die op de Gateway-host is verkregen."</string>
     <string name="native_387b2569e440838c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Verzenden mislukt: %1$s"</string>
     <string name="native_3892e10346fd2012" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Brug"</string>
     <string name="native_38d198cd5303680f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bezorgfout"</string>
@@ -403,6 +411,7 @@
     <string name="native_429f6057535c1ea3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sub-agent"</string>
     <string name="native_42e3a99c21767def" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wachten op apparaatgoedkeuring"</string>
     <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Thread laden"</string>
+    <string name="native_430df68ec29a85a2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Deze Gateway gebruikt nu een certificaat dat door dit apparaat wordt vertrouwd."</string>
     <string name="native_43905968a540af6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Spreiding ms"</string>
     <string name="native_43988c156beabf7d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"event create"</string>
     <string name="native_43cc23fa52b87b4c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"document"</string>
@@ -464,6 +473,7 @@
     <string name="native_4e8c72cab82e0711" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"De automatisering heeft een ongeldige configuratie."</string>
     <string name="native_4ec30e9d85725d41" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Toegestaan-lijst"</string>
     <string name="native_4ed379d418bb8629" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"groups"</string>
+    <string name="native_4ee252fb736effa2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Openbare sleutel"</string>
     <string name="native_4efca0d10c5feb8e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Over"</string>
     <string name="native_4f1bc100d1dccc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Er is geen installatie-QR-code gevonden in die afbeelding. Kies de QR-code die is gegenereerd door openclaw qr of voer de installatiecode handmatig in."</string>
     <string name="native_4fe3cdd404ea0290" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"permissions"</string>
@@ -550,6 +560,7 @@
     <string name="native_5c0c8c9aa658f4a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OPENCLAW"</string>
     <string name="native_5c1acea9c9b0e704" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Fetch"</string>
     <string name="native_5c39123805ffb4e2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Prompt"</string>
+    <string name="native_5c944156b5353428" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Apparaat goedkeuren?"</string>
     <string name="native_5d410adb9576e266" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s en de opgeslagen inloggegevens van deze telefoon verwijderen?"</string>
     <string name="native_5d6c41a67139ee26" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"De QR-code verwijst naar een onveilige externe Gateway. %1$s %2$s"</string>
     <string name="native_5d6cbac59f87e78d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Schermoppervlak gereed"</string>
@@ -567,6 +578,7 @@
     <string name="native_5fa1d457ddfcd26c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"rename group"</string>
     <string name="native_5fa7aac5375c5815" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gereed"</string>
     <string name="native_5fc1927ca948f31c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Het dagboek wacht op het eerste item."</string>
+    <string name="native_6007acbe30b2cd98" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Goedkeuren"</string>
     <string name="native_600c9c27960112a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Livepagina"</string>
     <string name="native_6030d1f6340776d2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"De automatisering wordt al uitgevoerd."</string>
     <string name="native_604e6d6faf8d0295" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Verwijder deze automatisering na een geslaagde eenmalige uitvoering."</string>
@@ -606,12 +618,14 @@
     <string name="native_6657cc73af00feac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cameratools toestaan wanneer daarom wordt gevraagd."</string>
     <string name="native_666067dd376e5d45" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Problemen"</string>
     <string name="native_666c8bc0319f3b54" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Spraakactivering"</string>
+    <string name="native_66713d713e3a41c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Koppelingsverzoek afgewezen."</string>
     <string name="native_66b23bae66fc0d79" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$sd geleden"</string>
     <string name="native_66cf5513b37462be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"roles"</string>
     <string name="native_66d0f523a379b2de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skills"</string>
     <string name="native_66f4804ee23ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Archiveren"</string>
     <string name="native_66fab2875ee427f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Node offline. Maak opnieuw verbinding en probeer het opnieuw."</string>
     <string name="native_6725e7bbcd28f3a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Systeem"</string>
+    <string name="native_672f3453e1dd571b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Extern IP-adres"</string>
     <string name="native_674b38cae72bb0c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Niet gegroepeerd"</string>
     <string name="native_674eb55d9c353900" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Planningsdetails"</string>
     <string name="native_67528858c36397f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Telefoonmogelijkheden"</string>
@@ -619,6 +633,7 @@
     <string name="native_67b696468610b879" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dashboard"</string>
     <string name="native_67fa416afa64d304" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Token plakken"</string>
     <string name="native_6827238fea72c88b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Geen providers"</string>
+    <string name="native_684889f0079cc145" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"SHA-256-vingerafdruk"</string>
     <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nog geen threads"</string>
     <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bluetooth-microfoon"</string>
     <string name="native_690dbe9dc0993c42" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Recent"</string>
@@ -653,6 +668,7 @@
     <string name="native_6d5d9004797377e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Licenties"</string>
     <string name="native_6d7c95a353d873cd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Verbind de gateway om ClawHub-skills te zoeken."</string>
     <string name="native_6df1bb18a59ab97d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skill"</string>
+    <string name="native_6e0a0b9d8c5ee4d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Apparaat-ID"</string>
     <string name="native_6e117ba97cbfb6f0" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway heeft de actieve %1$s-provider niet geïdentificeerd"</string>
     <string name="native_6e293a8c009e0011" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wachten"</string>
     <string name="native_6e2c0963d056e104" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Activeringswoorden opgeslagen"</string>
@@ -829,6 +845,7 @@
     <string name="native_8bb7ec15b1e350a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Inspecteren"</string>
     <string name="native_8bf253a125f66985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Scan of plak een installatiecode om een andere gateway toe te voegen."</string>
     <string name="native_8c4a3896e8f06d27" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Time-out bij TLS"</string>
+    <string name="native_8c55387fb6c584c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gekoppeld apparaat verwijderd."</string>
     <string name="native_8c93c68056cde54d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway gekoppeld. De goedkeuring van knooppuntmogelijkheden wordt gecontroleerd."</string>
     <string name="native_8ca344247c18317e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Beweging"</string>
     <string name="native_8cac4b77b9c54695" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cronactie mislukt."</string>
@@ -1021,7 +1038,6 @@
     <string name="native_ad1c341c65f84ede" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Voer de approve-opdracht uit op de Gateway-computer en controleer daarna opnieuw."</string>
     <string name="native_ad1fb9ec0cb3c7a4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatiseringen"</string>
     <string name="native_adb7eb8a03ad699c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s min."</string>
-    <string name="native_adca3171c270301a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Met deze Gateway-aanmelding kunt u verbonden knooppunten weergeven, maar geen nieuwe telefoonkoppelingen goedkeuren. Koppel nieuwe telefoons vanuit een Gateway-beheerderssessie. De goedkeuring van knooppuntmogelijkheden staat hiervan los en gebruikt nog steeds nodes approve &lt;request id&gt;."</string>
     <string name="native_ade9248e0132b411" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Vertrouwen"</string>
     <string name="native_ae27fa789a03c1db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Die QR-code is geen OpenClaw-installatie-QR. Genereer een nieuwe code met openclaw qr en probeer het opnieuw."</string>
     <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Voorkeursmicrofoon niet beschikbaar; automatische routering wordt gebruikt."</string>
@@ -1091,6 +1107,7 @@
     <string name="native_bb4f2558e4333834" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Widgetafbeelding opgeslagen in Downloads"</string>
     <string name="native_bbe5fc3b9ef39f99" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Starten…"</string>
     <string name="native_bc19cec293228fb8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Clientfout"</string>
+    <string name="native_bc1c94a6dfce1058" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Verifieer dit verzoekende apparaat voordat u toegang verleent."</string>
     <string name="native_bc6618670f3e8a17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bluetooth LE-microfoon"</string>
     <string name="native_bcb06651437caa15" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
     <string name="native_bd08450d63406844" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"De automatisering is ingeschakeld."</string>
@@ -1099,6 +1116,7 @@
     <string name="native_bdc090ec61e3fcfc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Opnieuw laden"</string>
     <string name="native_bdff71b20b9cf392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatiseringen zoeken"</string>
     <string name="native_be969becb173e0c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gekoppelde telefoons en nodehosts verschijnen hier na het koppelen."</string>
+    <string name="native_bf1870ff5c6322fb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s: %2$s"</string>
     <string name="native_bf350e6a0ed60b7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Deze automatisering is gewijzigd op de Gateway. Controleer de nieuwste versie voordat u opnieuw opslaat."</string>
     <string name="native_bf399ffa03617a96" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dicteren stoppen"</string>
     <string name="native_bf56ee2fe3345ce1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Leesbaar"</string>
@@ -1122,6 +1140,7 @@
     <string name="native_c1c224b03cd9bc7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Beheerder"</string>
     <string name="native_c1ebc7817870e5be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aandacht vereist"</string>
     <string name="native_c22d5e02fbec7d65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Koppel dit apparaat aan je Gateway om het alleen voor echt werk te activeren, een liveoverzicht van agents bij de hand te houden en batterijverslindende achtergrondlussen te voorkomen."</string>
+    <string name="native_c25337055464f8d3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rollen"</string>
     <string name="native_c253f451bdd56431" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Antwoorden"</string>
     <string name="native_c26225b6c16a4bc7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Providercatalogus"</string>
     <string name="native_c272b225cf5bd643" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Schakel toestemming in via Instellingen"</string>
@@ -1135,6 +1154,7 @@
     <string name="native_c34dd5eb8b0af56e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Waar vind ik een installatiecode?"</string>
     <string name="native_c3546b39ecbbed8a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kan skill niet inschakelen."</string>
     <string name="native_c35b21d6ca39aa7c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"pdf"</string>
+    <string name="native_c3812fc4acb861d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Verwijderen"</string>
     <string name="native_c382566dbe2ea49f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s%% online"</string>
     <string name="native_c385951198c45d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Geen kanalen"</string>
     <string name="native_c41ad84496b53420" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Realtime spraak"</string>
@@ -1163,6 +1183,7 @@
     <string name="native_c6d5ed757b66bfd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dromen"</string>
     <string name="native_c6dd061350fc69b8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Geen apps geblokkeerd. Apps kunnen doorsturen tenzij je blokkeringen toevoegt."</string>
     <string name="native_c753cdf0c19f1e38" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Spraakherkenning niet beschikbaar"</string>
+    <string name="native_c78ffe19571018fb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Platform"</string>
     <string name="native_c7985fa72daa6ea4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway heeft de installatie van %1$s niet geretourneerd"</string>
     <string name="native_c7b6dfd5c3a183c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway vergeten?"</string>
     <string name="native_c7b7b7f01360f6a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Optionele beschrijving"</string>
@@ -1225,6 +1246,7 @@
     <string name="native_d17d2d78d76e6a6c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Modellen"</string>
     <string name="native_d19c2dd2fb598b93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw Passief"</string>
     <string name="native_d1a574e23344c407" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway-wachtwoord ongeldig"</string>
+    <string name="native_d1af697abaff485f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"De wijziging in de apparaatkoppeling kon niet worden geverifieerd. Vernieuw en probeer het opnieuw."</string>
     <string name="native_d1bf045bb524dae5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Details bekijken"</string>
     <string name="native_d1e9567da9a8a4b0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bash"</string>
     <string name="native_d2089be672953d11" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Token"</string>
@@ -1239,6 +1261,7 @@
     <string name="native_d31de1a5c5c8ba2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Browser"</string>
     <string name="native_d354ee936f59115e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screen record"</string>
     <string name="native_d3974fd6d3b6c81f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Uitvoering in behandeling"</string>
+    <string name="native_d3e1c5f8a6e240fc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Herkomst"</string>
     <string name="native_d3f75e24411053c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Persoonlijke AI op je apparaten"</string>
     <string name="native_d406ade2958cb5b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attach"</string>
     <string name="native_d461a493a3753877" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatisch"</string>
@@ -1427,6 +1450,7 @@
     <string name="native_f2da2e47cd31a5dd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Deze afbeelding kan niet worden gedecodeerd."</string>
     <string name="native_f3753c0fe29b88db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway, spraak, meldingen, privacy"</string>
     <string name="native_f386c32c1bf437d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Werkruimtebestanden van agent"</string>
+    <string name="native_f418bf0894a1806a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dit apparaat verliest zijn vertrouwde toegang tot de Gateway."</string>
     <string name="native_f41d9e8b7e09aa24" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gebruik de requestId uit de opdracht in behandeling in de approve-opdracht."</string>
     <string name="native_f4830a1dae298044" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Planning"</string>
     <string name="native_f493f0ce7a52a8aa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Frequentielimiet"</string>
@@ -1434,6 +1458,7 @@
     <string name="native_f4cc820d308495c4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Payload · %1$s"</string>
     <string name="native_f4ccae29e1bb0c20" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Actief"</string>
     <string name="native_f4db1e48476f6075" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Beëindigen"</string>
+    <string name="native_f4e2076014711222" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Systeemvertrouwen gebruiken"</string>
     <string name="native_f4ef7a41caa88dd1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Geen providers gereed"</string>
     <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Geeft prioriteit aan verbonden Bluetooth-microfoons."</string>
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s app is geblokkeerd voor doorsturen."</string>

--- a/apps/android/app/src/main/res/values-pl/strings.xml
+++ b/apps/android/app/src/main/res/values-pl/strings.xml
@@ -494,7 +494,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dostarczenie"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wycisz głośnik"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nawiązywanie połączenia z Gateway"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitorowanie · %1$s wątków"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Uruchomienie automatyzacji zakończone."</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Brak pasujących aplikacji."</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wyślij do czatu"</string>
@@ -1277,7 +1277,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Profil"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Limity dostawcy pojawią się tutaj, gdy Twój Gateway je zgłosi."</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 problem"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wątki w grupie „%1$s” zostaną zachowane i przeniesione z powrotem do sekcji Bez grupy."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Utworzono"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s aktywnych tokenów"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>

--- a/apps/android/app/src/main/res/values-pl/strings.xml
+++ b/apps/android/app/src/main/res/values-pl/strings.xml
@@ -75,7 +75,6 @@
     <string name="native_0929c9dc7f794852" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Brak propozycji"</string>
     <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Główny wątek"</string>
     <string name="native_0979c6fdbdca1675" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Otwórz czat"</string>
-    <string name="native_09ce95090659d069" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Akcje parowania urządzeń są niedostępne w tej sesji Gateway. Uruchom openclaw devices list na hoście Gateway i tam zarządzaj żądaniem. Zatwierdzanie uprawnień węzła odbywa się oddzielnie i nadal używa polecenia nodes approve &lt;request id&gt;."</string>
     <string name="native_0a0b7cf7c428c703" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Żądanie działania"</string>
     <string name="native_0a708e7b03aaf1fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list pins"</string>
     <string name="native_0ab0e1629576aecf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Połącz się z Gateway, aby wczytać propozycje Warsztatu Skills."</string>
@@ -88,12 +87,10 @@
     <string name="native_0c3845dcd2f0f683" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sprawdź tę propozycję, aby wczytać jej treść w formacie Markdown."</string>
     <string name="native_0c3ea4e2f12153e7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"otwórz OpenClaw i zapytaj %1$s"</string>
     <string name="native_0c4d01e81bb3d1fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"rozumowanie"</string>
-    <string name="native_0c77fe09ab336a3e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Klient"</string>
     <string name="native_0c79a9c222840ed0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zastosowane"</string>
     <string name="native_0cab1c9617404faf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"wideo"</string>
     <string name="native_0cf04463c4276a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Promowane"</string>
     <string name="native_0d21bd52022ca7f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Online"</string>
-    <string name="native_0d5644ff52ce2ba3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zakresy"</string>
     <string name="native_0d5efd432e4fedf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dostawca głosu w czasie rzeczywistym nie jest skonfigurowany."</string>
     <string name="native_0d8ca811c3744a6d" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s · %2$s"</string>
     <string name="native_0db10f2c2f332cd2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"kick"</string>
@@ -141,7 +138,6 @@
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cel sesji"</string>
     <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sprawdź skill w ClawHub"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
-    <string name="native_16a5b7ad567a8093" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Odrzucić żądanie parowania z tego urządzenia?"</string>
     <string name="native_16b1a05e1d987ed1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Preferowany mikrofon"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Host węzła"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Poziom"</string>
@@ -187,7 +183,6 @@
     <string name="native_1d91629837639a5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ta automatyzacja została zmieniona podczas edycji. Przed zapisaniem przywróć najnowszą wersję z Gateway."</string>
     <string name="native_1dbf9d5979606697" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Po połączeniu Gateway może wybudzać telefon za pomocą cichego powiadomienia push zamiast utrzymywać stale aktywną sesję."</string>
     <string name="native_1e432ea5425e4a3a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tryb wybudzania"</string>
-    <string name="native_1e595a107c78b957" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Usunąć sparowane urządzenie?"</string>
     <string name="native_1e955a58278623a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tekst zdarzenia systemowego"</string>
     <string name="native_1ea44149be42d970" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nie udało się skopiować obrazu widżetu"</string>
     <string name="native_1ea442a134b2a184" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nie"</string>
@@ -202,7 +197,6 @@
     <string name="native_2065cc867eba1b39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nie udało się wczytać konfiguracji modelu dostawcy."</string>
     <string name="native_207ccb22d618db05" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zezwolono %1$s aplikacji na przekazywanie."</string>
     <string name="native_209b9e597963e7e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Konfiguracja głosu"</string>
-    <string name="native_211988ba9dd0570a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Odrzucić żądanie parowania?"</string>
     <string name="native_2132066dc9475cb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"This skill is installed but not available to the current agent. Agent filters stay on desktop or CLI."</string>
     <string name="native_21378545892f1fe2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wydawca"</string>
     <string name="native_214d4932fc767e8f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">" · Rozmowa: Mówienie"</string>
@@ -244,7 +238,6 @@
     <string name="native_2682bd813a3bccbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wprowadź kod konfiguracji z openclaw qr."</string>
     <string name="native_268f14bbfe119c1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Diagnostyka"</string>
     <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Spowoduje to trwałe usunięcie wątku i jego transkrypcji."</string>
-    <string name="native_26e47d73a55d7fa7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Urządzenie zatwierdzone."</string>
     <string name="native_26f0dd993530eb2d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatyczne ponawianie próby"</string>
     <string name="native_270ff82f36da987f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skopiowano obraz widżetu"</string>
     <string name="native_2728740a95d465c6" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s ról"</string>
@@ -353,7 +346,6 @@
     <string name="native_381428f5f251a764" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Conversation Send"</string>
     <string name="native_3824a9f4dafe92c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kanwa"</string>
     <string name="native_384ae4ab1a2830f9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 dostawca"</string>
-    <string name="native_385001409de8562a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nie udało się automatycznie odczytać certyfikatu Gateway. Wklej odcisk SHA-256 uzyskany na hoście Gateway."</string>
     <string name="native_387b2569e440838c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wysyłanie nie powiodło się: %1$s"</string>
     <string name="native_3892e10346fd2012" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Most"</string>
     <string name="native_38d198cd5303680f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Błąd dostarczenia"</string>
@@ -410,8 +402,7 @@
     <string name="native_4287d54ad5e78985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zaplanowane zadania OpenClaw z Twojego gateway."</string>
     <string name="native_429f6057535c1ea3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sub-agent"</string>
     <string name="native_42e3a99c21767def" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Oczekiwanie na zatwierdzenie urządzenia"</string>
-    <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wczytywanie wątku"</string>
-    <string name="native_430df68ec29a85a2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ten Gateway używa teraz certyfikatu zaufanego przez to urządzenie."</string>
+    <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ładowanie wątku"</string>
     <string name="native_43905968a540af6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rozłożenie ms"</string>
     <string name="native_43988c156beabf7d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"event create"</string>
     <string name="native_43cc23fa52b87b4c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"dokument"</string>
@@ -421,7 +412,7 @@
     <string name="native_4441146b0fe1d5c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screenshot"</string>
     <string name="native_4481c2190a1b4bca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wyrażenie cron, np. 0 9 * * *"</string>
     <string name="native_4499e7b7e1c9ddbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Powrót do głosu"</string>
-    <string name="native_449f5a775762cdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Mów"</string>
+    <string name="native_449f5a775762cdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rozmawiaj"</string>
     <string name="native_45a64dc17588f2ca" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s online"</string>
     <string name="native_45a8847c4a6b2c81" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zezwolono %1$s aplikacjom na przekazywanie."</string>
     <string name="native_460b3a7da007b7af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Czat"</string>
@@ -473,7 +464,6 @@
     <string name="native_4e8c72cab82e0711" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatyzacja ma nieprawidłową konfigurację."</string>
     <string name="native_4ec30e9d85725d41" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Lista dozwolonych"</string>
     <string name="native_4ed379d418bb8629" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"groups"</string>
-    <string name="native_4ee252fb736effa2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Klucz publiczny"</string>
     <string name="native_4efca0d10c5feb8e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Informacje"</string>
     <string name="native_4f1bc100d1dccc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Na tym obrazie nie znaleziono kodu QR konfiguracji. Wybierz kod QR wygenerowany przez openclaw qr lub wprowadź kod konfiguracji ręcznie."</string>
     <string name="native_4fe3cdd404ea0290" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"permissions"</string>
@@ -494,7 +484,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dostarczenie"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wycisz głośnik"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nawiązywanie połączenia z Gateway"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitorowanie · %1$s wątków"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Uruchomienie automatyzacji zakończone."</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Brak pasujących aplikacji."</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wyślij do czatu"</string>
@@ -560,7 +550,6 @@
     <string name="native_5c0c8c9aa658f4a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OPENCLAW"</string>
     <string name="native_5c1acea9c9b0e704" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Fetch"</string>
     <string name="native_5c39123805ffb4e2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Polecenie"</string>
-    <string name="native_5c944156b5353428" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zatwierdzić urządzenie?"</string>
     <string name="native_5d410adb9576e266" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Usunąć %1$s i zapisane dane logowania z tego telefonu?"</string>
     <string name="native_5d6c41a67139ee26" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kod QR wskazuje na niezabezpieczony zdalny Gateway. %1$s %2$s"</string>
     <string name="native_5d6cbac59f87e78d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Powierzchnia ekranu gotowa"</string>
@@ -578,7 +567,6 @@
     <string name="native_5fa1d457ddfcd26c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"rename group"</string>
     <string name="native_5fa7aac5375c5815" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gotowe"</string>
     <string name="native_5fc1927ca948f31c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dziennik czeka na pierwszy wpis."</string>
-    <string name="native_6007acbe30b2cd98" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zatwierdź"</string>
     <string name="native_600c9c27960112a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Strona na żywo"</string>
     <string name="native_6030d1f6340776d2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatyzacja jest już uruchomiona."</string>
     <string name="native_604e6d6faf8d0295" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Usuń tę automatyzację po pomyślnym jednorazowym uruchomieniu."</string>
@@ -618,14 +606,12 @@
     <string name="native_6657cc73af00feac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zezwalaj na używanie narzędzi aparatu na żądanie."</string>
     <string name="native_666067dd376e5d45" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Problemy"</string>
     <string name="native_666c8bc0319f3b54" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wybudzanie głosem"</string>
-    <string name="native_66713d713e3a41c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Żądanie parowania odrzucone."</string>
     <string name="native_66b23bae66fc0d79" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s dni temu"</string>
     <string name="native_66cf5513b37462be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"roles"</string>
     <string name="native_66d0f523a379b2de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skills"</string>
     <string name="native_66f4804ee23ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Archiwizuj"</string>
     <string name="native_66fab2875ee427f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Węzeł offline. Połącz się ponownie i spróbuj jeszcze raz."</string>
     <string name="native_6725e7bbcd28f3a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"System"</string>
-    <string name="native_672f3453e1dd571b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zdalny adres IP"</string>
     <string name="native_674b38cae72bb0c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bez grupy"</string>
     <string name="native_674eb55d9c353900" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Szczegóły harmonogramu"</string>
     <string name="native_67528858c36397f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Funkcje telefonu"</string>
@@ -633,7 +619,6 @@
     <string name="native_67b696468610b879" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dashboard"</string>
     <string name="native_67fa416afa64d304" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wklej token"</string>
     <string name="native_6827238fea72c88b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Brak dostawców"</string>
-    <string name="native_684889f0079cc145" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Odcisk SHA-256"</string>
     <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nie ma jeszcze żadnych wątków"</string>
     <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Mikrofon Bluetooth"</string>
     <string name="native_690dbe9dc0993c42" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ostatnie"</string>
@@ -668,7 +653,6 @@
     <string name="native_6d5d9004797377e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Licencje"</string>
     <string name="native_6d7c95a353d873cd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Połącz Gateway, aby wyszukiwać Skills w ClawHub."</string>
     <string name="native_6df1bb18a59ab97d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skill"</string>
-    <string name="native_6e0a0b9d8c5ee4d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Identyfikator urządzenia"</string>
     <string name="native_6e117ba97cbfb6f0" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway nie zidentyfikował aktywnego dostawcy %1$s"</string>
     <string name="native_6e293a8c009e0011" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Oczekiwanie"</string>
     <string name="native_6e2c0963d056e104" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Słowa aktywujące zapisane"</string>
@@ -717,7 +701,7 @@
     <string name="native_746f71ec623adc37" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Milisekundy epoki (opcjonalnie)"</string>
     <string name="native_7491b353909c1147" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Brak skonfigurowanych modeli. Odśwież, aby ponownie sprawdzić dostępność."</string>
     <string name="native_74a883a037bc227f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ustawienia"</string>
-    <string name="native_74c372f29b83df94" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tylna kamera"</string>
+    <string name="native_74c372f29b83df94" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tylny aparat"</string>
     <string name="native_74e21680eac7385c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"approve"</string>
     <string name="native_74e492d5d0df0bab" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zanim zaczniesz"</string>
     <string name="native_74f0a5d234edc4af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nie udało się wczytać Skills."</string>
@@ -845,7 +829,6 @@
     <string name="native_8bb7ec15b1e350a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sprawdzanie"</string>
     <string name="native_8bf253a125f66985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zeskanuj lub wklej kod konfiguracji, aby dodać kolejne Gateway."</string>
     <string name="native_8c4a3896e8f06d27" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Upłynął limit czasu TLS"</string>
-    <string name="native_8c55387fb6c584c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sparowane urządzenie usunięte."</string>
     <string name="native_8c93c68056cde54d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway sparowany. Sprawdzanie zatwierdzenia uprawnień węzła."</string>
     <string name="native_8ca344247c18317e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ruch"</string>
     <string name="native_8cac4b77b9c54695" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Operacja cron nie powiodła się."</string>
@@ -860,7 +843,7 @@
     <string name="native_8e19f962b0cd6587" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rozpocznij nową rozmowę, a pojawi się tutaj."</string>
     <string name="native_8e20431e6645ccdd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Problem z połączeniem"</string>
     <string name="native_8e588cd187741f1c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Średni"</string>
-    <string name="native_8e5b1a73152cf01c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Utwórz odgałęzienie"</string>
+    <string name="native_8e5b1a73152cf01c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rozgałęź"</string>
     <string name="native_8e6feeb36a83a707" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Włącz głośnik"</string>
     <string name="native_8e803d361324b459" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tekst zdarzenia systemowego"</string>
     <string name="native_8eb626078c16c726" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sortowanie: %1$s"</string>
@@ -1038,9 +1021,10 @@
     <string name="native_ad1c341c65f84ede" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Uruchom polecenie zatwierdzania na komputerze Gateway, a następnie sprawdź ponownie."</string>
     <string name="native_ad1fb9ec0cb3c7a4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatyzacje"</string>
     <string name="native_adb7eb8a03ad699c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s min"</string>
+    <string name="native_adca3171c270301a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"To logowanie do Gateway umożliwia wyświetlanie połączonych węzłów, ale nie pozwala zatwierdzać parowania nowych telefonów. Sparuj nowe telefony w sesji administratora Gateway. Zatwierdzanie uprawnień węzła odbywa się osobno i nadal używa polecenia nodes approve &lt;request id&gt;."</string>
     <string name="native_ade9248e0132b411" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zaufaj"</string>
     <string name="native_ae27fa789a03c1db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ten kod QR nie jest kodem konfiguracji OpenClaw. Wygeneruj nowy kod za pomocą openclaw qr, a następnie spróbuj ponownie."</string>
-    <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Preferowany mikrofon jest niedostępny; używane jest automatyczne kierowanie dźwięku."</string>
+    <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Preferowany mikrofon jest niedostępny; używane jest automatyczne przekierowanie."</string>
     <string name="native_aea4a04a80426ed8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Odrzucone"</string>
     <string name="native_aed306fbb63c0c68" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Uwzględnij pakiety Androida i działające w tle."</string>
     <string name="native_aedf1cf58372f943" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway jest gotowy."</string>
@@ -1107,7 +1091,6 @@
     <string name="native_bb4f2558e4333834" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Obraz widżetu zapisano w folderze Pobrane"</string>
     <string name="native_bbe5fc3b9ef39f99" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Uruchamianie…"</string>
     <string name="native_bc19cec293228fb8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Błąd klienta"</string>
-    <string name="native_bc1c94a6dfce1058" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zweryfikuj urządzenie wysyłające żądanie przed przyznaniem dostępu."</string>
     <string name="native_bc6618670f3e8a17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Mikrofon Bluetooth LE"</string>
     <string name="native_bcb06651437caa15" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
     <string name="native_bd08450d63406844" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatyzacja włączona."</string>
@@ -1116,7 +1099,6 @@
     <string name="native_bdc090ec61e3fcfc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Odśwież"</string>
     <string name="native_bdff71b20b9cf392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Szukaj automatyzacji"</string>
     <string name="native_be969becb173e0c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Połączone telefony i hosty węzłów pojawią się tutaj po sparowaniu."</string>
-    <string name="native_bf1870ff5c6322fb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s: %2$s"</string>
     <string name="native_bf350e6a0ed60b7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ta automatyzacja została zmieniona w Gateway. Przejrzyj najnowszą wersję przed ponownym zapisaniem."</string>
     <string name="native_bf399ffa03617a96" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zatrzymaj dyktowanie"</string>
     <string name="native_bf56ee2fe3345ce1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Czytelna"</string>
@@ -1140,7 +1122,6 @@
     <string name="native_c1c224b03cd9bc7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Administrator"</string>
     <string name="native_c1ebc7817870e5be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wymaga uwagi"</string>
     <string name="native_c22d5e02fbec7d65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sparuj to urządzenie ze swoim Gateway, aby wybudzać je tylko do rzeczywistych zadań, mieć pod ręką bieżący przegląd agentów i unikać wyczerpujących baterię pętli w tle."</string>
-    <string name="native_c25337055464f8d3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Role"</string>
     <string name="native_c253f451bdd56431" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Odpowiedz"</string>
     <string name="native_c26225b6c16a4bc7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Katalog dostawców"</string>
     <string name="native_c272b225cf5bd643" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Włącz uprawnienie w Ustawieniach"</string>
@@ -1154,7 +1135,6 @@
     <string name="native_c34dd5eb8b0af56e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skąd wziąć kod konfiguracji?"</string>
     <string name="native_c3546b39ecbbed8a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nie udało się włączyć umiejętności."</string>
     <string name="native_c35b21d6ca39aa7c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"pdf"</string>
-    <string name="native_c3812fc4acb861d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Usuń"</string>
     <string name="native_c382566dbe2ea49f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s%% online"</string>
     <string name="native_c385951198c45d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Brak kanałów"</string>
     <string name="native_c41ad84496b53420" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Głos w czasie rzeczywistym"</string>
@@ -1183,7 +1163,6 @@
     <string name="native_c6d5ed757b66bfd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sen"</string>
     <string name="native_c6dd061350fc69b8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nie zablokowano żadnych aplikacji. Aplikacje mogą przekazywać dane, dopóki nie dodasz blokad."</string>
     <string name="native_c753cdf0c19f1e38" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rozpoznawanie mowy jest niedostępne"</string>
-    <string name="native_c78ffe19571018fb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Platforma"</string>
     <string name="native_c7985fa72daa6ea4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway nie zwrócił konfiguracji %1$s"</string>
     <string name="native_c7b6dfd5c3a183c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zapomnieć Gateway?"</string>
     <string name="native_c7b7b7f01360f6a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Opcjonalny opis"</string>
@@ -1212,7 +1191,7 @@
     <string name="native_cc721e25d73938a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Domowy Gateway"</string>
     <string name="native_cc7a9a5cf8c4bc9d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Uruchom polecenie zatwierdzania w Gateway"</string>
     <string name="native_cc925e3c97ac7a35" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nie udało się wczytać propozycji Skill Workshop."</string>
-    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Podsumuj moje ostatnie wątki w OpenClaw i zaproponuj kolejne kroki."</string>
+    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Przedstaw mi podsumowanie ostatnich wątków OpenClaw i zaproponuj kolejne kroki."</string>
     <string name="native_ccb4c324f516c633" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nie teraz"</string>
     <string name="native_cced0b0d83a9e400" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw qr"</string>
     <string name="native_cced28c6dc3f99c2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"start"</string>
@@ -1246,7 +1225,6 @@
     <string name="native_d17d2d78d76e6a6c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Modele"</string>
     <string name="native_d19c2dd2fb598b93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw — pasywne"</string>
     <string name="native_d1a574e23344c407" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nieprawidłowe hasło Gateway"</string>
-    <string name="native_d1af697abaff485f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nie udało się zweryfikować zmiany parowania urządzenia. Odśwież i spróbuj ponownie."</string>
     <string name="native_d1bf045bb524dae5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wyświetl szczegóły"</string>
     <string name="native_d1e9567da9a8a4b0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bash"</string>
     <string name="native_d2089be672953d11" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Token"</string>
@@ -1261,7 +1239,6 @@
     <string name="native_d31de1a5c5c8ba2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Przeglądarka"</string>
     <string name="native_d354ee936f59115e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screen record"</string>
     <string name="native_d3974fd6d3b6c81f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Oczekujące uruchomienie"</string>
-    <string name="native_d3e1c5f8a6e240fc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Pochodzenie"</string>
     <string name="native_d3f75e24411053c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Osobista AI na Twoich urządzeniach"</string>
     <string name="native_d406ade2958cb5b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attach"</string>
     <string name="native_d461a493a3753877" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatycznie"</string>
@@ -1277,7 +1254,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Profil"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Limity dostawcy pojawią się tutaj, gdy Twój Gateway je zgłosi."</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 problem"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wątki w grupie „%1$s” zostaną zachowane i przeniesione z powrotem do sekcji Bez grupy."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Utworzono"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s aktywnych tokenów"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>
@@ -1294,7 +1271,7 @@
     <string name="native_d93e2b7a15efbc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nie udało się rozstrzygnąć prośby o zatwierdzenie. Odśwież i spróbuj ponownie."</string>
     <string name="native_d942f64886578d87" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"import"</string>
     <string name="native_d94cfb21b67ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Jak ten telefon jest widoczny dla OpenClaw."</string>
-    <string name="native_d96f2b0eab4e67b7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Przejdź do wyszukiwania wątków"</string>
+    <string name="native_d96f2b0eab4e67b7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ustaw fokus na wyszukiwaniu wątków"</string>
     <string name="native_d975ca28a64f8850" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Połącz Gateway"</string>
     <string name="native_d9be42d9b30ce057" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Odczyt kalendarza"</string>
     <string name="native_d9f641e1a02807cb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Przegląd jest odświeżany po ponownym połączeniu i po otwarciu tego ekranu."</string>
@@ -1450,7 +1427,6 @@
     <string name="native_f2da2e47cd31a5dd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nie udało się zdekodować tego obrazu."</string>
     <string name="native_f3753c0fe29b88db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway, głos, powiadomienia, prywatność"</string>
     <string name="native_f386c32c1bf437d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Pliki obszaru roboczego agenta"</string>
-    <string name="native_f418bf0894a1806a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"To urządzenie utraci zaufany dostęp do Gateway."</string>
     <string name="native_f41d9e8b7e09aa24" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Użyj requestId z oczekującego polecenia w poleceniu zatwierdzania."</string>
     <string name="native_f4830a1dae298044" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Harmonogram"</string>
     <string name="native_f493f0ce7a52a8aa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Limit częstotliwości"</string>
@@ -1458,7 +1434,6 @@
     <string name="native_f4cc820d308495c4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ładunek · %1$s"</string>
     <string name="native_f4ccae29e1bb0c20" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Uruchomione"</string>
     <string name="native_f4db1e48476f6075" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zakończ"</string>
-    <string name="native_f4e2076014711222" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Użyj zaufania systemowego"</string>
     <string name="native_f4ef7a41caa88dd1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Brak gotowych dostawców"</string>
     <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nadaje priorytet podłączonym mikrofonom Bluetooth."</string>
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zablokowano przekazywanie dla %1$s aplikacji."</string>
@@ -1508,7 +1483,7 @@
     <string name="native_fcdeb9947bc94101" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Test test 1 2 3"</string>
     <string name="native_fcea13c79c2f85a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nie udało się wyszukać Skills w ClawHub."</string>
     <string name="native_fd175ecd65f7353d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Brak monitu"</string>
-    <string name="native_fd301dc5d0e7ccf1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Przednia kamera"</string>
+    <string name="native_fd301dc5d0e7ccf1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Przedni aparat"</string>
     <string name="native_fda8fc3b85420d14" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Otwórz wpis dziennika"</string>
     <string name="native_fdd0d769c49517c2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Przekroczono limit czasu sieci"</string>
     <string name="native_fe18013d93d22f4f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Teraz"</string>
@@ -1522,7 +1497,7 @@
     <string name="native_ff716fc4735e067f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ustawienia dyktowania"</string>
     <string name="native_ff9dbbdfb84ddab2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Modele dostawców zostały wczytane, ale informacje o gotowości są niedostępne."</string>
     <string name="native_ffa7aa557b547a79" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Usunąć wątek?"</string>
-    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw zmienia ten telefon w przejrzysty mobilny interfejs sterowania wątkami, głosem, dostawcami i Gateway."</string>
+    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw zmienia ten telefon w przejrzysty mobilny interfejs do obsługi wątków, głosu, dostawców i Gateway."</string>
     <string name="native_ffb6f5764bddb68c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Najpierw najnowsze"</string>
     <string name="native_ffcf16006c652ee3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Następny cykl"</string>
 </resources>

--- a/apps/android/app/src/main/res/values-pl/strings.xml
+++ b/apps/android/app/src/main/res/values-pl/strings.xml
@@ -75,6 +75,7 @@
     <string name="native_0929c9dc7f794852" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Brak propozycji"</string>
     <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Główny wątek"</string>
     <string name="native_0979c6fdbdca1675" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Otwórz czat"</string>
+    <string name="native_09ce95090659d069" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Akcje parowania urządzeń są niedostępne w tej sesji Gateway. Uruchom openclaw devices list na hoście Gateway i tam zarządzaj żądaniem. Zatwierdzanie uprawnień węzła odbywa się oddzielnie i nadal używa polecenia nodes approve &lt;request id&gt;."</string>
     <string name="native_0a0b7cf7c428c703" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Żądanie działania"</string>
     <string name="native_0a708e7b03aaf1fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list pins"</string>
     <string name="native_0ab0e1629576aecf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Połącz się z Gateway, aby wczytać propozycje Warsztatu Skills."</string>
@@ -87,10 +88,12 @@
     <string name="native_0c3845dcd2f0f683" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sprawdź tę propozycję, aby wczytać jej treść w formacie Markdown."</string>
     <string name="native_0c3ea4e2f12153e7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"otwórz OpenClaw i zapytaj %1$s"</string>
     <string name="native_0c4d01e81bb3d1fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"rozumowanie"</string>
+    <string name="native_0c77fe09ab336a3e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Klient"</string>
     <string name="native_0c79a9c222840ed0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zastosowane"</string>
     <string name="native_0cab1c9617404faf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"wideo"</string>
     <string name="native_0cf04463c4276a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Promowane"</string>
     <string name="native_0d21bd52022ca7f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Online"</string>
+    <string name="native_0d5644ff52ce2ba3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zakresy"</string>
     <string name="native_0d5efd432e4fedf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dostawca głosu w czasie rzeczywistym nie jest skonfigurowany."</string>
     <string name="native_0d8ca811c3744a6d" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s · %2$s"</string>
     <string name="native_0db10f2c2f332cd2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"kick"</string>
@@ -138,6 +141,7 @@
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cel sesji"</string>
     <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sprawdź skill w ClawHub"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
+    <string name="native_16a5b7ad567a8093" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Odrzucić żądanie parowania z tego urządzenia?"</string>
     <string name="native_16b1a05e1d987ed1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Preferowany mikrofon"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Host węzła"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Poziom"</string>
@@ -183,6 +187,7 @@
     <string name="native_1d91629837639a5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ta automatyzacja została zmieniona podczas edycji. Przed zapisaniem przywróć najnowszą wersję z Gateway."</string>
     <string name="native_1dbf9d5979606697" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Po połączeniu Gateway może wybudzać telefon za pomocą cichego powiadomienia push zamiast utrzymywać stale aktywną sesję."</string>
     <string name="native_1e432ea5425e4a3a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tryb wybudzania"</string>
+    <string name="native_1e595a107c78b957" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Usunąć sparowane urządzenie?"</string>
     <string name="native_1e955a58278623a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tekst zdarzenia systemowego"</string>
     <string name="native_1ea44149be42d970" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nie udało się skopiować obrazu widżetu"</string>
     <string name="native_1ea442a134b2a184" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nie"</string>
@@ -197,6 +202,7 @@
     <string name="native_2065cc867eba1b39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nie udało się wczytać konfiguracji modelu dostawcy."</string>
     <string name="native_207ccb22d618db05" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zezwolono %1$s aplikacji na przekazywanie."</string>
     <string name="native_209b9e597963e7e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Konfiguracja głosu"</string>
+    <string name="native_211988ba9dd0570a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Odrzucić żądanie parowania?"</string>
     <string name="native_2132066dc9475cb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"This skill is installed but not available to the current agent. Agent filters stay on desktop or CLI."</string>
     <string name="native_21378545892f1fe2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wydawca"</string>
     <string name="native_214d4932fc767e8f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">" · Rozmowa: Mówienie"</string>
@@ -238,6 +244,7 @@
     <string name="native_2682bd813a3bccbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wprowadź kod konfiguracji z openclaw qr."</string>
     <string name="native_268f14bbfe119c1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Diagnostyka"</string>
     <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Spowoduje to trwałe usunięcie wątku i jego transkrypcji."</string>
+    <string name="native_26e47d73a55d7fa7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Urządzenie zatwierdzone."</string>
     <string name="native_26f0dd993530eb2d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatyczne ponawianie próby"</string>
     <string name="native_270ff82f36da987f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skopiowano obraz widżetu"</string>
     <string name="native_2728740a95d465c6" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s ról"</string>
@@ -346,6 +353,7 @@
     <string name="native_381428f5f251a764" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Conversation Send"</string>
     <string name="native_3824a9f4dafe92c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kanwa"</string>
     <string name="native_384ae4ab1a2830f9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 dostawca"</string>
+    <string name="native_385001409de8562a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nie udało się automatycznie odczytać certyfikatu Gateway. Wklej odcisk SHA-256 uzyskany na hoście Gateway."</string>
     <string name="native_387b2569e440838c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wysyłanie nie powiodło się: %1$s"</string>
     <string name="native_3892e10346fd2012" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Most"</string>
     <string name="native_38d198cd5303680f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Błąd dostarczenia"</string>
@@ -403,6 +411,7 @@
     <string name="native_429f6057535c1ea3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sub-agent"</string>
     <string name="native_42e3a99c21767def" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Oczekiwanie na zatwierdzenie urządzenia"</string>
     <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ładowanie wątku"</string>
+    <string name="native_430df68ec29a85a2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ten Gateway używa teraz certyfikatu zaufanego przez to urządzenie."</string>
     <string name="native_43905968a540af6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rozłożenie ms"</string>
     <string name="native_43988c156beabf7d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"event create"</string>
     <string name="native_43cc23fa52b87b4c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"dokument"</string>
@@ -412,7 +421,7 @@
     <string name="native_4441146b0fe1d5c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screenshot"</string>
     <string name="native_4481c2190a1b4bca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wyrażenie cron, np. 0 9 * * *"</string>
     <string name="native_4499e7b7e1c9ddbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Powrót do głosu"</string>
-    <string name="native_449f5a775762cdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rozmawiaj"</string>
+    <string name="native_449f5a775762cdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Mów"</string>
     <string name="native_45a64dc17588f2ca" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s online"</string>
     <string name="native_45a8847c4a6b2c81" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zezwolono %1$s aplikacjom na przekazywanie."</string>
     <string name="native_460b3a7da007b7af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Czat"</string>
@@ -464,6 +473,7 @@
     <string name="native_4e8c72cab82e0711" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatyzacja ma nieprawidłową konfigurację."</string>
     <string name="native_4ec30e9d85725d41" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Lista dozwolonych"</string>
     <string name="native_4ed379d418bb8629" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"groups"</string>
+    <string name="native_4ee252fb736effa2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Klucz publiczny"</string>
     <string name="native_4efca0d10c5feb8e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Informacje"</string>
     <string name="native_4f1bc100d1dccc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Na tym obrazie nie znaleziono kodu QR konfiguracji. Wybierz kod QR wygenerowany przez openclaw qr lub wprowadź kod konfiguracji ręcznie."</string>
     <string name="native_4fe3cdd404ea0290" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"permissions"</string>
@@ -550,6 +560,7 @@
     <string name="native_5c0c8c9aa658f4a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OPENCLAW"</string>
     <string name="native_5c1acea9c9b0e704" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Fetch"</string>
     <string name="native_5c39123805ffb4e2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Polecenie"</string>
+    <string name="native_5c944156b5353428" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zatwierdzić urządzenie?"</string>
     <string name="native_5d410adb9576e266" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Usunąć %1$s i zapisane dane logowania z tego telefonu?"</string>
     <string name="native_5d6c41a67139ee26" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kod QR wskazuje na niezabezpieczony zdalny Gateway. %1$s %2$s"</string>
     <string name="native_5d6cbac59f87e78d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Powierzchnia ekranu gotowa"</string>
@@ -567,6 +578,7 @@
     <string name="native_5fa1d457ddfcd26c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"rename group"</string>
     <string name="native_5fa7aac5375c5815" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gotowe"</string>
     <string name="native_5fc1927ca948f31c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dziennik czeka na pierwszy wpis."</string>
+    <string name="native_6007acbe30b2cd98" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zatwierdź"</string>
     <string name="native_600c9c27960112a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Strona na żywo"</string>
     <string name="native_6030d1f6340776d2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatyzacja jest już uruchomiona."</string>
     <string name="native_604e6d6faf8d0295" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Usuń tę automatyzację po pomyślnym jednorazowym uruchomieniu."</string>
@@ -606,12 +618,14 @@
     <string name="native_6657cc73af00feac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zezwalaj na używanie narzędzi aparatu na żądanie."</string>
     <string name="native_666067dd376e5d45" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Problemy"</string>
     <string name="native_666c8bc0319f3b54" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wybudzanie głosem"</string>
+    <string name="native_66713d713e3a41c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Żądanie parowania odrzucone."</string>
     <string name="native_66b23bae66fc0d79" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s dni temu"</string>
     <string name="native_66cf5513b37462be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"roles"</string>
     <string name="native_66d0f523a379b2de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skills"</string>
     <string name="native_66f4804ee23ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Archiwizuj"</string>
     <string name="native_66fab2875ee427f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Węzeł offline. Połącz się ponownie i spróbuj jeszcze raz."</string>
     <string name="native_6725e7bbcd28f3a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"System"</string>
+    <string name="native_672f3453e1dd571b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zdalny adres IP"</string>
     <string name="native_674b38cae72bb0c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bez grupy"</string>
     <string name="native_674eb55d9c353900" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Szczegóły harmonogramu"</string>
     <string name="native_67528858c36397f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Funkcje telefonu"</string>
@@ -619,6 +633,7 @@
     <string name="native_67b696468610b879" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dashboard"</string>
     <string name="native_67fa416afa64d304" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wklej token"</string>
     <string name="native_6827238fea72c88b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Brak dostawców"</string>
+    <string name="native_684889f0079cc145" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Odcisk SHA-256"</string>
     <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nie ma jeszcze żadnych wątków"</string>
     <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Mikrofon Bluetooth"</string>
     <string name="native_690dbe9dc0993c42" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ostatnie"</string>
@@ -653,6 +668,7 @@
     <string name="native_6d5d9004797377e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Licencje"</string>
     <string name="native_6d7c95a353d873cd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Połącz Gateway, aby wyszukiwać Skills w ClawHub."</string>
     <string name="native_6df1bb18a59ab97d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skill"</string>
+    <string name="native_6e0a0b9d8c5ee4d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Identyfikator urządzenia"</string>
     <string name="native_6e117ba97cbfb6f0" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway nie zidentyfikował aktywnego dostawcy %1$s"</string>
     <string name="native_6e293a8c009e0011" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Oczekiwanie"</string>
     <string name="native_6e2c0963d056e104" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Słowa aktywujące zapisane"</string>
@@ -829,6 +845,7 @@
     <string name="native_8bb7ec15b1e350a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sprawdzanie"</string>
     <string name="native_8bf253a125f66985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zeskanuj lub wklej kod konfiguracji, aby dodać kolejne Gateway."</string>
     <string name="native_8c4a3896e8f06d27" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Upłynął limit czasu TLS"</string>
+    <string name="native_8c55387fb6c584c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sparowane urządzenie usunięte."</string>
     <string name="native_8c93c68056cde54d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway sparowany. Sprawdzanie zatwierdzenia uprawnień węzła."</string>
     <string name="native_8ca344247c18317e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ruch"</string>
     <string name="native_8cac4b77b9c54695" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Operacja cron nie powiodła się."</string>
@@ -1021,7 +1038,6 @@
     <string name="native_ad1c341c65f84ede" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Uruchom polecenie zatwierdzania na komputerze Gateway, a następnie sprawdź ponownie."</string>
     <string name="native_ad1fb9ec0cb3c7a4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatyzacje"</string>
     <string name="native_adb7eb8a03ad699c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s min"</string>
-    <string name="native_adca3171c270301a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"To logowanie do Gateway umożliwia wyświetlanie połączonych węzłów, ale nie pozwala zatwierdzać parowania nowych telefonów. Sparuj nowe telefony w sesji administratora Gateway. Zatwierdzanie uprawnień węzła odbywa się osobno i nadal używa polecenia nodes approve &lt;request id&gt;."</string>
     <string name="native_ade9248e0132b411" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zaufaj"</string>
     <string name="native_ae27fa789a03c1db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ten kod QR nie jest kodem konfiguracji OpenClaw. Wygeneruj nowy kod za pomocą openclaw qr, a następnie spróbuj ponownie."</string>
     <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Preferowany mikrofon jest niedostępny; używane jest automatyczne przekierowanie."</string>
@@ -1091,6 +1107,7 @@
     <string name="native_bb4f2558e4333834" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Obraz widżetu zapisano w folderze Pobrane"</string>
     <string name="native_bbe5fc3b9ef39f99" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Uruchamianie…"</string>
     <string name="native_bc19cec293228fb8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Błąd klienta"</string>
+    <string name="native_bc1c94a6dfce1058" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zweryfikuj urządzenie wysyłające żądanie przed przyznaniem dostępu."</string>
     <string name="native_bc6618670f3e8a17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Mikrofon Bluetooth LE"</string>
     <string name="native_bcb06651437caa15" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
     <string name="native_bd08450d63406844" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatyzacja włączona."</string>
@@ -1099,6 +1116,7 @@
     <string name="native_bdc090ec61e3fcfc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Odśwież"</string>
     <string name="native_bdff71b20b9cf392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Szukaj automatyzacji"</string>
     <string name="native_be969becb173e0c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Połączone telefony i hosty węzłów pojawią się tutaj po sparowaniu."</string>
+    <string name="native_bf1870ff5c6322fb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s: %2$s"</string>
     <string name="native_bf350e6a0ed60b7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ta automatyzacja została zmieniona w Gateway. Przejrzyj najnowszą wersję przed ponownym zapisaniem."</string>
     <string name="native_bf399ffa03617a96" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zatrzymaj dyktowanie"</string>
     <string name="native_bf56ee2fe3345ce1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Czytelna"</string>
@@ -1122,6 +1140,7 @@
     <string name="native_c1c224b03cd9bc7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Administrator"</string>
     <string name="native_c1ebc7817870e5be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wymaga uwagi"</string>
     <string name="native_c22d5e02fbec7d65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sparuj to urządzenie ze swoim Gateway, aby wybudzać je tylko do rzeczywistych zadań, mieć pod ręką bieżący przegląd agentów i unikać wyczerpujących baterię pętli w tle."</string>
+    <string name="native_c25337055464f8d3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Role"</string>
     <string name="native_c253f451bdd56431" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Odpowiedz"</string>
     <string name="native_c26225b6c16a4bc7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Katalog dostawców"</string>
     <string name="native_c272b225cf5bd643" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Włącz uprawnienie w Ustawieniach"</string>
@@ -1135,6 +1154,7 @@
     <string name="native_c34dd5eb8b0af56e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skąd wziąć kod konfiguracji?"</string>
     <string name="native_c3546b39ecbbed8a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nie udało się włączyć umiejętności."</string>
     <string name="native_c35b21d6ca39aa7c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"pdf"</string>
+    <string name="native_c3812fc4acb861d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Usuń"</string>
     <string name="native_c382566dbe2ea49f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s%% online"</string>
     <string name="native_c385951198c45d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Brak kanałów"</string>
     <string name="native_c41ad84496b53420" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Głos w czasie rzeczywistym"</string>
@@ -1163,6 +1183,7 @@
     <string name="native_c6d5ed757b66bfd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sen"</string>
     <string name="native_c6dd061350fc69b8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nie zablokowano żadnych aplikacji. Aplikacje mogą przekazywać dane, dopóki nie dodasz blokad."</string>
     <string name="native_c753cdf0c19f1e38" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rozpoznawanie mowy jest niedostępne"</string>
+    <string name="native_c78ffe19571018fb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Platforma"</string>
     <string name="native_c7985fa72daa6ea4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway nie zwrócił konfiguracji %1$s"</string>
     <string name="native_c7b6dfd5c3a183c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zapomnieć Gateway?"</string>
     <string name="native_c7b7b7f01360f6a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Opcjonalny opis"</string>
@@ -1225,6 +1246,7 @@
     <string name="native_d17d2d78d76e6a6c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Modele"</string>
     <string name="native_d19c2dd2fb598b93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw — pasywne"</string>
     <string name="native_d1a574e23344c407" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nieprawidłowe hasło Gateway"</string>
+    <string name="native_d1af697abaff485f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nie udało się zweryfikować zmiany parowania urządzenia. Odśwież i spróbuj ponownie."</string>
     <string name="native_d1bf045bb524dae5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wyświetl szczegóły"</string>
     <string name="native_d1e9567da9a8a4b0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bash"</string>
     <string name="native_d2089be672953d11" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Token"</string>
@@ -1239,6 +1261,7 @@
     <string name="native_d31de1a5c5c8ba2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Przeglądarka"</string>
     <string name="native_d354ee936f59115e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screen record"</string>
     <string name="native_d3974fd6d3b6c81f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Oczekujące uruchomienie"</string>
+    <string name="native_d3e1c5f8a6e240fc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Pochodzenie"</string>
     <string name="native_d3f75e24411053c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Osobista AI na Twoich urządzeniach"</string>
     <string name="native_d406ade2958cb5b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attach"</string>
     <string name="native_d461a493a3753877" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatycznie"</string>
@@ -1427,6 +1450,7 @@
     <string name="native_f2da2e47cd31a5dd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nie udało się zdekodować tego obrazu."</string>
     <string name="native_f3753c0fe29b88db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway, głos, powiadomienia, prywatność"</string>
     <string name="native_f386c32c1bf437d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Pliki obszaru roboczego agenta"</string>
+    <string name="native_f418bf0894a1806a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"To urządzenie utraci zaufany dostęp do Gateway."</string>
     <string name="native_f41d9e8b7e09aa24" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Użyj requestId z oczekującego polecenia w poleceniu zatwierdzania."</string>
     <string name="native_f4830a1dae298044" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Harmonogram"</string>
     <string name="native_f493f0ce7a52a8aa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Limit częstotliwości"</string>
@@ -1434,6 +1458,7 @@
     <string name="native_f4cc820d308495c4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ładunek · %1$s"</string>
     <string name="native_f4ccae29e1bb0c20" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Uruchomione"</string>
     <string name="native_f4db1e48476f6075" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zakończ"</string>
+    <string name="native_f4e2076014711222" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Użyj zaufania systemowego"</string>
     <string name="native_f4ef7a41caa88dd1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Brak gotowych dostawców"</string>
     <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nadaje priorytet podłączonym mikrofonom Bluetooth."</string>
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zablokowano przekazywanie dla %1$s aplikacji."</string>

--- a/apps/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/apps/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -494,7 +494,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Entrega"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Silenciar alto-falante"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Abrindo conexão com o Gateway"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitorando · %1$s conversas"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"A execução da automação foi concluída."</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nenhum app correspondente."</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Enviar para o chat"</string>
@@ -1277,7 +1277,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Perfil"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Os limites do provedor aparecerão aqui quando seu Gateway os informar."</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 problema"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"As conversas em \"%1$s\" são mantidas e retornam para Sem grupo."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Criado"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s tokens ativos"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>

--- a/apps/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/apps/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -494,7 +494,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Entrega"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Silenciar alto-falante"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Abrindo conexão com o Gateway"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitorando · %1$s conversas"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"A execução da automação foi concluída."</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nenhum app correspondente."</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Enviar para o chat"</string>
@@ -519,7 +519,7 @@
     <string name="native_55898449eb74fb2e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Integridade"</string>
     <string name="native_55a12cbe0995e214" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Leitor de notificações"</string>
     <string name="native_55d8e7da6d0a752c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Alto-falante silenciado"</string>
-    <string name="native_560d3e826c413dc9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Pesquisar conversas"</string>
+    <string name="native_560d3e826c413dc9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Buscar conversas"</string>
     <string name="native_565339bc4d33d728" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OK"</string>
     <string name="native_56a508f3f2bf424a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Não foi possível abrir o guia de configuração."</string>
     <string name="native_56c41c606c44f3fc" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"perguntar ao OpenClaw %1$s"</string>
@@ -869,7 +869,7 @@
     <string name="native_8f54b0d1e30092d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nota de voz"</string>
     <string name="native_8fa196125b734940" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nada precisa da sua atenção"</string>
     <string name="native_8fce9ec6fd5432df" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"O OpenClaw precisa das permissões %1$s para continuar."</string>
-    <string name="native_8fe42acb8573244e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Microfone de headset com fio"</string>
+    <string name="native_8fe42acb8573244e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Microfone do headset com fio"</string>
     <string name="native_906115657390f367" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Entregue"</string>
     <string name="native_9071738f145962a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Prazo"</string>
     <string name="native_90bf81305006e6ed" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Os detalhes da Skill não estão disponíveis no status atual das Skills."</string>
@@ -1277,7 +1277,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Perfil"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Os limites do provedor aparecerão aqui quando seu Gateway os informar."</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 problema"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"As conversas em \"%1$s\" são mantidas e movidas de volta para Sem grupo."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Criado"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s tokens ativos"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>
@@ -1486,7 +1486,7 @@
     <string name="native_f8b32f4e92bd84ce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Instaladas"</string>
     <string name="native_f8c2745155505d39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"O tempo de espera por uma resposta esgotou; tente novamente ou atualize."</string>
     <string name="native_f8cd133f0ea1031b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Encontre conversas anteriores"</string>
-    <string name="native_f90f3791049b995d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Explorar conversas"</string>
+    <string name="native_f90f3791049b995d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Navegar pelas conversas"</string>
     <string name="native_f92e2ad582c0e13f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Atualizando"</string>
     <string name="native_f991ae9cb081e1f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Abra a câmera e enquadre o código do openclaw qr."</string>
     <string name="native_f9ea3f1540eaa584" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nenhum dispositivo"</string>
@@ -1522,7 +1522,7 @@
     <string name="native_ff716fc4735e067f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Configurações de ditado"</string>
     <string name="native_ff9dbbdfb84ddab2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Os modelos do provedor foram carregados, mas a disponibilidade não está acessível."</string>
     <string name="native_ffa7aa557b547a79" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Excluir conversa?"</string>
-    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"O OpenClaw transforma este telefone em uma interface móvel organizada para comandos de conversas, voz, provedores e Gateway."</string>
+    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"O OpenClaw transforma este celular em uma interface móvel simples para conversas, voz, provedores e Gateway."</string>
     <string name="native_ffb6f5764bddb68c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Mais recentes primeiro"</string>
     <string name="native_ffcf16006c652ee3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Próximo ciclo"</string>
 </resources>

--- a/apps/android/app/src/main/res/values-ru/strings.xml
+++ b/apps/android/app/src/main/res/values-ru/strings.xml
@@ -75,7 +75,6 @@
     <string name="native_0929c9dc7f794852" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Нет предложений"</string>
     <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Основная ветка"</string>
     <string name="native_0979c6fdbdca1675" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Открыть чат"</string>
-    <string name="native_09ce95090659d069" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Действия по сопряжению устройств недоступны в этом сеансе Gateway. Выполните openclaw devices list на хосте Gateway и обработайте запрос там. Одобрение возможностей узла выполняется отдельно с помощью nodes approve &lt;request id&gt;."</string>
     <string name="native_0a0b7cf7c428c703" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Запрос на действие"</string>
     <string name="native_0a708e7b03aaf1fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list pins"</string>
     <string name="native_0ab0e1629576aecf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Подключитесь к Gateway, чтобы загрузить предложения Мастерской Skills."</string>
@@ -88,12 +87,10 @@
     <string name="native_0c3845dcd2f0f683" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Откройте это предложение, чтобы загрузить его разметку Markdown."</string>
     <string name="native_0c3ea4e2f12153e7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"открыть OpenClaw и спросить %1$s"</string>
     <string name="native_0c4d01e81bb3d1fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"рассуждение"</string>
-    <string name="native_0c77fe09ab336a3e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Клиент"</string>
     <string name="native_0c79a9c222840ed0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Применено"</string>
     <string name="native_0cab1c9617404faf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"видео"</string>
     <string name="native_0cf04463c4276a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Продвигаемые"</string>
     <string name="native_0d21bd52022ca7f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"В сети"</string>
-    <string name="native_0d5644ff52ce2ba3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Области доступа"</string>
     <string name="native_0d5efd432e4fedf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Провайдер голосовой связи в реальном времени не настроен."</string>
     <string name="native_0d8ca811c3744a6d" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s · %2$s"</string>
     <string name="native_0db10f2c2f332cd2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"kick"</string>
@@ -104,7 +101,7 @@
     <string name="native_0e91610117029a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Обновить"</string>
     <string name="native_0ee30822ed35a792" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"В очереди: %1$s"</string>
     <string name="native_0f4c8529742b31ea" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Начать чат"</string>
-    <string name="native_0f559ff270904904" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ожидающие вызовы инструментов чата в активной ветке остаются видимыми здесь."</string>
+    <string name="native_0f559ff270904904" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Здесь отображаются ожидающие вызовы инструментов чата в активной ветке."</string>
     <string name="native_0f56cc286a4f23d8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Требуется проверка сертификата"</string>
     <string name="native_0f8fe3a9688138a1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Откройте текущую поверхность Canvas для просмотра или взаимодействия с ней."</string>
     <string name="native_0ff98f05be01ce5e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Автоматизация обновлена."</string>
@@ -141,8 +138,7 @@
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Целевая сессия"</string>
     <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Проверить навык ClawHub"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
-    <string name="native_16a5b7ad567a8093" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Отклонить запрос на сопряжение от этого устройства?"</string>
-    <string name="native_16b1a05e1d987ed1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Предпочтительный микрофон"</string>
+    <string name="native_16b1a05e1d987ed1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Предпочитаемый микрофон"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Хост узла"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Уровень"</string>
     <string name="native_172b997ffbc8c9a7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Закрыть выбор приложений"</string>
@@ -187,7 +183,6 @@
     <string name="native_1d91629837639a5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Эта автоматизация была изменена во время редактирования. Перед сохранением вернитесь к последней версии из Gateway."</string>
     <string name="native_1dbf9d5979606697" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"После подключения Gateway сможет активировать телефон с помощью беззвучного push-уведомления вместо поддержания постоянно активного сеанса."</string>
     <string name="native_1e432ea5425e4a3a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Режим пробуждения"</string>
-    <string name="native_1e595a107c78b957" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Удалить сопряжённое устройство?"</string>
     <string name="native_1e955a58278623a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Текст системного события"</string>
     <string name="native_1ea44149be42d970" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не удалось скопировать изображение виджета"</string>
     <string name="native_1ea442a134b2a184" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Нет"</string>
@@ -202,7 +197,6 @@
     <string name="native_2065cc867eba1b39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не удалось загрузить конфигурацию моделей провайдера."</string>
     <string name="native_207ccb22d618db05" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Приложений с разрешённой переадресацией: %1$s."</string>
     <string name="native_209b9e597963e7e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Настройка голоса"</string>
-    <string name="native_211988ba9dd0570a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Отклонить запрос на сопряжение?"</string>
     <string name="native_2132066dc9475cb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"This skill is installed but not available to the current agent. Agent filters stay on desktop or CLI."</string>
     <string name="native_21378545892f1fe2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Издатель"</string>
     <string name="native_214d4932fc767e8f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">" · Разговор: говорит"</string>
@@ -243,8 +237,7 @@
     <string name="native_262c897a1f408b0b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Подключитесь к вашему Gateway"</string>
     <string name="native_2682bd813a3bccbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Введите код настройки из openclaw qr."</string>
     <string name="native_268f14bbfe119c1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Диагностика"</string>
-    <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Обсуждение и его расшифровка будут удалены без возможности восстановления."</string>
-    <string name="native_26e47d73a55d7fa7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Устройство одобрено."</string>
+    <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Это действие безвозвратно удалит ветку и её расшифровку."</string>
     <string name="native_26f0dd993530eb2d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Автоматическая повторная попытка"</string>
     <string name="native_270ff82f36da987f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Изображение виджета скопировано"</string>
     <string name="native_2728740a95d465c6" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ролей: %1$s"</string>
@@ -353,7 +346,6 @@
     <string name="native_381428f5f251a764" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Conversation Send"</string>
     <string name="native_3824a9f4dafe92c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Холст"</string>
     <string name="native_384ae4ab1a2830f9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 провайдер"</string>
-    <string name="native_385001409de8562a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не удалось автоматически прочитать сертификат Gateway. Вставьте отпечаток SHA-256, полученный на хосте Gateway."</string>
     <string name="native_387b2569e440838c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не удалось отправить: %1$s"</string>
     <string name="native_3892e10346fd2012" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Мост"</string>
     <string name="native_38d198cd5303680f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ошибка доставки"</string>
@@ -411,7 +403,6 @@
     <string name="native_429f6057535c1ea3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sub-agent"</string>
     <string name="native_42e3a99c21767def" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ожидание подтверждения устройства"</string>
     <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Загрузка ветки"</string>
-    <string name="native_430df68ec29a85a2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Теперь этот Gateway предоставляет сертификат, которому доверяет это устройство."</string>
     <string name="native_43905968a540af6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Интервал разброса, мс"</string>
     <string name="native_43988c156beabf7d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"event create"</string>
     <string name="native_43cc23fa52b87b4c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"документ"</string>
@@ -421,7 +412,7 @@
     <string name="native_4441146b0fe1d5c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screenshot"</string>
     <string name="native_4481c2190a1b4bca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cron-выражение, например 0 9 * * *"</string>
     <string name="native_4499e7b7e1c9ddbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Вернуться к голосу"</string>
-    <string name="native_449f5a775762cdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Говорить"</string>
+    <string name="native_449f5a775762cdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Разговор"</string>
     <string name="native_45a64dc17588f2ca" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"В сети: %1$s/%2$s"</string>
     <string name="native_45a8847c4a6b2c81" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Разрешена переадресация для %1$s приложений."</string>
     <string name="native_460b3a7da007b7af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Чат"</string>
@@ -473,7 +464,6 @@
     <string name="native_4e8c72cab82e0711" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Конфигурация автоматизации недействительна."</string>
     <string name="native_4ec30e9d85725d41" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Список разрешений"</string>
     <string name="native_4ed379d418bb8629" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"groups"</string>
-    <string name="native_4ee252fb736effa2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Открытый ключ"</string>
     <string name="native_4efca0d10c5feb8e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"О приложении"</string>
     <string name="native_4f1bc100d1dccc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"На этом изображении не найден QR-код настройки. Выберите QR-код, созданный с помощью openclaw qr, или введите код настройки вручную."</string>
     <string name="native_4fe3cdd404ea0290" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"permissions"</string>
@@ -494,7 +484,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Доставка"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Отключить динамик"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Установка соединения с Gateway"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Мониторинг · %1$s веток"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Выполнение автоматизации завершено."</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Подходящих приложений нет."</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Отправить в чат"</string>
@@ -560,7 +550,6 @@
     <string name="native_5c0c8c9aa658f4a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OPENCLAW"</string>
     <string name="native_5c1acea9c9b0e704" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Fetch"</string>
     <string name="native_5c39123805ffb4e2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Запрос"</string>
-    <string name="native_5c944156b5353428" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Одобрить устройство?"</string>
     <string name="native_5d410adb9576e266" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Удалить %1$s и сохранённые учётные данные с этого телефона?"</string>
     <string name="native_5d6c41a67139ee26" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"QR-код указывает на небезопасный удаленный Gateway. %1$s %2$s"</string>
     <string name="native_5d6cbac59f87e78d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Поверхность экрана готова"</string>
@@ -578,7 +567,6 @@
     <string name="native_5fa1d457ddfcd26c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"rename group"</string>
     <string name="native_5fa7aac5375c5815" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Готово"</string>
     <string name="native_5fc1927ca948f31c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Дневник ожидает первой записи."</string>
-    <string name="native_6007acbe30b2cd98" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Одобрить"</string>
     <string name="native_600c9c27960112a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Страница в реальном времени"</string>
     <string name="native_6030d1f6340776d2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Автоматизация уже выполняется."</string>
     <string name="native_604e6d6faf8d0295" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Удалить эту автоматизацию после успешного однократного запуска."</string>
@@ -618,14 +606,12 @@
     <string name="native_6657cc73af00feac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Разрешать доступ к камере по запросу."</string>
     <string name="native_666067dd376e5d45" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Проблемы"</string>
     <string name="native_666c8bc0319f3b54" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Голосовая активация"</string>
-    <string name="native_66713d713e3a41c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Запрос на сопряжение отклонён."</string>
     <string name="native_66b23bae66fc0d79" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s дн. назад"</string>
     <string name="native_66cf5513b37462be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"roles"</string>
     <string name="native_66d0f523a379b2de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skills"</string>
     <string name="native_66f4804ee23ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Архивировать"</string>
     <string name="native_66fab2875ee427f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Узел не в сети. Переподключитесь и повторите попытку."</string>
     <string name="native_6725e7bbcd28f3a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Система"</string>
-    <string name="native_672f3453e1dd571b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Удалённый IP-адрес"</string>
     <string name="native_674b38cae72bb0c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Без группы"</string>
     <string name="native_674eb55d9c353900" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Сведения о расписании"</string>
     <string name="native_67528858c36397f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Возможности телефона"</string>
@@ -633,7 +619,6 @@
     <string name="native_67b696468610b879" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dashboard"</string>
     <string name="native_67fa416afa64d304" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Вставить токен"</string>
     <string name="native_6827238fea72c88b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Нет провайдеров"</string>
-    <string name="native_684889f0079cc145" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Отпечаток SHA-256"</string>
     <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Веток пока нет"</string>
     <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bluetooth-микрофон"</string>
     <string name="native_690dbe9dc0993c42" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Недавние"</string>
@@ -668,7 +653,6 @@
     <string name="native_6d5d9004797377e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Лицензии"</string>
     <string name="native_6d7c95a353d873cd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Подключите Gateway для поиска навыков ClawHub."</string>
     <string name="native_6df1bb18a59ab97d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Навык"</string>
-    <string name="native_6e0a0b9d8c5ee4d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ID устройства"</string>
     <string name="native_6e117ba97cbfb6f0" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway не определил активного поставщика %1$s"</string>
     <string name="native_6e293a8c009e0011" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ожидание"</string>
     <string name="native_6e2c0963d056e104" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Фразы активации сохранены"</string>
@@ -717,7 +701,7 @@
     <string name="native_746f71ec623adc37" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Миллисекунды эпохи (необязательно)"</string>
     <string name="native_7491b353909c1147" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Нет настроенных моделей. Обновите, чтобы повторно проверить доступность."</string>
     <string name="native_74a883a037bc227f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Настройки"</string>
-    <string name="native_74c372f29b83df94" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Основная камера"</string>
+    <string name="native_74c372f29b83df94" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Задняя камера"</string>
     <string name="native_74e21680eac7385c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"approve"</string>
     <string name="native_74e492d5d0df0bab" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Перед началом"</string>
     <string name="native_74f0a5d234edc4af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не удалось загрузить Skills."</string>
@@ -798,7 +782,7 @@
     <string name="native_82990a093599a9bb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s применено"</string>
     <string name="native_8340dad4f3be30a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Дневника снов пока нет."</string>
     <string name="native_837e39f46163ffb4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Обновить фоновые задачи"</string>
-    <string name="native_838337fd9ab30454" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Сводка недавних веток и дальнейших действий."</string>
+    <string name="native_838337fd9ab30454" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Подведите итоги недавних веток и предложите дальнейшие шаги."</string>
     <string name="native_83e2faed20a3cda4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Работает на устройстве, пока OpenClaw отображается на экране."</string>
     <string name="native_844e5b02f3ef05ca" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s работает"</string>
     <string name="native_846c75dca0b71591" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
@@ -845,7 +829,6 @@
     <string name="native_8bb7ec15b1e350a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Проверка"</string>
     <string name="native_8bf253a125f66985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Отсканируйте или вставьте код настройки, чтобы добавить еще один gateway."</string>
     <string name="native_8c4a3896e8f06d27" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Время ожидания TLS истекло"</string>
-    <string name="native_8c55387fb6c584c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Сопряжённое устройство удалено."</string>
     <string name="native_8c93c68056cde54d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway сопряжён. Проверяется разрешение возможностей узла."</string>
     <string name="native_8ca344247c18317e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Движение"</string>
     <string name="native_8cac4b77b9c54695" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не удалось выполнить действие cron."</string>
@@ -860,7 +843,7 @@
     <string name="native_8e19f962b0cd6587" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Начните новый разговор, и он появится здесь."</string>
     <string name="native_8e20431e6645ccdd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Проблема с подключением"</string>
     <string name="native_8e588cd187741f1c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Средний"</string>
-    <string name="native_8e5b1a73152cf01c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Создать ответвление"</string>
+    <string name="native_8e5b1a73152cf01c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ответвить"</string>
     <string name="native_8e6feeb36a83a707" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Включить динамик"</string>
     <string name="native_8e803d361324b459" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Текст системного события"</string>
     <string name="native_8eb626078c16c726" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Сортировка: %1$s"</string>
@@ -1038,9 +1021,10 @@
     <string name="native_ad1c341c65f84ede" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Выполните команду approve на компьютере Gateway, затем проверьте еще раз."</string>
     <string name="native_ad1fb9ec0cb3c7a4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Автоматизации"</string>
     <string name="native_adb7eb8a03ad699c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s мин"</string>
+    <string name="native_adca3171c270301a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"В этом сеансе входа в Gateway можно просматривать подключённые узлы, но нельзя одобрять сопряжение новых телефонов. Подключайте новые телефоны в сеансе администратора Gateway. Разрешение возможностей узла выполняется отдельно с помощью команды nodes approve &lt;request id&gt;."</string>
     <string name="native_ade9248e0132b411" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Доверять"</string>
     <string name="native_ae27fa789a03c1db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Этот QR-код не является QR-кодом настройки OpenClaw. Создайте новый код с помощью openclaw qr и повторите попытку."</string>
-    <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Предпочтительный микрофон недоступен; используется автоматическая маршрутизация."</string>
+    <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Предпочитаемый микрофон недоступен; используется автоматическая маршрутизация."</string>
     <string name="native_aea4a04a80426ed8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Отклонено"</string>
     <string name="native_aed306fbb63c0c68" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Включить Android и фоновые пакеты."</string>
     <string name="native_aedf1cf58372f943" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ваш Gateway готов."</string>
@@ -1107,8 +1091,7 @@
     <string name="native_bb4f2558e4333834" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Изображение виджета сохранено в папку «Загрузки»"</string>
     <string name="native_bbe5fc3b9ef39f99" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Запуск…"</string>
     <string name="native_bc19cec293228fb8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ошибка клиента"</string>
-    <string name="native_bc1c94a6dfce1058" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Проверьте запрашивающее устройство, прежде чем предоставлять доступ."</string>
-    <string name="native_bc6618670f3e8a17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Микрофон Bluetooth LE"</string>
+    <string name="native_bc6618670f3e8a17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bluetooth LE-микрофон"</string>
     <string name="native_bcb06651437caa15" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
     <string name="native_bd08450d63406844" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Автоматизация включена."</string>
     <string name="native_bd6719b455bcc898" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Memory Get"</string>
@@ -1116,7 +1099,6 @@
     <string name="native_bdc090ec61e3fcfc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Перезагрузить"</string>
     <string name="native_bdff71b20b9cf392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Поиск автоматизаций"</string>
     <string name="native_be969becb173e0c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Связанные телефоны и хосты узлов появятся здесь после сопряжения."</string>
-    <string name="native_bf1870ff5c6322fb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s: %2$s"</string>
     <string name="native_bf350e6a0ed60b7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Эта автоматизация была изменена в Gateway. Перед повторным сохранением проверьте последнюю версию."</string>
     <string name="native_bf399ffa03617a96" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Остановить диктовку"</string>
     <string name="native_bf56ee2fe3345ce1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Удобочитаемый"</string>
@@ -1140,7 +1122,6 @@
     <string name="native_c1c224b03cd9bc7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Администратор"</string>
     <string name="native_c1ebc7817870e5be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Требует внимания"</string>
     <string name="native_c22d5e02fbec7d65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Подключите это устройство к своему Gateway, чтобы активировать его только для реальной работы, всегда иметь под рукой актуальный обзор агентов и избежать фоновых циклов, расходующих заряд батареи."</string>
-    <string name="native_c25337055464f8d3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Роли"</string>
     <string name="native_c253f451bdd56431" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ответ"</string>
     <string name="native_c26225b6c16a4bc7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Каталог провайдеров"</string>
     <string name="native_c272b225cf5bd643" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Включите разрешение в настройках"</string>
@@ -1154,7 +1135,6 @@
     <string name="native_c34dd5eb8b0af56e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Где получить код настройки?"</string>
     <string name="native_c3546b39ecbbed8a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не удалось включить навык."</string>
     <string name="native_c35b21d6ca39aa7c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"pdf"</string>
-    <string name="native_c3812fc4acb861d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Удалить"</string>
     <string name="native_c382566dbe2ea49f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s%% в сети"</string>
     <string name="native_c385951198c45d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Нет каналов"</string>
     <string name="native_c41ad84496b53420" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Голос в реальном времени"</string>
@@ -1183,7 +1163,6 @@
     <string name="native_c6d5ed757b66bfd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Сон"</string>
     <string name="native_c6dd061350fc69b8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Заблокированных приложений нет. Приложения могут выполнять пересылку, пока вы не добавите блокировки."</string>
     <string name="native_c753cdf0c19f1e38" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Распознавание речи недоступно"</string>
-    <string name="native_c78ffe19571018fb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Платформа"</string>
     <string name="native_c7985fa72daa6ea4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway не вернул настройку %1$s"</string>
     <string name="native_c7b6dfd5c3a183c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Забыть gateway?"</string>
     <string name="native_c7b7b7f01360f6a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Необязательное описание"</string>
@@ -1212,7 +1191,7 @@
     <string name="native_cc721e25d73938a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Домашний Gateway"</string>
     <string name="native_cc7a9a5cf8c4bc9d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Выполните команду подтверждения на Gateway"</string>
     <string name="native_cc925e3c97ac7a35" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не удалось загрузить предложения Skill Workshop."</string>
-    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Расскажи о последних обсуждениях в OpenClaw и предложи следующие шаги."</string>
+    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Расскажите о последних событиях в моих недавних ветках OpenClaw и предложите дальнейшие шаги."</string>
     <string name="native_ccb4c324f516c633" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не сейчас"</string>
     <string name="native_cced0b0d83a9e400" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw qr"</string>
     <string name="native_cced28c6dc3f99c2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"start"</string>
@@ -1235,7 +1214,7 @@
     <string name="native_ceb6931ea57cc999" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Адаптивный"</string>
     <string name="native_cf0ee3547a4e51a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Скоро"</string>
     <string name="native_d04fc7d7e19702f8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Search"</string>
-    <string name="native_d053ba98d8bbcec1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Попробуйте чат, голосовой режим, ветки, провайдеров или настройки."</string>
+    <string name="native_d053ba98d8bbcec1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Попробуйте Чат, Голос, Ветки, Провайдеры или Настройки."</string>
     <string name="native_d056177742e27cf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw активен"</string>
     <string name="native_d0cda6559bb347db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"navigate"</string>
     <string name="native_d0d0de0039c7990b" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"запрошено %1$s"</string>
@@ -1246,7 +1225,6 @@
     <string name="native_d17d2d78d76e6a6c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Модели"</string>
     <string name="native_d19c2dd2fb598b93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw: пассивные"</string>
     <string name="native_d1a574e23344c407" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Недействительный пароль Gateway"</string>
-    <string name="native_d1af697abaff485f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не удалось проверить изменение сопряжения устройства. Обновите данные и повторите попытку."</string>
     <string name="native_d1bf045bb524dae5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Посмотреть подробности"</string>
     <string name="native_d1e9567da9a8a4b0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bash"</string>
     <string name="native_d2089be672953d11" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Токен"</string>
@@ -1261,7 +1239,6 @@
     <string name="native_d31de1a5c5c8ba2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Браузер"</string>
     <string name="native_d354ee936f59115e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screen record"</string>
     <string name="native_d3974fd6d3b6c81f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Запуск ожидается"</string>
-    <string name="native_d3e1c5f8a6e240fc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Источник"</string>
     <string name="native_d3f75e24411053c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Персональный ИИ на ваших устройствах"</string>
     <string name="native_d406ade2958cb5b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attach"</string>
     <string name="native_d461a493a3753877" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Автоматически"</string>
@@ -1277,7 +1254,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Профиль"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Лимиты провайдера появятся здесь, когда ваш Gateway сообщит о них."</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 проблема"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ветки в группе \"%1$s\" сохранятся и вернутся в раздел «Без группы»."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Создано"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s активных токенов"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>
@@ -1315,7 +1292,7 @@
     <string name="native_dc758e44eed7b7c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Микрофон выключен · отправка…"</string>
     <string name="native_dc937b59892604f5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Нет"</string>
     <string name="native_dcc839a4015c4b7d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Просмотр"</string>
-    <string name="native_dcd1d5223f73b3a9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Имя"</string>
+    <string name="native_dcd1d5223f73b3a9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Название"</string>
     <string name="native_dd167905de0defca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Версия"</string>
     <string name="native_dd9d24965dbedc02" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cron"</string>
     <string name="native_de2ae3a91cd112dd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Удалить фразу активации"</string>
@@ -1450,7 +1427,6 @@
     <string name="native_f2da2e47cd31a5dd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не удалось декодировать это изображение."</string>
     <string name="native_f3753c0fe29b88db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway, голос, уведомления, конфиденциальность"</string>
     <string name="native_f386c32c1bf437d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Файлы рабочего пространства агента"</string>
-    <string name="native_f418bf0894a1806a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Это устройство потеряет доверенный доступ к Gateway."</string>
     <string name="native_f41d9e8b7e09aa24" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Используйте requestId из ожидающей команды в команде approve."</string>
     <string name="native_f4830a1dae298044" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Расписание"</string>
     <string name="native_f493f0ce7a52a8aa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ограничение частоты"</string>
@@ -1458,9 +1434,8 @@
     <string name="native_f4cc820d308495c4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Полезная нагрузка · %1$s"</string>
     <string name="native_f4ccae29e1bb0c20" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Выполняется"</string>
     <string name="native_f4db1e48476f6075" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Завершить"</string>
-    <string name="native_f4e2076014711222" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Использовать системное доверие"</string>
     <string name="native_f4ef7a41caa88dd1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Нет готовых провайдеров"</string>
-    <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Приоритет отдается подключенным Bluetooth-микрофонам."</string>
+    <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Приоритет отдаётся подключённым Bluetooth-микрофонам."</string>
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Переадресация заблокирована для %1$s приложения."</string>
     <string name="native_f532ee1f7288365e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Действия с сообщением"</string>
     <string name="native_f5387f9bb6ed7031" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Тип"</string>
@@ -1522,7 +1497,7 @@
     <string name="native_ff716fc4735e067f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Настройки диктовки"</string>
     <string name="native_ff9dbbdfb84ddab2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Модели провайдеров загружены, но сведения о готовности недоступны."</string>
     <string name="native_ffa7aa557b547a79" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Удалить ветку?"</string>
-    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw превращает этот телефон в удобный мобильный интерфейс управления ветками, голосом, провайдерами и Gateway."</string>
+    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw превращает этот телефон в удобный мобильный интерфейс для управления ветками, голосом, провайдерами и Gateway."</string>
     <string name="native_ffb6f5764bddb68c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Сначала новые"</string>
     <string name="native_ffcf16006c652ee3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Следующий цикл"</string>
 </resources>

--- a/apps/android/app/src/main/res/values-ru/strings.xml
+++ b/apps/android/app/src/main/res/values-ru/strings.xml
@@ -75,6 +75,7 @@
     <string name="native_0929c9dc7f794852" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Нет предложений"</string>
     <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Основная ветка"</string>
     <string name="native_0979c6fdbdca1675" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Открыть чат"</string>
+    <string name="native_09ce95090659d069" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Действия по сопряжению устройств недоступны в этом сеансе Gateway. Выполните openclaw devices list на хосте Gateway и обработайте запрос там. Одобрение возможностей узла выполняется отдельно с помощью nodes approve &lt;request id&gt;."</string>
     <string name="native_0a0b7cf7c428c703" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Запрос на действие"</string>
     <string name="native_0a708e7b03aaf1fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list pins"</string>
     <string name="native_0ab0e1629576aecf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Подключитесь к Gateway, чтобы загрузить предложения Мастерской Skills."</string>
@@ -87,10 +88,12 @@
     <string name="native_0c3845dcd2f0f683" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Откройте это предложение, чтобы загрузить его разметку Markdown."</string>
     <string name="native_0c3ea4e2f12153e7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"открыть OpenClaw и спросить %1$s"</string>
     <string name="native_0c4d01e81bb3d1fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"рассуждение"</string>
+    <string name="native_0c77fe09ab336a3e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Клиент"</string>
     <string name="native_0c79a9c222840ed0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Применено"</string>
     <string name="native_0cab1c9617404faf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"видео"</string>
     <string name="native_0cf04463c4276a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Продвигаемые"</string>
     <string name="native_0d21bd52022ca7f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"В сети"</string>
+    <string name="native_0d5644ff52ce2ba3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Области доступа"</string>
     <string name="native_0d5efd432e4fedf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Провайдер голосовой связи в реальном времени не настроен."</string>
     <string name="native_0d8ca811c3744a6d" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s · %2$s"</string>
     <string name="native_0db10f2c2f332cd2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"kick"</string>
@@ -138,6 +141,7 @@
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Целевая сессия"</string>
     <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Проверить навык ClawHub"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
+    <string name="native_16a5b7ad567a8093" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Отклонить запрос на сопряжение от этого устройства?"</string>
     <string name="native_16b1a05e1d987ed1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Предпочитаемый микрофон"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Хост узла"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Уровень"</string>
@@ -183,6 +187,7 @@
     <string name="native_1d91629837639a5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Эта автоматизация была изменена во время редактирования. Перед сохранением вернитесь к последней версии из Gateway."</string>
     <string name="native_1dbf9d5979606697" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"После подключения Gateway сможет активировать телефон с помощью беззвучного push-уведомления вместо поддержания постоянно активного сеанса."</string>
     <string name="native_1e432ea5425e4a3a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Режим пробуждения"</string>
+    <string name="native_1e595a107c78b957" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Удалить сопряжённое устройство?"</string>
     <string name="native_1e955a58278623a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Текст системного события"</string>
     <string name="native_1ea44149be42d970" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не удалось скопировать изображение виджета"</string>
     <string name="native_1ea442a134b2a184" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Нет"</string>
@@ -197,6 +202,7 @@
     <string name="native_2065cc867eba1b39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не удалось загрузить конфигурацию моделей провайдера."</string>
     <string name="native_207ccb22d618db05" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Приложений с разрешённой переадресацией: %1$s."</string>
     <string name="native_209b9e597963e7e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Настройка голоса"</string>
+    <string name="native_211988ba9dd0570a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Отклонить запрос на сопряжение?"</string>
     <string name="native_2132066dc9475cb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"This skill is installed but not available to the current agent. Agent filters stay on desktop or CLI."</string>
     <string name="native_21378545892f1fe2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Издатель"</string>
     <string name="native_214d4932fc767e8f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">" · Разговор: говорит"</string>
@@ -238,6 +244,7 @@
     <string name="native_2682bd813a3bccbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Введите код настройки из openclaw qr."</string>
     <string name="native_268f14bbfe119c1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Диагностика"</string>
     <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Это действие безвозвратно удалит ветку и её расшифровку."</string>
+    <string name="native_26e47d73a55d7fa7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Устройство одобрено."</string>
     <string name="native_26f0dd993530eb2d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Автоматическая повторная попытка"</string>
     <string name="native_270ff82f36da987f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Изображение виджета скопировано"</string>
     <string name="native_2728740a95d465c6" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ролей: %1$s"</string>
@@ -346,6 +353,7 @@
     <string name="native_381428f5f251a764" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Conversation Send"</string>
     <string name="native_3824a9f4dafe92c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Холст"</string>
     <string name="native_384ae4ab1a2830f9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 провайдер"</string>
+    <string name="native_385001409de8562a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не удалось автоматически прочитать сертификат Gateway. Вставьте отпечаток SHA-256, полученный на хосте Gateway."</string>
     <string name="native_387b2569e440838c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не удалось отправить: %1$s"</string>
     <string name="native_3892e10346fd2012" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Мост"</string>
     <string name="native_38d198cd5303680f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ошибка доставки"</string>
@@ -403,6 +411,7 @@
     <string name="native_429f6057535c1ea3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sub-agent"</string>
     <string name="native_42e3a99c21767def" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ожидание подтверждения устройства"</string>
     <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Загрузка ветки"</string>
+    <string name="native_430df68ec29a85a2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Теперь этот Gateway предоставляет сертификат, которому доверяет это устройство."</string>
     <string name="native_43905968a540af6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Интервал разброса, мс"</string>
     <string name="native_43988c156beabf7d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"event create"</string>
     <string name="native_43cc23fa52b87b4c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"документ"</string>
@@ -412,7 +421,7 @@
     <string name="native_4441146b0fe1d5c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screenshot"</string>
     <string name="native_4481c2190a1b4bca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cron-выражение, например 0 9 * * *"</string>
     <string name="native_4499e7b7e1c9ddbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Вернуться к голосу"</string>
-    <string name="native_449f5a775762cdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Разговор"</string>
+    <string name="native_449f5a775762cdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Говорить"</string>
     <string name="native_45a64dc17588f2ca" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"В сети: %1$s/%2$s"</string>
     <string name="native_45a8847c4a6b2c81" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Разрешена переадресация для %1$s приложений."</string>
     <string name="native_460b3a7da007b7af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Чат"</string>
@@ -464,6 +473,7 @@
     <string name="native_4e8c72cab82e0711" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Конфигурация автоматизации недействительна."</string>
     <string name="native_4ec30e9d85725d41" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Список разрешений"</string>
     <string name="native_4ed379d418bb8629" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"groups"</string>
+    <string name="native_4ee252fb736effa2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Открытый ключ"</string>
     <string name="native_4efca0d10c5feb8e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"О приложении"</string>
     <string name="native_4f1bc100d1dccc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"На этом изображении не найден QR-код настройки. Выберите QR-код, созданный с помощью openclaw qr, или введите код настройки вручную."</string>
     <string name="native_4fe3cdd404ea0290" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"permissions"</string>
@@ -550,6 +560,7 @@
     <string name="native_5c0c8c9aa658f4a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OPENCLAW"</string>
     <string name="native_5c1acea9c9b0e704" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Fetch"</string>
     <string name="native_5c39123805ffb4e2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Запрос"</string>
+    <string name="native_5c944156b5353428" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Одобрить устройство?"</string>
     <string name="native_5d410adb9576e266" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Удалить %1$s и сохранённые учётные данные с этого телефона?"</string>
     <string name="native_5d6c41a67139ee26" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"QR-код указывает на небезопасный удаленный Gateway. %1$s %2$s"</string>
     <string name="native_5d6cbac59f87e78d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Поверхность экрана готова"</string>
@@ -567,6 +578,7 @@
     <string name="native_5fa1d457ddfcd26c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"rename group"</string>
     <string name="native_5fa7aac5375c5815" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Готово"</string>
     <string name="native_5fc1927ca948f31c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Дневник ожидает первой записи."</string>
+    <string name="native_6007acbe30b2cd98" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Одобрить"</string>
     <string name="native_600c9c27960112a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Страница в реальном времени"</string>
     <string name="native_6030d1f6340776d2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Автоматизация уже выполняется."</string>
     <string name="native_604e6d6faf8d0295" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Удалить эту автоматизацию после успешного однократного запуска."</string>
@@ -606,12 +618,14 @@
     <string name="native_6657cc73af00feac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Разрешать доступ к камере по запросу."</string>
     <string name="native_666067dd376e5d45" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Проблемы"</string>
     <string name="native_666c8bc0319f3b54" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Голосовая активация"</string>
+    <string name="native_66713d713e3a41c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Запрос на сопряжение отклонён."</string>
     <string name="native_66b23bae66fc0d79" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s дн. назад"</string>
     <string name="native_66cf5513b37462be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"roles"</string>
     <string name="native_66d0f523a379b2de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skills"</string>
     <string name="native_66f4804ee23ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Архивировать"</string>
     <string name="native_66fab2875ee427f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Узел не в сети. Переподключитесь и повторите попытку."</string>
     <string name="native_6725e7bbcd28f3a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Система"</string>
+    <string name="native_672f3453e1dd571b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Удалённый IP-адрес"</string>
     <string name="native_674b38cae72bb0c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Без группы"</string>
     <string name="native_674eb55d9c353900" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Сведения о расписании"</string>
     <string name="native_67528858c36397f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Возможности телефона"</string>
@@ -619,6 +633,7 @@
     <string name="native_67b696468610b879" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dashboard"</string>
     <string name="native_67fa416afa64d304" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Вставить токен"</string>
     <string name="native_6827238fea72c88b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Нет провайдеров"</string>
+    <string name="native_684889f0079cc145" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Отпечаток SHA-256"</string>
     <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Веток пока нет"</string>
     <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bluetooth-микрофон"</string>
     <string name="native_690dbe9dc0993c42" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Недавние"</string>
@@ -653,6 +668,7 @@
     <string name="native_6d5d9004797377e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Лицензии"</string>
     <string name="native_6d7c95a353d873cd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Подключите Gateway для поиска навыков ClawHub."</string>
     <string name="native_6df1bb18a59ab97d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Навык"</string>
+    <string name="native_6e0a0b9d8c5ee4d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ID устройства"</string>
     <string name="native_6e117ba97cbfb6f0" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway не определил активного поставщика %1$s"</string>
     <string name="native_6e293a8c009e0011" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ожидание"</string>
     <string name="native_6e2c0963d056e104" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Фразы активации сохранены"</string>
@@ -829,6 +845,7 @@
     <string name="native_8bb7ec15b1e350a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Проверка"</string>
     <string name="native_8bf253a125f66985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Отсканируйте или вставьте код настройки, чтобы добавить еще один gateway."</string>
     <string name="native_8c4a3896e8f06d27" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Время ожидания TLS истекло"</string>
+    <string name="native_8c55387fb6c584c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Сопряжённое устройство удалено."</string>
     <string name="native_8c93c68056cde54d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway сопряжён. Проверяется разрешение возможностей узла."</string>
     <string name="native_8ca344247c18317e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Движение"</string>
     <string name="native_8cac4b77b9c54695" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не удалось выполнить действие cron."</string>
@@ -1021,7 +1038,6 @@
     <string name="native_ad1c341c65f84ede" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Выполните команду approve на компьютере Gateway, затем проверьте еще раз."</string>
     <string name="native_ad1fb9ec0cb3c7a4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Автоматизации"</string>
     <string name="native_adb7eb8a03ad699c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s мин"</string>
-    <string name="native_adca3171c270301a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"В этом сеансе входа в Gateway можно просматривать подключённые узлы, но нельзя одобрять сопряжение новых телефонов. Подключайте новые телефоны в сеансе администратора Gateway. Разрешение возможностей узла выполняется отдельно с помощью команды nodes approve &lt;request id&gt;."</string>
     <string name="native_ade9248e0132b411" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Доверять"</string>
     <string name="native_ae27fa789a03c1db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Этот QR-код не является QR-кодом настройки OpenClaw. Создайте новый код с помощью openclaw qr и повторите попытку."</string>
     <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Предпочитаемый микрофон недоступен; используется автоматическая маршрутизация."</string>
@@ -1091,6 +1107,7 @@
     <string name="native_bb4f2558e4333834" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Изображение виджета сохранено в папку «Загрузки»"</string>
     <string name="native_bbe5fc3b9ef39f99" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Запуск…"</string>
     <string name="native_bc19cec293228fb8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ошибка клиента"</string>
+    <string name="native_bc1c94a6dfce1058" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Проверьте запрашивающее устройство, прежде чем предоставлять доступ."</string>
     <string name="native_bc6618670f3e8a17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bluetooth LE-микрофон"</string>
     <string name="native_bcb06651437caa15" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
     <string name="native_bd08450d63406844" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Автоматизация включена."</string>
@@ -1099,6 +1116,7 @@
     <string name="native_bdc090ec61e3fcfc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Перезагрузить"</string>
     <string name="native_bdff71b20b9cf392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Поиск автоматизаций"</string>
     <string name="native_be969becb173e0c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Связанные телефоны и хосты узлов появятся здесь после сопряжения."</string>
+    <string name="native_bf1870ff5c6322fb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s: %2$s"</string>
     <string name="native_bf350e6a0ed60b7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Эта автоматизация была изменена в Gateway. Перед повторным сохранением проверьте последнюю версию."</string>
     <string name="native_bf399ffa03617a96" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Остановить диктовку"</string>
     <string name="native_bf56ee2fe3345ce1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Удобочитаемый"</string>
@@ -1122,6 +1140,7 @@
     <string name="native_c1c224b03cd9bc7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Администратор"</string>
     <string name="native_c1ebc7817870e5be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Требует внимания"</string>
     <string name="native_c22d5e02fbec7d65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Подключите это устройство к своему Gateway, чтобы активировать его только для реальной работы, всегда иметь под рукой актуальный обзор агентов и избежать фоновых циклов, расходующих заряд батареи."</string>
+    <string name="native_c25337055464f8d3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Роли"</string>
     <string name="native_c253f451bdd56431" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ответ"</string>
     <string name="native_c26225b6c16a4bc7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Каталог провайдеров"</string>
     <string name="native_c272b225cf5bd643" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Включите разрешение в настройках"</string>
@@ -1135,6 +1154,7 @@
     <string name="native_c34dd5eb8b0af56e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Где получить код настройки?"</string>
     <string name="native_c3546b39ecbbed8a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не удалось включить навык."</string>
     <string name="native_c35b21d6ca39aa7c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"pdf"</string>
+    <string name="native_c3812fc4acb861d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Удалить"</string>
     <string name="native_c382566dbe2ea49f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s%% в сети"</string>
     <string name="native_c385951198c45d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Нет каналов"</string>
     <string name="native_c41ad84496b53420" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Голос в реальном времени"</string>
@@ -1163,6 +1183,7 @@
     <string name="native_c6d5ed757b66bfd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Сон"</string>
     <string name="native_c6dd061350fc69b8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Заблокированных приложений нет. Приложения могут выполнять пересылку, пока вы не добавите блокировки."</string>
     <string name="native_c753cdf0c19f1e38" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Распознавание речи недоступно"</string>
+    <string name="native_c78ffe19571018fb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Платформа"</string>
     <string name="native_c7985fa72daa6ea4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway не вернул настройку %1$s"</string>
     <string name="native_c7b6dfd5c3a183c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Забыть gateway?"</string>
     <string name="native_c7b7b7f01360f6a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Необязательное описание"</string>
@@ -1225,6 +1246,7 @@
     <string name="native_d17d2d78d76e6a6c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Модели"</string>
     <string name="native_d19c2dd2fb598b93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw: пассивные"</string>
     <string name="native_d1a574e23344c407" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Недействительный пароль Gateway"</string>
+    <string name="native_d1af697abaff485f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не удалось проверить изменение сопряжения устройства. Обновите данные и повторите попытку."</string>
     <string name="native_d1bf045bb524dae5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Посмотреть подробности"</string>
     <string name="native_d1e9567da9a8a4b0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bash"</string>
     <string name="native_d2089be672953d11" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Токен"</string>
@@ -1239,6 +1261,7 @@
     <string name="native_d31de1a5c5c8ba2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Браузер"</string>
     <string name="native_d354ee936f59115e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screen record"</string>
     <string name="native_d3974fd6d3b6c81f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Запуск ожидается"</string>
+    <string name="native_d3e1c5f8a6e240fc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Источник"</string>
     <string name="native_d3f75e24411053c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Персональный ИИ на ваших устройствах"</string>
     <string name="native_d406ade2958cb5b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attach"</string>
     <string name="native_d461a493a3753877" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Автоматически"</string>
@@ -1292,7 +1315,7 @@
     <string name="native_dc758e44eed7b7c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Микрофон выключен · отправка…"</string>
     <string name="native_dc937b59892604f5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Нет"</string>
     <string name="native_dcc839a4015c4b7d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Просмотр"</string>
-    <string name="native_dcd1d5223f73b3a9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Название"</string>
+    <string name="native_dcd1d5223f73b3a9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Имя"</string>
     <string name="native_dd167905de0defca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Версия"</string>
     <string name="native_dd9d24965dbedc02" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cron"</string>
     <string name="native_de2ae3a91cd112dd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Удалить фразу активации"</string>
@@ -1427,6 +1450,7 @@
     <string name="native_f2da2e47cd31a5dd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не удалось декодировать это изображение."</string>
     <string name="native_f3753c0fe29b88db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway, голос, уведомления, конфиденциальность"</string>
     <string name="native_f386c32c1bf437d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Файлы рабочего пространства агента"</string>
+    <string name="native_f418bf0894a1806a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Это устройство потеряет доверенный доступ к Gateway."</string>
     <string name="native_f41d9e8b7e09aa24" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Используйте requestId из ожидающей команды в команде approve."</string>
     <string name="native_f4830a1dae298044" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Расписание"</string>
     <string name="native_f493f0ce7a52a8aa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ограничение частоты"</string>
@@ -1434,6 +1458,7 @@
     <string name="native_f4cc820d308495c4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Полезная нагрузка · %1$s"</string>
     <string name="native_f4ccae29e1bb0c20" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Выполняется"</string>
     <string name="native_f4db1e48476f6075" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Завершить"</string>
+    <string name="native_f4e2076014711222" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Использовать системное доверие"</string>
     <string name="native_f4ef7a41caa88dd1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Нет готовых провайдеров"</string>
     <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Приоритет отдаётся подключённым Bluetooth-микрофонам."</string>
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Переадресация заблокирована для %1$s приложения."</string>

--- a/apps/android/app/src/main/res/values-ru/strings.xml
+++ b/apps/android/app/src/main/res/values-ru/strings.xml
@@ -494,7 +494,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Доставка"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Отключить динамик"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Установка соединения с Gateway"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Мониторинг · %1$s веток"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Выполнение автоматизации завершено."</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Подходящих приложений нет."</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Отправить в чат"</string>
@@ -1277,7 +1277,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Профиль"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Лимиты провайдера появятся здесь, когда ваш Gateway сообщит о них."</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 проблема"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ветки в группе \"%1$s\" будут сохранены и перемещены обратно в раздел «Без группы»."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Создано"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s активных токенов"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>

--- a/apps/android/app/src/main/res/values-sv/strings.xml
+++ b/apps/android/app/src/main/res/values-sv/strings.xml
@@ -75,6 +75,7 @@
     <string name="native_0929c9dc7f794852" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Inga förslag"</string>
     <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Huvudtråd"</string>
     <string name="native_0979c6fdbdca1675" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Öppna chatt"</string>
+    <string name="native_09ce95090659d069" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Åtgärder för enhetsparkoppling är inte tillgängliga i den här Gateway-sessionen. Kör openclaw devices list på Gateway-värden och hantera begäran där. Godkännande av nodfunktioner är separat och använder fortfarande nodes approve &lt;request id&gt;."</string>
     <string name="native_0a0b7cf7c428c703" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Åtgärdsbegäran"</string>
     <string name="native_0a708e7b03aaf1fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list pins"</string>
     <string name="native_0ab0e1629576aecf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Anslut till en Gateway för att läsa in Skill Workshop-förslag."</string>
@@ -87,10 +88,12 @@
     <string name="native_0c3845dcd2f0f683" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Granska förslaget för att läsa in dess markdown."</string>
     <string name="native_0c3ea4e2f12153e7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"öppna OpenClaw och fråga %1$s"</string>
     <string name="native_0c4d01e81bb3d1fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"resonemang"</string>
+    <string name="native_0c77fe09ab336a3e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Klient"</string>
     <string name="native_0c79a9c222840ed0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tillämpad"</string>
     <string name="native_0cab1c9617404faf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"video"</string>
     <string name="native_0cf04463c4276a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Framhävd"</string>
     <string name="native_0d21bd52022ca7f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Online"</string>
+    <string name="native_0d5644ff52ce2ba3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Omfattningar"</string>
     <string name="native_0d5efd432e4fedf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Leverantör för realtidsröst är inte konfigurerad."</string>
     <string name="native_0d8ca811c3744a6d" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s · %2$s"</string>
     <string name="native_0db10f2c2f332cd2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"kick"</string>
@@ -138,6 +141,7 @@
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sessionsmål"</string>
     <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Granska ClawHub-skill"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
+    <string name="native_16a5b7ad567a8093" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Avvisa parkopplingsbegäran från den här enheten?"</string>
     <string name="native_16b1a05e1d987ed1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Föredragen mikrofon"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nodvärd"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nivå"</string>
@@ -183,6 +187,7 @@
     <string name="native_1d91629837639a5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Den här automatiseringen ändrades medan du redigerade. Återställ till den senaste versionen från Gateway innan du sparar."</string>
     <string name="native_1dbf9d5979606697" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"När telefonen är ansluten kan Gateway väcka den med en tyst pushnotis i stället för att upprätthålla en session som alltid är aktiv."</string>
     <string name="native_1e432ea5425e4a3a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Väckningsläge"</string>
+    <string name="native_1e595a107c78b957" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ta bort den parkopplade enheten?"</string>
     <string name="native_1e955a58278623a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Systemhändelsetext"</string>
     <string name="native_1ea44149be42d970" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Det gick inte att kopiera widgetbilden"</string>
     <string name="native_1ea442a134b2a184" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nej"</string>
@@ -197,6 +202,7 @@
     <string name="native_2065cc867eba1b39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Det gick inte att läsa in leverantörens modellkonfiguration."</string>
     <string name="native_207ccb22d618db05" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s app får vidarebefordra."</string>
     <string name="native_209b9e597963e7e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Röstkonfiguration"</string>
+    <string name="native_211988ba9dd0570a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Avvisa parkopplingsbegäran?"</string>
     <string name="native_2132066dc9475cb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"This skill is installed but not available to the current agent. Agent filters stay on desktop or CLI."</string>
     <string name="native_21378545892f1fe2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Utgivare"</string>
     <string name="native_214d4932fc767e8f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">" · Samtal: Talar"</string>
@@ -238,6 +244,7 @@
     <string name="native_2682bd813a3bccbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ange konfigurationskoden från openclaw qr."</string>
     <string name="native_268f14bbfe119c1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Diagnostik"</string>
     <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Detta raderar tråden och dess transkription permanent."</string>
+    <string name="native_26e47d73a55d7fa7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Enheten har godkänts."</string>
     <string name="native_26f0dd993530eb2d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Försöker igen automatiskt"</string>
     <string name="native_270ff82f36da987f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Widgetbilden har kopierats"</string>
     <string name="native_2728740a95d465c6" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s roller"</string>
@@ -346,6 +353,7 @@
     <string name="native_381428f5f251a764" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Conversation Send"</string>
     <string name="native_3824a9f4dafe92c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Arbetsyta"</string>
     <string name="native_384ae4ab1a2830f9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 leverantör"</string>
+    <string name="native_385001409de8562a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway-certifikatet kunde inte läsas automatiskt. Klistra in SHA-256-fingeravtrycket som hämtats på Gateway-värden."</string>
     <string name="native_387b2569e440838c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Det gick inte att skicka: %1$s"</string>
     <string name="native_3892e10346fd2012" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Brygga"</string>
     <string name="native_38d198cd5303680f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Leveransfel"</string>
@@ -403,6 +411,7 @@
     <string name="native_429f6057535c1ea3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sub-agent"</string>
     <string name="native_42e3a99c21767def" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Väntar på enhetsgodkännande"</string>
     <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Läser in tråd"</string>
+    <string name="native_430df68ec29a85a2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Denna Gateway använder nu ett certifikat som den här enheten litar på."</string>
     <string name="native_43905968a540af6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Förskjutning ms"</string>
     <string name="native_43988c156beabf7d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"event create"</string>
     <string name="native_43cc23fa52b87b4c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"dokument"</string>
@@ -464,6 +473,7 @@
     <string name="native_4e8c72cab82e0711" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatiseringen har en ogiltig konfiguration."</string>
     <string name="native_4ec30e9d85725d41" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tillåtelselista"</string>
     <string name="native_4ed379d418bb8629" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"groups"</string>
+    <string name="native_4ee252fb736effa2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Offentlig nyckel"</string>
     <string name="native_4efca0d10c5feb8e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Om"</string>
     <string name="native_4f1bc100d1dccc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ingen QR-kod för konfiguration hittades i bilden. Välj QR-koden som genererades av openclaw qr eller ange konfigurationskoden manuellt."</string>
     <string name="native_4fe3cdd404ea0290" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"permissions"</string>
@@ -550,6 +560,7 @@
     <string name="native_5c0c8c9aa658f4a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OPENCLAW"</string>
     <string name="native_5c1acea9c9b0e704" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Fetch"</string>
     <string name="native_5c39123805ffb4e2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Prompt"</string>
+    <string name="native_5c944156b5353428" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Godkänn enheten?"</string>
     <string name="native_5d410adb9576e266" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ta bort %1$s och dess sparade inloggningsuppgifter från den här telefonen?"</string>
     <string name="native_5d6c41a67139ee26" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"QR-koden pekar på en osäker fjärr-Gateway. %1$s %2$s"</string>
     <string name="native_5d6cbac59f87e78d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skärmytan är klar"</string>
@@ -567,6 +578,7 @@
     <string name="native_5fa1d457ddfcd26c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"rename group"</string>
     <string name="native_5fa7aac5375c5815" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Klar"</string>
     <string name="native_5fc1927ca948f31c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dagboken väntar på sin första post."</string>
+    <string name="native_6007acbe30b2cd98" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Godkänn"</string>
     <string name="native_600c9c27960112a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Livesida"</string>
     <string name="native_6030d1f6340776d2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatiseringen körs redan."</string>
     <string name="native_604e6d6faf8d0295" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ta bort den här automatiseringen efter en lyckad engångskörning."</string>
@@ -606,12 +618,14 @@
     <string name="native_6657cc73af00feac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tillåt kameraverktyg på begäran."</string>
     <string name="native_666067dd376e5d45" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Problem"</string>
     <string name="native_666c8bc0319f3b54" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Röstaktivering"</string>
+    <string name="native_66713d713e3a41c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Parkopplingsbegäran avvisades."</string>
     <string name="native_66b23bae66fc0d79" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s d sedan"</string>
     <string name="native_66cf5513b37462be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"roles"</string>
     <string name="native_66d0f523a379b2de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skills"</string>
     <string name="native_66f4804ee23ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Arkivera"</string>
     <string name="native_66fab2875ee427f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Noden är offline. Anslut igen och försök på nytt."</string>
     <string name="native_6725e7bbcd28f3a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"System"</string>
+    <string name="native_672f3453e1dd571b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Fjärr-IP"</string>
     <string name="native_674b38cae72bb0c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ogrupperade"</string>
     <string name="native_674eb55d9c353900" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Schemadetaljer"</string>
     <string name="native_67528858c36397f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Telefonfunktioner"</string>
@@ -619,6 +633,7 @@
     <string name="native_67b696468610b879" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dashboard"</string>
     <string name="native_67fa416afa64d304" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Klistra in token"</string>
     <string name="native_6827238fea72c88b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Inga leverantörer"</string>
+    <string name="native_684889f0079cc145" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"SHA-256-fingeravtryck"</string>
     <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Inga trådar ännu"</string>
     <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bluetooth-mikrofon"</string>
     <string name="native_690dbe9dc0993c42" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Senaste"</string>
@@ -653,6 +668,7 @@
     <string name="native_6d5d9004797377e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Licenser"</string>
     <string name="native_6d7c95a353d873cd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Anslut Gateway för att söka efter Skills på ClawHub."</string>
     <string name="native_6df1bb18a59ab97d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skill"</string>
+    <string name="native_6e0a0b9d8c5ee4d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Enhets-ID"</string>
     <string name="native_6e117ba97cbfb6f0" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway identifierade inte den aktiva %1$s-leverantören"</string>
     <string name="native_6e293a8c009e0011" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Väntar"</string>
     <string name="native_6e2c0963d056e104" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aktiveringsorden har sparats"</string>
@@ -829,6 +845,7 @@
     <string name="native_8bb7ec15b1e350a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Granskar"</string>
     <string name="native_8bf253a125f66985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skanna eller klistra in en konfigurationskod för att lägga till en till Gateway."</string>
     <string name="native_8c4a3896e8f06d27" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tidsgränsen för TLS överskreds"</string>
+    <string name="native_8c55387fb6c584c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Den parkopplade enheten har tagits bort."</string>
     <string name="native_8c93c68056cde54d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway har parkopplats. Kontrollerar godkännande av nodfunktioner."</string>
     <string name="native_8ca344247c18317e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rörelse"</string>
     <string name="native_8cac4b77b9c54695" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cron-åtgärden misslyckades."</string>
@@ -1021,7 +1038,6 @@
     <string name="native_ad1c341c65f84ede" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kör godkännandekommandot på Gateway-datorn och kontrollera sedan igen."</string>
     <string name="native_ad1fb9ec0cb3c7a4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatiseringar"</string>
     <string name="native_adb7eb8a03ad699c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s min"</string>
-    <string name="native_adca3171c270301a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Den här Gateway-inloggningen kan visa anslutna noder, men den kan inte godkänna parkoppling av nya telefoner. Parkoppla nya telefoner från en Gateway-administratörssession. Godkännande av nodfunktioner är separat och använder fortfarande nodes approve &lt;request id&gt;."</string>
     <string name="native_ade9248e0132b411" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Lita på"</string>
     <string name="native_ae27fa789a03c1db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"QR-koden är inte en konfigurationskod för OpenClaw. Generera en ny kod med openclaw qr och försök igen."</string>
     <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Den föredragna mikrofonen är inte tillgänglig. Automatisk dirigering används."</string>
@@ -1091,6 +1107,7 @@
     <string name="native_bb4f2558e4333834" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Widgetbilden har sparats i Hämtade filer"</string>
     <string name="native_bbe5fc3b9ef39f99" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Startar…"</string>
     <string name="native_bc19cec293228fb8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Klientfel"</string>
+    <string name="native_bc1c94a6dfce1058" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Verifiera enheten som skickar begäran innan du beviljar åtkomst."</string>
     <string name="native_bc6618670f3e8a17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bluetooth LE-mikrofon"</string>
     <string name="native_bcb06651437caa15" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
     <string name="native_bd08450d63406844" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatiseringen har aktiverats."</string>
@@ -1099,6 +1116,7 @@
     <string name="native_bdc090ec61e3fcfc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Läs in igen"</string>
     <string name="native_bdff71b20b9cf392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sök efter automationer"</string>
     <string name="native_be969becb173e0c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Länkade telefoner och nodvärdar visas här efter parkoppling."</string>
+    <string name="native_bf1870ff5c6322fb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s: %2$s"</string>
     <string name="native_bf350e6a0ed60b7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Den här automatiseringen har ändrats på Gateway. Granska den senaste versionen innan du sparar igen."</string>
     <string name="native_bf399ffa03617a96" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Stoppa diktering"</string>
     <string name="native_bf56ee2fe3345ce1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Läsvänlig"</string>
@@ -1122,6 +1140,7 @@
     <string name="native_c1c224b03cd9bc7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Administratör"</string>
     <string name="native_c1ebc7817870e5be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kräver åtgärd"</string>
     <string name="native_c22d5e02fbec7d65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Parkoppla den här enheten med din Gateway för att endast väcka den vid faktiskt arbete, ha en aktuell agentöversikt nära till hands och undvika batterikrävande bakgrundsloopar."</string>
+    <string name="native_c25337055464f8d3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Roller"</string>
     <string name="native_c253f451bdd56431" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Svara"</string>
     <string name="native_c26225b6c16a4bc7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Leverantörskatalog"</string>
     <string name="native_c272b225cf5bd643" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aktivera behörighet i Inställningar"</string>
@@ -1135,6 +1154,7 @@
     <string name="native_c34dd5eb8b0af56e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Var hittar jag en konfigurationskod?"</string>
     <string name="native_c3546b39ecbbed8a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Det gick inte att aktivera skill."</string>
     <string name="native_c35b21d6ca39aa7c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"pdf"</string>
+    <string name="native_c3812fc4acb861d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ta bort"</string>
     <string name="native_c382566dbe2ea49f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s%% online"</string>
     <string name="native_c385951198c45d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Inga kanaler"</string>
     <string name="native_c41ad84496b53420" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Röst i realtid"</string>
@@ -1163,6 +1183,7 @@
     <string name="native_c6d5ed757b66bfd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dröm"</string>
     <string name="native_c6dd061350fc69b8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Inga appar har blockerats. Appar kan vidarebefordra tills du lägger till blockeringar."</string>
     <string name="native_c753cdf0c19f1e38" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Taligenkänning är inte tillgänglig"</string>
+    <string name="native_c78ffe19571018fb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Plattform"</string>
     <string name="native_c7985fa72daa6ea4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway returnerade inte konfiguration för %1$s"</string>
     <string name="native_c7b6dfd5c3a183c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Glöm Gateway?"</string>
     <string name="native_c7b7b7f01360f6a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Valfri beskrivning"</string>
@@ -1225,6 +1246,7 @@
     <string name="native_d17d2d78d76e6a6c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Modeller"</string>
     <string name="native_d19c2dd2fb598b93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw Passiv"</string>
     <string name="native_d1a574e23344c407" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway-lösenordet är ogiltigt"</string>
+    <string name="native_d1af697abaff485f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Det gick inte att verifiera ändringen av enhetsparkopplingen. Uppdatera och försök igen."</string>
     <string name="native_d1bf045bb524dae5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Visa detaljer"</string>
     <string name="native_d1e9567da9a8a4b0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bash"</string>
     <string name="native_d2089be672953d11" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Token"</string>
@@ -1239,6 +1261,7 @@
     <string name="native_d31de1a5c5c8ba2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Webbläsare"</string>
     <string name="native_d354ee936f59115e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screen record"</string>
     <string name="native_d3974fd6d3b6c81f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Körning väntar"</string>
+    <string name="native_d3e1c5f8a6e240fc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ursprung"</string>
     <string name="native_d3f75e24411053c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Personlig AI på dina enheter"</string>
     <string name="native_d406ade2958cb5b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attach"</string>
     <string name="native_d461a493a3753877" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatiskt"</string>
@@ -1427,6 +1450,7 @@
     <string name="native_f2da2e47cd31a5dd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Den här bilden kunde inte avkodas."</string>
     <string name="native_f3753c0fe29b88db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway, röst, aviseringar, integritet"</string>
     <string name="native_f386c32c1bf437d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Filer i agentens arbetsyta"</string>
+    <string name="native_f418bf0894a1806a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Den här enheten förlorar sin betrodda åtkomst till Gateway."</string>
     <string name="native_f41d9e8b7e09aa24" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Använd requestId från det väntande kommandot i godkännandekommandot."</string>
     <string name="native_f4830a1dae298044" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Schema"</string>
     <string name="native_f493f0ce7a52a8aa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Hastighetsgräns"</string>
@@ -1434,6 +1458,7 @@
     <string name="native_f4cc820d308495c4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nyttolast · %1$s"</string>
     <string name="native_f4ccae29e1bb0c20" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Körs"</string>
     <string name="native_f4db1e48476f6075" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Avsluta"</string>
+    <string name="native_f4e2076014711222" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Använd systemets förtroende"</string>
     <string name="native_f4ef7a41caa88dd1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Inga leverantörer redo"</string>
     <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Prioriterar anslutna Bluetooth-mikrofoner."</string>
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s app blockerad från att vidarebefordra."</string>

--- a/apps/android/app/src/main/res/values-sv/strings.xml
+++ b/apps/android/app/src/main/res/values-sv/strings.xml
@@ -494,7 +494,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Leverans"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Stäng av högtalare"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Öppnar anslutningen till Gateway"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Övervakning · %1$s trådar"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatiseringskörningen är slutförd."</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Inga matchande appar."</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skicka till chatt"</string>
@@ -1277,7 +1277,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Profil"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Leverantörsgränser visas här när din Gateway rapporterar dem."</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 problem"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Trådar i \"%1$s\" behålls och flyttas tillbaka till Ogrupperade."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skapad"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s aktiva token"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>

--- a/apps/android/app/src/main/res/values-sv/strings.xml
+++ b/apps/android/app/src/main/res/values-sv/strings.xml
@@ -75,7 +75,6 @@
     <string name="native_0929c9dc7f794852" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Inga förslag"</string>
     <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Huvudtråd"</string>
     <string name="native_0979c6fdbdca1675" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Öppna chatt"</string>
-    <string name="native_09ce95090659d069" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Åtgärder för enhetsparkoppling är inte tillgängliga i den här Gateway-sessionen. Kör openclaw devices list på Gateway-värden och hantera begäran där. Godkännande av nodfunktioner är separat och använder fortfarande nodes approve &lt;request id&gt;."</string>
     <string name="native_0a0b7cf7c428c703" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Åtgärdsbegäran"</string>
     <string name="native_0a708e7b03aaf1fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list pins"</string>
     <string name="native_0ab0e1629576aecf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Anslut till en Gateway för att läsa in Skill Workshop-förslag."</string>
@@ -88,12 +87,10 @@
     <string name="native_0c3845dcd2f0f683" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Granska förslaget för att läsa in dess markdown."</string>
     <string name="native_0c3ea4e2f12153e7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"öppna OpenClaw och fråga %1$s"</string>
     <string name="native_0c4d01e81bb3d1fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"resonemang"</string>
-    <string name="native_0c77fe09ab336a3e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Klient"</string>
     <string name="native_0c79a9c222840ed0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tillämpad"</string>
     <string name="native_0cab1c9617404faf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"video"</string>
     <string name="native_0cf04463c4276a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Framhävd"</string>
     <string name="native_0d21bd52022ca7f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Online"</string>
-    <string name="native_0d5644ff52ce2ba3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Omfattningar"</string>
     <string name="native_0d5efd432e4fedf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Leverantör för realtidsröst är inte konfigurerad."</string>
     <string name="native_0d8ca811c3744a6d" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s · %2$s"</string>
     <string name="native_0db10f2c2f332cd2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"kick"</string>
@@ -141,7 +138,6 @@
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sessionsmål"</string>
     <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Granska ClawHub-skill"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
-    <string name="native_16a5b7ad567a8093" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Avvisa parkopplingsbegäran från den här enheten?"</string>
     <string name="native_16b1a05e1d987ed1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Föredragen mikrofon"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nodvärd"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nivå"</string>
@@ -187,7 +183,6 @@
     <string name="native_1d91629837639a5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Den här automatiseringen ändrades medan du redigerade. Återställ till den senaste versionen från Gateway innan du sparar."</string>
     <string name="native_1dbf9d5979606697" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"När telefonen är ansluten kan Gateway väcka den med en tyst pushnotis i stället för att upprätthålla en session som alltid är aktiv."</string>
     <string name="native_1e432ea5425e4a3a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Väckningsläge"</string>
-    <string name="native_1e595a107c78b957" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ta bort den parkopplade enheten?"</string>
     <string name="native_1e955a58278623a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Systemhändelsetext"</string>
     <string name="native_1ea44149be42d970" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Det gick inte att kopiera widgetbilden"</string>
     <string name="native_1ea442a134b2a184" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nej"</string>
@@ -202,7 +197,6 @@
     <string name="native_2065cc867eba1b39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Det gick inte att läsa in leverantörens modellkonfiguration."</string>
     <string name="native_207ccb22d618db05" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s app får vidarebefordra."</string>
     <string name="native_209b9e597963e7e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Röstkonfiguration"</string>
-    <string name="native_211988ba9dd0570a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Avvisa parkopplingsbegäran?"</string>
     <string name="native_2132066dc9475cb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"This skill is installed but not available to the current agent. Agent filters stay on desktop or CLI."</string>
     <string name="native_21378545892f1fe2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Utgivare"</string>
     <string name="native_214d4932fc767e8f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">" · Samtal: Talar"</string>
@@ -243,8 +237,7 @@
     <string name="native_262c897a1f408b0b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Anslut till din Gateway"</string>
     <string name="native_2682bd813a3bccbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ange konfigurationskoden från openclaw qr."</string>
     <string name="native_268f14bbfe119c1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Diagnostik"</string>
-    <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Detta raderar tråden och dess transkript permanent."</string>
-    <string name="native_26e47d73a55d7fa7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Enheten har godkänts."</string>
+    <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Detta raderar tråden och dess transkription permanent."</string>
     <string name="native_26f0dd993530eb2d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Försöker igen automatiskt"</string>
     <string name="native_270ff82f36da987f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Widgetbilden har kopierats"</string>
     <string name="native_2728740a95d465c6" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s roller"</string>
@@ -353,7 +346,6 @@
     <string name="native_381428f5f251a764" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Conversation Send"</string>
     <string name="native_3824a9f4dafe92c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Arbetsyta"</string>
     <string name="native_384ae4ab1a2830f9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 leverantör"</string>
-    <string name="native_385001409de8562a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway-certifikatet kunde inte läsas automatiskt. Klistra in SHA-256-fingeravtrycket som hämtats på Gateway-värden."</string>
     <string name="native_387b2569e440838c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Det gick inte att skicka: %1$s"</string>
     <string name="native_3892e10346fd2012" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Brygga"</string>
     <string name="native_38d198cd5303680f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Leveransfel"</string>
@@ -411,7 +403,6 @@
     <string name="native_429f6057535c1ea3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sub-agent"</string>
     <string name="native_42e3a99c21767def" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Väntar på enhetsgodkännande"</string>
     <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Läser in tråd"</string>
-    <string name="native_430df68ec29a85a2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Denna Gateway använder nu ett certifikat som den här enheten litar på."</string>
     <string name="native_43905968a540af6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Förskjutning ms"</string>
     <string name="native_43988c156beabf7d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"event create"</string>
     <string name="native_43cc23fa52b87b4c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"dokument"</string>
@@ -473,7 +464,6 @@
     <string name="native_4e8c72cab82e0711" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatiseringen har en ogiltig konfiguration."</string>
     <string name="native_4ec30e9d85725d41" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tillåtelselista"</string>
     <string name="native_4ed379d418bb8629" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"groups"</string>
-    <string name="native_4ee252fb736effa2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Offentlig nyckel"</string>
     <string name="native_4efca0d10c5feb8e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Om"</string>
     <string name="native_4f1bc100d1dccc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ingen QR-kod för konfiguration hittades i bilden. Välj QR-koden som genererades av openclaw qr eller ange konfigurationskoden manuellt."</string>
     <string name="native_4fe3cdd404ea0290" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"permissions"</string>
@@ -494,7 +484,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Leverans"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Stäng av högtalare"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Öppnar anslutningen till Gateway"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Övervakning · %1$s trådar"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatiseringskörningen är slutförd."</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Inga matchande appar."</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skicka till chatt"</string>
@@ -519,7 +509,7 @@
     <string name="native_55898449eb74fb2e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Hälsa"</string>
     <string name="native_55a12cbe0995e214" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aviseringslyssnare"</string>
     <string name="native_55d8e7da6d0a752c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Högtalare avstängd"</string>
-    <string name="native_560d3e826c413dc9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sök bland trådar"</string>
+    <string name="native_560d3e826c413dc9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sök efter trådar"</string>
     <string name="native_565339bc4d33d728" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OK"</string>
     <string name="native_56a508f3f2bf424a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Det gick inte att öppna konfigurationsguiden."</string>
     <string name="native_56c41c606c44f3fc" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"fråga OpenClaw %1$s"</string>
@@ -560,7 +550,6 @@
     <string name="native_5c0c8c9aa658f4a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OPENCLAW"</string>
     <string name="native_5c1acea9c9b0e704" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Fetch"</string>
     <string name="native_5c39123805ffb4e2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Prompt"</string>
-    <string name="native_5c944156b5353428" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Godkänn enheten?"</string>
     <string name="native_5d410adb9576e266" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ta bort %1$s och dess sparade inloggningsuppgifter från den här telefonen?"</string>
     <string name="native_5d6c41a67139ee26" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"QR-koden pekar på en osäker fjärr-Gateway. %1$s %2$s"</string>
     <string name="native_5d6cbac59f87e78d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skärmytan är klar"</string>
@@ -578,7 +567,6 @@
     <string name="native_5fa1d457ddfcd26c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"rename group"</string>
     <string name="native_5fa7aac5375c5815" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Klar"</string>
     <string name="native_5fc1927ca948f31c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dagboken väntar på sin första post."</string>
-    <string name="native_6007acbe30b2cd98" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Godkänn"</string>
     <string name="native_600c9c27960112a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Livesida"</string>
     <string name="native_6030d1f6340776d2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatiseringen körs redan."</string>
     <string name="native_604e6d6faf8d0295" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ta bort den här automatiseringen efter en lyckad engångskörning."</string>
@@ -618,14 +606,12 @@
     <string name="native_6657cc73af00feac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tillåt kameraverktyg på begäran."</string>
     <string name="native_666067dd376e5d45" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Problem"</string>
     <string name="native_666c8bc0319f3b54" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Röstaktivering"</string>
-    <string name="native_66713d713e3a41c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Parkopplingsbegäran avvisades."</string>
     <string name="native_66b23bae66fc0d79" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s d sedan"</string>
     <string name="native_66cf5513b37462be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"roles"</string>
     <string name="native_66d0f523a379b2de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skills"</string>
     <string name="native_66f4804ee23ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Arkivera"</string>
     <string name="native_66fab2875ee427f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Noden är offline. Anslut igen och försök på nytt."</string>
     <string name="native_6725e7bbcd28f3a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"System"</string>
-    <string name="native_672f3453e1dd571b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Fjärr-IP"</string>
     <string name="native_674b38cae72bb0c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ogrupperade"</string>
     <string name="native_674eb55d9c353900" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Schemadetaljer"</string>
     <string name="native_67528858c36397f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Telefonfunktioner"</string>
@@ -633,7 +619,6 @@
     <string name="native_67b696468610b879" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dashboard"</string>
     <string name="native_67fa416afa64d304" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Klistra in token"</string>
     <string name="native_6827238fea72c88b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Inga leverantörer"</string>
-    <string name="native_684889f0079cc145" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"SHA-256-fingeravtryck"</string>
     <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Inga trådar ännu"</string>
     <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bluetooth-mikrofon"</string>
     <string name="native_690dbe9dc0993c42" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Senaste"</string>
@@ -668,7 +653,6 @@
     <string name="native_6d5d9004797377e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Licenser"</string>
     <string name="native_6d7c95a353d873cd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Anslut Gateway för att söka efter Skills på ClawHub."</string>
     <string name="native_6df1bb18a59ab97d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skill"</string>
-    <string name="native_6e0a0b9d8c5ee4d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Enhets-ID"</string>
     <string name="native_6e117ba97cbfb6f0" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway identifierade inte den aktiva %1$s-leverantören"</string>
     <string name="native_6e293a8c009e0011" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Väntar"</string>
     <string name="native_6e2c0963d056e104" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aktiveringsorden har sparats"</string>
@@ -845,7 +829,6 @@
     <string name="native_8bb7ec15b1e350a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Granskar"</string>
     <string name="native_8bf253a125f66985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skanna eller klistra in en konfigurationskod för att lägga till en till Gateway."</string>
     <string name="native_8c4a3896e8f06d27" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tidsgränsen för TLS överskreds"</string>
-    <string name="native_8c55387fb6c584c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Den parkopplade enheten har tagits bort."</string>
     <string name="native_8c93c68056cde54d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway har parkopplats. Kontrollerar godkännande av nodfunktioner."</string>
     <string name="native_8ca344247c18317e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rörelse"</string>
     <string name="native_8cac4b77b9c54695" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cron-åtgärden misslyckades."</string>
@@ -869,7 +852,7 @@
     <string name="native_8f54b0d1e30092d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Röstmeddelande"</string>
     <string name="native_8fa196125b734940" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Inget behöver din uppmärksamhet"</string>
     <string name="native_8fce9ec6fd5432df" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw behöver behörigheter för %1$s för att fortsätta."</string>
-    <string name="native_8fe42acb8573244e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Mikrofon i trådbundet headset"</string>
+    <string name="native_8fe42acb8573244e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Mikrofon på trådbundet headset"</string>
     <string name="native_906115657390f367" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Levererat"</string>
     <string name="native_9071738f145962a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Förfaller"</string>
     <string name="native_90bf81305006e6ed" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skill-information är inte tillgänglig i aktuell skills-status."</string>
@@ -1038,9 +1021,10 @@
     <string name="native_ad1c341c65f84ede" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kör godkännandekommandot på Gateway-datorn och kontrollera sedan igen."</string>
     <string name="native_ad1fb9ec0cb3c7a4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatiseringar"</string>
     <string name="native_adb7eb8a03ad699c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s min"</string>
+    <string name="native_adca3171c270301a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Den här Gateway-inloggningen kan visa anslutna noder, men den kan inte godkänna parkoppling av nya telefoner. Parkoppla nya telefoner från en Gateway-administratörssession. Godkännande av nodfunktioner är separat och använder fortfarande nodes approve &lt;request id&gt;."</string>
     <string name="native_ade9248e0132b411" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Lita på"</string>
     <string name="native_ae27fa789a03c1db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"QR-koden är inte en konfigurationskod för OpenClaw. Generera en ny kod med openclaw qr och försök igen."</string>
-    <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Den föredragna mikrofonen är inte tillgänglig; automatisk dirigering används."</string>
+    <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Den föredragna mikrofonen är inte tillgänglig. Automatisk dirigering används."</string>
     <string name="native_aea4a04a80426ed8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Avvisad"</string>
     <string name="native_aed306fbb63c0c68" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Inkludera Android och bakgrundspaket."</string>
     <string name="native_aedf1cf58372f943" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Din Gateway är redo."</string>
@@ -1107,7 +1091,6 @@
     <string name="native_bb4f2558e4333834" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Widgetbilden har sparats i Hämtade filer"</string>
     <string name="native_bbe5fc3b9ef39f99" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Startar…"</string>
     <string name="native_bc19cec293228fb8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Klientfel"</string>
-    <string name="native_bc1c94a6dfce1058" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Verifiera enheten som skickar begäran innan du beviljar åtkomst."</string>
     <string name="native_bc6618670f3e8a17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bluetooth LE-mikrofon"</string>
     <string name="native_bcb06651437caa15" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
     <string name="native_bd08450d63406844" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatiseringen har aktiverats."</string>
@@ -1116,7 +1099,6 @@
     <string name="native_bdc090ec61e3fcfc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Läs in igen"</string>
     <string name="native_bdff71b20b9cf392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sök efter automationer"</string>
     <string name="native_be969becb173e0c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Länkade telefoner och nodvärdar visas här efter parkoppling."</string>
-    <string name="native_bf1870ff5c6322fb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s: %2$s"</string>
     <string name="native_bf350e6a0ed60b7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Den här automatiseringen har ändrats på Gateway. Granska den senaste versionen innan du sparar igen."</string>
     <string name="native_bf399ffa03617a96" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Stoppa diktering"</string>
     <string name="native_bf56ee2fe3345ce1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Läsvänlig"</string>
@@ -1140,7 +1122,6 @@
     <string name="native_c1c224b03cd9bc7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Administratör"</string>
     <string name="native_c1ebc7817870e5be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kräver åtgärd"</string>
     <string name="native_c22d5e02fbec7d65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Parkoppla den här enheten med din Gateway för att endast väcka den vid faktiskt arbete, ha en aktuell agentöversikt nära till hands och undvika batterikrävande bakgrundsloopar."</string>
-    <string name="native_c25337055464f8d3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Roller"</string>
     <string name="native_c253f451bdd56431" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Svara"</string>
     <string name="native_c26225b6c16a4bc7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Leverantörskatalog"</string>
     <string name="native_c272b225cf5bd643" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aktivera behörighet i Inställningar"</string>
@@ -1154,7 +1135,6 @@
     <string name="native_c34dd5eb8b0af56e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Var hittar jag en konfigurationskod?"</string>
     <string name="native_c3546b39ecbbed8a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Det gick inte att aktivera skill."</string>
     <string name="native_c35b21d6ca39aa7c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"pdf"</string>
-    <string name="native_c3812fc4acb861d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ta bort"</string>
     <string name="native_c382566dbe2ea49f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s%% online"</string>
     <string name="native_c385951198c45d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Inga kanaler"</string>
     <string name="native_c41ad84496b53420" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Röst i realtid"</string>
@@ -1183,7 +1163,6 @@
     <string name="native_c6d5ed757b66bfd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dröm"</string>
     <string name="native_c6dd061350fc69b8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Inga appar har blockerats. Appar kan vidarebefordra tills du lägger till blockeringar."</string>
     <string name="native_c753cdf0c19f1e38" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Taligenkänning är inte tillgänglig"</string>
-    <string name="native_c78ffe19571018fb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Plattform"</string>
     <string name="native_c7985fa72daa6ea4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway returnerade inte konfiguration för %1$s"</string>
     <string name="native_c7b6dfd5c3a183c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Glöm Gateway?"</string>
     <string name="native_c7b7b7f01360f6a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Valfri beskrivning"</string>
@@ -1205,14 +1184,14 @@
     <string name="native_ca7981b46ecf2c17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Av"</string>
     <string name="native_cab94aba84f97f7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Typografi"</string>
     <string name="native_cae7d57bc067a514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Stoppa"</string>
-    <string name="native_cae98462b30650eb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Inga matchande trådar ännu."</string>
+    <string name="native_cae98462b30650eb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Inga matchande trådar än."</string>
     <string name="native_cba62d81f910c7f0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Parkopplingen med Gateway lyckades.\nGodkänn den här telefonens nodfunktioner via ett operatörsgränssnitt."</string>
     <string name="native_cc4b66e7e22230c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Denna skill är installerad men kan för närvarande inte köras. Använd datorn eller CLI för konfigurationsändringar."</string>
     <string name="native_cc5f45fb30a26e07" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Igenkännaren är upptagen"</string>
     <string name="native_cc721e25d73938a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway för hemmet"</string>
     <string name="native_cc7a9a5cf8c4bc9d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kör godkännandekommandot på Gateway"</string>
     <string name="native_cc925e3c97ac7a35" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Det gick inte att läsa in förslag från Skill Workshop."</string>
-    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ge mig en uppdatering om mina senaste OpenClaw-trådar och föreslå nästa steg."</string>
+    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Uppdatera mig om mina senaste OpenClaw-trådar och föreslå nästa steg."</string>
     <string name="native_ccb4c324f516c633" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Inte nu"</string>
     <string name="native_cced0b0d83a9e400" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw qr"</string>
     <string name="native_cced28c6dc3f99c2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"start"</string>
@@ -1246,7 +1225,6 @@
     <string name="native_d17d2d78d76e6a6c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Modeller"</string>
     <string name="native_d19c2dd2fb598b93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw Passiv"</string>
     <string name="native_d1a574e23344c407" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway-lösenordet är ogiltigt"</string>
-    <string name="native_d1af697abaff485f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Det gick inte att verifiera ändringen av enhetsparkopplingen. Uppdatera och försök igen."</string>
     <string name="native_d1bf045bb524dae5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Visa detaljer"</string>
     <string name="native_d1e9567da9a8a4b0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bash"</string>
     <string name="native_d2089be672953d11" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Token"</string>
@@ -1261,10 +1239,9 @@
     <string name="native_d31de1a5c5c8ba2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Webbläsare"</string>
     <string name="native_d354ee936f59115e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screen record"</string>
     <string name="native_d3974fd6d3b6c81f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Körning väntar"</string>
-    <string name="native_d3e1c5f8a6e240fc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ursprung"</string>
     <string name="native_d3f75e24411053c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Personlig AI på dina enheter"</string>
     <string name="native_d406ade2958cb5b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attach"</string>
-    <string name="native_d461a493a3753877" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatisk"</string>
+    <string name="native_d461a493a3753877" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatiskt"</string>
     <string name="native_d4b1ea5708dd5329" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Översikt"</string>
     <string name="native_d53167a3f66debec" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Det gick inte att begära återställning. Tryck för att försöka igen."</string>
     <string name="native_d588c689e03132fb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s\n\n"</string>
@@ -1277,7 +1254,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Profil"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Leverantörsgränser visas här när din Gateway rapporterar dem."</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 problem"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Trådar i \"%1$s\" behålls och flyttas tillbaka till Ogrupperade."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skapad"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s aktiva token"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>
@@ -1450,7 +1427,6 @@
     <string name="native_f2da2e47cd31a5dd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Den här bilden kunde inte avkodas."</string>
     <string name="native_f3753c0fe29b88db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway, röst, aviseringar, integritet"</string>
     <string name="native_f386c32c1bf437d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Filer i agentens arbetsyta"</string>
-    <string name="native_f418bf0894a1806a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Den här enheten förlorar sin betrodda åtkomst till Gateway."</string>
     <string name="native_f41d9e8b7e09aa24" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Använd requestId från det väntande kommandot i godkännandekommandot."</string>
     <string name="native_f4830a1dae298044" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Schema"</string>
     <string name="native_f493f0ce7a52a8aa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Hastighetsgräns"</string>
@@ -1458,7 +1434,6 @@
     <string name="native_f4cc820d308495c4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nyttolast · %1$s"</string>
     <string name="native_f4ccae29e1bb0c20" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Körs"</string>
     <string name="native_f4db1e48476f6075" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Avsluta"</string>
-    <string name="native_f4e2076014711222" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Använd systemets förtroende"</string>
     <string name="native_f4ef7a41caa88dd1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Inga leverantörer redo"</string>
     <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Prioriterar anslutna Bluetooth-mikrofoner."</string>
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s app blockerad från att vidarebefordra."</string>
@@ -1522,7 +1497,7 @@
     <string name="native_ff716fc4735e067f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dikteringsinställningar"</string>
     <string name="native_ff9dbbdfb84ddab2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Leverantörsmodellerna har lästs in, men beredskapsstatusen är inte tillgänglig."</string>
     <string name="native_ffa7aa557b547a79" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ta bort tråden?"</string>
-    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw gör den här telefonen till en stilren mobil kommandoyta för trådar, röst, leverantörer och Gateway."</string>
+    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw förvandlar den här telefonen till en ren mobil kommandoyta för trådar, röst, leverantörer och Gateway."</string>
     <string name="native_ffb6f5764bddb68c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nyaste först"</string>
     <string name="native_ffcf16006c652ee3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nästa cykel"</string>
 </resources>

--- a/apps/android/app/src/main/res/values-th/strings.xml
+++ b/apps/android/app/src/main/res/values-th/strings.xml
@@ -24,14 +24,12 @@
     <string name="native_002a6fcb30b2def4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถเตรียมไฟล์แนบสำหรับส่งได้"</string>
     <string name="native_003aaf9e0a0e6b9f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปิดไมค์"</string>
     <string name="native_0060cbfdd3cf13ba" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"แสดงการแจ้งเตือนจาก OpenClaw"</string>
-    <string name="native_0077032d7e9f9cbe" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กิจกรรมของเธรด"</string>
-    <string name="native_008dacb6d1e85bd8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เต็ม"</string>
+    <string name="native_008dacb6d1e85bd8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เต็มรูปแบบ"</string>
     <string name="native_009506aeb0484b2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อนุมัติและบันทึกแล้ว"</string>
     <string name="native_00d108e2e6466940" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"แสดงประวัติการโทรล่าสุด"</string>
     <string name="native_00e8aeba41d79ce3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รอดำเนินการ 1 รายการ"</string>
     <string name="native_010f6550a1c8f554" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไฟล์แนบที่ไม่รองรับ"</string>
     <string name="native_01267be21eb77392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"0 = แม่นยำ"</string>
-    <string name="native_0171e3d4e07f1861" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อ Gateway เพื่อค้นหากระทู้"</string>
     <string name="native_0174f83136630e7e" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s บัญชี"</string>
     <string name="native_01ac1c298e0cbd9a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การเปลี่ยนแปลง Cron ต้องใช้ operator.admin โดยรหัสตั้งใจจะไม่ให้สิทธิ์นี้ โปรดเชื่อมต่อกับโทเค็นที่ใช้ร่วมกันหรือรหัสผ่านของ Gateway อีกครั้งเพื่อขอสิทธิ์ผู้ดูแลระบบ หากอุปกรณ์นี้ยังไม่มีสิทธิ์ดังกล่าว ให้อนุมัติการอัปเกรดขอบเขตที่รอดำเนินการจากไคลเอนต์ผู้ดูแลระบบที่มีอยู่"</string>
     <string name="native_01bcfe7a9296b6d6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Apply Patch"</string>
@@ -70,12 +68,9 @@
     <string name="native_088e0e5ebc96c6ac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"แทนที่การตั้งค่า Gateway หรือไม่?"</string>
     <string name="native_08a5391c1de3078a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถโหลดระบบอัตโนมัติได้"</string>
     <string name="native_08b041935798fbf6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คุณ"</string>
-    <string name="native_08ea63ee26954dca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไมโครโฟนในตัว"</string>
     <string name="native_0905f7f59021c2a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"พื้นผิว"</string>
     <string name="native_0929c9dc7f794852" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีข้อเสนอ"</string>
-    <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เธรดหลัก"</string>
     <string name="native_0979c6fdbdca1675" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิดแชต"</string>
-    <string name="native_09ce95090659d069" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การดำเนินการจับคู่อุปกรณ์ไม่พร้อมใช้งานในเซสชัน Gateway นี้ ให้เรียกใช้ openclaw devices list บนโฮสต์ Gateway และจัดการคำขอที่นั่น การอนุมัติความสามารถของโหนดเป็นคนละส่วนกันและยังคงใช้ nodes approve &lt;request id&gt;"</string>
     <string name="native_0a0b7cf7c428c703" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คำขอดำเนินการ"</string>
     <string name="native_0a708e7b03aaf1fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list pins"</string>
     <string name="native_0ab0e1629576aecf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อกับ Gateway เพื่อโหลดข้อเสนอ Skill Workshop"</string>
@@ -88,12 +83,11 @@
     <string name="native_0c3845dcd2f0f683" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตรวจสอบข้อเสนอนี้เพื่อโหลด Markdown"</string>
     <string name="native_0c3ea4e2f12153e7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิด OpenClaw แล้วถาม %1$s"</string>
     <string name="native_0c4d01e81bb3d1fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การให้เหตุผล"</string>
-    <string name="native_0c77fe09ab336a3e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไคลเอนต์"</string>
     <string name="native_0c79a9c222840ed0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ใช้งานแล้ว"</string>
+    <string name="native_0c8056e18fdf290c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การเรียกใช้เครื่องมือแชทที่รออยู่ในเซสชันที่ใช้งานอยู่จะยังคงแสดงที่นี่"</string>
     <string name="native_0cab1c9617404faf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"วิดีโอ"</string>
     <string name="native_0cf04463c4276a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เลื่อนระดับแล้ว"</string>
     <string name="native_0d21bd52022ca7f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ออนไลน์"</string>
-    <string name="native_0d5644ff52ce2ba3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ขอบเขต"</string>
     <string name="native_0d5efd432e4fedf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ยังไม่ได้กำหนดค่าผู้ให้บริการเสียงแบบเรียลไทม์"</string>
     <string name="native_0d8ca811c3744a6d" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s · %2$s"</string>
     <string name="native_0db10f2c2f332cd2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"kick"</string>
@@ -104,10 +98,11 @@
     <string name="native_0e91610117029a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รีเฟรช"</string>
     <string name="native_0ee30822ed35a792" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อยู่ในคิว %1$s รายการ"</string>
     <string name="native_0f4c8529742b31ea" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เริ่มแชท"</string>
-    <string name="native_0f559ff270904904" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การเรียกใช้เครื่องมือแชทที่กำลังรอในเธรดที่ใช้งานอยู่จะยังคงแสดงที่นี่"</string>
     <string name="native_0f56cc286a4f23d8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"จำเป็นต้องตรวจสอบใบรับรอง"</string>
+    <string name="native_0f822f33a3100b5c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังตรวจสอบ · %1$s เซสชัน"</string>
     <string name="native_0f8fe3a9688138a1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิดพื้นผิว Canvas ปัจจุบันเพื่อตรวจสอบหรือโต้ตอบกับมัน"</string>
     <string name="native_0ff98f05be01ce5e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อัปเดตระบบอัตโนมัติแล้ว"</string>
+    <string name="native_100ac08064a6d586" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีเซสชันล่าสุด"</string>
     <string name="native_1039e92fa05c1279" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สถานะ Gateway, ความพร้อมของโหนดโทรศัพท์ และสตรีมบันทึกล่าสุด"</string>
     <string name="native_106808530413298b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิดรายละเอียดการทำงานอัตโนมัติ"</string>
     <string name="native_1093115897879aa3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รันไทม์"</string>
@@ -119,13 +114,13 @@
     <string name="native_1196c7b1e0e55580" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"reactions"</string>
     <string name="native_11a6767d5674c7e4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เสร็จสิ้น"</string>
     <string name="native_11e18d6748aa9128" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เวอร์ชันและการอัปเดต"</string>
+    <string name="native_11e47358a692d81b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สรุปเซสชันล่าสุดและขั้นตอนถัดไป"</string>
     <string name="native_11f37f9652a47b5b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw จะแสดงการอนุมัติ งานที่ล้มเหลว และปัญหาของช่องทางไว้ที่นี่"</string>
-    <string name="native_11f6dc0befae5081" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไมโครโฟน USB"</string>
     <string name="native_1242bf5561713a98" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"มีการแชร์รอเพิ่มมากเกินไป"</string>
+    <string name="native_1251aefc12b2b10e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ลบเซสชัน?"</string>
     <string name="native_12698ce1ea5cd4ab" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ข้ามแล้ว"</string>
     <string name="native_1291833ee42d8143" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ใช้ที่อยู่ LAN ของคอมพิวเตอร์ Gateway หรือชื่อโฮสต์ระยะไกลที่ปลอดภัย"</string>
     <string name="native_130011756125313c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิด"</string>
-    <string name="native_133f293961d7aa43" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังค้นหากระทู้"</string>
     <string name="native_13798c3256e792c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การพูดคุยแบบเรียลไทม์"</string>
     <string name="native_13b588109e423636" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw กำลังเตรียมคำตอบ"</string>
     <string name="native_13ba4cde12390943" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อนุมัติหนึ่งครั้ง"</string>
@@ -141,8 +136,6 @@
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เป้าหมายเซสชัน"</string>
     <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตรวจสอบ Skill จาก ClawHub"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
-    <string name="native_16a5b7ad567a8093" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปฏิเสธคำขอจับคู่จากอุปกรณ์นี้หรือไม่?"</string>
-    <string name="native_16b1a05e1d987ed1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไมโครโฟนที่ต้องการ"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โฮสต์โหนด"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ระดับ"</string>
     <string name="native_172b997ffbc8c9a7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปิดตัวเลือกแอป"</string>
@@ -162,7 +155,6 @@
     <string name="native_18f2a0947f9d6523" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ถูกบล็อก"</string>
     <string name="native_18f6e5973bc41268" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คำหรือวลีปลุก"</string>
     <string name="native_1906b261e6e0fdd0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway ต้องได้รับการอนุมัติอุปกรณ์"</string>
-    <string name="native_19408baaf5c2e446" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไมโครโฟนภายนอก"</string>
     <string name="native_194a05367fb28913" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"พร้อมใช้งาน %1$s/%2$s"</string>
     <string name="native_199e261f8ee0e97f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อแล้ว (ผู้ควบคุมออฟไลน์)"</string>
     <string name="native_19fc7a47df16fb1f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ความสามารถยังไม่ได้รับการอนุมัติ"</string>
@@ -187,7 +179,6 @@
     <string name="native_1d91629837639a5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ระบบอัตโนมัตินี้มีการเปลี่ยนแปลงขณะที่คุณกำลังแก้ไข โปรดย้อนกลับเป็นเวอร์ชันล่าสุดบน Gateway ก่อนบันทึก"</string>
     <string name="native_1dbf9d5979606697" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เมื่อเชื่อมต่อแล้ว Gateway สามารถปลุกโทรศัพท์ด้วยการแจ้งเตือนแบบเงียบแทนการคงเซสชันให้ทำงานตลอดเวลา"</string>
     <string name="native_1e432ea5425e4a3a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โหมดปลุก"</string>
-    <string name="native_1e595a107c78b957" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"นำอุปกรณ์ที่จับคู่ออกหรือไม่?"</string>
     <string name="native_1e955a58278623a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ข้อความเหตุการณ์ระบบ"</string>
     <string name="native_1ea44149be42d970" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถคัดลอกรูปภาพวิดเจ็ตได้"</string>
     <string name="native_1ea442a134b2a184" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่"</string>
@@ -202,7 +193,6 @@
     <string name="native_2065cc867eba1b39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถโหลดการกำหนดค่าโมเดลของผู้ให้บริการได้"</string>
     <string name="native_207ccb22d618db05" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อนุญาตให้ %1$s แอปส่งต่อได้"</string>
     <string name="native_209b9e597963e7e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การตั้งค่าเสียง"</string>
-    <string name="native_211988ba9dd0570a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปฏิเสธคำขอจับคู่หรือไม่?"</string>
     <string name="native_2132066dc9475cb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"This skill is installed but not available to the current agent. Agent filters stay on desktop or CLI."</string>
     <string name="native_21378545892f1fe2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ผู้เผยแพร่"</string>
     <string name="native_214d4932fc767e8f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">" · สนทนา: กำลังพูด"</string>
@@ -216,7 +206,6 @@
     <string name="native_22965568d22a14ee" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อแล้ว"</string>
     <string name="native_22a970d2e5b1cc23" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เสร็จสมบูรณ์"</string>
     <string name="native_22b8da9e693e94eb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โทรศัพท์ของคุณจับคู่กับ %1$s แล้ว ดำเนินการต่อเพื่อเปิดสิทธิ์เข้าถึงโหนดให้เสร็จสมบูรณ์"</string>
-    <string name="native_22f19ab686639b9a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กระทู้ปัจจุบัน"</string>
     <string name="native_23246d9852fed325" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การคิด %1$s"</string>
     <string name="native_2346f214ad56b180" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปิดเสียง"</string>
     <string name="native_2347fc06da5f60de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw ขอขอบคุณพันธมิตรในชุมชนโอเพนซอร์ส"</string>
@@ -243,12 +232,11 @@
     <string name="native_262c897a1f408b0b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อกับ Gateway ของคุณ"</string>
     <string name="native_2682bd813a3bccbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ป้อนรหัสตั้งค่าจาก openclaw qr"</string>
     <string name="native_268f14bbfe119c1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การวินิจฉัย"</string>
-    <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การดำเนินการนี้จะลบเธรดและบทสนทนาของเธรดอย่างถาวร"</string>
-    <string name="native_26e47d73a55d7fa7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อนุมัติอุปกรณ์แล้ว"</string>
     <string name="native_26f0dd993530eb2d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังลองใหม่โดยอัตโนมัติ"</string>
     <string name="native_270ff82f36da987f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คัดลอกรูปภาพวิดเจ็ตแล้ว"</string>
     <string name="native_2728740a95d465c6" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s บทบาท"</string>
     <string name="native_272955a627b71681" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ขาด 1 รายการ"</string>
+    <string name="native_2732406e3be52c5b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่พบเซสชันที่ตรงกัน"</string>
     <string name="native_2748442ae65e27e8" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำหนดเวลาไว้ %1$s งาน"</string>
     <string name="native_275976081ce1abf6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"react"</string>
     <string name="native_279b44d2ab4b40c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เอเจนต์"</string>
@@ -260,7 +248,6 @@
     <string name="native_27d773b934ed324f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตรวจสอบและติดตั้ง"</string>
     <string name="native_2821f0168d6dd9df" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปลี่ยนอุปกรณ์นี้ให้เป็นโหนด OpenClaw ที่ปลอดภัยสำหรับแชท, เสียง, กล้อง และเครื่องมืออุปกรณ์"</string>
     <string name="native_2831546121359362" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตั้งค่าด้วยตนเอง"</string>
-    <string name="native_287c4b113aafc215" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิดแชทเพื่อเริ่มหรือดำเนินการต่อในเธรดปัจจุบัน"</string>
     <string name="native_28bb849671cab958" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เคล็ดลับ: หยุดฟังเพื่อส่งช่วงที่บันทึกไว้"</string>
     <string name="native_28d03596d24eeb4e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ข้าม"</string>
     <string name="native_28d55ec6974d84e8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คำขอด้วยเสียงล้มเหลว"</string>
@@ -280,10 +267,9 @@
     <string name="native_2c19d584bf8ad518" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ทำเครื่องหมายว่ายังไม่ได้อ่าน"</string>
     <string name="native_2c75802a5f8df5f8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ค้นหาบุคคลและรายละเอียดการติดต่อ"</string>
     <string name="native_2c9cce8250d746e3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ต้องระบุตัวตนอุปกรณ์"</string>
-    <string name="native_2cd62f7a670b2819" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กระทู้ OpenClaw"</string>
+    <string name="native_2cad0766accc2d3f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปลี่ยนชื่อเซสชัน"</string>
     <string name="native_2d4dfe885f84629e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อนุญาตการเข้าถึงคลังรูปภาพ"</string>
     <string name="native_2d6416405eb44982" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การตอบกลับก่อนหน้านี้ดำเนินการอนุมัตินี้แล้ว"</string>
-    <string name="native_2d85de9d56c226e4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีเธรดล่าสุด"</string>
     <string name="native_2df01a03ff43400b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่พบรายการที่ตรงกัน"</string>
     <string name="native_2df30b117ad829ab" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อ่านการแจ้งเตือนจากแอปที่เลือก"</string>
     <string name="native_2e0078a8322d6f1f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่ทราบสถานะความพร้อมใช้งาน"</string>
@@ -345,7 +331,6 @@
     <string name="native_36c725ddb20f8bd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การตั้งค่าผู้ให้บริการ Talk"</string>
     <string name="native_36d88ed6cc91d2b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Music Generation"</string>
     <string name="native_36e8d5e94219dc37" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การตั้งค่าการคุย"</string>
-    <string name="native_36f1fac278711470" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังติดตาม · 1 เธรด"</string>
     <string name="native_37053dc1f680546b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ข้อความ Payload"</string>
     <string name="native_37582309e7a1dbe5" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การอนุมัติ %1$s"</string>
     <string name="native_379ce0aacf46c35f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway ไม่ได้ส่งคืนความพร้อมของ %1$s"</string>
@@ -353,7 +338,6 @@
     <string name="native_381428f5f251a764" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Conversation Send"</string>
     <string name="native_3824a9f4dafe92c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"แคนวาส"</string>
     <string name="native_384ae4ab1a2830f9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ผู้ให้บริการ 1 ราย"</string>
-    <string name="native_385001409de8562a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถอ่านใบรับรองของ Gateway โดยอัตโนมัติได้ ให้วางลายนิ้วมือ SHA-256 ที่ได้รับจากโฮสต์ Gateway"</string>
     <string name="native_387b2569e440838c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ส่งไม่สำเร็จ: %1$s"</string>
     <string name="native_3892e10346fd2012" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"บริดจ์"</string>
     <string name="native_38d198cd5303680f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ข้อผิดพลาดในการส่ง"</string>
@@ -371,19 +355,18 @@
     <string name="native_3a65cf1204f18864" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อแล้ว (โหนดออฟไลน์)"</string>
     <string name="native_3a78695388b38b5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"หน้าแรก"</string>
     <string name="native_3b28b535950f8175" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การป้อนตามคำบอกกำลังฟังอยู่"</string>
-    <string name="native_3b46b7912670bfb0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีเธรดที่เก็บถาวร"</string>
     <string name="native_3b851469ea31d489" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เลือกและตรวจสอบผู้ช่วยที่พร้อมใช้งานบน gateway นี้"</string>
     <string name="native_3be0085a6bd88cdd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โหมดพูดคุยทำงานอยู่"</string>
     <string name="native_3bee4ede6bf4436c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังทำงาน · มีงานที่ใช้งานอยู่ 1 รายการ"</string>
     <string name="native_3c6168bbf86e6e4b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ยอมรับและเปิดใช้งาน"</string>
     <string name="native_3cb27ae0fbca8ae3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คัดลอกรูปภาพ"</string>
+    <string name="native_3d013d4e9cf973f9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ลองใช้ Chat, Voice, Sessions, Providers หรือ Settings"</string>
     <string name="native_3d06950825de7452" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"URL ของ Gateway"</string>
     <string name="native_3d200f624b8bda8f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"main, isolated, current หรือ session:&lt;id&gt;"</string>
     <string name="native_3d61e9d54ffa2d93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อกับ Gateway ของคุณเพื่อเปิดเชลล์ในพื้นที่ทำงานของเอเจนต์"</string>
     <string name="native_3da4811eafea080a" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s://%2$s:%3$s"</string>
     <string name="native_3de3d401128d4395" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถโหลดรายละเอียดการอนุมัติได้ รีเฟรชแล้วลองอีกครั้ง"</string>
     <string name="native_3e398e6fb979557a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tool Call"</string>
-    <string name="native_3e42e385075b9b56" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เธรด"</string>
     <string name="native_3f00927a719345ed" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Write"</string>
     <string name="native_3f25ccebfa99dcf3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เริ่มต้นด้วยพรอมต์ หรือใช้เสียง"</string>
     <string name="native_3f39d5c348e5b79d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"D"</string>
@@ -410,8 +393,6 @@
     <string name="native_4287d54ad5e78985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"งาน OpenClaw ที่กำหนดเวลาไว้จาก gateway ของคุณ"</string>
     <string name="native_429f6057535c1ea3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sub-agent"</string>
     <string name="native_42e3a99c21767def" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังรอการอนุมัติอุปกรณ์"</string>
-    <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังโหลดเธรด"</string>
-    <string name="native_430df68ec29a85a2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ขณะนี้ Gateway นี้แสดงใบรับรองที่อุปกรณ์นี้เชื่อถือ"</string>
     <string name="native_43905968a540af6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การหน่วงเหลื่อม ms"</string>
     <string name="native_43988c156beabf7d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"event create"</string>
     <string name="native_43cc23fa52b87b4c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เอกสาร"</string>
@@ -421,7 +402,7 @@
     <string name="native_4441146b0fe1d5c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screenshot"</string>
     <string name="native_4481c2190a1b4bca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"นิพจน์ cron เช่น 0 9 * * *"</string>
     <string name="native_4499e7b7e1c9ddbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กลับไปที่เสียง"</string>
-    <string name="native_449f5a775762cdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"พูด"</string>
+    <string name="native_449f5a775762cdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"พูดคุย"</string>
     <string name="native_45a64dc17588f2ca" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ออนไลน์ %1$s/%2$s"</string>
     <string name="native_45a8847c4a6b2c81" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อนุญาตให้ส่งต่อ %1$s แอป"</string>
     <string name="native_460b3a7da007b7af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"แชท"</string>
@@ -470,12 +451,13 @@
     <string name="native_4d5e590b23745b4d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skills ที่ติดตั้งบน Gateway จะแสดงที่นี่"</string>
     <string name="native_4dee3342f86128c1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รหัสอาจหมดอายุแล้วหรือถูกสร้างขึ้นสำหรับ Gateway อื่น"</string>
     <string name="native_4e25d34a20313a61" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ต้องได้รับอนุญาต"</string>
+    <string name="native_4e35d595e6975128" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กิจกรรมเซสชัน"</string>
     <string name="native_4e8c72cab82e0711" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ระบบอัตโนมัติมีการกำหนดค่าที่ไม่ถูกต้อง"</string>
     <string name="native_4ec30e9d85725d41" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รายการที่อนุญาต"</string>
     <string name="native_4ed379d418bb8629" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"groups"</string>
-    <string name="native_4ee252fb736effa2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คีย์สาธารณะ"</string>
     <string name="native_4efca0d10c5feb8e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เกี่ยวกับ"</string>
     <string name="native_4f1bc100d1dccc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่พบคิวอาร์โค้ดสำหรับตั้งค่าในรูปภาพนั้น โปรดเลือกคิวอาร์ที่สร้างโดย openclaw qr หรือป้อนรหัสตั้งค่าด้วยตนเอง"</string>
+    <string name="native_4f993457edb69110" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เรียกดูเซสชัน"</string>
     <string name="native_4fe3cdd404ea0290" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"permissions"</string>
     <string name="native_5047cfb3b607e7d0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อ Gateway เพื่อโหลดโหนดและอุปกรณ์ที่จับคู่แล้ว"</string>
     <string name="native_5083cd4b96b0d09d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มี Skills"</string>
@@ -494,7 +476,6 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การส่ง"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปิดเสียงลำโพง"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังเปิดการเชื่อมต่อ Gateway"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังติดตาม · %1$s เธรด"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การทำงานของระบบอัตโนมัติเสร็จสิ้นแล้ว"</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่พบแอปที่ตรงกัน"</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ส่งไปยังแชท"</string>
@@ -511,6 +492,7 @@
     <string name="native_544731b8da90eb65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"emoji list"</string>
     <string name="native_544d9e42216c2ac0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ทำซ้ำ"</string>
     <string name="native_54b41550b1247912" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ค้นหา OpenClaw"</string>
+    <string name="native_54d5c8a4eb7898dc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เซสชันหลัก"</string>
     <string name="native_54e08ca4a25fe3f1" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รอดำเนินการ %1$s รายการ"</string>
     <string name="native_5542bc6a5f3ae4da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถใช้การรู้จำเสียงบนอุปกรณ์ได้"</string>
     <string name="native_55546edf686ab168" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีแอปที่สามารถแชร์ข้อความนี้ได้"</string>
@@ -519,13 +501,13 @@
     <string name="native_55898449eb74fb2e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สถานภาพ"</string>
     <string name="native_55a12cbe0995e214" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตัวรับฟังการแจ้งเตือน"</string>
     <string name="native_55d8e7da6d0a752c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปิดเสียงลำโพงแล้ว"</string>
-    <string name="native_560d3e826c413dc9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ค้นหาเธรด"</string>
+    <string name="native_5638a97380146882" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิดแชทเพื่อเริ่มหรือกลับไปใช้เซสชันปัจจุบัน"</string>
     <string name="native_565339bc4d33d728" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตกลง"</string>
     <string name="native_56a508f3f2bf424a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถเปิดคู่มือการตั้งค่าได้"</string>
     <string name="native_56c41c606c44f3fc" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ถาม OpenClaw %1$s"</string>
-    <string name="native_56c4c3d30ceda56e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wait for Agents"</string>
     <string name="native_56ef8f20955f2564" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ที่อยู่"</string>
     <string name="native_5702e1d243eeb4e9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"งานตามกำหนดการที่สร้างบน Gateway จะปรากฏที่นี่"</string>
+    <string name="native_5719080df7834f1b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อ Gateway เพื่อค้นหาเซสชัน"</string>
     <string name="native_572739b05d138f8a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังแสดงส่วนบันทึกล่าสุด"</string>
     <string name="native_57666930af1af35e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ใช้รหัสตั้งค่า"</string>
     <string name="native_57c4b13a4c7335e7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"sticker"</string>
@@ -537,6 +519,7 @@
     <string name="native_5855b3ac2fcc1b3e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"แก้ไขการเชื่อมต่อ"</string>
     <string name="native_58e909c0f4cc5723" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"บันทึกรูปภาพ"</string>
     <string name="native_590b0003ccaad929" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โหนด %1$s"</string>
+    <string name="native_5922c3814cbbdbce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สรุปเซสชัน OpenClaw ล่าสุดของฉันและแนะนำขั้นตอนถัดไป"</string>
     <string name="native_59235e6ebfd03967" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ต้องใช้รหัสผ่าน Gateway"</string>
     <string name="native_592acaa91843913b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Update Plan"</string>
     <string name="native_595b066a8838734a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ลบไฟล์แนบ"</string>
@@ -551,6 +534,7 @@
     <string name="native_5a7d4412c13abceb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw กำลังพูด"</string>
     <string name="native_5a99f6fa7e98657a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สแกน QR"</string>
     <string name="native_5ab9d81fd481e71f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"แอปที่เลือก"</string>
+    <string name="native_5b3522ef7c1c149e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โฟกัสช่องค้นหาเซสชัน"</string>
     <string name="native_5b36e77f2018303f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ย้อนกลับการเปลี่ยนแปลง"</string>
     <string name="native_5b4ddab77c412d6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คัดลอกคำสั่งอนุมัติแล้ว"</string>
     <string name="native_5b7c4c081e9c5810" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สถานะการส่ง"</string>
@@ -560,7 +544,6 @@
     <string name="native_5c0c8c9aa658f4a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OPENCLAW"</string>
     <string name="native_5c1acea9c9b0e704" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Fetch"</string>
     <string name="native_5c39123805ffb4e2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"พรอมต์"</string>
-    <string name="native_5c944156b5353428" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อนุมัติอุปกรณ์หรือไม่?"</string>
     <string name="native_5d410adb9576e266" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"นำ %1$s และข้อมูลประจำตัวที่บันทึกไว้ออกจากโทรศัพท์เครื่องนี้หรือไม่?"</string>
     <string name="native_5d6c41a67139ee26" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คิวอาร์โค้ดชี้ไปยัง Gateway ระยะไกลที่ไม่ปลอดภัย %1$s %2$s"</string>
     <string name="native_5d6cbac59f87e78d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"พื้นผิวหน้าจอพร้อมแล้ว"</string>
@@ -578,7 +561,6 @@
     <string name="native_5fa1d457ddfcd26c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"rename group"</string>
     <string name="native_5fa7aac5375c5815" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"พร้อม"</string>
     <string name="native_5fc1927ca948f31c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไดอารีกำลังรอรายการแรก"</string>
-    <string name="native_6007acbe30b2cd98" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อนุมัติ"</string>
     <string name="native_600c9c27960112a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"หน้าไลฟ์"</string>
     <string name="native_6030d1f6340776d2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ระบบอัตโนมัติกำลังทำงานอยู่แล้ว"</string>
     <string name="native_604e6d6faf8d0295" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ลบระบบอัตโนมัตินี้หลังจากเรียกใช้แบบครั้งเดียวสำเร็จ"</string>
@@ -588,7 +570,6 @@
     <string name="native_60ea1847c2ba5446" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ยกเลิกการตอบกลับแล้ว"</string>
     <string name="native_6105d6cc76af4003" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รูปภาพ"</string>
     <string name="native_614b8348a2dbe46b" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"พักไว้ %1$s รายการ"</string>
-    <string name="native_614e83ef17c13f3c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีกระทู้ที่ตรงกัน"</string>
     <string name="native_6197595503f01ee2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"delete"</string>
     <string name="native_619837a134285528" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เลย์เอาต์: กะทัดรัด"</string>
     <string name="native_61ffa9c8c703dd5e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"channels"</string>
@@ -618,26 +599,19 @@
     <string name="native_6657cc73af00feac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อนุญาตให้ใช้เครื่องมือกล้องเมื่อมีการร้องขอ"</string>
     <string name="native_666067dd376e5d45" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปัญหา"</string>
     <string name="native_666c8bc0319f3b54" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การปลุกด้วยเสียง"</string>
-    <string name="native_66713d713e3a41c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปฏิเสธคำขอจับคู่แล้ว"</string>
     <string name="native_66b23bae66fc0d79" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s วันที่แล้ว"</string>
     <string name="native_66cf5513b37462be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"roles"</string>
     <string name="native_66d0f523a379b2de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skills"</string>
     <string name="native_66f4804ee23ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เก็บถาวร"</string>
     <string name="native_66fab2875ee427f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โหนดออฟไลน์ โปรดเชื่อมต่อใหม่แล้วลองอีกครั้ง"</string>
     <string name="native_6725e7bbcd28f3a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ระบบ"</string>
-    <string name="native_672f3453e1dd571b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"IP ระยะไกล"</string>
     <string name="native_674b38cae72bb0c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่ได้จัดกลุ่ม"</string>
     <string name="native_674eb55d9c353900" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รายละเอียดกำหนดการ"</string>
     <string name="native_67528858c36397f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ความสามารถของโทรศัพท์"</string>
     <string name="native_67a926f7008e2b0e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่พร้อมใช้งาน"</string>
-    <string name="native_67b696468610b879" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dashboard"</string>
     <string name="native_67fa416afa64d304" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"วางโทเค็น"</string>
     <string name="native_6827238fea72c88b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีผู้ให้บริการ"</string>
-    <string name="native_684889f0079cc145" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ลายนิ้วมือ SHA-256"</string>
-    <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ยังไม่มีเธรด"</string>
-    <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไมโครโฟน Bluetooth"</string>
     <string name="native_690dbe9dc0993c42" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ล่าสุด"</string>
-    <string name="native_6930c8d1fc4f01d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปลี่ยนชื่อกระทู้"</string>
     <string name="native_69384c1c4d99f6eb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่ทราบผลการดำเนินการ การดำเนินการจะยังคงถูกปิดใช้งานจนกว่าจะยืนยันบันทึกของ Gateway"</string>
     <string name="native_6940189433657105" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"dialog"</string>
     <string name="native_695c03727ff0251f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ฟังคำปลุก"</string>
@@ -668,7 +642,6 @@
     <string name="native_6d5d9004797377e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ใบอนุญาต"</string>
     <string name="native_6d7c95a353d873cd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อ Gateway เพื่อค้นหา Skills ใน ClawHub"</string>
     <string name="native_6df1bb18a59ab97d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ทักษะ"</string>
-    <string name="native_6e0a0b9d8c5ee4d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รหัสอุปกรณ์"</string>
     <string name="native_6e117ba97cbfb6f0" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway ไม่ได้ระบุผู้ให้บริการ %1$s ที่ใช้งานอยู่"</string>
     <string name="native_6e293a8c009e0011" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังรอ"</string>
     <string name="native_6e2c0963d056e104" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"บันทึกคำปลุกแล้ว"</string>
@@ -696,6 +669,7 @@
     <string name="native_710a5600e8adc434" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ClawHub ไม่ได้ส่งคืนเวอร์ชันที่ติดตั้งได้สำหรับ %1$s"</string>
     <string name="native_713166971d730f81" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คำสั่ง"</string>
     <string name="native_7143e424a2bf2663" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การอนุมัตินี้ถูกยกเลิกก่อนที่จะสามารถดำเนินการได้"</string>
+    <string name="native_71463bd14f924604" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีเซสชันปัจจุบัน"</string>
     <string name="native_716c3d1f55a7cd37" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไมค์เปิด · กำลังรอ Gateway"</string>
     <string name="native_7198eaa9f18ee413" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังแสดง %1$s จาก %2$s รายการ ปรับการค้นหาเพื่อดูเพิ่มเติม"</string>
     <string name="native_71aec38e93393296" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"มี v%1$s พร้อมใช้งาน"</string>
@@ -707,6 +681,7 @@
     <string name="native_7234213a42c2635b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิดโปรไฟล์"</string>
     <string name="native_7234d010e91c7bcf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เริ่ม Gateway ของคุณ"</string>
     <string name="native_72361961ef893ce1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ช่วยเปลี่ยนเป้าหมายนี้ให้เป็นรายการตรวจสอบที่นำไปใช้ได้จริง: "</string>
+    <string name="native_7296bfd468e09713" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ล้างการค้นหาเซสชัน"</string>
     <string name="native_72e9a59f5a1d6289" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"พอร์ต"</string>
     <string name="native_7344ef8e67c5337e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ป้อนรหัสตั้งค่า"</string>
     <string name="native_735cca45016888d0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถโหลดบันทึกของ Gateway ได้"</string>
@@ -717,7 +692,7 @@
     <string name="native_746f71ec623adc37" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Epoch มิลลิวินาที (ไม่บังคับ)"</string>
     <string name="native_7491b353909c1147" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีโมเดลที่กำหนดค่าไว้ รีเฟรชเพื่อตรวจสอบความพร้อมใช้งานอีกครั้ง"</string>
     <string name="native_74a883a037bc227f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การตั้งค่า"</string>
-    <string name="native_74c372f29b83df94" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กล้องหลัง"</string>
+    <string name="native_74cdd65b358733f1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สลับเลย์เอาต์เซสชัน"</string>
     <string name="native_74e21680eac7385c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"approve"</string>
     <string name="native_74e492d5d0df0bab" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ก่อนเริ่มต้น"</string>
     <string name="native_74f0a5d234edc4af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถโหลด Skills ได้"</string>
@@ -750,6 +725,7 @@
     <string name="native_78f25f393aa9bcbf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"sticker upload"</string>
     <string name="native_790d78931c21b895" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Messages to recover"</string>
     <string name="native_792175fb265c32bc" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw devices approve %1$s"</string>
+    <string name="native_7981cbd5763dfcbb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ยังไม่มีเซสชันที่ตรงกัน"</string>
     <string name="native_79a68a0d42388125" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รายละเอียดบันทึก Gateway ที่อ่านได้"</string>
     <string name="native_79a7ab236717f90d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตรวจสอบข้อเสนอ skill ที่สร้างขึ้นก่อนที่จะกลายเป็น skills ที่ใช้งานได้จริง"</string>
     <string name="native_79d3a1f108e8d9c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"มาพร้อมแพ็กเกจ"</string>
@@ -792,13 +768,11 @@
     <string name="native_8193ee8a22d25208" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปักหมุดโมเดล"</string>
     <string name="native_81c2c4f30a4bec68" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ล้างการค้นหา"</string>
     <string name="native_81d38aca5306940b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิดใช้งานสำหรับเอเจนต์ที่มีสิทธิ์"</string>
-    <string name="native_820d08e12968baff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีเธรดปัจจุบัน"</string>
     <string name="native_82250171708918de" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"หลังจาก %1$s"</string>
     <string name="native_825b9c75d7fed691" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อนุญาตให้ตัวจัดกำหนดการเรียกใช้ระบบอัตโนมัตินี้"</string>
     <string name="native_82990a093599a9bb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"นำไปใช้แล้ว %1$s รายการ"</string>
     <string name="native_8340dad4f3be30a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ยังไม่มีไดอารีความฝัน"</string>
     <string name="native_837e39f46163ffb4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รีเฟรชงานเบื้องหลัง"</string>
-    <string name="native_838337fd9ab30454" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สรุปเธรดล่าสุดและขั้นตอนถัดไป"</string>
     <string name="native_83e2faed20a3cda4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ทำงานบนอุปกรณ์ขณะที่ OpenClaw แสดงอยู่"</string>
     <string name="native_844e5b02f3ef05ca" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s กำลังทำงาน"</string>
     <string name="native_846c75dca0b71591" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
@@ -830,6 +804,7 @@
     <string name="native_88b01c8a4bff9a08" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สัญญาณ"</string>
     <string name="native_88e6e8384a7fc7ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เป้าหมายเซสชัน"</string>
     <string name="native_893a3e37d71c4563" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway บันทึกการปฏิเสธ"</string>
+    <string name="native_895f1e14d75d1239" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เซสชันที่เก็บถาวรจะแสดงที่นี่"</string>
     <string name="native_89713b9c9c1b8f65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ยอมรับ"</string>
     <string name="native_8998824610d49175" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ถาม OpenClaw ได้ทุกอย่าง"</string>
     <string name="native_89bbfe23c3917a3f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อใหม่เพื่อดำเนินการต่อ"</string>
@@ -845,11 +820,11 @@
     <string name="native_8bb7ec15b1e350a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังตรวจสอบ"</string>
     <string name="native_8bf253a125f66985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สแกนหรือวางรหัสการตั้งค่าเพื่อเพิ่ม Gateway อื่น"</string>
     <string name="native_8c4a3896e8f06d27" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"TLS หมดเวลา"</string>
-    <string name="native_8c55387fb6c584c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"นำอุปกรณ์ที่จับคู่ออกแล้ว"</string>
     <string name="native_8c93c68056cde54d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"จับคู่ Gateway แล้ว กำลังตรวจสอบการอนุมัติความสามารถของโหนด"</string>
     <string name="native_8ca344247c18317e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การเคลื่อนไหว"</string>
     <string name="native_8cac4b77b9c54695" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การดำเนินการ cron ล้มเหลว"</string>
     <string name="native_8cb2bab2ce6a17b2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"บนคอมพิวเตอร์ Gateway ให้รัน:"</string>
+    <string name="native_8cb650539ec84aa5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ค้นหาเซสชัน"</string>
     <string name="native_8d0839802b4d6aca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รีเฟรชบันทึก"</string>
     <string name="native_8d20273207a2fe99" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw nodes approve %1$s"</string>
     <string name="native_8d57374bc09c8756" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ข้อความเสียง · %1$s"</string>
@@ -869,7 +844,6 @@
     <string name="native_8f54b0d1e30092d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ข้อความเสียง"</string>
     <string name="native_8fa196125b734940" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีสิ่งใดต้องให้คุณดำเนินการ"</string>
     <string name="native_8fce9ec6fd5432df" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw ต้องการสิทธิ์อนุญาต %1$s เพื่อดำเนินการต่อ"</string>
-    <string name="native_8fe42acb8573244e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไมโครโฟนชุดหูฟังแบบมีสาย"</string>
     <string name="native_906115657390f367" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ส่งแล้ว"</string>
     <string name="native_9071738f145962a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ครบกำหนด"</string>
     <string name="native_90bf81305006e6ed" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รายละเอียด Skill ไม่พร้อมใช้งานในสถานะ Skills ปัจจุบัน"</string>
@@ -958,7 +932,6 @@
     <string name="native_9e37aa0704a3cf44" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ติดตั้ง %1$s แล้ว"</string>
     <string name="native_9e4635769f0aaf0d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway"</string>
     <string name="native_9e9bef85bb320b81" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โหมดการส่งต่อ"</string>
-    <string name="native_9f6e180ff696bec5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สลับเค้าโครงกระทู้"</string>
     <string name="native_9fb7c4ebcbc3e558" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีปลายทาง TLS"</string>
     <string name="native_9fe101a0ec7ef416" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway ของ OpenClaw"</string>
     <string name="native_9ffc843f501acdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตั้งค่าด้วยตนเอง"</string>
@@ -975,11 +948,14 @@
     <string name="native_a181b2c15994a7fc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ผู้ให้บริการเสียงพูด"</string>
     <string name="native_a190013f72efad35" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังดำเนินการอนุมัติ Gateway OpenClaw จะลองใหม่โดยอัตโนมัติ"</string>
     <string name="native_a1a5936d3b0f8a69" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สูงสุด"</string>
+    <string name="native_a1b5653a9f1b842b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีเซสชันที่เก็บถาวร"</string>
     <string name="native_a1bca979bc69befb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การเปลี่ยนแปลง cron ต้องมีสิทธิ์เข้าถึง operator.admin"</string>
     <string name="native_a20d12c5e9c428c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังคิด"</string>
     <string name="native_a23967c129397864" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screen snapshot"</string>
     <string name="native_a2bbc7ffd69f9c49" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่พบการดำเนินการ"</string>
     <string name="native_a2f29836cda5ceb1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"บันทึกและเชื่อมต่อ"</string>
+    <string name="native_a2fcbab533267340" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังตรวจสอบ · 1 เซสชัน"</string>
+    <string name="native_a32789d2b53dc704" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เซสชันปัจจุบัน"</string>
     <string name="native_a330395cc0a53ad1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list"</string>
     <string name="native_a34f54e488b48e66" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway บันทึกการอนุมัติและบันทึกตัวเลือกไว้แล้ว"</string>
     <string name="native_a37cf0a1111bf41c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ป้อน endpoint ด้วยตนเองที่ถูกต้องเพื่อเชื่อมต่อ"</string>
@@ -987,6 +963,7 @@
     <string name="native_a3e96435cb1ec7c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังส่งไปยังแชท..."</string>
     <string name="native_a4212f1e2fb0f506" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"บันทึกโปรไฟล์"</string>
     <string name="native_a424e33d90931d1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ล็อกแล้ว"</string>
+    <string name="native_a43f3627c39f1354" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังโหลดเซสชัน"</string>
     <string name="native_a450ea5e177b4787" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"แก้ไขระบบอัตโนมัติ"</string>
     <string name="native_a484bc216860979e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ใช้เครือข่ายเดียวกัน หรือ URL ของ Gateway ระยะไกลที่ปลอดภัย"</string>
     <string name="native_a4ae750b610e875e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"จุดยึด"</string>
@@ -1006,7 +983,6 @@
     <string name="native_a89bac8b89022bde" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังฟัง · อยู่ในคิว %1$s รายการ"</string>
     <string name="native_a8bbbd7231a6c191" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปิดเสียงพูดของผู้ช่วยแล้ว"</string>
     <string name="native_a8ef5cdf31a6505a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ยังไม่พบ Gateway ใช้การตั้งค่าด้วยตนเองหากการค้นหาถูกบล็อก"</string>
-    <string name="native_a901aa25b833cf33" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิดกระทู้"</string>
     <string name="native_a92f0449a9f7235b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังทำงาน"</string>
     <string name="native_a9624cf0b6ae80c1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เริ่มพูด..."</string>
     <string name="native_a9ac253267d07365" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โหนดโทรศัพท์"</string>
@@ -1038,14 +1014,14 @@
     <string name="native_ad1c341c65f84ede" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รันคำสั่ง approve บนคอมพิวเตอร์ Gateway แล้วตรวจสอบอีกครั้ง"</string>
     <string name="native_ad1fb9ec0cb3c7a4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การทำงานอัตโนมัติ"</string>
     <string name="native_adb7eb8a03ad699c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s นาที"</string>
+    <string name="native_adca3171c270301a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การลงชื่อเข้าใช้ Gateway นี้สามารถแสดงรายการโหนดที่เชื่อมต่อได้ แต่ไม่สามารถอนุมัติการจับคู่โทรศัพท์เครื่องใหม่ได้ โปรดจับคู่โทรศัพท์เครื่องใหม่จากเซสชันผู้ดูแล Gateway การอนุมัติความสามารถของโหนดเป็นกระบวนการแยกต่างหากและยังคงใช้ nodes approve &lt;request id&gt;"</string>
     <string name="native_ade9248e0132b411" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อถือ"</string>
     <string name="native_ae27fa789a03c1db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คิวอาร์โค้ดนั้นไม่ใช่คิวอาร์สำหรับตั้งค่า OpenClaw โปรดสร้างรหัสใหม่ด้วย openclaw qr แล้วลองอีกครั้ง"</string>
-    <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไมโครโฟนที่ต้องการไม่พร้อมใช้งาน กำลังใช้การกำหนดเส้นทางอัตโนมัติ"</string>
+    <string name="native_ae86062126fc1a52" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เซสชันใน \"%1$s\" จะถูกเก็บไว้และย้ายกลับไปยังไม่จัดกลุ่ม"</string>
     <string name="native_aea4a04a80426ed8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปฏิเสธแล้ว"</string>
     <string name="native_aed306fbb63c0c68" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รวมแพ็กเกจของ Android และแพ็กเกจเบื้องหลัง"</string>
     <string name="native_aedf1cf58372f943" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway ของคุณพร้อมใช้งานแล้ว"</string>
     <string name="native_aeffb9182e3d7f3d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ทริกเกอร์แล้ว"</string>
-    <string name="native_af1f10e9b3af3250" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Structured Output"</string>
     <string name="native_af60a38d6b5866ce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ใช้เวลานานกว่าที่คาดไว้\nตรวจสอบว่า Gateway กำลังทำงานและสามารถเข้าถึงได้"</string>
     <string name="native_af7deaf2c81b107d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีงานเบื้องหลังสำหรับเอเจนต์นี้"</string>
     <string name="native_afb118fcb16c3727" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังเชื่อมต่อใหม่"</string>
@@ -1059,6 +1035,7 @@
     <string name="native_b140db2544c7f8f5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw กำลังซิงค์ข้อมูลอีกครั้ง"</string>
     <string name="native_b1b3f74fe7e32ae1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สตรีมเหตุการณ์ถูกขัดจังหวะ โปรดลองรีเฟรช"</string>
     <string name="native_b1c1be6b126d151f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถโหลดโหนดและอุปกรณ์ได้"</string>
+    <string name="native_b205bb47f81a3096" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิดเซสชัน"</string>
     <string name="native_b2087b2e689f4946" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อ Gateway เพื่อโหลด Skills"</string>
     <string name="native_b23a6a8439c0dde5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่ทราบ"</string>
     <string name="native_b2439bcb8dee14b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ผลลัพธ์"</string>
@@ -1076,7 +1053,6 @@
     <string name="native_b4aca584eecea590" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถโหลดรายละเอียดงานได้"</string>
     <string name="native_b51702b087112113" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ข้อความจากเอเจนต์"</string>
     <string name="native_b538b9d40695a6fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway ต้องใช้อัตลักษณ์ของอุปกรณ์นี้ ยืนยันตัวตนใหม่หรือรีเซ็ตการเชื่อมต่อ Gateway นี้"</string>
-    <string name="native_b53b35163f7588c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เซสชันถัดไป"</string>
     <string name="native_b55dae19fcb48a4d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ความปลอดภัยของการเชื่อมต่อ"</string>
     <string name="native_b5a229ac8becc603" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เว็บไซต์"</string>
     <string name="native_b5af0517c02601fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อ Gateway เพื่อโหลดคำขออนุมัติในแอป"</string>
@@ -1104,11 +1080,10 @@
     <string name="native_b9d5d026db17b9e4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ล้มเหลว — %1$s"</string>
     <string name="native_ba599a4fe4b45b36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การเชื่อมต่อระหว่างโทรศัพท์เครื่องนี้กับ OpenClaw"</string>
     <string name="native_bae9264d6d972b80" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"summarize"</string>
+    <string name="native_bb4069d372f67683" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การดำเนินการนี้จะลบเซสชันและข้อความถอดเสียงอย่างถาวร"</string>
     <string name="native_bb4f2558e4333834" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"บันทึกรูปภาพวิดเจ็ตไปยัง Downloads แล้ว"</string>
     <string name="native_bbe5fc3b9ef39f99" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังเริ่มต้น…"</string>
     <string name="native_bc19cec293228fb8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ข้อผิดพลาดของไคลเอนต์"</string>
-    <string name="native_bc1c94a6dfce1058" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตรวจสอบอุปกรณ์ที่ส่งคำขอนี้ก่อนอนุญาตให้เข้าถึง"</string>
-    <string name="native_bc6618670f3e8a17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไมโครโฟน Bluetooth LE"</string>
     <string name="native_bcb06651437caa15" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
     <string name="native_bd08450d63406844" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิดใช้งานระบบอัตโนมัติแล้ว"</string>
     <string name="native_bd6719b455bcc898" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Memory Get"</string>
@@ -1116,7 +1091,6 @@
     <string name="native_bdc090ec61e3fcfc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โหลดใหม่"</string>
     <string name="native_bdff71b20b9cf392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ค้นหาระบบอัตโนมัติ"</string>
     <string name="native_be969becb173e0c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โทรศัพท์ที่เชื่อมโยงและโฮสต์โหนดจะแสดงที่นี่หลังจากการจับคู่"</string>
-    <string name="native_bf1870ff5c6322fb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s: %2$s"</string>
     <string name="native_bf350e6a0ed60b7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ระบบอัตโนมัตินี้มีการเปลี่ยนแปลงบน Gateway โปรดตรวจสอบเวอร์ชันล่าสุดก่อนบันทึกอีกครั้ง"</string>
     <string name="native_bf399ffa03617a96" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"หยุดการป้อนตามคำบอก"</string>
     <string name="native_bf56ee2fe3345ce1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อ่านง่าย"</string>
@@ -1134,13 +1108,11 @@
     <string name="native_c12a06263b75eb23" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อ Gateway เพื่อโหลดรายละเอียด Skill"</string>
     <string name="native_c156b9eaf502aabc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตัวฟังคำปลุก"</string>
     <string name="native_c184b2ada7abc688" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ขยายตัวอย่างลิงก์"</string>
-    <string name="native_c18ee03d3906a488" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ล้างการค้นหากระทู้"</string>
     <string name="native_c1970bb2cdf299b7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"NULL (ล้มเหลว)"</string>
     <string name="native_c1c1009d3f37ec05" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อัปเดต"</string>
     <string name="native_c1c224b03cd9bc7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ผู้ดูแลระบบ"</string>
     <string name="native_c1ebc7817870e5be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ต้องตรวจสอบ"</string>
     <string name="native_c22d5e02fbec7d65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"จับคู่อุปกรณ์นี้กับ Gateway ของคุณเพื่อปลุกอุปกรณ์เฉพาะเมื่อต้องทำงานจริง ดูภาพรวมของเอเจนต์แบบสดได้อย่างสะดวก และหลีกเลี่ยงลูปเบื้องหลังที่สิ้นเปลืองแบตเตอรี่"</string>
-    <string name="native_c25337055464f8d3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"บทบาท"</string>
     <string name="native_c253f451bdd56431" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตอบกลับ"</string>
     <string name="native_c26225b6c16a4bc7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"แค็ตตาล็อกผู้ให้บริการ"</string>
     <string name="native_c272b225cf5bd643" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิดใช้สิทธิ์อนุญาตในการตั้งค่า"</string>
@@ -1154,7 +1126,6 @@
     <string name="native_c34dd5eb8b0af56e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ฉันจะรับรหัสตั้งค่าได้จากที่ไหน?"</string>
     <string name="native_c3546b39ecbbed8a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถเปิดใช้งาน Skill ได้"</string>
     <string name="native_c35b21d6ca39aa7c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"pdf"</string>
-    <string name="native_c3812fc4acb861d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"นำออก"</string>
     <string name="native_c382566dbe2ea49f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s%% ออนไลน์"</string>
     <string name="native_c385951198c45d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีช่องทาง"</string>
     <string name="native_c41ad84496b53420" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เสียงแบบเรียลไทม์"</string>
@@ -1183,7 +1154,6 @@
     <string name="native_c6d5ed757b66bfd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ฝัน"</string>
     <string name="native_c6dd061350fc69b8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ยังไม่ได้บล็อกแอป แอปสามารถส่งต่อได้เว้นแต่คุณจะเพิ่มรายการบล็อก"</string>
     <string name="native_c753cdf0c19f1e38" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถใช้ตัวจดจำเสียงพูดได้"</string>
-    <string name="native_c78ffe19571018fb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"แพลตฟอร์ม"</string>
     <string name="native_c7985fa72daa6ea4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway ไม่ได้ส่งคืนการตั้งค่า %1$s"</string>
     <string name="native_c7b6dfd5c3a183c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ลืม Gateway หรือไม่?"</string>
     <string name="native_c7b7b7f01360f6a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คำอธิบายเพิ่มเติม (ไม่บังคับ)"</string>
@@ -1205,14 +1175,12 @@
     <string name="native_ca7981b46ecf2c17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปิด"</string>
     <string name="native_cab94aba84f97f7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รูปแบบตัวอักษร"</string>
     <string name="native_cae7d57bc067a514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"หยุด"</string>
-    <string name="native_cae98462b30650eb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ยังไม่มีกระทู้ที่ตรงกัน"</string>
     <string name="native_cba62d81f910c7f0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"จับคู่ Gateway สำเร็จแล้ว\nอนุมัติความสามารถของโหนดสำหรับโทรศัพท์เครื่องนี้จาก UI ของผู้ดูแลระบบ"</string>
     <string name="native_cc4b66e7e22230c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skills นี้ได้รับการติดตั้งแล้ว แต่ยังไม่พร้อมใช้งานในขณะนี้ โปรดใช้เดสก์ท็อปหรือ CLI เพื่อเปลี่ยนแปลงการกำหนดค่า"</string>
     <string name="native_cc5f45fb30a26e07" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตัวรู้จำไม่ว่าง"</string>
     <string name="native_cc721e25d73938a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway หลัก"</string>
     <string name="native_cc7a9a5cf8c4bc9d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เรียกใช้คำสั่งอนุมัติบน Gateway"</string>
     <string name="native_cc925e3c97ac7a35" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถโหลดข้อเสนอ Skill Workshop ได้"</string>
-    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สรุปเธรด OpenClaw ล่าสุดของฉันและแนะนำขั้นตอนถัดไป"</string>
     <string name="native_ccb4c324f516c633" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่ใช่ตอนนี้"</string>
     <string name="native_cced0b0d83a9e400" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw qr"</string>
     <string name="native_cced28c6dc3f99c2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"start"</string>
@@ -1235,7 +1203,6 @@
     <string name="native_ceb6931ea57cc999" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปรับอัตโนมัติ"</string>
     <string name="native_cf0ee3547a4e51a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เร็วๆ นี้"</string>
     <string name="native_d04fc7d7e19702f8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Search"</string>
-    <string name="native_d053ba98d8bbcec1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ลองใช้แชท เสียง กระทู้ ผู้ให้บริการ หรือการตั้งค่า"</string>
     <string name="native_d056177742e27cf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw กำลังทำงาน"</string>
     <string name="native_d0cda6559bb347db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"navigate"</string>
     <string name="native_d0d0de0039c7990b" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ส่งคำขอเมื่อ %1$s"</string>
@@ -1246,8 +1213,8 @@
     <string name="native_d17d2d78d76e6a6c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โมเดล"</string>
     <string name="native_d19c2dd2fb598b93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw แบบพาสซีฟ"</string>
     <string name="native_d1a574e23344c407" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รหัสผ่าน Gateway ไม่ถูกต้อง"</string>
-    <string name="native_d1af697abaff485f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถตรวจสอบการเปลี่ยนแปลงการจับคู่อุปกรณ์ได้ โปรดรีเฟรชแล้วลองอีกครั้ง"</string>
     <string name="native_d1bf045bb524dae5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ดูรายละเอียด"</string>
+    <string name="native_d1c835016021c20b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เซสชัน OpenClaw"</string>
     <string name="native_d1e9567da9a8a4b0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bash"</string>
     <string name="native_d2089be672953d11" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โทเค็น"</string>
     <string name="native_d20f43f925e706ce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เอเจนต์ OpenClaw ที่เชื่อมต่ออยู่สามารถใช้ความสามารถของอุปกรณ์ที่คุณเปิดใช้งานได้ ดำเนินการต่อเฉพาะเมื่อคุณเชื่อถือ Gateway และเอเจนต์ที่คุณเชื่อมต่อเท่านั้น"</string>
@@ -1261,10 +1228,8 @@
     <string name="native_d31de1a5c5c8ba2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เบราว์เซอร์"</string>
     <string name="native_d354ee936f59115e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screen record"</string>
     <string name="native_d3974fd6d3b6c81f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รอการเรียกใช้"</string>
-    <string name="native_d3e1c5f8a6e240fc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ต้นทาง"</string>
     <string name="native_d3f75e24411053c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"AI ส่วนตัวบนอุปกรณ์ของคุณ"</string>
     <string name="native_d406ade2958cb5b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attach"</string>
-    <string name="native_d461a493a3753877" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อัตโนมัติ"</string>
     <string name="native_d4b1ea5708dd5329" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ภาพรวม"</string>
     <string name="native_d53167a3f66debec" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ขอคืนค่าไม่สำเร็จ แตะเพื่อลองอีกครั้ง"</string>
     <string name="native_d588c689e03132fb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s\n\n"</string>
@@ -1277,7 +1242,6 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โปรไฟล์"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ขีดจำกัดของผู้ให้บริการจะแสดงที่นี่เมื่อ Gateway ของคุณรายงานข้อมูลดังกล่าว"</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปัญหา 1 รายการ"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กระทู้ใน \"%1$s\" จะยังคงอยู่และย้ายกลับไปยังไม่ได้จัดกลุ่ม"</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สร้างเมื่อ"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โทเค็นที่ใช้งานอยู่ %1$s/%2$s"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>
@@ -1294,7 +1258,6 @@
     <string name="native_d93e2b7a15efbc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถดำเนินการอนุมัติให้เสร็จสิ้นได้ โปรดรีเฟรชแล้วลองอีกครั้ง"</string>
     <string name="native_d942f64886578d87" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"import"</string>
     <string name="native_d94cfb21b67ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ลักษณะที่โทรศัพท์เครื่องนี้ปรากฏต่อ OpenClaw"</string>
-    <string name="native_d96f2b0eab4e67b7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โฟกัสการค้นหากระทู้"</string>
     <string name="native_d975ca28a64f8850" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อ Gateway"</string>
     <string name="native_d9be42d9b30ce057" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อ่านปฏิทิน"</string>
     <string name="native_d9f641e1a02807cb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ภาพรวมจะรีเฟรชเมื่อเชื่อมต่อใหม่และเมื่อเปิดหน้าจอนี้"</string>
@@ -1340,7 +1303,6 @@
     <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ค้นหา Skills ที่ติดตั้ง"</string>
     <string name="native_e0723a86a5b9408a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตรวจสอบ"</string>
     <string name="native_e083bd83e9d3e97e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Process"</string>
-    <string name="native_e08a8fc53e29e5c9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เธรดล่าสุด"</string>
     <string name="native_e0926fdac700b094" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เทอร์มินัล"</string>
     <string name="native_e0d1b68224bf0b31" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปัจจุบัน"</string>
     <string name="native_e10435f6306b06d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 บัญชี"</string>
@@ -1361,6 +1323,7 @@
     <string name="native_e3f0caab85e62600" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถอ่านคิวอาร์โค้ดจากรูปภาพนั้นได้ โปรดเลือกรูปภาพที่ชัดเจนกว่านี้หรือป้อนรหัสตั้งค่าด้วยตนเอง"</string>
     <string name="native_e3f90d1d0b07fb04" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway เก่ากว่าแอปนี้ โปรดอัปเดต OpenClaw บนโฮสต์ Gateway แล้วลองอีกครั้ง"</string>
     <string name="native_e41cc128c73bc85e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อก่อนใช้แชต เสียง และสถานะแบบเรียลไทม์"</string>
+    <string name="native_e424b24d86953102" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังค้นหาเซสชัน"</string>
     <string name="native_e4582b6fb1f57494" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อ Gateway อีกครั้ง"</string>
     <string name="native_e4696640127b9126" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"บุคคลที่สาม"</string>
     <string name="native_e482357257d6c2fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตรวจสอบความพร้อม"</string>
@@ -1369,13 +1332,11 @@
     <string name="native_e52b3044724b9f4d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เลิกปักหมุดโมเดล"</string>
     <string name="native_e5584bc5057284ae" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"พื้นผิวการส่งข้อความที่เชื่อมต่อกับ Gateway นี้"</string>
     <string name="native_e595f17fac1d8384" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังส่ง"</string>
-    <string name="native_e5b87192a9e6321f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เธรดที่เก็บถาวรจะแสดงที่นี่"</string>
     <string name="native_e5c02424e511e1ef" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คัดลอกคำสั่งแล้ว"</string>
     <string name="native_e5c083cf41ff6472" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีตัวอย่างให้ใช้งาน"</string>
     <string name="native_e5c3e7b8110e7087" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อนุมัติโทรศัพท์เครื่องนี้บน Gateway\nจากนั้นลองเชื่อมต่ออีกครั้ง"</string>
     <string name="native_e5c7478bbce26eb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สแกนรหัส QR"</string>
     <string name="native_e5e4f854dcd3ffc6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไดเรกทอรีทำงานของคำสั่ง · ไม่สามารถล้างได้"</string>
-    <string name="native_e614ccf26ec5d312" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กิจกรรมของเธรด"</string>
     <string name="native_e674447337e83c13" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"พร้อมใช้งาน"</string>
     <string name="native_e68e23dc04b0f986" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ลบระบบอัตโนมัติหรือไม่?"</string>
     <string name="native_e7053d96b6704dbb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s วันนี้ · ทั้งหมด %2$s"</string>
@@ -1448,9 +1409,9 @@
     <string name="native_f2bfed0b0c0055db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การตอบกลับด้วยเสียงหมดเวลา กำลังลองส่งรายการที่รออยู่อีกครั้ง"</string>
     <string name="native_f2cb21c53a33f72c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เลย์เอาต์: รายละเอียด"</string>
     <string name="native_f2da2e47cd31a5dd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถถอดรหัสรูปภาพนี้ได้"</string>
+    <string name="native_f2ecdaf77d1d98d3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw เปลี่ยนโทรศัพท์เครื่องนี้ให้เป็นอินเทอร์เฟซคำสั่งบนมือถือที่เรียบง่ายสำหรับเซสชัน เสียง ผู้ให้บริการ และ Gateway"</string>
     <string name="native_f3753c0fe29b88db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway, เสียง, การแจ้งเตือน, ความเป็นส่วนตัว"</string>
     <string name="native_f386c32c1bf437d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไฟล์พื้นที่ทำงานของเอเจนต์"</string>
-    <string name="native_f418bf0894a1806a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อุปกรณ์นี้จะสูญเสียสิทธิ์การเข้าถึง Gateway ที่เชื่อถือได้"</string>
     <string name="native_f41d9e8b7e09aa24" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ใช้ requestId จากคำสั่งที่รอดำเนินการในคำสั่ง approve"</string>
     <string name="native_f4830a1dae298044" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำหนดการ"</string>
     <string name="native_f493f0ce7a52a8aa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ขีดจำกัดอัตรา"</string>
@@ -1458,14 +1419,14 @@
     <string name="native_f4cc820d308495c4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เพย์โหลด · %1$s"</string>
     <string name="native_f4ccae29e1bb0c20" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังทำงาน"</string>
     <string name="native_f4db1e48476f6075" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สิ้นสุด"</string>
-    <string name="native_f4e2076014711222" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ใช้ความเชื่อถือของระบบ"</string>
     <string name="native_f4ef7a41caa88dd1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีผู้ให้บริการที่พร้อมใช้งาน"</string>
-    <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ให้ความสำคัญกับไมโครโฟน Bluetooth ที่เชื่อมต่ออยู่"</string>
+    <string name="native_f502267deff4108d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ยังไม่มีเซสชัน"</string>
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"บล็อกไม่ให้ส่งต่อ %1$s แอป"</string>
     <string name="native_f532ee1f7288365e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การดำเนินการกับข้อความ"</string>
     <string name="native_f5387f9bb6ed7031" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ประเภท"</string>
     <string name="native_f565318d124534cf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ยกเลิกการเก็บถาวร"</string>
     <string name="native_f584049cab5f523e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Transcripts"</string>
+    <string name="native_f59b46c265d8d38f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เซสชันล่าสุด"</string>
     <string name="native_f5f0563199a5b403" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คำปลุก"</string>
     <string name="native_f616dfac9815faea" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำหนดค่า %1$s บน Gateway"</string>
     <string name="native_f61d0c645f00a4ed" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สแกนคิวอาร์โค้ดหรือใช้รหัสตั้งค่าจาก OpenClaw Gateway ของคุณ"</string>
@@ -1486,7 +1447,6 @@
     <string name="native_f8b32f4e92bd84ce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ติดตั้งแล้ว"</string>
     <string name="native_f8c2745155505d39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"หมดเวลารอการตอบกลับ โปรดลองอีกครั้งหรือรีเฟรช"</string>
     <string name="native_f8cd133f0ea1031b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ค้นหาการสนทนาก่อนหน้า"</string>
-    <string name="native_f90f3791049b995d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เรียกดูกระทู้"</string>
     <string name="native_f92e2ad582c0e13f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังรีเฟรช"</string>
     <string name="native_f991ae9cb081e1f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิดกล้องและจัดให้รหัสจาก openclaw qr อยู่ในกรอบ"</string>
     <string name="native_f9ea3f1540eaa584" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีอุปกรณ์"</string>
@@ -1508,7 +1468,6 @@
     <string name="native_fcdeb9947bc94101" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ทดสอบ ทดสอบ 1 2 3"</string>
     <string name="native_fcea13c79c2f85a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถค้นหา Skills ใน ClawHub ได้"</string>
     <string name="native_fd175ecd65f7353d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีพรอมต์"</string>
-    <string name="native_fd301dc5d0e7ccf1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กล้องหน้า"</string>
     <string name="native_fda8fc3b85420d14" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิดรายการบันทึก"</string>
     <string name="native_fdd0d769c49517c2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"หมดเวลาการเชื่อมต่อเครือข่าย"</string>
     <string name="native_fe18013d93d22f4f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตอนนี้"</string>
@@ -1518,11 +1477,10 @@
     <string name="native_ff2670a0df18e148" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"thread list"</string>
     <string name="native_ff332eeb6b2de1da" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิด %1$s"</string>
     <string name="native_ff4085ad157354dc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"upload"</string>
+    <string name="native_ff4d6b7484fbfc1f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กิจกรรมของเซสชัน"</string>
     <string name="native_ff52188203241c29" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ยังไม่ได้กำหนดค่ารหัสผ่าน Gateway"</string>
     <string name="native_ff716fc4735e067f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การตั้งค่าการป้อนตามคำบอก"</string>
     <string name="native_ff9dbbdfb84ddab2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โหลดโมเดลของผู้ให้บริการแล้ว แต่ไม่มีข้อมูลความพร้อมใช้งาน"</string>
-    <string name="native_ffa7aa557b547a79" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ลบกระทู้หรือไม่?"</string>
-    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw เปลี่ยนโทรศัพท์เครื่องนี้ให้เป็นอินเทอร์เฟซคำสั่งบนมือถือที่เรียบง่ายสำหรับเธรด เสียง ผู้ให้บริการ และ Gateway"</string>
     <string name="native_ffb6f5764bddb68c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ใหม่สุดก่อน"</string>
     <string name="native_ffcf16006c652ee3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รอบถัดไป"</string>
 </resources>

--- a/apps/android/app/src/main/res/values-th/strings.xml
+++ b/apps/android/app/src/main/res/values-th/strings.xml
@@ -24,12 +24,14 @@
     <string name="native_002a6fcb30b2def4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถเตรียมไฟล์แนบสำหรับส่งได้"</string>
     <string name="native_003aaf9e0a0e6b9f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปิดไมค์"</string>
     <string name="native_0060cbfdd3cf13ba" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"แสดงการแจ้งเตือนจาก OpenClaw"</string>
+    <string name="native_0077032d7e9f9cbe" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Thread activity"</string>
     <string name="native_008dacb6d1e85bd8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เต็มรูปแบบ"</string>
     <string name="native_009506aeb0484b2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อนุมัติและบันทึกแล้ว"</string>
     <string name="native_00d108e2e6466940" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"แสดงประวัติการโทรล่าสุด"</string>
     <string name="native_00e8aeba41d79ce3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รอดำเนินการ 1 รายการ"</string>
     <string name="native_010f6550a1c8f554" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไฟล์แนบที่ไม่รองรับ"</string>
     <string name="native_01267be21eb77392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"0 = แม่นยำ"</string>
+    <string name="native_0171e3d4e07f1861" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Connect the Gateway to search threads."</string>
     <string name="native_0174f83136630e7e" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s บัญชี"</string>
     <string name="native_01ac1c298e0cbd9a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การเปลี่ยนแปลง Cron ต้องใช้ operator.admin โดยรหัสตั้งใจจะไม่ให้สิทธิ์นี้ โปรดเชื่อมต่อกับโทเค็นที่ใช้ร่วมกันหรือรหัสผ่านของ Gateway อีกครั้งเพื่อขอสิทธิ์ผู้ดูแลระบบ หากอุปกรณ์นี้ยังไม่มีสิทธิ์ดังกล่าว ให้อนุมัติการอัปเกรดขอบเขตที่รอดำเนินการจากไคลเอนต์ผู้ดูแลระบบที่มีอยู่"</string>
     <string name="native_01bcfe7a9296b6d6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Apply Patch"</string>
@@ -68,8 +70,10 @@
     <string name="native_088e0e5ebc96c6ac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"แทนที่การตั้งค่า Gateway หรือไม่?"</string>
     <string name="native_08a5391c1de3078a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถโหลดระบบอัตโนมัติได้"</string>
     <string name="native_08b041935798fbf6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คุณ"</string>
+    <string name="native_08ea63ee26954dca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Built-in microphone"</string>
     <string name="native_0905f7f59021c2a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"พื้นผิว"</string>
     <string name="native_0929c9dc7f794852" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีข้อเสนอ"</string>
+    <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Main thread"</string>
     <string name="native_0979c6fdbdca1675" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิดแชต"</string>
     <string name="native_0a0b7cf7c428c703" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คำขอดำเนินการ"</string>
     <string name="native_0a708e7b03aaf1fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list pins"</string>
@@ -84,7 +88,6 @@
     <string name="native_0c3ea4e2f12153e7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิด OpenClaw แล้วถาม %1$s"</string>
     <string name="native_0c4d01e81bb3d1fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การให้เหตุผล"</string>
     <string name="native_0c79a9c222840ed0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ใช้งานแล้ว"</string>
-    <string name="native_0c8056e18fdf290c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การเรียกใช้เครื่องมือแชทที่รออยู่ในเซสชันที่ใช้งานอยู่จะยังคงแสดงที่นี่"</string>
     <string name="native_0cab1c9617404faf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"วิดีโอ"</string>
     <string name="native_0cf04463c4276a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เลื่อนระดับแล้ว"</string>
     <string name="native_0d21bd52022ca7f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ออนไลน์"</string>
@@ -98,11 +101,10 @@
     <string name="native_0e91610117029a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รีเฟรช"</string>
     <string name="native_0ee30822ed35a792" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อยู่ในคิว %1$s รายการ"</string>
     <string name="native_0f4c8529742b31ea" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เริ่มแชท"</string>
+    <string name="native_0f559ff270904904" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Chat tool calls waiting in the active thread remain visible here."</string>
     <string name="native_0f56cc286a4f23d8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"จำเป็นต้องตรวจสอบใบรับรอง"</string>
-    <string name="native_0f822f33a3100b5c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังตรวจสอบ · %1$s เซสชัน"</string>
     <string name="native_0f8fe3a9688138a1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิดพื้นผิว Canvas ปัจจุบันเพื่อตรวจสอบหรือโต้ตอบกับมัน"</string>
     <string name="native_0ff98f05be01ce5e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อัปเดตระบบอัตโนมัติแล้ว"</string>
-    <string name="native_100ac08064a6d586" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีเซสชันล่าสุด"</string>
     <string name="native_1039e92fa05c1279" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สถานะ Gateway, ความพร้อมของโหนดโทรศัพท์ และสตรีมบันทึกล่าสุด"</string>
     <string name="native_106808530413298b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิดรายละเอียดการทำงานอัตโนมัติ"</string>
     <string name="native_1093115897879aa3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รันไทม์"</string>
@@ -114,13 +116,13 @@
     <string name="native_1196c7b1e0e55580" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"reactions"</string>
     <string name="native_11a6767d5674c7e4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เสร็จสิ้น"</string>
     <string name="native_11e18d6748aa9128" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เวอร์ชันและการอัปเดต"</string>
-    <string name="native_11e47358a692d81b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สรุปเซสชันล่าสุดและขั้นตอนถัดไป"</string>
     <string name="native_11f37f9652a47b5b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw จะแสดงการอนุมัติ งานที่ล้มเหลว และปัญหาของช่องทางไว้ที่นี่"</string>
+    <string name="native_11f6dc0befae5081" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"USB microphone"</string>
     <string name="native_1242bf5561713a98" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"มีการแชร์รอเพิ่มมากเกินไป"</string>
-    <string name="native_1251aefc12b2b10e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ลบเซสชัน?"</string>
     <string name="native_12698ce1ea5cd4ab" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ข้ามแล้ว"</string>
     <string name="native_1291833ee42d8143" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ใช้ที่อยู่ LAN ของคอมพิวเตอร์ Gateway หรือชื่อโฮสต์ระยะไกลที่ปลอดภัย"</string>
     <string name="native_130011756125313c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิด"</string>
+    <string name="native_133f293961d7aa43" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Searching threads"</string>
     <string name="native_13798c3256e792c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การพูดคุยแบบเรียลไทม์"</string>
     <string name="native_13b588109e423636" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw กำลังเตรียมคำตอบ"</string>
     <string name="native_13ba4cde12390943" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อนุมัติหนึ่งครั้ง"</string>
@@ -136,6 +138,7 @@
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เป้าหมายเซสชัน"</string>
     <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตรวจสอบ Skill จาก ClawHub"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
+    <string name="native_16b1a05e1d987ed1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Preferred microphone"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โฮสต์โหนด"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ระดับ"</string>
     <string name="native_172b997ffbc8c9a7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปิดตัวเลือกแอป"</string>
@@ -155,6 +158,7 @@
     <string name="native_18f2a0947f9d6523" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ถูกบล็อก"</string>
     <string name="native_18f6e5973bc41268" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คำหรือวลีปลุก"</string>
     <string name="native_1906b261e6e0fdd0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway ต้องได้รับการอนุมัติอุปกรณ์"</string>
+    <string name="native_19408baaf5c2e446" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"External microphone"</string>
     <string name="native_194a05367fb28913" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"พร้อมใช้งาน %1$s/%2$s"</string>
     <string name="native_199e261f8ee0e97f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อแล้ว (ผู้ควบคุมออฟไลน์)"</string>
     <string name="native_19fc7a47df16fb1f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ความสามารถยังไม่ได้รับการอนุมัติ"</string>
@@ -206,6 +210,7 @@
     <string name="native_22965568d22a14ee" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อแล้ว"</string>
     <string name="native_22a970d2e5b1cc23" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เสร็จสมบูรณ์"</string>
     <string name="native_22b8da9e693e94eb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โทรศัพท์ของคุณจับคู่กับ %1$s แล้ว ดำเนินการต่อเพื่อเปิดสิทธิ์เข้าถึงโหนดให้เสร็จสมบูรณ์"</string>
+    <string name="native_22f19ab686639b9a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Current thread"</string>
     <string name="native_23246d9852fed325" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การคิด %1$s"</string>
     <string name="native_2346f214ad56b180" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปิดเสียง"</string>
     <string name="native_2347fc06da5f60de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw ขอขอบคุณพันธมิตรในชุมชนโอเพนซอร์ส"</string>
@@ -232,11 +237,11 @@
     <string name="native_262c897a1f408b0b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อกับ Gateway ของคุณ"</string>
     <string name="native_2682bd813a3bccbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ป้อนรหัสตั้งค่าจาก openclaw qr"</string>
     <string name="native_268f14bbfe119c1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การวินิจฉัย"</string>
+    <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"This permanently deletes the thread and its transcript."</string>
     <string name="native_26f0dd993530eb2d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังลองใหม่โดยอัตโนมัติ"</string>
     <string name="native_270ff82f36da987f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คัดลอกรูปภาพวิดเจ็ตแล้ว"</string>
     <string name="native_2728740a95d465c6" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s บทบาท"</string>
     <string name="native_272955a627b71681" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ขาด 1 รายการ"</string>
-    <string name="native_2732406e3be52c5b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่พบเซสชันที่ตรงกัน"</string>
     <string name="native_2748442ae65e27e8" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำหนดเวลาไว้ %1$s งาน"</string>
     <string name="native_275976081ce1abf6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"react"</string>
     <string name="native_279b44d2ab4b40c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เอเจนต์"</string>
@@ -248,6 +253,7 @@
     <string name="native_27d773b934ed324f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตรวจสอบและติดตั้ง"</string>
     <string name="native_2821f0168d6dd9df" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปลี่ยนอุปกรณ์นี้ให้เป็นโหนด OpenClaw ที่ปลอดภัยสำหรับแชท, เสียง, กล้อง และเครื่องมืออุปกรณ์"</string>
     <string name="native_2831546121359362" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตั้งค่าด้วยตนเอง"</string>
+    <string name="native_287c4b113aafc215" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Open Chat to start or resume the current thread."</string>
     <string name="native_28bb849671cab958" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เคล็ดลับ: หยุดฟังเพื่อส่งช่วงที่บันทึกไว้"</string>
     <string name="native_28d03596d24eeb4e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ข้าม"</string>
     <string name="native_28d55ec6974d84e8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คำขอด้วยเสียงล้มเหลว"</string>
@@ -267,9 +273,10 @@
     <string name="native_2c19d584bf8ad518" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ทำเครื่องหมายว่ายังไม่ได้อ่าน"</string>
     <string name="native_2c75802a5f8df5f8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ค้นหาบุคคลและรายละเอียดการติดต่อ"</string>
     <string name="native_2c9cce8250d746e3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ต้องระบุตัวตนอุปกรณ์"</string>
-    <string name="native_2cad0766accc2d3f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปลี่ยนชื่อเซสชัน"</string>
+    <string name="native_2cd62f7a670b2819" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw thread"</string>
     <string name="native_2d4dfe885f84629e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อนุญาตการเข้าถึงคลังรูปภาพ"</string>
     <string name="native_2d6416405eb44982" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การตอบกลับก่อนหน้านี้ดำเนินการอนุมัตินี้แล้ว"</string>
+    <string name="native_2d85de9d56c226e4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"No recent threads"</string>
     <string name="native_2df01a03ff43400b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่พบรายการที่ตรงกัน"</string>
     <string name="native_2df30b117ad829ab" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อ่านการแจ้งเตือนจากแอปที่เลือก"</string>
     <string name="native_2e0078a8322d6f1f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่ทราบสถานะความพร้อมใช้งาน"</string>
@@ -331,6 +338,7 @@
     <string name="native_36c725ddb20f8bd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การตั้งค่าผู้ให้บริการ Talk"</string>
     <string name="native_36d88ed6cc91d2b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Music Generation"</string>
     <string name="native_36e8d5e94219dc37" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การตั้งค่าการคุย"</string>
+    <string name="native_36f1fac278711470" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · 1 thread"</string>
     <string name="native_37053dc1f680546b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ข้อความ Payload"</string>
     <string name="native_37582309e7a1dbe5" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การอนุมัติ %1$s"</string>
     <string name="native_379ce0aacf46c35f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway ไม่ได้ส่งคืนความพร้อมของ %1$s"</string>
@@ -355,18 +363,19 @@
     <string name="native_3a65cf1204f18864" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อแล้ว (โหนดออฟไลน์)"</string>
     <string name="native_3a78695388b38b5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"หน้าแรก"</string>
     <string name="native_3b28b535950f8175" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การป้อนตามคำบอกกำลังฟังอยู่"</string>
+    <string name="native_3b46b7912670bfb0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"No archived threads"</string>
     <string name="native_3b851469ea31d489" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เลือกและตรวจสอบผู้ช่วยที่พร้อมใช้งานบน gateway นี้"</string>
     <string name="native_3be0085a6bd88cdd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โหมดพูดคุยทำงานอยู่"</string>
     <string name="native_3bee4ede6bf4436c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังทำงาน · มีงานที่ใช้งานอยู่ 1 รายการ"</string>
     <string name="native_3c6168bbf86e6e4b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ยอมรับและเปิดใช้งาน"</string>
     <string name="native_3cb27ae0fbca8ae3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คัดลอกรูปภาพ"</string>
-    <string name="native_3d013d4e9cf973f9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ลองใช้ Chat, Voice, Sessions, Providers หรือ Settings"</string>
     <string name="native_3d06950825de7452" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"URL ของ Gateway"</string>
     <string name="native_3d200f624b8bda8f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"main, isolated, current หรือ session:&lt;id&gt;"</string>
     <string name="native_3d61e9d54ffa2d93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อกับ Gateway ของคุณเพื่อเปิดเชลล์ในพื้นที่ทำงานของเอเจนต์"</string>
     <string name="native_3da4811eafea080a" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s://%2$s:%3$s"</string>
     <string name="native_3de3d401128d4395" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถโหลดรายละเอียดการอนุมัติได้ รีเฟรชแล้วลองอีกครั้ง"</string>
     <string name="native_3e398e6fb979557a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tool Call"</string>
+    <string name="native_3e42e385075b9b56" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads"</string>
     <string name="native_3f00927a719345ed" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Write"</string>
     <string name="native_3f25ccebfa99dcf3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เริ่มต้นด้วยพรอมต์ หรือใช้เสียง"</string>
     <string name="native_3f39d5c348e5b79d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"D"</string>
@@ -393,6 +402,7 @@
     <string name="native_4287d54ad5e78985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"งาน OpenClaw ที่กำหนดเวลาไว้จาก gateway ของคุณ"</string>
     <string name="native_429f6057535c1ea3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sub-agent"</string>
     <string name="native_42e3a99c21767def" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังรอการอนุมัติอุปกรณ์"</string>
+    <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Loading thread"</string>
     <string name="native_43905968a540af6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การหน่วงเหลื่อม ms"</string>
     <string name="native_43988c156beabf7d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"event create"</string>
     <string name="native_43cc23fa52b87b4c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เอกสาร"</string>
@@ -451,13 +461,11 @@
     <string name="native_4d5e590b23745b4d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skills ที่ติดตั้งบน Gateway จะแสดงที่นี่"</string>
     <string name="native_4dee3342f86128c1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รหัสอาจหมดอายุแล้วหรือถูกสร้างขึ้นสำหรับ Gateway อื่น"</string>
     <string name="native_4e25d34a20313a61" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ต้องได้รับอนุญาต"</string>
-    <string name="native_4e35d595e6975128" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กิจกรรมเซสชัน"</string>
     <string name="native_4e8c72cab82e0711" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ระบบอัตโนมัติมีการกำหนดค่าที่ไม่ถูกต้อง"</string>
     <string name="native_4ec30e9d85725d41" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รายการที่อนุญาต"</string>
     <string name="native_4ed379d418bb8629" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"groups"</string>
     <string name="native_4efca0d10c5feb8e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เกี่ยวกับ"</string>
     <string name="native_4f1bc100d1dccc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่พบคิวอาร์โค้ดสำหรับตั้งค่าในรูปภาพนั้น โปรดเลือกคิวอาร์ที่สร้างโดย openclaw qr หรือป้อนรหัสตั้งค่าด้วยตนเอง"</string>
-    <string name="native_4f993457edb69110" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เรียกดูเซสชัน"</string>
     <string name="native_4fe3cdd404ea0290" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"permissions"</string>
     <string name="native_5047cfb3b607e7d0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อ Gateway เพื่อโหลดโหนดและอุปกรณ์ที่จับคู่แล้ว"</string>
     <string name="native_5083cd4b96b0d09d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มี Skills"</string>
@@ -476,6 +484,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การส่ง"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปิดเสียงลำโพง"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังเปิดการเชื่อมต่อ Gateway"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การทำงานของระบบอัตโนมัติเสร็จสิ้นแล้ว"</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่พบแอปที่ตรงกัน"</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ส่งไปยังแชท"</string>
@@ -492,7 +501,6 @@
     <string name="native_544731b8da90eb65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"emoji list"</string>
     <string name="native_544d9e42216c2ac0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ทำซ้ำ"</string>
     <string name="native_54b41550b1247912" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ค้นหา OpenClaw"</string>
-    <string name="native_54d5c8a4eb7898dc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เซสชันหลัก"</string>
     <string name="native_54e08ca4a25fe3f1" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รอดำเนินการ %1$s รายการ"</string>
     <string name="native_5542bc6a5f3ae4da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถใช้การรู้จำเสียงบนอุปกรณ์ได้"</string>
     <string name="native_55546edf686ab168" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีแอปที่สามารถแชร์ข้อความนี้ได้"</string>
@@ -501,13 +509,13 @@
     <string name="native_55898449eb74fb2e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สถานภาพ"</string>
     <string name="native_55a12cbe0995e214" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตัวรับฟังการแจ้งเตือน"</string>
     <string name="native_55d8e7da6d0a752c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปิดเสียงลำโพงแล้ว"</string>
-    <string name="native_5638a97380146882" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิดแชทเพื่อเริ่มหรือกลับไปใช้เซสชันปัจจุบัน"</string>
+    <string name="native_560d3e826c413dc9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Search threads"</string>
     <string name="native_565339bc4d33d728" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตกลง"</string>
     <string name="native_56a508f3f2bf424a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถเปิดคู่มือการตั้งค่าได้"</string>
     <string name="native_56c41c606c44f3fc" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ถาม OpenClaw %1$s"</string>
+    <string name="native_56c4c3d30ceda56e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wait for Agents"</string>
     <string name="native_56ef8f20955f2564" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ที่อยู่"</string>
     <string name="native_5702e1d243eeb4e9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"งานตามกำหนดการที่สร้างบน Gateway จะปรากฏที่นี่"</string>
-    <string name="native_5719080df7834f1b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อ Gateway เพื่อค้นหาเซสชัน"</string>
     <string name="native_572739b05d138f8a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังแสดงส่วนบันทึกล่าสุด"</string>
     <string name="native_57666930af1af35e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ใช้รหัสตั้งค่า"</string>
     <string name="native_57c4b13a4c7335e7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"sticker"</string>
@@ -519,7 +527,6 @@
     <string name="native_5855b3ac2fcc1b3e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"แก้ไขการเชื่อมต่อ"</string>
     <string name="native_58e909c0f4cc5723" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"บันทึกรูปภาพ"</string>
     <string name="native_590b0003ccaad929" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โหนด %1$s"</string>
-    <string name="native_5922c3814cbbdbce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สรุปเซสชัน OpenClaw ล่าสุดของฉันและแนะนำขั้นตอนถัดไป"</string>
     <string name="native_59235e6ebfd03967" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ต้องใช้รหัสผ่าน Gateway"</string>
     <string name="native_592acaa91843913b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Update Plan"</string>
     <string name="native_595b066a8838734a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ลบไฟล์แนบ"</string>
@@ -534,7 +541,6 @@
     <string name="native_5a7d4412c13abceb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw กำลังพูด"</string>
     <string name="native_5a99f6fa7e98657a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สแกน QR"</string>
     <string name="native_5ab9d81fd481e71f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"แอปที่เลือก"</string>
-    <string name="native_5b3522ef7c1c149e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โฟกัสช่องค้นหาเซสชัน"</string>
     <string name="native_5b36e77f2018303f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ย้อนกลับการเปลี่ยนแปลง"</string>
     <string name="native_5b4ddab77c412d6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คัดลอกคำสั่งอนุมัติแล้ว"</string>
     <string name="native_5b7c4c081e9c5810" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สถานะการส่ง"</string>
@@ -570,6 +576,7 @@
     <string name="native_60ea1847c2ba5446" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ยกเลิกการตอบกลับแล้ว"</string>
     <string name="native_6105d6cc76af4003" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รูปภาพ"</string>
     <string name="native_614b8348a2dbe46b" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"พักไว้ %1$s รายการ"</string>
+    <string name="native_614e83ef17c13f3c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"No matching threads"</string>
     <string name="native_6197595503f01ee2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"delete"</string>
     <string name="native_619837a134285528" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เลย์เอาต์: กะทัดรัด"</string>
     <string name="native_61ffa9c8c703dd5e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"channels"</string>
@@ -609,9 +616,13 @@
     <string name="native_674eb55d9c353900" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รายละเอียดกำหนดการ"</string>
     <string name="native_67528858c36397f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ความสามารถของโทรศัพท์"</string>
     <string name="native_67a926f7008e2b0e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่พร้อมใช้งาน"</string>
+    <string name="native_67b696468610b879" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dashboard"</string>
     <string name="native_67fa416afa64d304" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"วางโทเค็น"</string>
     <string name="native_6827238fea72c88b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีผู้ให้บริการ"</string>
+    <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"No threads yet"</string>
+    <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bluetooth microphone"</string>
     <string name="native_690dbe9dc0993c42" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ล่าสุด"</string>
+    <string name="native_6930c8d1fc4f01d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rename thread"</string>
     <string name="native_69384c1c4d99f6eb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่ทราบผลการดำเนินการ การดำเนินการจะยังคงถูกปิดใช้งานจนกว่าจะยืนยันบันทึกของ Gateway"</string>
     <string name="native_6940189433657105" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"dialog"</string>
     <string name="native_695c03727ff0251f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ฟังคำปลุก"</string>
@@ -669,7 +680,6 @@
     <string name="native_710a5600e8adc434" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ClawHub ไม่ได้ส่งคืนเวอร์ชันที่ติดตั้งได้สำหรับ %1$s"</string>
     <string name="native_713166971d730f81" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คำสั่ง"</string>
     <string name="native_7143e424a2bf2663" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การอนุมัตินี้ถูกยกเลิกก่อนที่จะสามารถดำเนินการได้"</string>
-    <string name="native_71463bd14f924604" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีเซสชันปัจจุบัน"</string>
     <string name="native_716c3d1f55a7cd37" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไมค์เปิด · กำลังรอ Gateway"</string>
     <string name="native_7198eaa9f18ee413" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังแสดง %1$s จาก %2$s รายการ ปรับการค้นหาเพื่อดูเพิ่มเติม"</string>
     <string name="native_71aec38e93393296" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"มี v%1$s พร้อมใช้งาน"</string>
@@ -681,7 +691,6 @@
     <string name="native_7234213a42c2635b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิดโปรไฟล์"</string>
     <string name="native_7234d010e91c7bcf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เริ่ม Gateway ของคุณ"</string>
     <string name="native_72361961ef893ce1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ช่วยเปลี่ยนเป้าหมายนี้ให้เป็นรายการตรวจสอบที่นำไปใช้ได้จริง: "</string>
-    <string name="native_7296bfd468e09713" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ล้างการค้นหาเซสชัน"</string>
     <string name="native_72e9a59f5a1d6289" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"พอร์ต"</string>
     <string name="native_7344ef8e67c5337e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ป้อนรหัสตั้งค่า"</string>
     <string name="native_735cca45016888d0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถโหลดบันทึกของ Gateway ได้"</string>
@@ -692,7 +701,7 @@
     <string name="native_746f71ec623adc37" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Epoch มิลลิวินาที (ไม่บังคับ)"</string>
     <string name="native_7491b353909c1147" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีโมเดลที่กำหนดค่าไว้ รีเฟรชเพื่อตรวจสอบความพร้อมใช้งานอีกครั้ง"</string>
     <string name="native_74a883a037bc227f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การตั้งค่า"</string>
-    <string name="native_74cdd65b358733f1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สลับเลย์เอาต์เซสชัน"</string>
+    <string name="native_74c372f29b83df94" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Back camera"</string>
     <string name="native_74e21680eac7385c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"approve"</string>
     <string name="native_74e492d5d0df0bab" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ก่อนเริ่มต้น"</string>
     <string name="native_74f0a5d234edc4af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถโหลด Skills ได้"</string>
@@ -725,7 +734,6 @@
     <string name="native_78f25f393aa9bcbf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"sticker upload"</string>
     <string name="native_790d78931c21b895" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Messages to recover"</string>
     <string name="native_792175fb265c32bc" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw devices approve %1$s"</string>
-    <string name="native_7981cbd5763dfcbb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ยังไม่มีเซสชันที่ตรงกัน"</string>
     <string name="native_79a68a0d42388125" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รายละเอียดบันทึก Gateway ที่อ่านได้"</string>
     <string name="native_79a7ab236717f90d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตรวจสอบข้อเสนอ skill ที่สร้างขึ้นก่อนที่จะกลายเป็น skills ที่ใช้งานได้จริง"</string>
     <string name="native_79d3a1f108e8d9c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"มาพร้อมแพ็กเกจ"</string>
@@ -768,11 +776,13 @@
     <string name="native_8193ee8a22d25208" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปักหมุดโมเดล"</string>
     <string name="native_81c2c4f30a4bec68" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ล้างการค้นหา"</string>
     <string name="native_81d38aca5306940b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิดใช้งานสำหรับเอเจนต์ที่มีสิทธิ์"</string>
+    <string name="native_820d08e12968baff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"No current thread"</string>
     <string name="native_82250171708918de" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"หลังจาก %1$s"</string>
     <string name="native_825b9c75d7fed691" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อนุญาตให้ตัวจัดกำหนดการเรียกใช้ระบบอัตโนมัตินี้"</string>
     <string name="native_82990a093599a9bb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"นำไปใช้แล้ว %1$s รายการ"</string>
     <string name="native_8340dad4f3be30a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ยังไม่มีไดอารีความฝัน"</string>
     <string name="native_837e39f46163ffb4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รีเฟรชงานเบื้องหลัง"</string>
+    <string name="native_838337fd9ab30454" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Summarize recent threads and next steps."</string>
     <string name="native_83e2faed20a3cda4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ทำงานบนอุปกรณ์ขณะที่ OpenClaw แสดงอยู่"</string>
     <string name="native_844e5b02f3ef05ca" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s กำลังทำงาน"</string>
     <string name="native_846c75dca0b71591" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
@@ -804,7 +814,6 @@
     <string name="native_88b01c8a4bff9a08" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สัญญาณ"</string>
     <string name="native_88e6e8384a7fc7ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เป้าหมายเซสชัน"</string>
     <string name="native_893a3e37d71c4563" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway บันทึกการปฏิเสธ"</string>
-    <string name="native_895f1e14d75d1239" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เซสชันที่เก็บถาวรจะแสดงที่นี่"</string>
     <string name="native_89713b9c9c1b8f65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ยอมรับ"</string>
     <string name="native_8998824610d49175" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ถาม OpenClaw ได้ทุกอย่าง"</string>
     <string name="native_89bbfe23c3917a3f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อใหม่เพื่อดำเนินการต่อ"</string>
@@ -824,7 +833,6 @@
     <string name="native_8ca344247c18317e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การเคลื่อนไหว"</string>
     <string name="native_8cac4b77b9c54695" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การดำเนินการ cron ล้มเหลว"</string>
     <string name="native_8cb2bab2ce6a17b2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"บนคอมพิวเตอร์ Gateway ให้รัน:"</string>
-    <string name="native_8cb650539ec84aa5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ค้นหาเซสชัน"</string>
     <string name="native_8d0839802b4d6aca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รีเฟรชบันทึก"</string>
     <string name="native_8d20273207a2fe99" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw nodes approve %1$s"</string>
     <string name="native_8d57374bc09c8756" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ข้อความเสียง · %1$s"</string>
@@ -844,6 +852,7 @@
     <string name="native_8f54b0d1e30092d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ข้อความเสียง"</string>
     <string name="native_8fa196125b734940" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีสิ่งใดต้องให้คุณดำเนินการ"</string>
     <string name="native_8fce9ec6fd5432df" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw ต้องการสิทธิ์อนุญาต %1$s เพื่อดำเนินการต่อ"</string>
+    <string name="native_8fe42acb8573244e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wired headset microphone"</string>
     <string name="native_906115657390f367" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ส่งแล้ว"</string>
     <string name="native_9071738f145962a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ครบกำหนด"</string>
     <string name="native_90bf81305006e6ed" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รายละเอียด Skill ไม่พร้อมใช้งานในสถานะ Skills ปัจจุบัน"</string>
@@ -932,6 +941,7 @@
     <string name="native_9e37aa0704a3cf44" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ติดตั้ง %1$s แล้ว"</string>
     <string name="native_9e4635769f0aaf0d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway"</string>
     <string name="native_9e9bef85bb320b81" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โหมดการส่งต่อ"</string>
+    <string name="native_9f6e180ff696bec5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Toggle thread layout"</string>
     <string name="native_9fb7c4ebcbc3e558" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีปลายทาง TLS"</string>
     <string name="native_9fe101a0ec7ef416" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway ของ OpenClaw"</string>
     <string name="native_9ffc843f501acdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตั้งค่าด้วยตนเอง"</string>
@@ -948,14 +958,11 @@
     <string name="native_a181b2c15994a7fc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ผู้ให้บริการเสียงพูด"</string>
     <string name="native_a190013f72efad35" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังดำเนินการอนุมัติ Gateway OpenClaw จะลองใหม่โดยอัตโนมัติ"</string>
     <string name="native_a1a5936d3b0f8a69" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สูงสุด"</string>
-    <string name="native_a1b5653a9f1b842b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีเซสชันที่เก็บถาวร"</string>
     <string name="native_a1bca979bc69befb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การเปลี่ยนแปลง cron ต้องมีสิทธิ์เข้าถึง operator.admin"</string>
     <string name="native_a20d12c5e9c428c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังคิด"</string>
     <string name="native_a23967c129397864" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screen snapshot"</string>
     <string name="native_a2bbc7ffd69f9c49" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่พบการดำเนินการ"</string>
     <string name="native_a2f29836cda5ceb1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"บันทึกและเชื่อมต่อ"</string>
-    <string name="native_a2fcbab533267340" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังตรวจสอบ · 1 เซสชัน"</string>
-    <string name="native_a32789d2b53dc704" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เซสชันปัจจุบัน"</string>
     <string name="native_a330395cc0a53ad1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list"</string>
     <string name="native_a34f54e488b48e66" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway บันทึกการอนุมัติและบันทึกตัวเลือกไว้แล้ว"</string>
     <string name="native_a37cf0a1111bf41c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ป้อน endpoint ด้วยตนเองที่ถูกต้องเพื่อเชื่อมต่อ"</string>
@@ -963,7 +970,6 @@
     <string name="native_a3e96435cb1ec7c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังส่งไปยังแชท..."</string>
     <string name="native_a4212f1e2fb0f506" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"บันทึกโปรไฟล์"</string>
     <string name="native_a424e33d90931d1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ล็อกแล้ว"</string>
-    <string name="native_a43f3627c39f1354" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังโหลดเซสชัน"</string>
     <string name="native_a450ea5e177b4787" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"แก้ไขระบบอัตโนมัติ"</string>
     <string name="native_a484bc216860979e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ใช้เครือข่ายเดียวกัน หรือ URL ของ Gateway ระยะไกลที่ปลอดภัย"</string>
     <string name="native_a4ae750b610e875e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"จุดยึด"</string>
@@ -983,6 +989,7 @@
     <string name="native_a89bac8b89022bde" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังฟัง · อยู่ในคิว %1$s รายการ"</string>
     <string name="native_a8bbbd7231a6c191" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปิดเสียงพูดของผู้ช่วยแล้ว"</string>
     <string name="native_a8ef5cdf31a6505a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ยังไม่พบ Gateway ใช้การตั้งค่าด้วยตนเองหากการค้นหาถูกบล็อก"</string>
+    <string name="native_a901aa25b833cf33" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Open thread"</string>
     <string name="native_a92f0449a9f7235b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังทำงาน"</string>
     <string name="native_a9624cf0b6ae80c1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เริ่มพูด..."</string>
     <string name="native_a9ac253267d07365" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โหนดโทรศัพท์"</string>
@@ -1017,11 +1024,12 @@
     <string name="native_adca3171c270301a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การลงชื่อเข้าใช้ Gateway นี้สามารถแสดงรายการโหนดที่เชื่อมต่อได้ แต่ไม่สามารถอนุมัติการจับคู่โทรศัพท์เครื่องใหม่ได้ โปรดจับคู่โทรศัพท์เครื่องใหม่จากเซสชันผู้ดูแล Gateway การอนุมัติความสามารถของโหนดเป็นกระบวนการแยกต่างหากและยังคงใช้ nodes approve &lt;request id&gt;"</string>
     <string name="native_ade9248e0132b411" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อถือ"</string>
     <string name="native_ae27fa789a03c1db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คิวอาร์โค้ดนั้นไม่ใช่คิวอาร์สำหรับตั้งค่า OpenClaw โปรดสร้างรหัสใหม่ด้วย openclaw qr แล้วลองอีกครั้ง"</string>
-    <string name="native_ae86062126fc1a52" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เซสชันใน \"%1$s\" จะถูกเก็บไว้และย้ายกลับไปยังไม่จัดกลุ่ม"</string>
+    <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Preferred microphone unavailable; using automatic routing."</string>
     <string name="native_aea4a04a80426ed8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปฏิเสธแล้ว"</string>
     <string name="native_aed306fbb63c0c68" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รวมแพ็กเกจของ Android และแพ็กเกจเบื้องหลัง"</string>
     <string name="native_aedf1cf58372f943" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway ของคุณพร้อมใช้งานแล้ว"</string>
     <string name="native_aeffb9182e3d7f3d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ทริกเกอร์แล้ว"</string>
+    <string name="native_af1f10e9b3af3250" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Structured Output"</string>
     <string name="native_af60a38d6b5866ce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ใช้เวลานานกว่าที่คาดไว้\nตรวจสอบว่า Gateway กำลังทำงานและสามารถเข้าถึงได้"</string>
     <string name="native_af7deaf2c81b107d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีงานเบื้องหลังสำหรับเอเจนต์นี้"</string>
     <string name="native_afb118fcb16c3727" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังเชื่อมต่อใหม่"</string>
@@ -1035,7 +1043,6 @@
     <string name="native_b140db2544c7f8f5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw กำลังซิงค์ข้อมูลอีกครั้ง"</string>
     <string name="native_b1b3f74fe7e32ae1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สตรีมเหตุการณ์ถูกขัดจังหวะ โปรดลองรีเฟรช"</string>
     <string name="native_b1c1be6b126d151f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถโหลดโหนดและอุปกรณ์ได้"</string>
-    <string name="native_b205bb47f81a3096" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิดเซสชัน"</string>
     <string name="native_b2087b2e689f4946" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อ Gateway เพื่อโหลด Skills"</string>
     <string name="native_b23a6a8439c0dde5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่ทราบ"</string>
     <string name="native_b2439bcb8dee14b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ผลลัพธ์"</string>
@@ -1053,6 +1060,7 @@
     <string name="native_b4aca584eecea590" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถโหลดรายละเอียดงานได้"</string>
     <string name="native_b51702b087112113" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ข้อความจากเอเจนต์"</string>
     <string name="native_b538b9d40695a6fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway ต้องใช้อัตลักษณ์ของอุปกรณ์นี้ ยืนยันตัวตนใหม่หรือรีเซ็ตการเชื่อมต่อ Gateway นี้"</string>
+    <string name="native_b53b35163f7588c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Next session"</string>
     <string name="native_b55dae19fcb48a4d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ความปลอดภัยของการเชื่อมต่อ"</string>
     <string name="native_b5a229ac8becc603" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เว็บไซต์"</string>
     <string name="native_b5af0517c02601fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อ Gateway เพื่อโหลดคำขออนุมัติในแอป"</string>
@@ -1080,10 +1088,10 @@
     <string name="native_b9d5d026db17b9e4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ล้มเหลว — %1$s"</string>
     <string name="native_ba599a4fe4b45b36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การเชื่อมต่อระหว่างโทรศัพท์เครื่องนี้กับ OpenClaw"</string>
     <string name="native_bae9264d6d972b80" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"summarize"</string>
-    <string name="native_bb4069d372f67683" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การดำเนินการนี้จะลบเซสชันและข้อความถอดเสียงอย่างถาวร"</string>
     <string name="native_bb4f2558e4333834" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"บันทึกรูปภาพวิดเจ็ตไปยัง Downloads แล้ว"</string>
     <string name="native_bbe5fc3b9ef39f99" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังเริ่มต้น…"</string>
     <string name="native_bc19cec293228fb8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ข้อผิดพลาดของไคลเอนต์"</string>
+    <string name="native_bc6618670f3e8a17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bluetooth LE microphone"</string>
     <string name="native_bcb06651437caa15" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
     <string name="native_bd08450d63406844" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิดใช้งานระบบอัตโนมัติแล้ว"</string>
     <string name="native_bd6719b455bcc898" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Memory Get"</string>
@@ -1108,6 +1116,7 @@
     <string name="native_c12a06263b75eb23" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อ Gateway เพื่อโหลดรายละเอียด Skill"</string>
     <string name="native_c156b9eaf502aabc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตัวฟังคำปลุก"</string>
     <string name="native_c184b2ada7abc688" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ขยายตัวอย่างลิงก์"</string>
+    <string name="native_c18ee03d3906a488" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Clear thread search"</string>
     <string name="native_c1970bb2cdf299b7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"NULL (ล้มเหลว)"</string>
     <string name="native_c1c1009d3f37ec05" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อัปเดต"</string>
     <string name="native_c1c224b03cd9bc7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ผู้ดูแลระบบ"</string>
@@ -1175,12 +1184,14 @@
     <string name="native_ca7981b46ecf2c17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปิด"</string>
     <string name="native_cab94aba84f97f7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รูปแบบตัวอักษร"</string>
     <string name="native_cae7d57bc067a514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"หยุด"</string>
+    <string name="native_cae98462b30650eb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"No matching threads yet."</string>
     <string name="native_cba62d81f910c7f0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"จับคู่ Gateway สำเร็จแล้ว\nอนุมัติความสามารถของโหนดสำหรับโทรศัพท์เครื่องนี้จาก UI ของผู้ดูแลระบบ"</string>
     <string name="native_cc4b66e7e22230c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skills นี้ได้รับการติดตั้งแล้ว แต่ยังไม่พร้อมใช้งานในขณะนี้ โปรดใช้เดสก์ท็อปหรือ CLI เพื่อเปลี่ยนแปลงการกำหนดค่า"</string>
     <string name="native_cc5f45fb30a26e07" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตัวรู้จำไม่ว่าง"</string>
     <string name="native_cc721e25d73938a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway หลัก"</string>
     <string name="native_cc7a9a5cf8c4bc9d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เรียกใช้คำสั่งอนุมัติบน Gateway"</string>
     <string name="native_cc925e3c97ac7a35" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถโหลดข้อเสนอ Skill Workshop ได้"</string>
+    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Catch me up on my recent OpenClaw threads and suggest next steps."</string>
     <string name="native_ccb4c324f516c633" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่ใช่ตอนนี้"</string>
     <string name="native_cced0b0d83a9e400" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw qr"</string>
     <string name="native_cced28c6dc3f99c2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"start"</string>
@@ -1203,6 +1214,7 @@
     <string name="native_ceb6931ea57cc999" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปรับอัตโนมัติ"</string>
     <string name="native_cf0ee3547a4e51a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เร็วๆ นี้"</string>
     <string name="native_d04fc7d7e19702f8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Search"</string>
+    <string name="native_d053ba98d8bbcec1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Try Chat, Voice, Threads, Providers, or Settings."</string>
     <string name="native_d056177742e27cf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw กำลังทำงาน"</string>
     <string name="native_d0cda6559bb347db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"navigate"</string>
     <string name="native_d0d0de0039c7990b" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ส่งคำขอเมื่อ %1$s"</string>
@@ -1214,7 +1226,6 @@
     <string name="native_d19c2dd2fb598b93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw แบบพาสซีฟ"</string>
     <string name="native_d1a574e23344c407" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รหัสผ่าน Gateway ไม่ถูกต้อง"</string>
     <string name="native_d1bf045bb524dae5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ดูรายละเอียด"</string>
-    <string name="native_d1c835016021c20b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เซสชัน OpenClaw"</string>
     <string name="native_d1e9567da9a8a4b0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bash"</string>
     <string name="native_d2089be672953d11" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โทเค็น"</string>
     <string name="native_d20f43f925e706ce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เอเจนต์ OpenClaw ที่เชื่อมต่ออยู่สามารถใช้ความสามารถของอุปกรณ์ที่คุณเปิดใช้งานได้ ดำเนินการต่อเฉพาะเมื่อคุณเชื่อถือ Gateway และเอเจนต์ที่คุณเชื่อมต่อเท่านั้น"</string>
@@ -1230,6 +1241,7 @@
     <string name="native_d3974fd6d3b6c81f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รอการเรียกใช้"</string>
     <string name="native_d3f75e24411053c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"AI ส่วนตัวบนอุปกรณ์ของคุณ"</string>
     <string name="native_d406ade2958cb5b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attach"</string>
+    <string name="native_d461a493a3753877" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatic"</string>
     <string name="native_d4b1ea5708dd5329" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ภาพรวม"</string>
     <string name="native_d53167a3f66debec" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ขอคืนค่าไม่สำเร็จ แตะเพื่อลองอีกครั้ง"</string>
     <string name="native_d588c689e03132fb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s\n\n"</string>
@@ -1242,6 +1254,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โปรไฟล์"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ขีดจำกัดของผู้ให้บริการจะแสดงที่นี่เมื่อ Gateway ของคุณรายงานข้อมูลดังกล่าว"</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปัญหา 1 รายการ"</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สร้างเมื่อ"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โทเค็นที่ใช้งานอยู่ %1$s/%2$s"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>
@@ -1258,6 +1271,7 @@
     <string name="native_d93e2b7a15efbc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถดำเนินการอนุมัติให้เสร็จสิ้นได้ โปรดรีเฟรชแล้วลองอีกครั้ง"</string>
     <string name="native_d942f64886578d87" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"import"</string>
     <string name="native_d94cfb21b67ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ลักษณะที่โทรศัพท์เครื่องนี้ปรากฏต่อ OpenClaw"</string>
+    <string name="native_d96f2b0eab4e67b7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Focus thread search"</string>
     <string name="native_d975ca28a64f8850" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อ Gateway"</string>
     <string name="native_d9be42d9b30ce057" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อ่านปฏิทิน"</string>
     <string name="native_d9f641e1a02807cb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ภาพรวมจะรีเฟรชเมื่อเชื่อมต่อใหม่และเมื่อเปิดหน้าจอนี้"</string>
@@ -1303,6 +1317,7 @@
     <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ค้นหา Skills ที่ติดตั้ง"</string>
     <string name="native_e0723a86a5b9408a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตรวจสอบ"</string>
     <string name="native_e083bd83e9d3e97e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Process"</string>
+    <string name="native_e08a8fc53e29e5c9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Recent Threads"</string>
     <string name="native_e0926fdac700b094" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เทอร์มินัล"</string>
     <string name="native_e0d1b68224bf0b31" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปัจจุบัน"</string>
     <string name="native_e10435f6306b06d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 บัญชี"</string>
@@ -1323,7 +1338,6 @@
     <string name="native_e3f0caab85e62600" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถอ่านคิวอาร์โค้ดจากรูปภาพนั้นได้ โปรดเลือกรูปภาพที่ชัดเจนกว่านี้หรือป้อนรหัสตั้งค่าด้วยตนเอง"</string>
     <string name="native_e3f90d1d0b07fb04" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway เก่ากว่าแอปนี้ โปรดอัปเดต OpenClaw บนโฮสต์ Gateway แล้วลองอีกครั้ง"</string>
     <string name="native_e41cc128c73bc85e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อก่อนใช้แชต เสียง และสถานะแบบเรียลไทม์"</string>
-    <string name="native_e424b24d86953102" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังค้นหาเซสชัน"</string>
     <string name="native_e4582b6fb1f57494" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อ Gateway อีกครั้ง"</string>
     <string name="native_e4696640127b9126" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"บุคคลที่สาม"</string>
     <string name="native_e482357257d6c2fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตรวจสอบความพร้อม"</string>
@@ -1332,11 +1346,13 @@
     <string name="native_e52b3044724b9f4d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เลิกปักหมุดโมเดล"</string>
     <string name="native_e5584bc5057284ae" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"พื้นผิวการส่งข้อความที่เชื่อมต่อกับ Gateway นี้"</string>
     <string name="native_e595f17fac1d8384" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังส่ง"</string>
+    <string name="native_e5b87192a9e6321f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Archived threads will show up here."</string>
     <string name="native_e5c02424e511e1ef" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คัดลอกคำสั่งแล้ว"</string>
     <string name="native_e5c083cf41ff6472" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีตัวอย่างให้ใช้งาน"</string>
     <string name="native_e5c3e7b8110e7087" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อนุมัติโทรศัพท์เครื่องนี้บน Gateway\nจากนั้นลองเชื่อมต่ออีกครั้ง"</string>
     <string name="native_e5c7478bbce26eb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สแกนรหัส QR"</string>
     <string name="native_e5e4f854dcd3ffc6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไดเรกทอรีทำงานของคำสั่ง · ไม่สามารถล้างได้"</string>
+    <string name="native_e614ccf26ec5d312" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Thread Activity"</string>
     <string name="native_e674447337e83c13" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"พร้อมใช้งาน"</string>
     <string name="native_e68e23dc04b0f986" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ลบระบบอัตโนมัติหรือไม่?"</string>
     <string name="native_e7053d96b6704dbb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s วันนี้ · ทั้งหมด %2$s"</string>
@@ -1409,7 +1425,6 @@
     <string name="native_f2bfed0b0c0055db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การตอบกลับด้วยเสียงหมดเวลา กำลังลองส่งรายการที่รออยู่อีกครั้ง"</string>
     <string name="native_f2cb21c53a33f72c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เลย์เอาต์: รายละเอียด"</string>
     <string name="native_f2da2e47cd31a5dd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถถอดรหัสรูปภาพนี้ได้"</string>
-    <string name="native_f2ecdaf77d1d98d3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw เปลี่ยนโทรศัพท์เครื่องนี้ให้เป็นอินเทอร์เฟซคำสั่งบนมือถือที่เรียบง่ายสำหรับเซสชัน เสียง ผู้ให้บริการ และ Gateway"</string>
     <string name="native_f3753c0fe29b88db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway, เสียง, การแจ้งเตือน, ความเป็นส่วนตัว"</string>
     <string name="native_f386c32c1bf437d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไฟล์พื้นที่ทำงานของเอเจนต์"</string>
     <string name="native_f41d9e8b7e09aa24" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ใช้ requestId จากคำสั่งที่รอดำเนินการในคำสั่ง approve"</string>
@@ -1420,13 +1435,12 @@
     <string name="native_f4ccae29e1bb0c20" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังทำงาน"</string>
     <string name="native_f4db1e48476f6075" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สิ้นสุด"</string>
     <string name="native_f4ef7a41caa88dd1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีผู้ให้บริการที่พร้อมใช้งาน"</string>
-    <string name="native_f502267deff4108d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ยังไม่มีเซสชัน"</string>
+    <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Prioritizes connected Bluetooth microphones."</string>
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"บล็อกไม่ให้ส่งต่อ %1$s แอป"</string>
     <string name="native_f532ee1f7288365e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การดำเนินการกับข้อความ"</string>
     <string name="native_f5387f9bb6ed7031" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ประเภท"</string>
     <string name="native_f565318d124534cf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ยกเลิกการเก็บถาวร"</string>
     <string name="native_f584049cab5f523e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Transcripts"</string>
-    <string name="native_f59b46c265d8d38f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เซสชันล่าสุด"</string>
     <string name="native_f5f0563199a5b403" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คำปลุก"</string>
     <string name="native_f616dfac9815faea" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำหนดค่า %1$s บน Gateway"</string>
     <string name="native_f61d0c645f00a4ed" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สแกนคิวอาร์โค้ดหรือใช้รหัสตั้งค่าจาก OpenClaw Gateway ของคุณ"</string>
@@ -1447,6 +1461,7 @@
     <string name="native_f8b32f4e92bd84ce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ติดตั้งแล้ว"</string>
     <string name="native_f8c2745155505d39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"หมดเวลารอการตอบกลับ โปรดลองอีกครั้งหรือรีเฟรช"</string>
     <string name="native_f8cd133f0ea1031b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ค้นหาการสนทนาก่อนหน้า"</string>
+    <string name="native_f90f3791049b995d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Browse Threads"</string>
     <string name="native_f92e2ad582c0e13f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังรีเฟรช"</string>
     <string name="native_f991ae9cb081e1f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิดกล้องและจัดให้รหัสจาก openclaw qr อยู่ในกรอบ"</string>
     <string name="native_f9ea3f1540eaa584" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีอุปกรณ์"</string>
@@ -1468,6 +1483,7 @@
     <string name="native_fcdeb9947bc94101" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ทดสอบ ทดสอบ 1 2 3"</string>
     <string name="native_fcea13c79c2f85a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถค้นหา Skills ใน ClawHub ได้"</string>
     <string name="native_fd175ecd65f7353d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีพรอมต์"</string>
+    <string name="native_fd301dc5d0e7ccf1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Front camera"</string>
     <string name="native_fda8fc3b85420d14" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิดรายการบันทึก"</string>
     <string name="native_fdd0d769c49517c2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"หมดเวลาการเชื่อมต่อเครือข่าย"</string>
     <string name="native_fe18013d93d22f4f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตอนนี้"</string>
@@ -1477,10 +1493,11 @@
     <string name="native_ff2670a0df18e148" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"thread list"</string>
     <string name="native_ff332eeb6b2de1da" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิด %1$s"</string>
     <string name="native_ff4085ad157354dc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"upload"</string>
-    <string name="native_ff4d6b7484fbfc1f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กิจกรรมของเซสชัน"</string>
     <string name="native_ff52188203241c29" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ยังไม่ได้กำหนดค่ารหัสผ่าน Gateway"</string>
     <string name="native_ff716fc4735e067f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การตั้งค่าการป้อนตามคำบอก"</string>
     <string name="native_ff9dbbdfb84ddab2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โหลดโมเดลของผู้ให้บริการแล้ว แต่ไม่มีข้อมูลความพร้อมใช้งาน"</string>
+    <string name="native_ffa7aa557b547a79" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Delete thread?"</string>
+    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway."</string>
     <string name="native_ffb6f5764bddb68c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ใหม่สุดก่อน"</string>
     <string name="native_ffcf16006c652ee3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รอบถัดไป"</string>
 </resources>

--- a/apps/android/app/src/main/res/values-th/strings.xml
+++ b/apps/android/app/src/main/res/values-th/strings.xml
@@ -75,6 +75,7 @@
     <string name="native_0929c9dc7f794852" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีข้อเสนอ"</string>
     <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เธรดหลัก"</string>
     <string name="native_0979c6fdbdca1675" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิดแชต"</string>
+    <string name="native_09ce95090659d069" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การดำเนินการจับคู่อุปกรณ์ไม่พร้อมใช้งานในเซสชัน Gateway นี้ ให้เรียกใช้ openclaw devices list บนโฮสต์ Gateway และจัดการคำขอที่นั่น การอนุมัติความสามารถของโหนดเป็นคนละส่วนกันและยังคงใช้ nodes approve &lt;request id&gt;"</string>
     <string name="native_0a0b7cf7c428c703" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คำขอดำเนินการ"</string>
     <string name="native_0a708e7b03aaf1fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list pins"</string>
     <string name="native_0ab0e1629576aecf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อกับ Gateway เพื่อโหลดข้อเสนอ Skill Workshop"</string>
@@ -87,10 +88,12 @@
     <string name="native_0c3845dcd2f0f683" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตรวจสอบข้อเสนอนี้เพื่อโหลด Markdown"</string>
     <string name="native_0c3ea4e2f12153e7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิด OpenClaw แล้วถาม %1$s"</string>
     <string name="native_0c4d01e81bb3d1fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การให้เหตุผล"</string>
+    <string name="native_0c77fe09ab336a3e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไคลเอนต์"</string>
     <string name="native_0c79a9c222840ed0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ใช้งานแล้ว"</string>
     <string name="native_0cab1c9617404faf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"วิดีโอ"</string>
     <string name="native_0cf04463c4276a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เลื่อนระดับแล้ว"</string>
     <string name="native_0d21bd52022ca7f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ออนไลน์"</string>
+    <string name="native_0d5644ff52ce2ba3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ขอบเขต"</string>
     <string name="native_0d5efd432e4fedf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ยังไม่ได้กำหนดค่าผู้ให้บริการเสียงแบบเรียลไทม์"</string>
     <string name="native_0d8ca811c3744a6d" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s · %2$s"</string>
     <string name="native_0db10f2c2f332cd2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"kick"</string>
@@ -138,6 +141,7 @@
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เป้าหมายเซสชัน"</string>
     <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตรวจสอบ Skill จาก ClawHub"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
+    <string name="native_16a5b7ad567a8093" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปฏิเสธคำขอจับคู่จากอุปกรณ์นี้หรือไม่?"</string>
     <string name="native_16b1a05e1d987ed1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไมโครโฟนที่ต้องการ"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โฮสต์โหนด"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ระดับ"</string>
@@ -183,6 +187,7 @@
     <string name="native_1d91629837639a5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ระบบอัตโนมัตินี้มีการเปลี่ยนแปลงขณะที่คุณกำลังแก้ไข โปรดย้อนกลับเป็นเวอร์ชันล่าสุดบน Gateway ก่อนบันทึก"</string>
     <string name="native_1dbf9d5979606697" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เมื่อเชื่อมต่อแล้ว Gateway สามารถปลุกโทรศัพท์ด้วยการแจ้งเตือนแบบเงียบแทนการคงเซสชันให้ทำงานตลอดเวลา"</string>
     <string name="native_1e432ea5425e4a3a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โหมดปลุก"</string>
+    <string name="native_1e595a107c78b957" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"นำอุปกรณ์ที่จับคู่ออกหรือไม่?"</string>
     <string name="native_1e955a58278623a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ข้อความเหตุการณ์ระบบ"</string>
     <string name="native_1ea44149be42d970" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถคัดลอกรูปภาพวิดเจ็ตได้"</string>
     <string name="native_1ea442a134b2a184" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่"</string>
@@ -197,6 +202,7 @@
     <string name="native_2065cc867eba1b39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถโหลดการกำหนดค่าโมเดลของผู้ให้บริการได้"</string>
     <string name="native_207ccb22d618db05" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อนุญาตให้ %1$s แอปส่งต่อได้"</string>
     <string name="native_209b9e597963e7e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การตั้งค่าเสียง"</string>
+    <string name="native_211988ba9dd0570a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปฏิเสธคำขอจับคู่หรือไม่?"</string>
     <string name="native_2132066dc9475cb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"This skill is installed but not available to the current agent. Agent filters stay on desktop or CLI."</string>
     <string name="native_21378545892f1fe2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ผู้เผยแพร่"</string>
     <string name="native_214d4932fc767e8f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">" · สนทนา: กำลังพูด"</string>
@@ -238,6 +244,7 @@
     <string name="native_2682bd813a3bccbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ป้อนรหัสตั้งค่าจาก openclaw qr"</string>
     <string name="native_268f14bbfe119c1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การวินิจฉัย"</string>
     <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การดำเนินการนี้จะลบเธรดและบันทึกการสนทนาอย่างถาวร"</string>
+    <string name="native_26e47d73a55d7fa7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อนุมัติอุปกรณ์แล้ว"</string>
     <string name="native_26f0dd993530eb2d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังลองใหม่โดยอัตโนมัติ"</string>
     <string name="native_270ff82f36da987f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คัดลอกรูปภาพวิดเจ็ตแล้ว"</string>
     <string name="native_2728740a95d465c6" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s บทบาท"</string>
@@ -346,6 +353,7 @@
     <string name="native_381428f5f251a764" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Conversation Send"</string>
     <string name="native_3824a9f4dafe92c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"แคนวาส"</string>
     <string name="native_384ae4ab1a2830f9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ผู้ให้บริการ 1 ราย"</string>
+    <string name="native_385001409de8562a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถอ่านใบรับรองของ Gateway โดยอัตโนมัติได้ ให้วางลายนิ้วมือ SHA-256 ที่ได้รับจากโฮสต์ Gateway"</string>
     <string name="native_387b2569e440838c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ส่งไม่สำเร็จ: %1$s"</string>
     <string name="native_3892e10346fd2012" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"บริดจ์"</string>
     <string name="native_38d198cd5303680f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ข้อผิดพลาดในการส่ง"</string>
@@ -403,6 +411,7 @@
     <string name="native_429f6057535c1ea3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sub-agent"</string>
     <string name="native_42e3a99c21767def" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังรอการอนุมัติอุปกรณ์"</string>
     <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังโหลดเธรด"</string>
+    <string name="native_430df68ec29a85a2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ขณะนี้ Gateway นี้แสดงใบรับรองที่อุปกรณ์นี้เชื่อถือ"</string>
     <string name="native_43905968a540af6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การหน่วงเหลื่อม ms"</string>
     <string name="native_43988c156beabf7d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"event create"</string>
     <string name="native_43cc23fa52b87b4c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เอกสาร"</string>
@@ -412,7 +421,7 @@
     <string name="native_4441146b0fe1d5c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screenshot"</string>
     <string name="native_4481c2190a1b4bca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"นิพจน์ cron เช่น 0 9 * * *"</string>
     <string name="native_4499e7b7e1c9ddbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กลับไปที่เสียง"</string>
-    <string name="native_449f5a775762cdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"พูดคุย"</string>
+    <string name="native_449f5a775762cdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"พูด"</string>
     <string name="native_45a64dc17588f2ca" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ออนไลน์ %1$s/%2$s"</string>
     <string name="native_45a8847c4a6b2c81" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อนุญาตให้ส่งต่อ %1$s แอป"</string>
     <string name="native_460b3a7da007b7af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"แชท"</string>
@@ -464,6 +473,7 @@
     <string name="native_4e8c72cab82e0711" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ระบบอัตโนมัติมีการกำหนดค่าที่ไม่ถูกต้อง"</string>
     <string name="native_4ec30e9d85725d41" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รายการที่อนุญาต"</string>
     <string name="native_4ed379d418bb8629" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"groups"</string>
+    <string name="native_4ee252fb736effa2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คีย์สาธารณะ"</string>
     <string name="native_4efca0d10c5feb8e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เกี่ยวกับ"</string>
     <string name="native_4f1bc100d1dccc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่พบคิวอาร์โค้ดสำหรับตั้งค่าในรูปภาพนั้น โปรดเลือกคิวอาร์ที่สร้างโดย openclaw qr หรือป้อนรหัสตั้งค่าด้วยตนเอง"</string>
     <string name="native_4fe3cdd404ea0290" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"permissions"</string>
@@ -550,6 +560,7 @@
     <string name="native_5c0c8c9aa658f4a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OPENCLAW"</string>
     <string name="native_5c1acea9c9b0e704" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Fetch"</string>
     <string name="native_5c39123805ffb4e2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"พรอมต์"</string>
+    <string name="native_5c944156b5353428" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อนุมัติอุปกรณ์หรือไม่?"</string>
     <string name="native_5d410adb9576e266" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"นำ %1$s และข้อมูลประจำตัวที่บันทึกไว้ออกจากโทรศัพท์เครื่องนี้หรือไม่?"</string>
     <string name="native_5d6c41a67139ee26" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คิวอาร์โค้ดชี้ไปยัง Gateway ระยะไกลที่ไม่ปลอดภัย %1$s %2$s"</string>
     <string name="native_5d6cbac59f87e78d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"พื้นผิวหน้าจอพร้อมแล้ว"</string>
@@ -567,6 +578,7 @@
     <string name="native_5fa1d457ddfcd26c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"rename group"</string>
     <string name="native_5fa7aac5375c5815" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"พร้อม"</string>
     <string name="native_5fc1927ca948f31c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไดอารีกำลังรอรายการแรก"</string>
+    <string name="native_6007acbe30b2cd98" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อนุมัติ"</string>
     <string name="native_600c9c27960112a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"หน้าไลฟ์"</string>
     <string name="native_6030d1f6340776d2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ระบบอัตโนมัติกำลังทำงานอยู่แล้ว"</string>
     <string name="native_604e6d6faf8d0295" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ลบระบบอัตโนมัตินี้หลังจากเรียกใช้แบบครั้งเดียวสำเร็จ"</string>
@@ -606,12 +618,14 @@
     <string name="native_6657cc73af00feac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อนุญาตให้ใช้เครื่องมือกล้องเมื่อมีการร้องขอ"</string>
     <string name="native_666067dd376e5d45" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปัญหา"</string>
     <string name="native_666c8bc0319f3b54" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การปลุกด้วยเสียง"</string>
+    <string name="native_66713d713e3a41c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปฏิเสธคำขอจับคู่แล้ว"</string>
     <string name="native_66b23bae66fc0d79" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s วันที่แล้ว"</string>
     <string name="native_66cf5513b37462be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"roles"</string>
     <string name="native_66d0f523a379b2de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skills"</string>
     <string name="native_66f4804ee23ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เก็บถาวร"</string>
     <string name="native_66fab2875ee427f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โหนดออฟไลน์ โปรดเชื่อมต่อใหม่แล้วลองอีกครั้ง"</string>
     <string name="native_6725e7bbcd28f3a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ระบบ"</string>
+    <string name="native_672f3453e1dd571b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"IP ระยะไกล"</string>
     <string name="native_674b38cae72bb0c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่ได้จัดกลุ่ม"</string>
     <string name="native_674eb55d9c353900" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รายละเอียดกำหนดการ"</string>
     <string name="native_67528858c36397f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ความสามารถของโทรศัพท์"</string>
@@ -619,6 +633,7 @@
     <string name="native_67b696468610b879" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dashboard"</string>
     <string name="native_67fa416afa64d304" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"วางโทเค็น"</string>
     <string name="native_6827238fea72c88b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีผู้ให้บริการ"</string>
+    <string name="native_684889f0079cc145" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ลายนิ้วมือ SHA-256"</string>
     <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ยังไม่มีเธรด"</string>
     <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไมโครโฟน Bluetooth"</string>
     <string name="native_690dbe9dc0993c42" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ล่าสุด"</string>
@@ -653,6 +668,7 @@
     <string name="native_6d5d9004797377e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ใบอนุญาต"</string>
     <string name="native_6d7c95a353d873cd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อ Gateway เพื่อค้นหา Skills ใน ClawHub"</string>
     <string name="native_6df1bb18a59ab97d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ทักษะ"</string>
+    <string name="native_6e0a0b9d8c5ee4d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รหัสอุปกรณ์"</string>
     <string name="native_6e117ba97cbfb6f0" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway ไม่ได้ระบุผู้ให้บริการ %1$s ที่ใช้งานอยู่"</string>
     <string name="native_6e293a8c009e0011" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังรอ"</string>
     <string name="native_6e2c0963d056e104" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"บันทึกคำปลุกแล้ว"</string>
@@ -829,6 +845,7 @@
     <string name="native_8bb7ec15b1e350a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังตรวจสอบ"</string>
     <string name="native_8bf253a125f66985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สแกนหรือวางรหัสการตั้งค่าเพื่อเพิ่ม Gateway อื่น"</string>
     <string name="native_8c4a3896e8f06d27" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"TLS หมดเวลา"</string>
+    <string name="native_8c55387fb6c584c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"นำอุปกรณ์ที่จับคู่ออกแล้ว"</string>
     <string name="native_8c93c68056cde54d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"จับคู่ Gateway แล้ว กำลังตรวจสอบการอนุมัติความสามารถของโหนด"</string>
     <string name="native_8ca344247c18317e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การเคลื่อนไหว"</string>
     <string name="native_8cac4b77b9c54695" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การดำเนินการ cron ล้มเหลว"</string>
@@ -1021,7 +1038,6 @@
     <string name="native_ad1c341c65f84ede" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รันคำสั่ง approve บนคอมพิวเตอร์ Gateway แล้วตรวจสอบอีกครั้ง"</string>
     <string name="native_ad1fb9ec0cb3c7a4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การทำงานอัตโนมัติ"</string>
     <string name="native_adb7eb8a03ad699c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s นาที"</string>
-    <string name="native_adca3171c270301a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การลงชื่อเข้าใช้ Gateway นี้สามารถแสดงรายการโหนดที่เชื่อมต่อได้ แต่ไม่สามารถอนุมัติการจับคู่โทรศัพท์เครื่องใหม่ได้ โปรดจับคู่โทรศัพท์เครื่องใหม่จากเซสชันผู้ดูแล Gateway การอนุมัติความสามารถของโหนดเป็นกระบวนการแยกต่างหากและยังคงใช้ nodes approve &lt;request id&gt;"</string>
     <string name="native_ade9248e0132b411" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อถือ"</string>
     <string name="native_ae27fa789a03c1db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คิวอาร์โค้ดนั้นไม่ใช่คิวอาร์สำหรับตั้งค่า OpenClaw โปรดสร้างรหัสใหม่ด้วย openclaw qr แล้วลองอีกครั้ง"</string>
     <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไมโครโฟนที่ต้องการไม่พร้อมใช้งาน กำลังใช้การกำหนดเส้นทางอัตโนมัติ"</string>
@@ -1091,6 +1107,7 @@
     <string name="native_bb4f2558e4333834" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"บันทึกรูปภาพวิดเจ็ตไปยัง Downloads แล้ว"</string>
     <string name="native_bbe5fc3b9ef39f99" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังเริ่มต้น…"</string>
     <string name="native_bc19cec293228fb8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ข้อผิดพลาดของไคลเอนต์"</string>
+    <string name="native_bc1c94a6dfce1058" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตรวจสอบอุปกรณ์ที่ส่งคำขอนี้ก่อนอนุญาตให้เข้าถึง"</string>
     <string name="native_bc6618670f3e8a17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไมโครโฟน Bluetooth LE"</string>
     <string name="native_bcb06651437caa15" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
     <string name="native_bd08450d63406844" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิดใช้งานระบบอัตโนมัติแล้ว"</string>
@@ -1099,6 +1116,7 @@
     <string name="native_bdc090ec61e3fcfc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โหลดใหม่"</string>
     <string name="native_bdff71b20b9cf392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ค้นหาระบบอัตโนมัติ"</string>
     <string name="native_be969becb173e0c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โทรศัพท์ที่เชื่อมโยงและโฮสต์โหนดจะแสดงที่นี่หลังจากการจับคู่"</string>
+    <string name="native_bf1870ff5c6322fb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s: %2$s"</string>
     <string name="native_bf350e6a0ed60b7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ระบบอัตโนมัตินี้มีการเปลี่ยนแปลงบน Gateway โปรดตรวจสอบเวอร์ชันล่าสุดก่อนบันทึกอีกครั้ง"</string>
     <string name="native_bf399ffa03617a96" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"หยุดการป้อนตามคำบอก"</string>
     <string name="native_bf56ee2fe3345ce1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อ่านง่าย"</string>
@@ -1122,6 +1140,7 @@
     <string name="native_c1c224b03cd9bc7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ผู้ดูแลระบบ"</string>
     <string name="native_c1ebc7817870e5be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ต้องตรวจสอบ"</string>
     <string name="native_c22d5e02fbec7d65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"จับคู่อุปกรณ์นี้กับ Gateway ของคุณเพื่อปลุกอุปกรณ์เฉพาะเมื่อต้องทำงานจริง ดูภาพรวมของเอเจนต์แบบสดได้อย่างสะดวก และหลีกเลี่ยงลูปเบื้องหลังที่สิ้นเปลืองแบตเตอรี่"</string>
+    <string name="native_c25337055464f8d3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"บทบาท"</string>
     <string name="native_c253f451bdd56431" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตอบกลับ"</string>
     <string name="native_c26225b6c16a4bc7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"แค็ตตาล็อกผู้ให้บริการ"</string>
     <string name="native_c272b225cf5bd643" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิดใช้สิทธิ์อนุญาตในการตั้งค่า"</string>
@@ -1135,6 +1154,7 @@
     <string name="native_c34dd5eb8b0af56e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ฉันจะรับรหัสตั้งค่าได้จากที่ไหน?"</string>
     <string name="native_c3546b39ecbbed8a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถเปิดใช้งาน Skill ได้"</string>
     <string name="native_c35b21d6ca39aa7c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"pdf"</string>
+    <string name="native_c3812fc4acb861d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"นำออก"</string>
     <string name="native_c382566dbe2ea49f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s%% ออนไลน์"</string>
     <string name="native_c385951198c45d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีช่องทาง"</string>
     <string name="native_c41ad84496b53420" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เสียงแบบเรียลไทม์"</string>
@@ -1163,6 +1183,7 @@
     <string name="native_c6d5ed757b66bfd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ฝัน"</string>
     <string name="native_c6dd061350fc69b8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ยังไม่ได้บล็อกแอป แอปสามารถส่งต่อได้เว้นแต่คุณจะเพิ่มรายการบล็อก"</string>
     <string name="native_c753cdf0c19f1e38" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถใช้ตัวจดจำเสียงพูดได้"</string>
+    <string name="native_c78ffe19571018fb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"แพลตฟอร์ม"</string>
     <string name="native_c7985fa72daa6ea4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway ไม่ได้ส่งคืนการตั้งค่า %1$s"</string>
     <string name="native_c7b6dfd5c3a183c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ลืม Gateway หรือไม่?"</string>
     <string name="native_c7b7b7f01360f6a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คำอธิบายเพิ่มเติม (ไม่บังคับ)"</string>
@@ -1225,6 +1246,7 @@
     <string name="native_d17d2d78d76e6a6c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โมเดล"</string>
     <string name="native_d19c2dd2fb598b93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw แบบพาสซีฟ"</string>
     <string name="native_d1a574e23344c407" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รหัสผ่าน Gateway ไม่ถูกต้อง"</string>
+    <string name="native_d1af697abaff485f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถตรวจสอบการเปลี่ยนแปลงการจับคู่อุปกรณ์ได้ โปรดรีเฟรชแล้วลองอีกครั้ง"</string>
     <string name="native_d1bf045bb524dae5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ดูรายละเอียด"</string>
     <string name="native_d1e9567da9a8a4b0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bash"</string>
     <string name="native_d2089be672953d11" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โทเค็น"</string>
@@ -1239,6 +1261,7 @@
     <string name="native_d31de1a5c5c8ba2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เบราว์เซอร์"</string>
     <string name="native_d354ee936f59115e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screen record"</string>
     <string name="native_d3974fd6d3b6c81f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รอการเรียกใช้"</string>
+    <string name="native_d3e1c5f8a6e240fc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ต้นทาง"</string>
     <string name="native_d3f75e24411053c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"AI ส่วนตัวบนอุปกรณ์ของคุณ"</string>
     <string name="native_d406ade2958cb5b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attach"</string>
     <string name="native_d461a493a3753877" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อัตโนมัติ"</string>
@@ -1427,6 +1450,7 @@
     <string name="native_f2da2e47cd31a5dd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถถอดรหัสรูปภาพนี้ได้"</string>
     <string name="native_f3753c0fe29b88db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway, เสียง, การแจ้งเตือน, ความเป็นส่วนตัว"</string>
     <string name="native_f386c32c1bf437d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไฟล์พื้นที่ทำงานของเอเจนต์"</string>
+    <string name="native_f418bf0894a1806a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อุปกรณ์นี้จะสูญเสียสิทธิ์การเข้าถึง Gateway ที่เชื่อถือได้"</string>
     <string name="native_f41d9e8b7e09aa24" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ใช้ requestId จากคำสั่งที่รอดำเนินการในคำสั่ง approve"</string>
     <string name="native_f4830a1dae298044" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำหนดการ"</string>
     <string name="native_f493f0ce7a52a8aa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ขีดจำกัดอัตรา"</string>
@@ -1434,6 +1458,7 @@
     <string name="native_f4cc820d308495c4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เพย์โหลด · %1$s"</string>
     <string name="native_f4ccae29e1bb0c20" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังทำงาน"</string>
     <string name="native_f4db1e48476f6075" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สิ้นสุด"</string>
+    <string name="native_f4e2076014711222" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ใช้ความเชื่อถือของระบบ"</string>
     <string name="native_f4ef7a41caa88dd1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีผู้ให้บริการที่พร้อมใช้งาน"</string>
     <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ให้ความสำคัญกับไมโครโฟน Bluetooth ที่เชื่อมต่ออยู่"</string>
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"บล็อกไม่ให้ส่งต่อ %1$s แอป"</string>

--- a/apps/android/app/src/main/res/values-th/strings.xml
+++ b/apps/android/app/src/main/res/values-th/strings.xml
@@ -24,14 +24,14 @@
     <string name="native_002a6fcb30b2def4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถเตรียมไฟล์แนบสำหรับส่งได้"</string>
     <string name="native_003aaf9e0a0e6b9f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปิดไมค์"</string>
     <string name="native_0060cbfdd3cf13ba" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"แสดงการแจ้งเตือนจาก OpenClaw"</string>
-    <string name="native_0077032d7e9f9cbe" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Thread activity"</string>
+    <string name="native_0077032d7e9f9cbe" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กิจกรรมของเธรด"</string>
     <string name="native_008dacb6d1e85bd8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เต็มรูปแบบ"</string>
     <string name="native_009506aeb0484b2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อนุมัติและบันทึกแล้ว"</string>
     <string name="native_00d108e2e6466940" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"แสดงประวัติการโทรล่าสุด"</string>
     <string name="native_00e8aeba41d79ce3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รอดำเนินการ 1 รายการ"</string>
     <string name="native_010f6550a1c8f554" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไฟล์แนบที่ไม่รองรับ"</string>
     <string name="native_01267be21eb77392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"0 = แม่นยำ"</string>
-    <string name="native_0171e3d4e07f1861" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Connect the Gateway to search threads."</string>
+    <string name="native_0171e3d4e07f1861" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อ Gateway เพื่อค้นหาเธรด"</string>
     <string name="native_0174f83136630e7e" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s บัญชี"</string>
     <string name="native_01ac1c298e0cbd9a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การเปลี่ยนแปลง Cron ต้องใช้ operator.admin โดยรหัสตั้งใจจะไม่ให้สิทธิ์นี้ โปรดเชื่อมต่อกับโทเค็นที่ใช้ร่วมกันหรือรหัสผ่านของ Gateway อีกครั้งเพื่อขอสิทธิ์ผู้ดูแลระบบ หากอุปกรณ์นี้ยังไม่มีสิทธิ์ดังกล่าว ให้อนุมัติการอัปเกรดขอบเขตที่รอดำเนินการจากไคลเอนต์ผู้ดูแลระบบที่มีอยู่"</string>
     <string name="native_01bcfe7a9296b6d6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Apply Patch"</string>
@@ -70,10 +70,10 @@
     <string name="native_088e0e5ebc96c6ac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"แทนที่การตั้งค่า Gateway หรือไม่?"</string>
     <string name="native_08a5391c1de3078a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถโหลดระบบอัตโนมัติได้"</string>
     <string name="native_08b041935798fbf6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คุณ"</string>
-    <string name="native_08ea63ee26954dca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Built-in microphone"</string>
+    <string name="native_08ea63ee26954dca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไมโครโฟนในตัว"</string>
     <string name="native_0905f7f59021c2a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"พื้นผิว"</string>
     <string name="native_0929c9dc7f794852" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีข้อเสนอ"</string>
-    <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Main thread"</string>
+    <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เธรดหลัก"</string>
     <string name="native_0979c6fdbdca1675" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิดแชต"</string>
     <string name="native_0a0b7cf7c428c703" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คำขอดำเนินการ"</string>
     <string name="native_0a708e7b03aaf1fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list pins"</string>
@@ -101,7 +101,7 @@
     <string name="native_0e91610117029a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รีเฟรช"</string>
     <string name="native_0ee30822ed35a792" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อยู่ในคิว %1$s รายการ"</string>
     <string name="native_0f4c8529742b31ea" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เริ่มแชท"</string>
-    <string name="native_0f559ff270904904" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Chat tool calls waiting in the active thread remain visible here."</string>
+    <string name="native_0f559ff270904904" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การเรียกใช้เครื่องมือแชทที่รอดำเนินการในเธรดที่ใช้งานอยู่จะยังคงแสดงที่นี่"</string>
     <string name="native_0f56cc286a4f23d8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"จำเป็นต้องตรวจสอบใบรับรอง"</string>
     <string name="native_0f8fe3a9688138a1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิดพื้นผิว Canvas ปัจจุบันเพื่อตรวจสอบหรือโต้ตอบกับมัน"</string>
     <string name="native_0ff98f05be01ce5e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อัปเดตระบบอัตโนมัติแล้ว"</string>
@@ -117,12 +117,12 @@
     <string name="native_11a6767d5674c7e4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เสร็จสิ้น"</string>
     <string name="native_11e18d6748aa9128" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เวอร์ชันและการอัปเดต"</string>
     <string name="native_11f37f9652a47b5b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw จะแสดงการอนุมัติ งานที่ล้มเหลว และปัญหาของช่องทางไว้ที่นี่"</string>
-    <string name="native_11f6dc0befae5081" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"USB microphone"</string>
+    <string name="native_11f6dc0befae5081" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไมโครโฟน USB"</string>
     <string name="native_1242bf5561713a98" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"มีการแชร์รอเพิ่มมากเกินไป"</string>
     <string name="native_12698ce1ea5cd4ab" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ข้ามแล้ว"</string>
     <string name="native_1291833ee42d8143" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ใช้ที่อยู่ LAN ของคอมพิวเตอร์ Gateway หรือชื่อโฮสต์ระยะไกลที่ปลอดภัย"</string>
     <string name="native_130011756125313c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิด"</string>
-    <string name="native_133f293961d7aa43" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Searching threads"</string>
+    <string name="native_133f293961d7aa43" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังค้นหาเธรด"</string>
     <string name="native_13798c3256e792c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การพูดคุยแบบเรียลไทม์"</string>
     <string name="native_13b588109e423636" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw กำลังเตรียมคำตอบ"</string>
     <string name="native_13ba4cde12390943" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อนุมัติหนึ่งครั้ง"</string>
@@ -138,7 +138,7 @@
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เป้าหมายเซสชัน"</string>
     <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตรวจสอบ Skill จาก ClawHub"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
-    <string name="native_16b1a05e1d987ed1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Preferred microphone"</string>
+    <string name="native_16b1a05e1d987ed1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไมโครโฟนที่ต้องการ"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โฮสต์โหนด"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ระดับ"</string>
     <string name="native_172b997ffbc8c9a7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปิดตัวเลือกแอป"</string>
@@ -158,7 +158,7 @@
     <string name="native_18f2a0947f9d6523" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ถูกบล็อก"</string>
     <string name="native_18f6e5973bc41268" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คำหรือวลีปลุก"</string>
     <string name="native_1906b261e6e0fdd0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway ต้องได้รับการอนุมัติอุปกรณ์"</string>
-    <string name="native_19408baaf5c2e446" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"External microphone"</string>
+    <string name="native_19408baaf5c2e446" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไมโครโฟนภายนอก"</string>
     <string name="native_194a05367fb28913" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"พร้อมใช้งาน %1$s/%2$s"</string>
     <string name="native_199e261f8ee0e97f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อแล้ว (ผู้ควบคุมออฟไลน์)"</string>
     <string name="native_19fc7a47df16fb1f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ความสามารถยังไม่ได้รับการอนุมัติ"</string>
@@ -210,7 +210,7 @@
     <string name="native_22965568d22a14ee" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อแล้ว"</string>
     <string name="native_22a970d2e5b1cc23" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เสร็จสมบูรณ์"</string>
     <string name="native_22b8da9e693e94eb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โทรศัพท์ของคุณจับคู่กับ %1$s แล้ว ดำเนินการต่อเพื่อเปิดสิทธิ์เข้าถึงโหนดให้เสร็จสมบูรณ์"</string>
-    <string name="native_22f19ab686639b9a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Current thread"</string>
+    <string name="native_22f19ab686639b9a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เธรดปัจจุบัน"</string>
     <string name="native_23246d9852fed325" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การคิด %1$s"</string>
     <string name="native_2346f214ad56b180" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปิดเสียง"</string>
     <string name="native_2347fc06da5f60de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw ขอขอบคุณพันธมิตรในชุมชนโอเพนซอร์ส"</string>
@@ -237,7 +237,7 @@
     <string name="native_262c897a1f408b0b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อกับ Gateway ของคุณ"</string>
     <string name="native_2682bd813a3bccbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ป้อนรหัสตั้งค่าจาก openclaw qr"</string>
     <string name="native_268f14bbfe119c1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การวินิจฉัย"</string>
-    <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"This permanently deletes the thread and its transcript."</string>
+    <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การดำเนินการนี้จะลบเธรดและบันทึกการสนทนาอย่างถาวร"</string>
     <string name="native_26f0dd993530eb2d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังลองใหม่โดยอัตโนมัติ"</string>
     <string name="native_270ff82f36da987f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คัดลอกรูปภาพวิดเจ็ตแล้ว"</string>
     <string name="native_2728740a95d465c6" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s บทบาท"</string>
@@ -253,7 +253,7 @@
     <string name="native_27d773b934ed324f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตรวจสอบและติดตั้ง"</string>
     <string name="native_2821f0168d6dd9df" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปลี่ยนอุปกรณ์นี้ให้เป็นโหนด OpenClaw ที่ปลอดภัยสำหรับแชท, เสียง, กล้อง และเครื่องมืออุปกรณ์"</string>
     <string name="native_2831546121359362" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตั้งค่าด้วยตนเอง"</string>
-    <string name="native_287c4b113aafc215" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Open Chat to start or resume the current thread."</string>
+    <string name="native_287c4b113aafc215" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิดแชทเพื่อเริ่มหรือดำเนินการต่อในเธรดปัจจุบัน"</string>
     <string name="native_28bb849671cab958" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เคล็ดลับ: หยุดฟังเพื่อส่งช่วงที่บันทึกไว้"</string>
     <string name="native_28d03596d24eeb4e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ข้าม"</string>
     <string name="native_28d55ec6974d84e8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คำขอด้วยเสียงล้มเหลว"</string>
@@ -273,10 +273,10 @@
     <string name="native_2c19d584bf8ad518" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ทำเครื่องหมายว่ายังไม่ได้อ่าน"</string>
     <string name="native_2c75802a5f8df5f8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ค้นหาบุคคลและรายละเอียดการติดต่อ"</string>
     <string name="native_2c9cce8250d746e3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ต้องระบุตัวตนอุปกรณ์"</string>
-    <string name="native_2cd62f7a670b2819" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw thread"</string>
+    <string name="native_2cd62f7a670b2819" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เธรด OpenClaw"</string>
     <string name="native_2d4dfe885f84629e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อนุญาตการเข้าถึงคลังรูปภาพ"</string>
     <string name="native_2d6416405eb44982" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การตอบกลับก่อนหน้านี้ดำเนินการอนุมัตินี้แล้ว"</string>
-    <string name="native_2d85de9d56c226e4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"No recent threads"</string>
+    <string name="native_2d85de9d56c226e4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีเธรดล่าสุด"</string>
     <string name="native_2df01a03ff43400b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่พบรายการที่ตรงกัน"</string>
     <string name="native_2df30b117ad829ab" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อ่านการแจ้งเตือนจากแอปที่เลือก"</string>
     <string name="native_2e0078a8322d6f1f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่ทราบสถานะความพร้อมใช้งาน"</string>
@@ -338,7 +338,7 @@
     <string name="native_36c725ddb20f8bd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การตั้งค่าผู้ให้บริการ Talk"</string>
     <string name="native_36d88ed6cc91d2b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Music Generation"</string>
     <string name="native_36e8d5e94219dc37" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การตั้งค่าการคุย"</string>
-    <string name="native_36f1fac278711470" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · 1 thread"</string>
+    <string name="native_36f1fac278711470" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังตรวจสอบ · 1 เธรด"</string>
     <string name="native_37053dc1f680546b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ข้อความ Payload"</string>
     <string name="native_37582309e7a1dbe5" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การอนุมัติ %1$s"</string>
     <string name="native_379ce0aacf46c35f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway ไม่ได้ส่งคืนความพร้อมของ %1$s"</string>
@@ -363,7 +363,7 @@
     <string name="native_3a65cf1204f18864" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อแล้ว (โหนดออฟไลน์)"</string>
     <string name="native_3a78695388b38b5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"หน้าแรก"</string>
     <string name="native_3b28b535950f8175" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การป้อนตามคำบอกกำลังฟังอยู่"</string>
-    <string name="native_3b46b7912670bfb0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"No archived threads"</string>
+    <string name="native_3b46b7912670bfb0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีเธรดที่เก็บถาวร"</string>
     <string name="native_3b851469ea31d489" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เลือกและตรวจสอบผู้ช่วยที่พร้อมใช้งานบน gateway นี้"</string>
     <string name="native_3be0085a6bd88cdd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โหมดพูดคุยทำงานอยู่"</string>
     <string name="native_3bee4ede6bf4436c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังทำงาน · มีงานที่ใช้งานอยู่ 1 รายการ"</string>
@@ -375,7 +375,7 @@
     <string name="native_3da4811eafea080a" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s://%2$s:%3$s"</string>
     <string name="native_3de3d401128d4395" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถโหลดรายละเอียดการอนุมัติได้ รีเฟรชแล้วลองอีกครั้ง"</string>
     <string name="native_3e398e6fb979557a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tool Call"</string>
-    <string name="native_3e42e385075b9b56" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads"</string>
+    <string name="native_3e42e385075b9b56" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เธรด"</string>
     <string name="native_3f00927a719345ed" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Write"</string>
     <string name="native_3f25ccebfa99dcf3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เริ่มต้นด้วยพรอมต์ หรือใช้เสียง"</string>
     <string name="native_3f39d5c348e5b79d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"D"</string>
@@ -402,7 +402,7 @@
     <string name="native_4287d54ad5e78985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"งาน OpenClaw ที่กำหนดเวลาไว้จาก gateway ของคุณ"</string>
     <string name="native_429f6057535c1ea3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sub-agent"</string>
     <string name="native_42e3a99c21767def" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังรอการอนุมัติอุปกรณ์"</string>
-    <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Loading thread"</string>
+    <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังโหลดเธรด"</string>
     <string name="native_43905968a540af6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การหน่วงเหลื่อม ms"</string>
     <string name="native_43988c156beabf7d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"event create"</string>
     <string name="native_43cc23fa52b87b4c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เอกสาร"</string>
@@ -484,7 +484,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การส่ง"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปิดเสียงลำโพง"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังเปิดการเชื่อมต่อ Gateway"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังตรวจสอบ · %1$s เธรด"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การทำงานของระบบอัตโนมัติเสร็จสิ้นแล้ว"</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่พบแอปที่ตรงกัน"</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ส่งไปยังแชท"</string>
@@ -509,7 +509,7 @@
     <string name="native_55898449eb74fb2e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สถานภาพ"</string>
     <string name="native_55a12cbe0995e214" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตัวรับฟังการแจ้งเตือน"</string>
     <string name="native_55d8e7da6d0a752c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปิดเสียงลำโพงแล้ว"</string>
-    <string name="native_560d3e826c413dc9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Search threads"</string>
+    <string name="native_560d3e826c413dc9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ค้นหาเธรด"</string>
     <string name="native_565339bc4d33d728" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตกลง"</string>
     <string name="native_56a508f3f2bf424a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถเปิดคู่มือการตั้งค่าได้"</string>
     <string name="native_56c41c606c44f3fc" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ถาม OpenClaw %1$s"</string>
@@ -576,7 +576,7 @@
     <string name="native_60ea1847c2ba5446" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ยกเลิกการตอบกลับแล้ว"</string>
     <string name="native_6105d6cc76af4003" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รูปภาพ"</string>
     <string name="native_614b8348a2dbe46b" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"พักไว้ %1$s รายการ"</string>
-    <string name="native_614e83ef17c13f3c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"No matching threads"</string>
+    <string name="native_614e83ef17c13f3c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีเธรดที่ตรงกัน"</string>
     <string name="native_6197595503f01ee2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"delete"</string>
     <string name="native_619837a134285528" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เลย์เอาต์: กะทัดรัด"</string>
     <string name="native_61ffa9c8c703dd5e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"channels"</string>
@@ -619,10 +619,10 @@
     <string name="native_67b696468610b879" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dashboard"</string>
     <string name="native_67fa416afa64d304" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"วางโทเค็น"</string>
     <string name="native_6827238fea72c88b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีผู้ให้บริการ"</string>
-    <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"No threads yet"</string>
-    <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bluetooth microphone"</string>
+    <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ยังไม่มีเธรด"</string>
+    <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไมโครโฟน Bluetooth"</string>
     <string name="native_690dbe9dc0993c42" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ล่าสุด"</string>
-    <string name="native_6930c8d1fc4f01d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rename thread"</string>
+    <string name="native_6930c8d1fc4f01d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปลี่ยนชื่อเธรด"</string>
     <string name="native_69384c1c4d99f6eb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่ทราบผลการดำเนินการ การดำเนินการจะยังคงถูกปิดใช้งานจนกว่าจะยืนยันบันทึกของ Gateway"</string>
     <string name="native_6940189433657105" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"dialog"</string>
     <string name="native_695c03727ff0251f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ฟังคำปลุก"</string>
@@ -701,7 +701,7 @@
     <string name="native_746f71ec623adc37" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Epoch มิลลิวินาที (ไม่บังคับ)"</string>
     <string name="native_7491b353909c1147" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีโมเดลที่กำหนดค่าไว้ รีเฟรชเพื่อตรวจสอบความพร้อมใช้งานอีกครั้ง"</string>
     <string name="native_74a883a037bc227f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การตั้งค่า"</string>
-    <string name="native_74c372f29b83df94" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Back camera"</string>
+    <string name="native_74c372f29b83df94" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กล้องหลัง"</string>
     <string name="native_74e21680eac7385c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"approve"</string>
     <string name="native_74e492d5d0df0bab" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ก่อนเริ่มต้น"</string>
     <string name="native_74f0a5d234edc4af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถโหลด Skills ได้"</string>
@@ -776,13 +776,13 @@
     <string name="native_8193ee8a22d25208" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปักหมุดโมเดล"</string>
     <string name="native_81c2c4f30a4bec68" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ล้างการค้นหา"</string>
     <string name="native_81d38aca5306940b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิดใช้งานสำหรับเอเจนต์ที่มีสิทธิ์"</string>
-    <string name="native_820d08e12968baff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"No current thread"</string>
+    <string name="native_820d08e12968baff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีเธรดปัจจุบัน"</string>
     <string name="native_82250171708918de" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"หลังจาก %1$s"</string>
     <string name="native_825b9c75d7fed691" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อนุญาตให้ตัวจัดกำหนดการเรียกใช้ระบบอัตโนมัตินี้"</string>
     <string name="native_82990a093599a9bb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"นำไปใช้แล้ว %1$s รายการ"</string>
     <string name="native_8340dad4f3be30a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ยังไม่มีไดอารีความฝัน"</string>
     <string name="native_837e39f46163ffb4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รีเฟรชงานเบื้องหลัง"</string>
-    <string name="native_838337fd9ab30454" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Summarize recent threads and next steps."</string>
+    <string name="native_838337fd9ab30454" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สรุปเธรดล่าสุดและขั้นตอนถัดไป"</string>
     <string name="native_83e2faed20a3cda4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ทำงานบนอุปกรณ์ขณะที่ OpenClaw แสดงอยู่"</string>
     <string name="native_844e5b02f3ef05ca" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s กำลังทำงาน"</string>
     <string name="native_846c75dca0b71591" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
@@ -852,7 +852,7 @@
     <string name="native_8f54b0d1e30092d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ข้อความเสียง"</string>
     <string name="native_8fa196125b734940" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีสิ่งใดต้องให้คุณดำเนินการ"</string>
     <string name="native_8fce9ec6fd5432df" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw ต้องการสิทธิ์อนุญาต %1$s เพื่อดำเนินการต่อ"</string>
-    <string name="native_8fe42acb8573244e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wired headset microphone"</string>
+    <string name="native_8fe42acb8573244e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไมโครโฟนชุดหูฟังแบบมีสาย"</string>
     <string name="native_906115657390f367" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ส่งแล้ว"</string>
     <string name="native_9071738f145962a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ครบกำหนด"</string>
     <string name="native_90bf81305006e6ed" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รายละเอียด Skill ไม่พร้อมใช้งานในสถานะ Skills ปัจจุบัน"</string>
@@ -941,7 +941,7 @@
     <string name="native_9e37aa0704a3cf44" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ติดตั้ง %1$s แล้ว"</string>
     <string name="native_9e4635769f0aaf0d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway"</string>
     <string name="native_9e9bef85bb320b81" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โหมดการส่งต่อ"</string>
-    <string name="native_9f6e180ff696bec5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Toggle thread layout"</string>
+    <string name="native_9f6e180ff696bec5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สลับเค้าโครงเธรด"</string>
     <string name="native_9fb7c4ebcbc3e558" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีปลายทาง TLS"</string>
     <string name="native_9fe101a0ec7ef416" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway ของ OpenClaw"</string>
     <string name="native_9ffc843f501acdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตั้งค่าด้วยตนเอง"</string>
@@ -989,7 +989,7 @@
     <string name="native_a89bac8b89022bde" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังฟัง · อยู่ในคิว %1$s รายการ"</string>
     <string name="native_a8bbbd7231a6c191" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปิดเสียงพูดของผู้ช่วยแล้ว"</string>
     <string name="native_a8ef5cdf31a6505a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ยังไม่พบ Gateway ใช้การตั้งค่าด้วยตนเองหากการค้นหาถูกบล็อก"</string>
-    <string name="native_a901aa25b833cf33" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Open thread"</string>
+    <string name="native_a901aa25b833cf33" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิดเธรด"</string>
     <string name="native_a92f0449a9f7235b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังทำงาน"</string>
     <string name="native_a9624cf0b6ae80c1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เริ่มพูด..."</string>
     <string name="native_a9ac253267d07365" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โหนดโทรศัพท์"</string>
@@ -1024,7 +1024,7 @@
     <string name="native_adca3171c270301a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การลงชื่อเข้าใช้ Gateway นี้สามารถแสดงรายการโหนดที่เชื่อมต่อได้ แต่ไม่สามารถอนุมัติการจับคู่โทรศัพท์เครื่องใหม่ได้ โปรดจับคู่โทรศัพท์เครื่องใหม่จากเซสชันผู้ดูแล Gateway การอนุมัติความสามารถของโหนดเป็นกระบวนการแยกต่างหากและยังคงใช้ nodes approve &lt;request id&gt;"</string>
     <string name="native_ade9248e0132b411" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อถือ"</string>
     <string name="native_ae27fa789a03c1db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คิวอาร์โค้ดนั้นไม่ใช่คิวอาร์สำหรับตั้งค่า OpenClaw โปรดสร้างรหัสใหม่ด้วย openclaw qr แล้วลองอีกครั้ง"</string>
-    <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Preferred microphone unavailable; using automatic routing."</string>
+    <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไมโครโฟนที่ต้องการไม่พร้อมใช้งาน กำลังใช้การกำหนดเส้นทางอัตโนมัติ"</string>
     <string name="native_aea4a04a80426ed8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปฏิเสธแล้ว"</string>
     <string name="native_aed306fbb63c0c68" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รวมแพ็กเกจของ Android และแพ็กเกจเบื้องหลัง"</string>
     <string name="native_aedf1cf58372f943" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway ของคุณพร้อมใช้งานแล้ว"</string>
@@ -1060,7 +1060,7 @@
     <string name="native_b4aca584eecea590" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถโหลดรายละเอียดงานได้"</string>
     <string name="native_b51702b087112113" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ข้อความจากเอเจนต์"</string>
     <string name="native_b538b9d40695a6fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway ต้องใช้อัตลักษณ์ของอุปกรณ์นี้ ยืนยันตัวตนใหม่หรือรีเซ็ตการเชื่อมต่อ Gateway นี้"</string>
-    <string name="native_b53b35163f7588c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Next session"</string>
+    <string name="native_b53b35163f7588c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เซสชันถัดไป"</string>
     <string name="native_b55dae19fcb48a4d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ความปลอดภัยของการเชื่อมต่อ"</string>
     <string name="native_b5a229ac8becc603" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เว็บไซต์"</string>
     <string name="native_b5af0517c02601fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อ Gateway เพื่อโหลดคำขออนุมัติในแอป"</string>
@@ -1091,7 +1091,7 @@
     <string name="native_bb4f2558e4333834" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"บันทึกรูปภาพวิดเจ็ตไปยัง Downloads แล้ว"</string>
     <string name="native_bbe5fc3b9ef39f99" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังเริ่มต้น…"</string>
     <string name="native_bc19cec293228fb8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ข้อผิดพลาดของไคลเอนต์"</string>
-    <string name="native_bc6618670f3e8a17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bluetooth LE microphone"</string>
+    <string name="native_bc6618670f3e8a17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไมโครโฟน Bluetooth LE"</string>
     <string name="native_bcb06651437caa15" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
     <string name="native_bd08450d63406844" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิดใช้งานระบบอัตโนมัติแล้ว"</string>
     <string name="native_bd6719b455bcc898" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Memory Get"</string>
@@ -1116,7 +1116,7 @@
     <string name="native_c12a06263b75eb23" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อ Gateway เพื่อโหลดรายละเอียด Skill"</string>
     <string name="native_c156b9eaf502aabc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตัวฟังคำปลุก"</string>
     <string name="native_c184b2ada7abc688" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ขยายตัวอย่างลิงก์"</string>
-    <string name="native_c18ee03d3906a488" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Clear thread search"</string>
+    <string name="native_c18ee03d3906a488" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ล้างการค้นหาเธรด"</string>
     <string name="native_c1970bb2cdf299b7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"NULL (ล้มเหลว)"</string>
     <string name="native_c1c1009d3f37ec05" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อัปเดต"</string>
     <string name="native_c1c224b03cd9bc7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ผู้ดูแลระบบ"</string>
@@ -1184,14 +1184,14 @@
     <string name="native_ca7981b46ecf2c17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปิด"</string>
     <string name="native_cab94aba84f97f7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รูปแบบตัวอักษร"</string>
     <string name="native_cae7d57bc067a514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"หยุด"</string>
-    <string name="native_cae98462b30650eb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"No matching threads yet."</string>
+    <string name="native_cae98462b30650eb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ยังไม่มีเธรดที่ตรงกัน"</string>
     <string name="native_cba62d81f910c7f0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"จับคู่ Gateway สำเร็จแล้ว\nอนุมัติความสามารถของโหนดสำหรับโทรศัพท์เครื่องนี้จาก UI ของผู้ดูแลระบบ"</string>
     <string name="native_cc4b66e7e22230c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skills นี้ได้รับการติดตั้งแล้ว แต่ยังไม่พร้อมใช้งานในขณะนี้ โปรดใช้เดสก์ท็อปหรือ CLI เพื่อเปลี่ยนแปลงการกำหนดค่า"</string>
     <string name="native_cc5f45fb30a26e07" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตัวรู้จำไม่ว่าง"</string>
     <string name="native_cc721e25d73938a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway หลัก"</string>
     <string name="native_cc7a9a5cf8c4bc9d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เรียกใช้คำสั่งอนุมัติบน Gateway"</string>
     <string name="native_cc925e3c97ac7a35" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถโหลดข้อเสนอ Skill Workshop ได้"</string>
-    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Catch me up on my recent OpenClaw threads and suggest next steps."</string>
+    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สรุปความคืบหน้าจากเธรด OpenClaw ล่าสุดของฉันและแนะนำขั้นตอนถัดไป"</string>
     <string name="native_ccb4c324f516c633" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่ใช่ตอนนี้"</string>
     <string name="native_cced0b0d83a9e400" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw qr"</string>
     <string name="native_cced28c6dc3f99c2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"start"</string>
@@ -1214,7 +1214,7 @@
     <string name="native_ceb6931ea57cc999" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปรับอัตโนมัติ"</string>
     <string name="native_cf0ee3547a4e51a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เร็วๆ นี้"</string>
     <string name="native_d04fc7d7e19702f8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Search"</string>
-    <string name="native_d053ba98d8bbcec1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Try Chat, Voice, Threads, Providers, or Settings."</string>
+    <string name="native_d053ba98d8bbcec1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ลองใช้แชท เสียง เธรด ผู้ให้บริการ หรือการตั้งค่า"</string>
     <string name="native_d056177742e27cf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw กำลังทำงาน"</string>
     <string name="native_d0cda6559bb347db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"navigate"</string>
     <string name="native_d0d0de0039c7990b" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ส่งคำขอเมื่อ %1$s"</string>
@@ -1241,7 +1241,7 @@
     <string name="native_d3974fd6d3b6c81f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รอการเรียกใช้"</string>
     <string name="native_d3f75e24411053c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"AI ส่วนตัวบนอุปกรณ์ของคุณ"</string>
     <string name="native_d406ade2958cb5b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attach"</string>
-    <string name="native_d461a493a3753877" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatic"</string>
+    <string name="native_d461a493a3753877" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อัตโนมัติ"</string>
     <string name="native_d4b1ea5708dd5329" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ภาพรวม"</string>
     <string name="native_d53167a3f66debec" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ขอคืนค่าไม่สำเร็จ แตะเพื่อลองอีกครั้ง"</string>
     <string name="native_d588c689e03132fb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s\n\n"</string>
@@ -1254,7 +1254,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โปรไฟล์"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ขีดจำกัดของผู้ให้บริการจะแสดงที่นี่เมื่อ Gateway ของคุณรายงานข้อมูลดังกล่าว"</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปัญหา 1 รายการ"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เธรดใน \"%1$s\" จะยังคงอยู่และย้ายกลับไปที่ไม่ได้จัดกลุ่ม"</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สร้างเมื่อ"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โทเค็นที่ใช้งานอยู่ %1$s/%2$s"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>
@@ -1271,7 +1271,7 @@
     <string name="native_d93e2b7a15efbc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถดำเนินการอนุมัติให้เสร็จสิ้นได้ โปรดรีเฟรชแล้วลองอีกครั้ง"</string>
     <string name="native_d942f64886578d87" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"import"</string>
     <string name="native_d94cfb21b67ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ลักษณะที่โทรศัพท์เครื่องนี้ปรากฏต่อ OpenClaw"</string>
-    <string name="native_d96f2b0eab4e67b7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Focus thread search"</string>
+    <string name="native_d96f2b0eab4e67b7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โฟกัสการค้นหาเธรด"</string>
     <string name="native_d975ca28a64f8850" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เชื่อมต่อ Gateway"</string>
     <string name="native_d9be42d9b30ce057" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อ่านปฏิทิน"</string>
     <string name="native_d9f641e1a02807cb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ภาพรวมจะรีเฟรชเมื่อเชื่อมต่อใหม่และเมื่อเปิดหน้าจอนี้"</string>
@@ -1317,7 +1317,7 @@
     <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ค้นหา Skills ที่ติดตั้ง"</string>
     <string name="native_e0723a86a5b9408a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตรวจสอบ"</string>
     <string name="native_e083bd83e9d3e97e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Process"</string>
-    <string name="native_e08a8fc53e29e5c9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Recent Threads"</string>
+    <string name="native_e08a8fc53e29e5c9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เธรดล่าสุด"</string>
     <string name="native_e0926fdac700b094" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เทอร์มินัล"</string>
     <string name="native_e0d1b68224bf0b31" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ปัจจุบัน"</string>
     <string name="native_e10435f6306b06d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 บัญชี"</string>
@@ -1346,13 +1346,13 @@
     <string name="native_e52b3044724b9f4d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เลิกปักหมุดโมเดล"</string>
     <string name="native_e5584bc5057284ae" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"พื้นผิวการส่งข้อความที่เชื่อมต่อกับ Gateway นี้"</string>
     <string name="native_e595f17fac1d8384" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังส่ง"</string>
-    <string name="native_e5b87192a9e6321f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Archived threads will show up here."</string>
+    <string name="native_e5b87192a9e6321f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เธรดที่เก็บถาวรจะแสดงที่นี่"</string>
     <string name="native_e5c02424e511e1ef" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"คัดลอกคำสั่งแล้ว"</string>
     <string name="native_e5c083cf41ff6472" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีตัวอย่างให้ใช้งาน"</string>
     <string name="native_e5c3e7b8110e7087" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อนุมัติโทรศัพท์เครื่องนี้บน Gateway\nจากนั้นลองเชื่อมต่ออีกครั้ง"</string>
     <string name="native_e5c7478bbce26eb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สแกนรหัส QR"</string>
     <string name="native_e5e4f854dcd3ffc6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไดเรกทอรีทำงานของคำสั่ง · ไม่สามารถล้างได้"</string>
-    <string name="native_e614ccf26ec5d312" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Thread Activity"</string>
+    <string name="native_e614ccf26ec5d312" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กิจกรรมของเธรด"</string>
     <string name="native_e674447337e83c13" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"พร้อมใช้งาน"</string>
     <string name="native_e68e23dc04b0f986" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ลบระบบอัตโนมัติหรือไม่?"</string>
     <string name="native_e7053d96b6704dbb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s วันนี้ · ทั้งหมด %2$s"</string>
@@ -1435,7 +1435,7 @@
     <string name="native_f4ccae29e1bb0c20" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังทำงาน"</string>
     <string name="native_f4db1e48476f6075" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"สิ้นสุด"</string>
     <string name="native_f4ef7a41caa88dd1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีผู้ให้บริการที่พร้อมใช้งาน"</string>
-    <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Prioritizes connected Bluetooth microphones."</string>
+    <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ให้ความสำคัญกับไมโครโฟน Bluetooth ที่เชื่อมต่ออยู่"</string>
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"บล็อกไม่ให้ส่งต่อ %1$s แอป"</string>
     <string name="native_f532ee1f7288365e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การดำเนินการกับข้อความ"</string>
     <string name="native_f5387f9bb6ed7031" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ประเภท"</string>
@@ -1461,7 +1461,7 @@
     <string name="native_f8b32f4e92bd84ce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ติดตั้งแล้ว"</string>
     <string name="native_f8c2745155505d39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"หมดเวลารอการตอบกลับ โปรดลองอีกครั้งหรือรีเฟรช"</string>
     <string name="native_f8cd133f0ea1031b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ค้นหาการสนทนาก่อนหน้า"</string>
-    <string name="native_f90f3791049b995d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Browse Threads"</string>
+    <string name="native_f90f3791049b995d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เรียกดูเธรด"</string>
     <string name="native_f92e2ad582c0e13f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กำลังรีเฟรช"</string>
     <string name="native_f991ae9cb081e1f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิดกล้องและจัดให้รหัสจาก openclaw qr อยู่ในกรอบ"</string>
     <string name="native_f9ea3f1540eaa584" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีอุปกรณ์"</string>
@@ -1483,7 +1483,7 @@
     <string name="native_fcdeb9947bc94101" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ทดสอบ ทดสอบ 1 2 3"</string>
     <string name="native_fcea13c79c2f85a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่สามารถค้นหา Skills ใน ClawHub ได้"</string>
     <string name="native_fd175ecd65f7353d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ไม่มีพรอมต์"</string>
-    <string name="native_fd301dc5d0e7ccf1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Front camera"</string>
+    <string name="native_fd301dc5d0e7ccf1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กล้องหน้า"</string>
     <string name="native_fda8fc3b85420d14" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"เปิดรายการบันทึก"</string>
     <string name="native_fdd0d769c49517c2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"หมดเวลาการเชื่อมต่อเครือข่าย"</string>
     <string name="native_fe18013d93d22f4f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ตอนนี้"</string>
@@ -1496,8 +1496,8 @@
     <string name="native_ff52188203241c29" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ยังไม่ได้กำหนดค่ารหัสผ่าน Gateway"</string>
     <string name="native_ff716fc4735e067f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"การตั้งค่าการป้อนตามคำบอก"</string>
     <string name="native_ff9dbbdfb84ddab2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"โหลดโมเดลของผู้ให้บริการแล้ว แต่ไม่มีข้อมูลความพร้อมใช้งาน"</string>
-    <string name="native_ffa7aa557b547a79" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Delete thread?"</string>
-    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway."</string>
+    <string name="native_ffa7aa557b547a79" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ลบเธรดหรือไม่?"</string>
+    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw เปลี่ยนโทรศัพท์เครื่องนี้ให้เป็นอินเทอร์เฟซคำสั่งบนมือถือที่เรียบง่ายสำหรับเธรด เสียง ผู้ให้บริการ และ Gateway"</string>
     <string name="native_ffb6f5764bddb68c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ใหม่สุดก่อน"</string>
     <string name="native_ffcf16006c652ee3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"รอบถัดไป"</string>
 </resources>

--- a/apps/android/app/src/main/res/values-tr/strings.xml
+++ b/apps/android/app/src/main/res/values-tr/strings.xml
@@ -75,6 +75,7 @@
     <string name="native_0929c9dc7f794852" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Öneri yok"</string>
     <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ana iletişim dizisi"</string>
     <string name="native_0979c6fdbdca1675" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Chat\'i Aç"</string>
+    <string name="native_09ce95090659d069" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cihaz eşleştirme işlemleri bu Gateway oturumunda kullanılamıyor. Gateway ana makinesinde openclaw devices list komutunu çalıştırın ve isteği buradan yönetin. Düğüm yeteneği onayı ayrı bir işlemdir ve hâlâ nodes approve &lt;request id&gt; komutunu kullanır."</string>
     <string name="native_0a0b7cf7c428c703" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Eylem İsteği"</string>
     <string name="native_0a708e7b03aaf1fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list pins"</string>
     <string name="native_0ab0e1629576aecf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skill Atölyesi önerilerini yüklemek için bir Gateway\'e bağlanın."</string>
@@ -87,10 +88,12 @@
     <string name="native_0c3845dcd2f0f683" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Markdown içeriğini yüklemek için bu teklifi inceleyin."</string>
     <string name="native_0c3ea4e2f12153e7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw\'ı aç ve %1$s sor"</string>
     <string name="native_0c4d01e81bb3d1fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"akıl yürütme"</string>
+    <string name="native_0c77fe09ab336a3e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"İstemci"</string>
     <string name="native_0c79a9c222840ed0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Uygulandı"</string>
     <string name="native_0cab1c9617404faf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"video"</string>
     <string name="native_0cf04463c4276a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Yükseltildi"</string>
     <string name="native_0d21bd52022ca7f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Çevrimiçi"</string>
+    <string name="native_0d5644ff52ce2ba3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kapsamlar"</string>
     <string name="native_0d5efd432e4fedf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gerçek zamanlı ses sağlayıcısı yapılandırılmamış."</string>
     <string name="native_0d8ca811c3744a6d" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s · %2$s"</string>
     <string name="native_0db10f2c2f332cd2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"kick"</string>
@@ -138,6 +141,7 @@
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Oturum hedefi"</string>
     <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ClawHub Skill\'ini incele"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
+    <string name="native_16a5b7ad567a8093" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bu cihazdan gelen eşleştirme isteği reddedilsin mi?"</string>
     <string name="native_16b1a05e1d987ed1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tercih edilen mikrofon"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Düğüm ana makinesi"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Düzey"</string>
@@ -183,6 +187,7 @@
     <string name="native_1d91629837639a5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bu otomasyon, siz düzenlerken değişti. Kaydetmeden önce en son Gateway sürümüne geri dönün."</string>
     <string name="native_1dbf9d5979606697" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bağlantı kurulduğunda Gateway, sürekli açık bir oturum sürdürmek yerine sessiz bir anlık bildirimle telefonu uyandırabilir."</string>
     <string name="native_1e432ea5425e4a3a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Uyandırma Modu"</string>
+    <string name="native_1e595a107c78b957" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Eşleştirilmiş cihaz kaldırılsın mı?"</string>
     <string name="native_1e955a58278623a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sistem etkinliği metni"</string>
     <string name="native_1ea44149be42d970" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Widget görseli kopyalanamadı"</string>
     <string name="native_1ea442a134b2a184" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Hayır"</string>
@@ -197,6 +202,7 @@
     <string name="native_2065cc867eba1b39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sağlayıcı model yapılandırması yüklenemedi."</string>
     <string name="native_207ccb22d618db05" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s uygulamanın yönlendirmesine izin verildi."</string>
     <string name="native_209b9e597963e7e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ses kurulumu"</string>
+    <string name="native_211988ba9dd0570a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Eşleştirme isteği reddedilsin mi?"</string>
     <string name="native_2132066dc9475cb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"This skill is installed but not available to the current agent. Agent filters stay on desktop or CLI."</string>
     <string name="native_21378545892f1fe2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Yayıncı"</string>
     <string name="native_214d4932fc767e8f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">" · Konuşma: Konuşuyor"</string>
@@ -238,6 +244,7 @@
     <string name="native_2682bd813a3bccbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw qr tarafından oluşturulan kurulum kodunu girin."</string>
     <string name="native_268f14bbfe119c1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tanılama"</string>
     <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bu işlem, iş parçacığını ve dökümünü kalıcı olarak siler."</string>
+    <string name="native_26e47d73a55d7fa7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cihaz onaylandı."</string>
     <string name="native_26f0dd993530eb2d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Otomatik olarak yeniden deneniyor"</string>
     <string name="native_270ff82f36da987f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Widget görseli kopyalandı"</string>
     <string name="native_2728740a95d465c6" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s rol"</string>
@@ -346,6 +353,7 @@
     <string name="native_381428f5f251a764" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Conversation Send"</string>
     <string name="native_3824a9f4dafe92c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tuval"</string>
     <string name="native_384ae4ab1a2830f9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 sağlayıcı"</string>
+    <string name="native_385001409de8562a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway sertifikası otomatik olarak okunamadı. Gateway ana bilgisayarından alınan SHA-256 parmak izini yapıştırın."</string>
     <string name="native_387b2569e440838c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gönderilemedi: %1$s"</string>
     <string name="native_3892e10346fd2012" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Köprü"</string>
     <string name="native_38d198cd5303680f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Teslim Hatası"</string>
@@ -403,6 +411,7 @@
     <string name="native_429f6057535c1ea3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sub-agent"</string>
     <string name="native_42e3a99c21767def" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cihaz onayı bekleniyor"</string>
     <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"İletişim dizisi yükleniyor"</string>
+    <string name="native_430df68ec29a85a2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bu Gateway artık bu cihazın güvendiği bir sertifika sunuyor."</string>
     <string name="native_43905968a540af6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kaydırma ms"</string>
     <string name="native_43988c156beabf7d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"event create"</string>
     <string name="native_43cc23fa52b87b4c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"belge"</string>
@@ -464,6 +473,7 @@
     <string name="native_4e8c72cab82e0711" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Otomasyonun yapılandırması geçersiz."</string>
     <string name="native_4ec30e9d85725d41" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"İzin verilenler listesi"</string>
     <string name="native_4ed379d418bb8629" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"groups"</string>
+    <string name="native_4ee252fb736effa2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Açık anahtar"</string>
     <string name="native_4efca0d10c5feb8e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Hakkında"</string>
     <string name="native_4f1bc100d1dccc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bu görüntüde kurulum QR kodu bulunamadı. openclaw qr tarafından oluşturulan QR kodunu seçin veya kurulum kodunu manuel olarak girin."</string>
     <string name="native_4fe3cdd404ea0290" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"permissions"</string>
@@ -550,6 +560,7 @@
     <string name="native_5c0c8c9aa658f4a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OPENCLAW"</string>
     <string name="native_5c1acea9c9b0e704" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Fetch"</string>
     <string name="native_5c39123805ffb4e2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"İstem"</string>
+    <string name="native_5c944156b5353428" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cihaz onaylansın mı?"</string>
     <string name="native_5d410adb9576e266" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s ve kayıtlı kimlik bilgileri bu telefondan kaldırılsın mı?"</string>
     <string name="native_5d6c41a67139ee26" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"QR kodu güvenli olmayan bir uzak gateway\'i işaret ediyor. %1$s %2$s"</string>
     <string name="native_5d6cbac59f87e78d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ekran yüzeyi hazır"</string>
@@ -567,6 +578,7 @@
     <string name="native_5fa1d457ddfcd26c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"rename group"</string>
     <string name="native_5fa7aac5375c5815" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Hazır"</string>
     <string name="native_5fc1927ca948f31c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Günlük ilk kaydını bekliyor."</string>
+    <string name="native_6007acbe30b2cd98" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Onayla"</string>
     <string name="native_600c9c27960112a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Canlı sayfa"</string>
     <string name="native_6030d1f6340776d2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Otomasyon zaten çalışıyor."</string>
     <string name="native_604e6d6faf8d0295" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tek seferlik başarılı bir çalıştırmanın ardından bu otomasyonu kaldırın."</string>
@@ -606,12 +618,14 @@
     <string name="native_6657cc73af00feac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"İstendiğinde kamera araçlarına izin ver."</string>
     <string name="native_666067dd376e5d45" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sorunlar"</string>
     <string name="native_666c8bc0319f3b54" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sesle Uyandırma"</string>
+    <string name="native_66713d713e3a41c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Eşleştirme isteği reddedildi."</string>
     <string name="native_66b23bae66fc0d79" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s gün önce"</string>
     <string name="native_66cf5513b37462be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"roles"</string>
     <string name="native_66d0f523a379b2de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skills"</string>
     <string name="native_66f4804ee23ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Arşivle"</string>
     <string name="native_66fab2875ee427f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Düğüm çevrimdışı. Yeniden bağlanıp tekrar deneyin."</string>
     <string name="native_6725e7bbcd28f3a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sistem"</string>
+    <string name="native_672f3453e1dd571b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Uzak IP"</string>
     <string name="native_674b38cae72bb0c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gruplandırılmamış"</string>
     <string name="native_674eb55d9c353900" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zamanlama Ayrıntısı"</string>
     <string name="native_67528858c36397f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Telefon Özellikleri"</string>
@@ -619,6 +633,7 @@
     <string name="native_67b696468610b879" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dashboard"</string>
     <string name="native_67fa416afa64d304" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Token\'ı yapıştır"</string>
     <string name="native_6827238fea72c88b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sağlayıcı yok"</string>
+    <string name="native_684889f0079cc145" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"SHA-256 parmak izi"</string>
     <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Henüz konu dizisi yok"</string>
     <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bluetooth mikrofonu"</string>
     <string name="native_690dbe9dc0993c42" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Son"</string>
@@ -653,6 +668,7 @@
     <string name="native_6d5d9004797377e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Lisanslar"</string>
     <string name="native_6d7c95a353d873cd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ClawHub Skills\'ı aramak için Gateway\'e bağlanın."</string>
     <string name="native_6df1bb18a59ab97d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Beceri"</string>
+    <string name="native_6e0a0b9d8c5ee4d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cihaz kimliği"</string>
     <string name="native_6e117ba97cbfb6f0" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway, etkin %1$s sağlayıcısını tanımlamadı"</string>
     <string name="native_6e293a8c009e0011" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bekleniyor"</string>
     <string name="native_6e2c0963d056e104" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Uyandırma sözcükleri kaydedildi"</string>
@@ -829,6 +845,7 @@
     <string name="native_8bb7ec15b1e350a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"İnceleniyor"</string>
     <string name="native_8bf253a125f66985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Başka bir Gateway eklemek için bir kurulum kodunu tarayın veya yapıştırın."</string>
     <string name="native_8c4a3896e8f06d27" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"TLS zaman aşımına uğradı"</string>
+    <string name="native_8c55387fb6c584c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Eşleştirilmiş cihaz kaldırıldı."</string>
     <string name="native_8c93c68056cde54d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway eşleştirildi. Düğüm yeteneği onayı kontrol ediliyor."</string>
     <string name="native_8ca344247c18317e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Hareket"</string>
     <string name="native_8cac4b77b9c54695" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cron işlemi başarısız oldu."</string>
@@ -1021,7 +1038,6 @@
     <string name="native_ad1c341c65f84ede" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway bilgisayarında onay komutunu çalıştırın, ardından tekrar kontrol edin."</string>
     <string name="native_ad1fb9ec0cb3c7a4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Otomasyonlar"</string>
     <string name="native_adb7eb8a03ad699c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s dk"</string>
-    <string name="native_adca3171c270301a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bu Gateway oturumu bağlı düğümleri listeleyebilir, ancak yeni telefon eşleştirmelerini onaylayamaz. Yeni telefonları bir Gateway yönetici oturumundan eşleştirin. Düğüm yeteneği onayı ayrıdır ve yine nodes approve &lt;request id&gt; komutunu kullanır."</string>
     <string name="native_ade9248e0132b411" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Güven"</string>
     <string name="native_ae27fa789a03c1db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bu QR kodu bir OpenClaw kurulum QR kodu değil. openclaw qr ile yeni bir kod oluşturup tekrar deneyin."</string>
     <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tercih edilen mikrofon kullanılamıyor; otomatik yönlendirme kullanılıyor."</string>
@@ -1091,6 +1107,7 @@
     <string name="native_bb4f2558e4333834" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Widget görseli İndirilenler\'e kaydedildi"</string>
     <string name="native_bbe5fc3b9ef39f99" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Başlatılıyor…"</string>
     <string name="native_bc19cec293228fb8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"İstemci hatası"</string>
+    <string name="native_bc1c94a6dfce1058" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Erişim izni vermeden önce istekte bulunan bu cihazı doğrulayın."</string>
     <string name="native_bc6618670f3e8a17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bluetooth LE mikrofonu"</string>
     <string name="native_bcb06651437caa15" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
     <string name="native_bd08450d63406844" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Otomasyon etkinleştirildi."</string>
@@ -1099,6 +1116,7 @@
     <string name="native_bdc090ec61e3fcfc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Yeniden yükle"</string>
     <string name="native_bdff71b20b9cf392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Otomasyonlarda ara"</string>
     <string name="native_be969becb173e0c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bağlı telefonlar ve düğüm ana makineleri eşleştirmeden sonra burada görünecek."</string>
+    <string name="native_bf1870ff5c6322fb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s: %2$s"</string>
     <string name="native_bf350e6a0ed60b7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bu otomasyon Gateway üzerinde değiştirildi. Yeniden kaydetmeden önce en son sürümü inceleyin."</string>
     <string name="native_bf399ffa03617a96" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dikteyi Durdur"</string>
     <string name="native_bf56ee2fe3345ce1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Okunaklı"</string>
@@ -1122,6 +1140,7 @@
     <string name="native_c1c224b03cd9bc7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Yönetici"</string>
     <string name="native_c1ebc7817870e5be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dikkat gerekiyor"</string>
     <string name="native_c22d5e02fbec7d65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bu cihazı Gateway\'inizle eşleştirerek yalnızca gerçek işler için uyandırılmasını sağlayın, canlı aracı genel görünümünü elinizin altında tutun ve pili tüketen arka plan döngülerinden kaçının."</string>
+    <string name="native_c25337055464f8d3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Roller"</string>
     <string name="native_c253f451bdd56431" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Yanıtla"</string>
     <string name="native_c26225b6c16a4bc7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sağlayıcı kataloğu"</string>
     <string name="native_c272b225cf5bd643" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"İzni Ayarlar’dan etkinleştirin"</string>
@@ -1135,6 +1154,7 @@
     <string name="native_c34dd5eb8b0af56e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kurulum kodunu nereden alabilirim?"</string>
     <string name="native_c3546b39ecbbed8a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skill etkinleştirilemedi."</string>
     <string name="native_c35b21d6ca39aa7c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"pdf"</string>
+    <string name="native_c3812fc4acb861d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kaldır"</string>
     <string name="native_c382566dbe2ea49f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s%% çevrimiçi"</string>
     <string name="native_c385951198c45d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kanal yok"</string>
     <string name="native_c41ad84496b53420" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gerçek zamanlı ses"</string>
@@ -1163,6 +1183,7 @@
     <string name="native_c6d5ed757b66bfd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Hayal"</string>
     <string name="native_c6dd061350fc69b8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Engellenen uygulama yok. Engelleme eklemediğiniz sürece uygulamalar yönlendirme yapabilir."</string>
     <string name="native_c753cdf0c19f1e38" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Konuşma tanıyıcı kullanılamıyor"</string>
+    <string name="native_c78ffe19571018fb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Platform"</string>
     <string name="native_c7985fa72daa6ea4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway, %1$s kurulumunu döndürmedi"</string>
     <string name="native_c7b6dfd5c3a183c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway unutulsun mu?"</string>
     <string name="native_c7b7b7f01360f6a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"İsteğe bağlı açıklama"</string>
@@ -1225,6 +1246,7 @@
     <string name="native_d17d2d78d76e6a6c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Modeller"</string>
     <string name="native_d19c2dd2fb598b93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw Pasif"</string>
     <string name="native_d1a574e23344c407" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway parolası geçersiz"</string>
+    <string name="native_d1af697abaff485f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cihaz eşleştirme değişikliği doğrulanamadı. Yenileyip tekrar deneyin."</string>
     <string name="native_d1bf045bb524dae5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ayrıntıları görüntüle"</string>
     <string name="native_d1e9567da9a8a4b0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bash"</string>
     <string name="native_d2089be672953d11" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Belirteç"</string>
@@ -1239,6 +1261,7 @@
     <string name="native_d31de1a5c5c8ba2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tarayıcı"</string>
     <string name="native_d354ee936f59115e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screen record"</string>
     <string name="native_d3974fd6d3b6c81f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Çalıştırma Bekliyor"</string>
+    <string name="native_d3e1c5f8a6e240fc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kaynak"</string>
     <string name="native_d3f75e24411053c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cihazlarınızda kişisel AI"</string>
     <string name="native_d406ade2958cb5b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attach"</string>
     <string name="native_d461a493a3753877" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Otomatik"</string>
@@ -1427,6 +1450,7 @@
     <string name="native_f2da2e47cd31a5dd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bu görüntünün kodu çözülemedi."</string>
     <string name="native_f3753c0fe29b88db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway, ses, bildirimler, gizlilik"</string>
     <string name="native_f386c32c1bf437d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Agent çalışma alanı dosyaları"</string>
+    <string name="native_f418bf0894a1806a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bu cihaz, güvenilir Gateway erişimini kaybedecek."</string>
     <string name="native_f41d9e8b7e09aa24" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Onay komutunda bekleyen komuttaki requestId değerini kullanın."</string>
     <string name="native_f4830a1dae298044" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zamanlama"</string>
     <string name="native_f493f0ce7a52a8aa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Hız Sınırı"</string>
@@ -1434,6 +1458,7 @@
     <string name="native_f4cc820d308495c4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Veri yükü · %1$s"</string>
     <string name="native_f4ccae29e1bb0c20" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Çalışıyor"</string>
     <string name="native_f4db1e48476f6075" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bitir"</string>
+    <string name="native_f4e2076014711222" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sistem güvenini kullan"</string>
     <string name="native_f4ef7a41caa88dd1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Hazır sağlayıcı yok"</string>
     <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bağlı Bluetooth mikrofonlarına öncelik verir."</string>
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s uygulamanın yönlendirmesi engellendi."</string>

--- a/apps/android/app/src/main/res/values-tr/strings.xml
+++ b/apps/android/app/src/main/res/values-tr/strings.xml
@@ -494,7 +494,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Teslimat"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Hoparlörü sessize al"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway bağlantısı açılıyor"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"İzleniyor · %1$s ileti dizisi"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Otomasyon çalıştırması tamamlandı."</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Eşleşen uygulama yok."</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sohbete Gönder"</string>
@@ -1277,7 +1277,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Profil"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway\'iniz bildirdiğinde sağlayıcı limitleri burada görünecek."</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 sorun"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"\"%1$s\" grubundaki konular korunur ve Gruplandırılmamış\'a geri taşınır."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Oluşturulma"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s etkin belirteç"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>

--- a/apps/android/app/src/main/res/values-tr/strings.xml
+++ b/apps/android/app/src/main/res/values-tr/strings.xml
@@ -24,14 +24,14 @@
     <string name="native_002a6fcb30b2def4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ek, gönderilmek üzere hazırlanamadı."</string>
     <string name="native_003aaf9e0a0e6b9f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Mikrofon kapalı"</string>
     <string name="native_0060cbfdd3cf13ba" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw uyarılarını göster"</string>
-    <string name="native_0077032d7e9f9cbe" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"İleti dizisi etkinliği"</string>
+    <string name="native_0077032d7e9f9cbe" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Konu dizisi etkinliği"</string>
     <string name="native_008dacb6d1e85bd8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tam"</string>
     <string name="native_009506aeb0484b2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Onay verildi ve kaydedildi."</string>
     <string name="native_00d108e2e6466940" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Son arama geçmişini göster"</string>
     <string name="native_00e8aeba41d79ce3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 beklemede"</string>
     <string name="native_010f6550a1c8f554" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Desteklenmeyen ek"</string>
     <string name="native_01267be21eb77392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"0 = tam"</string>
-    <string name="native_0171e3d4e07f1861" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Konularda arama yapmak için Gateway\'e bağlanın."</string>
+    <string name="native_0171e3d4e07f1861" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Konuları aramak için Gateway\'e bağlanın."</string>
     <string name="native_0174f83136630e7e" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s hesap"</string>
     <string name="native_01ac1c298e0cbd9a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cron değişiklikleri operator.admin gerektirir. Kurulum kodları bunu kasıtlı olarak sağlamaz. Yönetici erişimi istemek için Gateway\'in paylaşılan token\'ı veya parolasıyla yeniden bağlanın. Bu cihazda hâlâ bu yetki yoksa bekleyen kapsam yükseltmesini mevcut bir yönetici istemcisinden onaylayın."</string>
     <string name="native_01bcfe7a9296b6d6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Apply Patch"</string>
@@ -70,12 +70,11 @@
     <string name="native_088e0e5ebc96c6ac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway kurulumu değiştirilsin mi?"</string>
     <string name="native_08a5391c1de3078a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Otomasyonlar yüklenemedi."</string>
     <string name="native_08b041935798fbf6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Siz"</string>
-    <string name="native_08ea63ee26954dca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dahili mikrofon"</string>
+    <string name="native_08ea63ee26954dca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Yerleşik mikrofon"</string>
     <string name="native_0905f7f59021c2a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Yüzey"</string>
     <string name="native_0929c9dc7f794852" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Öneri yok"</string>
-    <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ana ileti dizisi"</string>
+    <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ana iletişim dizisi"</string>
     <string name="native_0979c6fdbdca1675" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Chat\'i Aç"</string>
-    <string name="native_09ce95090659d069" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cihaz eşleştirme işlemleri bu Gateway oturumunda kullanılamıyor. Gateway ana makinesinde openclaw devices list komutunu çalıştırın ve isteği buradan yönetin. Düğüm yeteneği onayı ayrı bir işlemdir ve hâlâ nodes approve &lt;request id&gt; komutunu kullanır."</string>
     <string name="native_0a0b7cf7c428c703" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Eylem İsteği"</string>
     <string name="native_0a708e7b03aaf1fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list pins"</string>
     <string name="native_0ab0e1629576aecf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skill Atölyesi önerilerini yüklemek için bir Gateway\'e bağlanın."</string>
@@ -88,12 +87,10 @@
     <string name="native_0c3845dcd2f0f683" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Markdown içeriğini yüklemek için bu teklifi inceleyin."</string>
     <string name="native_0c3ea4e2f12153e7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw\'ı aç ve %1$s sor"</string>
     <string name="native_0c4d01e81bb3d1fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"akıl yürütme"</string>
-    <string name="native_0c77fe09ab336a3e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"İstemci"</string>
     <string name="native_0c79a9c222840ed0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Uygulandı"</string>
     <string name="native_0cab1c9617404faf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"video"</string>
     <string name="native_0cf04463c4276a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Yükseltildi"</string>
     <string name="native_0d21bd52022ca7f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Çevrimiçi"</string>
-    <string name="native_0d5644ff52ce2ba3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kapsamlar"</string>
     <string name="native_0d5efd432e4fedf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gerçek zamanlı ses sağlayıcısı yapılandırılmamış."</string>
     <string name="native_0d8ca811c3744a6d" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s · %2$s"</string>
     <string name="native_0db10f2c2f332cd2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"kick"</string>
@@ -104,7 +101,7 @@
     <string name="native_0e91610117029a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Yenile"</string>
     <string name="native_0ee30822ed35a792" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s kuyrukta"</string>
     <string name="native_0f4c8529742b31ea" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sohbet Başlat"</string>
-    <string name="native_0f559ff270904904" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Etkin ileti dizisinde bekleyen sohbet aracı çağrıları burada görünür durumda kalır."</string>
+    <string name="native_0f559ff270904904" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Etkin konu dizisinde bekleyen sohbet aracı çağrıları burada görünmeye devam eder."</string>
     <string name="native_0f56cc286a4f23d8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sertifikanın incelenmesi gerekiyor"</string>
     <string name="native_0f8fe3a9688138a1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Mevcut Canvas yüzeyini incelemek veya onunla etkileşime geçmek için açın."</string>
     <string name="native_0ff98f05be01ce5e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Otomasyon güncellendi."</string>
@@ -141,7 +138,6 @@
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Oturum hedefi"</string>
     <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ClawHub Skill\'ini incele"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
-    <string name="native_16a5b7ad567a8093" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bu cihazdan gelen eşleştirme isteği reddedilsin mi?"</string>
     <string name="native_16b1a05e1d987ed1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tercih edilen mikrofon"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Düğüm ana makinesi"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Düzey"</string>
@@ -187,7 +183,6 @@
     <string name="native_1d91629837639a5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bu otomasyon, siz düzenlerken değişti. Kaydetmeden önce en son Gateway sürümüne geri dönün."</string>
     <string name="native_1dbf9d5979606697" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bağlantı kurulduğunda Gateway, sürekli açık bir oturum sürdürmek yerine sessiz bir anlık bildirimle telefonu uyandırabilir."</string>
     <string name="native_1e432ea5425e4a3a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Uyandırma Modu"</string>
-    <string name="native_1e595a107c78b957" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Eşleştirilmiş cihaz kaldırılsın mı?"</string>
     <string name="native_1e955a58278623a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sistem etkinliği metni"</string>
     <string name="native_1ea44149be42d970" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Widget görseli kopyalanamadı"</string>
     <string name="native_1ea442a134b2a184" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Hayır"</string>
@@ -202,7 +197,6 @@
     <string name="native_2065cc867eba1b39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sağlayıcı model yapılandırması yüklenemedi."</string>
     <string name="native_207ccb22d618db05" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s uygulamanın yönlendirmesine izin verildi."</string>
     <string name="native_209b9e597963e7e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ses kurulumu"</string>
-    <string name="native_211988ba9dd0570a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Eşleştirme isteği reddedilsin mi?"</string>
     <string name="native_2132066dc9475cb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"This skill is installed but not available to the current agent. Agent filters stay on desktop or CLI."</string>
     <string name="native_21378545892f1fe2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Yayıncı"</string>
     <string name="native_214d4932fc767e8f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">" · Konuşma: Konuşuyor"</string>
@@ -243,8 +237,7 @@
     <string name="native_262c897a1f408b0b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway\'nize bağlanın"</string>
     <string name="native_2682bd813a3bccbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw qr tarafından oluşturulan kurulum kodunu girin."</string>
     <string name="native_268f14bbfe119c1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tanılama"</string>
-    <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bu işlem, ileti dizisini ve dökümünü kalıcı olarak siler."</string>
-    <string name="native_26e47d73a55d7fa7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cihaz onaylandı."</string>
+    <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bu işlem, iş parçacığını ve dökümünü kalıcı olarak siler."</string>
     <string name="native_26f0dd993530eb2d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Otomatik olarak yeniden deneniyor"</string>
     <string name="native_270ff82f36da987f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Widget görseli kopyalandı"</string>
     <string name="native_2728740a95d465c6" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s rol"</string>
@@ -260,7 +253,7 @@
     <string name="native_27d773b934ed324f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Doğrula ve yükle"</string>
     <string name="native_2821f0168d6dd9df" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bu cihazı sohbet, ses, kamera ve cihaz araçları için güvenli bir OpenClaw düğümüne dönüştürün."</string>
     <string name="native_2831546121359362" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Manuel kurulum"</string>
-    <string name="native_287c4b113aafc215" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Geçerli ileti dizisini başlatmak veya sürdürmek için Sohbet\'i açın."</string>
+    <string name="native_287c4b113aafc215" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Geçerli konu dizisini başlatmak veya sürdürmek için Sohbet\'i açın."</string>
     <string name="native_28bb849671cab958" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"İpucu: yakalanan sırayı göndermek için dinlemeyi durdurun."</string>
     <string name="native_28d03596d24eeb4e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Atla"</string>
     <string name="native_28d55ec6974d84e8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sesli istek başarısız oldu"</string>
@@ -283,7 +276,7 @@
     <string name="native_2cd62f7a670b2819" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw konusu"</string>
     <string name="native_2d4dfe885f84629e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Fotoğraf arşivine erişime izin verin."</string>
     <string name="native_2d6416405eb44982" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Önceki bir yanıt bu onayı zaten çözdü."</string>
-    <string name="native_2d85de9d56c226e4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Son yazışma yok"</string>
+    <string name="native_2d85de9d56c226e4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Son iş parçacığı yok"</string>
     <string name="native_2df01a03ff43400b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Eşleşme yok"</string>
     <string name="native_2df30b117ad829ab" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Seçilen uygulamaların bildirimlerini oku"</string>
     <string name="native_2e0078a8322d6f1f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kullanılabilirlik bilinmiyor"</string>
@@ -345,7 +338,7 @@
     <string name="native_36c725ddb20f8bd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Konuşma Sağlayıcısı Kurulumu"</string>
     <string name="native_36d88ed6cc91d2b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Music Generation"</string>
     <string name="native_36e8d5e94219dc37" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Konuşma ayarları"</string>
-    <string name="native_36f1fac278711470" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"İzleniyor · 1 ileti dizisi"</string>
+    <string name="native_36f1fac278711470" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"İzleniyor · 1 iletişim dizisi"</string>
     <string name="native_37053dc1f680546b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Yük Metni"</string>
     <string name="native_37582309e7a1dbe5" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Onay %1$s"</string>
     <string name="native_379ce0aacf46c35f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway, %1$s hazır olma durumunu döndürmedi"</string>
@@ -353,7 +346,6 @@
     <string name="native_381428f5f251a764" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Conversation Send"</string>
     <string name="native_3824a9f4dafe92c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tuval"</string>
     <string name="native_384ae4ab1a2830f9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 sağlayıcı"</string>
-    <string name="native_385001409de8562a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway sertifikası otomatik olarak okunamadı. Gateway ana bilgisayarından alınan SHA-256 parmak izini yapıştırın."</string>
     <string name="native_387b2569e440838c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gönderilemedi: %1$s"</string>
     <string name="native_3892e10346fd2012" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Köprü"</string>
     <string name="native_38d198cd5303680f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Teslim Hatası"</string>
@@ -371,7 +363,7 @@
     <string name="native_3a65cf1204f18864" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bağlandı (düğüm çevrimdışı)"</string>
     <string name="native_3a78695388b38b5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ana Sayfa"</string>
     <string name="native_3b28b535950f8175" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dikte dinliyor"</string>
-    <string name="native_3b46b7912670bfb0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Arşivlenmiş ileti dizisi yok"</string>
+    <string name="native_3b46b7912670bfb0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Arşivlenmiş iş parçacığı yok"</string>
     <string name="native_3b851469ea31d489" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bu gateway\'de kullanılabilen asistanları seçin ve inceleyin."</string>
     <string name="native_3be0085a6bd88cdd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Konuşma modu etkin"</string>
     <string name="native_3bee4ede6bf4436c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Çalışıyor · 1 etkin çalıştırma"</string>
@@ -383,7 +375,7 @@
     <string name="native_3da4811eafea080a" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s://%2$s:%3$s"</string>
     <string name="native_3de3d401128d4395" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Onay ayrıntıları yüklenemedi. Yenileyip tekrar deneyin."</string>
     <string name="native_3e398e6fb979557a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tool Call"</string>
-    <string name="native_3e42e385075b9b56" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Konular"</string>
+    <string name="native_3e42e385075b9b56" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Diziler"</string>
     <string name="native_3f00927a719345ed" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Write"</string>
     <string name="native_3f25ccebfa99dcf3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bir istemle başlayın veya sesinizi kullanın."</string>
     <string name="native_3f39d5c348e5b79d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"D"</string>
@@ -410,8 +402,7 @@
     <string name="native_4287d54ad5e78985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway\'inizden zamanlanmış OpenClaw işleri."</string>
     <string name="native_429f6057535c1ea3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sub-agent"</string>
     <string name="native_42e3a99c21767def" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cihaz onayı bekleniyor"</string>
-    <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"İleti dizisi yükleniyor"</string>
-    <string name="native_430df68ec29a85a2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bu Gateway artık bu cihazın güvendiği bir sertifika sunuyor."</string>
+    <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"İletişim dizisi yükleniyor"</string>
     <string name="native_43905968a540af6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kaydırma ms"</string>
     <string name="native_43988c156beabf7d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"event create"</string>
     <string name="native_43cc23fa52b87b4c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"belge"</string>
@@ -473,7 +464,6 @@
     <string name="native_4e8c72cab82e0711" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Otomasyonun yapılandırması geçersiz."</string>
     <string name="native_4ec30e9d85725d41" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"İzin verilenler listesi"</string>
     <string name="native_4ed379d418bb8629" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"groups"</string>
-    <string name="native_4ee252fb736effa2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Açık anahtar"</string>
     <string name="native_4efca0d10c5feb8e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Hakkında"</string>
     <string name="native_4f1bc100d1dccc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bu görüntüde kurulum QR kodu bulunamadı. openclaw qr tarafından oluşturulan QR kodunu seçin veya kurulum kodunu manuel olarak girin."</string>
     <string name="native_4fe3cdd404ea0290" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"permissions"</string>
@@ -494,7 +484,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Teslimat"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Hoparlörü sessize al"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway bağlantısı açılıyor"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"İzleniyor · %1$s iletişim dizisi"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Otomasyon çalıştırması tamamlandı."</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Eşleşen uygulama yok."</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sohbete Gönder"</string>
@@ -519,7 +509,7 @@
     <string name="native_55898449eb74fb2e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sağlık"</string>
     <string name="native_55a12cbe0995e214" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bildirim dinleyicisi"</string>
     <string name="native_55d8e7da6d0a752c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Hoparlör sessize alındı"</string>
-    <string name="native_560d3e826c413dc9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Konularda ara"</string>
+    <string name="native_560d3e826c413dc9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"İleti dizilerinde ara"</string>
     <string name="native_565339bc4d33d728" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tamam"</string>
     <string name="native_56a508f3f2bf424a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kurulum kılavuzu açılamadı."</string>
     <string name="native_56c41c606c44f3fc" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw\'a %1$s sor"</string>
@@ -560,7 +550,6 @@
     <string name="native_5c0c8c9aa658f4a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OPENCLAW"</string>
     <string name="native_5c1acea9c9b0e704" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Fetch"</string>
     <string name="native_5c39123805ffb4e2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"İstem"</string>
-    <string name="native_5c944156b5353428" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cihaz onaylansın mı?"</string>
     <string name="native_5d410adb9576e266" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s ve kayıtlı kimlik bilgileri bu telefondan kaldırılsın mı?"</string>
     <string name="native_5d6c41a67139ee26" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"QR kodu güvenli olmayan bir uzak gateway\'i işaret ediyor. %1$s %2$s"</string>
     <string name="native_5d6cbac59f87e78d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ekran yüzeyi hazır"</string>
@@ -578,7 +567,6 @@
     <string name="native_5fa1d457ddfcd26c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"rename group"</string>
     <string name="native_5fa7aac5375c5815" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Hazır"</string>
     <string name="native_5fc1927ca948f31c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Günlük ilk kaydını bekliyor."</string>
-    <string name="native_6007acbe30b2cd98" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Onayla"</string>
     <string name="native_600c9c27960112a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Canlı sayfa"</string>
     <string name="native_6030d1f6340776d2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Otomasyon zaten çalışıyor."</string>
     <string name="native_604e6d6faf8d0295" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tek seferlik başarılı bir çalıştırmanın ardından bu otomasyonu kaldırın."</string>
@@ -618,14 +606,12 @@
     <string name="native_6657cc73af00feac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"İstendiğinde kamera araçlarına izin ver."</string>
     <string name="native_666067dd376e5d45" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sorunlar"</string>
     <string name="native_666c8bc0319f3b54" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sesle Uyandırma"</string>
-    <string name="native_66713d713e3a41c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Eşleştirme isteği reddedildi."</string>
     <string name="native_66b23bae66fc0d79" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s gün önce"</string>
     <string name="native_66cf5513b37462be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"roles"</string>
     <string name="native_66d0f523a379b2de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skills"</string>
     <string name="native_66f4804ee23ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Arşivle"</string>
     <string name="native_66fab2875ee427f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Düğüm çevrimdışı. Yeniden bağlanıp tekrar deneyin."</string>
     <string name="native_6725e7bbcd28f3a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sistem"</string>
-    <string name="native_672f3453e1dd571b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Uzak IP"</string>
     <string name="native_674b38cae72bb0c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gruplandırılmamış"</string>
     <string name="native_674eb55d9c353900" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zamanlama Ayrıntısı"</string>
     <string name="native_67528858c36397f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Telefon Özellikleri"</string>
@@ -633,8 +619,7 @@
     <string name="native_67b696468610b879" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dashboard"</string>
     <string name="native_67fa416afa64d304" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Token\'ı yapıştır"</string>
     <string name="native_6827238fea72c88b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sağlayıcı yok"</string>
-    <string name="native_684889f0079cc145" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"SHA-256 parmak izi"</string>
-    <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Henüz ileti dizisi yok"</string>
+    <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Henüz konu dizisi yok"</string>
     <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bluetooth mikrofonu"</string>
     <string name="native_690dbe9dc0993c42" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Son"</string>
     <string name="native_6930c8d1fc4f01d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Konuyu yeniden adlandır"</string>
@@ -668,7 +653,6 @@
     <string name="native_6d5d9004797377e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Lisanslar"</string>
     <string name="native_6d7c95a353d873cd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ClawHub Skills\'ı aramak için Gateway\'e bağlanın."</string>
     <string name="native_6df1bb18a59ab97d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Beceri"</string>
-    <string name="native_6e0a0b9d8c5ee4d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cihaz kimliği"</string>
     <string name="native_6e117ba97cbfb6f0" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway, etkin %1$s sağlayıcısını tanımlamadı"</string>
     <string name="native_6e293a8c009e0011" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bekleniyor"</string>
     <string name="native_6e2c0963d056e104" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Uyandırma sözcükleri kaydedildi"</string>
@@ -792,13 +776,13 @@
     <string name="native_8193ee8a22d25208" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Modeli sabitle"</string>
     <string name="native_81c2c4f30a4bec68" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Aramayı Temizle"</string>
     <string name="native_81d38aca5306940b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Uygun aracılar için etkin."</string>
-    <string name="native_820d08e12968baff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Geçerli ileti dizisi yok"</string>
+    <string name="native_820d08e12968baff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Geçerli konu dizisi yok"</string>
     <string name="native_82250171708918de" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s sonrasında"</string>
     <string name="native_825b9c75d7fed691" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zamanlayıcının bu otomasyonu çalıştırmasına izin verin."</string>
     <string name="native_82990a093599a9bb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s uygulandı"</string>
     <string name="native_8340dad4f3be30a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Henüz rüya günlüğü yok."</string>
     <string name="native_837e39f46163ffb4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Arka plan görevlerini yenile"</string>
-    <string name="native_838337fd9ab30454" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Son ileti dizilerini ve sonraki adımları özetle."</string>
+    <string name="native_838337fd9ab30454" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Son iletişim dizilerini ve sonraki adımları özetle."</string>
     <string name="native_83e2faed20a3cda4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw görünür durumdayken cihaz üzerinde çalışır."</string>
     <string name="native_844e5b02f3ef05ca" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s çalışıyor"</string>
     <string name="native_846c75dca0b71591" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
@@ -845,7 +829,6 @@
     <string name="native_8bb7ec15b1e350a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"İnceleniyor"</string>
     <string name="native_8bf253a125f66985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Başka bir Gateway eklemek için bir kurulum kodunu tarayın veya yapıştırın."</string>
     <string name="native_8c4a3896e8f06d27" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"TLS zaman aşımına uğradı"</string>
-    <string name="native_8c55387fb6c584c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Eşleştirilmiş cihaz kaldırıldı."</string>
     <string name="native_8c93c68056cde54d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway eşleştirildi. Düğüm yeteneği onayı kontrol ediliyor."</string>
     <string name="native_8ca344247c18317e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Hareket"</string>
     <string name="native_8cac4b77b9c54695" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cron işlemi başarısız oldu."</string>
@@ -1038,6 +1021,7 @@
     <string name="native_ad1c341c65f84ede" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway bilgisayarında onay komutunu çalıştırın, ardından tekrar kontrol edin."</string>
     <string name="native_ad1fb9ec0cb3c7a4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Otomasyonlar"</string>
     <string name="native_adb7eb8a03ad699c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s dk"</string>
+    <string name="native_adca3171c270301a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bu Gateway oturumu bağlı düğümleri listeleyebilir, ancak yeni telefon eşleştirmelerini onaylayamaz. Yeni telefonları bir Gateway yönetici oturumundan eşleştirin. Düğüm yeteneği onayı ayrıdır ve yine nodes approve &lt;request id&gt; komutunu kullanır."</string>
     <string name="native_ade9248e0132b411" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Güven"</string>
     <string name="native_ae27fa789a03c1db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bu QR kodu bir OpenClaw kurulum QR kodu değil. openclaw qr ile yeni bir kod oluşturup tekrar deneyin."</string>
     <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tercih edilen mikrofon kullanılamıyor; otomatik yönlendirme kullanılıyor."</string>
@@ -1107,7 +1091,6 @@
     <string name="native_bb4f2558e4333834" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Widget görseli İndirilenler\'e kaydedildi"</string>
     <string name="native_bbe5fc3b9ef39f99" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Başlatılıyor…"</string>
     <string name="native_bc19cec293228fb8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"İstemci hatası"</string>
-    <string name="native_bc1c94a6dfce1058" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Erişim izni vermeden önce istekte bulunan bu cihazı doğrulayın."</string>
     <string name="native_bc6618670f3e8a17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bluetooth LE mikrofonu"</string>
     <string name="native_bcb06651437caa15" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
     <string name="native_bd08450d63406844" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Otomasyon etkinleştirildi."</string>
@@ -1116,7 +1099,6 @@
     <string name="native_bdc090ec61e3fcfc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Yeniden yükle"</string>
     <string name="native_bdff71b20b9cf392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Otomasyonlarda ara"</string>
     <string name="native_be969becb173e0c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bağlı telefonlar ve düğüm ana makineleri eşleştirmeden sonra burada görünecek."</string>
-    <string name="native_bf1870ff5c6322fb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s: %2$s"</string>
     <string name="native_bf350e6a0ed60b7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bu otomasyon Gateway üzerinde değiştirildi. Yeniden kaydetmeden önce en son sürümü inceleyin."</string>
     <string name="native_bf399ffa03617a96" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dikteyi Durdur"</string>
     <string name="native_bf56ee2fe3345ce1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Okunaklı"</string>
@@ -1140,7 +1122,6 @@
     <string name="native_c1c224b03cd9bc7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Yönetici"</string>
     <string name="native_c1ebc7817870e5be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dikkat gerekiyor"</string>
     <string name="native_c22d5e02fbec7d65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bu cihazı Gateway\'inizle eşleştirerek yalnızca gerçek işler için uyandırılmasını sağlayın, canlı aracı genel görünümünü elinizin altında tutun ve pili tüketen arka plan döngülerinden kaçının."</string>
-    <string name="native_c25337055464f8d3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Roller"</string>
     <string name="native_c253f451bdd56431" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Yanıtla"</string>
     <string name="native_c26225b6c16a4bc7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sağlayıcı kataloğu"</string>
     <string name="native_c272b225cf5bd643" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"İzni Ayarlar’dan etkinleştirin"</string>
@@ -1154,7 +1135,6 @@
     <string name="native_c34dd5eb8b0af56e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kurulum kodunu nereden alabilirim?"</string>
     <string name="native_c3546b39ecbbed8a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skill etkinleştirilemedi."</string>
     <string name="native_c35b21d6ca39aa7c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"pdf"</string>
-    <string name="native_c3812fc4acb861d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kaldır"</string>
     <string name="native_c382566dbe2ea49f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s%% çevrimiçi"</string>
     <string name="native_c385951198c45d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kanal yok"</string>
     <string name="native_c41ad84496b53420" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gerçek zamanlı ses"</string>
@@ -1183,7 +1163,6 @@
     <string name="native_c6d5ed757b66bfd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Hayal"</string>
     <string name="native_c6dd061350fc69b8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Engellenen uygulama yok. Engelleme eklemediğiniz sürece uygulamalar yönlendirme yapabilir."</string>
     <string name="native_c753cdf0c19f1e38" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Konuşma tanıyıcı kullanılamıyor"</string>
-    <string name="native_c78ffe19571018fb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Platform"</string>
     <string name="native_c7985fa72daa6ea4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway, %1$s kurulumunu döndürmedi"</string>
     <string name="native_c7b6dfd5c3a183c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway unutulsun mu?"</string>
     <string name="native_c7b7b7f01360f6a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"İsteğe bağlı açıklama"</string>
@@ -1212,7 +1191,7 @@
     <string name="native_cc721e25d73938a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ev Gateway\'i"</string>
     <string name="native_cc7a9a5cf8c4bc9d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Onay komutunu Gateway üzerinde çalıştırın"</string>
     <string name="native_cc925e3c97ac7a35" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skill Workshop önerileri yüklenemedi."</string>
-    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Son OpenClaw yazışmalarımı özetle ve sonraki adımları öner."</string>
+    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Son OpenClaw iletişim dizilerimdeki gelişmeleri aktar ve sonraki adımları öner."</string>
     <string name="native_ccb4c324f516c633" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Şimdi Değil"</string>
     <string name="native_cced0b0d83a9e400" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw qr"</string>
     <string name="native_cced28c6dc3f99c2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"start"</string>
@@ -1246,7 +1225,6 @@
     <string name="native_d17d2d78d76e6a6c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Modeller"</string>
     <string name="native_d19c2dd2fb598b93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw Pasif"</string>
     <string name="native_d1a574e23344c407" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway parolası geçersiz"</string>
-    <string name="native_d1af697abaff485f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cihaz eşleştirme değişikliği doğrulanamadı. Yenileyip tekrar deneyin."</string>
     <string name="native_d1bf045bb524dae5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ayrıntıları görüntüle"</string>
     <string name="native_d1e9567da9a8a4b0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bash"</string>
     <string name="native_d2089be672953d11" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Belirteç"</string>
@@ -1261,7 +1239,6 @@
     <string name="native_d31de1a5c5c8ba2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tarayıcı"</string>
     <string name="native_d354ee936f59115e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screen record"</string>
     <string name="native_d3974fd6d3b6c81f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Çalıştırma Bekliyor"</string>
-    <string name="native_d3e1c5f8a6e240fc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kaynak"</string>
     <string name="native_d3f75e24411053c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cihazlarınızda kişisel AI"</string>
     <string name="native_d406ade2958cb5b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attach"</string>
     <string name="native_d461a493a3753877" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Otomatik"</string>
@@ -1277,7 +1254,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Profil"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway\'iniz bildirdiğinde sağlayıcı limitleri burada görünecek."</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 sorun"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"\"%1$s\" grubundaki konular korunur ve Gruplandırılmamış\'a geri taşınır."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Oluşturulma"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s etkin belirteç"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>
@@ -1340,7 +1317,7 @@
     <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Yüklü Skills içinde ara"</string>
     <string name="native_e0723a86a5b9408a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"İncele"</string>
     <string name="native_e083bd83e9d3e97e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Process"</string>
-    <string name="native_e08a8fc53e29e5c9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Son İleti Dizileri"</string>
+    <string name="native_e08a8fc53e29e5c9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Son İletişim Dizileri"</string>
     <string name="native_e0926fdac700b094" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Terminal"</string>
     <string name="native_e0d1b68224bf0b31" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Geçerli"</string>
     <string name="native_e10435f6306b06d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 hesap"</string>
@@ -1369,13 +1346,13 @@
     <string name="native_e52b3044724b9f4d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Modelin sabitlemesini kaldır"</string>
     <string name="native_e5584bc5057284ae" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bu gateway’e bağlı mesajlaşma yüzeyleri."</string>
     <string name="native_e595f17fac1d8384" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gönderiliyor"</string>
-    <string name="native_e5b87192a9e6321f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Arşivlenen ileti dizileri burada gösterilir."</string>
+    <string name="native_e5b87192a9e6321f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Arşivlenen konu dizileri burada görünür."</string>
     <string name="native_e5c02424e511e1ef" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Komut kopyalandı"</string>
     <string name="native_e5c083cf41ff6472" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Önizleme yok"</string>
     <string name="native_e5c3e7b8110e7087" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bu telefonu Gateway üzerinde onaylayın.\nArdından bağlantıyı yeniden deneyin."</string>
     <string name="native_e5c7478bbce26eb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"QR kodunu tara"</string>
     <string name="native_e5e4f854dcd3ffc6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Komut çalışma dizini · temizlenemez"</string>
-    <string name="native_e614ccf26ec5d312" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"İleti Dizisi Etkinliği"</string>
+    <string name="native_e614ccf26ec5d312" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Konu Dizisi Etkinliği"</string>
     <string name="native_e674447337e83c13" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kullanılabilir"</string>
     <string name="native_e68e23dc04b0f986" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Otomasyon silinsin mi?"</string>
     <string name="native_e7053d96b6704dbb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bugün %1$s · Toplam %2$s"</string>
@@ -1450,7 +1427,6 @@
     <string name="native_f2da2e47cd31a5dd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bu görüntünün kodu çözülemedi."</string>
     <string name="native_f3753c0fe29b88db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway, ses, bildirimler, gizlilik"</string>
     <string name="native_f386c32c1bf437d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Agent çalışma alanı dosyaları"</string>
-    <string name="native_f418bf0894a1806a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bu cihaz, güvenilir Gateway erişimini kaybedecek."</string>
     <string name="native_f41d9e8b7e09aa24" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Onay komutunda bekleyen komuttaki requestId değerini kullanın."</string>
     <string name="native_f4830a1dae298044" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zamanlama"</string>
     <string name="native_f493f0ce7a52a8aa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Hız Sınırı"</string>
@@ -1458,7 +1434,6 @@
     <string name="native_f4cc820d308495c4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Veri yükü · %1$s"</string>
     <string name="native_f4ccae29e1bb0c20" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Çalışıyor"</string>
     <string name="native_f4db1e48476f6075" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bitir"</string>
-    <string name="native_f4e2076014711222" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sistem güvenini kullan"</string>
     <string name="native_f4ef7a41caa88dd1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Hazır sağlayıcı yok"</string>
     <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bağlı Bluetooth mikrofonlarına öncelik verir."</string>
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s uygulamanın yönlendirmesi engellendi."</string>
@@ -1522,7 +1497,7 @@
     <string name="native_ff716fc4735e067f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dikte ayarları"</string>
     <string name="native_ff9dbbdfb84ddab2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sağlayıcı modelleri yüklendi ancak hazır olma durumu kullanılamıyor."</string>
     <string name="native_ffa7aa557b547a79" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Konu silinsin mi?"</string>
-    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw, bu telefonu ileti dizileri, ses, sağlayıcılar ve Gateway için sade bir mobil komut arayüzüne dönüştürür."</string>
+    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw bu telefonu ileti dizileri, ses, sağlayıcılar ve Gateway için sade bir mobil komuta arayüzüne dönüştürür."</string>
     <string name="native_ffb6f5764bddb68c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Önce en yeni"</string>
     <string name="native_ffcf16006c652ee3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sonraki Döngü"</string>
 </resources>

--- a/apps/android/app/src/main/res/values-uk/strings.xml
+++ b/apps/android/app/src/main/res/values-uk/strings.xml
@@ -494,7 +494,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Доставка"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Вимкнути динамік"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Відкриття підключення до Gateway"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Моніторинг · %1$s гілок"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Виконання автоматизації завершено."</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Немає відповідних застосунків."</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Надіслати в чат"</string>
@@ -520,7 +520,7 @@
     <string name="native_55a12cbe0995e214" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Слухач сповіщень"</string>
     <string name="native_55d8e7da6d0a752c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Динамік вимкнено"</string>
     <string name="native_560d3e826c413dc9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Пошук гілок"</string>
-    <string name="native_565339bc4d33d728" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ОК"</string>
+    <string name="native_565339bc4d33d728" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OK"</string>
     <string name="native_56a508f3f2bf424a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не вдалося відкрити посібник із налаштування."</string>
     <string name="native_56c41c606c44f3fc" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"запитати OpenClaw %1$s"</string>
     <string name="native_56c4c3d30ceda56e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wait for Agents"</string>
@@ -1277,7 +1277,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Профіль"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Обмеження провайдера з’являться тут, коли ваш Gateway повідомить про них."</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 проблема"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Гілки в групі \"%1$s\" буде збережено й переміщено назад до розділу «Без групи»."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Створено"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s активних токенів"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>

--- a/apps/android/app/src/main/res/values-uk/strings.xml
+++ b/apps/android/app/src/main/res/values-uk/strings.xml
@@ -73,9 +73,8 @@
     <string name="native_08ea63ee26954dca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Вбудований мікрофон"</string>
     <string name="native_0905f7f59021c2a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Інтерфейс"</string>
     <string name="native_0929c9dc7f794852" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Немає пропозицій"</string>
-    <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Головна гілка"</string>
+    <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Основна гілка"</string>
     <string name="native_0979c6fdbdca1675" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Відкрити чат"</string>
-    <string name="native_09ce95090659d069" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Дії зі сполучення пристроїв недоступні в цьому сеансі Gateway. Виконайте openclaw devices list на хості Gateway і керуйте запитом там. Схвалення можливостей вузла виконується окремо й досі використовує nodes approve &lt;request id&gt;."</string>
     <string name="native_0a0b7cf7c428c703" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Запит на дію"</string>
     <string name="native_0a708e7b03aaf1fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list pins"</string>
     <string name="native_0ab0e1629576aecf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Підключіться до Gateway, щоб завантажити пропозиції Майстерні Skills."</string>
@@ -88,12 +87,10 @@
     <string name="native_0c3845dcd2f0f683" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Перегляньте цю пропозицію, щоб завантажити її Markdown."</string>
     <string name="native_0c3ea4e2f12153e7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"відкрити OpenClaw і запитати %1$s"</string>
     <string name="native_0c4d01e81bb3d1fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"міркування"</string>
-    <string name="native_0c77fe09ab336a3e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Клієнт"</string>
     <string name="native_0c79a9c222840ed0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Застосовано"</string>
     <string name="native_0cab1c9617404faf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"відео"</string>
     <string name="native_0cf04463c4276a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Просунуті"</string>
     <string name="native_0d21bd52022ca7f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Онлайн"</string>
-    <string name="native_0d5644ff52ce2ba3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Області"</string>
     <string name="native_0d5efd432e4fedf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Постачальника голосового зв’язку в реальному часі не налаштовано."</string>
     <string name="native_0d8ca811c3744a6d" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s · %2$s"</string>
     <string name="native_0db10f2c2f332cd2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"kick"</string>
@@ -141,7 +138,6 @@
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ціль сеансу"</string>
     <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Переглянути навичку ClawHub"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
-    <string name="native_16a5b7ad567a8093" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Відхилити запит на сполучення від цього пристрою?"</string>
     <string name="native_16b1a05e1d987ed1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Бажаний мікрофон"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Хост вузла"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Рівень"</string>
@@ -187,7 +183,6 @@
     <string name="native_1d91629837639a5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Цю автоматизацію було змінено під час редагування. Перед збереженням відновіть останню версію з Gateway."</string>
     <string name="native_1dbf9d5979606697" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Після підключення Gateway може активувати телефон за допомогою тихого push-сповіщення замість постійно активної сесії."</string>
     <string name="native_1e432ea5425e4a3a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Режим пробудження"</string>
-    <string name="native_1e595a107c78b957" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Видалити сполучений пристрій?"</string>
     <string name="native_1e955a58278623a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Текст системної події"</string>
     <string name="native_1ea44149be42d970" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не вдалося скопіювати зображення віджета"</string>
     <string name="native_1ea442a134b2a184" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ні"</string>
@@ -202,7 +197,6 @@
     <string name="native_2065cc867eba1b39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не вдалося завантажити конфігурацію моделей постачальника."</string>
     <string name="native_207ccb22d618db05" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Застосунку %1$s дозволено пересилання."</string>
     <string name="native_209b9e597963e7e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Налаштування голосу"</string>
-    <string name="native_211988ba9dd0570a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Відхилити запит на сполучення?"</string>
     <string name="native_2132066dc9475cb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"This skill is installed but not available to the current agent. Agent filters stay on desktop or CLI."</string>
     <string name="native_21378545892f1fe2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Видавець"</string>
     <string name="native_214d4932fc767e8f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">" · Розмова: мовлення"</string>
@@ -243,8 +237,7 @@
     <string name="native_262c897a1f408b0b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Підключіться до свого Gateway"</string>
     <string name="native_2682bd813a3bccbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Введіть код налаштування з openclaw qr."</string>
     <string name="native_268f14bbfe119c1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Діагностика"</string>
-    <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Це назавжди видалить гілку та її розшифрування."</string>
-    <string name="native_26e47d73a55d7fa7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Пристрій схвалено."</string>
+    <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Це назавжди видалить гілку та її журнал."</string>
     <string name="native_26f0dd993530eb2d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Автоматична повторна спроба"</string>
     <string name="native_270ff82f36da987f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Зображення віджета скопійовано"</string>
     <string name="native_2728740a95d465c6" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s ролей"</string>
@@ -283,7 +276,7 @@
     <string name="native_2cd62f7a670b2819" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Гілка OpenClaw"</string>
     <string name="native_2d4dfe885f84629e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Дозвольте доступ до фототеки."</string>
     <string name="native_2d6416405eb44982" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Попередня відповідь уже вирішила це схвалення."</string>
-    <string name="native_2d85de9d56c226e4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Немає останніх гілок"</string>
+    <string name="native_2d85de9d56c226e4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Немає недавніх гілок"</string>
     <string name="native_2df01a03ff43400b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Збігів немає"</string>
     <string name="native_2df30b117ad829ab" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Читати сповіщення вибраних застосунків"</string>
     <string name="native_2e0078a8322d6f1f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Доступність невідома"</string>
@@ -353,7 +346,6 @@
     <string name="native_381428f5f251a764" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Conversation Send"</string>
     <string name="native_3824a9f4dafe92c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Полотно"</string>
     <string name="native_384ae4ab1a2830f9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 провайдер"</string>
-    <string name="native_385001409de8562a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не вдалося автоматично прочитати сертифікат Gateway. Вставте відбиток SHA-256, отриманий на хості Gateway."</string>
     <string name="native_387b2569e440838c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не вдалося надіслати: %1$s"</string>
     <string name="native_3892e10346fd2012" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Міст"</string>
     <string name="native_38d198cd5303680f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Помилка доставки"</string>
@@ -411,7 +403,6 @@
     <string name="native_429f6057535c1ea3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sub-agent"</string>
     <string name="native_42e3a99c21767def" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Очікування схвалення пристрою"</string>
     <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Завантаження гілки"</string>
-    <string name="native_430df68ec29a85a2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Тепер цей Gateway надає сертифікат, якому довіряє цей пристрій."</string>
     <string name="native_43905968a540af6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Зсув мс"</string>
     <string name="native_43988c156beabf7d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"event create"</string>
     <string name="native_43cc23fa52b87b4c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"документ"</string>
@@ -473,7 +464,6 @@
     <string name="native_4e8c72cab82e0711" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Автоматизація має недійсну конфігурацію."</string>
     <string name="native_4ec30e9d85725d41" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Список дозволених"</string>
     <string name="native_4ed379d418bb8629" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"groups"</string>
-    <string name="native_4ee252fb736effa2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Відкритий ключ"</string>
     <string name="native_4efca0d10c5feb8e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Про застосунок"</string>
     <string name="native_4f1bc100d1dccc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"На цьому зображенні не знайдено QR-коду налаштування. Виберіть QR-код, згенерований за допомогою openclaw qr, або введіть код налаштування вручну."</string>
     <string name="native_4fe3cdd404ea0290" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"permissions"</string>
@@ -494,7 +484,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Доставка"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Вимкнути динамік"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Відкриття підключення до Gateway"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Моніторинг · гілок: %1$s"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Виконання автоматизації завершено."</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Немає відповідних застосунків."</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Надіслати в чат"</string>
@@ -560,7 +550,6 @@
     <string name="native_5c0c8c9aa658f4a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OPENCLAW"</string>
     <string name="native_5c1acea9c9b0e704" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Fetch"</string>
     <string name="native_5c39123805ffb4e2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Запит"</string>
-    <string name="native_5c944156b5353428" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Схвалити пристрій?"</string>
     <string name="native_5d410adb9576e266" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Видалити %1$s і збережені облікові дані з цього телефона?"</string>
     <string name="native_5d6c41a67139ee26" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"QR-код вказує на небезпечний віддалений gateway. %1$s %2$s"</string>
     <string name="native_5d6cbac59f87e78d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Поверхня екрана готова"</string>
@@ -578,7 +567,6 @@
     <string name="native_5fa1d457ddfcd26c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"rename group"</string>
     <string name="native_5fa7aac5375c5815" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Готово"</string>
     <string name="native_5fc1927ca948f31c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Щоденник очікує на перший запис."</string>
-    <string name="native_6007acbe30b2cd98" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Схвалити"</string>
     <string name="native_600c9c27960112a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Сторінка наживо"</string>
     <string name="native_6030d1f6340776d2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Автоматизація вже виконується."</string>
     <string name="native_604e6d6faf8d0295" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Видалити цю автоматизацію після успішного одноразового запуску."</string>
@@ -588,7 +576,7 @@
     <string name="native_60ea1847c2ba5446" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Відповідь перервано"</string>
     <string name="native_6105d6cc76af4003" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"зображення"</string>
     <string name="native_614b8348a2dbe46b" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s утримано"</string>
-    <string name="native_614e83ef17c13f3c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Відповідних гілок немає"</string>
+    <string name="native_614e83ef17c13f3c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Немає відповідних гілок"</string>
     <string name="native_6197595503f01ee2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"delete"</string>
     <string name="native_619837a134285528" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Макет: компактний"</string>
     <string name="native_61ffa9c8c703dd5e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"channels"</string>
@@ -618,14 +606,12 @@
     <string name="native_6657cc73af00feac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Дозволяти інструменти камери за запитом."</string>
     <string name="native_666067dd376e5d45" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Проблеми"</string>
     <string name="native_666c8bc0319f3b54" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Голосова активація"</string>
-    <string name="native_66713d713e3a41c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Запит на сполучення відхилено."</string>
     <string name="native_66b23bae66fc0d79" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s дн тому"</string>
     <string name="native_66cf5513b37462be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"roles"</string>
     <string name="native_66d0f523a379b2de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skills"</string>
     <string name="native_66f4804ee23ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Архівувати"</string>
     <string name="native_66fab2875ee427f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Вузол не в мережі. Підключіться знову та повторіть спробу."</string>
     <string name="native_6725e7bbcd28f3a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Система"</string>
-    <string name="native_672f3453e1dd571b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Віддалена IP-адреса"</string>
     <string name="native_674b38cae72bb0c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Без групи"</string>
     <string name="native_674eb55d9c353900" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Відомості про розклад"</string>
     <string name="native_67528858c36397f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Можливості телефона"</string>
@@ -633,9 +619,8 @@
     <string name="native_67b696468610b879" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dashboard"</string>
     <string name="native_67fa416afa64d304" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Вставити токен"</string>
     <string name="native_6827238fea72c88b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Немає постачальників"</string>
-    <string name="native_684889f0079cc145" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Відбиток SHA-256"</string>
     <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Гілок ще немає"</string>
-    <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bluetooth-мікрофон"</string>
+    <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Мікрофон Bluetooth"</string>
     <string name="native_690dbe9dc0993c42" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Нещодавні"</string>
     <string name="native_6930c8d1fc4f01d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Перейменувати гілку"</string>
     <string name="native_69384c1c4d99f6eb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Результат вирішення невідомий. Дії залишатимуться недоступними, доки запис у Gateway не буде перевірено."</string>
@@ -668,7 +653,6 @@
     <string name="native_6d5d9004797377e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ліцензії"</string>
     <string name="native_6d7c95a353d873cd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Підключіть Gateway, щоб шукати навички ClawHub."</string>
     <string name="native_6df1bb18a59ab97d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Навичка"</string>
-    <string name="native_6e0a0b9d8c5ee4d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ідентифікатор пристрою"</string>
     <string name="native_6e117ba97cbfb6f0" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway не визначив активного постачальника %1$s"</string>
     <string name="native_6e293a8c009e0011" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Очікування"</string>
     <string name="native_6e2c0963d056e104" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Слова активації збережено"</string>
@@ -798,7 +782,7 @@
     <string name="native_82990a093599a9bb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s застосовано"</string>
     <string name="native_8340dad4f3be30a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Щоденника снів ще немає."</string>
     <string name="native_837e39f46163ffb4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Оновити фонові завдання"</string>
-    <string name="native_838337fd9ab30454" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Підсумуйте останні гілки та наступні кроки."</string>
+    <string name="native_838337fd9ab30454" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Підсумувати нещодавні гілки та наступні кроки."</string>
     <string name="native_83e2faed20a3cda4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Працює на пристрої, поки OpenClaw відображається на екрані."</string>
     <string name="native_844e5b02f3ef05ca" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s працює"</string>
     <string name="native_846c75dca0b71591" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
@@ -845,7 +829,6 @@
     <string name="native_8bb7ec15b1e350a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Перевірка"</string>
     <string name="native_8bf253a125f66985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Відскануйте або вставте код налаштування, щоб додати ще один gateway."</string>
     <string name="native_8c4a3896e8f06d27" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Час очікування TLS вичерпано"</string>
-    <string name="native_8c55387fb6c584c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Сполучений пристрій видалено."</string>
     <string name="native_8c93c68056cde54d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway сполучено. Перевіряємо схвалення можливостей вузла."</string>
     <string name="native_8ca344247c18317e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Рух"</string>
     <string name="native_8cac4b77b9c54695" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не вдалося виконати дію cron."</string>
@@ -958,7 +941,7 @@
     <string name="native_9e37aa0704a3cf44" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Установлено %1$s."</string>
     <string name="native_9e4635769f0aaf0d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Шлюзи"</string>
     <string name="native_9e9bef85bb320b81" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Режим пересилання"</string>
-    <string name="native_9f6e180ff696bec5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Змінити вигляд гілок"</string>
+    <string name="native_9f6e180ff696bec5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Змінити компонування гілок"</string>
     <string name="native_9fb7c4ebcbc3e558" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Немає кінцевої точки TLS"</string>
     <string name="native_9fe101a0ec7ef416" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway OpenClaw"</string>
     <string name="native_9ffc843f501acdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Налаштувати вручну"</string>
@@ -1038,9 +1021,10 @@
     <string name="native_ad1c341c65f84ede" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Виконайте команду approve на комп’ютері Gateway, а потім перевірте ще раз."</string>
     <string name="native_ad1fb9ec0cb3c7a4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Автоматизації"</string>
     <string name="native_adb7eb8a03ad699c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s хв"</string>
+    <string name="native_adca3171c270301a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Цей вхід у Gateway дає змогу переглядати список підключених вузлів, але не схвалювати сполучення з новими телефонами. Сполучайте нові телефони в сеансі адміністратора Gateway. Схвалення можливостей вузла виконується окремо й надалі використовує команду nodes approve &lt;request id&gt;."</string>
     <string name="native_ade9248e0132b411" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Довіряти"</string>
     <string name="native_ae27fa789a03c1db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Цей QR-код не є QR-кодом налаштування OpenClaw. Згенеруйте новий код за допомогою openclaw qr, а потім повторіть спробу."</string>
-    <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Бажаний мікрофон недоступний; використовується автоматична маршрутизація."</string>
+    <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Бажаний мікрофон недоступний; використовується автоматичне маршрутизування."</string>
     <string name="native_aea4a04a80426ed8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Відхилено"</string>
     <string name="native_aed306fbb63c0c68" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Включати Android і фонові пакети."</string>
     <string name="native_aedf1cf58372f943" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ваш Gateway готовий."</string>
@@ -1107,7 +1091,6 @@
     <string name="native_bb4f2558e4333834" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Зображення віджета збережено в папці «Завантаження»"</string>
     <string name="native_bbe5fc3b9ef39f99" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Запуск…"</string>
     <string name="native_bc19cec293228fb8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Помилка клієнта"</string>
-    <string name="native_bc1c94a6dfce1058" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Перевірте пристрій, що надсилає запит, перш ніж надавати доступ."</string>
     <string name="native_bc6618670f3e8a17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Мікрофон Bluetooth LE"</string>
     <string name="native_bcb06651437caa15" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
     <string name="native_bd08450d63406844" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Автоматизацію ввімкнено."</string>
@@ -1116,7 +1099,6 @@
     <string name="native_bdc090ec61e3fcfc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Перезавантажити"</string>
     <string name="native_bdff71b20b9cf392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Пошук автоматизацій"</string>
     <string name="native_be969becb173e0c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Пов’язані телефони та хости вузлів з’являться тут після спарювання."</string>
-    <string name="native_bf1870ff5c6322fb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s: %2$s"</string>
     <string name="native_bf350e6a0ed60b7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Цю автоматизацію змінено на Gateway. Перегляньте останню версію, перш ніж зберігати її знову."</string>
     <string name="native_bf399ffa03617a96" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Зупинити диктування"</string>
     <string name="native_bf56ee2fe3345ce1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Читабельний"</string>
@@ -1140,7 +1122,6 @@
     <string name="native_c1c224b03cd9bc7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Адміністратор"</string>
     <string name="native_c1ebc7817870e5be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Потребує уваги"</string>
     <string name="native_c22d5e02fbec7d65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Підключіть цей пристрій до свого Gateway, щоб активувати його лише для реальної роботи, мати під рукою актуальний огляд агентів і уникати фонових циклів, що розряджають акумулятор."</string>
-    <string name="native_c25337055464f8d3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ролі"</string>
     <string name="native_c253f451bdd56431" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Відповісти"</string>
     <string name="native_c26225b6c16a4bc7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Каталог постачальників"</string>
     <string name="native_c272b225cf5bd643" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Увімкніть дозвіл у Налаштуваннях"</string>
@@ -1154,7 +1135,6 @@
     <string name="native_c34dd5eb8b0af56e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Де отримати код налаштування?"</string>
     <string name="native_c3546b39ecbbed8a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не вдалося ввімкнути навичку."</string>
     <string name="native_c35b21d6ca39aa7c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"pdf"</string>
-    <string name="native_c3812fc4acb861d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Видалити"</string>
     <string name="native_c382566dbe2ea49f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s%% у мережі"</string>
     <string name="native_c385951198c45d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Немає каналів"</string>
     <string name="native_c41ad84496b53420" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Голос у реальному часі"</string>
@@ -1183,7 +1163,6 @@
     <string name="native_c6d5ed757b66bfd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Мрія"</string>
     <string name="native_c6dd061350fc69b8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не заблоковано жодного застосунку. Застосунки можуть пересилати дані, якщо ви не додасте блокування."</string>
     <string name="native_c753cdf0c19f1e38" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Розпізнавання мовлення недоступне"</string>
-    <string name="native_c78ffe19571018fb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Платформа"</string>
     <string name="native_c7985fa72daa6ea4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway не повернув налаштування %1$s"</string>
     <string name="native_c7b6dfd5c3a183c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Забути gateway?"</string>
     <string name="native_c7b7b7f01360f6a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Необов’язковий опис"</string>
@@ -1205,14 +1184,14 @@
     <string name="native_ca7981b46ecf2c17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Вимкнено"</string>
     <string name="native_cab94aba84f97f7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Типографіка"</string>
     <string name="native_cae7d57bc067a514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Зупинити"</string>
-    <string name="native_cae98462b30650eb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Відповідних гілок поки немає."</string>
+    <string name="native_cae98462b30650eb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Поки немає відповідних гілок."</string>
     <string name="native_cba62d81f910c7f0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Спарювання з Gateway виконано.\nПідтвердьте можливості вузла цього телефона в інтерфейсі оператора."</string>
     <string name="native_cc4b66e7e22230c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Цю навичку встановлено, але наразі її не можна запустити. Для зміни конфігурації скористайтеся комп’ютером або CLI."</string>
     <string name="native_cc5f45fb30a26e07" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Розпізнавач зайнятий"</string>
     <string name="native_cc721e25d73938a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Домашній Gateway"</string>
     <string name="native_cc7a9a5cf8c4bc9d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Виконайте команду схвалення на Gateway"</string>
     <string name="native_cc925e3c97ac7a35" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не вдалося завантажити пропозиції Skill Workshop."</string>
-    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ознайом мене з останніми гілками OpenClaw і запропонуй подальші кроки."</string>
+    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ознайом мене з моїми нещодавніми гілками OpenClaw і запропонуй наступні кроки."</string>
     <string name="native_ccb4c324f516c633" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не зараз"</string>
     <string name="native_cced0b0d83a9e400" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw qr"</string>
     <string name="native_cced28c6dc3f99c2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"start"</string>
@@ -1235,7 +1214,7 @@
     <string name="native_ceb6931ea57cc999" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Адаптивний"</string>
     <string name="native_cf0ee3547a4e51a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Незабаром"</string>
     <string name="native_d04fc7d7e19702f8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Search"</string>
-    <string name="native_d053ba98d8bbcec1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Спробуйте чат, голос, гілки, провайдерів або налаштування."</string>
+    <string name="native_d053ba98d8bbcec1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Спробуйте чат, голос, гілки, постачальників або налаштування."</string>
     <string name="native_d056177742e27cf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw активний"</string>
     <string name="native_d0cda6559bb347db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"navigate"</string>
     <string name="native_d0d0de0039c7990b" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"запит надіслано %1$s"</string>
@@ -1246,7 +1225,6 @@
     <string name="native_d17d2d78d76e6a6c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Моделі"</string>
     <string name="native_d19c2dd2fb598b93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw: пасивні"</string>
     <string name="native_d1a574e23344c407" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Недійсний пароль Gateway"</string>
-    <string name="native_d1af697abaff485f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не вдалося перевірити зміну сполучення пристрою. Оновіть сторінку та повторіть спробу."</string>
     <string name="native_d1bf045bb524dae5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Переглянути подробиці"</string>
     <string name="native_d1e9567da9a8a4b0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bash"</string>
     <string name="native_d2089be672953d11" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Токен"</string>
@@ -1261,7 +1239,6 @@
     <string name="native_d31de1a5c5c8ba2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Браузер"</string>
     <string name="native_d354ee936f59115e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screen record"</string>
     <string name="native_d3974fd6d3b6c81f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Очікує запуску"</string>
-    <string name="native_d3e1c5f8a6e240fc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Джерело"</string>
     <string name="native_d3f75e24411053c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Персональний ШІ на ваших пристроях"</string>
     <string name="native_d406ade2958cb5b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attach"</string>
     <string name="native_d461a493a3753877" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Автоматично"</string>
@@ -1277,7 +1254,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Профіль"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Обмеження провайдера з’являться тут, коли ваш Gateway повідомить про них."</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 проблема"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Гілки в групі \"%1$s\" буде збережено й переміщено назад до розділу «Без групи»."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Створено"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s активних токенів"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>
@@ -1340,7 +1317,7 @@
     <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Пошук установлених навичок"</string>
     <string name="native_e0723a86a5b9408a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Переглянути"</string>
     <string name="native_e083bd83e9d3e97e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Process"</string>
-    <string name="native_e08a8fc53e29e5c9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Останні гілки"</string>
+    <string name="native_e08a8fc53e29e5c9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Нещодавні гілки"</string>
     <string name="native_e0926fdac700b094" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Термінал"</string>
     <string name="native_e0d1b68224bf0b31" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Поточний"</string>
     <string name="native_e10435f6306b06d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 обліковий запис"</string>
@@ -1369,7 +1346,7 @@
     <string name="native_e52b3044724b9f4d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Відкріпити модель"</string>
     <string name="native_e5584bc5057284ae" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Поверхні обміну повідомленнями, підключені до цього Gateway."</string>
     <string name="native_e595f17fac1d8384" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Надсилання"</string>
-    <string name="native_e5b87192a9e6321f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Архівовані гілки з’являться тут."</string>
+    <string name="native_e5b87192a9e6321f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Тут відображатимуться архівовані гілки."</string>
     <string name="native_e5c02424e511e1ef" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Команду скопійовано"</string>
     <string name="native_e5c083cf41ff6472" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Попередній перегляд недоступний"</string>
     <string name="native_e5c3e7b8110e7087" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Підтвердьте цей телефон у Gateway.\nПотім повторіть спробу підключення."</string>
@@ -1450,7 +1427,6 @@
     <string name="native_f2da2e47cd31a5dd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не вдалося декодувати це зображення."</string>
     <string name="native_f3753c0fe29b88db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway, голос, сповіщення, конфіденційність"</string>
     <string name="native_f386c32c1bf437d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Файли робочого простору агента"</string>
-    <string name="native_f418bf0894a1806a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Цей пристрій утратить довірений доступ до Gateway."</string>
     <string name="native_f41d9e8b7e09aa24" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Використайте requestId з команди, що очікує, у команді approve."</string>
     <string name="native_f4830a1dae298044" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Розклад"</string>
     <string name="native_f493f0ce7a52a8aa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Обмеження частоти"</string>
@@ -1458,9 +1434,8 @@
     <string name="native_f4cc820d308495c4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Корисне навантаження · %1$s"</string>
     <string name="native_f4ccae29e1bb0c20" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Виконується"</string>
     <string name="native_f4db1e48476f6075" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Завершити"</string>
-    <string name="native_f4e2076014711222" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Використовувати системну довіру"</string>
     <string name="native_f4ef7a41caa88dd1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Немає готових провайдерів"</string>
-    <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Надає пріоритет підключеним Bluetooth-мікрофонам."</string>
+    <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Надає пріоритет підключеним мікрофонам Bluetooth."</string>
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Пересилання заблоковано для %1$s застосунку."</string>
     <string name="native_f532ee1f7288365e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Дії з повідомленням"</string>
     <string name="native_f5387f9bb6ed7031" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Тип"</string>
@@ -1508,7 +1483,7 @@
     <string name="native_fcdeb9947bc94101" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Тестування тестування 1 2 3"</string>
     <string name="native_fcea13c79c2f85a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не вдалося виконати пошук навичок ClawHub."</string>
     <string name="native_fd175ecd65f7353d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Без запиту"</string>
-    <string name="native_fd301dc5d0e7ccf1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Фронтальна камера"</string>
+    <string name="native_fd301dc5d0e7ccf1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Передня камера"</string>
     <string name="native_fda8fc3b85420d14" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Відкрити запис журналу"</string>
     <string name="native_fdd0d769c49517c2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Час очікування мережі вичерпано"</string>
     <string name="native_fe18013d93d22f4f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Зараз"</string>

--- a/apps/android/app/src/main/res/values-uk/strings.xml
+++ b/apps/android/app/src/main/res/values-uk/strings.xml
@@ -75,6 +75,7 @@
     <string name="native_0929c9dc7f794852" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Немає пропозицій"</string>
     <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Основна гілка"</string>
     <string name="native_0979c6fdbdca1675" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Відкрити чат"</string>
+    <string name="native_09ce95090659d069" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Дії зі сполучення пристроїв недоступні в цьому сеансі Gateway. Виконайте openclaw devices list на хості Gateway і керуйте запитом там. Схвалення можливостей вузла виконується окремо й досі використовує nodes approve &lt;request id&gt;."</string>
     <string name="native_0a0b7cf7c428c703" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Запит на дію"</string>
     <string name="native_0a708e7b03aaf1fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list pins"</string>
     <string name="native_0ab0e1629576aecf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Підключіться до Gateway, щоб завантажити пропозиції Майстерні Skills."</string>
@@ -87,10 +88,12 @@
     <string name="native_0c3845dcd2f0f683" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Перегляньте цю пропозицію, щоб завантажити її Markdown."</string>
     <string name="native_0c3ea4e2f12153e7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"відкрити OpenClaw і запитати %1$s"</string>
     <string name="native_0c4d01e81bb3d1fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"міркування"</string>
+    <string name="native_0c77fe09ab336a3e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Клієнт"</string>
     <string name="native_0c79a9c222840ed0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Застосовано"</string>
     <string name="native_0cab1c9617404faf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"відео"</string>
     <string name="native_0cf04463c4276a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Просунуті"</string>
     <string name="native_0d21bd52022ca7f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Онлайн"</string>
+    <string name="native_0d5644ff52ce2ba3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Області"</string>
     <string name="native_0d5efd432e4fedf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Постачальника голосового зв’язку в реальному часі не налаштовано."</string>
     <string name="native_0d8ca811c3744a6d" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s · %2$s"</string>
     <string name="native_0db10f2c2f332cd2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"kick"</string>
@@ -138,6 +141,7 @@
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ціль сеансу"</string>
     <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Переглянути навичку ClawHub"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
+    <string name="native_16a5b7ad567a8093" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Відхилити запит на сполучення від цього пристрою?"</string>
     <string name="native_16b1a05e1d987ed1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Бажаний мікрофон"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Хост вузла"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Рівень"</string>
@@ -183,6 +187,7 @@
     <string name="native_1d91629837639a5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Цю автоматизацію було змінено під час редагування. Перед збереженням відновіть останню версію з Gateway."</string>
     <string name="native_1dbf9d5979606697" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Після підключення Gateway може активувати телефон за допомогою тихого push-сповіщення замість постійно активної сесії."</string>
     <string name="native_1e432ea5425e4a3a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Режим пробудження"</string>
+    <string name="native_1e595a107c78b957" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Видалити сполучений пристрій?"</string>
     <string name="native_1e955a58278623a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Текст системної події"</string>
     <string name="native_1ea44149be42d970" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не вдалося скопіювати зображення віджета"</string>
     <string name="native_1ea442a134b2a184" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ні"</string>
@@ -197,6 +202,7 @@
     <string name="native_2065cc867eba1b39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не вдалося завантажити конфігурацію моделей постачальника."</string>
     <string name="native_207ccb22d618db05" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Застосунку %1$s дозволено пересилання."</string>
     <string name="native_209b9e597963e7e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Налаштування голосу"</string>
+    <string name="native_211988ba9dd0570a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Відхилити запит на сполучення?"</string>
     <string name="native_2132066dc9475cb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"This skill is installed but not available to the current agent. Agent filters stay on desktop or CLI."</string>
     <string name="native_21378545892f1fe2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Видавець"</string>
     <string name="native_214d4932fc767e8f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">" · Розмова: мовлення"</string>
@@ -238,6 +244,7 @@
     <string name="native_2682bd813a3bccbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Введіть код налаштування з openclaw qr."</string>
     <string name="native_268f14bbfe119c1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Діагностика"</string>
     <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Це назавжди видалить гілку та її журнал."</string>
+    <string name="native_26e47d73a55d7fa7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Пристрій схвалено."</string>
     <string name="native_26f0dd993530eb2d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Автоматична повторна спроба"</string>
     <string name="native_270ff82f36da987f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Зображення віджета скопійовано"</string>
     <string name="native_2728740a95d465c6" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s ролей"</string>
@@ -346,6 +353,7 @@
     <string name="native_381428f5f251a764" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Conversation Send"</string>
     <string name="native_3824a9f4dafe92c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Полотно"</string>
     <string name="native_384ae4ab1a2830f9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 провайдер"</string>
+    <string name="native_385001409de8562a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не вдалося автоматично прочитати сертифікат Gateway. Вставте відбиток SHA-256, отриманий на хості Gateway."</string>
     <string name="native_387b2569e440838c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не вдалося надіслати: %1$s"</string>
     <string name="native_3892e10346fd2012" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Міст"</string>
     <string name="native_38d198cd5303680f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Помилка доставки"</string>
@@ -403,6 +411,7 @@
     <string name="native_429f6057535c1ea3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sub-agent"</string>
     <string name="native_42e3a99c21767def" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Очікування схвалення пристрою"</string>
     <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Завантаження гілки"</string>
+    <string name="native_430df68ec29a85a2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Тепер цей Gateway надає сертифікат, якому довіряє цей пристрій."</string>
     <string name="native_43905968a540af6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Зсув мс"</string>
     <string name="native_43988c156beabf7d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"event create"</string>
     <string name="native_43cc23fa52b87b4c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"документ"</string>
@@ -464,6 +473,7 @@
     <string name="native_4e8c72cab82e0711" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Автоматизація має недійсну конфігурацію."</string>
     <string name="native_4ec30e9d85725d41" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Список дозволених"</string>
     <string name="native_4ed379d418bb8629" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"groups"</string>
+    <string name="native_4ee252fb736effa2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Відкритий ключ"</string>
     <string name="native_4efca0d10c5feb8e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Про застосунок"</string>
     <string name="native_4f1bc100d1dccc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"На цьому зображенні не знайдено QR-коду налаштування. Виберіть QR-код, згенерований за допомогою openclaw qr, або введіть код налаштування вручну."</string>
     <string name="native_4fe3cdd404ea0290" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"permissions"</string>
@@ -550,6 +560,7 @@
     <string name="native_5c0c8c9aa658f4a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OPENCLAW"</string>
     <string name="native_5c1acea9c9b0e704" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Fetch"</string>
     <string name="native_5c39123805ffb4e2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Запит"</string>
+    <string name="native_5c944156b5353428" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Схвалити пристрій?"</string>
     <string name="native_5d410adb9576e266" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Видалити %1$s і збережені облікові дані з цього телефона?"</string>
     <string name="native_5d6c41a67139ee26" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"QR-код вказує на небезпечний віддалений gateway. %1$s %2$s"</string>
     <string name="native_5d6cbac59f87e78d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Поверхня екрана готова"</string>
@@ -567,6 +578,7 @@
     <string name="native_5fa1d457ddfcd26c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"rename group"</string>
     <string name="native_5fa7aac5375c5815" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Готово"</string>
     <string name="native_5fc1927ca948f31c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Щоденник очікує на перший запис."</string>
+    <string name="native_6007acbe30b2cd98" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Схвалити"</string>
     <string name="native_600c9c27960112a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Сторінка наживо"</string>
     <string name="native_6030d1f6340776d2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Автоматизація вже виконується."</string>
     <string name="native_604e6d6faf8d0295" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Видалити цю автоматизацію після успішного одноразового запуску."</string>
@@ -606,12 +618,14 @@
     <string name="native_6657cc73af00feac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Дозволяти інструменти камери за запитом."</string>
     <string name="native_666067dd376e5d45" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Проблеми"</string>
     <string name="native_666c8bc0319f3b54" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Голосова активація"</string>
+    <string name="native_66713d713e3a41c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Запит на сполучення відхилено."</string>
     <string name="native_66b23bae66fc0d79" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s дн тому"</string>
     <string name="native_66cf5513b37462be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"roles"</string>
     <string name="native_66d0f523a379b2de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skills"</string>
     <string name="native_66f4804ee23ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Архівувати"</string>
     <string name="native_66fab2875ee427f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Вузол не в мережі. Підключіться знову та повторіть спробу."</string>
     <string name="native_6725e7bbcd28f3a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Система"</string>
+    <string name="native_672f3453e1dd571b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Віддалена IP-адреса"</string>
     <string name="native_674b38cae72bb0c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Без групи"</string>
     <string name="native_674eb55d9c353900" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Відомості про розклад"</string>
     <string name="native_67528858c36397f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Можливості телефона"</string>
@@ -619,6 +633,7 @@
     <string name="native_67b696468610b879" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dashboard"</string>
     <string name="native_67fa416afa64d304" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Вставити токен"</string>
     <string name="native_6827238fea72c88b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Немає постачальників"</string>
+    <string name="native_684889f0079cc145" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Відбиток SHA-256"</string>
     <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Гілок ще немає"</string>
     <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Мікрофон Bluetooth"</string>
     <string name="native_690dbe9dc0993c42" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Нещодавні"</string>
@@ -653,6 +668,7 @@
     <string name="native_6d5d9004797377e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ліцензії"</string>
     <string name="native_6d7c95a353d873cd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Підключіть Gateway, щоб шукати навички ClawHub."</string>
     <string name="native_6df1bb18a59ab97d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Навичка"</string>
+    <string name="native_6e0a0b9d8c5ee4d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ідентифікатор пристрою"</string>
     <string name="native_6e117ba97cbfb6f0" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway не визначив активного постачальника %1$s"</string>
     <string name="native_6e293a8c009e0011" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Очікування"</string>
     <string name="native_6e2c0963d056e104" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Слова активації збережено"</string>
@@ -829,6 +845,7 @@
     <string name="native_8bb7ec15b1e350a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Перевірка"</string>
     <string name="native_8bf253a125f66985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Відскануйте або вставте код налаштування, щоб додати ще один gateway."</string>
     <string name="native_8c4a3896e8f06d27" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Час очікування TLS вичерпано"</string>
+    <string name="native_8c55387fb6c584c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Сполучений пристрій видалено."</string>
     <string name="native_8c93c68056cde54d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway сполучено. Перевіряємо схвалення можливостей вузла."</string>
     <string name="native_8ca344247c18317e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Рух"</string>
     <string name="native_8cac4b77b9c54695" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не вдалося виконати дію cron."</string>
@@ -1021,7 +1038,6 @@
     <string name="native_ad1c341c65f84ede" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Виконайте команду approve на комп’ютері Gateway, а потім перевірте ще раз."</string>
     <string name="native_ad1fb9ec0cb3c7a4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Автоматизації"</string>
     <string name="native_adb7eb8a03ad699c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s хв"</string>
-    <string name="native_adca3171c270301a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Цей вхід у Gateway дає змогу переглядати список підключених вузлів, але не схвалювати сполучення з новими телефонами. Сполучайте нові телефони в сеансі адміністратора Gateway. Схвалення можливостей вузла виконується окремо й надалі використовує команду nodes approve &lt;request id&gt;."</string>
     <string name="native_ade9248e0132b411" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Довіряти"</string>
     <string name="native_ae27fa789a03c1db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Цей QR-код не є QR-кодом налаштування OpenClaw. Згенеруйте новий код за допомогою openclaw qr, а потім повторіть спробу."</string>
     <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Бажаний мікрофон недоступний; використовується автоматичне маршрутизування."</string>
@@ -1091,6 +1107,7 @@
     <string name="native_bb4f2558e4333834" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Зображення віджета збережено в папці «Завантаження»"</string>
     <string name="native_bbe5fc3b9ef39f99" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Запуск…"</string>
     <string name="native_bc19cec293228fb8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Помилка клієнта"</string>
+    <string name="native_bc1c94a6dfce1058" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Перевірте пристрій, що надсилає запит, перш ніж надавати доступ."</string>
     <string name="native_bc6618670f3e8a17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Мікрофон Bluetooth LE"</string>
     <string name="native_bcb06651437caa15" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
     <string name="native_bd08450d63406844" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Автоматизацію ввімкнено."</string>
@@ -1099,6 +1116,7 @@
     <string name="native_bdc090ec61e3fcfc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Перезавантажити"</string>
     <string name="native_bdff71b20b9cf392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Пошук автоматизацій"</string>
     <string name="native_be969becb173e0c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Пов’язані телефони та хости вузлів з’являться тут після спарювання."</string>
+    <string name="native_bf1870ff5c6322fb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s: %2$s"</string>
     <string name="native_bf350e6a0ed60b7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Цю автоматизацію змінено на Gateway. Перегляньте останню версію, перш ніж зберігати її знову."</string>
     <string name="native_bf399ffa03617a96" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Зупинити диктування"</string>
     <string name="native_bf56ee2fe3345ce1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Читабельний"</string>
@@ -1122,6 +1140,7 @@
     <string name="native_c1c224b03cd9bc7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Адміністратор"</string>
     <string name="native_c1ebc7817870e5be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Потребує уваги"</string>
     <string name="native_c22d5e02fbec7d65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Підключіть цей пристрій до свого Gateway, щоб активувати його лише для реальної роботи, мати під рукою актуальний огляд агентів і уникати фонових циклів, що розряджають акумулятор."</string>
+    <string name="native_c25337055464f8d3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ролі"</string>
     <string name="native_c253f451bdd56431" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Відповісти"</string>
     <string name="native_c26225b6c16a4bc7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Каталог постачальників"</string>
     <string name="native_c272b225cf5bd643" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Увімкніть дозвіл у Налаштуваннях"</string>
@@ -1135,6 +1154,7 @@
     <string name="native_c34dd5eb8b0af56e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Де отримати код налаштування?"</string>
     <string name="native_c3546b39ecbbed8a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не вдалося ввімкнути навичку."</string>
     <string name="native_c35b21d6ca39aa7c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"pdf"</string>
+    <string name="native_c3812fc4acb861d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Видалити"</string>
     <string name="native_c382566dbe2ea49f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s%% у мережі"</string>
     <string name="native_c385951198c45d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Немає каналів"</string>
     <string name="native_c41ad84496b53420" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Голос у реальному часі"</string>
@@ -1163,6 +1183,7 @@
     <string name="native_c6d5ed757b66bfd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Мрія"</string>
     <string name="native_c6dd061350fc69b8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не заблоковано жодного застосунку. Застосунки можуть пересилати дані, якщо ви не додасте блокування."</string>
     <string name="native_c753cdf0c19f1e38" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Розпізнавання мовлення недоступне"</string>
+    <string name="native_c78ffe19571018fb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Платформа"</string>
     <string name="native_c7985fa72daa6ea4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway не повернув налаштування %1$s"</string>
     <string name="native_c7b6dfd5c3a183c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Забути gateway?"</string>
     <string name="native_c7b7b7f01360f6a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Необов’язковий опис"</string>
@@ -1225,6 +1246,7 @@
     <string name="native_d17d2d78d76e6a6c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Моделі"</string>
     <string name="native_d19c2dd2fb598b93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw: пасивні"</string>
     <string name="native_d1a574e23344c407" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Недійсний пароль Gateway"</string>
+    <string name="native_d1af697abaff485f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не вдалося перевірити зміну сполучення пристрою. Оновіть сторінку та повторіть спробу."</string>
     <string name="native_d1bf045bb524dae5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Переглянути подробиці"</string>
     <string name="native_d1e9567da9a8a4b0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bash"</string>
     <string name="native_d2089be672953d11" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Токен"</string>
@@ -1239,6 +1261,7 @@
     <string name="native_d31de1a5c5c8ba2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Браузер"</string>
     <string name="native_d354ee936f59115e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screen record"</string>
     <string name="native_d3974fd6d3b6c81f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Очікує запуску"</string>
+    <string name="native_d3e1c5f8a6e240fc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Джерело"</string>
     <string name="native_d3f75e24411053c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Персональний ШІ на ваших пристроях"</string>
     <string name="native_d406ade2958cb5b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attach"</string>
     <string name="native_d461a493a3753877" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Автоматично"</string>
@@ -1427,6 +1450,7 @@
     <string name="native_f2da2e47cd31a5dd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Не вдалося декодувати це зображення."</string>
     <string name="native_f3753c0fe29b88db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway, голос, сповіщення, конфіденційність"</string>
     <string name="native_f386c32c1bf437d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Файли робочого простору агента"</string>
+    <string name="native_f418bf0894a1806a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Цей пристрій утратить довірений доступ до Gateway."</string>
     <string name="native_f41d9e8b7e09aa24" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Використайте requestId з команди, що очікує, у команді approve."</string>
     <string name="native_f4830a1dae298044" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Розклад"</string>
     <string name="native_f493f0ce7a52a8aa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Обмеження частоти"</string>
@@ -1434,6 +1458,7 @@
     <string name="native_f4cc820d308495c4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Корисне навантаження · %1$s"</string>
     <string name="native_f4ccae29e1bb0c20" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Виконується"</string>
     <string name="native_f4db1e48476f6075" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Завершити"</string>
+    <string name="native_f4e2076014711222" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Використовувати системну довіру"</string>
     <string name="native_f4ef7a41caa88dd1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Немає готових провайдерів"</string>
     <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Надає пріоритет підключеним мікрофонам Bluetooth."</string>
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Пересилання заблоковано для %1$s застосунку."</string>

--- a/apps/android/app/src/main/res/values-vi/strings.xml
+++ b/apps/android/app/src/main/res/values-vi/strings.xml
@@ -494,7 +494,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gửi"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tắt tiếng loa"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Đang mở kết nối Gateway"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Đang giám sát · %1$s luồng"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Lượt chạy tác vụ tự động đã hoàn tất."</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Không có ứng dụng phù hợp."</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gửi đến cuộc trò chuyện"</string>
@@ -1277,7 +1277,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Hồ sơ"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Giới hạn của nhà cung cấp sẽ xuất hiện ở đây khi gateway báo cáo."</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 sự cố"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Các luồng trong \"%1$s\" được giữ lại và chuyển về Chưa nhóm."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Đã tạo"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s token đang hoạt động"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>

--- a/apps/android/app/src/main/res/values-vi/strings.xml
+++ b/apps/android/app/src/main/res/values-vi/strings.xml
@@ -104,7 +104,7 @@
     <string name="native_0e91610117029a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Làm mới"</string>
     <string name="native_0ee30822ed35a792" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s đang chờ"</string>
     <string name="native_0f4c8529742b31ea" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bắt đầu trò chuyện"</string>
-    <string name="native_0f559ff270904904" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Các lệnh gọi công cụ Chat đang chờ trong luồng hoạt động vẫn hiển thị tại đây."</string>
+    <string name="native_0f559ff270904904" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Các lệnh gọi công cụ Chat đang chờ trong luồng đang hoạt động vẫn hiển thị tại đây."</string>
     <string name="native_0f56cc286a4f23d8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cần xem xét chứng chỉ"</string>
     <string name="native_0f8fe3a9688138a1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Mở bề mặt Canvas hiện tại để kiểm tra hoặc tương tác với nó."</string>
     <string name="native_0ff98f05be01ce5e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Đã cập nhật tác vụ tự động."</string>
@@ -283,7 +283,7 @@
     <string name="native_2cd62f7a670b2819" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Luồng OpenClaw"</string>
     <string name="native_2d4dfe885f84629e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cho phép truy cập thư viện ảnh."</string>
     <string name="native_2d6416405eb44982" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Một phản hồi trước đó đã xử lý phê duyệt này."</string>
-    <string name="native_2d85de9d56c226e4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Không có luồng gần đây"</string>
+    <string name="native_2d85de9d56c226e4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Không có luồng nào gần đây"</string>
     <string name="native_2df01a03ff43400b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Không có kết quả phù hợp"</string>
     <string name="native_2df30b117ad829ab" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Đọc thông báo từ các ứng dụng đã chọn"</string>
     <string name="native_2e0078a8322d6f1f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Không rõ trạng thái khả dụng"</string>
@@ -345,7 +345,7 @@
     <string name="native_36c725ddb20f8bd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Thiết lập nhà cung cấp Talk"</string>
     <string name="native_36d88ed6cc91d2b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Music Generation"</string>
     <string name="native_36e8d5e94219dc37" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cài đặt Talk"</string>
-    <string name="native_36f1fac278711470" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Đang giám sát · 1 luồng"</string>
+    <string name="native_36f1fac278711470" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Đang theo dõi · 1 luồng"</string>
     <string name="native_37053dc1f680546b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Văn bản payload"</string>
     <string name="native_37582309e7a1dbe5" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Phê duyệt %1$s"</string>
     <string name="native_379ce0aacf46c35f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway không trả về trạng thái sẵn sàng của %1$s"</string>
@@ -371,7 +371,7 @@
     <string name="native_3a65cf1204f18864" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Đã kết nối (nút đang ngoại tuyến)"</string>
     <string name="native_3a78695388b38b5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Trang chủ"</string>
     <string name="native_3b28b535950f8175" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tính năng đọc chính tả đang lắng nghe"</string>
-    <string name="native_3b46b7912670bfb0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Không có luồng đã lưu trữ"</string>
+    <string name="native_3b46b7912670bfb0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Không có luồng nào đã lưu trữ"</string>
     <string name="native_3b851469ea31d489" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Chọn và kiểm tra các trợ lý có sẵn trên gateway này."</string>
     <string name="native_3be0085a6bd88cdd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Chế độ nói đang hoạt động"</string>
     <string name="native_3bee4ede6bf4436c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Đang hoạt động · 1 lượt chạy đang hoạt động"</string>
@@ -494,7 +494,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gửi"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tắt tiếng loa"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Đang mở kết nối Gateway"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Đang theo dõi · %1$s luồng"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Lượt chạy tác vụ tự động đã hoàn tất."</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Không có ứng dụng phù hợp."</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gửi đến cuộc trò chuyện"</string>
@@ -519,7 +519,7 @@
     <string name="native_55898449eb74fb2e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tình trạng"</string>
     <string name="native_55a12cbe0995e214" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Trình nghe thông báo"</string>
     <string name="native_55d8e7da6d0a752c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Đã tắt tiếng loa"</string>
-    <string name="native_560d3e826c413dc9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tìm kiếm cuộc trò chuyện"</string>
+    <string name="native_560d3e826c413dc9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tìm kiếm luồng"</string>
     <string name="native_565339bc4d33d728" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OK"</string>
     <string name="native_56a508f3f2bf424a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Không thể mở hướng dẫn thiết lập."</string>
     <string name="native_56c41c606c44f3fc" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"hỏi OpenClaw %1$s"</string>
@@ -1212,7 +1212,7 @@
     <string name="native_cc721e25d73938a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway gia đình"</string>
     <string name="native_cc7a9a5cf8c4bc9d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Chạy lệnh phê duyệt trên Gateway"</string>
     <string name="native_cc925e3c97ac7a35" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Không thể tải các đề xuất Skill Workshop."</string>
-    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tóm tắt cho tôi các luồng OpenClaw gần đây và đề xuất các bước tiếp theo."</string>
+    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cập nhật cho tôi về các luồng OpenClaw gần đây và đề xuất các bước tiếp theo."</string>
     <string name="native_ccb4c324f516c633" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Không phải bây giờ"</string>
     <string name="native_cced0b0d83a9e400" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw qr"</string>
     <string name="native_cced28c6dc3f99c2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"start"</string>
@@ -1235,7 +1235,7 @@
     <string name="native_ceb6931ea57cc999" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Thích ứng"</string>
     <string name="native_cf0ee3547a4e51a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sắp có"</string>
     <string name="native_d04fc7d7e19702f8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Search"</string>
-    <string name="native_d053ba98d8bbcec1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Hãy thử Trò chuyện, Giọng nói, Luồng, Nhà cung cấp hoặc Cài đặt."</string>
+    <string name="native_d053ba98d8bbcec1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Thử Trò chuyện, Giọng nói, Luồng, Nhà cung cấp hoặc Cài đặt."</string>
     <string name="native_d056177742e27cf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw Hoạt động"</string>
     <string name="native_d0cda6559bb347db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"navigate"</string>
     <string name="native_d0d0de0039c7990b" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"đã yêu cầu %1$s"</string>
@@ -1277,7 +1277,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Hồ sơ"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Giới hạn của nhà cung cấp sẽ xuất hiện ở đây khi gateway báo cáo."</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 sự cố"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Các luồng trong \"%1$s\" được giữ lại và chuyển về Chưa nhóm."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Đã tạo"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s token đang hoạt động"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>
@@ -1294,7 +1294,7 @@
     <string name="native_d93e2b7a15efbc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Không thể xử lý phê duyệt. Hãy làm mới và thử lại."</string>
     <string name="native_d942f64886578d87" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"import"</string>
     <string name="native_d94cfb21b67ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cách điện thoại này hiển thị với OpenClaw."</string>
-    <string name="native_d96f2b0eab4e67b7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tập trung vào ô tìm kiếm luồng"</string>
+    <string name="native_d96f2b0eab4e67b7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Đưa con trỏ vào ô tìm kiếm luồng"</string>
     <string name="native_d975ca28a64f8850" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kết nối Gateway"</string>
     <string name="native_d9be42d9b30ce057" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Đọc lịch"</string>
     <string name="native_d9f641e1a02807cb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Phần tổng quan sẽ được làm mới khi kết nối lại và khi màn hình này mở."</string>
@@ -1460,7 +1460,7 @@
     <string name="native_f4db1e48476f6075" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Kết thúc"</string>
     <string name="native_f4e2076014711222" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sử dụng độ tin cậy của hệ thống"</string>
     <string name="native_f4ef7a41caa88dd1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Không có nhà cung cấp nào sẵn sàng"</string>
-    <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ưu tiên micrô Bluetooth đã kết nối."</string>
+    <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Ưu tiên các micrô Bluetooth đã kết nối."</string>
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s ứng dụng bị chặn chuyển tiếp."</string>
     <string name="native_f532ee1f7288365e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Hành động với tin nhắn"</string>
     <string name="native_f5387f9bb6ed7031" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Loại"</string>
@@ -1522,7 +1522,7 @@
     <string name="native_ff716fc4735e067f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cài đặt đọc chính tả"</string>
     <string name="native_ff9dbbdfb84ddab2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Đã tải các mô hình của nhà cung cấp, nhưng không có thông tin về trạng thái sẵn sàng."</string>
     <string name="native_ffa7aa557b547a79" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Xóa luồng?"</string>
-    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw biến điện thoại này thành một giao diện điều khiển di động gọn gàng cho các luồng, giọng nói, nhà cung cấp và Gateway."</string>
+    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw biến điện thoại này thành một giao diện lệnh di động gọn gàng cho các luồng, giọng nói, nhà cung cấp và Gateway."</string>
     <string name="native_ffb6f5764bddb68c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Mới nhất trước"</string>
     <string name="native_ffcf16006c652ee3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Chu kỳ tiếp theo"</string>
 </resources>

--- a/apps/android/app/src/main/res/values-zh-rCN/strings.xml
+++ b/apps/android/app/src/main/res/values-zh-rCN/strings.xml
@@ -24,14 +24,12 @@
     <string name="native_002a6fcb30b2def4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法准备待发送的附件。"</string>
     <string name="native_003aaf9e0a0e6b9f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"麦克风关闭"</string>
     <string name="native_0060cbfdd3cf13ba" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"显示 OpenClaw 提醒"</string>
-    <string name="native_0077032d7e9f9cbe" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"对话活动"</string>
-    <string name="native_008dacb6d1e85bd8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"完全"</string>
+    <string name="native_008dacb6d1e85bd8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"完整"</string>
     <string name="native_009506aeb0484b2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已批准并保存。"</string>
     <string name="native_00d108e2e6466940" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"显示最近的通话记录"</string>
     <string name="native_00e8aeba41d79ce3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 个待处理"</string>
     <string name="native_010f6550a1c8f554" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"不支持的附件"</string>
     <string name="native_01267be21eb77392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"0 = 精确"</string>
-    <string name="native_0171e3d4e07f1861" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接 Gateway 以搜索对话。"</string>
     <string name="native_0174f83136630e7e" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 个账户"</string>
     <string name="native_01ac1c298e0cbd9a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cron 更改需要 operator.admin 权限。设置代码不会授予此权限。请使用 Gateway 的共享令牌或密码重新连接，以请求管理员访问权限。如果此设备仍缺少该权限，请从现有管理员客户端批准待处理的权限范围升级。"</string>
     <string name="native_01bcfe7a9296b6d6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Apply Patch"</string>
@@ -70,12 +68,9 @@
     <string name="native_088e0e5ebc96c6ac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"替换 Gateway 设置？"</string>
     <string name="native_08a5391c1de3078a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法加载自动化。"</string>
     <string name="native_08b041935798fbf6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"你"</string>
-    <string name="native_08ea63ee26954dca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"内置麦克风"</string>
     <string name="native_0905f7f59021c2a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"界面"</string>
     <string name="native_0929c9dc7f794852" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有提案"</string>
-    <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"主对话"</string>
     <string name="native_0979c6fdbdca1675" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"打开聊天"</string>
-    <string name="native_09ce95090659d069" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此 Gateway 会话中无法执行设备配对操作。请在 Gateway 主机上运行 openclaw devices list，并在那里处理请求。节点能力批准是独立操作，仍需使用 nodes approve &lt;request id&gt;。"</string>
     <string name="native_0a0b7cf7c428c703" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"操作请求"</string>
     <string name="native_0a708e7b03aaf1fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list pins"</string>
     <string name="native_0ab0e1629576aecf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接到 Gateway 以加载 Skill Workshop 提案。"</string>
@@ -88,12 +83,11 @@
     <string name="native_0c3845dcd2f0f683" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"检查此提案以加载其 Markdown。"</string>
     <string name="native_0c3ea4e2f12153e7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"打开 OpenClaw 并询问 %1$s"</string>
     <string name="native_0c4d01e81bb3d1fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"推理"</string>
-    <string name="native_0c77fe09ab336a3e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"客户端"</string>
     <string name="native_0c79a9c222840ed0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已应用"</string>
+    <string name="native_0c8056e18fdf290c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"活动会话中等待处理的聊天工具调用会保留显示在此处。"</string>
     <string name="native_0cab1c9617404faf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"视频"</string>
     <string name="native_0cf04463c4276a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已推广"</string>
     <string name="native_0d21bd52022ca7f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在线"</string>
-    <string name="native_0d5644ff52ce2ba3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"权限范围"</string>
     <string name="native_0d5efd432e4fedf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"尚未配置实时语音提供商。"</string>
     <string name="native_0d8ca811c3744a6d" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s · %2$s"</string>
     <string name="native_0db10f2c2f332cd2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"kick"</string>
@@ -104,10 +98,11 @@
     <string name="native_0e91610117029a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"刷新"</string>
     <string name="native_0ee30822ed35a792" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 条已排队"</string>
     <string name="native_0f4c8529742b31ea" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"开始聊天"</string>
-    <string name="native_0f559ff270904904" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"活动对话中等待处理的聊天工具调用仍会显示在此处。"</string>
     <string name="native_0f56cc286a4f23d8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"需要审核证书"</string>
+    <string name="native_0f822f33a3100b5c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"监控中 · %1$s 个会话"</string>
     <string name="native_0f8fe3a9688138a1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"打开当前 Canvas 界面以检查或与之交互。"</string>
     <string name="native_0ff98f05be01ce5e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自动化已更新。"</string>
+    <string name="native_100ac08064a6d586" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有最近会话"</string>
     <string name="native_1039e92fa05c1279" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 状态、手机节点就绪情况和最近的日志流。"</string>
     <string name="native_106808530413298b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"打开自动化任务详情"</string>
     <string name="native_1093115897879aa3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"运行时"</string>
@@ -119,13 +114,13 @@
     <string name="native_1196c7b1e0e55580" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"reactions"</string>
     <string name="native_11a6767d5674c7e4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"完成"</string>
     <string name="native_11e18d6748aa9128" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"版本和更新"</string>
+    <string name="native_11e47358a692d81b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"总结最近的会话和后续步骤。"</string>
     <string name="native_11f37f9652a47b5b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 将在此显示审批、失败的任务和频道问题。"</string>
-    <string name="native_11f6dc0befae5081" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"USB 麦克风"</string>
     <string name="native_1242bf5561713a98" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"等待添加的共享过多。"</string>
+    <string name="native_1251aefc12b2b10e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"删除会话？"</string>
     <string name="native_12698ce1ea5cd4ab" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已跳过"</string>
     <string name="native_1291833ee42d8143" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"使用 Gateway 计算机的局域网地址或安全的远程主机名。"</string>
     <string name="native_130011756125313c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"开启"</string>
-    <string name="native_133f293961d7aa43" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在搜索对话"</string>
     <string name="native_13798c3256e792c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"实时对话"</string>
     <string name="native_13b588109e423636" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 正在准备回复。"</string>
     <string name="native_13ba4cde12390943" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已批准一次。"</string>
@@ -141,8 +136,6 @@
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"会话目标"</string>
     <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"查看 ClawHub 技能"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
-    <string name="native_16a5b7ad567a8093" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"拒绝来自此设备的配对请求？"</string>
-    <string name="native_16b1a05e1d987ed1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"首选麦克风"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"节点主机"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"级别"</string>
     <string name="native_172b997ffbc8c9a7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"关闭应用选择器"</string>
@@ -162,7 +155,6 @@
     <string name="native_18f2a0947f9d6523" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已阻止"</string>
     <string name="native_18f6e5973bc41268" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"唤醒词或短语"</string>
     <string name="native_1906b261e6e0fdd0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 需要设备批准"</string>
-    <string name="native_19408baaf5c2e446" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"外接麦克风"</string>
     <string name="native_194a05367fb28913" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s 个已就绪"</string>
     <string name="native_199e261f8ee0e97f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已连接（操作员离线）"</string>
     <string name="native_19fc7a47df16fb1f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"功能未批准"</string>
@@ -187,7 +179,6 @@
     <string name="native_1d91629837639a5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此自动化在你编辑期间发生了更改。保存前，请还原到 Gateway 上的最新版本。"</string>
     <string name="native_1dbf9d5979606697" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接后，Gateway 可以通过静默推送唤醒手机，而无需维持始终在线的会话。"</string>
     <string name="native_1e432ea5425e4a3a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"唤醒模式"</string>
-    <string name="native_1e595a107c78b957" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"移除配对设备？"</string>
     <string name="native_1e955a58278623a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"系统事件文本"</string>
     <string name="native_1ea44149be42d970" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法复制小组件图片"</string>
     <string name="native_1ea442a134b2a184" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"否"</string>
@@ -202,7 +193,6 @@
     <string name="native_2065cc867eba1b39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法加载提供商模型配置。"</string>
     <string name="native_207ccb22d618db05" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"允许 %1$s 个应用转发。"</string>
     <string name="native_209b9e597963e7e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"语音设置"</string>
-    <string name="native_211988ba9dd0570a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"拒绝配对请求？"</string>
     <string name="native_2132066dc9475cb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"This skill is installed but not available to the current agent. Agent filters stay on desktop or CLI."</string>
     <string name="native_21378545892f1fe2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"发布者"</string>
     <string name="native_214d4932fc767e8f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">" · 通话：正在说话"</string>
@@ -216,7 +206,6 @@
     <string name="native_22965568d22a14ee" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已连接"</string>
     <string name="native_22a970d2e5b1cc23" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已完成"</string>
     <string name="native_22b8da9e693e94eb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"你的手机已与 %1$s 配对。请继续完成节点访问设置。"</string>
-    <string name="native_22f19ab686639b9a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"当前对话"</string>
     <string name="native_23246d9852fed325" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"思考 %1$s"</string>
     <string name="native_2346f214ad56b180" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已静音"</string>
     <string name="native_2347fc06da5f60de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 感谢其在开源社区中的合作伙伴。"</string>
@@ -243,12 +232,11 @@
     <string name="native_262c897a1f408b0b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接到你的 Gateway"</string>
     <string name="native_2682bd813a3bccbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"输入 openclaw qr 中的设置代码。"</string>
     <string name="native_268f14bbfe119c1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"诊断"</string>
-    <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"这将永久删除该对话及其记录。"</string>
-    <string name="native_26e47d73a55d7fa7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"设备已批准。"</string>
     <string name="native_26f0dd993530eb2d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在自动重试"</string>
     <string name="native_270ff82f36da987f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已复制小组件图片"</string>
     <string name="native_2728740a95d465c6" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 个角色"</string>
     <string name="native_272955a627b71681" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"缺少 1 项"</string>
+    <string name="native_2732406e3be52c5b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有匹配的会话"</string>
     <string name="native_2748442ae65e27e8" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 个已计划"</string>
     <string name="native_275976081ce1abf6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"react"</string>
     <string name="native_279b44d2ab4b40c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"代理"</string>
@@ -260,7 +248,6 @@
     <string name="native_27d773b934ed324f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"验证并安装"</string>
     <string name="native_2821f0168d6dd9df" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"将此设备变成安全的 OpenClaw 节点，用于聊天、语音、摄像头和设备工具。"</string>
     <string name="native_2831546121359362" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"手动设置"</string>
-    <string name="native_287c4b113aafc215" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"打开聊天以开始或继续当前对话。"</string>
     <string name="native_28bb849671cab958" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"提示：停止聆听即可发送已捕获的发言。"</string>
     <string name="native_28d03596d24eeb4e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"跳过"</string>
     <string name="native_28d55ec6974d84e8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"语音请求失败"</string>
@@ -280,10 +267,9 @@
     <string name="native_2c19d584bf8ad518" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"标记为未读"</string>
     <string name="native_2c75802a5f8df5f8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"查找人员和联系方式"</string>
     <string name="native_2c9cce8250d746e3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"需要设备身份"</string>
-    <string name="native_2cd62f7a670b2819" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 对话"</string>
+    <string name="native_2cad0766accc2d3f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"重命名会话"</string>
     <string name="native_2d4dfe885f84629e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"允许访问照片图库。"</string>
     <string name="native_2d6416405eb44982" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"先前的响应已处理此批准。"</string>
-    <string name="native_2d85de9d56c226e4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有最近的对话"</string>
     <string name="native_2df01a03ff43400b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无匹配项"</string>
     <string name="native_2df30b117ad829ab" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"读取所选应用的通知"</string>
     <string name="native_2e0078a8322d6f1f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"可用性未知"</string>
@@ -345,7 +331,6 @@
     <string name="native_36c725ddb20f8bd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Talk Provider 设置"</string>
     <string name="native_36d88ed6cc91d2b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Music Generation"</string>
     <string name="native_36e8d5e94219dc37" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"对话设置"</string>
-    <string name="native_36f1fac278711470" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在监控 · 1 个对话"</string>
     <string name="native_37053dc1f680546b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"负载文本"</string>
     <string name="native_37582309e7a1dbe5" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"批准 %1$s"</string>
     <string name="native_379ce0aacf46c35f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 未返回 %1$s 就绪状态"</string>
@@ -353,7 +338,6 @@
     <string name="native_381428f5f251a764" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Conversation Send"</string>
     <string name="native_3824a9f4dafe92c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"画布"</string>
     <string name="native_384ae4ab1a2830f9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 个提供商"</string>
-    <string name="native_385001409de8562a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法自动读取 Gateway 证书。请粘贴在 Gateway 主机上获取的 SHA-256 指纹。"</string>
     <string name="native_387b2569e440838c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"发送失败：%1$s"</string>
     <string name="native_3892e10346fd2012" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"桥接"</string>
     <string name="native_38d198cd5303680f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"投递错误"</string>
@@ -371,19 +355,18 @@
     <string name="native_3a65cf1204f18864" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已连接（节点离线）"</string>
     <string name="native_3a78695388b38b5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"首页"</string>
     <string name="native_3b28b535950f8175" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在听写"</string>
-    <string name="native_3b46b7912670bfb0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有已归档的对话"</string>
     <string name="native_3b851469ea31d489" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"选择并检查此 gateway 上可用的助手。"</string>
     <string name="native_3be0085a6bd88cdd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"通话模式已启用"</string>
     <string name="native_3bee4ede6bf4436c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"工作中 · 1 个活跃运行"</string>
     <string name="native_3c6168bbf86e6e4b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"同意并启用"</string>
     <string name="native_3cb27ae0fbca8ae3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"复制图片"</string>
+    <string name="native_3d013d4e9cf973f9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"尝试聊天、语音、会话、提供商或设置。"</string>
     <string name="native_3d06950825de7452" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway URL"</string>
     <string name="native_3d200f624b8bda8f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"main、isolated、current 或 session:&lt;id&gt;"</string>
     <string name="native_3d61e9d54ffa2d93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接到你的 Gateway，以在代理工作区中打开 shell。"</string>
     <string name="native_3da4811eafea080a" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s://%2$s:%3$s"</string>
     <string name="native_3de3d401128d4395" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法加载批准详情。请刷新后重试。"</string>
     <string name="native_3e398e6fb979557a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tool Call"</string>
-    <string name="native_3e42e385075b9b56" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"对话"</string>
     <string name="native_3f00927a719345ed" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Write"</string>
     <string name="native_3f25ccebfa99dcf3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"输入提示词开始，或使用语音。"</string>
     <string name="native_3f39d5c348e5b79d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"D"</string>
@@ -410,8 +393,6 @@
     <string name="native_4287d54ad5e78985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"来自你的 gateway 的已计划 OpenClaw 工作。"</string>
     <string name="native_429f6057535c1ea3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sub-agent"</string>
     <string name="native_42e3a99c21767def" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在等待设备批准"</string>
-    <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在加载对话"</string>
-    <string name="native_430df68ec29a85a2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此 Gateway 现在提供的证书已受此设备信任。"</string>
     <string name="native_43905968a540af6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"错开毫秒数"</string>
     <string name="native_43988c156beabf7d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"event create"</string>
     <string name="native_43cc23fa52b87b4c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"文档"</string>
@@ -470,12 +451,13 @@
     <string name="native_4d5e590b23745b4d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"安装在 Gateway 上的 Skills 将显示在此处。"</string>
     <string name="native_4dee3342f86128c1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"该代码可能已过期，或是为另一个 Gateway 生成的。"</string>
     <string name="native_4e25d34a20313a61" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"需要权限"</string>
+    <string name="native_4e35d595e6975128" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"会话活动"</string>
     <string name="native_4e8c72cab82e0711" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自动化配置无效。"</string>
     <string name="native_4ec30e9d85725d41" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"允许列表"</string>
     <string name="native_4ed379d418bb8629" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"groups"</string>
-    <string name="native_4ee252fb736effa2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"公钥"</string>
     <string name="native_4efca0d10c5feb8e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"关于"</string>
     <string name="native_4f1bc100d1dccc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在该图片中未找到设置二维码。请选择由 openclaw qr 生成的二维码，或手动输入设置代码。"</string>
+    <string name="native_4f993457edb69110" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"浏览会话"</string>
     <string name="native_4fe3cdd404ea0290" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"permissions"</string>
     <string name="native_5047cfb3b607e7d0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接 Gateway 以加载节点和已配对设备。"</string>
     <string name="native_5083cd4b96b0d09d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有 Skills"</string>
@@ -494,7 +476,6 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"投递"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"将扬声器静音"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在打开 Gateway 连接"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在监控 · %1$s 个对话"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自动化运行已完成。"</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有匹配的应用。"</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"发送到聊天"</string>
@@ -511,6 +492,7 @@
     <string name="native_544731b8da90eb65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"emoji list"</string>
     <string name="native_544d9e42216c2ac0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"重复"</string>
     <string name="native_54b41550b1247912" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"搜索 OpenClaw"</string>
+    <string name="native_54d5c8a4eb7898dc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"主会话"</string>
     <string name="native_54e08ca4a25fe3f1" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 个待处理"</string>
     <string name="native_5542bc6a5f3ae4da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"设备端语音识别不可用"</string>
     <string name="native_55546edf686ab168" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有应用可以分享此消息"</string>
@@ -519,13 +501,13 @@
     <string name="native_55898449eb74fb2e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"健康状况"</string>
     <string name="native_55a12cbe0995e214" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"通知监听器"</string>
     <string name="native_55d8e7da6d0a752c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"扬声器已静音"</string>
-    <string name="native_560d3e826c413dc9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"搜索对话"</string>
+    <string name="native_5638a97380146882" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"打开聊天以开始或继续当前会话。"</string>
     <string name="native_565339bc4d33d728" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"确定"</string>
     <string name="native_56a508f3f2bf424a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法打开设置指南。"</string>
     <string name="native_56c41c606c44f3fc" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"询问 OpenClaw %1$s"</string>
-    <string name="native_56c4c3d30ceda56e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wait for Agents"</string>
     <string name="native_56ef8f20955f2564" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"地址"</string>
     <string name="native_5702e1d243eeb4e9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在 Gateway 上创建的计划任务将显示在此处。"</string>
+    <string name="native_5719080df7834f1b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接 Gateway 以搜索会话。"</string>
     <string name="native_572739b05d138f8a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在显示最新的日志块。"</string>
     <string name="native_57666930af1af35e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"使用设置代码"</string>
     <string name="native_57c4b13a4c7335e7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"sticker"</string>
@@ -537,6 +519,7 @@
     <string name="native_5855b3ac2fcc1b3e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"修复连接"</string>
     <string name="native_58e909c0f4cc5723" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"保存图片"</string>
     <string name="native_590b0003ccaad929" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"节点 %1$s"</string>
+    <string name="native_5922c3814cbbdbce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"帮我了解最近 OpenClaw 会话的最新进展，并建议后续步骤。"</string>
     <string name="native_59235e6ebfd03967" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"需要 Gateway 密码"</string>
     <string name="native_592acaa91843913b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Update Plan"</string>
     <string name="native_595b066a8838734a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"移除附件"</string>
@@ -551,6 +534,7 @@
     <string name="native_5a7d4412c13abceb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 正在说话"</string>
     <string name="native_5a99f6fa7e98657a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"扫描二维码"</string>
     <string name="native_5ab9d81fd481e71f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已选应用"</string>
+    <string name="native_5b3522ef7c1c149e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"聚焦会话搜索"</string>
     <string name="native_5b36e77f2018303f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"撤销更改"</string>
     <string name="native_5b4ddab77c412d6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"审批命令已复制"</string>
     <string name="native_5b7c4c081e9c5810" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"投递状态"</string>
@@ -560,7 +544,6 @@
     <string name="native_5c0c8c9aa658f4a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OPENCLAW"</string>
     <string name="native_5c1acea9c9b0e704" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Fetch"</string>
     <string name="native_5c39123805ffb4e2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"提示词"</string>
-    <string name="native_5c944156b5353428" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"批准设备？"</string>
     <string name="native_5d410adb9576e266" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"要从此手机中移除 %1$s 及其保存的凭据吗？"</string>
     <string name="native_5d6c41a67139ee26" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"二维码指向不安全的远程 Gateway。%1$s %2$s"</string>
     <string name="native_5d6cbac59f87e78d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"屏幕表面已就绪"</string>
@@ -578,7 +561,6 @@
     <string name="native_5fa1d457ddfcd26c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"rename group"</string>
     <string name="native_5fa7aac5375c5815" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"就绪"</string>
     <string name="native_5fc1927ca948f31c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"日记正在等待第一条记录。"</string>
-    <string name="native_6007acbe30b2cd98" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"批准"</string>
     <string name="native_600c9c27960112a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"实时页面"</string>
     <string name="native_6030d1f6340776d2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自动化已在运行。"</string>
     <string name="native_604e6d6faf8d0295" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在一次性运行成功后移除此自动化。"</string>
@@ -588,7 +570,6 @@
     <string name="native_60ea1847c2ba5446" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"响应已中止"</string>
     <string name="native_6105d6cc76af4003" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"图像"</string>
     <string name="native_614b8348a2dbe46b" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 个已保留"</string>
-    <string name="native_614e83ef17c13f3c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有匹配的对话"</string>
     <string name="native_6197595503f01ee2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"delete"</string>
     <string name="native_619837a134285528" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"布局：紧凑"</string>
     <string name="native_61ffa9c8c703dd5e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"channels"</string>
@@ -618,26 +599,19 @@
     <string name="native_6657cc73af00feac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在请求时允许使用相机工具。"</string>
     <string name="native_666067dd376e5d45" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"问题"</string>
     <string name="native_666c8bc0319f3b54" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"语音唤醒"</string>
-    <string name="native_66713d713e3a41c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"配对请求已拒绝。"</string>
     <string name="native_66b23bae66fc0d79" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 天前"</string>
     <string name="native_66cf5513b37462be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"roles"</string>
     <string name="native_66d0f523a379b2de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skills"</string>
     <string name="native_66f4804ee23ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"归档"</string>
     <string name="native_66fab2875ee427f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"节点离线。请重新连接并重试。"</string>
     <string name="native_6725e7bbcd28f3a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"系统"</string>
-    <string name="native_672f3453e1dd571b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"远程 IP"</string>
     <string name="native_674b38cae72bb0c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"未分组"</string>
     <string name="native_674eb55d9c353900" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"计划详情"</string>
     <string name="native_67528858c36397f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"手机功能"</string>
     <string name="native_67a926f7008e2b0e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"不可用"</string>
-    <string name="native_67b696468610b879" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dashboard"</string>
     <string name="native_67fa416afa64d304" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"粘贴令牌"</string>
     <string name="native_6827238fea72c88b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无提供商"</string>
-    <string name="native_684889f0079cc145" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"SHA-256 指纹"</string>
-    <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"暂无对话"</string>
-    <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"蓝牙麦克风"</string>
     <string name="native_690dbe9dc0993c42" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"最近"</string>
-    <string name="native_6930c8d1fc4f01d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"重命名对话"</string>
     <string name="native_69384c1c4d99f6eb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"处理结果未知。在验证 Gateway 记录之前，操作将保持禁用。"</string>
     <string name="native_6940189433657105" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"dialog"</string>
     <string name="native_695c03727ff0251f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"监听唤醒词"</string>
@@ -668,7 +642,6 @@
     <string name="native_6d5d9004797377e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"许可证"</string>
     <string name="native_6d7c95a353d873cd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接 Gateway 以搜索 ClawHub Skills。"</string>
     <string name="native_6df1bb18a59ab97d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"技能"</string>
-    <string name="native_6e0a0b9d8c5ee4d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"设备 ID"</string>
     <string name="native_6e117ba97cbfb6f0" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 未识别活动的 %1$s 提供商"</string>
     <string name="native_6e293a8c009e0011" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"等待中"</string>
     <string name="native_6e2c0963d056e104" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"唤醒词已保存"</string>
@@ -696,6 +669,7 @@
     <string name="native_710a5600e8adc434" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ClawHub 未返回适用于 %1$s 的可安装版本。"</string>
     <string name="native_713166971d730f81" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"命令"</string>
     <string name="native_7143e424a2bf2663" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此批准在处理完成前已取消。"</string>
+    <string name="native_71463bd14f924604" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有当前会话"</string>
     <string name="native_716c3d1f55a7cd37" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"麦克风开启 · 正在等待 Gateway"</string>
     <string name="native_7198eaa9f18ee413" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"显示 %1$s / %2$s。优化搜索以查看更多。"</string>
     <string name="native_71aec38e93393296" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"v%1$s 可用"</string>
@@ -707,6 +681,7 @@
     <string name="native_7234213a42c2635b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"打开个人资料"</string>
     <string name="native_7234d010e91c7bcf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"启动你的 Gateway。"</string>
     <string name="native_72361961ef893ce1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"帮我将此目标转化为实用的检查清单："</string>
+    <string name="native_7296bfd468e09713" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"清除会话搜索"</string>
     <string name="native_72e9a59f5a1d6289" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"端口"</string>
     <string name="native_7344ef8e67c5337e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"输入设置代码"</string>
     <string name="native_735cca45016888d0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法加载 Gateway 日志。"</string>
@@ -717,7 +692,7 @@
     <string name="native_746f71ec623adc37" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Epoch 毫秒（可选）"</string>
     <string name="native_7491b353909c1147" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有已配置的模型。刷新以重新检查可用性。"</string>
     <string name="native_74a883a037bc227f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"设置"</string>
-    <string name="native_74c372f29b83df94" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"后置摄像头"</string>
+    <string name="native_74cdd65b358733f1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"切换会话布局"</string>
     <string name="native_74e21680eac7385c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"approve"</string>
     <string name="native_74e492d5d0df0bab" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"开始之前"</string>
     <string name="native_74f0a5d234edc4af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法加载 Skills。"</string>
@@ -750,6 +725,7 @@
     <string name="native_78f25f393aa9bcbf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"sticker upload"</string>
     <string name="native_790d78931c21b895" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Messages to recover"</string>
     <string name="native_792175fb265c32bc" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw devices approve %1$s"</string>
+    <string name="native_7981cbd5763dfcbb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"尚无匹配的会话。"</string>
     <string name="native_79a68a0d42388125" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"可读的 Gateway 日志详情。"</string>
     <string name="native_79a7ab236717f90d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在生成的 Skills 提案成为正式 Skills 之前进行审查。"</string>
     <string name="native_79d3a1f108e8d9c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已捆绑"</string>
@@ -792,13 +768,11 @@
     <string name="native_8193ee8a22d25208" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"固定模型"</string>
     <string name="native_81c2c4f30a4bec68" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"清除搜索"</string>
     <string name="native_81d38aca5306940b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已对符合条件的代理启用。"</string>
-    <string name="native_820d08e12968baff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"当前无对话"</string>
     <string name="native_82250171708918de" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在 %1$s 后"</string>
     <string name="native_825b9c75d7fed691" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"允许调度程序运行此自动化。"</string>
     <string name="native_82990a093599a9bb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 个已应用"</string>
     <string name="native_8340dad4f3be30a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"还没有梦境日记。"</string>
     <string name="native_837e39f46163ffb4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"刷新后台任务"</string>
-    <string name="native_838337fd9ab30454" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"总结最近的对话和后续步骤。"</string>
     <string name="native_83e2faed20a3cda4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"当 OpenClaw 可见时在设备上运行。"</string>
     <string name="native_844e5b02f3ef05ca" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 正在工作"</string>
     <string name="native_846c75dca0b71591" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
@@ -830,6 +804,7 @@
     <string name="native_88b01c8a4bff9a08" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"信号"</string>
     <string name="native_88e6e8384a7fc7ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"会话目标"</string>
     <string name="native_893a3e37d71c4563" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 已记录一次拒绝。"</string>
+    <string name="native_895f1e14d75d1239" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已归档的会话将显示在这里。"</string>
     <string name="native_89713b9c9c1b8f65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"接受"</string>
     <string name="native_8998824610d49175" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"向 OpenClaw 提问任何问题"</string>
     <string name="native_89bbfe23c3917a3f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"重新连接以继续"</string>
@@ -845,11 +820,11 @@
     <string name="native_8bb7ec15b1e350a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在检查"</string>
     <string name="native_8bf253a125f66985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"扫描或粘贴设置代码以添加另一个 Gateway。"</string>
     <string name="native_8c4a3896e8f06d27" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"TLS 超时"</string>
-    <string name="native_8c55387fb6c584c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已移除配对设备。"</string>
     <string name="native_8c93c68056cde54d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 已配对。正在检查节点功能批准状态。"</string>
     <string name="native_8ca344247c18317e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"运动"</string>
     <string name="native_8cac4b77b9c54695" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"cron 操作失败。"</string>
     <string name="native_8cb2bab2ce6a17b2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在 Gateway 电脑上运行："</string>
+    <string name="native_8cb650539ec84aa5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"搜索会话"</string>
     <string name="native_8d0839802b4d6aca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"刷新日志"</string>
     <string name="native_8d20273207a2fe99" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw nodes approve %1$s"</string>
     <string name="native_8d57374bc09c8756" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"语音消息 · %1$s"</string>
@@ -860,7 +835,7 @@
     <string name="native_8e19f962b0cd6587" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"开始新的对话后，它会显示在这里。"</string>
     <string name="native_8e20431e6645ccdd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接问题"</string>
     <string name="native_8e588cd187741f1c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"中"</string>
-    <string name="native_8e5b1a73152cf01c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"分支"</string>
+    <string name="native_8e5b1a73152cf01c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"创建分支"</string>
     <string name="native_8e6feeb36a83a707" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"启用扬声器"</string>
     <string name="native_8e803d361324b459" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"系统事件文本"</string>
     <string name="native_8eb626078c16c726" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"排序：%1$s"</string>
@@ -869,7 +844,6 @@
     <string name="native_8f54b0d1e30092d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"语音消息"</string>
     <string name="native_8fa196125b734940" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有需要你注意的事项"</string>
     <string name="native_8fce9ec6fd5432df" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 需要 %1$s 权限才能继续。"</string>
-    <string name="native_8fe42acb8573244e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"有线耳机麦克风"</string>
     <string name="native_906115657390f367" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已送达"</string>
     <string name="native_9071738f145962a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"到期"</string>
     <string name="native_90bf81305006e6ed" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"当前 Skills 状态中没有可用的 Skill 详情。"</string>
@@ -958,7 +932,6 @@
     <string name="native_9e37aa0704a3cf44" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已安装 %1$s。"</string>
     <string name="native_9e4635769f0aaf0d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateways"</string>
     <string name="native_9e9bef85bb320b81" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"转发模式"</string>
-    <string name="native_9f6e180ff696bec5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"切换对话布局"</string>
     <string name="native_9fb7c4ebcbc3e558" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无 TLS 端点"</string>
     <string name="native_9fe101a0ec7ef416" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw Gateway"</string>
     <string name="native_9ffc843f501acdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"手动设置"</string>
@@ -975,11 +948,14 @@
     <string name="native_a181b2c15994a7fc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"语音提供商"</string>
     <string name="native_a190013f72efad35" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在进行 Gateway 批准。OpenClaw 将自动重试。"</string>
     <string name="native_a1a5936d3b0f8a69" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"最高"</string>
+    <string name="native_a1b5653a9f1b842b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有已归档的会话"</string>
     <string name="native_a1bca979bc69befb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"更改 cron 需要 operator.admin 访问权限。"</string>
     <string name="native_a20d12c5e9c428c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在思考"</string>
     <string name="native_a23967c129397864" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screen snapshot"</string>
     <string name="native_a2bbc7ffd69f9c49" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"未找到操作"</string>
     <string name="native_a2f29836cda5ceb1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"保存并连接"</string>
+    <string name="native_a2fcbab533267340" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"监控中 · 1 个会话"</string>
+    <string name="native_a32789d2b53dc704" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"当前会话"</string>
     <string name="native_a330395cc0a53ad1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list"</string>
     <string name="native_a34f54e488b48e66" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 已记录批准并保存了选择。"</string>
     <string name="native_a37cf0a1111bf41c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"请输入有效的手动端点以连接。"</string>
@@ -987,6 +963,7 @@
     <string name="native_a3e96435cb1ec7c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在发送到聊天..."</string>
     <string name="native_a4212f1e2fb0f506" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"保存个人资料"</string>
     <string name="native_a424e33d90931d1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已锁定"</string>
+    <string name="native_a43f3627c39f1354" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在加载会话"</string>
     <string name="native_a450ea5e177b4787" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"编辑自动化"</string>
     <string name="native_a484bc216860979e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"使用同一网络，或安全的远程 Gateway URL。"</string>
     <string name="native_a4ae750b610e875e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"锚点"</string>
@@ -1006,7 +983,6 @@
     <string name="native_a89bac8b89022bde" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在聆听 · %1$s 条排队中"</string>
     <string name="native_a8bbbd7231a6c191" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"助手语音已静音"</string>
     <string name="native_a8ef5cdf31a6505a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"尚未找到 Gateway。如果发现功能受阻，请使用手动设置。"</string>
-    <string name="native_a901aa25b833cf33" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"打开对话"</string>
     <string name="native_a92f0449a9f7235b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"处理中"</string>
     <string name="native_a9624cf0b6ae80c1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"开始说话..."</string>
     <string name="native_a9ac253267d07365" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"手机节点"</string>
@@ -1038,14 +1014,14 @@
     <string name="native_ad1c341c65f84ede" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在 Gateway 电脑上运行批准命令，然后再次检查。"</string>
     <string name="native_ad1fb9ec0cb3c7a4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自动化"</string>
     <string name="native_adb7eb8a03ad699c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s分钟"</string>
+    <string name="native_adca3171c270301a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此 Gateway 登录会话可以列出已连接的节点，但无法批准新的手机配对。请通过 Gateway 管理员会话配对新手机。节点功能批准是独立的，仍需使用 nodes approve &lt;request id&gt;。"</string>
     <string name="native_ade9248e0132b411" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"信任"</string>
     <string name="native_ae27fa789a03c1db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"该二维码不是 OpenClaw 设置二维码。请使用 openclaw qr 生成新代码，然后重试。"</string>
-    <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"首选麦克风不可用；正在使用自动路由。"</string>
+    <string name="native_ae86062126fc1a52" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"“%1$s”中的会话将被保留并移回未分组。"</string>
     <string name="native_aea4a04a80426ed8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已拒绝"</string>
     <string name="native_aed306fbb63c0c68" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"包括 Android 和后台包。"</string>
     <string name="native_aedf1cf58372f943" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"您的 Gateway 已准备就绪。"</string>
     <string name="native_aeffb9182e3d7f3d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已触发"</string>
-    <string name="native_af1f10e9b3af3250" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Structured Output"</string>
     <string name="native_af60a38d6b5866ce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"所需时间比预期更长。\n请检查 Gateway 是否正在运行且可访问。"</string>
     <string name="native_af7deaf2c81b107d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此代理没有后台任务。"</string>
     <string name="native_afb118fcb16c3727" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在重新连接"</string>
@@ -1059,6 +1035,7 @@
     <string name="native_b140db2544c7f8f5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 正在恢复同步"</string>
     <string name="native_b1b3f74fe7e32ae1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"事件流已中断；请尝试刷新。"</string>
     <string name="native_b1c1be6b126d151f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法加载节点和设备。"</string>
+    <string name="native_b205bb47f81a3096" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"打开会话"</string>
     <string name="native_b2087b2e689f4946" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接 Gateway 以加载 Skills。"</string>
     <string name="native_b23a6a8439c0dde5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"未知"</string>
     <string name="native_b2439bcb8dee14b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"输出"</string>
@@ -1076,7 +1053,6 @@
     <string name="native_b4aca584eecea590" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法加载任务详情"</string>
     <string name="native_b51702b087112113" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Agent 消息"</string>
     <string name="native_b538b9d40695a6fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 需要此设备身份。请重新认证或重置此 Gateway 连接。"</string>
-    <string name="native_b53b35163f7588c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"下次会话"</string>
     <string name="native_b55dae19fcb48a4d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接安全性"</string>
     <string name="native_b5a229ac8becc603" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"网站"</string>
     <string name="native_b5af0517c02601fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接 Gateway 以在应用中加载审批请求。"</string>
@@ -1104,11 +1080,10 @@
     <string name="native_b9d5d026db17b9e4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"失败 — %1$s"</string>
     <string name="native_ba599a4fe4b45b36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"这部手机与 OpenClaw 之间的连接。"</string>
     <string name="native_bae9264d6d972b80" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"summarize"</string>
+    <string name="native_bb4069d372f67683" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"这将永久删除该会话及其转录内容。"</string>
     <string name="native_bb4f2558e4333834" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"小组件图片已保存到“下载”"</string>
     <string name="native_bbe5fc3b9ef39f99" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在启动…"</string>
     <string name="native_bc19cec293228fb8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"客户端错误"</string>
-    <string name="native_bc1c94a6dfce1058" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"授予访问权限前，请验证发出请求的设备。"</string>
-    <string name="native_bc6618670f3e8a17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"低功耗蓝牙麦克风"</string>
     <string name="native_bcb06651437caa15" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
     <string name="native_bd08450d63406844" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自动化已启用。"</string>
     <string name="native_bd6719b455bcc898" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Memory Get"</string>
@@ -1116,7 +1091,6 @@
     <string name="native_bdc090ec61e3fcfc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"重新加载"</string>
     <string name="native_bdff71b20b9cf392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"搜索自动化"</string>
     <string name="native_be969becb173e0c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"配对后，已关联的手机和节点主机将显示在这里。"</string>
-    <string name="native_bf1870ff5c6322fb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s：%2$s"</string>
     <string name="native_bf350e6a0ed60b7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此自动化已在 Gateway 上更改。再次保存前，请查看最新版本。"</string>
     <string name="native_bf399ffa03617a96" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"停止听写"</string>
     <string name="native_bf56ee2fe3345ce1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"易读"</string>
@@ -1134,13 +1108,11 @@
     <string name="native_c12a06263b75eb23" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接 Gateway 以加载 Skill 详情。"</string>
     <string name="native_c156b9eaf502aabc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"唤醒监听器"</string>
     <string name="native_c184b2ada7abc688" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"展开链接预览"</string>
-    <string name="native_c18ee03d3906a488" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"清除对话搜索"</string>
     <string name="native_c1970bb2cdf299b7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"NULL（失败）"</string>
     <string name="native_c1c1009d3f37ec05" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"更新"</string>
     <string name="native_c1c224b03cd9bc7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"管理员"</string>
     <string name="native_c1ebc7817870e5be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"需要注意"</string>
     <string name="native_c22d5e02fbec7d65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"将此设备与您的 Gateway 配对，使其仅在有实际任务时唤醒设备，方便随时查看实时智能体概览，并避免耗电的后台循环。"</string>
-    <string name="native_c25337055464f8d3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"角色"</string>
     <string name="native_c253f451bdd56431" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"回复"</string>
     <string name="native_c26225b6c16a4bc7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"提供商目录"</string>
     <string name="native_c272b225cf5bd643" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在“设置”中启用权限"</string>
@@ -1154,7 +1126,6 @@
     <string name="native_c34dd5eb8b0af56e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"如何获取设置代码？"</string>
     <string name="native_c3546b39ecbbed8a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法启用 Skill。"</string>
     <string name="native_c35b21d6ca39aa7c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"pdf"</string>
-    <string name="native_c3812fc4acb861d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"移除"</string>
     <string name="native_c382566dbe2ea49f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s%% 在线"</string>
     <string name="native_c385951198c45d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有频道"</string>
     <string name="native_c41ad84496b53420" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"实时语音"</string>
@@ -1183,7 +1154,6 @@
     <string name="native_c6d5ed757b66bfd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"梦境"</string>
     <string name="native_c6dd061350fc69b8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"未阻止任何应用。除非添加阻止项，否则应用可以转发。"</string>
     <string name="native_c753cdf0c19f1e38" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"语音识别器不可用"</string>
-    <string name="native_c78ffe19571018fb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"平台"</string>
     <string name="native_c7985fa72daa6ea4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 未返回 %1$s 设置"</string>
     <string name="native_c7b6dfd5c3a183c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"忘记 Gateway？"</string>
     <string name="native_c7b7b7f01360f6a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"可选描述"</string>
@@ -1205,14 +1175,12 @@
     <string name="native_ca7981b46ecf2c17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"关闭"</string>
     <string name="native_cab94aba84f97f7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"字体排版"</string>
     <string name="native_cae7d57bc067a514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"停止"</string>
-    <string name="native_cae98462b30650eb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"暂无匹配的对话。"</string>
     <string name="native_cba62d81f910c7f0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 配对成功。\n请通过操作员 UI 批准此手机的节点功能。"</string>
     <string name="native_cc4b66e7e22230c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此技能已安装，但目前不符合运行条件。请通过桌面端或 CLI 更改配置。"</string>
     <string name="native_cc5f45fb30a26e07" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"识别器正忙"</string>
     <string name="native_cc721e25d73938a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"家庭 Gateway"</string>
     <string name="native_cc7a9a5cf8c4bc9d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在 Gateway 上运行批准命令"</string>
     <string name="native_cc925e3c97ac7a35" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法加载 Skill Workshop 提案。"</string>
-    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"帮我了解最近的 OpenClaw 对话，并建议后续步骤。"</string>
     <string name="native_ccb4c324f516c633" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"暂不"</string>
     <string name="native_cced0b0d83a9e400" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw qr"</string>
     <string name="native_cced28c6dc3f99c2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"start"</string>
@@ -1235,7 +1203,6 @@
     <string name="native_ceb6931ea57cc999" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自适应"</string>
     <string name="native_cf0ee3547a4e51a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"即将"</string>
     <string name="native_d04fc7d7e19702f8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Search"</string>
-    <string name="native_d053ba98d8bbcec1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"试试聊天、语音、对话、提供商或设置。"</string>
     <string name="native_d056177742e27cf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 处于活动状态"</string>
     <string name="native_d0cda6559bb347db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"navigate"</string>
     <string name="native_d0d0de0039c7990b" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"请求于 %1$s"</string>
@@ -1246,8 +1213,8 @@
     <string name="native_d17d2d78d76e6a6c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"模型"</string>
     <string name="native_d19c2dd2fb598b93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 被动"</string>
     <string name="native_d1a574e23344c407" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 密码无效"</string>
-    <string name="native_d1af697abaff485f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法验证设备配对变更。请刷新后重试。"</string>
     <string name="native_d1bf045bb524dae5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"查看详细信息"</string>
+    <string name="native_d1c835016021c20b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 会话"</string>
     <string name="native_d1e9567da9a8a4b0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bash"</string>
     <string name="native_d2089be672953d11" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"令牌"</string>
     <string name="native_d20f43f925e706ce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已连接的 OpenClaw 代理可以使用你启用的设备功能。仅在你信任所连接的 Gateway 和代理时继续。"</string>
@@ -1261,10 +1228,8 @@
     <string name="native_d31de1a5c5c8ba2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"浏览器"</string>
     <string name="native_d354ee936f59115e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screen record"</string>
     <string name="native_d3974fd6d3b6c81f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"运行待处理项"</string>
-    <string name="native_d3e1c5f8a6e240fc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"来源"</string>
     <string name="native_d3f75e24411053c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"您设备上的个人 AI"</string>
     <string name="native_d406ade2958cb5b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attach"</string>
-    <string name="native_d461a493a3753877" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自动"</string>
     <string name="native_d4b1ea5708dd5329" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"概览"</string>
     <string name="native_d53167a3f66debec" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"请求恢复失败。点按以重试。"</string>
     <string name="native_d588c689e03132fb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s\n\n"</string>
@@ -1277,7 +1242,6 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"个人资料"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"当您的 Gateway 报告提供商限制时，将显示在此处。"</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 个问题"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"“%1$s”中的对话将被保留并移回未分组。"</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"创建时间"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s 个活跃令牌"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>
@@ -1294,7 +1258,6 @@
     <string name="native_d93e2b7a15efbc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法处理批准。请刷新后重试。"</string>
     <string name="native_d942f64886578d87" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"import"</string>
     <string name="native_d94cfb21b67ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"这部手机在 OpenClaw 中的显示方式。"</string>
-    <string name="native_d96f2b0eab4e67b7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"聚焦对话搜索"</string>
     <string name="native_d975ca28a64f8850" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接 Gateway"</string>
     <string name="native_d9be42d9b30ce057" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"读取日历"</string>
     <string name="native_d9f641e1a02807cb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"重新连接以及打开此屏幕时，概览将刷新。"</string>
@@ -1340,7 +1303,6 @@
     <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"搜索已安装的 Skills"</string>
     <string name="native_e0723a86a5b9408a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"检查"</string>
     <string name="native_e083bd83e9d3e97e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Process"</string>
-    <string name="native_e08a8fc53e29e5c9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"最近的对话"</string>
     <string name="native_e0926fdac700b094" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"终端"</string>
     <string name="native_e0d1b68224bf0b31" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"当前"</string>
     <string name="native_e10435f6306b06d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 个账户"</string>
@@ -1361,6 +1323,7 @@
     <string name="native_e3f0caab85e62600" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法从该图片中读取二维码。请选择更清晰的图片，或手动输入设置代码。"</string>
     <string name="native_e3f90d1d0b07fb04" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 的版本低于此应用。请更新 Gateway 主机上的 OpenClaw，然后重试。"</string>
     <string name="native_e41cc128c73bc85e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"请先连接，再使用聊天、语音和实时状态功能。"</string>
+    <string name="native_e424b24d86953102" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在搜索会话"</string>
     <string name="native_e4582b6fb1f57494" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"重新连接 Gateway"</string>
     <string name="native_e4696640127b9126" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"第三方"</string>
     <string name="native_e482357257d6c2fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"检查就绪状态"</string>
@@ -1369,13 +1332,11 @@
     <string name="native_e52b3044724b9f4d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"取消固定模型"</string>
     <string name="native_e5584bc5057284ae" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接到此 Gateway 的消息界面。"</string>
     <string name="native_e595f17fac1d8384" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在发送"</string>
-    <string name="native_e5b87192a9e6321f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已归档的对话将显示在此处。"</string>
     <string name="native_e5c02424e511e1ef" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已复制命令"</string>
     <string name="native_e5c083cf41ff6472" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无可用预览"</string>
     <string name="native_e5c3e7b8110e7087" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"请在 Gateway 上批准此手机。\n然后重试连接。"</string>
     <string name="native_e5c7478bbce26eb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"扫描二维码"</string>
     <string name="native_e5e4f854dcd3ffc6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"命令工作目录 · 无法清除"</string>
-    <string name="native_e614ccf26ec5d312" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"对话活动"</string>
     <string name="native_e674447337e83c13" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"可用"</string>
     <string name="native_e68e23dc04b0f986" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"删除自动化？"</string>
     <string name="native_e7053d96b6704dbb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"今天 %1$s 个 · 共 %2$s 个"</string>
@@ -1448,9 +1409,9 @@
     <string name="native_f2bfed0b0c0055db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"语音回复超时；正在重试已排队的轮次"</string>
     <string name="native_f2cb21c53a33f72c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"布局：详细"</string>
     <string name="native_f2da2e47cd31a5dd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法解码此图像。"</string>
+    <string name="native_f2ecdaf77d1d98d3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 将此手机变成一个简洁的移动命令界面，用于管理会话、语音、提供商和 Gateway。"</string>
     <string name="native_f3753c0fe29b88db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway、语音、通知、隐私"</string>
     <string name="native_f386c32c1bf437d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Agent 工作区文件"</string>
-    <string name="native_f418bf0894a1806a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此设备将失去其受信任的 Gateway 访问权限。"</string>
     <string name="native_f41d9e8b7e09aa24" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在批准命令中使用待处理命令中的 requestId。"</string>
     <string name="native_f4830a1dae298044" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"计划"</string>
     <string name="native_f493f0ce7a52a8aa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"速率限制"</string>
@@ -1458,14 +1419,14 @@
     <string name="native_f4cc820d308495c4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"负载 · %1$s"</string>
     <string name="native_f4ccae29e1bb0c20" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"运行中"</string>
     <string name="native_f4db1e48476f6075" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"结束"</string>
-    <string name="native_f4e2076014711222" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"使用系统信任"</string>
     <string name="native_f4ef7a41caa88dd1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有就绪的提供方"</string>
-    <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"优先使用已连接的蓝牙麦克风。"</string>
+    <string name="native_f502267deff4108d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"还没有会话"</string>
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已阻止 %1$s 个应用转发。"</string>
     <string name="native_f532ee1f7288365e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"消息操作"</string>
     <string name="native_f5387f9bb6ed7031" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"类型"</string>
     <string name="native_f565318d124534cf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"取消归档"</string>
     <string name="native_f584049cab5f523e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Transcripts"</string>
+    <string name="native_f59b46c265d8d38f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"最近会话"</string>
     <string name="native_f5f0563199a5b403" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"唤醒词"</string>
     <string name="native_f616dfac9815faea" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在 Gateway 上配置 %1$s"</string>
     <string name="native_f61d0c645f00a4ed" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"扫描二维码或使用来自您的 OpenClaw Gateway 的设置代码。"</string>
@@ -1486,7 +1447,6 @@
     <string name="native_f8b32f4e92bd84ce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已安装"</string>
     <string name="native_f8c2745155505d39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"等待回复超时；请重试或刷新。"</string>
     <string name="native_f8cd133f0ea1031b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"查找之前的对话"</string>
-    <string name="native_f90f3791049b995d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"浏览对话"</string>
     <string name="native_f92e2ad582c0e13f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在刷新"</string>
     <string name="native_f991ae9cb081e1f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"打开相机并框选 openclaw qr 中的代码。"</string>
     <string name="native_f9ea3f1540eaa584" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有设备"</string>
@@ -1508,7 +1468,6 @@
     <string name="native_fcdeb9947bc94101" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"测试测试 1 2 3"</string>
     <string name="native_fcea13c79c2f85a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法搜索 ClawHub Skills。"</string>
     <string name="native_fd175ecd65f7353d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无提示词"</string>
-    <string name="native_fd301dc5d0e7ccf1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"前置摄像头"</string>
     <string name="native_fda8fc3b85420d14" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"打开日志条目"</string>
     <string name="native_fdd0d769c49517c2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"网络超时"</string>
     <string name="native_fe18013d93d22f4f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"现在"</string>
@@ -1518,11 +1477,10 @@
     <string name="native_ff2670a0df18e148" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"thread list"</string>
     <string name="native_ff332eeb6b2de1da" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"打开 %1$s"</string>
     <string name="native_ff4085ad157354dc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"upload"</string>
+    <string name="native_ff4d6b7484fbfc1f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"会话活动"</string>
     <string name="native_ff52188203241c29" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 密码未配置"</string>
     <string name="native_ff716fc4735e067f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"听写设置"</string>
     <string name="native_ff9dbbdfb84ddab2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已加载提供商模型，但无法获取就绪状态。"</string>
-    <string name="native_ffa7aa557b547a79" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"删除对话？"</string>
-    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 将这部手机变成简洁的移动命令界面，用于管理对话、语音、提供商和 Gateway。"</string>
     <string name="native_ffb6f5764bddb68c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"最新优先"</string>
     <string name="native_ffcf16006c652ee3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"下个周期"</string>
 </resources>

--- a/apps/android/app/src/main/res/values-zh-rCN/strings.xml
+++ b/apps/android/app/src/main/res/values-zh-rCN/strings.xml
@@ -75,6 +75,7 @@
     <string name="native_0929c9dc7f794852" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有提案"</string>
     <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"主会话"</string>
     <string name="native_0979c6fdbdca1675" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"打开聊天"</string>
+    <string name="native_09ce95090659d069" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此 Gateway 会话中无法执行设备配对操作。请在 Gateway 主机上运行 openclaw devices list，并在那里处理请求。节点能力批准是独立操作，仍需使用 nodes approve &lt;request id&gt;。"</string>
     <string name="native_0a0b7cf7c428c703" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"操作请求"</string>
     <string name="native_0a708e7b03aaf1fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list pins"</string>
     <string name="native_0ab0e1629576aecf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接到 Gateway 以加载 Skill Workshop 提案。"</string>
@@ -87,10 +88,12 @@
     <string name="native_0c3845dcd2f0f683" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"检查此提案以加载其 Markdown。"</string>
     <string name="native_0c3ea4e2f12153e7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"打开 OpenClaw 并询问 %1$s"</string>
     <string name="native_0c4d01e81bb3d1fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"推理"</string>
+    <string name="native_0c77fe09ab336a3e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"客户端"</string>
     <string name="native_0c79a9c222840ed0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已应用"</string>
     <string name="native_0cab1c9617404faf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"视频"</string>
     <string name="native_0cf04463c4276a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已推广"</string>
     <string name="native_0d21bd52022ca7f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在线"</string>
+    <string name="native_0d5644ff52ce2ba3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"权限范围"</string>
     <string name="native_0d5efd432e4fedf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"尚未配置实时语音提供商。"</string>
     <string name="native_0d8ca811c3744a6d" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s · %2$s"</string>
     <string name="native_0db10f2c2f332cd2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"kick"</string>
@@ -138,6 +141,7 @@
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"会话目标"</string>
     <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"查看 ClawHub 技能"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
+    <string name="native_16a5b7ad567a8093" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"拒绝来自此设备的配对请求？"</string>
     <string name="native_16b1a05e1d987ed1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"首选麦克风"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"节点主机"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"级别"</string>
@@ -183,6 +187,7 @@
     <string name="native_1d91629837639a5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此自动化在你编辑期间发生了更改。保存前，请还原到 Gateway 上的最新版本。"</string>
     <string name="native_1dbf9d5979606697" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接后，Gateway 可以通过静默推送唤醒手机，而无需维持始终在线的会话。"</string>
     <string name="native_1e432ea5425e4a3a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"唤醒模式"</string>
+    <string name="native_1e595a107c78b957" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"移除配对设备？"</string>
     <string name="native_1e955a58278623a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"系统事件文本"</string>
     <string name="native_1ea44149be42d970" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法复制小组件图片"</string>
     <string name="native_1ea442a134b2a184" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"否"</string>
@@ -197,6 +202,7 @@
     <string name="native_2065cc867eba1b39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法加载提供商模型配置。"</string>
     <string name="native_207ccb22d618db05" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"允许 %1$s 个应用转发。"</string>
     <string name="native_209b9e597963e7e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"语音设置"</string>
+    <string name="native_211988ba9dd0570a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"拒绝配对请求？"</string>
     <string name="native_2132066dc9475cb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"This skill is installed but not available to the current agent. Agent filters stay on desktop or CLI."</string>
     <string name="native_21378545892f1fe2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"发布者"</string>
     <string name="native_214d4932fc767e8f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">" · 通话：正在说话"</string>
@@ -238,6 +244,7 @@
     <string name="native_2682bd813a3bccbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"输入 openclaw qr 中的设置代码。"</string>
     <string name="native_268f14bbfe119c1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"诊断"</string>
     <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"这将永久删除该对话及其对话记录。"</string>
+    <string name="native_26e47d73a55d7fa7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"设备已批准。"</string>
     <string name="native_26f0dd993530eb2d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在自动重试"</string>
     <string name="native_270ff82f36da987f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已复制小组件图片"</string>
     <string name="native_2728740a95d465c6" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 个角色"</string>
@@ -346,6 +353,7 @@
     <string name="native_381428f5f251a764" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Conversation Send"</string>
     <string name="native_3824a9f4dafe92c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"画布"</string>
     <string name="native_384ae4ab1a2830f9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 个提供商"</string>
+    <string name="native_385001409de8562a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法自动读取 Gateway 证书。请粘贴在 Gateway 主机上获取的 SHA-256 指纹。"</string>
     <string name="native_387b2569e440838c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"发送失败：%1$s"</string>
     <string name="native_3892e10346fd2012" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"桥接"</string>
     <string name="native_38d198cd5303680f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"投递错误"</string>
@@ -403,6 +411,7 @@
     <string name="native_429f6057535c1ea3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sub-agent"</string>
     <string name="native_42e3a99c21767def" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在等待设备批准"</string>
     <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在加载会话"</string>
+    <string name="native_430df68ec29a85a2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此 Gateway 现在提供的证书已受此设备信任。"</string>
     <string name="native_43905968a540af6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"错开毫秒数"</string>
     <string name="native_43988c156beabf7d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"event create"</string>
     <string name="native_43cc23fa52b87b4c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"文档"</string>
@@ -464,6 +473,7 @@
     <string name="native_4e8c72cab82e0711" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自动化配置无效。"</string>
     <string name="native_4ec30e9d85725d41" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"允许列表"</string>
     <string name="native_4ed379d418bb8629" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"groups"</string>
+    <string name="native_4ee252fb736effa2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"公钥"</string>
     <string name="native_4efca0d10c5feb8e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"关于"</string>
     <string name="native_4f1bc100d1dccc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在该图片中未找到设置二维码。请选择由 openclaw qr 生成的二维码，或手动输入设置代码。"</string>
     <string name="native_4fe3cdd404ea0290" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"permissions"</string>
@@ -550,6 +560,7 @@
     <string name="native_5c0c8c9aa658f4a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OPENCLAW"</string>
     <string name="native_5c1acea9c9b0e704" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Fetch"</string>
     <string name="native_5c39123805ffb4e2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"提示词"</string>
+    <string name="native_5c944156b5353428" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"批准设备？"</string>
     <string name="native_5d410adb9576e266" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"要从此手机中移除 %1$s 及其保存的凭据吗？"</string>
     <string name="native_5d6c41a67139ee26" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"二维码指向不安全的远程 Gateway。%1$s %2$s"</string>
     <string name="native_5d6cbac59f87e78d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"屏幕表面已就绪"</string>
@@ -567,6 +578,7 @@
     <string name="native_5fa1d457ddfcd26c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"rename group"</string>
     <string name="native_5fa7aac5375c5815" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"就绪"</string>
     <string name="native_5fc1927ca948f31c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"日记正在等待第一条记录。"</string>
+    <string name="native_6007acbe30b2cd98" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"批准"</string>
     <string name="native_600c9c27960112a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"实时页面"</string>
     <string name="native_6030d1f6340776d2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自动化已在运行。"</string>
     <string name="native_604e6d6faf8d0295" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在一次性运行成功后移除此自动化。"</string>
@@ -606,12 +618,14 @@
     <string name="native_6657cc73af00feac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在请求时允许使用相机工具。"</string>
     <string name="native_666067dd376e5d45" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"问题"</string>
     <string name="native_666c8bc0319f3b54" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"语音唤醒"</string>
+    <string name="native_66713d713e3a41c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"配对请求已拒绝。"</string>
     <string name="native_66b23bae66fc0d79" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 天前"</string>
     <string name="native_66cf5513b37462be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"roles"</string>
     <string name="native_66d0f523a379b2de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skills"</string>
     <string name="native_66f4804ee23ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"归档"</string>
     <string name="native_66fab2875ee427f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"节点离线。请重新连接并重试。"</string>
     <string name="native_6725e7bbcd28f3a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"系统"</string>
+    <string name="native_672f3453e1dd571b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"远程 IP"</string>
     <string name="native_674b38cae72bb0c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"未分组"</string>
     <string name="native_674eb55d9c353900" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"计划详情"</string>
     <string name="native_67528858c36397f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"手机功能"</string>
@@ -619,6 +633,7 @@
     <string name="native_67b696468610b879" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dashboard"</string>
     <string name="native_67fa416afa64d304" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"粘贴令牌"</string>
     <string name="native_6827238fea72c88b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无提供商"</string>
+    <string name="native_684889f0079cc145" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"SHA-256 指纹"</string>
     <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"暂无对话线程"</string>
     <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"蓝牙麦克风"</string>
     <string name="native_690dbe9dc0993c42" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"最近"</string>
@@ -653,6 +668,7 @@
     <string name="native_6d5d9004797377e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"许可证"</string>
     <string name="native_6d7c95a353d873cd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接 Gateway 以搜索 ClawHub Skills。"</string>
     <string name="native_6df1bb18a59ab97d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"技能"</string>
+    <string name="native_6e0a0b9d8c5ee4d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"设备 ID"</string>
     <string name="native_6e117ba97cbfb6f0" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 未识别活动的 %1$s 提供商"</string>
     <string name="native_6e293a8c009e0011" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"等待中"</string>
     <string name="native_6e2c0963d056e104" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"唤醒词已保存"</string>
@@ -829,6 +845,7 @@
     <string name="native_8bb7ec15b1e350a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在检查"</string>
     <string name="native_8bf253a125f66985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"扫描或粘贴设置代码以添加另一个 Gateway。"</string>
     <string name="native_8c4a3896e8f06d27" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"TLS 超时"</string>
+    <string name="native_8c55387fb6c584c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已移除配对设备。"</string>
     <string name="native_8c93c68056cde54d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 已配对。正在检查节点功能批准状态。"</string>
     <string name="native_8ca344247c18317e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"运动"</string>
     <string name="native_8cac4b77b9c54695" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"cron 操作失败。"</string>
@@ -1021,7 +1038,6 @@
     <string name="native_ad1c341c65f84ede" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在 Gateway 电脑上运行批准命令，然后再次检查。"</string>
     <string name="native_ad1fb9ec0cb3c7a4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自动化"</string>
     <string name="native_adb7eb8a03ad699c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s分钟"</string>
-    <string name="native_adca3171c270301a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此 Gateway 登录会话可以列出已连接的节点，但无法批准新的手机配对。请通过 Gateway 管理员会话配对新手机。节点功能批准是独立的，仍需使用 nodes approve &lt;request id&gt;。"</string>
     <string name="native_ade9248e0132b411" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"信任"</string>
     <string name="native_ae27fa789a03c1db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"该二维码不是 OpenClaw 设置二维码。请使用 openclaw qr 生成新代码，然后重试。"</string>
     <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"首选麦克风不可用；正在使用自动路由。"</string>
@@ -1091,6 +1107,7 @@
     <string name="native_bb4f2558e4333834" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"小组件图片已保存到“下载”"</string>
     <string name="native_bbe5fc3b9ef39f99" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在启动…"</string>
     <string name="native_bc19cec293228fb8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"客户端错误"</string>
+    <string name="native_bc1c94a6dfce1058" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"授予访问权限前，请验证发出请求的设备。"</string>
     <string name="native_bc6618670f3e8a17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bluetooth LE 麦克风"</string>
     <string name="native_bcb06651437caa15" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
     <string name="native_bd08450d63406844" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自动化已启用。"</string>
@@ -1099,6 +1116,7 @@
     <string name="native_bdc090ec61e3fcfc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"重新加载"</string>
     <string name="native_bdff71b20b9cf392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"搜索自动化"</string>
     <string name="native_be969becb173e0c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"配对后，已关联的手机和节点主机将显示在这里。"</string>
+    <string name="native_bf1870ff5c6322fb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s：%2$s"</string>
     <string name="native_bf350e6a0ed60b7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此自动化已在 Gateway 上更改。再次保存前，请查看最新版本。"</string>
     <string name="native_bf399ffa03617a96" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"停止听写"</string>
     <string name="native_bf56ee2fe3345ce1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"易读"</string>
@@ -1122,6 +1140,7 @@
     <string name="native_c1c224b03cd9bc7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"管理员"</string>
     <string name="native_c1ebc7817870e5be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"需要注意"</string>
     <string name="native_c22d5e02fbec7d65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"将此设备与您的 Gateway 配对，使其仅在有实际任务时唤醒设备，方便随时查看实时智能体概览，并避免耗电的后台循环。"</string>
+    <string name="native_c25337055464f8d3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"角色"</string>
     <string name="native_c253f451bdd56431" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"回复"</string>
     <string name="native_c26225b6c16a4bc7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"提供商目录"</string>
     <string name="native_c272b225cf5bd643" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在“设置”中启用权限"</string>
@@ -1135,6 +1154,7 @@
     <string name="native_c34dd5eb8b0af56e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"如何获取设置代码？"</string>
     <string name="native_c3546b39ecbbed8a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法启用 Skill。"</string>
     <string name="native_c35b21d6ca39aa7c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"pdf"</string>
+    <string name="native_c3812fc4acb861d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"移除"</string>
     <string name="native_c382566dbe2ea49f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s%% 在线"</string>
     <string name="native_c385951198c45d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有频道"</string>
     <string name="native_c41ad84496b53420" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"实时语音"</string>
@@ -1163,6 +1183,7 @@
     <string name="native_c6d5ed757b66bfd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"梦境"</string>
     <string name="native_c6dd061350fc69b8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"未阻止任何应用。除非添加阻止项，否则应用可以转发。"</string>
     <string name="native_c753cdf0c19f1e38" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"语音识别器不可用"</string>
+    <string name="native_c78ffe19571018fb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"平台"</string>
     <string name="native_c7985fa72daa6ea4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 未返回 %1$s 设置"</string>
     <string name="native_c7b6dfd5c3a183c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"忘记 Gateway？"</string>
     <string name="native_c7b7b7f01360f6a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"可选描述"</string>
@@ -1225,6 +1246,7 @@
     <string name="native_d17d2d78d76e6a6c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"模型"</string>
     <string name="native_d19c2dd2fb598b93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 被动"</string>
     <string name="native_d1a574e23344c407" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 密码无效"</string>
+    <string name="native_d1af697abaff485f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法验证设备配对变更。请刷新后重试。"</string>
     <string name="native_d1bf045bb524dae5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"查看详细信息"</string>
     <string name="native_d1e9567da9a8a4b0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bash"</string>
     <string name="native_d2089be672953d11" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"令牌"</string>
@@ -1239,6 +1261,7 @@
     <string name="native_d31de1a5c5c8ba2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"浏览器"</string>
     <string name="native_d354ee936f59115e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screen record"</string>
     <string name="native_d3974fd6d3b6c81f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"运行待处理项"</string>
+    <string name="native_d3e1c5f8a6e240fc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"来源"</string>
     <string name="native_d3f75e24411053c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"您设备上的个人 AI"</string>
     <string name="native_d406ade2958cb5b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attach"</string>
     <string name="native_d461a493a3753877" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自动"</string>
@@ -1427,6 +1450,7 @@
     <string name="native_f2da2e47cd31a5dd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法解码此图像。"</string>
     <string name="native_f3753c0fe29b88db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway、语音、通知、隐私"</string>
     <string name="native_f386c32c1bf437d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Agent 工作区文件"</string>
+    <string name="native_f418bf0894a1806a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此设备将失去其受信任的 Gateway 访问权限。"</string>
     <string name="native_f41d9e8b7e09aa24" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在批准命令中使用待处理命令中的 requestId。"</string>
     <string name="native_f4830a1dae298044" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"计划"</string>
     <string name="native_f493f0ce7a52a8aa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"速率限制"</string>
@@ -1434,6 +1458,7 @@
     <string name="native_f4cc820d308495c4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"负载 · %1$s"</string>
     <string name="native_f4ccae29e1bb0c20" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"运行中"</string>
     <string name="native_f4db1e48476f6075" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"结束"</string>
+    <string name="native_f4e2076014711222" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"使用系统信任"</string>
     <string name="native_f4ef7a41caa88dd1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有就绪的提供方"</string>
     <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"优先使用已连接的蓝牙麦克风。"</string>
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已阻止 %1$s 个应用转发。"</string>

--- a/apps/android/app/src/main/res/values-zh-rCN/strings.xml
+++ b/apps/android/app/src/main/res/values-zh-rCN/strings.xml
@@ -24,14 +24,14 @@
     <string name="native_002a6fcb30b2def4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法准备待发送的附件。"</string>
     <string name="native_003aaf9e0a0e6b9f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"麦克风关闭"</string>
     <string name="native_0060cbfdd3cf13ba" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"显示 OpenClaw 提醒"</string>
-    <string name="native_0077032d7e9f9cbe" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Thread activity"</string>
+    <string name="native_0077032d7e9f9cbe" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"对话线程活动"</string>
     <string name="native_008dacb6d1e85bd8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"完整"</string>
     <string name="native_009506aeb0484b2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已批准并保存。"</string>
     <string name="native_00d108e2e6466940" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"显示最近的通话记录"</string>
     <string name="native_00e8aeba41d79ce3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 个待处理"</string>
     <string name="native_010f6550a1c8f554" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"不支持的附件"</string>
     <string name="native_01267be21eb77392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"0 = 精确"</string>
-    <string name="native_0171e3d4e07f1861" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Connect the Gateway to search threads."</string>
+    <string name="native_0171e3d4e07f1861" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接 Gateway 以搜索会话。"</string>
     <string name="native_0174f83136630e7e" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 个账户"</string>
     <string name="native_01ac1c298e0cbd9a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cron 更改需要 operator.admin 权限。设置代码不会授予此权限。请使用 Gateway 的共享令牌或密码重新连接，以请求管理员访问权限。如果此设备仍缺少该权限，请从现有管理员客户端批准待处理的权限范围升级。"</string>
     <string name="native_01bcfe7a9296b6d6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Apply Patch"</string>
@@ -70,10 +70,10 @@
     <string name="native_088e0e5ebc96c6ac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"替换 Gateway 设置？"</string>
     <string name="native_08a5391c1de3078a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法加载自动化。"</string>
     <string name="native_08b041935798fbf6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"你"</string>
-    <string name="native_08ea63ee26954dca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Built-in microphone"</string>
+    <string name="native_08ea63ee26954dca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"内置麦克风"</string>
     <string name="native_0905f7f59021c2a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"界面"</string>
     <string name="native_0929c9dc7f794852" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有提案"</string>
-    <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Main thread"</string>
+    <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"主会话"</string>
     <string name="native_0979c6fdbdca1675" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"打开聊天"</string>
     <string name="native_0a0b7cf7c428c703" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"操作请求"</string>
     <string name="native_0a708e7b03aaf1fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list pins"</string>
@@ -101,7 +101,7 @@
     <string name="native_0e91610117029a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"刷新"</string>
     <string name="native_0ee30822ed35a792" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 条已排队"</string>
     <string name="native_0f4c8529742b31ea" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"开始聊天"</string>
-    <string name="native_0f559ff270904904" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Chat tool calls waiting in the active thread remain visible here."</string>
+    <string name="native_0f559ff270904904" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"当前对话线程中等待处理的聊天工具调用仍会显示在此处。"</string>
     <string name="native_0f56cc286a4f23d8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"需要审核证书"</string>
     <string name="native_0f8fe3a9688138a1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"打开当前 Canvas 界面以检查或与之交互。"</string>
     <string name="native_0ff98f05be01ce5e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自动化已更新。"</string>
@@ -117,12 +117,12 @@
     <string name="native_11a6767d5674c7e4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"完成"</string>
     <string name="native_11e18d6748aa9128" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"版本和更新"</string>
     <string name="native_11f37f9652a47b5b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 将在此显示审批、失败的任务和频道问题。"</string>
-    <string name="native_11f6dc0befae5081" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"USB microphone"</string>
+    <string name="native_11f6dc0befae5081" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"USB 麦克风"</string>
     <string name="native_1242bf5561713a98" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"等待添加的共享过多。"</string>
     <string name="native_12698ce1ea5cd4ab" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已跳过"</string>
     <string name="native_1291833ee42d8143" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"使用 Gateway 计算机的局域网地址或安全的远程主机名。"</string>
     <string name="native_130011756125313c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"开启"</string>
-    <string name="native_133f293961d7aa43" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Searching threads"</string>
+    <string name="native_133f293961d7aa43" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在搜索会话"</string>
     <string name="native_13798c3256e792c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"实时对话"</string>
     <string name="native_13b588109e423636" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 正在准备回复。"</string>
     <string name="native_13ba4cde12390943" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已批准一次。"</string>
@@ -138,7 +138,7 @@
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"会话目标"</string>
     <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"查看 ClawHub 技能"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
-    <string name="native_16b1a05e1d987ed1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Preferred microphone"</string>
+    <string name="native_16b1a05e1d987ed1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"首选麦克风"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"节点主机"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"级别"</string>
     <string name="native_172b997ffbc8c9a7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"关闭应用选择器"</string>
@@ -158,7 +158,7 @@
     <string name="native_18f2a0947f9d6523" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已阻止"</string>
     <string name="native_18f6e5973bc41268" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"唤醒词或短语"</string>
     <string name="native_1906b261e6e0fdd0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 需要设备批准"</string>
-    <string name="native_19408baaf5c2e446" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"External microphone"</string>
+    <string name="native_19408baaf5c2e446" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"外接麦克风"</string>
     <string name="native_194a05367fb28913" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s 个已就绪"</string>
     <string name="native_199e261f8ee0e97f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已连接（操作员离线）"</string>
     <string name="native_19fc7a47df16fb1f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"功能未批准"</string>
@@ -210,7 +210,7 @@
     <string name="native_22965568d22a14ee" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已连接"</string>
     <string name="native_22a970d2e5b1cc23" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已完成"</string>
     <string name="native_22b8da9e693e94eb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"你的手机已与 %1$s 配对。请继续完成节点访问设置。"</string>
-    <string name="native_22f19ab686639b9a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Current thread"</string>
+    <string name="native_22f19ab686639b9a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"当前会话"</string>
     <string name="native_23246d9852fed325" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"思考 %1$s"</string>
     <string name="native_2346f214ad56b180" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已静音"</string>
     <string name="native_2347fc06da5f60de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 感谢其在开源社区中的合作伙伴。"</string>
@@ -237,7 +237,7 @@
     <string name="native_262c897a1f408b0b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接到你的 Gateway"</string>
     <string name="native_2682bd813a3bccbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"输入 openclaw qr 中的设置代码。"</string>
     <string name="native_268f14bbfe119c1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"诊断"</string>
-    <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"This permanently deletes the thread and its transcript."</string>
+    <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"这将永久删除该对话及其对话记录。"</string>
     <string name="native_26f0dd993530eb2d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在自动重试"</string>
     <string name="native_270ff82f36da987f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已复制小组件图片"</string>
     <string name="native_2728740a95d465c6" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 个角色"</string>
@@ -253,7 +253,7 @@
     <string name="native_27d773b934ed324f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"验证并安装"</string>
     <string name="native_2821f0168d6dd9df" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"将此设备变成安全的 OpenClaw 节点，用于聊天、语音、摄像头和设备工具。"</string>
     <string name="native_2831546121359362" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"手动设置"</string>
-    <string name="native_287c4b113aafc215" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Open Chat to start or resume the current thread."</string>
+    <string name="native_287c4b113aafc215" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"打开聊天以开始或继续当前对话线程。"</string>
     <string name="native_28bb849671cab958" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"提示：停止聆听即可发送已捕获的发言。"</string>
     <string name="native_28d03596d24eeb4e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"跳过"</string>
     <string name="native_28d55ec6974d84e8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"语音请求失败"</string>
@@ -273,10 +273,10 @@
     <string name="native_2c19d584bf8ad518" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"标记为未读"</string>
     <string name="native_2c75802a5f8df5f8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"查找人员和联系方式"</string>
     <string name="native_2c9cce8250d746e3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"需要设备身份"</string>
-    <string name="native_2cd62f7a670b2819" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw thread"</string>
+    <string name="native_2cd62f7a670b2819" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 会话"</string>
     <string name="native_2d4dfe885f84629e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"允许访问照片图库。"</string>
     <string name="native_2d6416405eb44982" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"先前的响应已处理此批准。"</string>
-    <string name="native_2d85de9d56c226e4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"No recent threads"</string>
+    <string name="native_2d85de9d56c226e4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有最近的对话"</string>
     <string name="native_2df01a03ff43400b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无匹配项"</string>
     <string name="native_2df30b117ad829ab" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"读取所选应用的通知"</string>
     <string name="native_2e0078a8322d6f1f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"可用性未知"</string>
@@ -338,7 +338,7 @@
     <string name="native_36c725ddb20f8bd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Talk Provider 设置"</string>
     <string name="native_36d88ed6cc91d2b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Music Generation"</string>
     <string name="native_36e8d5e94219dc37" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"对话设置"</string>
-    <string name="native_36f1fac278711470" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · 1 thread"</string>
+    <string name="native_36f1fac278711470" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在监控 · 1 个会话"</string>
     <string name="native_37053dc1f680546b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"负载文本"</string>
     <string name="native_37582309e7a1dbe5" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"批准 %1$s"</string>
     <string name="native_379ce0aacf46c35f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 未返回 %1$s 就绪状态"</string>
@@ -363,19 +363,19 @@
     <string name="native_3a65cf1204f18864" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已连接（节点离线）"</string>
     <string name="native_3a78695388b38b5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"首页"</string>
     <string name="native_3b28b535950f8175" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在听写"</string>
-    <string name="native_3b46b7912670bfb0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"No archived threads"</string>
+    <string name="native_3b46b7912670bfb0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有已归档的对话"</string>
     <string name="native_3b851469ea31d489" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"选择并检查此 gateway 上可用的助手。"</string>
     <string name="native_3be0085a6bd88cdd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"通话模式已启用"</string>
     <string name="native_3bee4ede6bf4436c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"工作中 · 1 个活跃运行"</string>
     <string name="native_3c6168bbf86e6e4b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"同意并启用"</string>
-    <string name="native_3cb27ae0fbca8ae3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"复制图片"</string>
+    <string name="native_3cb27ae0fbca8ae3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"复制图像"</string>
     <string name="native_3d06950825de7452" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway URL"</string>
     <string name="native_3d200f624b8bda8f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"main、isolated、current 或 session:&lt;id&gt;"</string>
     <string name="native_3d61e9d54ffa2d93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接到你的 Gateway，以在代理工作区中打开 shell。"</string>
     <string name="native_3da4811eafea080a" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s://%2$s:%3$s"</string>
     <string name="native_3de3d401128d4395" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法加载批准详情。请刷新后重试。"</string>
     <string name="native_3e398e6fb979557a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tool Call"</string>
-    <string name="native_3e42e385075b9b56" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads"</string>
+    <string name="native_3e42e385075b9b56" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"会话"</string>
     <string name="native_3f00927a719345ed" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Write"</string>
     <string name="native_3f25ccebfa99dcf3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"输入提示词开始，或使用语音。"</string>
     <string name="native_3f39d5c348e5b79d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"D"</string>
@@ -402,7 +402,7 @@
     <string name="native_4287d54ad5e78985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"来自你的 gateway 的已计划 OpenClaw 工作。"</string>
     <string name="native_429f6057535c1ea3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sub-agent"</string>
     <string name="native_42e3a99c21767def" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在等待设备批准"</string>
-    <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Loading thread"</string>
+    <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在加载会话"</string>
     <string name="native_43905968a540af6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"错开毫秒数"</string>
     <string name="native_43988c156beabf7d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"event create"</string>
     <string name="native_43cc23fa52b87b4c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"文档"</string>
@@ -484,7 +484,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"投递"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"将扬声器静音"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在打开 Gateway 连接"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在监控 · %1$s 个会话"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自动化运行已完成。"</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有匹配的应用。"</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"发送到聊天"</string>
@@ -509,7 +509,7 @@
     <string name="native_55898449eb74fb2e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"健康状况"</string>
     <string name="native_55a12cbe0995e214" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"通知监听器"</string>
     <string name="native_55d8e7da6d0a752c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"扬声器已静音"</string>
-    <string name="native_560d3e826c413dc9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Search threads"</string>
+    <string name="native_560d3e826c413dc9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"搜索话题"</string>
     <string name="native_565339bc4d33d728" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"确定"</string>
     <string name="native_56a508f3f2bf424a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法打开设置指南。"</string>
     <string name="native_56c41c606c44f3fc" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"询问 OpenClaw %1$s"</string>
@@ -576,7 +576,7 @@
     <string name="native_60ea1847c2ba5446" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"响应已中止"</string>
     <string name="native_6105d6cc76af4003" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"图像"</string>
     <string name="native_614b8348a2dbe46b" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 个已保留"</string>
-    <string name="native_614e83ef17c13f3c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"No matching threads"</string>
+    <string name="native_614e83ef17c13f3c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有匹配的会话"</string>
     <string name="native_6197595503f01ee2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"delete"</string>
     <string name="native_619837a134285528" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"布局：紧凑"</string>
     <string name="native_61ffa9c8c703dd5e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"channels"</string>
@@ -619,10 +619,10 @@
     <string name="native_67b696468610b879" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dashboard"</string>
     <string name="native_67fa416afa64d304" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"粘贴令牌"</string>
     <string name="native_6827238fea72c88b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无提供商"</string>
-    <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"No threads yet"</string>
-    <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bluetooth microphone"</string>
+    <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"暂无对话线程"</string>
+    <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"蓝牙麦克风"</string>
     <string name="native_690dbe9dc0993c42" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"最近"</string>
-    <string name="native_6930c8d1fc4f01d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rename thread"</string>
+    <string name="native_6930c8d1fc4f01d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"重命名会话"</string>
     <string name="native_69384c1c4d99f6eb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"处理结果未知。在验证 Gateway 记录之前，操作将保持禁用。"</string>
     <string name="native_6940189433657105" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"dialog"</string>
     <string name="native_695c03727ff0251f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"监听唤醒词"</string>
@@ -701,7 +701,7 @@
     <string name="native_746f71ec623adc37" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Epoch 毫秒（可选）"</string>
     <string name="native_7491b353909c1147" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有已配置的模型。刷新以重新检查可用性。"</string>
     <string name="native_74a883a037bc227f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"设置"</string>
-    <string name="native_74c372f29b83df94" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Back camera"</string>
+    <string name="native_74c372f29b83df94" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"后置摄像头"</string>
     <string name="native_74e21680eac7385c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"approve"</string>
     <string name="native_74e492d5d0df0bab" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"开始之前"</string>
     <string name="native_74f0a5d234edc4af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法加载 Skills。"</string>
@@ -776,13 +776,13 @@
     <string name="native_8193ee8a22d25208" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"固定模型"</string>
     <string name="native_81c2c4f30a4bec68" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"清除搜索"</string>
     <string name="native_81d38aca5306940b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已对符合条件的代理启用。"</string>
-    <string name="native_820d08e12968baff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"No current thread"</string>
+    <string name="native_820d08e12968baff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"暂无当前对话线程"</string>
     <string name="native_82250171708918de" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在 %1$s 后"</string>
     <string name="native_825b9c75d7fed691" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"允许调度程序运行此自动化。"</string>
     <string name="native_82990a093599a9bb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 个已应用"</string>
     <string name="native_8340dad4f3be30a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"还没有梦境日记。"</string>
     <string name="native_837e39f46163ffb4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"刷新后台任务"</string>
-    <string name="native_838337fd9ab30454" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Summarize recent threads and next steps."</string>
+    <string name="native_838337fd9ab30454" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"总结最近的会话和后续步骤。"</string>
     <string name="native_83e2faed20a3cda4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"当 OpenClaw 可见时在设备上运行。"</string>
     <string name="native_844e5b02f3ef05ca" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 正在工作"</string>
     <string name="native_846c75dca0b71591" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
@@ -852,7 +852,7 @@
     <string name="native_8f54b0d1e30092d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"语音消息"</string>
     <string name="native_8fa196125b734940" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有需要你注意的事项"</string>
     <string name="native_8fce9ec6fd5432df" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 需要 %1$s 权限才能继续。"</string>
-    <string name="native_8fe42acb8573244e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wired headset microphone"</string>
+    <string name="native_8fe42acb8573244e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"有线耳机麦克风"</string>
     <string name="native_906115657390f367" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已送达"</string>
     <string name="native_9071738f145962a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"到期"</string>
     <string name="native_90bf81305006e6ed" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"当前 Skills 状态中没有可用的 Skill 详情。"</string>
@@ -941,7 +941,7 @@
     <string name="native_9e37aa0704a3cf44" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已安装 %1$s。"</string>
     <string name="native_9e4635769f0aaf0d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateways"</string>
     <string name="native_9e9bef85bb320b81" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"转发模式"</string>
-    <string name="native_9f6e180ff696bec5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Toggle thread layout"</string>
+    <string name="native_9f6e180ff696bec5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"切换会话布局"</string>
     <string name="native_9fb7c4ebcbc3e558" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无 TLS 端点"</string>
     <string name="native_9fe101a0ec7ef416" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw Gateway"</string>
     <string name="native_9ffc843f501acdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"手动设置"</string>
@@ -989,7 +989,7 @@
     <string name="native_a89bac8b89022bde" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在聆听 · %1$s 条排队中"</string>
     <string name="native_a8bbbd7231a6c191" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"助手语音已静音"</string>
     <string name="native_a8ef5cdf31a6505a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"尚未找到 Gateway。如果发现功能受阻，请使用手动设置。"</string>
-    <string name="native_a901aa25b833cf33" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Open thread"</string>
+    <string name="native_a901aa25b833cf33" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"打开会话"</string>
     <string name="native_a92f0449a9f7235b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"处理中"</string>
     <string name="native_a9624cf0b6ae80c1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"开始说话..."</string>
     <string name="native_a9ac253267d07365" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"手机节点"</string>
@@ -1024,7 +1024,7 @@
     <string name="native_adca3171c270301a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此 Gateway 登录会话可以列出已连接的节点，但无法批准新的手机配对。请通过 Gateway 管理员会话配对新手机。节点功能批准是独立的，仍需使用 nodes approve &lt;request id&gt;。"</string>
     <string name="native_ade9248e0132b411" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"信任"</string>
     <string name="native_ae27fa789a03c1db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"该二维码不是 OpenClaw 设置二维码。请使用 openclaw qr 生成新代码，然后重试。"</string>
-    <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Preferred microphone unavailable; using automatic routing."</string>
+    <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"首选麦克风不可用；正在使用自动路由。"</string>
     <string name="native_aea4a04a80426ed8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已拒绝"</string>
     <string name="native_aed306fbb63c0c68" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"包括 Android 和后台包。"</string>
     <string name="native_aedf1cf58372f943" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"您的 Gateway 已准备就绪。"</string>
@@ -1060,7 +1060,7 @@
     <string name="native_b4aca584eecea590" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法加载任务详情"</string>
     <string name="native_b51702b087112113" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Agent 消息"</string>
     <string name="native_b538b9d40695a6fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 需要此设备身份。请重新认证或重置此 Gateway 连接。"</string>
-    <string name="native_b53b35163f7588c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Next session"</string>
+    <string name="native_b53b35163f7588c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"下次会话"</string>
     <string name="native_b55dae19fcb48a4d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接安全性"</string>
     <string name="native_b5a229ac8becc603" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"网站"</string>
     <string name="native_b5af0517c02601fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接 Gateway 以在应用中加载审批请求。"</string>
@@ -1091,7 +1091,7 @@
     <string name="native_bb4f2558e4333834" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"小组件图片已保存到“下载”"</string>
     <string name="native_bbe5fc3b9ef39f99" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在启动…"</string>
     <string name="native_bc19cec293228fb8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"客户端错误"</string>
-    <string name="native_bc6618670f3e8a17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bluetooth LE microphone"</string>
+    <string name="native_bc6618670f3e8a17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bluetooth LE 麦克风"</string>
     <string name="native_bcb06651437caa15" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
     <string name="native_bd08450d63406844" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自动化已启用。"</string>
     <string name="native_bd6719b455bcc898" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Memory Get"</string>
@@ -1116,7 +1116,7 @@
     <string name="native_c12a06263b75eb23" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接 Gateway 以加载 Skill 详情。"</string>
     <string name="native_c156b9eaf502aabc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"唤醒监听器"</string>
     <string name="native_c184b2ada7abc688" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"展开链接预览"</string>
-    <string name="native_c18ee03d3906a488" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Clear thread search"</string>
+    <string name="native_c18ee03d3906a488" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"清除会话搜索"</string>
     <string name="native_c1970bb2cdf299b7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"NULL（失败）"</string>
     <string name="native_c1c1009d3f37ec05" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"更新"</string>
     <string name="native_c1c224b03cd9bc7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"管理员"</string>
@@ -1184,14 +1184,14 @@
     <string name="native_ca7981b46ecf2c17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"关闭"</string>
     <string name="native_cab94aba84f97f7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"字体排版"</string>
     <string name="native_cae7d57bc067a514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"停止"</string>
-    <string name="native_cae98462b30650eb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"No matching threads yet."</string>
+    <string name="native_cae98462b30650eb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"暂无匹配的会话。"</string>
     <string name="native_cba62d81f910c7f0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 配对成功。\n请通过操作员 UI 批准此手机的节点功能。"</string>
     <string name="native_cc4b66e7e22230c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此技能已安装，但目前不符合运行条件。请通过桌面端或 CLI 更改配置。"</string>
     <string name="native_cc5f45fb30a26e07" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"识别器正忙"</string>
     <string name="native_cc721e25d73938a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"家庭 Gateway"</string>
     <string name="native_cc7a9a5cf8c4bc9d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在 Gateway 上运行批准命令"</string>
     <string name="native_cc925e3c97ac7a35" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法加载 Skill Workshop 提案。"</string>
-    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Catch me up on my recent OpenClaw threads and suggest next steps."</string>
+    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"帮我了解最近的 OpenClaw 会话，并建议后续步骤。"</string>
     <string name="native_ccb4c324f516c633" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"暂不"</string>
     <string name="native_cced0b0d83a9e400" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw qr"</string>
     <string name="native_cced28c6dc3f99c2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"start"</string>
@@ -1214,7 +1214,7 @@
     <string name="native_ceb6931ea57cc999" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自适应"</string>
     <string name="native_cf0ee3547a4e51a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"即将"</string>
     <string name="native_d04fc7d7e19702f8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Search"</string>
-    <string name="native_d053ba98d8bbcec1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Try Chat, Voice, Threads, Providers, or Settings."</string>
+    <string name="native_d053ba98d8bbcec1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"试试聊天、语音、会话、提供商或设置。"</string>
     <string name="native_d056177742e27cf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 处于活动状态"</string>
     <string name="native_d0cda6559bb347db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"navigate"</string>
     <string name="native_d0d0de0039c7990b" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"请求于 %1$s"</string>
@@ -1241,7 +1241,7 @@
     <string name="native_d3974fd6d3b6c81f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"运行待处理项"</string>
     <string name="native_d3f75e24411053c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"您设备上的个人 AI"</string>
     <string name="native_d406ade2958cb5b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attach"</string>
-    <string name="native_d461a493a3753877" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatic"</string>
+    <string name="native_d461a493a3753877" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自动"</string>
     <string name="native_d4b1ea5708dd5329" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"概览"</string>
     <string name="native_d53167a3f66debec" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"请求恢复失败。点按以重试。"</string>
     <string name="native_d588c689e03132fb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s\n\n"</string>
@@ -1254,7 +1254,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"个人资料"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"当您的 Gateway 报告提供商限制时，将显示在此处。"</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 个问题"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"“%1$s”中的会话将被保留并移回“未分组”。"</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"创建时间"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s 个活跃令牌"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>
@@ -1271,7 +1271,7 @@
     <string name="native_d93e2b7a15efbc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法处理批准。请刷新后重试。"</string>
     <string name="native_d942f64886578d87" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"import"</string>
     <string name="native_d94cfb21b67ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"这部手机在 OpenClaw 中的显示方式。"</string>
-    <string name="native_d96f2b0eab4e67b7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Focus thread search"</string>
+    <string name="native_d96f2b0eab4e67b7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"聚焦会话搜索"</string>
     <string name="native_d975ca28a64f8850" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接 Gateway"</string>
     <string name="native_d9be42d9b30ce057" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"读取日历"</string>
     <string name="native_d9f641e1a02807cb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"重新连接以及打开此屏幕时，概览将刷新。"</string>
@@ -1317,7 +1317,7 @@
     <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"搜索已安装的 Skills"</string>
     <string name="native_e0723a86a5b9408a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"检查"</string>
     <string name="native_e083bd83e9d3e97e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Process"</string>
-    <string name="native_e08a8fc53e29e5c9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Recent Threads"</string>
+    <string name="native_e08a8fc53e29e5c9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"最近的会话"</string>
     <string name="native_e0926fdac700b094" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"终端"</string>
     <string name="native_e0d1b68224bf0b31" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"当前"</string>
     <string name="native_e10435f6306b06d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 个账户"</string>
@@ -1346,13 +1346,13 @@
     <string name="native_e52b3044724b9f4d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"取消固定模型"</string>
     <string name="native_e5584bc5057284ae" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接到此 Gateway 的消息界面。"</string>
     <string name="native_e595f17fac1d8384" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在发送"</string>
-    <string name="native_e5b87192a9e6321f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Archived threads will show up here."</string>
+    <string name="native_e5b87192a9e6321f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已归档的对话线程将显示在此处。"</string>
     <string name="native_e5c02424e511e1ef" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已复制命令"</string>
     <string name="native_e5c083cf41ff6472" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无可用预览"</string>
     <string name="native_e5c3e7b8110e7087" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"请在 Gateway 上批准此手机。\n然后重试连接。"</string>
     <string name="native_e5c7478bbce26eb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"扫描二维码"</string>
     <string name="native_e5e4f854dcd3ffc6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"命令工作目录 · 无法清除"</string>
-    <string name="native_e614ccf26ec5d312" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Thread Activity"</string>
+    <string name="native_e614ccf26ec5d312" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"对话线程活动"</string>
     <string name="native_e674447337e83c13" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"可用"</string>
     <string name="native_e68e23dc04b0f986" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"删除自动化？"</string>
     <string name="native_e7053d96b6704dbb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"今天 %1$s 个 · 共 %2$s 个"</string>
@@ -1435,7 +1435,7 @@
     <string name="native_f4ccae29e1bb0c20" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"运行中"</string>
     <string name="native_f4db1e48476f6075" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"结束"</string>
     <string name="native_f4ef7a41caa88dd1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有就绪的提供方"</string>
-    <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Prioritizes connected Bluetooth microphones."</string>
+    <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"优先使用已连接的蓝牙麦克风。"</string>
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已阻止 %1$s 个应用转发。"</string>
     <string name="native_f532ee1f7288365e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"消息操作"</string>
     <string name="native_f5387f9bb6ed7031" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"类型"</string>
@@ -1461,7 +1461,7 @@
     <string name="native_f8b32f4e92bd84ce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已安装"</string>
     <string name="native_f8c2745155505d39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"等待回复超时；请重试或刷新。"</string>
     <string name="native_f8cd133f0ea1031b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"查找之前的对话"</string>
-    <string name="native_f90f3791049b995d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Browse Threads"</string>
+    <string name="native_f90f3791049b995d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"浏览会话"</string>
     <string name="native_f92e2ad582c0e13f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在刷新"</string>
     <string name="native_f991ae9cb081e1f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"打开相机并框选 openclaw qr 中的代码。"</string>
     <string name="native_f9ea3f1540eaa584" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有设备"</string>
@@ -1483,7 +1483,7 @@
     <string name="native_fcdeb9947bc94101" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"测试测试 1 2 3"</string>
     <string name="native_fcea13c79c2f85a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法搜索 ClawHub Skills。"</string>
     <string name="native_fd175ecd65f7353d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无提示词"</string>
-    <string name="native_fd301dc5d0e7ccf1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Front camera"</string>
+    <string name="native_fd301dc5d0e7ccf1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"前置摄像头"</string>
     <string name="native_fda8fc3b85420d14" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"打开日志条目"</string>
     <string name="native_fdd0d769c49517c2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"网络超时"</string>
     <string name="native_fe18013d93d22f4f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"现在"</string>
@@ -1496,8 +1496,8 @@
     <string name="native_ff52188203241c29" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 密码未配置"</string>
     <string name="native_ff716fc4735e067f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"听写设置"</string>
     <string name="native_ff9dbbdfb84ddab2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已加载提供商模型，但无法获取就绪状态。"</string>
-    <string name="native_ffa7aa557b547a79" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Delete thread?"</string>
-    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway."</string>
+    <string name="native_ffa7aa557b547a79" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"删除会话？"</string>
+    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 将此手机变成简洁的移动命令界面，用于管理会话、语音、提供商和 Gateway。"</string>
     <string name="native_ffb6f5764bddb68c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"最新优先"</string>
     <string name="native_ffcf16006c652ee3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"下个周期"</string>
 </resources>

--- a/apps/android/app/src/main/res/values-zh-rCN/strings.xml
+++ b/apps/android/app/src/main/res/values-zh-rCN/strings.xml
@@ -24,12 +24,14 @@
     <string name="native_002a6fcb30b2def4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法准备待发送的附件。"</string>
     <string name="native_003aaf9e0a0e6b9f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"麦克风关闭"</string>
     <string name="native_0060cbfdd3cf13ba" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"显示 OpenClaw 提醒"</string>
+    <string name="native_0077032d7e9f9cbe" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Thread activity"</string>
     <string name="native_008dacb6d1e85bd8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"完整"</string>
     <string name="native_009506aeb0484b2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已批准并保存。"</string>
     <string name="native_00d108e2e6466940" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"显示最近的通话记录"</string>
     <string name="native_00e8aeba41d79ce3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 个待处理"</string>
     <string name="native_010f6550a1c8f554" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"不支持的附件"</string>
     <string name="native_01267be21eb77392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"0 = 精确"</string>
+    <string name="native_0171e3d4e07f1861" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Connect the Gateway to search threads."</string>
     <string name="native_0174f83136630e7e" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 个账户"</string>
     <string name="native_01ac1c298e0cbd9a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cron 更改需要 operator.admin 权限。设置代码不会授予此权限。请使用 Gateway 的共享令牌或密码重新连接，以请求管理员访问权限。如果此设备仍缺少该权限，请从现有管理员客户端批准待处理的权限范围升级。"</string>
     <string name="native_01bcfe7a9296b6d6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Apply Patch"</string>
@@ -68,8 +70,10 @@
     <string name="native_088e0e5ebc96c6ac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"替换 Gateway 设置？"</string>
     <string name="native_08a5391c1de3078a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法加载自动化。"</string>
     <string name="native_08b041935798fbf6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"你"</string>
+    <string name="native_08ea63ee26954dca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Built-in microphone"</string>
     <string name="native_0905f7f59021c2a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"界面"</string>
     <string name="native_0929c9dc7f794852" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有提案"</string>
+    <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Main thread"</string>
     <string name="native_0979c6fdbdca1675" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"打开聊天"</string>
     <string name="native_0a0b7cf7c428c703" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"操作请求"</string>
     <string name="native_0a708e7b03aaf1fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list pins"</string>
@@ -84,7 +88,6 @@
     <string name="native_0c3ea4e2f12153e7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"打开 OpenClaw 并询问 %1$s"</string>
     <string name="native_0c4d01e81bb3d1fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"推理"</string>
     <string name="native_0c79a9c222840ed0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已应用"</string>
-    <string name="native_0c8056e18fdf290c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"活动会话中等待处理的聊天工具调用会保留显示在此处。"</string>
     <string name="native_0cab1c9617404faf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"视频"</string>
     <string name="native_0cf04463c4276a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已推广"</string>
     <string name="native_0d21bd52022ca7f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在线"</string>
@@ -98,11 +101,10 @@
     <string name="native_0e91610117029a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"刷新"</string>
     <string name="native_0ee30822ed35a792" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 条已排队"</string>
     <string name="native_0f4c8529742b31ea" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"开始聊天"</string>
+    <string name="native_0f559ff270904904" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Chat tool calls waiting in the active thread remain visible here."</string>
     <string name="native_0f56cc286a4f23d8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"需要审核证书"</string>
-    <string name="native_0f822f33a3100b5c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"监控中 · %1$s 个会话"</string>
     <string name="native_0f8fe3a9688138a1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"打开当前 Canvas 界面以检查或与之交互。"</string>
     <string name="native_0ff98f05be01ce5e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自动化已更新。"</string>
-    <string name="native_100ac08064a6d586" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有最近会话"</string>
     <string name="native_1039e92fa05c1279" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 状态、手机节点就绪情况和最近的日志流。"</string>
     <string name="native_106808530413298b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"打开自动化任务详情"</string>
     <string name="native_1093115897879aa3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"运行时"</string>
@@ -114,13 +116,13 @@
     <string name="native_1196c7b1e0e55580" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"reactions"</string>
     <string name="native_11a6767d5674c7e4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"完成"</string>
     <string name="native_11e18d6748aa9128" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"版本和更新"</string>
-    <string name="native_11e47358a692d81b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"总结最近的会话和后续步骤。"</string>
     <string name="native_11f37f9652a47b5b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 将在此显示审批、失败的任务和频道问题。"</string>
+    <string name="native_11f6dc0befae5081" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"USB microphone"</string>
     <string name="native_1242bf5561713a98" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"等待添加的共享过多。"</string>
-    <string name="native_1251aefc12b2b10e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"删除会话？"</string>
     <string name="native_12698ce1ea5cd4ab" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已跳过"</string>
     <string name="native_1291833ee42d8143" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"使用 Gateway 计算机的局域网地址或安全的远程主机名。"</string>
     <string name="native_130011756125313c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"开启"</string>
+    <string name="native_133f293961d7aa43" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Searching threads"</string>
     <string name="native_13798c3256e792c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"实时对话"</string>
     <string name="native_13b588109e423636" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 正在准备回复。"</string>
     <string name="native_13ba4cde12390943" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已批准一次。"</string>
@@ -136,6 +138,7 @@
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"会话目标"</string>
     <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"查看 ClawHub 技能"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
+    <string name="native_16b1a05e1d987ed1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Preferred microphone"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"节点主机"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"级别"</string>
     <string name="native_172b997ffbc8c9a7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"关闭应用选择器"</string>
@@ -155,6 +158,7 @@
     <string name="native_18f2a0947f9d6523" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已阻止"</string>
     <string name="native_18f6e5973bc41268" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"唤醒词或短语"</string>
     <string name="native_1906b261e6e0fdd0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 需要设备批准"</string>
+    <string name="native_19408baaf5c2e446" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"External microphone"</string>
     <string name="native_194a05367fb28913" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s 个已就绪"</string>
     <string name="native_199e261f8ee0e97f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已连接（操作员离线）"</string>
     <string name="native_19fc7a47df16fb1f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"功能未批准"</string>
@@ -206,6 +210,7 @@
     <string name="native_22965568d22a14ee" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已连接"</string>
     <string name="native_22a970d2e5b1cc23" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已完成"</string>
     <string name="native_22b8da9e693e94eb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"你的手机已与 %1$s 配对。请继续完成节点访问设置。"</string>
+    <string name="native_22f19ab686639b9a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Current thread"</string>
     <string name="native_23246d9852fed325" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"思考 %1$s"</string>
     <string name="native_2346f214ad56b180" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已静音"</string>
     <string name="native_2347fc06da5f60de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 感谢其在开源社区中的合作伙伴。"</string>
@@ -232,11 +237,11 @@
     <string name="native_262c897a1f408b0b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接到你的 Gateway"</string>
     <string name="native_2682bd813a3bccbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"输入 openclaw qr 中的设置代码。"</string>
     <string name="native_268f14bbfe119c1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"诊断"</string>
+    <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"This permanently deletes the thread and its transcript."</string>
     <string name="native_26f0dd993530eb2d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在自动重试"</string>
     <string name="native_270ff82f36da987f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已复制小组件图片"</string>
     <string name="native_2728740a95d465c6" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 个角色"</string>
     <string name="native_272955a627b71681" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"缺少 1 项"</string>
-    <string name="native_2732406e3be52c5b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有匹配的会话"</string>
     <string name="native_2748442ae65e27e8" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 个已计划"</string>
     <string name="native_275976081ce1abf6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"react"</string>
     <string name="native_279b44d2ab4b40c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"代理"</string>
@@ -248,6 +253,7 @@
     <string name="native_27d773b934ed324f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"验证并安装"</string>
     <string name="native_2821f0168d6dd9df" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"将此设备变成安全的 OpenClaw 节点，用于聊天、语音、摄像头和设备工具。"</string>
     <string name="native_2831546121359362" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"手动设置"</string>
+    <string name="native_287c4b113aafc215" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Open Chat to start or resume the current thread."</string>
     <string name="native_28bb849671cab958" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"提示：停止聆听即可发送已捕获的发言。"</string>
     <string name="native_28d03596d24eeb4e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"跳过"</string>
     <string name="native_28d55ec6974d84e8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"语音请求失败"</string>
@@ -267,9 +273,10 @@
     <string name="native_2c19d584bf8ad518" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"标记为未读"</string>
     <string name="native_2c75802a5f8df5f8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"查找人员和联系方式"</string>
     <string name="native_2c9cce8250d746e3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"需要设备身份"</string>
-    <string name="native_2cad0766accc2d3f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"重命名会话"</string>
+    <string name="native_2cd62f7a670b2819" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw thread"</string>
     <string name="native_2d4dfe885f84629e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"允许访问照片图库。"</string>
     <string name="native_2d6416405eb44982" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"先前的响应已处理此批准。"</string>
+    <string name="native_2d85de9d56c226e4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"No recent threads"</string>
     <string name="native_2df01a03ff43400b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无匹配项"</string>
     <string name="native_2df30b117ad829ab" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"读取所选应用的通知"</string>
     <string name="native_2e0078a8322d6f1f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"可用性未知"</string>
@@ -331,6 +338,7 @@
     <string name="native_36c725ddb20f8bd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Talk Provider 设置"</string>
     <string name="native_36d88ed6cc91d2b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Music Generation"</string>
     <string name="native_36e8d5e94219dc37" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"对话设置"</string>
+    <string name="native_36f1fac278711470" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · 1 thread"</string>
     <string name="native_37053dc1f680546b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"负载文本"</string>
     <string name="native_37582309e7a1dbe5" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"批准 %1$s"</string>
     <string name="native_379ce0aacf46c35f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 未返回 %1$s 就绪状态"</string>
@@ -355,18 +363,19 @@
     <string name="native_3a65cf1204f18864" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已连接（节点离线）"</string>
     <string name="native_3a78695388b38b5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"首页"</string>
     <string name="native_3b28b535950f8175" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在听写"</string>
+    <string name="native_3b46b7912670bfb0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"No archived threads"</string>
     <string name="native_3b851469ea31d489" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"选择并检查此 gateway 上可用的助手。"</string>
     <string name="native_3be0085a6bd88cdd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"通话模式已启用"</string>
     <string name="native_3bee4ede6bf4436c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"工作中 · 1 个活跃运行"</string>
     <string name="native_3c6168bbf86e6e4b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"同意并启用"</string>
     <string name="native_3cb27ae0fbca8ae3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"复制图片"</string>
-    <string name="native_3d013d4e9cf973f9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"尝试聊天、语音、会话、提供商或设置。"</string>
     <string name="native_3d06950825de7452" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway URL"</string>
     <string name="native_3d200f624b8bda8f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"main、isolated、current 或 session:&lt;id&gt;"</string>
     <string name="native_3d61e9d54ffa2d93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接到你的 Gateway，以在代理工作区中打开 shell。"</string>
     <string name="native_3da4811eafea080a" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s://%2$s:%3$s"</string>
     <string name="native_3de3d401128d4395" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法加载批准详情。请刷新后重试。"</string>
     <string name="native_3e398e6fb979557a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tool Call"</string>
+    <string name="native_3e42e385075b9b56" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads"</string>
     <string name="native_3f00927a719345ed" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Write"</string>
     <string name="native_3f25ccebfa99dcf3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"输入提示词开始，或使用语音。"</string>
     <string name="native_3f39d5c348e5b79d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"D"</string>
@@ -393,6 +402,7 @@
     <string name="native_4287d54ad5e78985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"来自你的 gateway 的已计划 OpenClaw 工作。"</string>
     <string name="native_429f6057535c1ea3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sub-agent"</string>
     <string name="native_42e3a99c21767def" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在等待设备批准"</string>
+    <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Loading thread"</string>
     <string name="native_43905968a540af6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"错开毫秒数"</string>
     <string name="native_43988c156beabf7d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"event create"</string>
     <string name="native_43cc23fa52b87b4c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"文档"</string>
@@ -451,13 +461,11 @@
     <string name="native_4d5e590b23745b4d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"安装在 Gateway 上的 Skills 将显示在此处。"</string>
     <string name="native_4dee3342f86128c1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"该代码可能已过期，或是为另一个 Gateway 生成的。"</string>
     <string name="native_4e25d34a20313a61" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"需要权限"</string>
-    <string name="native_4e35d595e6975128" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"会话活动"</string>
     <string name="native_4e8c72cab82e0711" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自动化配置无效。"</string>
     <string name="native_4ec30e9d85725d41" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"允许列表"</string>
     <string name="native_4ed379d418bb8629" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"groups"</string>
     <string name="native_4efca0d10c5feb8e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"关于"</string>
     <string name="native_4f1bc100d1dccc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在该图片中未找到设置二维码。请选择由 openclaw qr 生成的二维码，或手动输入设置代码。"</string>
-    <string name="native_4f993457edb69110" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"浏览会话"</string>
     <string name="native_4fe3cdd404ea0290" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"permissions"</string>
     <string name="native_5047cfb3b607e7d0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接 Gateway 以加载节点和已配对设备。"</string>
     <string name="native_5083cd4b96b0d09d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有 Skills"</string>
@@ -476,6 +484,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"投递"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"将扬声器静音"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在打开 Gateway 连接"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自动化运行已完成。"</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有匹配的应用。"</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"发送到聊天"</string>
@@ -492,7 +501,6 @@
     <string name="native_544731b8da90eb65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"emoji list"</string>
     <string name="native_544d9e42216c2ac0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"重复"</string>
     <string name="native_54b41550b1247912" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"搜索 OpenClaw"</string>
-    <string name="native_54d5c8a4eb7898dc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"主会话"</string>
     <string name="native_54e08ca4a25fe3f1" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 个待处理"</string>
     <string name="native_5542bc6a5f3ae4da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"设备端语音识别不可用"</string>
     <string name="native_55546edf686ab168" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有应用可以分享此消息"</string>
@@ -501,13 +509,13 @@
     <string name="native_55898449eb74fb2e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"健康状况"</string>
     <string name="native_55a12cbe0995e214" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"通知监听器"</string>
     <string name="native_55d8e7da6d0a752c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"扬声器已静音"</string>
-    <string name="native_5638a97380146882" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"打开聊天以开始或继续当前会话。"</string>
+    <string name="native_560d3e826c413dc9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Search threads"</string>
     <string name="native_565339bc4d33d728" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"确定"</string>
     <string name="native_56a508f3f2bf424a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法打开设置指南。"</string>
     <string name="native_56c41c606c44f3fc" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"询问 OpenClaw %1$s"</string>
+    <string name="native_56c4c3d30ceda56e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wait for Agents"</string>
     <string name="native_56ef8f20955f2564" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"地址"</string>
     <string name="native_5702e1d243eeb4e9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在 Gateway 上创建的计划任务将显示在此处。"</string>
-    <string name="native_5719080df7834f1b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接 Gateway 以搜索会话。"</string>
     <string name="native_572739b05d138f8a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在显示最新的日志块。"</string>
     <string name="native_57666930af1af35e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"使用设置代码"</string>
     <string name="native_57c4b13a4c7335e7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"sticker"</string>
@@ -519,7 +527,6 @@
     <string name="native_5855b3ac2fcc1b3e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"修复连接"</string>
     <string name="native_58e909c0f4cc5723" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"保存图片"</string>
     <string name="native_590b0003ccaad929" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"节点 %1$s"</string>
-    <string name="native_5922c3814cbbdbce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"帮我了解最近 OpenClaw 会话的最新进展，并建议后续步骤。"</string>
     <string name="native_59235e6ebfd03967" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"需要 Gateway 密码"</string>
     <string name="native_592acaa91843913b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Update Plan"</string>
     <string name="native_595b066a8838734a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"移除附件"</string>
@@ -534,7 +541,6 @@
     <string name="native_5a7d4412c13abceb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 正在说话"</string>
     <string name="native_5a99f6fa7e98657a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"扫描二维码"</string>
     <string name="native_5ab9d81fd481e71f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已选应用"</string>
-    <string name="native_5b3522ef7c1c149e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"聚焦会话搜索"</string>
     <string name="native_5b36e77f2018303f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"撤销更改"</string>
     <string name="native_5b4ddab77c412d6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"审批命令已复制"</string>
     <string name="native_5b7c4c081e9c5810" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"投递状态"</string>
@@ -570,6 +576,7 @@
     <string name="native_60ea1847c2ba5446" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"响应已中止"</string>
     <string name="native_6105d6cc76af4003" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"图像"</string>
     <string name="native_614b8348a2dbe46b" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 个已保留"</string>
+    <string name="native_614e83ef17c13f3c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"No matching threads"</string>
     <string name="native_6197595503f01ee2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"delete"</string>
     <string name="native_619837a134285528" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"布局：紧凑"</string>
     <string name="native_61ffa9c8c703dd5e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"channels"</string>
@@ -609,9 +616,13 @@
     <string name="native_674eb55d9c353900" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"计划详情"</string>
     <string name="native_67528858c36397f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"手机功能"</string>
     <string name="native_67a926f7008e2b0e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"不可用"</string>
+    <string name="native_67b696468610b879" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dashboard"</string>
     <string name="native_67fa416afa64d304" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"粘贴令牌"</string>
     <string name="native_6827238fea72c88b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无提供商"</string>
+    <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"No threads yet"</string>
+    <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bluetooth microphone"</string>
     <string name="native_690dbe9dc0993c42" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"最近"</string>
+    <string name="native_6930c8d1fc4f01d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rename thread"</string>
     <string name="native_69384c1c4d99f6eb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"处理结果未知。在验证 Gateway 记录之前，操作将保持禁用。"</string>
     <string name="native_6940189433657105" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"dialog"</string>
     <string name="native_695c03727ff0251f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"监听唤醒词"</string>
@@ -669,7 +680,6 @@
     <string name="native_710a5600e8adc434" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ClawHub 未返回适用于 %1$s 的可安装版本。"</string>
     <string name="native_713166971d730f81" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"命令"</string>
     <string name="native_7143e424a2bf2663" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此批准在处理完成前已取消。"</string>
-    <string name="native_71463bd14f924604" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有当前会话"</string>
     <string name="native_716c3d1f55a7cd37" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"麦克风开启 · 正在等待 Gateway"</string>
     <string name="native_7198eaa9f18ee413" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"显示 %1$s / %2$s。优化搜索以查看更多。"</string>
     <string name="native_71aec38e93393296" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"v%1$s 可用"</string>
@@ -681,7 +691,6 @@
     <string name="native_7234213a42c2635b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"打开个人资料"</string>
     <string name="native_7234d010e91c7bcf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"启动你的 Gateway。"</string>
     <string name="native_72361961ef893ce1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"帮我将此目标转化为实用的检查清单："</string>
-    <string name="native_7296bfd468e09713" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"清除会话搜索"</string>
     <string name="native_72e9a59f5a1d6289" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"端口"</string>
     <string name="native_7344ef8e67c5337e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"输入设置代码"</string>
     <string name="native_735cca45016888d0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法加载 Gateway 日志。"</string>
@@ -692,7 +701,7 @@
     <string name="native_746f71ec623adc37" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Epoch 毫秒（可选）"</string>
     <string name="native_7491b353909c1147" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有已配置的模型。刷新以重新检查可用性。"</string>
     <string name="native_74a883a037bc227f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"设置"</string>
-    <string name="native_74cdd65b358733f1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"切换会话布局"</string>
+    <string name="native_74c372f29b83df94" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Back camera"</string>
     <string name="native_74e21680eac7385c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"approve"</string>
     <string name="native_74e492d5d0df0bab" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"开始之前"</string>
     <string name="native_74f0a5d234edc4af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法加载 Skills。"</string>
@@ -725,7 +734,6 @@
     <string name="native_78f25f393aa9bcbf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"sticker upload"</string>
     <string name="native_790d78931c21b895" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Messages to recover"</string>
     <string name="native_792175fb265c32bc" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw devices approve %1$s"</string>
-    <string name="native_7981cbd5763dfcbb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"尚无匹配的会话。"</string>
     <string name="native_79a68a0d42388125" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"可读的 Gateway 日志详情。"</string>
     <string name="native_79a7ab236717f90d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在生成的 Skills 提案成为正式 Skills 之前进行审查。"</string>
     <string name="native_79d3a1f108e8d9c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已捆绑"</string>
@@ -768,11 +776,13 @@
     <string name="native_8193ee8a22d25208" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"固定模型"</string>
     <string name="native_81c2c4f30a4bec68" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"清除搜索"</string>
     <string name="native_81d38aca5306940b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已对符合条件的代理启用。"</string>
+    <string name="native_820d08e12968baff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"No current thread"</string>
     <string name="native_82250171708918de" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在 %1$s 后"</string>
     <string name="native_825b9c75d7fed691" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"允许调度程序运行此自动化。"</string>
     <string name="native_82990a093599a9bb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 个已应用"</string>
     <string name="native_8340dad4f3be30a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"还没有梦境日记。"</string>
     <string name="native_837e39f46163ffb4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"刷新后台任务"</string>
+    <string name="native_838337fd9ab30454" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Summarize recent threads and next steps."</string>
     <string name="native_83e2faed20a3cda4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"当 OpenClaw 可见时在设备上运行。"</string>
     <string name="native_844e5b02f3ef05ca" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 正在工作"</string>
     <string name="native_846c75dca0b71591" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
@@ -804,7 +814,6 @@
     <string name="native_88b01c8a4bff9a08" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"信号"</string>
     <string name="native_88e6e8384a7fc7ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"会话目标"</string>
     <string name="native_893a3e37d71c4563" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 已记录一次拒绝。"</string>
-    <string name="native_895f1e14d75d1239" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已归档的会话将显示在这里。"</string>
     <string name="native_89713b9c9c1b8f65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"接受"</string>
     <string name="native_8998824610d49175" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"向 OpenClaw 提问任何问题"</string>
     <string name="native_89bbfe23c3917a3f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"重新连接以继续"</string>
@@ -824,7 +833,6 @@
     <string name="native_8ca344247c18317e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"运动"</string>
     <string name="native_8cac4b77b9c54695" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"cron 操作失败。"</string>
     <string name="native_8cb2bab2ce6a17b2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在 Gateway 电脑上运行："</string>
-    <string name="native_8cb650539ec84aa5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"搜索会话"</string>
     <string name="native_8d0839802b4d6aca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"刷新日志"</string>
     <string name="native_8d20273207a2fe99" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw nodes approve %1$s"</string>
     <string name="native_8d57374bc09c8756" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"语音消息 · %1$s"</string>
@@ -844,6 +852,7 @@
     <string name="native_8f54b0d1e30092d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"语音消息"</string>
     <string name="native_8fa196125b734940" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有需要你注意的事项"</string>
     <string name="native_8fce9ec6fd5432df" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 需要 %1$s 权限才能继续。"</string>
+    <string name="native_8fe42acb8573244e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wired headset microphone"</string>
     <string name="native_906115657390f367" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已送达"</string>
     <string name="native_9071738f145962a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"到期"</string>
     <string name="native_90bf81305006e6ed" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"当前 Skills 状态中没有可用的 Skill 详情。"</string>
@@ -932,6 +941,7 @@
     <string name="native_9e37aa0704a3cf44" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已安装 %1$s。"</string>
     <string name="native_9e4635769f0aaf0d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateways"</string>
     <string name="native_9e9bef85bb320b81" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"转发模式"</string>
+    <string name="native_9f6e180ff696bec5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Toggle thread layout"</string>
     <string name="native_9fb7c4ebcbc3e558" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无 TLS 端点"</string>
     <string name="native_9fe101a0ec7ef416" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw Gateway"</string>
     <string name="native_9ffc843f501acdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"手动设置"</string>
@@ -948,14 +958,11 @@
     <string name="native_a181b2c15994a7fc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"语音提供商"</string>
     <string name="native_a190013f72efad35" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在进行 Gateway 批准。OpenClaw 将自动重试。"</string>
     <string name="native_a1a5936d3b0f8a69" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"最高"</string>
-    <string name="native_a1b5653a9f1b842b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有已归档的会话"</string>
     <string name="native_a1bca979bc69befb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"更改 cron 需要 operator.admin 访问权限。"</string>
     <string name="native_a20d12c5e9c428c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在思考"</string>
     <string name="native_a23967c129397864" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screen snapshot"</string>
     <string name="native_a2bbc7ffd69f9c49" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"未找到操作"</string>
     <string name="native_a2f29836cda5ceb1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"保存并连接"</string>
-    <string name="native_a2fcbab533267340" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"监控中 · 1 个会话"</string>
-    <string name="native_a32789d2b53dc704" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"当前会话"</string>
     <string name="native_a330395cc0a53ad1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list"</string>
     <string name="native_a34f54e488b48e66" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 已记录批准并保存了选择。"</string>
     <string name="native_a37cf0a1111bf41c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"请输入有效的手动端点以连接。"</string>
@@ -963,7 +970,6 @@
     <string name="native_a3e96435cb1ec7c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在发送到聊天..."</string>
     <string name="native_a4212f1e2fb0f506" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"保存个人资料"</string>
     <string name="native_a424e33d90931d1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已锁定"</string>
-    <string name="native_a43f3627c39f1354" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在加载会话"</string>
     <string name="native_a450ea5e177b4787" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"编辑自动化"</string>
     <string name="native_a484bc216860979e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"使用同一网络，或安全的远程 Gateway URL。"</string>
     <string name="native_a4ae750b610e875e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"锚点"</string>
@@ -983,6 +989,7 @@
     <string name="native_a89bac8b89022bde" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在聆听 · %1$s 条排队中"</string>
     <string name="native_a8bbbd7231a6c191" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"助手语音已静音"</string>
     <string name="native_a8ef5cdf31a6505a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"尚未找到 Gateway。如果发现功能受阻，请使用手动设置。"</string>
+    <string name="native_a901aa25b833cf33" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Open thread"</string>
     <string name="native_a92f0449a9f7235b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"处理中"</string>
     <string name="native_a9624cf0b6ae80c1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"开始说话..."</string>
     <string name="native_a9ac253267d07365" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"手机节点"</string>
@@ -1017,11 +1024,12 @@
     <string name="native_adca3171c270301a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此 Gateway 登录会话可以列出已连接的节点，但无法批准新的手机配对。请通过 Gateway 管理员会话配对新手机。节点功能批准是独立的，仍需使用 nodes approve &lt;request id&gt;。"</string>
     <string name="native_ade9248e0132b411" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"信任"</string>
     <string name="native_ae27fa789a03c1db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"该二维码不是 OpenClaw 设置二维码。请使用 openclaw qr 生成新代码，然后重试。"</string>
-    <string name="native_ae86062126fc1a52" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"“%1$s”中的会话将被保留并移回未分组。"</string>
+    <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Preferred microphone unavailable; using automatic routing."</string>
     <string name="native_aea4a04a80426ed8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已拒绝"</string>
     <string name="native_aed306fbb63c0c68" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"包括 Android 和后台包。"</string>
     <string name="native_aedf1cf58372f943" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"您的 Gateway 已准备就绪。"</string>
     <string name="native_aeffb9182e3d7f3d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已触发"</string>
+    <string name="native_af1f10e9b3af3250" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Structured Output"</string>
     <string name="native_af60a38d6b5866ce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"所需时间比预期更长。\n请检查 Gateway 是否正在运行且可访问。"</string>
     <string name="native_af7deaf2c81b107d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此代理没有后台任务。"</string>
     <string name="native_afb118fcb16c3727" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在重新连接"</string>
@@ -1035,7 +1043,6 @@
     <string name="native_b140db2544c7f8f5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 正在恢复同步"</string>
     <string name="native_b1b3f74fe7e32ae1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"事件流已中断；请尝试刷新。"</string>
     <string name="native_b1c1be6b126d151f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法加载节点和设备。"</string>
-    <string name="native_b205bb47f81a3096" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"打开会话"</string>
     <string name="native_b2087b2e689f4946" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接 Gateway 以加载 Skills。"</string>
     <string name="native_b23a6a8439c0dde5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"未知"</string>
     <string name="native_b2439bcb8dee14b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"输出"</string>
@@ -1053,6 +1060,7 @@
     <string name="native_b4aca584eecea590" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法加载任务详情"</string>
     <string name="native_b51702b087112113" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Agent 消息"</string>
     <string name="native_b538b9d40695a6fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 需要此设备身份。请重新认证或重置此 Gateway 连接。"</string>
+    <string name="native_b53b35163f7588c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Next session"</string>
     <string name="native_b55dae19fcb48a4d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接安全性"</string>
     <string name="native_b5a229ac8becc603" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"网站"</string>
     <string name="native_b5af0517c02601fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接 Gateway 以在应用中加载审批请求。"</string>
@@ -1080,10 +1088,10 @@
     <string name="native_b9d5d026db17b9e4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"失败 — %1$s"</string>
     <string name="native_ba599a4fe4b45b36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"这部手机与 OpenClaw 之间的连接。"</string>
     <string name="native_bae9264d6d972b80" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"summarize"</string>
-    <string name="native_bb4069d372f67683" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"这将永久删除该会话及其转录内容。"</string>
     <string name="native_bb4f2558e4333834" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"小组件图片已保存到“下载”"</string>
     <string name="native_bbe5fc3b9ef39f99" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在启动…"</string>
     <string name="native_bc19cec293228fb8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"客户端错误"</string>
+    <string name="native_bc6618670f3e8a17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bluetooth LE microphone"</string>
     <string name="native_bcb06651437caa15" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
     <string name="native_bd08450d63406844" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自动化已启用。"</string>
     <string name="native_bd6719b455bcc898" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Memory Get"</string>
@@ -1108,6 +1116,7 @@
     <string name="native_c12a06263b75eb23" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接 Gateway 以加载 Skill 详情。"</string>
     <string name="native_c156b9eaf502aabc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"唤醒监听器"</string>
     <string name="native_c184b2ada7abc688" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"展开链接预览"</string>
+    <string name="native_c18ee03d3906a488" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Clear thread search"</string>
     <string name="native_c1970bb2cdf299b7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"NULL（失败）"</string>
     <string name="native_c1c1009d3f37ec05" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"更新"</string>
     <string name="native_c1c224b03cd9bc7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"管理员"</string>
@@ -1175,12 +1184,14 @@
     <string name="native_ca7981b46ecf2c17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"关闭"</string>
     <string name="native_cab94aba84f97f7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"字体排版"</string>
     <string name="native_cae7d57bc067a514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"停止"</string>
+    <string name="native_cae98462b30650eb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"No matching threads yet."</string>
     <string name="native_cba62d81f910c7f0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 配对成功。\n请通过操作员 UI 批准此手机的节点功能。"</string>
     <string name="native_cc4b66e7e22230c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此技能已安装，但目前不符合运行条件。请通过桌面端或 CLI 更改配置。"</string>
     <string name="native_cc5f45fb30a26e07" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"识别器正忙"</string>
     <string name="native_cc721e25d73938a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"家庭 Gateway"</string>
     <string name="native_cc7a9a5cf8c4bc9d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在 Gateway 上运行批准命令"</string>
     <string name="native_cc925e3c97ac7a35" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法加载 Skill Workshop 提案。"</string>
+    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Catch me up on my recent OpenClaw threads and suggest next steps."</string>
     <string name="native_ccb4c324f516c633" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"暂不"</string>
     <string name="native_cced0b0d83a9e400" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw qr"</string>
     <string name="native_cced28c6dc3f99c2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"start"</string>
@@ -1203,6 +1214,7 @@
     <string name="native_ceb6931ea57cc999" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自适应"</string>
     <string name="native_cf0ee3547a4e51a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"即将"</string>
     <string name="native_d04fc7d7e19702f8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Search"</string>
+    <string name="native_d053ba98d8bbcec1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Try Chat, Voice, Threads, Providers, or Settings."</string>
     <string name="native_d056177742e27cf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 处于活动状态"</string>
     <string name="native_d0cda6559bb347db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"navigate"</string>
     <string name="native_d0d0de0039c7990b" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"请求于 %1$s"</string>
@@ -1214,7 +1226,6 @@
     <string name="native_d19c2dd2fb598b93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 被动"</string>
     <string name="native_d1a574e23344c407" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 密码无效"</string>
     <string name="native_d1bf045bb524dae5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"查看详细信息"</string>
-    <string name="native_d1c835016021c20b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 会话"</string>
     <string name="native_d1e9567da9a8a4b0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bash"</string>
     <string name="native_d2089be672953d11" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"令牌"</string>
     <string name="native_d20f43f925e706ce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已连接的 OpenClaw 代理可以使用你启用的设备功能。仅在你信任所连接的 Gateway 和代理时继续。"</string>
@@ -1230,6 +1241,7 @@
     <string name="native_d3974fd6d3b6c81f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"运行待处理项"</string>
     <string name="native_d3f75e24411053c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"您设备上的个人 AI"</string>
     <string name="native_d406ade2958cb5b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attach"</string>
+    <string name="native_d461a493a3753877" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Automatic"</string>
     <string name="native_d4b1ea5708dd5329" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"概览"</string>
     <string name="native_d53167a3f66debec" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"请求恢复失败。点按以重试。"</string>
     <string name="native_d588c689e03132fb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s\n\n"</string>
@@ -1242,6 +1254,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"个人资料"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"当您的 Gateway 报告提供商限制时，将显示在此处。"</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 个问题"</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"创建时间"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s 个活跃令牌"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>
@@ -1258,6 +1271,7 @@
     <string name="native_d93e2b7a15efbc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法处理批准。请刷新后重试。"</string>
     <string name="native_d942f64886578d87" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"import"</string>
     <string name="native_d94cfb21b67ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"这部手机在 OpenClaw 中的显示方式。"</string>
+    <string name="native_d96f2b0eab4e67b7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Focus thread search"</string>
     <string name="native_d975ca28a64f8850" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接 Gateway"</string>
     <string name="native_d9be42d9b30ce057" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"读取日历"</string>
     <string name="native_d9f641e1a02807cb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"重新连接以及打开此屏幕时，概览将刷新。"</string>
@@ -1303,6 +1317,7 @@
     <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"搜索已安装的 Skills"</string>
     <string name="native_e0723a86a5b9408a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"检查"</string>
     <string name="native_e083bd83e9d3e97e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Process"</string>
+    <string name="native_e08a8fc53e29e5c9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Recent Threads"</string>
     <string name="native_e0926fdac700b094" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"终端"</string>
     <string name="native_e0d1b68224bf0b31" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"当前"</string>
     <string name="native_e10435f6306b06d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 个账户"</string>
@@ -1323,7 +1338,6 @@
     <string name="native_e3f0caab85e62600" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法从该图片中读取二维码。请选择更清晰的图片，或手动输入设置代码。"</string>
     <string name="native_e3f90d1d0b07fb04" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 的版本低于此应用。请更新 Gateway 主机上的 OpenClaw，然后重试。"</string>
     <string name="native_e41cc128c73bc85e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"请先连接，再使用聊天、语音和实时状态功能。"</string>
-    <string name="native_e424b24d86953102" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在搜索会话"</string>
     <string name="native_e4582b6fb1f57494" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"重新连接 Gateway"</string>
     <string name="native_e4696640127b9126" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"第三方"</string>
     <string name="native_e482357257d6c2fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"检查就绪状态"</string>
@@ -1332,11 +1346,13 @@
     <string name="native_e52b3044724b9f4d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"取消固定模型"</string>
     <string name="native_e5584bc5057284ae" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"连接到此 Gateway 的消息界面。"</string>
     <string name="native_e595f17fac1d8384" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在发送"</string>
+    <string name="native_e5b87192a9e6321f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Archived threads will show up here."</string>
     <string name="native_e5c02424e511e1ef" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已复制命令"</string>
     <string name="native_e5c083cf41ff6472" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无可用预览"</string>
     <string name="native_e5c3e7b8110e7087" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"请在 Gateway 上批准此手机。\n然后重试连接。"</string>
     <string name="native_e5c7478bbce26eb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"扫描二维码"</string>
     <string name="native_e5e4f854dcd3ffc6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"命令工作目录 · 无法清除"</string>
+    <string name="native_e614ccf26ec5d312" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Thread Activity"</string>
     <string name="native_e674447337e83c13" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"可用"</string>
     <string name="native_e68e23dc04b0f986" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"删除自动化？"</string>
     <string name="native_e7053d96b6704dbb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"今天 %1$s 个 · 共 %2$s 个"</string>
@@ -1409,7 +1425,6 @@
     <string name="native_f2bfed0b0c0055db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"语音回复超时；正在重试已排队的轮次"</string>
     <string name="native_f2cb21c53a33f72c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"布局：详细"</string>
     <string name="native_f2da2e47cd31a5dd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法解码此图像。"</string>
-    <string name="native_f2ecdaf77d1d98d3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 将此手机变成一个简洁的移动命令界面，用于管理会话、语音、提供商和 Gateway。"</string>
     <string name="native_f3753c0fe29b88db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway、语音、通知、隐私"</string>
     <string name="native_f386c32c1bf437d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Agent 工作区文件"</string>
     <string name="native_f41d9e8b7e09aa24" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在批准命令中使用待处理命令中的 requestId。"</string>
@@ -1420,13 +1435,12 @@
     <string name="native_f4ccae29e1bb0c20" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"运行中"</string>
     <string name="native_f4db1e48476f6075" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"结束"</string>
     <string name="native_f4ef7a41caa88dd1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有就绪的提供方"</string>
-    <string name="native_f502267deff4108d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"还没有会话"</string>
+    <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Prioritizes connected Bluetooth microphones."</string>
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已阻止 %1$s 个应用转发。"</string>
     <string name="native_f532ee1f7288365e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"消息操作"</string>
     <string name="native_f5387f9bb6ed7031" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"类型"</string>
     <string name="native_f565318d124534cf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"取消归档"</string>
     <string name="native_f584049cab5f523e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Transcripts"</string>
-    <string name="native_f59b46c265d8d38f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"最近会话"</string>
     <string name="native_f5f0563199a5b403" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"唤醒词"</string>
     <string name="native_f616dfac9815faea" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在 Gateway 上配置 %1$s"</string>
     <string name="native_f61d0c645f00a4ed" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"扫描二维码或使用来自您的 OpenClaw Gateway 的设置代码。"</string>
@@ -1447,6 +1461,7 @@
     <string name="native_f8b32f4e92bd84ce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已安装"</string>
     <string name="native_f8c2745155505d39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"等待回复超时；请重试或刷新。"</string>
     <string name="native_f8cd133f0ea1031b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"查找之前的对话"</string>
+    <string name="native_f90f3791049b995d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Browse Threads"</string>
     <string name="native_f92e2ad582c0e13f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在刷新"</string>
     <string name="native_f991ae9cb081e1f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"打开相机并框选 openclaw qr 中的代码。"</string>
     <string name="native_f9ea3f1540eaa584" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"没有设备"</string>
@@ -1468,6 +1483,7 @@
     <string name="native_fcdeb9947bc94101" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"测试测试 1 2 3"</string>
     <string name="native_fcea13c79c2f85a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无法搜索 ClawHub Skills。"</string>
     <string name="native_fd175ecd65f7353d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"无提示词"</string>
+    <string name="native_fd301dc5d0e7ccf1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Front camera"</string>
     <string name="native_fda8fc3b85420d14" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"打开日志条目"</string>
     <string name="native_fdd0d769c49517c2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"网络超时"</string>
     <string name="native_fe18013d93d22f4f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"现在"</string>
@@ -1477,10 +1493,11 @@
     <string name="native_ff2670a0df18e148" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"thread list"</string>
     <string name="native_ff332eeb6b2de1da" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"打开 %1$s"</string>
     <string name="native_ff4085ad157354dc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"upload"</string>
-    <string name="native_ff4d6b7484fbfc1f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"会话活动"</string>
     <string name="native_ff52188203241c29" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 密码未配置"</string>
     <string name="native_ff716fc4735e067f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"听写设置"</string>
     <string name="native_ff9dbbdfb84ddab2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已加载提供商模型，但无法获取就绪状态。"</string>
+    <string name="native_ffa7aa557b547a79" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Delete thread?"</string>
+    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway."</string>
     <string name="native_ffb6f5764bddb68c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"最新优先"</string>
     <string name="native_ffcf16006c652ee3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"下个周期"</string>
 </resources>

--- a/apps/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/apps/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -31,7 +31,7 @@
     <string name="native_00e8aeba41d79ce3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 個待處理"</string>
     <string name="native_010f6550a1c8f554" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"不支援的附件"</string>
     <string name="native_01267be21eb77392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"0 = 精確"</string>
-    <string name="native_0171e3d4e07f1861" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"連線至 Gateway 以搜尋對話串。"</string>
+    <string name="native_0171e3d4e07f1861" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"連線至 Gateway 以搜尋討論串。"</string>
     <string name="native_0174f83136630e7e" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 個帳號"</string>
     <string name="native_01ac1c298e0cbd9a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"變更 Cron 需要 operator.admin 權限。設定代碼刻意不授予此權限。請使用 Gateway 的共用權杖或密碼重新連線，以要求管理員存取權。若此裝置仍缺少該權限，請從現有的管理員用戶端核准待處理的範圍升級。"</string>
     <string name="native_01bcfe7a9296b6d6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Apply Patch"</string>
@@ -73,9 +73,8 @@
     <string name="native_08ea63ee26954dca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"內建麥克風"</string>
     <string name="native_0905f7f59021c2a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"介面"</string>
     <string name="native_0929c9dc7f794852" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"沒有提案"</string>
-    <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"主要對話串"</string>
+    <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"主要討論串"</string>
     <string name="native_0979c6fdbdca1675" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"開啟聊天"</string>
-    <string name="native_09ce95090659d069" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此 Gateway 工作階段無法使用裝置配對操作。請在 Gateway 主機上執行 openclaw devices list，並在該處管理請求。節點功能核准是獨立的，仍需使用 nodes approve &lt;request id&gt;。"</string>
     <string name="native_0a0b7cf7c428c703" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"動作請求"</string>
     <string name="native_0a708e7b03aaf1fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list pins"</string>
     <string name="native_0ab0e1629576aecf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"連線至 Gateway 以載入 Skill Workshop 提案。"</string>
@@ -88,12 +87,10 @@
     <string name="native_0c3845dcd2f0f683" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"檢查此提案以載入其 Markdown。"</string>
     <string name="native_0c3ea4e2f12153e7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"開啟 OpenClaw 並詢問 %1$s"</string>
     <string name="native_0c4d01e81bb3d1fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"推理"</string>
-    <string name="native_0c77fe09ab336a3e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"用戶端"</string>
     <string name="native_0c79a9c222840ed0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已套用"</string>
     <string name="native_0cab1c9617404faf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"影片"</string>
     <string name="native_0cf04463c4276a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已推廣"</string>
     <string name="native_0d21bd52022ca7f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"線上"</string>
-    <string name="native_0d5644ff52ce2ba3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"範圍"</string>
     <string name="native_0d5efd432e4fedf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"尚未設定即時語音服務供應商。"</string>
     <string name="native_0d8ca811c3744a6d" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s · %2$s"</string>
     <string name="native_0db10f2c2f332cd2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"kick"</string>
@@ -104,7 +101,7 @@
     <string name="native_0e91610117029a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"重新整理"</string>
     <string name="native_0ee30822ed35a792" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 則排隊中的訊息"</string>
     <string name="native_0f4c8529742b31ea" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"開始聊天"</string>
-    <string name="native_0f559ff270904904" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"使用中對話串內等待中的聊天工具呼叫會繼續顯示在這裡。"</string>
+    <string name="native_0f559ff270904904" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"使用中對話串內等待中的聊天工具呼叫仍會顯示在這裡。"</string>
     <string name="native_0f56cc286a4f23d8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"需要審查憑證"</string>
     <string name="native_0f8fe3a9688138a1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"開啟目前的 Canvas 介面以檢查或與其互動。"</string>
     <string name="native_0ff98f05be01ce5e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自動化已更新。"</string>
@@ -125,7 +122,7 @@
     <string name="native_12698ce1ea5cd4ab" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已略過"</string>
     <string name="native_1291833ee42d8143" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"使用 Gateway 電腦的 LAN 位址或安全的遠端主機名稱。"</string>
     <string name="native_130011756125313c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"開啟"</string>
-    <string name="native_133f293961d7aa43" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在搜尋對話串"</string>
+    <string name="native_133f293961d7aa43" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在搜尋討論串"</string>
     <string name="native_13798c3256e792c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"即時對話"</string>
     <string name="native_13b588109e423636" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 正在準備回應。"</string>
     <string name="native_13ba4cde12390943" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已允許核准一次。"</string>
@@ -141,7 +138,6 @@
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"工作階段目標"</string>
     <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"檢閱 ClawHub Skill"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
-    <string name="native_16a5b7ad567a8093" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"要拒絕此裝置的配對要求嗎？"</string>
     <string name="native_16b1a05e1d987ed1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"偏好的麥克風"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"節點主機"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"層級"</string>
@@ -187,7 +183,6 @@
     <string name="native_1d91629837639a5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此自動化在您編輯期間已變更。儲存前，請還原為 Gateway 上的最新版本。"</string>
     <string name="native_1dbf9d5979606697" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"連線後，Gateway 可透過靜默推播喚醒手機，而不必維持永遠開啟的工作階段。"</string>
     <string name="native_1e432ea5425e4a3a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"喚醒模式"</string>
-    <string name="native_1e595a107c78b957" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"要移除配對裝置嗎？"</string>
     <string name="native_1e955a58278623a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"系統事件文字"</string>
     <string name="native_1ea44149be42d970" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"無法複製小工具圖片"</string>
     <string name="native_1ea442a134b2a184" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"否"</string>
@@ -202,7 +197,6 @@
     <string name="native_2065cc867eba1b39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"無法載入供應商模型設定。"</string>
     <string name="native_207ccb22d618db05" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"允許 %1$s 個應用程式轉送。"</string>
     <string name="native_209b9e597963e7e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"語音設定"</string>
-    <string name="native_211988ba9dd0570a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"要拒絕配對要求嗎？"</string>
     <string name="native_2132066dc9475cb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"This skill is installed but not available to the current agent. Agent filters stay on desktop or CLI."</string>
     <string name="native_21378545892f1fe2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"發布者"</string>
     <string name="native_214d4932fc767e8f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">" · 對話：正在說話"</string>
@@ -216,7 +210,7 @@
     <string name="native_22965568d22a14ee" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已連線"</string>
     <string name="native_22a970d2e5b1cc23" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已完成"</string>
     <string name="native_22b8da9e693e94eb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"您的手機已與 %1$s 配對。請繼續以完成節點存取設定。"</string>
-    <string name="native_22f19ab686639b9a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"目前的對話串"</string>
+    <string name="native_22f19ab686639b9a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"目前的討論串"</string>
     <string name="native_23246d9852fed325" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"思考 %1$s"</string>
     <string name="native_2346f214ad56b180" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已靜音"</string>
     <string name="native_2347fc06da5f60de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 感謝其開源社群夥伴。"</string>
@@ -243,8 +237,7 @@
     <string name="native_262c897a1f408b0b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"連線到您的 Gateway"</string>
     <string name="native_2682bd813a3bccbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"輸入來自 openclaw qr 的設定代碼。"</string>
     <string name="native_268f14bbfe119c1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"診斷"</string>
-    <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"這將永久刪除對話串及其文字記錄。"</string>
-    <string name="native_26e47d73a55d7fa7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"裝置已核准。"</string>
+    <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"這會永久刪除此對話串及其文字記錄。"</string>
     <string name="native_26f0dd993530eb2d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在自動重試"</string>
     <string name="native_270ff82f36da987f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已複製小工具圖片"</string>
     <string name="native_2728740a95d465c6" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 個角色"</string>
@@ -280,10 +273,10 @@
     <string name="native_2c19d584bf8ad518" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"標示為未讀"</string>
     <string name="native_2c75802a5f8df5f8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"尋找人員和聯絡資料"</string>
     <string name="native_2c9cce8250d746e3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"需要裝置身分"</string>
-    <string name="native_2cd62f7a670b2819" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 對話串"</string>
+    <string name="native_2cd62f7a670b2819" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 討論串"</string>
     <string name="native_2d4dfe885f84629e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"允許相片圖庫存取權限。"</string>
     <string name="native_2d6416405eb44982" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"先前的回應已解決此核准。"</string>
-    <string name="native_2d85de9d56c226e4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"沒有最近的對話串"</string>
+    <string name="native_2d85de9d56c226e4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"沒有最近的討論串"</string>
     <string name="native_2df01a03ff43400b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"沒有相符項目"</string>
     <string name="native_2df30b117ad829ab" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"讀取所選應用程式的通知"</string>
     <string name="native_2e0078a8322d6f1f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"可用性未知"</string>
@@ -345,7 +338,7 @@
     <string name="native_36c725ddb20f8bd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Talk Provider 設定"</string>
     <string name="native_36d88ed6cc91d2b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Music Generation"</string>
     <string name="native_36e8d5e94219dc37" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Talk 設定"</string>
-    <string name="native_36f1fac278711470" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"監控中 · 1 個對話串"</string>
+    <string name="native_36f1fac278711470" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"監控中 · 1 個討論串"</string>
     <string name="native_37053dc1f680546b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"承載文字"</string>
     <string name="native_37582309e7a1dbe5" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"核准 %1$s"</string>
     <string name="native_379ce0aacf46c35f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 未傳回 %1$s 就緒狀態"</string>
@@ -353,7 +346,6 @@
     <string name="native_381428f5f251a764" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Conversation Send"</string>
     <string name="native_3824a9f4dafe92c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"畫布"</string>
     <string name="native_384ae4ab1a2830f9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 個提供者"</string>
-    <string name="native_385001409de8562a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"無法自動讀取 Gateway 憑證。請貼上從 Gateway 主機取得的 SHA-256 指紋。"</string>
     <string name="native_387b2569e440838c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"傳送失敗：%1$s"</string>
     <string name="native_3892e10346fd2012" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"橋接"</string>
     <string name="native_38d198cd5303680f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"傳送錯誤"</string>
@@ -376,14 +368,14 @@
     <string name="native_3be0085a6bd88cdd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"通話模式已啟用"</string>
     <string name="native_3bee4ede6bf4436c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"運作中 · 1 個執行項目進行中"</string>
     <string name="native_3c6168bbf86e6e4b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"同意並啟用"</string>
-    <string name="native_3cb27ae0fbca8ae3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"複製圖片"</string>
+    <string name="native_3cb27ae0fbca8ae3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"拷貝影像"</string>
     <string name="native_3d06950825de7452" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway URL"</string>
     <string name="native_3d200f624b8bda8f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"main、isolated、current 或 session:&lt;id&gt;"</string>
     <string name="native_3d61e9d54ffa2d93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"連線到您的 Gateway，以在代理程式工作區中開啟 shell。"</string>
     <string name="native_3da4811eafea080a" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s://%2$s:%3$s"</string>
     <string name="native_3de3d401128d4395" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"無法載入核准詳細資料。請重新整理後再試一次。"</string>
     <string name="native_3e398e6fb979557a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tool Call"</string>
-    <string name="native_3e42e385075b9b56" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"對話串"</string>
+    <string name="native_3e42e385075b9b56" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"討論串"</string>
     <string name="native_3f00927a719345ed" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Write"</string>
     <string name="native_3f25ccebfa99dcf3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"請先輸入提示詞，或使用語音。"</string>
     <string name="native_3f39d5c348e5b79d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"D"</string>
@@ -410,8 +402,7 @@
     <string name="native_4287d54ad5e78985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"來自您 gateway 的已排程 OpenClaw 工作。"</string>
     <string name="native_429f6057535c1ea3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sub-agent"</string>
     <string name="native_42e3a99c21767def" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在等待裝置核准"</string>
-    <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在載入對話串"</string>
-    <string name="native_430df68ec29a85a2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此 Gateway 現在提供的憑證已受此裝置信任。"</string>
+    <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在載入討論串"</string>
     <string name="native_43905968a540af6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"錯開毫秒數"</string>
     <string name="native_43988c156beabf7d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"event create"</string>
     <string name="native_43cc23fa52b87b4c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"文件"</string>
@@ -473,7 +464,6 @@
     <string name="native_4e8c72cab82e0711" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自動化的設定無效。"</string>
     <string name="native_4ec30e9d85725d41" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"允許清單"</string>
     <string name="native_4ed379d418bb8629" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"groups"</string>
-    <string name="native_4ee252fb736effa2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"公開金鑰"</string>
     <string name="native_4efca0d10c5feb8e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"關於"</string>
     <string name="native_4f1bc100d1dccc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在該圖片中找不到設定用 QR code。請選擇 openclaw qr 所產生的 QR，或手動輸入設定代碼。"</string>
     <string name="native_4fe3cdd404ea0290" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"permissions"</string>
@@ -494,7 +484,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"傳送"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"將喇叭靜音"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在開啟 Gateway 連線"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"監控中 · %1$s 個討論串"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自動化執行完畢。"</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"沒有相符的 App。"</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"傳送至聊天"</string>
@@ -560,7 +550,6 @@
     <string name="native_5c0c8c9aa658f4a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OPENCLAW"</string>
     <string name="native_5c1acea9c9b0e704" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Fetch"</string>
     <string name="native_5c39123805ffb4e2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"提示詞"</string>
-    <string name="native_5c944156b5353428" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"要核准裝置嗎？"</string>
     <string name="native_5d410adb9576e266" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"要從此手機移除 %1$s 及其已儲存的認證嗎？"</string>
     <string name="native_5d6c41a67139ee26" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"QR code 指向不安全的遠端 Gateway。%1$s %2$s"</string>
     <string name="native_5d6cbac59f87e78d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"螢幕介面已就緒"</string>
@@ -578,7 +567,6 @@
     <string name="native_5fa1d457ddfcd26c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"rename group"</string>
     <string name="native_5fa7aac5375c5815" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"就緒"</string>
     <string name="native_5fc1927ca948f31c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"日記正在等待第一筆項目。"</string>
-    <string name="native_6007acbe30b2cd98" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"核准"</string>
     <string name="native_600c9c27960112a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"即時頁面"</string>
     <string name="native_6030d1f6340776d2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自動化已在執行中。"</string>
     <string name="native_604e6d6faf8d0295" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此單次自動化成功執行後將其移除。"</string>
@@ -588,7 +576,7 @@
     <string name="native_60ea1847c2ba5446" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"回應已中止"</string>
     <string name="native_6105d6cc76af4003" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"圖片"</string>
     <string name="native_614b8348a2dbe46b" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 個已保留"</string>
-    <string name="native_614e83ef17c13f3c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"沒有相符的對話串"</string>
+    <string name="native_614e83ef17c13f3c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"沒有相符的討論串"</string>
     <string name="native_6197595503f01ee2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"delete"</string>
     <string name="native_619837a134285528" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"版面配置：精簡"</string>
     <string name="native_61ffa9c8c703dd5e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"channels"</string>
@@ -618,14 +606,12 @@
     <string name="native_6657cc73af00feac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在要求時允許使用相機工具。"</string>
     <string name="native_666067dd376e5d45" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"問題"</string>
     <string name="native_666c8bc0319f3b54" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"語音喚醒"</string>
-    <string name="native_66713d713e3a41c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"配對要求已拒絕。"</string>
     <string name="native_66b23bae66fc0d79" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 天前"</string>
     <string name="native_66cf5513b37462be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"roles"</string>
     <string name="native_66d0f523a379b2de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skills"</string>
     <string name="native_66f4804ee23ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"封存"</string>
     <string name="native_66fab2875ee427f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"節點離線。請重新連線後再試一次。"</string>
     <string name="native_6725e7bbcd28f3a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"系統"</string>
-    <string name="native_672f3453e1dd571b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"遠端 IP"</string>
     <string name="native_674b38cae72bb0c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"未分組"</string>
     <string name="native_674eb55d9c353900" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"排程詳細資料"</string>
     <string name="native_67528858c36397f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"手機功能"</string>
@@ -633,11 +619,10 @@
     <string name="native_67b696468610b879" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dashboard"</string>
     <string name="native_67fa416afa64d304" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"貼上 token"</string>
     <string name="native_6827238fea72c88b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"沒有提供者"</string>
-    <string name="native_684889f0079cc145" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"SHA-256 指紋"</string>
     <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"尚無對話串"</string>
-    <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bluetooth 麥克風"</string>
+    <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"藍牙麥克風"</string>
     <string name="native_690dbe9dc0993c42" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"最近"</string>
-    <string name="native_6930c8d1fc4f01d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"重新命名對話串"</string>
+    <string name="native_6930c8d1fc4f01d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"重新命名討論串"</string>
     <string name="native_69384c1c4d99f6eb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"解析結果不明。在驗證 Gateway 記錄之前，操作將維持停用。"</string>
     <string name="native_6940189433657105" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"dialog"</string>
     <string name="native_695c03727ff0251f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"聆聽喚醒詞"</string>
@@ -668,7 +653,6 @@
     <string name="native_6d5d9004797377e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"授權"</string>
     <string name="native_6d7c95a353d873cd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"連線至 Gateway 以搜尋 ClawHub Skills。"</string>
     <string name="native_6df1bb18a59ab97d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skill"</string>
-    <string name="native_6e0a0b9d8c5ee4d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"裝置 ID"</string>
     <string name="native_6e117ba97cbfb6f0" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 未識別作用中的 %1$s 供應商"</string>
     <string name="native_6e293a8c009e0011" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"等待中"</string>
     <string name="native_6e2c0963d056e104" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已儲存喚醒詞"</string>
@@ -798,7 +782,7 @@
     <string name="native_82990a093599a9bb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 個已套用"</string>
     <string name="native_8340dad4f3be30a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"尚無夢境日記。"</string>
     <string name="native_837e39f46163ffb4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"重新整理背景任務"</string>
-    <string name="native_838337fd9ab30454" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"摘要最近的對話串和後續步驟。"</string>
+    <string name="native_838337fd9ab30454" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"摘要最近的討論串和後續步驟。"</string>
     <string name="native_83e2faed20a3cda4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"當 OpenClaw 顯示於畫面時，會在裝置上執行。"</string>
     <string name="native_844e5b02f3ef05ca" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 正在運作"</string>
     <string name="native_846c75dca0b71591" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
@@ -845,7 +829,6 @@
     <string name="native_8bb7ec15b1e350a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"檢查中"</string>
     <string name="native_8bf253a125f66985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"掃描或貼上設定代碼以新增另一個 gateway。"</string>
     <string name="native_8c4a3896e8f06d27" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"TLS 逾時"</string>
-    <string name="native_8c55387fb6c584c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已移除配對裝置。"</string>
     <string name="native_8c93c68056cde54d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 已配對。正在檢查節點功能核准狀態。"</string>
     <string name="native_8ca344247c18317e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"動態"</string>
     <string name="native_8cac4b77b9c54695" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"cron 操作失敗。"</string>
@@ -958,7 +941,7 @@
     <string name="native_9e37aa0704a3cf44" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已安裝 %1$s。"</string>
     <string name="native_9e4635769f0aaf0d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateways"</string>
     <string name="native_9e9bef85bb320b81" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"轉發模式"</string>
-    <string name="native_9f6e180ff696bec5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"切換對話串版面配置"</string>
+    <string name="native_9f6e180ff696bec5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"切換討論串版面配置"</string>
     <string name="native_9fb7c4ebcbc3e558" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"沒有 TLS 端點"</string>
     <string name="native_9fe101a0ec7ef416" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw Gateway"</string>
     <string name="native_9ffc843f501acdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"手動設定"</string>
@@ -1006,7 +989,7 @@
     <string name="native_a89bac8b89022bde" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在聆聽 · %1$s 則已排入佇列"</string>
     <string name="native_a8bbbd7231a6c191" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"助理語音已靜音"</string>
     <string name="native_a8ef5cdf31a6505a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"尚未找到任何 Gateway。若探索功能遭封鎖，請使用手動設定。"</string>
-    <string name="native_a901aa25b833cf33" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"開啟對話串"</string>
+    <string name="native_a901aa25b833cf33" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"開啟討論串"</string>
     <string name="native_a92f0449a9f7235b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"處理中"</string>
     <string name="native_a9624cf0b6ae80c1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"開始說話..."</string>
     <string name="native_a9ac253267d07365" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"手機節點"</string>
@@ -1038,9 +1021,10 @@
     <string name="native_ad1c341c65f84ede" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在 Gateway 電腦上執行 approve 命令，然後再次檢查。"</string>
     <string name="native_ad1fb9ec0cb3c7a4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自動化"</string>
     <string name="native_adb7eb8a03ad699c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 分鐘"</string>
+    <string name="native_adca3171c270301a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此 Gateway 登入工作階段可以列出已連線的節點，但無法核准新手機配對。請從 Gateway 管理員工作階段配對新手機。節點功能核准是獨立程序，仍需使用 nodes approve &lt;request id&gt;。"</string>
     <string name="native_ade9248e0132b411" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"信任"</string>
     <string name="native_ae27fa789a03c1db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"該 QR code 不是 OpenClaw 設定用 QR。請使用 openclaw qr 產生新的代碼，然後再試一次。"</string>
-    <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"偏好的麥克風無法使用；目前使用自動路由。"</string>
+    <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"偏好的麥克風無法使用；正在使用自動路由。"</string>
     <string name="native_aea4a04a80426ed8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已拒絕"</string>
     <string name="native_aed306fbb63c0c68" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"包含 Android 和背景套件。"</string>
     <string name="native_aedf1cf58372f943" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"您的 Gateway 已準備就緒。"</string>
@@ -1107,7 +1091,6 @@
     <string name="native_bb4f2558e4333834" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"小工具圖片已儲存至「下載」"</string>
     <string name="native_bbe5fc3b9ef39f99" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在啟動…"</string>
     <string name="native_bc19cec293228fb8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"用戶端錯誤"</string>
-    <string name="native_bc1c94a6dfce1058" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"授予存取權前，請先驗證提出要求的裝置。"</string>
     <string name="native_bc6618670f3e8a17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bluetooth LE 麥克風"</string>
     <string name="native_bcb06651437caa15" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
     <string name="native_bd08450d63406844" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自動化已啟用。"</string>
@@ -1116,7 +1099,6 @@
     <string name="native_bdc090ec61e3fcfc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"重新載入"</string>
     <string name="native_bdff71b20b9cf392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"搜尋自動化"</string>
     <string name="native_be969becb173e0c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"配對後，已連結的手機和節點主機會顯示在這裡。"</string>
-    <string name="native_bf1870ff5c6322fb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s：%2$s"</string>
     <string name="native_bf350e6a0ed60b7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此自動化已在 Gateway 上變更。再次儲存前，請先檢閱最新版本。"</string>
     <string name="native_bf399ffa03617a96" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"停止聽寫"</string>
     <string name="native_bf56ee2fe3345ce1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"易於閱讀"</string>
@@ -1134,13 +1116,12 @@
     <string name="native_c12a06263b75eb23" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"連接 Gateway 以載入 Skill 詳細資料。"</string>
     <string name="native_c156b9eaf502aabc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"喚醒詞偵聽器"</string>
     <string name="native_c184b2ada7abc688" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"展開連結預覽"</string>
-    <string name="native_c18ee03d3906a488" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"清除對話串搜尋"</string>
+    <string name="native_c18ee03d3906a488" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"清除討論串搜尋"</string>
     <string name="native_c1970bb2cdf299b7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"NULL（失敗）"</string>
     <string name="native_c1c1009d3f37ec05" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"更新"</string>
     <string name="native_c1c224b03cd9bc7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"管理"</string>
     <string name="native_c1ebc7817870e5be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"需要注意"</string>
     <string name="native_c22d5e02fbec7d65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"將此裝置與您的 Gateway 配對，僅在有實際工作時喚醒裝置、隨時掌握代理程式即時概況，並避免耗電的背景循環。"</string>
-    <string name="native_c25337055464f8d3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"角色"</string>
     <string name="native_c253f451bdd56431" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"回覆"</string>
     <string name="native_c26225b6c16a4bc7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"供應商目錄"</string>
     <string name="native_c272b225cf5bd643" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在「設定」中啟用權限"</string>
@@ -1154,7 +1135,6 @@
     <string name="native_c34dd5eb8b0af56e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"如何取得設定代碼？"</string>
     <string name="native_c3546b39ecbbed8a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"無法啟用技能。"</string>
     <string name="native_c35b21d6ca39aa7c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"pdf"</string>
-    <string name="native_c3812fc4acb861d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"移除"</string>
     <string name="native_c382566dbe2ea49f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s%% 在線"</string>
     <string name="native_c385951198c45d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"沒有頻道"</string>
     <string name="native_c41ad84496b53420" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"即時語音"</string>
@@ -1183,7 +1163,6 @@
     <string name="native_c6d5ed757b66bfd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"夢境"</string>
     <string name="native_c6dd061350fc69b8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"未封鎖任何應用程式。除非您新增封鎖規則，否則應用程式可以轉送。"</string>
     <string name="native_c753cdf0c19f1e38" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"語音辨識器無法使用"</string>
-    <string name="native_c78ffe19571018fb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"平台"</string>
     <string name="native_c7985fa72daa6ea4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 未傳回 %1$s 設定"</string>
     <string name="native_c7b6dfd5c3a183c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"忘記 Gateway？"</string>
     <string name="native_c7b7b7f01360f6a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"選填描述"</string>
@@ -1205,14 +1184,14 @@
     <string name="native_ca7981b46ecf2c17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"關閉"</string>
     <string name="native_cab94aba84f97f7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"字體排印"</string>
     <string name="native_cae7d57bc067a514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"停止"</string>
-    <string name="native_cae98462b30650eb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"尚無相符的對話串。"</string>
+    <string name="native_cae98462b30650eb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"目前沒有相符的討論串。"</string>
     <string name="native_cba62d81f910c7f0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 配對成功。\n請從操作員 UI 核准此手機的節點功能。"</string>
     <string name="native_cc4b66e7e22230c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此技能已安裝，但目前不符合執行條件。請使用桌面版或 CLI 變更設定。"</string>
     <string name="native_cc5f45fb30a26e07" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"辨識器忙碌中"</string>
     <string name="native_cc721e25d73938a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"住家 Gateway"</string>
     <string name="native_cc7a9a5cf8c4bc9d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在 Gateway 上執行核准命令"</string>
     <string name="native_cc925e3c97ac7a35" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"無法載入 Skill Workshop 提案。"</string>
-    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"整理我最近的 OpenClaw 對話串，並建議後續步驟。"</string>
+    <string name="native_ccb452b3c43f6862" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"讓我掌握最近的 OpenClaw 討論串，並建議後續步驟。"</string>
     <string name="native_ccb4c324f516c633" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"暫時不要"</string>
     <string name="native_cced0b0d83a9e400" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"openclaw qr"</string>
     <string name="native_cced28c6dc3f99c2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"start"</string>
@@ -1235,7 +1214,7 @@
     <string name="native_ceb6931ea57cc999" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自適應"</string>
     <string name="native_cf0ee3547a4e51a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"即將"</string>
     <string name="native_d04fc7d7e19702f8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Search"</string>
-    <string name="native_d053ba98d8bbcec1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"試試聊天、語音、對話串、供應商或設定。"</string>
+    <string name="native_d053ba98d8bbcec1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"試試聊天、語音、討論串、提供者或設定。"</string>
     <string name="native_d056177742e27cf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 主動"</string>
     <string name="native_d0cda6559bb347db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"navigate"</string>
     <string name="native_d0d0de0039c7990b" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"於 %1$s 要求"</string>
@@ -1246,7 +1225,6 @@
     <string name="native_d17d2d78d76e6a6c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"模型"</string>
     <string name="native_d19c2dd2fb598b93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 被動"</string>
     <string name="native_d1a574e23344c407" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 密碼無效"</string>
-    <string name="native_d1af697abaff485f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"無法驗證裝置配對變更。請重新整理後再試一次。"</string>
     <string name="native_d1bf045bb524dae5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"檢視詳細資料"</string>
     <string name="native_d1e9567da9a8a4b0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bash"</string>
     <string name="native_d2089be672953d11" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"權杖"</string>
@@ -1261,7 +1239,6 @@
     <string name="native_d31de1a5c5c8ba2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"瀏覽器"</string>
     <string name="native_d354ee936f59115e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screen record"</string>
     <string name="native_d3974fd6d3b6c81f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"執行待處理項目"</string>
-    <string name="native_d3e1c5f8a6e240fc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"來源"</string>
     <string name="native_d3f75e24411053c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"您裝置上的個人 AI"</string>
     <string name="native_d406ade2958cb5b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attach"</string>
     <string name="native_d461a493a3753877" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自動"</string>
@@ -1277,7 +1254,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"個人資料"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"當您的 Gateway 回報提供者限制時，會顯示在這裡。"</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 個問題"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"「%1$s」中的討論串會被保留並移回「未分組」。"</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"建立時間"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s 個有效權杖"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>
@@ -1294,7 +1271,7 @@
     <string name="native_d93e2b7a15efbc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"無法處理核准。請重新整理後再試一次。"</string>
     <string name="native_d942f64886578d87" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"import"</string>
     <string name="native_d94cfb21b67ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"這部手機在 OpenClaw 中的顯示方式。"</string>
-    <string name="native_d96f2b0eab4e67b7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"聚焦對話串搜尋"</string>
+    <string name="native_d96f2b0eab4e67b7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"聚焦討論串搜尋"</string>
     <string name="native_d975ca28a64f8850" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"連接 Gateway"</string>
     <string name="native_d9be42d9b30ce057" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"讀取行事曆"</string>
     <string name="native_d9f641e1a02807cb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"重新連線及開啟此畫面時，概覽會重新整理。"</string>
@@ -1340,7 +1317,7 @@
     <string name="native_e06f5f8456a05351" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"搜尋已安裝的 Skills"</string>
     <string name="native_e0723a86a5b9408a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"檢查"</string>
     <string name="native_e083bd83e9d3e97e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Process"</string>
-    <string name="native_e08a8fc53e29e5c9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"最近的對話串"</string>
+    <string name="native_e08a8fc53e29e5c9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"最近的討論串"</string>
     <string name="native_e0926fdac700b094" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"終端機"</string>
     <string name="native_e0d1b68224bf0b31" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"目前"</string>
     <string name="native_e10435f6306b06d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 個帳號"</string>
@@ -1450,7 +1427,6 @@
     <string name="native_f2da2e47cd31a5dd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"無法解碼此圖片。"</string>
     <string name="native_f3753c0fe29b88db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway、語音、通知、隱私權"</string>
     <string name="native_f386c32c1bf437d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"代理程式工作區檔案"</string>
-    <string name="native_f418bf0894a1806a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此裝置將失去受信任的 Gateway 存取權。"</string>
     <string name="native_f41d9e8b7e09aa24" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在 approve 命令中使用待處理命令的 requestId。"</string>
     <string name="native_f4830a1dae298044" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"排程"</string>
     <string name="native_f493f0ce7a52a8aa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"速率限制"</string>
@@ -1458,9 +1434,8 @@
     <string name="native_f4cc820d308495c4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"承載內容 · %1$s"</string>
     <string name="native_f4ccae29e1bb0c20" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"執行中"</string>
     <string name="native_f4db1e48476f6075" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"結束"</string>
-    <string name="native_f4e2076014711222" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"使用系統信任設定"</string>
     <string name="native_f4ef7a41caa88dd1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"沒有已就緒的提供者"</string>
-    <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"優先使用已連線的 Bluetooth 麥克風。"</string>
+    <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"優先使用已連線的藍牙麥克風。"</string>
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已封鎖 %1$s 個應用程式進行轉送。"</string>
     <string name="native_f532ee1f7288365e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"訊息動作"</string>
     <string name="native_f5387f9bb6ed7031" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"類型"</string>
@@ -1486,7 +1461,7 @@
     <string name="native_f8b32f4e92bd84ce" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已安裝"</string>
     <string name="native_f8c2745155505d39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"等待回覆逾時；請重試或重新整理。"</string>
     <string name="native_f8cd133f0ea1031b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"尋找先前的對話"</string>
-    <string name="native_f90f3791049b995d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"瀏覽對話串"</string>
+    <string name="native_f90f3791049b995d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"瀏覽討論串"</string>
     <string name="native_f92e2ad582c0e13f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在重新整理"</string>
     <string name="native_f991ae9cb081e1f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"開啟相機並對準 openclaw qr 的代碼。"</string>
     <string name="native_f9ea3f1540eaa584" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"沒有裝置"</string>
@@ -1521,8 +1496,8 @@
     <string name="native_ff52188203241c29" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"尚未設定 Gateway 密碼"</string>
     <string name="native_ff716fc4735e067f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"聽寫設定"</string>
     <string name="native_ff9dbbdfb84ddab2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已載入供應商模型，但無法取得就緒狀態。"</string>
-    <string name="native_ffa7aa557b547a79" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"要刪除對話串嗎？"</string>
-    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 將此手機化為簡潔的行動指令介面，可管理對話串、語音、供應商和 Gateway。"</string>
+    <string name="native_ffa7aa557b547a79" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"要刪除討論串嗎？"</string>
+    <string name="native_ffaed354e7fe5514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 將這支手機化為簡潔的行動指令介面，用於討論串、語音、提供者和 Gateway。"</string>
     <string name="native_ffb6f5764bddb68c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"最新優先"</string>
     <string name="native_ffcf16006c652ee3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"下一個週期"</string>
 </resources>

--- a/apps/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/apps/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -494,7 +494,7 @@
     <string name="native_52bfe584a5fc4505" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"傳送"</string>
     <string name="native_52d200a2d9f278ad" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"將喇叭靜音"</string>
     <string name="native_52dd413279b26d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在開啟 Gateway 連線"</string>
-    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"監控中 · %1$s 個對話串"</string>
+    <string name="native_52fbec07af8ae846" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Monitoring · %1$s threads"</string>
     <string name="native_5309fee1f35f049b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自動化執行完畢。"</string>
     <string name="native_531b2fa39f9fad36" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"沒有相符的 App。"</string>
     <string name="native_531f83e5eedcd348" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"傳送至聊天"</string>
@@ -1277,7 +1277,7 @@
     <string name="native_d696a35bdd1883da" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"個人資料"</string>
     <string name="native_d6a99dbee26515ff" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"當您的 Gateway 回報提供者限制時，會顯示在這裡。"</string>
     <string name="native_d6bfda034106ecd6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 個問題"</string>
-    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"「%1$s」中的對話串會保留並移回「未分組」。"</string>
+    <string name="native_d6f931ca6d5f5b60" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Threads in \"%1$s\" are kept and move back to Ungrouped."</string>
     <string name="native_d70b9e24bca26b40" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"建立時間"</string>
     <string name="native_d729f71dabe85839" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s 個有效權杖"</string>
     <string name="native_d799abd9fa4df2a7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s…"</string>

--- a/apps/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/apps/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -75,6 +75,7 @@
     <string name="native_0929c9dc7f794852" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"沒有提案"</string>
     <string name="native_096ea9b3665fb503" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"主要討論串"</string>
     <string name="native_0979c6fdbdca1675" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"開啟聊天"</string>
+    <string name="native_09ce95090659d069" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此 Gateway 工作階段無法使用裝置配對操作。請在 Gateway 主機上執行 openclaw devices list，並在該處管理請求。節點功能核准是獨立的，仍需使用 nodes approve &lt;request id&gt;。"</string>
     <string name="native_0a0b7cf7c428c703" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"動作請求"</string>
     <string name="native_0a708e7b03aaf1fa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"list pins"</string>
     <string name="native_0ab0e1629576aecf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"連線至 Gateway 以載入 Skill Workshop 提案。"</string>
@@ -87,10 +88,12 @@
     <string name="native_0c3845dcd2f0f683" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"檢查此提案以載入其 Markdown。"</string>
     <string name="native_0c3ea4e2f12153e7" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"開啟 OpenClaw 並詢問 %1$s"</string>
     <string name="native_0c4d01e81bb3d1fd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"推理"</string>
+    <string name="native_0c77fe09ab336a3e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"用戶端"</string>
     <string name="native_0c79a9c222840ed0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已套用"</string>
     <string name="native_0cab1c9617404faf" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"影片"</string>
     <string name="native_0cf04463c4276a62" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已推廣"</string>
     <string name="native_0d21bd52022ca7f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"線上"</string>
+    <string name="native_0d5644ff52ce2ba3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"範圍"</string>
     <string name="native_0d5efd432e4fedf5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"尚未設定即時語音服務供應商。"</string>
     <string name="native_0d8ca811c3744a6d" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s · %2$s"</string>
     <string name="native_0db10f2c2f332cd2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"kick"</string>
@@ -138,6 +141,7 @@
     <string name="native_16524d7409d37507" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"工作階段目標"</string>
     <string name="native_1669ad8d6f188594" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"檢閱 ClawHub Skill"</string>
     <string name="native_16a0eeb0791b6c92" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"snapshot"</string>
+    <string name="native_16a5b7ad567a8093" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"要拒絕此裝置的配對要求嗎？"</string>
     <string name="native_16b1a05e1d987ed1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"偏好的麥克風"</string>
     <string name="native_170421cc4a4c2f30" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"節點主機"</string>
     <string name="native_1709305c9fa966d1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"層級"</string>
@@ -183,6 +187,7 @@
     <string name="native_1d91629837639a5c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此自動化在您編輯期間已變更。儲存前，請還原為 Gateway 上的最新版本。"</string>
     <string name="native_1dbf9d5979606697" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"連線後，Gateway 可透過靜默推播喚醒手機，而不必維持永遠開啟的工作階段。"</string>
     <string name="native_1e432ea5425e4a3a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"喚醒模式"</string>
+    <string name="native_1e595a107c78b957" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"要移除配對裝置嗎？"</string>
     <string name="native_1e955a58278623a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"系統事件文字"</string>
     <string name="native_1ea44149be42d970" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"無法複製小工具圖片"</string>
     <string name="native_1ea442a134b2a184" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"否"</string>
@@ -197,6 +202,7 @@
     <string name="native_2065cc867eba1b39" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"無法載入供應商模型設定。"</string>
     <string name="native_207ccb22d618db05" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"允許 %1$s 個應用程式轉送。"</string>
     <string name="native_209b9e597963e7e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"語音設定"</string>
+    <string name="native_211988ba9dd0570a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"要拒絕配對要求嗎？"</string>
     <string name="native_2132066dc9475cb7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"This skill is installed but not available to the current agent. Agent filters stay on desktop or CLI."</string>
     <string name="native_21378545892f1fe2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"發布者"</string>
     <string name="native_214d4932fc767e8f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">" · 對話：正在說話"</string>
@@ -238,6 +244,7 @@
     <string name="native_2682bd813a3bccbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"輸入來自 openclaw qr 的設定代碼。"</string>
     <string name="native_268f14bbfe119c1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"診斷"</string>
     <string name="native_26d00d15c465cd73" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"這會永久刪除此對話串及其文字記錄。"</string>
+    <string name="native_26e47d73a55d7fa7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"裝置已核准。"</string>
     <string name="native_26f0dd993530eb2d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在自動重試"</string>
     <string name="native_270ff82f36da987f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已複製小工具圖片"</string>
     <string name="native_2728740a95d465c6" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 個角色"</string>
@@ -346,6 +353,7 @@
     <string name="native_381428f5f251a764" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Conversation Send"</string>
     <string name="native_3824a9f4dafe92c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"畫布"</string>
     <string name="native_384ae4ab1a2830f9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"1 個提供者"</string>
+    <string name="native_385001409de8562a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"無法自動讀取 Gateway 憑證。請貼上從 Gateway 主機取得的 SHA-256 指紋。"</string>
     <string name="native_387b2569e440838c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"傳送失敗：%1$s"</string>
     <string name="native_3892e10346fd2012" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"橋接"</string>
     <string name="native_38d198cd5303680f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"傳送錯誤"</string>
@@ -403,6 +411,7 @@
     <string name="native_429f6057535c1ea3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Sub-agent"</string>
     <string name="native_42e3a99c21767def" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在等待裝置核准"</string>
     <string name="native_430798d3e8250938" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在載入討論串"</string>
+    <string name="native_430df68ec29a85a2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此 Gateway 現在提供的憑證已受此裝置信任。"</string>
     <string name="native_43905968a540af6a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"錯開毫秒數"</string>
     <string name="native_43988c156beabf7d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"event create"</string>
     <string name="native_43cc23fa52b87b4c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"文件"</string>
@@ -464,6 +473,7 @@
     <string name="native_4e8c72cab82e0711" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自動化的設定無效。"</string>
     <string name="native_4ec30e9d85725d41" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"允許清單"</string>
     <string name="native_4ed379d418bb8629" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"groups"</string>
+    <string name="native_4ee252fb736effa2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"公開金鑰"</string>
     <string name="native_4efca0d10c5feb8e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"關於"</string>
     <string name="native_4f1bc100d1dccc1e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在該圖片中找不到設定用 QR code。請選擇 openclaw qr 所產生的 QR，或手動輸入設定代碼。"</string>
     <string name="native_4fe3cdd404ea0290" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"permissions"</string>
@@ -550,6 +560,7 @@
     <string name="native_5c0c8c9aa658f4a0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OPENCLAW"</string>
     <string name="native_5c1acea9c9b0e704" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Web Fetch"</string>
     <string name="native_5c39123805ffb4e2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"提示詞"</string>
+    <string name="native_5c944156b5353428" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"要核准裝置嗎？"</string>
     <string name="native_5d410adb9576e266" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"要從此手機移除 %1$s 及其已儲存的認證嗎？"</string>
     <string name="native_5d6c41a67139ee26" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"QR code 指向不安全的遠端 Gateway。%1$s %2$s"</string>
     <string name="native_5d6cbac59f87e78d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"螢幕介面已就緒"</string>
@@ -567,6 +578,7 @@
     <string name="native_5fa1d457ddfcd26c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"rename group"</string>
     <string name="native_5fa7aac5375c5815" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"就緒"</string>
     <string name="native_5fc1927ca948f31c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"日記正在等待第一筆項目。"</string>
+    <string name="native_6007acbe30b2cd98" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"核准"</string>
     <string name="native_600c9c27960112a6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"即時頁面"</string>
     <string name="native_6030d1f6340776d2" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自動化已在執行中。"</string>
     <string name="native_604e6d6faf8d0295" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此單次自動化成功執行後將其移除。"</string>
@@ -606,12 +618,14 @@
     <string name="native_6657cc73af00feac" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在要求時允許使用相機工具。"</string>
     <string name="native_666067dd376e5d45" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"問題"</string>
     <string name="native_666c8bc0319f3b54" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"語音喚醒"</string>
+    <string name="native_66713d713e3a41c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"配對要求已拒絕。"</string>
     <string name="native_66b23bae66fc0d79" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 天前"</string>
     <string name="native_66cf5513b37462be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"roles"</string>
     <string name="native_66d0f523a379b2de" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skills"</string>
     <string name="native_66f4804ee23ddc09" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"封存"</string>
     <string name="native_66fab2875ee427f3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"節點離線。請重新連線後再試一次。"</string>
     <string name="native_6725e7bbcd28f3a8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"系統"</string>
+    <string name="native_672f3453e1dd571b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"遠端 IP"</string>
     <string name="native_674b38cae72bb0c8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"未分組"</string>
     <string name="native_674eb55d9c353900" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"排程詳細資料"</string>
     <string name="native_67528858c36397f7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"手機功能"</string>
@@ -619,6 +633,7 @@
     <string name="native_67b696468610b879" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Dashboard"</string>
     <string name="native_67fa416afa64d304" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"貼上 token"</string>
     <string name="native_6827238fea72c88b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"沒有提供者"</string>
+    <string name="native_684889f0079cc145" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"SHA-256 指紋"</string>
     <string name="native_68944e10a8b4b9be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"尚無對話串"</string>
     <string name="native_68a0cdfcc76d6ebd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"藍牙麥克風"</string>
     <string name="native_690dbe9dc0993c42" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"最近"</string>
@@ -653,6 +668,7 @@
     <string name="native_6d5d9004797377e1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"授權"</string>
     <string name="native_6d7c95a353d873cd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"連線至 Gateway 以搜尋 ClawHub Skills。"</string>
     <string name="native_6df1bb18a59ab97d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skill"</string>
+    <string name="native_6e0a0b9d8c5ee4d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"裝置 ID"</string>
     <string name="native_6e117ba97cbfb6f0" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 未識別作用中的 %1$s 供應商"</string>
     <string name="native_6e293a8c009e0011" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"等待中"</string>
     <string name="native_6e2c0963d056e104" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已儲存喚醒詞"</string>
@@ -829,6 +845,7 @@
     <string name="native_8bb7ec15b1e350a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"檢查中"</string>
     <string name="native_8bf253a125f66985" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"掃描或貼上設定代碼以新增另一個 gateway。"</string>
     <string name="native_8c4a3896e8f06d27" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"TLS 逾時"</string>
+    <string name="native_8c55387fb6c584c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已移除配對裝置。"</string>
     <string name="native_8c93c68056cde54d" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 已配對。正在檢查節點功能核准狀態。"</string>
     <string name="native_8ca344247c18317e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"動態"</string>
     <string name="native_8cac4b77b9c54695" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"cron 操作失敗。"</string>
@@ -1021,7 +1038,6 @@
     <string name="native_ad1c341c65f84ede" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在 Gateway 電腦上執行 approve 命令，然後再次檢查。"</string>
     <string name="native_ad1fb9ec0cb3c7a4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自動化"</string>
     <string name="native_adb7eb8a03ad699c" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s 分鐘"</string>
-    <string name="native_adca3171c270301a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此 Gateway 登入工作階段可以列出已連線的節點，但無法核准新手機配對。請從 Gateway 管理員工作階段配對新手機。節點功能核准是獨立程序，仍需使用 nodes approve &lt;request id&gt;。"</string>
     <string name="native_ade9248e0132b411" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"信任"</string>
     <string name="native_ae27fa789a03c1db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"該 QR code 不是 OpenClaw 設定用 QR。請使用 openclaw qr 產生新的代碼，然後再試一次。"</string>
     <string name="native_ae38b50b9a3a0a2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"偏好的麥克風無法使用；正在使用自動路由。"</string>
@@ -1091,6 +1107,7 @@
     <string name="native_bb4f2558e4333834" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"小工具圖片已儲存至「下載」"</string>
     <string name="native_bbe5fc3b9ef39f99" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"正在啟動…"</string>
     <string name="native_bc19cec293228fb8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"用戶端錯誤"</string>
+    <string name="native_bc1c94a6dfce1058" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"授予存取權前，請先驗證提出要求的裝置。"</string>
     <string name="native_bc6618670f3e8a17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bluetooth LE 麥克風"</string>
     <string name="native_bcb06651437caa15" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s %2$s"</string>
     <string name="native_bd08450d63406844" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自動化已啟用。"</string>
@@ -1099,6 +1116,7 @@
     <string name="native_bdc090ec61e3fcfc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"重新載入"</string>
     <string name="native_bdff71b20b9cf392" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"搜尋自動化"</string>
     <string name="native_be969becb173e0c5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"配對後，已連結的手機和節點主機會顯示在這裡。"</string>
+    <string name="native_bf1870ff5c6322fb" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s：%2$s"</string>
     <string name="native_bf350e6a0ed60b7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此自動化已在 Gateway 上變更。再次儲存前，請先檢閱最新版本。"</string>
     <string name="native_bf399ffa03617a96" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"停止聽寫"</string>
     <string name="native_bf56ee2fe3345ce1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"易於閱讀"</string>
@@ -1122,6 +1140,7 @@
     <string name="native_c1c224b03cd9bc7b" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"管理"</string>
     <string name="native_c1ebc7817870e5be" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"需要注意"</string>
     <string name="native_c22d5e02fbec7d65" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"將此裝置與您的 Gateway 配對，僅在有實際工作時喚醒裝置、隨時掌握代理程式即時概況，並避免耗電的背景循環。"</string>
+    <string name="native_c25337055464f8d3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"角色"</string>
     <string name="native_c253f451bdd56431" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"回覆"</string>
     <string name="native_c26225b6c16a4bc7" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"供應商目錄"</string>
     <string name="native_c272b225cf5bd643" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在「設定」中啟用權限"</string>
@@ -1135,6 +1154,7 @@
     <string name="native_c34dd5eb8b0af56e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"如何取得設定代碼？"</string>
     <string name="native_c3546b39ecbbed8a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"無法啟用技能。"</string>
     <string name="native_c35b21d6ca39aa7c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"pdf"</string>
+    <string name="native_c3812fc4acb861d5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"移除"</string>
     <string name="native_c382566dbe2ea49f" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s%% 在線"</string>
     <string name="native_c385951198c45d9c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"沒有頻道"</string>
     <string name="native_c41ad84496b53420" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"即時語音"</string>
@@ -1163,6 +1183,7 @@
     <string name="native_c6d5ed757b66bfd3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"夢境"</string>
     <string name="native_c6dd061350fc69b8" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"未封鎖任何應用程式。除非您新增封鎖規則，否則應用程式可以轉送。"</string>
     <string name="native_c753cdf0c19f1e38" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"語音辨識器無法使用"</string>
+    <string name="native_c78ffe19571018fb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"平台"</string>
     <string name="native_c7985fa72daa6ea4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 未傳回 %1$s 設定"</string>
     <string name="native_c7b6dfd5c3a183c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"忘記 Gateway？"</string>
     <string name="native_c7b7b7f01360f6a5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"選填描述"</string>
@@ -1225,6 +1246,7 @@
     <string name="native_d17d2d78d76e6a6c" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"模型"</string>
     <string name="native_d19c2dd2fb598b93" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"OpenClaw 被動"</string>
     <string name="native_d1a574e23344c407" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway 密碼無效"</string>
+    <string name="native_d1af697abaff485f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"無法驗證裝置配對變更。請重新整理後再試一次。"</string>
     <string name="native_d1bf045bb524dae5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"檢視詳細資料"</string>
     <string name="native_d1e9567da9a8a4b0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Bash"</string>
     <string name="native_d2089be672953d11" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"權杖"</string>
@@ -1239,6 +1261,7 @@
     <string name="native_d31de1a5c5c8ba2a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"瀏覽器"</string>
     <string name="native_d354ee936f59115e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screen record"</string>
     <string name="native_d3974fd6d3b6c81f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"執行待處理項目"</string>
+    <string name="native_d3e1c5f8a6e240fc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"來源"</string>
     <string name="native_d3f75e24411053c4" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"您裝置上的個人 AI"</string>
     <string name="native_d406ade2958cb5b6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Attach"</string>
     <string name="native_d461a493a3753877" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"自動"</string>
@@ -1427,6 +1450,7 @@
     <string name="native_f2da2e47cd31a5dd" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"無法解碼此圖片。"</string>
     <string name="native_f3753c0fe29b88db" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Gateway、語音、通知、隱私權"</string>
     <string name="native_f386c32c1bf437d9" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"代理程式工作區檔案"</string>
+    <string name="native_f418bf0894a1806a" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"此裝置將失去受信任的 Gateway 存取權。"</string>
     <string name="native_f41d9e8b7e09aa24" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"在 approve 命令中使用待處理命令的 requestId。"</string>
     <string name="native_f4830a1dae298044" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"排程"</string>
     <string name="native_f493f0ce7a52a8aa" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"速率限制"</string>
@@ -1434,6 +1458,7 @@
     <string name="native_f4cc820d308495c4" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"承載內容 · %1$s"</string>
     <string name="native_f4ccae29e1bb0c20" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"執行中"</string>
     <string name="native_f4db1e48476f6075" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"結束"</string>
+    <string name="native_f4e2076014711222" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"使用系統信任設定"</string>
     <string name="native_f4ef7a41caa88dd1" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"沒有已就緒的提供者"</string>
     <string name="native_f503d14f0c32a9c0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"優先使用已連線的藍牙麥克風。"</string>
     <string name="native_f5171b47ebca6202" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"已封鎖 %1$s 個應用程式進行轉送。"</string>

--- a/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
+++ b/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
@@ -69,11 +69,7 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
     }
 
     func acquireSessionSettingsRouteLease() async -> OpenClawChatSessionSettingsRouteLease? {
-        let route: GatewayNodeSessionRoute? = if let outboxGatewayID {
-            await self.gateway.currentRoute(ifGatewayID: outboxGatewayID)
-        } else {
-            await self.gateway.currentRoute()
-        }
+        let route = await self.currentSessionMutationRoute()
         guard let route else { return nil }
         let transport = self
         return OpenClawChatSessionSettingsRouteLease { sessionKey, agentID, patch in
@@ -83,6 +79,78 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
                 patch: patch,
                 ifCurrentRoute: route)
         }
+    }
+
+    func acquireSessionMutationRouteLease() async -> OpenClawChatSessionMutationRouteLease? {
+        guard let route = await self.currentSessionMutationRoute() else { return nil }
+        let transport = self
+        return OpenClawChatSessionMutationRouteLease(
+            patchSession: { key, label, category, pinned, archived, unread in
+                let target = transport.sessionTarget(for: key)
+                let request = OpenClawChatGatewayRequests.patchSession(
+                    sessionKey: target.sessionKey,
+                    agentID: target.agentID,
+                    label: label,
+                    category: category,
+                    pinned: pinned,
+                    archived: archived,
+                    unread: unread)
+                _ = try await transport.requestSessionMutation(request, ifCurrentRoute: route)
+            },
+            deleteSession: { key in
+                let target = transport.sessionTarget(for: key)
+                let request = OpenClawChatGatewayRequests.deleteSession(
+                    sessionKey: target.sessionKey,
+                    agentID: target.agentID)
+                _ = try await transport.requestSessionMutation(request, ifCurrentRoute: route)
+            })
+    }
+
+    func acquireSessionGroupsRouteLease() async -> OpenClawChatSessionGroupsRouteLease? {
+        guard let route = await self.currentSessionMutationRoute() else { return nil }
+        let transport = self
+        return Self.makeSessionGroupsRouteLease { request in
+            try await transport.requestSessionMutation(request, ifCurrentRoute: route)
+        }
+    }
+
+    func acquireNewSessionRouteLease() async -> OpenClawChatNewSessionRouteLease? {
+        guard let route = await self.currentSessionMutationRoute() else { return nil }
+        let transport = self
+        let request: @Sendable (OpenClawChatGatewayRequest) async throws -> Data = { request in
+            try await transport.requestSessionMutation(request, ifCurrentRoute: route)
+        }
+        return OpenClawChatNewSessionRouteLease(
+            listAgents: {
+                let data = try await request(OpenClawChatGatewayRequests.agentsList())
+                let result = try JSONDecoder().decode(AgentsListResult.self, from: data)
+                return OpenClawChatAgentsListResponse(
+                    defaultId: result.defaultid,
+                    agents: result.agents.map {
+                        OpenClawChatAgentChoice(
+                            id: $0.id,
+                            name: $0.name,
+                            workspaceGit: $0.workspacegit)
+                    })
+            },
+            createSession: { key, label, agentID, parentSessionKey, worktree, worktreeBaseRef in
+                let createRequest = transport.createSessionRequest(
+                    key: key,
+                    label: label,
+                    agentID: agentID,
+                    parentSessionKey: parentSessionKey,
+                    worktree: worktree,
+                    worktreeBaseRef: worktreeBaseRef)
+                let data = try await request(createRequest)
+                return try JSONDecoder().decode(OpenClawChatCreateSessionResponse.self, from: data)
+            })
+    }
+
+    private func currentSessionMutationRoute() async -> GatewayNodeSessionRoute? {
+        if let outboxGatewayID {
+            return await self.gateway.currentRoute(ifGatewayID: outboxGatewayID)
+        }
+        return await self.gateway.currentRoute()
     }
 
     private func sessionRoutingContract(
@@ -125,22 +193,95 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
         return try await self.gateway.request(request)
     }
 
+    private func requestSessionMutation(
+        _ request: OpenClawChatGatewayRequest,
+        ifCurrentRoute route: GatewayNodeSessionRoute) async throws -> Data
+    {
+        try await self.gateway.request(
+            request,
+            ifCurrentRoute: route,
+            distinguishPreDispatchRouteChange: true)
+    }
+
+    static func makeSessionGroupsRouteLease(
+        request: @escaping @Sendable (OpenClawChatGatewayRequest) async throws -> Data)
+        -> OpenClawChatSessionGroupsRouteLease
+    {
+        OpenClawChatSessionGroupsRouteLease(
+            listGroups: {
+                let data = try await request(OpenClawChatGatewayRequests.sessionGroupsList())
+                return try JSONDecoder().decode(OpenClawChatSessionGroupsResponse.self, from: data)
+            },
+            putGroups: { names in
+                let data = try await request(OpenClawChatGatewayRequests.sessionGroupsPut(names: names))
+                return try JSONDecoder().decode(OpenClawChatSessionGroupsMutationResponse.self, from: data)
+            },
+            renameGroup: { name, to in
+                let data = try await request(OpenClawChatGatewayRequests.sessionGroupsRename(name: name, to: to))
+                return try JSONDecoder().decode(OpenClawChatSessionGroupsMutationResponse.self, from: data)
+            },
+            deleteGroup: { name in
+                let data = try await request(OpenClawChatGatewayRequests.sessionGroupsDelete(name: name))
+                return try JSONDecoder().decode(OpenClawChatSessionGroupsMutationResponse.self, from: data)
+            })
+    }
+
     func createSession(
         key: String,
         label: String?,
         parentSessionKey: String?,
         worktree: Bool?) async throws -> OpenClawChatCreateSessionResponse
     {
-        let target = self.sessionTarget(for: key)
+        try await self.createSession(
+            key: key,
+            label: label,
+            agentID: nil,
+            parentSessionKey: parentSessionKey,
+            worktree: worktree,
+            worktreeBaseRef: nil)
+    }
+
+    func createSession(
+        key: String,
+        label: String?,
+        agentID: String?,
+        parentSessionKey: String?,
+        worktree: Bool?,
+        worktreeBaseRef: String?) async throws -> OpenClawChatCreateSessionResponse
+    {
+        let request = self.createSessionRequest(
+            key: key,
+            label: label,
+            agentID: agentID,
+            parentSessionKey: parentSessionKey,
+            worktree: worktree,
+            worktreeBaseRef: worktreeBaseRef)
+        let res = try await self.requestSessionMutation(request)
+        return try JSONDecoder().decode(OpenClawChatCreateSessionResponse.self, from: res)
+    }
+
+    private func createSessionRequest(
+        key: String,
+        label: String?,
+        agentID: String?,
+        parentSessionKey: String?,
+        worktree: Bool?,
+        worktreeBaseRef: String?) -> OpenClawChatGatewayRequest
+    {
+        let target = self.sessionTarget(for: key, overrideAgentID: agentID)
         let parentTarget = parentSessionKey.map { self.sessionTarget(for: $0) }
-        let request = OpenClawChatGatewayRequests.createSession(
+        let explicitAgentID = agentID?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        return OpenClawChatGatewayRequests.createSession(
             key: target.sessionKey,
-            agentID: target.agentID ?? parentTarget?.agentID,
+            agentID: explicitAgentID?.isEmpty == false
+                ? explicitAgentID
+                : target.agentID ?? parentTarget?.agentID,
             label: label,
             parentSessionKey: parentTarget?.sessionKey,
-            worktree: worktree)
-        let res = try await gateway.request(request)
-        return try JSONDecoder().decode(OpenClawChatCreateSessionResponse.self, from: res)
+            worktree: worktree,
+            worktreeBaseRef: worktreeBaseRef)
     }
 
     func abortRun(sessionKey: String, runId: String) async throws {
@@ -209,6 +350,7 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
             agentID: target.agentID,
             model: patch.model,
             thinkingLevel: patch.thinkingLevel,
+            fastMode: patch.fastMode,
             verboseLevel: patch.verboseLevel)
         let response = if let expectedRoute {
             try await self.gateway.request(

--- a/apps/ios/Sources/Design/ChatModelControlsMenu.swift
+++ b/apps/ios/Sources/Design/ChatModelControlsMenu.swift
@@ -1,0 +1,146 @@
+import Observation
+import OpenClawChatUI
+import SwiftUI
+
+@MainActor
+struct ChatModelControlsMenuItems: View {
+    @Bindable var viewModel: OpenClawChatViewModel
+
+    var body: some View {
+        if self.viewModel.showsModelPicker {
+            self.modelPicker
+        }
+        if self.viewModel.showsThinkingPicker {
+            self.thinkingPicker
+        }
+        if self.viewModel.selectedModelSupportsFastMode {
+            self.fastModePicker
+        }
+        self.verbosityPicker
+    }
+
+    private var modelPicker: some View {
+        let sections = self.viewModel.modelPickerSections
+        return Picker(selection: Binding(
+            get: { self.viewModel.modelSelectionID },
+            set: { self.viewModel.selectModel($0) }))
+        {
+            Text(self.viewModel.defaultModelLabel)
+                .font(OpenClawType.body)
+                .tag(OpenClawChatViewModel.defaultModelSelectionID)
+            if !sections.pinned.isEmpty {
+                Section("Pinned") {
+                    self.modelOptions(sections.pinned)
+                }
+            }
+            if !sections.recent.isEmpty {
+                Section("Recent") {
+                    self.modelOptions(sections.recent)
+                }
+            }
+            ForEach(sections.providers) { provider in
+                Section {
+                    self.modelOptions(provider.models)
+                } header: {
+                    HStack(spacing: 4) {
+                        Text(provider.displayName)
+                            .font(OpenClawType.body)
+                        if provider.isDefaultProvider {
+                            Text("Default")
+                                .font(OpenClawType.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+        } label: {
+            Text("Model")
+                .font(OpenClawType.body)
+        }
+        .disabled(self.viewModel.isUpdatingSessionSettings)
+    }
+
+    private var thinkingPicker: some View {
+        Picker(selection: Binding(
+            get: { self.viewModel.thinkingSelectionID },
+            set: { self.viewModel.selectThinkingLevel($0) }))
+        {
+            Text("Default (inherited)")
+                .font(OpenClawType.body)
+                .tag(OpenClawChatViewModel.inheritedThinkingSelectionID)
+            ForEach(self.viewModel.thinkingLevelOptions) { option in
+                Text(verbatim: option.label)
+                    .font(OpenClawType.body)
+                    .tag(option.id)
+            }
+        } label: {
+            Text("Thinking")
+                .font(OpenClawType.body)
+        }
+        .disabled(self.viewModel.isUpdatingSessionSettings)
+    }
+
+    private var fastModePicker: some View {
+        Picker(selection: Binding(
+            get: { self.viewModel.fastModeSelectionID },
+            set: { self.viewModel.selectFastMode($0) }))
+        {
+            Text("Default (inherited)")
+                .font(OpenClawType.body)
+                .tag(OpenClawChatViewModel.inheritedThinkingSelectionID)
+            Text("On")
+                .font(OpenClawType.body)
+                .tag("on")
+            Text("Off")
+                .font(OpenClawType.body)
+                .tag("off")
+        } label: {
+            Label {
+                Text("Fast")
+                    .font(OpenClawType.body)
+            } icon: {
+                Image(systemName: "bolt.fill")
+            }
+        }
+        .disabled(self.viewModel.isUpdatingSessionSettings)
+    }
+
+    private var verbosityPicker: some View {
+        Picker(selection: Binding(
+            get: { self.viewModel.verboseLevel },
+            set: { self.viewModel.selectVerboseLevel($0) }))
+        {
+            Text("Default (inherited)")
+                .font(OpenClawType.body)
+                .tag(OpenClawChatViewModel.inheritedThinkingSelectionID)
+            Text("Off")
+                .font(OpenClawType.body)
+                .tag("off")
+            Text("On")
+                .font(OpenClawType.body)
+                .tag("on")
+            Text("Full")
+                .font(OpenClawType.body)
+                .tag("full")
+        } label: {
+            Text("Verbosity")
+                .font(OpenClawType.body)
+        }
+        .disabled(self.viewModel.isUpdatingSessionSettings)
+    }
+
+    private func modelOptions(_ models: [OpenClawChatModelChoice]) -> some View {
+        ForEach(models) { model in
+            HStack(spacing: 4) {
+                Text(model.displayLabel)
+                    .font(OpenClawType.body)
+                if self.viewModel.isDefaultModel(model) {
+                    Text("Default")
+                        .font(OpenClawType.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .tag(model.selectionID)
+        }
+    }
+}

--- a/apps/ios/Sources/Design/ChatProTab.swift
+++ b/apps/ios/Sources/Design/ChatProTab.swift
@@ -36,6 +36,7 @@ struct ChatProTab: View {
     @State private var showsTranscriptExportError = false
     @State private var showsBackgroundTasks = false
     @State private var showsSessions = false
+    @State private var showsNewSessionOptions = false
     // Transport can start unscoped while the UI uses its "main" fallback.
     // Track the real agent so gateway metadata replaces the captured transport.
     @State private var viewModelTransportAgentID = ""
@@ -164,10 +165,17 @@ struct ChatProTab: View {
                 BackgroundTasksScreen(agentID: self.currentAgentID)
             }
             .sheet(isPresented: self.$showsSessions) {
-                NavigationStack {
-                    CommandSessionsScreen(
-                        usesNativeNavigationChrome: true,
-                        openChat: { self.showsSessions = false })
+                if let viewModel {
+                    ChatSessionsSheet(viewModel: viewModel)
+                }
+            }
+            .sheet(isPresented: self.$showsNewSessionOptions) {
+                if let viewModel {
+                    ChatNewSessionOptionsPopover(viewModel: viewModel) {
+                        self.showsNewSessionOptions = false
+                    }
+                    .presentationDetents([.medium])
+                    .presentationDragIndicator(.visible)
                 }
             }
             .alert(
@@ -588,6 +596,18 @@ struct ChatProTab: View {
             }
 
             Button {
+                self.showsNewSessionOptions = true
+            } label: {
+                Label {
+                    Text("New Session Options…")
+                        .font(OpenClawType.body)
+                } icon: {
+                    Image(systemName: "slider.horizontal.3")
+                }
+            }
+            .disabled(self.viewModel == nil || !self.gatewayConnected || self.isAttachmentOwnerPinned)
+
+            Button {
                 self.showsSessions = true
             } label: {
                 Label {
@@ -599,6 +619,11 @@ struct ChatProTab: View {
             }
 
             Divider()
+
+            if let viewModel {
+                ChatModelControlsMenuItems(viewModel: viewModel)
+                Divider()
+            }
 
             Button {
                 self.showsBackgroundTasks = true

--- a/apps/ios/Tests/IOSGatewayChatTransportTests.swift
+++ b/apps/ios/Tests/IOSGatewayChatTransportTests.swift
@@ -11,7 +11,15 @@ struct IOSGatewayChatTransportTests {
 
         func record(_ request: OpenClawChatGatewayRequest) -> Data {
             self.requests.append(request)
-            return Data(#"{"key":"forked","entry":{}}"#.utf8)
+            if request.method == "sessions.create" {
+                return Data(#"{"key":"forked"}"#.utf8)
+            }
+            return Data(#"{"entry":{}}"#.utf8)
+        }
+
+        func record(_ request: OpenClawChatGatewayRequest, response: Data) -> Data {
+            self.requests.append(request)
+            return response
         }
 
         func all() -> [OpenClawChatGatewayRequest] {
@@ -147,6 +155,34 @@ struct IOSGatewayChatTransportTests {
         #expect(request.params["thinkingLevel"]?.value as? String == "high")
     }
 
+    @Test func `advanced session creation forwards agent worktree and base ref`() async throws {
+        let recorder = RequestRecorder()
+        let transport = IOSGatewayChatTransport(
+            gateway: GatewayNodeSession(),
+            globalAgentId: " Reviewer ",
+            sessionMutationRequest: { request in
+                await recorder.record(request)
+            })
+
+        let created = try await transport.createSession(
+            key: "agent:builder:ios-new",
+            label: "Build",
+            agentID: " Builder ",
+            parentSessionKey: "agent:builder:main",
+            worktree: true,
+            worktreeBaseRef: " origin/release ")
+
+        #expect(created.key == "forked")
+        let request = try #require(await recorder.all().first)
+        #expect(request.method == "sessions.create")
+        #expect(request.params["key"]?.value as? String == "agent:builder:ios-new")
+        #expect(request.params["label"]?.value as? String == "Build")
+        #expect(request.params["agentId"]?.value as? String == "builder")
+        #expect(request.params["parentSessionKey"]?.value as? String == "agent:builder:main")
+        #expect(request.params["worktree"]?.value as? Bool == true)
+        #expect(request.params["worktreeBaseRef"]?.value as? String == "origin/release")
+    }
+
     @Test func `verbosity patches preserve set and clear values`() async throws {
         let recorder = RequestRecorder()
         let transport = IOSGatewayChatTransport(
@@ -174,6 +210,64 @@ struct IOSGatewayChatTransportTests {
         #expect(requests[1].params["verboseLevel"]?.value is NSNull)
         #expect(requests.allSatisfy { $0.params["model"] == nil })
         #expect(requests.allSatisfy { $0.params["thinkingLevel"] == nil })
+    }
+
+    @Test func `fast mode patches preserve boolean and explicit null`() async throws {
+        let recorder = RequestRecorder()
+        let transport = IOSGatewayChatTransport(
+            gateway: GatewayNodeSession(),
+            globalAgentId: " Reviewer ",
+            sessionMutationRequest: { request in
+                await recorder.record(request)
+            })
+
+        _ = try await transport.patchSessionSettings(
+            sessionKey: "global",
+            agentID: nil,
+            patch: OpenClawChatSessionSettingsPatch(fastMode: .some(.on)))
+        _ = try await transport.patchSessionSettings(
+            sessionKey: "global",
+            agentID: nil,
+            patch: OpenClawChatSessionSettingsPatch(fastMode: .some(nil)))
+
+        let requests = await recorder.all()
+        #expect(requests.count == 2)
+        #expect(requests[0].params["fastMode"]?.value as? Bool == true)
+        #expect(requests[1].params["fastMode"]?.value is NSNull)
+        #expect(requests.allSatisfy { $0.params["verboseLevel"] == nil })
+    }
+
+    @Test func `session groups lease uses the supplied pinned request path`() async throws {
+        let recorder = RequestRecorder()
+        let lease = IOSGatewayChatTransport.makeSessionGroupsRouteLease { request in
+            let response = if request.method == "sessions.groups.list" {
+                Data(#"{"groups":[{"name":"Work","position":0}]}"#.utf8)
+            } else {
+                Data(#"{"ok":true,"groups":[{"name":"Projects","position":0}]}"#.utf8)
+            }
+            return await recorder.record(request, response: response)
+        }
+
+        let listed = try await lease.listGroups()
+        let put = try await lease.putGroups(names: ["Work", "Personal"])
+        let renamed = try await lease.renameGroup(name: "Work", to: "Projects")
+        let deleted = try await lease.deleteGroup(name: "Personal")
+
+        #expect(listed?.groups.map(\.name) == ["Work"])
+        #expect(put.groups.map(\.name) == ["Projects"])
+        #expect(renamed.groups.map(\.name) == ["Projects"])
+        #expect(deleted.groups.map(\.name) == ["Projects"])
+        let requests = await recorder.all()
+        #expect(requests.map(\.method) == [
+            "sessions.groups.list",
+            "sessions.groups.put",
+            "sessions.groups.rename",
+            "sessions.groups.delete",
+        ])
+        #expect(requests[1].params["names"]?.value as? [String] == ["Work", "Personal"])
+        #expect(requests[2].params["name"]?.value as? String == "Work")
+        #expect(requests[2].params["to"]?.value as? String == "Projects")
+        #expect(requests[3].params["name"]?.value as? String == "Personal")
     }
 
     @Test func `requests fail fast when gateway not connected`() async {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -886,6 +886,19 @@ struct OpenClawChatComposer: View {
                         self.setSlashPanelPresented(false)
                     }
                 }
+                // SwiftUI exposes neither the caret row nor soft-wrap geometry.
+                // Start recall only from an empty draft; an active recall can
+                // still walk both directions through the shared state machine.
+                .onKeyPress(.upArrow) {
+                    guard !self.isSlashPopoverPresented else { return .ignored }
+                    return self.viewModel.recallPreviousInput(caretOnFirstLine: false)
+                        ? .handled
+                        : .ignored
+                }
+                .onKeyPress(.downArrow) {
+                    guard !self.isSlashPopoverPresented else { return .ignored }
+                    return self.viewModel.recallNextInput() ? .handled : .ignored
+                }
             #endif
         }
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionManagementViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionManagementViews.swift
@@ -525,7 +525,7 @@ struct ChatSessionGroupsSheet: View {
 }
 
 @MainActor
-struct ChatNewSessionOptionsPopover: View {
+public struct ChatNewSessionOptionsPopover: View {
     @Bindable var viewModel: OpenClawChatViewModel
     let onComplete: () -> Void
 
@@ -537,6 +537,11 @@ struct ChatNewSessionOptionsPopover: View {
     @State private var isCreating = false
     @State private var routeLease: OpenClawChatNewSessionRouteLease?
     @State private var errorText: String?
+
+    public init(viewModel: OpenClawChatViewModel, onComplete: @escaping () -> Void) {
+        self.viewModel = viewModel
+        self.onComplete = onComplete
+    }
 
     private var selectedAgent: OpenClawChatAgentChoice? {
         self.agents.first { $0.id == self.selectedAgentID }
@@ -565,7 +570,7 @@ struct ChatNewSessionOptionsPopover: View {
         }
     }
 
-    var body: some View {
+    public var body: some View {
         VStack(alignment: .leading, spacing: 14) {
             Text("New Thread Options")
                 .font(OpenClawChatTypography.body(size: 15, weight: .semibold, relativeTo: .headline))

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessions.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessions.swift
@@ -255,31 +255,16 @@ public struct OpenClawChatSessionGroup: Codable, Identifiable, Sendable, Hashabl
 
     public let name: String
     public let position: Int
-
-    public init(name: String, position: Int) {
-        self.name = name
-        self.position = position
-    }
 }
 
 public struct OpenClawChatSessionGroupsResponse: Codable, Sendable, Equatable {
     public let groups: [OpenClawChatSessionGroup]
-
-    public init(groups: [OpenClawChatSessionGroup]) {
-        self.groups = groups
-    }
 }
 
 public struct OpenClawChatSessionGroupsMutationResponse: Codable, Sendable, Equatable {
     public let ok: Bool
     public let groups: [OpenClawChatSessionGroup]
     public let updatedSessions: Int?
-
-    public init(ok: Bool, groups: [OpenClawChatSessionGroup], updatedSessions: Int? = nil) {
-        self.ok = ok
-        self.groups = groups
-        self.updatedSessions = updatedSessions
-    }
 }
 
 public struct OpenClawChatAgentChoice: Codable, Identifiable, Sendable, Hashable {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessions.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessions.swift
@@ -256,6 +256,7 @@ public struct OpenClawChatSessionGroup: Codable, Identifiable, Sendable, Hashabl
     public let name: String
     public let position: Int
 
+    // periphery:ignore - Public DTO initializer for external OpenClawKit transport consumers.
     public init(name: String, position: Int) {
         self.name = name
         self.position = position
@@ -265,6 +266,7 @@ public struct OpenClawChatSessionGroup: Codable, Identifiable, Sendable, Hashabl
 public struct OpenClawChatSessionGroupsResponse: Codable, Sendable, Equatable {
     public let groups: [OpenClawChatSessionGroup]
 
+    // periphery:ignore - Public DTO initializer for external OpenClawKit transport consumers.
     public init(groups: [OpenClawChatSessionGroup]) {
         self.groups = groups
     }
@@ -275,6 +277,7 @@ public struct OpenClawChatSessionGroupsMutationResponse: Codable, Sendable, Equa
     public let groups: [OpenClawChatSessionGroup]
     public let updatedSessions: Int?
 
+    // periphery:ignore - Public DTO initializer for external OpenClawKit transport consumers.
     public init(ok: Bool, groups: [OpenClawChatSessionGroup], updatedSessions: Int? = nil) {
         self.ok = ok
         self.groups = groups

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessions.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessions.swift
@@ -255,34 +255,16 @@ public struct OpenClawChatSessionGroup: Codable, Identifiable, Sendable, Hashabl
 
     public let name: String
     public let position: Int
-
-    // periphery:ignore - Public DTO initializer for external OpenClawKit transport consumers.
-    public init(name: String, position: Int) {
-        self.name = name
-        self.position = position
-    }
 }
 
 public struct OpenClawChatSessionGroupsResponse: Codable, Sendable, Equatable {
     public let groups: [OpenClawChatSessionGroup]
-
-    // periphery:ignore - Public DTO initializer for external OpenClawKit transport consumers.
-    public init(groups: [OpenClawChatSessionGroup]) {
-        self.groups = groups
-    }
 }
 
 public struct OpenClawChatSessionGroupsMutationResponse: Codable, Sendable, Equatable {
     public let ok: Bool
     public let groups: [OpenClawChatSessionGroup]
     public let updatedSessions: Int?
-
-    // periphery:ignore - Public DTO initializer for external OpenClawKit transport consumers.
-    public init(ok: Bool, groups: [OpenClawChatSessionGroup], updatedSessions: Int? = nil) {
-        self.ok = ok
-        self.groups = groups
-        self.updatedSessions = updatedSessions
-    }
 }
 
 public struct OpenClawChatAgentChoice: Codable, Identifiable, Sendable, Hashable {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessions.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessions.swift
@@ -255,16 +255,31 @@ public struct OpenClawChatSessionGroup: Codable, Identifiable, Sendable, Hashabl
 
     public let name: String
     public let position: Int
+
+    public init(name: String, position: Int) {
+        self.name = name
+        self.position = position
+    }
 }
 
 public struct OpenClawChatSessionGroupsResponse: Codable, Sendable, Equatable {
     public let groups: [OpenClawChatSessionGroup]
+
+    public init(groups: [OpenClawChatSessionGroup]) {
+        self.groups = groups
+    }
 }
 
 public struct OpenClawChatSessionGroupsMutationResponse: Codable, Sendable, Equatable {
     public let ok: Bool
     public let groups: [OpenClawChatSessionGroup]
     public let updatedSessions: Int?
+
+    public init(ok: Bool, groups: [OpenClawChatSessionGroup], updatedSessions: Int? = nil) {
+        self.ok = ok
+        self.groups = groups
+        self.updatedSessions = updatedSessions
+    }
 }
 
 public struct OpenClawChatAgentChoice: Codable, Identifiable, Sendable, Hashable {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift
@@ -2,7 +2,7 @@ import Observation
 import SwiftUI
 
 @MainActor
-struct ChatSessionsSheet: View {
+public struct ChatSessionsSheet: View {
     private enum SessionScope: String, CaseIterable, Identifiable {
         case active
         case archived
@@ -35,6 +35,10 @@ struct ChatSessionsSheet: View {
     @State private var inspectedSession: OpenClawChatSessionEntry?
     @State private var isPresentingGroups = false
 
+    public init(viewModel: OpenClawChatViewModel) {
+        self.viewModel = viewModel
+    }
+
     /// Live view-model sessions serve the default active list; search and the
     /// archived scope fetch one-shot lists (server-side search with local
     /// cached fallback inside the view model).
@@ -58,7 +62,7 @@ struct ChatSessionsSheet: View {
         "\(self.scope.rawValue)|\(self.trimmedSearchText.lowercased())"
     }
 
-    var body: some View {
+    public var body: some View {
         NavigationStack {
             List(selection: self.$selectedSessionKeys) {
                 Section {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelSessionActionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelSessionActionTests.swift
@@ -172,13 +172,14 @@ private final class SessionActionTransport: @unchecked Sendable, OpenClawChatTra
                     ok: true,
                     groups: names.enumerated().map {
                         OpenClawChatSessionGroup(name: $0.element, position: $0.offset)
-                    })
+                    },
+                    updatedSessions: nil)
             },
             renameGroup: { _, _ in
-                OpenClawChatSessionGroupsMutationResponse(ok: true, groups: [])
+                OpenClawChatSessionGroupsMutationResponse(ok: true, groups: [], updatedSessions: nil)
             },
             deleteGroup: { _ in
-                OpenClawChatSessionGroupsMutationResponse(ok: true, groups: [])
+                OpenClawChatSessionGroupsMutationResponse(ok: true, groups: [], updatedSessions: nil)
             })
     }
 


### PR DESCRIPTION
## What Problem This Solves

The macOS/web chat parity rounds (#110254, #110276, #110339, #110347) landed all capability in shared `OpenClawKit`, but iOS still only forwarded transport fields: no model controls, no session groups/batch/inspector, no worktree-aware creation, and no hardware-keyboard input history.

## Why This Change Was Made

Adopt the shared surfaces on iOS with iOS-idiomatic UX, keeping the shared API additive:

- **Model controls** (`ChatModelControlsMenu.swift`, wired from ChatPro's existing action menu): provider-grouped model picker via the shared `ChatModelPickerStore` (pinned + recents first, default badges), thinking with `Default (inherited)`, Fast as Default/On/Off (Default patches `fastMode: null`; display rides `effectiveFastMode`; legacy `auto` not re-selectable), verbosity as Default/off/on/full (Default patches null).
- **Session management**: the sessions affordance now presents the shared `ChatSessionsSheet` (groups, select/batch mode, inspector); advanced new-session options (agent, managed worktree, base ref) present in a medium-detent sheet.
- **Transport** (`IOSGatewayChatTransport.swift`): exact-route leases for settings, mutations, groups, and new-session; 6-arg `createSession` mapping `agentId`/`worktree`/`worktreeBaseRef`; settings patches forward the fast-mode double-optional including explicit null. Implementing the real overload removes iOS from the fail-closed protocol default.
- **Input history**: hardware-keyboard ↑ starts recall only from an empty draft; active recall supports ↑/↓; non-empty and soft-wrapped drafts keep native caret movement; no touch-UX change (shared `ChatInputHistory` state machine).

## User Impact

iOS chat users get the same model, Fast, verbosity, and thinking controls as web/macOS, full session organization (groups, batch actions, inspector, worktree sessions from a chosen base ref), and terminal-style input history on hardware keyboards.

## Evidence

- Shared OpenClawKit suite: 994 tests green (48 XCTest + 946 Swift Testing, 81+ suites).
- iOS `build-for-testing` (generic simulator, Xcode project via xcodegen): green — app and test targets compile.
- `IOSGatewayChatTransportTests`: 15/15, including advanced-create encoding, fast-mode set/null, and groups-lease methods/params/decoding.
- `pnpm format:swift` clean; `pnpm lint:swift` 0 violations; all touched files under the 1500-line cap; `git diff --check` clean.
- i18n: new strings translated across all locales; `pnpm native:i18n:check` clean; apple/android i18n vitest gates green.
- Autoreview (branch mode): "patch is correct", zero accepted/actionable findings (one earlier P2 — soft-wrapped draft caret interception — found and fixed during development).
- Known non-gate: the local-only `OpenClawTypographyTests` broad source audit flags pre-existing lines in untouched shared/macOS files; CI's `ios-build` job compiles but does not execute the iOS test bundle, and the new controls use branded typography.
