### PR TITLE
fix(googlechat): preserve webhook messages across restarts

### DIFF
--- a/extensions/googlechat/src/approval-card-click.test.ts
+++ b/extensions/googlechat/src/approval-card-click.test.ts
@@ -81,6 +81,7 @@ function createTarget(): WebhookTarget {
     core: {} as never,
     path: "/googlechat",
     mediaMaxMb: 20,
+    ingress: { receive: vi.fn(async () => ({ kind: "ignored" as const })) },
   };
 }
 

--- a/extensions/googlechat/src/gateway.ts
+++ b/extensions/googlechat/src/gateway.ts
@@ -84,7 +84,7 @@ export async function startGoogleChatGatewayAccount(ctx: {
           statusSink,
         }),
       stop: async (unregister) => {
-        unregister?.();
+        await unregister?.();
       },
       onStop: async () => {
         markStopped();

--- a/extensions/googlechat/src/monitor-event.ts
+++ b/extensions/googlechat/src/monitor-event.ts
@@ -1,0 +1,124 @@
+// Googlechat plugin module parses standard and Workspace Add-on webhook envelopes.
+import type {
+  GoogleChatAction,
+  GoogleChatActionParameter,
+  GoogleChatEvent,
+  GoogleChatMessage,
+  GoogleChatSpace,
+  GoogleChatUser,
+} from "./types.js";
+
+export class GoogleChatEventPayloadError extends Error {
+  constructor(message = "invalid payload") {
+    super(message);
+    this.name = "GoogleChatEventPayloadError";
+  }
+}
+
+type ParsedGoogleChatInboundPayload = {
+  event: GoogleChatEvent;
+  addOnBearerToken: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function recordParamsToActionParameters(
+  params?: Record<string, string>,
+): GoogleChatActionParameter[] | undefined {
+  if (!params) {
+    return undefined;
+  }
+  const entries = Object.entries(params)
+    .filter((entry): entry is [string, string] => typeof entry[1] === "string")
+    .map(([key, value]) => ({ key, value }));
+  return entries.length > 0 ? entries : undefined;
+}
+
+/** Normalize only at authenticated dispatch; durable admission stores the untouched envelope. */
+export function parseGoogleChatInboundPayload(raw: unknown): ParsedGoogleChatInboundPayload {
+  if (!isRecord(raw)) {
+    throw new GoogleChatEventPayloadError();
+  }
+
+  let eventPayload: Record<string, unknown> = raw;
+  let addOnBearerToken = "";
+  const rawObj = raw as {
+    commonEventObject?: {
+      hostApp?: string;
+      invokedFunction?: string;
+      parameters?: Record<string, string>;
+    };
+    chat?: {
+      messagePayload?: { space?: GoogleChatSpace; message?: GoogleChatMessage };
+      buttonClickedPayload?: {
+        space?: GoogleChatSpace;
+        message?: GoogleChatMessage;
+        user?: GoogleChatUser;
+        action?: GoogleChatAction;
+      };
+      user?: GoogleChatUser;
+      eventTime?: string;
+    };
+    authorizationEventObject?: { systemIdToken?: string };
+  };
+
+  if (rawObj.commonEventObject?.hostApp === "CHAT") {
+    addOnBearerToken =
+      typeof rawObj.authorizationEventObject?.systemIdToken === "string"
+        ? rawObj.authorizationEventObject.systemIdToken.trim()
+        : "";
+  }
+
+  const chat = rawObj.chat;
+  const messagePayload = chat?.messagePayload;
+  if (rawObj.commonEventObject?.hostApp === "CHAT" && chat && messagePayload) {
+    eventPayload = {
+      type: "MESSAGE",
+      space: messagePayload.space,
+      message: messagePayload.message,
+      user: chat.user,
+      eventTime: chat.eventTime,
+    };
+  } else if (rawObj.commonEventObject?.hostApp === "CHAT") {
+    const chatPayload = rawObj.chat;
+    const buttonClickedPayload = chatPayload?.buttonClickedPayload;
+    if (buttonClickedPayload) {
+      const invokedFunction = rawObj.commonEventObject.invokedFunction;
+      const actionParameters = recordParamsToActionParameters(rawObj.commonEventObject.parameters);
+      eventPayload = {
+        type: "CARD_CLICKED",
+        space: buttonClickedPayload.space,
+        message: buttonClickedPayload.message,
+        user: buttonClickedPayload.user ?? chatPayload?.user,
+        eventTime: chatPayload?.eventTime,
+        action:
+          buttonClickedPayload.action ??
+          ({
+            ...(typeof invokedFunction === "string" ? { actionMethodName: invokedFunction } : {}),
+            ...(actionParameters ? { parameters: actionParameters } : {}),
+          } satisfies GoogleChatAction),
+        commonEventObject: {
+          ...(typeof invokedFunction === "string" ? { invokedFunction } : {}),
+          parameters: rawObj.commonEventObject.parameters,
+        },
+      };
+    }
+  }
+
+  const event = eventPayload as GoogleChatEvent;
+  const eventType = event.type ?? event.eventType;
+  if (typeof eventType !== "string" || !isRecord(event.space)) {
+    throw new GoogleChatEventPayloadError();
+  }
+  if (eventType === "MESSAGE") {
+    if (!isRecord(event.message) || !event.space?.name?.trim() || !event.message?.name?.trim()) {
+      throw new GoogleChatEventPayloadError();
+    }
+  } else if (eventType === "CARD_CLICKED" && !isRecord(event.user)) {
+    throw new GoogleChatEventPayloadError();
+  }
+
+  return { event, addOnBearerToken };
+}

--- a/extensions/googlechat/src/monitor-ingress.test.ts
+++ b/extensions/googlechat/src/monitor-ingress.test.ts
@@ -1,0 +1,372 @@
+// Googlechat durable ingress tests cover admission, recovery, replay, and shutdown.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  closeOpenClawStateDatabaseForTest,
+  createChannelIngressQueueForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createGoogleChatIngressMonitor } from "./monitor-ingress.js";
+
+type GoogleChatIngressQueue = NonNullable<
+  Parameters<typeof createGoogleChatIngressMonitor>[0]["queue"]
+>;
+type GoogleChatIngressPayload = Parameters<GoogleChatIngressQueue["enqueue"]>[1];
+type GoogleChatIngressDispatch = Parameters<typeof createGoogleChatIngressMonitor>[0]["dispatch"];
+
+function messageEvent(params?: { messageName?: string; spaceName?: string; text?: string }) {
+  const spaceName = params?.spaceName ?? "spaces/AAA";
+  return {
+    type: "MESSAGE",
+    eventTime: "2026-07-18T10:00:00.000Z",
+    space: { name: spaceName, type: "SPACE" },
+    message: {
+      name: params?.messageName ?? `${spaceName}/messages/message-1`,
+      text: params?.text ?? "hello",
+      sender: { name: "users/123", type: "HUMAN" },
+    },
+  };
+}
+
+function addOnMessageEvent(params?: { messageName?: string; spaceName?: string; text?: string }) {
+  const standard = messageEvent(params);
+  return {
+    commonEventObject: { hostApp: "CHAT" },
+    authorizationEventObject: {
+      systemIdToken: "redacted",
+      userOAuthToken: "redacted",
+      userIdToken: "redacted",
+      authorizedScopes: ["scope"],
+    },
+    chat: {
+      eventTime: standard.eventTime,
+      user: standard.message.sender,
+      messagePayload: {
+        space: standard.space,
+        message: standard.message,
+      },
+    },
+  };
+}
+
+function cardClickEvent(messageName = "spaces/AAA/messages/message-1") {
+  return {
+    type: "CARD_CLICKED",
+    space: { name: "spaces/AAA" },
+    message: { name: messageName },
+    user: { name: "users/123" },
+  };
+}
+
+function startIngress(queue: GoogleChatIngressQueue, dispatch: GoogleChatIngressDispatch) {
+  const ingress = createGoogleChatIngressMonitor({
+    accountId: "default",
+    queue,
+    dispatch,
+    runtime: { error: vi.fn(), log: vi.fn() },
+    pollIntervalMs: 10,
+    adoptionStallTimeoutMs: 5_000,
+  });
+  ingress.start();
+  return ingress;
+}
+
+async function withQueue<T>(fn: (queue: GoogleChatIngressQueue) => Promise<T>): Promise<T> {
+  const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-googlechat-ingress-"));
+  const stateDir = await fs.realpath(created);
+  const queue = createChannelIngressQueueForTests<GoogleChatIngressPayload>({
+    channelId: "googlechat",
+    accountId: "default",
+    stateDir,
+  });
+  try {
+    return await fn(queue);
+  } finally {
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  }
+}
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  vi.restoreAllMocks();
+});
+
+describe("Google Chat durable ingress", () => {
+  it("recovers an uncompleted message with a fresh drain and dispatches exactly once", async () => {
+    await withQueue(async (queue) => {
+      const interruptedDispatch = vi.fn((_event, lifecycle) => {
+        lifecycle.onDeferred();
+        return { kind: "deferred" } as const;
+      });
+      const interrupted = startIngress(queue, interruptedDispatch);
+      await interrupted.receive(messageEvent({ messageName: "spaces/AAA/messages/restart" }));
+      await interrupted.waitForIdle();
+      expect(await queue.listClaims()).toHaveLength(1);
+      await interrupted.stop();
+
+      const recoveredDispatch = vi.fn(async (_event, lifecycle) => {
+        await lifecycle.onAdopted();
+      });
+      const recovered = startIngress(queue, recoveredDispatch);
+      try {
+        await vi.waitFor(() => expect(recoveredDispatch).toHaveBeenCalledTimes(1));
+        await recovered.waitForIdle();
+      } finally {
+        await recovered.stop();
+      }
+    });
+  });
+
+  it("retains completion so a duplicate message resource cannot dispatch twice", async () => {
+    await withQueue(async (queue) => {
+      const dispatch = vi.fn(async (_event, lifecycle) => {
+        await lifecycle.onAdopted();
+      });
+      const ingress = startIngress(queue, dispatch);
+      try {
+        const event = messageEvent({ messageName: "spaces/AAA/messages/completed" });
+        await ingress.receive(event);
+        await ingress.waitForIdle();
+        await ingress.receive({ ...event, message: { ...event.message, text: "redelivery" } });
+        await ingress.waitForIdle();
+        expect(dispatch).toHaveBeenCalledTimes(1);
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("redacts Add-on auth while preserving event data until claim-time normalization", async () => {
+    await withQueue(async (queue) => {
+      const raw = addOnMessageEvent({
+        messageName: "spaces/ADDON/messages/raw",
+        spaceName: "spaces/ADDON",
+        text: "before",
+      });
+      const texts: string[] = [];
+      const dispatch = vi.fn((event, lifecycle) => {
+        texts.push(event.message?.text ?? "");
+        lifecycle.onDeferred();
+        return { kind: "deferred" } as const;
+      });
+      const ingress = startIngress(queue, dispatch);
+      try {
+        await ingress.receive(raw);
+        await ingress.waitForIdle();
+        expect(await queue.listClaims()).toEqual([
+          expect.objectContaining({
+            id: "spaces/ADDON/messages/raw",
+            laneKey: "space:spaces/ADDON",
+            payload: {
+              version: 1,
+              rawEvent: JSON.stringify({
+                commonEventObject: raw.commonEventObject,
+                chat: raw.chat,
+              }),
+            },
+          }),
+        ]);
+        expect(texts).toEqual(["before"]);
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("journals only MESSAGE turns, so card events cannot tombstone the message", async () => {
+    await withQueue(async (queue) => {
+      const dispatch = vi.fn(async (_event, lifecycle) => {
+        await lifecycle.onAdopted();
+      });
+      const ingress = startIngress(queue, dispatch);
+      try {
+        const messageName = "spaces/AAA/messages/card-and-message";
+        await expect(ingress.receive(cardClickEvent(messageName))).resolves.toEqual({
+          kind: "ignored",
+        });
+        expect(await queue.listPending({ limit: "all" })).toEqual([]);
+
+        await ingress.receive(messageEvent({ messageName }));
+        await ingress.waitForIdle();
+        expect(dispatch).toHaveBeenCalledTimes(1);
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("rejects messages without a stable resource name before admission", async () => {
+    await withQueue(async (queue) => {
+      const ingress = startIngress(queue, vi.fn());
+      try {
+        const invalid = { ...messageEvent(), message: { text: "missing resource name" } };
+        await expect(ingress.receive(invalid)).resolves.toEqual({
+          kind: "invalid",
+          message: "Google Chat MESSAGE event is missing message.name.",
+        });
+        expect(await queue.listPending({ limit: "all" })).toEqual([]);
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("completes a terminally suppressed message without explicit adoption", async () => {
+    await withQueue(async (queue) => {
+      const dispatch = vi.fn(() => undefined);
+      const ingress = startIngress(queue, dispatch);
+      try {
+        const event = messageEvent({ messageName: "spaces/AAA/messages/suppressed" });
+        await ingress.receive(event);
+        await ingress.waitForIdle();
+        await ingress.receive(event);
+        await ingress.waitForIdle();
+        expect(dispatch).toHaveBeenCalledTimes(1);
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("preserves same-space order across append retry backoff", async () => {
+    await withQueue(async (queue) => {
+      let failFirst = true;
+      const enqueue = queue.enqueue.bind(queue);
+      queue.enqueue = async (...args) => {
+        if (failFirst) {
+          failFirst = false;
+          throw new Error("sqlite busy");
+        }
+        return await enqueue(...args);
+      };
+      const dispatched: string[] = [];
+      const ingress = startIngress(queue, async (event, lifecycle) => {
+        dispatched.push(event.message?.name ?? "");
+        await lifecycle.onAdopted();
+      });
+      try {
+        const first = ingress.receive(messageEvent({ messageName: "spaces/AAA/messages/A" }));
+        const second = ingress.receive(messageEvent({ messageName: "spaces/AAA/messages/B" }));
+        await Promise.all([first, second]);
+        await vi.waitFor(
+          () => expect(dispatched).toEqual(["spaces/AAA/messages/A", "spaces/AAA/messages/B"]),
+          { timeout: 5_000 },
+        );
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("waits for active delivery before stop returns", async () => {
+    await withQueue(async (queue) => {
+      let releaseDelivery = () => {};
+      const deliveryGate = new Promise<void>((resolve) => {
+        releaseDelivery = resolve;
+      });
+      const dispatch = vi.fn(async () => {
+        await deliveryGate;
+      });
+      const ingress = startIngress(queue, dispatch);
+      await ingress.receive(messageEvent({ messageName: "spaces/AAA/messages/active" }));
+      await vi.waitFor(() => expect(dispatch).toHaveBeenCalledTimes(1));
+
+      let stopped = false;
+      const stopping = ingress.stop().then(() => {
+        stopped = true;
+      });
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 50);
+      });
+      expect(stopped).toBe(false);
+
+      releaseDelivery();
+      await stopping;
+      expect(stopped).toBe(true);
+      expect(await queue.listClaims()).toHaveLength(1);
+    });
+  });
+
+  it("dead-letters malformed persisted payloads without dispatch", async () => {
+    await withQueue(async (queue) => {
+      await queue.enqueue(
+        "spaces/AAA/messages/malformed",
+        { version: 1, rawEvent: "{" },
+        { laneKey: "space:spaces/AAA" },
+      );
+      const dispatch = vi.fn();
+      const ingress = startIngress(queue, dispatch);
+      try {
+        await vi.waitFor(async () => {
+          const verdict = await queue.enqueue(
+            "spaces/AAA/messages/malformed",
+            {} as GoogleChatIngressPayload,
+          );
+          expect(verdict.kind).toBe("failed");
+        });
+        expect(dispatch).not.toHaveBeenCalled();
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("dead-letters permanent Google authentication failures", async () => {
+    await withQueue(async (queue) => {
+      const dispatch = vi.fn(async () => {
+        throw new Error("Google Chat API 401: invalid credential");
+      });
+      const ingress = startIngress(queue, dispatch);
+      try {
+        const id = "spaces/AAA/messages/auth";
+        await ingress.receive(messageEvent({ messageName: id }));
+        await vi.waitFor(async () => {
+          expect((await queue.enqueue(id, {} as GoogleChatIngressPayload)).kind).toBe("failed");
+        });
+        expect(dispatch).toHaveBeenCalledTimes(1);
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("keeps unrelated downstream authentication failures retryable", async () => {
+    await withQueue(async (queue) => {
+      const dispatch = vi.fn(async () => {
+        throw Object.assign(new Error("model provider unauthorized"), { status: 401 });
+      });
+      const ingress = startIngress(queue, dispatch);
+      try {
+        await ingress.receive(messageEvent({ messageName: "spaces/AAA/messages/model-auth" }));
+        await vi.waitFor(async () => {
+          expect(await queue.listPending({ limit: "all" })).toEqual([
+            expect.objectContaining({ id: "spaces/AAA/messages/model-auth" }),
+          ]);
+        });
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("leaves transient dispatch failures retryable", async () => {
+    await withQueue(async (queue) => {
+      const dispatch = vi.fn(async () => {
+        throw Object.assign(new Error("Google Chat unavailable"), { status: 503 });
+      });
+      const ingress = startIngress(queue, dispatch);
+      try {
+        await ingress.receive(messageEvent({ messageName: "spaces/AAA/messages/transient" }));
+        await vi.waitFor(async () => {
+          expect(await queue.listPending({ limit: "all" })).toEqual([
+            expect.objectContaining({ id: "spaces/AAA/messages/transient" }),
+          ]);
+        });
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+});

--- a/extensions/googlechat/src/monitor-ingress.test.ts
+++ b/extensions/googlechat/src/monitor-ingress.test.ts
@@ -138,6 +138,42 @@ describe("Google Chat durable ingress", () => {
     });
   });
 
+  it("retains more than 1,000 completed webhook tombstones within the retry horizon", async () => {
+    await withQueue(async (queue) => {
+      const completedAt = Date.now();
+      const oldestId = "spaces/AAA/messages/completed-0000";
+      for (let index = 0; index < 1_050; index += 1) {
+        const id = `spaces/AAA/messages/completed-${String(index).padStart(4, "0")}`;
+        const event = messageEvent({ messageName: id });
+        await queue.enqueue(
+          id,
+          { version: 1, rawEvent: JSON.stringify(event) },
+          { receivedAt: completedAt - 1_050 + index, laneKey: "space:spaces/AAA" },
+        );
+        await queue.complete(id, { completedAt: completedAt - 1_050 + index });
+      }
+
+      const dispatch = vi.fn();
+      const ingress = startIngress(queue, dispatch);
+      try {
+        await ingress.waitForIdle();
+        await ingress.receive(messageEvent({ messageName: oldestId, text: "redelivery" }));
+        await ingress.waitForIdle();
+
+        expect(
+          await queue.enqueue(oldestId, {
+            version: 1,
+            rawEvent: JSON.stringify(messageEvent({ messageName: oldestId })),
+          }),
+        ).toMatchObject({ kind: "completed", duplicate: true });
+        expect(await queue.listPending({ limit: "all" })).toEqual([]);
+        expect(dispatch).not.toHaveBeenCalled();
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
   it("redacts Add-on auth while preserving event data until claim-time normalization", async () => {
     await withQueue(async (queue) => {
       const raw = addOnMessageEvent({

--- a/extensions/googlechat/src/monitor-ingress.ts
+++ b/extensions/googlechat/src/monitor-ingress.ts
@@ -1,0 +1,407 @@
+// Googlechat plugin module owns raw webhook durable admission and draining.
+import {
+  bindIngressLifecycleToReplyOptions,
+  createChannelIngressDrain,
+  DEFAULT_INGRESS_ADOPTION_STALL_MS,
+  DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
+  DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
+  type ChannelIngressDrain,
+  type ChannelIngressQueue,
+} from "openclaw/plugin-sdk/channel-outbound";
+import { collectErrorGraphCandidates, formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { GoogleChatEventPayloadError, parseGoogleChatInboundPayload } from "./monitor-event.js";
+import type { GoogleChatRuntimeEnv } from "./monitor-types.js";
+import { getGoogleChatRuntime } from "./runtime.js";
+import type { GoogleChatEvent } from "./types.js";
+
+const GOOGLECHAT_INGRESS_PAYLOAD_VERSION = 1;
+const GOOGLECHAT_INGRESS_POLL_INTERVAL_MS = 500;
+const GOOGLECHAT_INGRESS_PRUNE_INTERVAL_MS = 60 * 60 * 1_000;
+const GOOGLECHAT_INGRESS_MAX_CONCURRENT_DELIVERIES = 8;
+const GOOGLECHAT_INGRESS_COMPLETED_TTL_MS = 30 * 24 * 60 * 60 * 1_000;
+const GOOGLECHAT_INGRESS_COMPLETED_MAX_ENTRIES = 1_000;
+const GOOGLECHAT_INGRESS_FAILED_TTL_MS = 30 * 24 * 60 * 60 * 1_000;
+const GOOGLECHAT_INGRESS_FAILED_MAX_ENTRIES = 1_000;
+
+type GoogleChatIngressPayload = {
+  version: 1;
+  rawEvent: string;
+};
+
+export type GoogleChatIngressLifecycle = ReturnType<
+  typeof bindIngressLifecycleToReplyOptions
+>["turnAdoptionLifecycle"];
+
+type GoogleChatIngressDispatchResult =
+  | { kind: "completed" }
+  | { kind: "deferred" }
+  | { kind: "failed-retryable"; error: unknown };
+
+type GoogleChatIngressDispatch = (
+  event: GoogleChatEvent,
+  lifecycle: GoogleChatIngressLifecycle,
+) => Promise<GoogleChatIngressDispatchResult | void> | GoogleChatIngressDispatchResult | void;
+
+class GoogleChatIngressPermanentError extends Error {
+  constructor(
+    readonly reason: "invalid-event" | "googlechat-auth",
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "GoogleChatIngressPermanentError";
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requiredString(value: unknown, field: string): string {
+  if (typeof value === "string" && value.trim()) {
+    return value.trim();
+  }
+  throw new GoogleChatIngressPermanentError(
+    "invalid-event",
+    `Google Chat MESSAGE event is missing ${field}.`,
+  );
+}
+
+function inspectGoogleChatIngressEvent(raw: unknown): { eventId: string; laneKey: string } | null {
+  if (!isRecord(raw)) {
+    throw new GoogleChatIngressPermanentError(
+      "invalid-event",
+      "Google Chat webhook envelope must be an object.",
+    );
+  }
+
+  const commonEventObject = isRecord(raw.commonEventObject) ? raw.commonEventObject : null;
+  const chat = isRecord(raw.chat) ? raw.chat : null;
+  const isAddOn = commonEventObject?.hostApp === "CHAT";
+  let eventType: unknown = raw.type ?? raw.eventType;
+  let space: Record<string, unknown> | null = isRecord(raw.space) ? raw.space : null;
+  let message: Record<string, unknown> | null = isRecord(raw.message) ? raw.message : null;
+
+  if (isAddOn) {
+    const messagePayload = isRecord(chat?.messagePayload) ? chat.messagePayload : null;
+    if (!messagePayload) {
+      // Card clicks and other Add-on actions do not start agent turns.
+      return null;
+    }
+    eventType = "MESSAGE";
+    space = isRecord(messagePayload.space) ? messagePayload.space : null;
+    message = isRecord(messagePayload.message) ? messagePayload.message : null;
+  }
+
+  if (eventType !== "MESSAGE") {
+    return null;
+  }
+  const spaceName = requiredString(space?.name, "space.name");
+  const messageName = requiredString(message?.name, "message.name");
+  return { eventId: messageName, laneKey: `space:${spaceName}` };
+}
+
+function parseClaimedGoogleChatEvent(
+  payload: GoogleChatIngressPayload,
+  claimedId: string,
+): GoogleChatEvent {
+  if (
+    payload.version !== GOOGLECHAT_INGRESS_PAYLOAD_VERSION ||
+    typeof payload.rawEvent !== "string"
+  ) {
+    throw new GoogleChatIngressPermanentError(
+      "invalid-event",
+      `Google Chat ingress row ${claimedId} has an invalid payload.`,
+    );
+  }
+  let raw: unknown;
+  try {
+    raw = JSON.parse(payload.rawEvent);
+  } catch (error) {
+    throw new GoogleChatIngressPermanentError(
+      "invalid-event",
+      `Google Chat ingress row ${claimedId} contains invalid JSON.`,
+      { cause: error },
+    );
+  }
+  const facts = inspectGoogleChatIngressEvent(raw);
+  if (!facts || facts.eventId !== claimedId) {
+    throw new GoogleChatIngressPermanentError(
+      "invalid-event",
+      `Google Chat ingress row ${claimedId} has invalid message identity.`,
+    );
+  }
+  try {
+    const parsed = parseGoogleChatInboundPayload(raw);
+    const eventType = parsed.event.type ?? parsed.event.eventType;
+    if (eventType !== "MESSAGE") {
+      throw new GoogleChatEventPayloadError();
+    }
+    return parsed.event;
+  } catch (error) {
+    throw new GoogleChatIngressPermanentError(
+      "invalid-event",
+      `Google Chat ingress row ${claimedId} cannot be normalized.`,
+      { cause: error },
+    );
+  }
+}
+
+function resolveGoogleChatIngressNonRetryableFailure(error: unknown) {
+  for (const candidate of collectErrorGraphCandidates(error, (current) => [current.cause])) {
+    if (candidate instanceof GoogleChatIngressPermanentError) {
+      return { reason: candidate.reason, message: candidate.message };
+    }
+    const message = formatErrorMessage(candidate);
+    if (
+      /Google Chat API 401\b/.test(message) ||
+      /^(?:Missing Google Chat access token|Google Chat (?:credentials|service account)\b|(?:Failed to load|Invalid) Google Chat service account\b)/.test(
+        message,
+      )
+    ) {
+      return { reason: "googlechat-auth", message };
+    }
+  }
+  return null;
+}
+
+export type GoogleChatIngressMonitor = {
+  receive: (
+    rawEvent: unknown,
+  ) => Promise<{ kind: "durable" | "ignored" } | { kind: "invalid"; message: string }>;
+  start: () => void;
+  stop: () => Promise<void>;
+  waitForIdle: () => Promise<void>;
+};
+
+export function createGoogleChatIngressMonitor(options: {
+  accountId: string;
+  queue?: ChannelIngressQueue<GoogleChatIngressPayload>;
+  dispatch: GoogleChatIngressDispatch;
+  runtime: Pick<GoogleChatRuntimeEnv, "error" | "log">;
+  pollIntervalMs?: number;
+  adoptionStallTimeoutMs?: number;
+  abortSignal?: AbortSignal;
+}): GoogleChatIngressMonitor {
+  let queue = options.queue;
+  let drain: ChannelIngressDrain | undefined;
+  let running = false;
+  let requested = false;
+  let pumping: Promise<void> | undefined;
+  let pollTimer: ReturnType<typeof setInterval> | undefined;
+  let lastPrunedAt = 0;
+  const activeDeliveries = new Set<Promise<GoogleChatIngressDispatchResult | void>>();
+
+  const getQueue = (): ChannelIngressQueue<GoogleChatIngressPayload> => {
+    queue ??= getGoogleChatRuntime().state.openChannelIngressQueue<GoogleChatIngressPayload>({
+      accountId: options.accountId,
+    });
+    return queue;
+  };
+
+  const getDrain = (): ChannelIngressDrain => {
+    drain ??= createChannelIngressDrain<GoogleChatIngressPayload>({
+      queue: getQueue(),
+      adoptionStallTimeoutMs: options.adoptionStallTimeoutMs ?? DEFAULT_INGRESS_ADOPTION_STALL_MS,
+      startLimit: GOOGLECHAT_INGRESS_MAX_CONCURRENT_DELIVERIES,
+      retryPolicy: {
+        maxAttempts: DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
+        deadLetterMinAgeMs: DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
+      },
+      resolveNonRetryableFailure: resolveGoogleChatIngressNonRetryableFailure,
+      ...(options.abortSignal ? { abortSignal: options.abortSignal } : {}),
+      onLog: (message) => options.runtime.error?.(`googlechat: ${message}`),
+      dispatchClaimedEvent: async (record, lifecycle) => {
+        if (lifecycle.abortSignal.aborted) {
+          return { kind: "failed-retryable", error: lifecycle.abortSignal.reason };
+        }
+        const event = parseClaimedGoogleChatEvent(record.payload, record.id);
+        const boundLifecycle = bindIngressLifecycleToReplyOptions(lifecycle).turnAdoptionLifecycle;
+        if (boundLifecycle.abortSignal.aborted) {
+          return { kind: "failed-retryable", error: boundLifecycle.abortSignal.reason };
+        }
+        const delivery = Promise.resolve().then(() => options.dispatch(event, boundLifecycle));
+        activeDeliveries.add(delivery);
+        try {
+          return await delivery;
+        } finally {
+          activeDeliveries.delete(delivery);
+        }
+      },
+    });
+    return drain;
+  };
+
+  const pruneIfDue = async (): Promise<void> => {
+    const now = Date.now();
+    if (now - lastPrunedAt < GOOGLECHAT_INGRESS_PRUNE_INTERVAL_MS) {
+      return;
+    }
+    await getQueue().prune({
+      completedTtlMs: GOOGLECHAT_INGRESS_COMPLETED_TTL_MS,
+      completedMaxEntries: GOOGLECHAT_INGRESS_COMPLETED_MAX_ENTRIES,
+      failedTtlMs: GOOGLECHAT_INGRESS_FAILED_TTL_MS,
+      failedMaxEntries: GOOGLECHAT_INGRESS_FAILED_MAX_ENTRIES,
+      now,
+    });
+    lastPrunedAt = now;
+  };
+
+  const waitForActiveDeliveries = async (): Promise<void> => {
+    while (activeDeliveries.size > 0) {
+      await Promise.allSettled(activeDeliveries);
+    }
+  };
+
+  const runPump = async (): Promise<void> => {
+    try {
+      for (;;) {
+        requested = false;
+        await pruneIfDue();
+        // stop() may race the async prune; never create a fresh drain afterward.
+        if (!running) {
+          break;
+        }
+        const activeDrain = getDrain();
+        const { started } = await activeDrain.drainOnce({
+          shouldStop: () =>
+            !running || activeDeliveries.size >= GOOGLECHAT_INGRESS_MAX_CONCURRENT_DELIVERIES,
+        });
+        await waitForActiveDeliveries();
+        if (!running || (!requested && started === 0)) {
+          break;
+        }
+      }
+    } catch (error) {
+      options.runtime.error?.(`googlechat ingress drain failed: ${formatErrorMessage(error)}`);
+    } finally {
+      pumping = undefined;
+      if (running && requested) {
+        requestDrain();
+      }
+    }
+  };
+
+  const requestDrain = (): void => {
+    requested = true;
+    if (!running || pumping) {
+      return;
+    }
+    pumping = runPump();
+  };
+
+  // Serialize concurrent HTTP admissions so append retry cannot invert a space lane.
+  let admissionTail: Promise<void> = Promise.resolve();
+
+  const serializeForIngress = (rawEvent: unknown): string => {
+    if (!isRecord(rawEvent)) {
+      throw new GoogleChatIngressPermanentError(
+        "invalid-event",
+        "Google Chat webhook envelope must be an object.",
+      );
+    }
+    const durableEvent = { ...rawEvent };
+    // Authentication is complete before admission; no Add-on authorization token is replay data.
+    delete durableEvent.authorizationEventObject;
+    const serialized = JSON.stringify(durableEvent);
+    if (typeof serialized !== "string") {
+      throw new GoogleChatIngressPermanentError(
+        "invalid-event",
+        "Google Chat webhook envelope cannot be serialized.",
+      );
+    }
+    return serialized;
+  };
+
+  const admitOnce = async (params: {
+    rawEvent: string;
+    facts: { eventId: string; laneKey: string };
+    receivedAt: number;
+  }): Promise<void> => {
+    let lastError: unknown;
+    for (const delayMs of [0, 100, 300]) {
+      if (delayMs > 0) {
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, delayMs);
+        });
+      }
+      try {
+        await getQueue().enqueue(
+          params.facts.eventId,
+          { version: GOOGLECHAT_INGRESS_PAYLOAD_VERSION, rawEvent: params.rawEvent },
+          { receivedAt: params.receivedAt, laneKey: params.facts.laneKey },
+        );
+        requestDrain();
+        return;
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    throw lastError;
+  };
+
+  return {
+    receive: async (rawEvent) => {
+      if (!running) {
+        throw new Error("Google Chat ingress is stopped.");
+      }
+      let facts: ReturnType<typeof inspectGoogleChatIngressEvent>;
+      try {
+        facts = inspectGoogleChatIngressEvent(rawEvent);
+      } catch (error) {
+        if (error instanceof GoogleChatIngressPermanentError) {
+          return { kind: "invalid", message: error.message };
+        }
+        throw error;
+      }
+      if (!facts) {
+        return { kind: "ignored" };
+      }
+      const serialized = serializeForIngress(rawEvent);
+      const receivedAt = Date.now();
+      const admission = admissionTail.then(async () => {
+        await admitOnce({ rawEvent: serialized, facts, receivedAt });
+      });
+      admissionTail = admission.catch(() => undefined);
+      await admission;
+      return { kind: "durable" };
+    },
+    start: () => {
+      if (running) {
+        return;
+      }
+      running = true;
+      pollTimer = setInterval(
+        requestDrain,
+        options.pollIntervalMs ?? GOOGLECHAT_INGRESS_POLL_INTERVAL_MS,
+      );
+      pollTimer.unref?.();
+      requestDrain();
+    },
+    stop: async () => {
+      running = false;
+      if (pollTimer) {
+        clearInterval(pollTimer);
+        pollTimer = undefined;
+      }
+      await admissionTail;
+      drain?.dispose();
+      await pumping;
+      await waitForActiveDeliveries();
+      // The pump can lazily create the drain before observing running=false.
+      drain?.dispose();
+      await drain?.waitForIdle();
+    },
+    waitForIdle: async () => {
+      for (;;) {
+        const activePump = pumping;
+        if (!activePump) {
+          break;
+        }
+        await activePump;
+      }
+      await waitForActiveDeliveries();
+      await drain?.waitForIdle();
+    },
+  };
+}

--- a/extensions/googlechat/src/monitor-ingress.ts
+++ b/extensions/googlechat/src/monitor-ingress.ts
@@ -10,7 +10,6 @@ import {
 } from "openclaw/plugin-sdk/channel-outbound";
 import { collectErrorGraphCandidates, formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { GoogleChatEventPayloadError, parseGoogleChatInboundPayload } from "./monitor-event.js";
-import type { GoogleChatRuntimeEnv } from "./monitor-types.js";
 import { getGoogleChatRuntime } from "./runtime.js";
 import type { GoogleChatEvent } from "./types.js";
 
@@ -180,7 +179,10 @@ export function createGoogleChatIngressMonitor(options: {
   accountId: string;
   queue?: ChannelIngressQueue<GoogleChatIngressPayload>;
   dispatch: GoogleChatIngressDispatch;
-  runtime: Pick<GoogleChatRuntimeEnv, "error" | "log">;
+  runtime: {
+    error?: (message: string) => void;
+    log?: (message: string) => void;
+  };
   pollIntervalMs?: number;
   adoptionStallTimeoutMs?: number;
   abortSignal?: AbortSignal;

--- a/extensions/googlechat/src/monitor-ingress.ts
+++ b/extensions/googlechat/src/monitor-ingress.ts
@@ -19,9 +19,11 @@ const GOOGLECHAT_INGRESS_POLL_INTERVAL_MS = 500;
 const GOOGLECHAT_INGRESS_PRUNE_INTERVAL_MS = 60 * 60 * 1_000;
 const GOOGLECHAT_INGRESS_MAX_CONCURRENT_DELIVERIES = 8;
 const GOOGLECHAT_INGRESS_COMPLETED_TTL_MS = 30 * 24 * 60 * 60 * 1_000;
-const GOOGLECHAT_INGRESS_COMPLETED_MAX_ENTRIES = 1_000;
+// The webhook retry horizon must fit beneath this cap; match Slack/Mattermost fleet sizing.
+// The 30-day TTL is the real horizon, while the cap only bounds disk usage.
+const GOOGLECHAT_INGRESS_COMPLETED_MAX_ENTRIES = 20_000;
 const GOOGLECHAT_INGRESS_FAILED_TTL_MS = 30 * 24 * 60 * 60 * 1_000;
-const GOOGLECHAT_INGRESS_FAILED_MAX_ENTRIES = 1_000;
+const GOOGLECHAT_INGRESS_FAILED_MAX_ENTRIES = 20_000;
 
 type GoogleChatIngressPayload = {
   version: 1;

--- a/extensions/googlechat/src/monitor-types.ts
+++ b/extensions/googlechat/src/monitor-types.ts
@@ -2,6 +2,7 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
 import type { GoogleChatAudienceType } from "./auth.js";
+import type { GoogleChatIngressMonitor } from "./monitor-ingress.js";
 import type { getGoogleChatRuntime } from "./runtime.js";
 
 export type GoogleChatRuntimeEnv = {
@@ -31,4 +32,5 @@ export type WebhookTarget = {
   audience?: string;
   statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
   mediaMaxMb: number;
+  ingress: Pick<GoogleChatIngressMonitor, "receive">;
 };

--- a/extensions/googlechat/src/monitor-webhook.test.ts
+++ b/extensions/googlechat/src/monitor-webhook.test.ts
@@ -10,6 +10,7 @@ const runDetachedWebhookWork = vi.hoisted(() => vi.fn((run: () => Promise<void>)
 const resolveWebhookTargetWithAuthOrReject = vi.hoisted(() => vi.fn());
 const withResolvedWebhookRequestPipeline = vi.hoisted(() => vi.fn());
 const verifyGoogleChatRequest = vi.hoisted(() => vi.fn());
+const ingressReceive = vi.hoisted(() => vi.fn());
 
 vi.mock("openclaw/plugin-sdk/webhook-request-guards", () => ({
   readJsonWebhookBodyOrReject,
@@ -63,7 +64,10 @@ function createResponse() {
   return res;
 }
 
-function installSimplePipeline(targets: unknown[]) {
+function installSimplePipeline(targets: Array<Record<string, unknown>>) {
+  for (const target of targets) {
+    target.ingress = { receive: ingressReceive };
+  }
   withResolvedWebhookRequestPipeline.mockImplementation(
     async ({
       handle,
@@ -117,6 +121,7 @@ describe("googlechat monitor webhook", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    ingressReceive.mockResolvedValue({ kind: "durable" });
   });
 
   afterAll(() => {
@@ -286,17 +291,18 @@ describe("googlechat monitor webhook", () => {
       audience: "https://example.com/googlechat",
       expectedAddOnPrincipal: "chat-app",
     });
-    expect(processEvent).toHaveBeenCalledWith(
-      {
-        type: "MESSAGE",
-        space: { name: "spaces/AAA" },
-        message: { name: "spaces/AAA/messages/1", text: "hello" },
-        user: { name: "users/123" },
-        eventTime: "2026-03-22T00:00:00.000Z",
-      },
-      target,
+    expect(ingressReceive).toHaveBeenCalledWith(
+      expect.objectContaining({
+        commonEventObject: { hostApp: "CHAT" },
+        chat: expect.objectContaining({
+          messagePayload: expect.objectContaining({
+            message: { name: "spaces/AAA/messages/1", text: "hello" },
+          }),
+        }),
+      }),
     );
-    expect(runDetachedWebhookWork).toHaveBeenCalledTimes(1);
+    expect(processEvent).not.toHaveBeenCalled();
+    expect(runDetachedWebhookWork).not.toHaveBeenCalled();
     expect(res.statusCode).toBe(200);
     expect(res.headers["Content-Type"]).toBe("application/json");
     expect(res.body).toBe("{}");
@@ -313,6 +319,7 @@ describe("googlechat monitor webhook", () => {
       audienceType: "app-url",
       audience: "https://example.com/googlechat",
     };
+    ingressReceive.mockResolvedValue({ kind: "ignored" });
     installSimplePipeline([target]);
     readJsonWebhookBodyOrReject.mockResolvedValue({
       ok: true,
@@ -377,6 +384,109 @@ describe("googlechat monitor webhook", () => {
     expect(res.statusCode).toBe(200);
     expect(res.headers["Content-Type"]).toBe("application/json");
     expect(res.body).toBe("{}");
+  });
+
+  it("waits for durable admission before acknowledging a message", async () => {
+    const target = {
+      account: { accountId: "default", config: {} },
+      runtime: { error: vi.fn() },
+      statusSink: vi.fn(),
+      audienceType: "app-url",
+      audience: "https://example.com/googlechat",
+    };
+    installSimplePipeline([target]);
+    const raw = {
+      type: "MESSAGE",
+      space: { name: "spaces/AAA" },
+      message: { name: "spaces/AAA/messages/durable", text: "hello" },
+    };
+    readJsonWebhookBodyOrReject.mockResolvedValue({ ok: true, value: raw });
+    resolveWebhookTargetWithAuthOrReject.mockResolvedValue(target);
+    verifyGoogleChatRequest.mockResolvedValue({ ok: true });
+    let releaseAdmission: (result: { kind: "durable" }) => void = () => {};
+    ingressReceive.mockImplementation(
+      () =>
+        new Promise<{ kind: "durable" }>((resolve) => {
+          releaseAdmission = resolve;
+        }),
+    );
+    const handler = createGoogleChatWebhookRequestHandler({
+      webhookTargets: new Map(),
+      webhookRateLimiter: {
+        isRateLimited: vi.fn(() => false),
+        size: vi.fn(() => 0),
+        clear: vi.fn(),
+      },
+      webhookInFlightLimiter: {} as never,
+      processEvent: vi.fn(async () => {}),
+    });
+    const res = createResponse();
+    const handling = handler(createRequest({ authorization: "Bearer valid" }), res);
+
+    await vi.waitFor(() => expect(ingressReceive).toHaveBeenCalledWith(raw));
+    expect(res.statusCode).toBe(0);
+    releaseAdmission({ kind: "durable" });
+    await expect(handling).resolves.toBe(true);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("returns 503 instead of acknowledging when durable admission fails", async () => {
+    const target = {
+      account: { accountId: "default", config: {} },
+      runtime: { error: vi.fn() },
+      statusSink: vi.fn(),
+      audienceType: "app-url",
+      audience: "https://example.com/googlechat",
+    };
+    installSimplePipeline([target]);
+    readJsonWebhookBodyOrReject.mockResolvedValue({
+      ok: true,
+      value: {
+        type: "MESSAGE",
+        space: { name: "spaces/AAA" },
+        message: { name: "spaces/AAA/messages/failed", text: "hello" },
+      },
+    });
+    resolveWebhookTargetWithAuthOrReject.mockResolvedValue(target);
+    verifyGoogleChatRequest.mockResolvedValue({ ok: true });
+    ingressReceive.mockRejectedValue(new Error("sqlite busy"));
+
+    const { processEvent, res } = await runWebhookHandler({ authorization: "Bearer valid" });
+
+    expect(res.statusCode).toBe(503);
+    expect(res.body).toBe("failed to persist event");
+    expect(processEvent).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a permanently invalid message identity", async () => {
+    const target = {
+      account: { accountId: "default", config: {} },
+      runtime: { error: vi.fn() },
+      statusSink: vi.fn(),
+      audienceType: "app-url",
+      audience: "https://example.com/googlechat",
+    };
+    installSimplePipeline([target]);
+    readJsonWebhookBodyOrReject.mockResolvedValue({
+      ok: true,
+      value: {
+        type: "MESSAGE",
+        space: { name: "spaces/AAA" },
+        message: { text: "missing resource name" },
+      },
+    });
+    resolveWebhookTargetWithAuthOrReject.mockResolvedValue(target);
+    verifyGoogleChatRequest.mockResolvedValue({ ok: true });
+    ingressReceive.mockResolvedValue({
+      kind: "invalid",
+      message: "Google Chat MESSAGE event is missing message.name.",
+    });
+
+    const { processEvent, res } = await runWebhookHandler({ authorization: "Bearer valid" });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toBe("invalid payload");
+    expect(processEvent).not.toHaveBeenCalled();
   });
 
   it("logs WARN with reason when verification fails (missing token)", async () => {
@@ -571,16 +681,16 @@ describe("googlechat monitor webhook", () => {
 
     expect(logA).not.toHaveBeenCalled();
     expect(logB).not.toHaveBeenCalled();
-    expect(processEvent).toHaveBeenCalledWith(
-      {
-        type: "MESSAGE",
-        space: { name: "spaces/BBB" },
-        message: { name: "spaces/BBB/messages/1", text: "hi" },
-        user: { name: "users/123" },
-        eventTime: "2026-03-22T00:00:00.000Z",
-      },
-      targetB,
+    expect(ingressReceive).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chat: expect.objectContaining({
+          messagePayload: expect.objectContaining({
+            message: { name: "spaces/BBB/messages/1", text: "hi" },
+          }),
+        }),
+      }),
     );
+    expect(processEvent).not.toHaveBeenCalled();
     expect(res.statusCode).toBe(200);
     expect(res.headers["Content-Type"]).toBe("application/json");
     expect(res.body).toBe("{}");

--- a/extensions/googlechat/src/monitor-webhook.ts
+++ b/extensions/googlechat/src/monitor-webhook.ts
@@ -16,15 +16,9 @@ import {
   withResolvedWebhookRequestPipeline,
 } from "openclaw/plugin-sdk/webhook-targets";
 import { verifyGoogleChatRequest } from "./auth.js";
+import { parseGoogleChatInboundPayload as normalizeGoogleChatInboundPayload } from "./monitor-event.js";
 import type { WebhookTarget } from "./monitor-types.js";
-import type {
-  GoogleChatAction,
-  GoogleChatActionParameter,
-  GoogleChatEvent,
-  GoogleChatMessage,
-  GoogleChatSpace,
-  GoogleChatUser,
-} from "./types.js";
+import type { GoogleChatEvent } from "./types.js";
 
 function extractBearerToken(header: unknown): string {
   const authHeader = Array.isArray(header)
@@ -42,129 +36,36 @@ function extractBearerToken(header: unknown): string {
 const ADD_ON_PREAUTH_MAX_BYTES = 16 * 1024;
 const ADD_ON_PREAUTH_TIMEOUT_MS = 3_000;
 
-type ParsedGoogleChatInboundPayload =
-  | { ok: true; event: GoogleChatEvent; addOnBearerToken: string }
-  | { ok: false };
-type ParsedGoogleChatInboundSuccess = Extract<ParsedGoogleChatInboundPayload, { ok: true }>;
+type ParsedGoogleChatInboundSuccess = {
+  raw: Record<string, unknown>;
+  addOnBearerToken: string;
+};
 
-function recordParamsToActionParameters(
-  params?: Record<string, string>,
-): GoogleChatActionParameter[] | undefined {
-  if (!params) {
-    return undefined;
-  }
-  const entries = Object.entries(params)
-    .filter((entry): entry is [string, string] => typeof entry[1] === "string")
-    .map(([key, value]) => ({ key, value }));
-  return entries.length > 0 ? entries : undefined;
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function parseGoogleChatInboundPayload(
+function parseGoogleChatInboundPayloadOrReject(
   raw: unknown,
   res: ServerResponse,
-): ParsedGoogleChatInboundPayload {
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+): ParsedGoogleChatInboundSuccess | null {
+  if (!isRecord(raw)) {
     res.statusCode = 400;
     res.end("invalid payload");
-    return { ok: false };
+    return null;
   }
-
-  let eventPayload = raw;
+  const commonEventObject = isRecord(raw.commonEventObject) ? raw.commonEventObject : null;
+  const authorizationEventObject = isRecord(raw.authorizationEventObject)
+    ? raw.authorizationEventObject
+    : null;
   let addOnBearerToken = "";
-
-  // Transform Google Workspace Add-on format to standard Chat API format.
-  const rawObj = raw as {
-    commonEventObject?: {
-      hostApp?: string;
-      invokedFunction?: string;
-      parameters?: Record<string, string>;
-    };
-    chat?: {
-      messagePayload?: { space?: GoogleChatSpace; message?: GoogleChatMessage };
-      buttonClickedPayload?: {
-        space?: GoogleChatSpace;
-        message?: GoogleChatMessage;
-        user?: GoogleChatUser;
-        action?: GoogleChatAction;
-      };
-      user?: GoogleChatUser;
-      eventTime?: string;
-    };
-    authorizationEventObject?: { systemIdToken?: string };
-  };
-
-  if (rawObj.commonEventObject?.hostApp === "CHAT") {
-    addOnBearerToken =
-      typeof rawObj.authorizationEventObject?.systemIdToken === "string"
-        ? rawObj.authorizationEventObject.systemIdToken.trim()
-        : "";
+  if (
+    commonEventObject?.hostApp === "CHAT" &&
+    typeof authorizationEventObject?.systemIdToken === "string"
+  ) {
+    addOnBearerToken = authorizationEventObject.systemIdToken.trim();
   }
-
-  if (rawObj.commonEventObject?.hostApp === "CHAT" && rawObj.chat?.messagePayload) {
-    const chat = rawObj.chat;
-    const messagePayload = chat.messagePayload;
-    eventPayload = {
-      type: "MESSAGE",
-      space: messagePayload?.space,
-      message: messagePayload?.message,
-      user: chat.user,
-      eventTime: chat.eventTime,
-    };
-  } else if (rawObj.commonEventObject?.hostApp === "CHAT") {
-    const chat = rawObj.chat;
-    const buttonClickedPayload = chat?.buttonClickedPayload;
-    if (buttonClickedPayload) {
-      const invokedFunction = rawObj.commonEventObject.invokedFunction;
-      const actionParameters = recordParamsToActionParameters(rawObj.commonEventObject.parameters);
-      eventPayload = {
-        type: "CARD_CLICKED",
-        space: buttonClickedPayload.space,
-        message: buttonClickedPayload.message,
-        user: buttonClickedPayload.user ?? chat.user,
-        eventTime: chat.eventTime,
-        action:
-          buttonClickedPayload.action ??
-          ({
-            ...(typeof invokedFunction === "string" ? { actionMethodName: invokedFunction } : {}),
-            ...(actionParameters ? { parameters: actionParameters } : {}),
-          } satisfies GoogleChatAction),
-        commonEventObject: {
-          ...(typeof invokedFunction === "string" ? { invokedFunction } : {}),
-          parameters: rawObj.commonEventObject.parameters,
-        },
-      };
-    }
-  }
-
-  const event = eventPayload as GoogleChatEvent;
-  const eventType = event.type ?? (eventPayload as { eventType?: string }).eventType;
-  if (typeof eventType !== "string") {
-    res.statusCode = 400;
-    res.end("invalid payload");
-    return { ok: false };
-  }
-
-  if (!event.space || typeof event.space !== "object" || Array.isArray(event.space)) {
-    res.statusCode = 400;
-    res.end("invalid payload");
-    return { ok: false };
-  }
-
-  if (eventType === "MESSAGE") {
-    if (!event.message || typeof event.message !== "object" || Array.isArray(event.message)) {
-      res.statusCode = 400;
-      res.end("invalid payload");
-      return { ok: false };
-    }
-  } else if (eventType === "CARD_CLICKED") {
-    if (!event.user || typeof event.user !== "object" || Array.isArray(event.user)) {
-      res.statusCode = 400;
-      res.end("invalid payload");
-      return { ok: false };
-    }
-  }
-
-  return { ok: true, event, addOnBearerToken };
+  return { raw, addOnBearerToken };
 }
 
 type GoogleChatWebhookAuthRejection = {
@@ -276,7 +177,7 @@ export function createGoogleChatWebhookRequestHandler(params: {
       handle: async ({ targets }) => {
         const headerBearer = extractBearerToken(req.headers.authorization);
         let selectedTarget: WebhookTarget | null;
-        let parsedEvent: GoogleChatEvent | null;
+        let parsedInbound: ParsedGoogleChatInboundSuccess;
         const readAndParseEvent = async (
           profile: "pre-auth" | "post-auth",
         ): Promise<ParsedGoogleChatInboundSuccess | null> => {
@@ -297,8 +198,7 @@ export function createGoogleChatWebhookRequestHandler(params: {
             return null;
           }
 
-          const parsed = parseGoogleChatInboundPayload(body.value, res);
-          return parsed.ok ? parsed : null;
+          return parseGoogleChatInboundPayloadOrReject(body.value, res);
         };
 
         if (headerBearer) {
@@ -315,13 +215,13 @@ export function createGoogleChatWebhookRequestHandler(params: {
           if (!parsed) {
             return true;
           }
-          parsedEvent = parsed.event;
+          parsedInbound = parsed;
         } else {
           const parsed = await readAndParseEvent("pre-auth");
           if (!parsed) {
             return true;
           }
-          parsedEvent = parsed.event;
+          parsedInbound = parsed;
 
           if (!parsed.addOnBearerToken) {
             logGoogleChatWebhookAuthRejectedForTargets(targets, "missing token");
@@ -340,7 +240,7 @@ export function createGoogleChatWebhookRequestHandler(params: {
           }
         }
 
-        if (!selectedTarget || !parsedEvent) {
+        if (!selectedTarget || !parsedInbound) {
           res.statusCode = 401;
           res.end("unauthorized");
           return true;
@@ -348,15 +248,39 @@ export function createGoogleChatWebhookRequestHandler(params: {
 
         const dispatchTarget = selectedTarget;
         dispatchTarget.statusSink?.({ lastInboundAt: Date.now() });
-        // Reserve the detached task before the HTTP admission is released;
-        // otherwise later queue work inherits a released admission root.
-        void runDetachedWebhookWork(() => params.processEvent(parsedEvent, dispatchTarget)).catch(
-          (err: unknown) => {
-            dispatchTarget.runtime.error?.(
-              `[${dispatchTarget.account.accountId}] Google Chat webhook failed: ${String(err)}`,
+        try {
+          const admission = await dispatchTarget.ingress.receive(parsedInbound.raw);
+          if (admission.kind === "invalid") {
+            res.statusCode = 400;
+            res.end("invalid payload");
+            return true;
+          }
+          if (admission.kind === "ignored") {
+            // Non-turn actions preserve their existing detached webhook path.
+            let event: GoogleChatEvent;
+            try {
+              event = normalizeGoogleChatInboundPayload(parsedInbound.raw).event;
+            } catch {
+              res.statusCode = 400;
+              res.end("invalid payload");
+              return true;
+            }
+            void runDetachedWebhookWork(() => params.processEvent(event, dispatchTarget)).catch(
+              (err: unknown) => {
+                dispatchTarget.runtime.error?.(
+                  `[${dispatchTarget.account.accountId}] Google Chat webhook failed: ${String(err)}`,
+                );
+              },
             );
-          },
-        );
+          }
+        } catch (error) {
+          dispatchTarget.runtime.error?.(
+            `[${dispatchTarget.account.accountId}] Google Chat durable admission failed: ${String(error)}`,
+          );
+          res.statusCode = 503;
+          res.end("failed to persist event");
+          return true;
+        }
 
         res.statusCode = 200;
         res.setHeader("Content-Type", "application/json");

--- a/extensions/googlechat/src/monitor.test.ts
+++ b/extensions/googlechat/src/monitor.test.ts
@@ -2,6 +2,7 @@
 import { recordChannelBotPairLoopAndCheckSuppression } from "openclaw/plugin-sdk/channel-inbound";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
+import type { GoogleChatIngressLifecycle } from "./monitor-ingress.js";
 import type { GoogleChatCoreRuntime, GoogleChatRuntimeEnv } from "./monitor-types.js";
 import "./monitor.js";
 import type { GoogleChatEvent } from "./types.js";
@@ -17,7 +18,11 @@ const accessMocks = vi.hoisted(() => ({
 
 const routingMocks = vi.hoisted(() => ({
   processEvent: undefined as
-    | ((event: GoogleChatEvent, target: Record<string, unknown>) => Promise<void>)
+    | ((
+        event: GoogleChatEvent,
+        target: Record<string, unknown>,
+        turnAdoptionLifecycle?: GoogleChatIngressLifecycle,
+      ) => Promise<void>)
     | undefined,
 }));
 
@@ -46,7 +51,13 @@ vi.mock("./monitor-access.js", () => ({
 vi.mock("./monitor-routing.js", () => ({
   registerGoogleChatWebhookTarget: vi.fn(),
   setGoogleChatWebhookEventProcessor: vi.fn(
-    (processEvent: (event: GoogleChatEvent, target: Record<string, unknown>) => Promise<void>) => {
+    (
+      processEvent: (
+        event: GoogleChatEvent,
+        target: Record<string, unknown>,
+        turnAdoptionLifecycle?: GoogleChatIngressLifecycle,
+      ) => Promise<void>,
+    ) => {
       routingMocks.processEvent = processEvent;
     },
   ),
@@ -88,18 +99,23 @@ async function processGoogleChatTestEvent(params: {
   runtime: GoogleChatRuntimeEnv;
   core: GoogleChatCoreRuntime;
   mediaMaxMb: number;
+  turnAdoptionLifecycle?: GoogleChatIngressLifecycle;
 }): Promise<void> {
   if (!routingMocks.processEvent) {
     throw new Error("Expected Google Chat webhook event processor registration");
   }
-  await routingMocks.processEvent(params.event, {
-    account: params.account,
-    config: params.config,
-    runtime: params.runtime,
-    core: params.core,
-    mediaMaxMb: params.mediaMaxMb,
-    path: "/googlechat",
-  });
+  await routingMocks.processEvent(
+    params.event,
+    {
+      account: params.account,
+      config: params.config,
+      runtime: params.runtime,
+      core: params.core,
+      mediaMaxMb: params.mediaMaxMb,
+      path: "/googlechat",
+    },
+    params.turnAdoptionLifecycle,
+  );
 }
 
 describe("googlechat monitor bot loop protection", () => {
@@ -235,6 +251,48 @@ describe("googlechat monitor inbound space classification", () => {
       }),
     );
     expect(runTurn).toHaveBeenCalledOnce();
+  });
+
+  it("passes durable ingress adoption ownership into the inbound turn", async () => {
+    const { core, runTurn } = createInboundClassificationHarness();
+    const turnAdoptionLifecycle = {
+      admission: "exclusive",
+      onAdopted: vi.fn(async () => {}),
+      onDeferred: vi.fn(),
+      onAbandoned: vi.fn(async () => {}),
+      abortSignal: new AbortController().signal,
+    } satisfies GoogleChatIngressLifecycle;
+    accessMocks.applyGoogleChatInboundAccessPolicy.mockResolvedValue({
+      ok: true,
+      commandAuthorized: undefined,
+      effectiveWasMentioned: undefined,
+      groupBotLoopProtection: undefined,
+      groupSystemPrompt: undefined,
+    });
+
+    await processGoogleChatTestEvent({
+      event: {
+        type: "MESSAGE",
+        space: { name: "spaces/DURABLE", type: "DM" },
+        message: {
+          name: "spaces/DURABLE/messages/1",
+          text: "hello",
+          sender: { name: "users/alice", type: "HUMAN" },
+        },
+      },
+      account: {
+        accountId: "work",
+        config: { typingIndicator: "none" },
+        credentialSource: "inline",
+      } as ResolvedGoogleChatAccount,
+      config: {},
+      runtime: { error: vi.fn(), log: vi.fn() },
+      core,
+      mediaMaxMb: 10,
+      turnAdoptionLifecycle,
+    });
+
+    expect(runTurn).toHaveBeenCalledWith(expect.objectContaining({ turnAdoptionLifecycle }));
   });
 
   it.each([

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -14,6 +14,10 @@ import { maybeHandleGoogleChatApprovalCardClick } from "./approval-card-click.js
 import type { GoogleChatAudienceType } from "./auth.js";
 import { applyGoogleChatInboundAccessPolicy } from "./monitor-access.js";
 import { resolveGoogleChatDurableReplyOptions } from "./monitor-durable.js";
+import {
+  createGoogleChatIngressMonitor,
+  type GoogleChatIngressLifecycle,
+} from "./monitor-ingress.js";
 import { deliverGoogleChatReply, type GoogleChatTypingMessage } from "./monitor-reply-delivery.js";
 import {
   registerGoogleChatWebhookTarget,
@@ -119,7 +123,11 @@ function shouldSuppressGoogleChatBotLoop(params: {
   return true;
 }
 
-async function processGoogleChatEvent(event: GoogleChatEvent, target: WebhookTarget) {
+async function processGoogleChatEvent(
+  event: GoogleChatEvent,
+  target: WebhookTarget,
+  turnAdoptionLifecycle?: GoogleChatIngressLifecycle,
+) {
   const eventType = event.type ?? (event as { eventType?: string }).eventType;
   if (eventType === "CARD_CLICKED") {
     await maybeHandleGoogleChatApprovalCardClick({ event, target });
@@ -140,6 +148,7 @@ async function processGoogleChatEvent(event: GoogleChatEvent, target: WebhookTar
     core: target.core,
     statusSink: target.statusSink,
     mediaMaxMb: target.mediaMaxMb,
+    turnAdoptionLifecycle,
   });
 }
 
@@ -173,8 +182,10 @@ async function processMessageWithPipeline(params: {
   core: GoogleChatCoreRuntime;
   statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
   mediaMaxMb: number;
+  turnAdoptionLifecycle?: GoogleChatIngressLifecycle;
 }): Promise<void> {
-  const { event, account, config, runtime, core, statusSink, mediaMaxMb } = params;
+  const { event, account, config, runtime, core, statusSink, mediaMaxMb, turnAdoptionLifecycle } =
+    params;
   const space = event.space;
   const message = event.message;
   if (!space || !message) {
@@ -383,6 +394,7 @@ async function processMessageWithPipeline(params: {
     channel: "googlechat",
     accountId: route.accountId,
     raw: message,
+    ...(turnAdoptionLifecycle ? { turnAdoptionLifecycle } : {}),
     adapter: {
       ingest: () => ({
         id: message.name ?? spaceId,
@@ -462,7 +474,9 @@ async function downloadAttachment(
   return { path: saved.path, contentType: saved.contentType };
 }
 
-function monitorGoogleChatProvider(options: GoogleChatMonitorOptions): () => void {
+async function monitorGoogleChatProvider(
+  options: GoogleChatMonitorOptions,
+): Promise<() => Promise<void>> {
   const core = getGoogleChatRuntime();
   const webhookPath = resolveWebhookPath({
     webhookPath: options.webhookPath,
@@ -471,7 +485,7 @@ function monitorGoogleChatProvider(options: GoogleChatMonitorOptions): () => voi
   });
   if (!webhookPath) {
     options.runtime.error?.(`[${options.account.accountId}] invalid webhook path`);
-    return () => {};
+    return async () => {};
   }
 
   const audienceType = normalizeAudienceType(options.account.config.audienceType);
@@ -485,7 +499,15 @@ function monitorGoogleChatProvider(options: GoogleChatMonitorOptions): () => voi
     log: options.runtime.log,
   });
 
-  const unregisterTarget = registerGoogleChatWebhookTarget({
+  const ingress = createGoogleChatIngressMonitor({
+    accountId: options.account.accountId,
+    runtime: options.runtime,
+    abortSignal: options.abortSignal,
+    dispatch: async (event, lifecycle) => {
+      await processGoogleChatEvent(event, target, lifecycle);
+    },
+  });
+  const target: WebhookTarget = {
     account: options.account,
     config: options.config,
     runtime: options.runtime,
@@ -495,17 +517,27 @@ function monitorGoogleChatProvider(options: GoogleChatMonitorOptions): () => voi
     audience,
     statusSink: options.statusSink,
     mediaMaxMb,
-  });
+    ingress,
+  };
+  ingress.start();
+  let unregisterTarget: (() => void) | undefined;
+  try {
+    unregisterTarget = registerGoogleChatWebhookTarget(target);
+  } catch (error) {
+    await ingress.stop();
+    throw error;
+  }
 
-  return () => {
-    unregisterTarget();
+  return async () => {
+    unregisterTarget?.();
+    await ingress.stop();
   };
 }
 
 export async function startGoogleChatMonitor(
   params: GoogleChatMonitorOptions,
-): Promise<() => void> {
-  return monitorGoogleChatProvider(params);
+): Promise<() => Promise<void>> {
+  return await monitorGoogleChatProvider(params);
 }
 
 export function resolveGoogleChatWebhookPath(params: {

--- a/extensions/googlechat/src/monitor.webhook-routing.test.ts
+++ b/extensions/googlechat/src/monitor.webhook-routing.test.ts
@@ -100,6 +100,7 @@ function registerTwoTargets() {
   const logB = vi.fn();
   const core = {} as PluginRuntime;
   const config = {} as OpenClawConfig;
+  const ingress = { receive: vi.fn(async () => ({ kind: "ignored" as const })) };
 
   const unregisterA = registerGoogleChatWebhookTarget({
     account: baseAccount("A"),
@@ -109,6 +110,7 @@ function registerTwoTargets() {
     path: "/googlechat",
     statusSink: sinkA,
     mediaMaxMb: 5,
+    ingress,
   });
   const unregisterB = registerGoogleChatWebhookTarget({
     account: baseAccount("B"),
@@ -118,6 +120,7 @@ function registerTwoTargets() {
     path: "/googlechat",
     statusSink: sinkB,
     mediaMaxMb: 5,
+    ingress,
   });
   webhookRouteHandler = expectDefined(registry.httpRoutes[0], "Google Chat webhook route").handler;
 
@@ -247,7 +250,10 @@ describe("Google Chat webhook routing", () => {
               user: { name: "users/12345", displayName: "Test User" },
               messagePayload: {
                 space: { name: "spaces/AAA" },
-                message: { text: "Hello from add-on" },
+                message: {
+                  name: "spaces/AAA/messages/add-on-1",
+                  text: "Hello from add-on",
+                },
               },
             },
           },


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where acknowledged Google Chat message webhooks could be lost if the process stopped before turn ownership transferred, and where delayed webhook redeliveries could run the same completed message again after an undersized tombstone cap pruned its identity.

## Why This Change Was Made

Authenticated `MESSAGE` events are now durably admitted before acknowledgment, drained in per-space order, and retained through restart recovery while add-on authorization tokens are excluded from persisted replay data. Completed and failed tombstones use the 20,000-entry webhook-channel fleet convention, with the 30-day TTL as the real deduplication horizon and the cap only as a disk bound.

Google documents that failed HTTPS deliveries can be retried and that a Chat app can receive the same message multiple times: https://developers.google.com/workspace/chat/receive-respond-interactions#handle_http_call_retries_to_your_service

## User Impact

Google Chat users can expect admitted messages to survive gateway restarts and webhook retries to remain idempotent, avoiding lost turns, duplicate replies, and repeated side effects.

## Evidence

- `pnpm test extensions/googlechat`: 23 test files, 226 tests passed, including direct 1,050-tombstone prune/deduplication coverage.
- `pnpm deadcode:unused-files`: production and full-tree scans passed with 0 entries.
- `pnpm deadcode:exports`: production, full-tree, and script scans passed with 0 entries.
- `pnpm format:check extensions/googlechat/src/monitor-ingress.ts extensions/googlechat/src/monitor-ingress.test.ts`: clean.
- `git diff --check`: clean.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`: clean, no accepted/actionable findings.

AI-assisted; implementation and behavior reviewed against the full branch diff.
