### PR TITLE
fix(doctor): stream JSONL line counts without full-file reads

### DIFF
--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -975,4 +975,46 @@ describe("doctor state integrity oauth dir checks", () => {
     const text = await runStateIntegrityText(cfg);
     expect(text).toContain("Main session transcript has only 1 line");
   });
+
+  it("keeps line counting fail-soft when closeSync throws", async () => {
+    const cfg: OpenClawConfig = {};
+    setupSessionState(cfg, process.env, tempHome);
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main", process.env, () => tempHome);
+    const transcriptPath = path.join(sessionsDir, "close-fail.jsonl");
+    fs.writeFileSync(transcriptPath, '{"type":"session"}\n{"x":1}\n');
+    writeSessionStore(cfg, {
+      "agent:main:main": {
+        sessionId: "close-fail",
+        updatedAt: Date.now(),
+      },
+    });
+
+    const realOpenSync = fs.openSync.bind(fs);
+    const realCloseSync = fs.closeSync.bind(fs);
+    const transcriptFds = new Set<number>();
+    const openSpy = vi.spyOn(fs, "openSync").mockImplementation(((
+      target: fs.PathLike,
+      flags: fs.OpenMode | undefined,
+      mode?: fs.Mode,
+    ) => {
+      const fd = realOpenSync(target, flags as never, mode as never);
+      if (typeof target === "string" && path.resolve(target) === path.resolve(transcriptPath)) {
+        transcriptFds.add(fd);
+      }
+      return fd;
+    }) as typeof fs.openSync);
+    const closeSpy = vi.spyOn(fs, "closeSync").mockImplementation(((fd: number) => {
+      if (transcriptFds.has(fd)) {
+        throw new Error("close boom");
+      }
+      return realCloseSync(fd);
+    }) as typeof fs.closeSync);
+    try {
+      const text = await runStateIntegrityText(cfg);
+      expect(text).not.toContain("Main session transcript has only");
+    } finally {
+      openSpy.mockRestore();
+      closeSpy.mockRestore();
+    }
+  });
 });

--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -923,4 +923,56 @@ describe("doctor state integrity oauth dir checks", () => {
     const text = await runStateIntegrityText(cfg);
     expect(text).not.toContain("recent sessions are missing transcripts");
   });
+
+  it("counts a multi-chunk main transcript without readFileSync", async () => {
+    const cfg: OpenClawConfig = {};
+    setupSessionState(cfg, process.env, tempHome);
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main", process.env, () => tempHome);
+    const transcriptPath = path.join(sessionsDir, "chunked-main.jsonl");
+    const fd = fs.openSync(transcriptPath, "w");
+    try {
+      const line = `${"x".repeat(64 * 1024)}\n`;
+      for (let i = 0; i < 8; i += 1) {
+        fs.writeSync(fd, line);
+      }
+    } finally {
+      fs.closeSync(fd);
+    }
+    writeSessionStore(cfg, {
+      "agent:main:main": {
+        sessionId: "chunked-main",
+        updatedAt: Date.now(),
+      },
+    });
+
+    const readFileSyncSpy = vi.spyOn(fs, "readFileSync");
+    try {
+      const text = await runStateIntegrityText(cfg);
+      expect(text).not.toContain("Main session transcript has only");
+      expect(
+        readFileSyncSpy.mock.calls.some((call) => {
+          const target = call[0];
+          return typeof target === "string" && path.resolve(target) === path.resolve(transcriptPath);
+        }),
+      ).toBe(false);
+    } finally {
+      readFileSyncSpy.mockRestore();
+    }
+  });
+
+  it("still warns when the main transcript has only one line", async () => {
+    const cfg: OpenClawConfig = {};
+    setupSessionState(cfg, process.env, tempHome);
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main", process.env, () => tempHome);
+    fs.writeFileSync(path.join(sessionsDir, "short-main.jsonl"), '{"type":"session"}');
+    writeSessionStore(cfg, {
+      "agent:main:main": {
+        sessionId: "short-main",
+        updatedAt: Date.now(),
+      },
+    });
+
+    const text = await runStateIntegrityText(cfg);
+    expect(text).toContain("Main session transcript has only 1 line");
+  });
 });

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -286,10 +286,17 @@ function countJsonlLines(filePath: string): number {
     }
     return count;
   } catch {
+    // Preserve the old fail-soft contract: unreadable transcripts count as 0 lines.
     return 0;
   } finally {
+    // closeSync must not escape: a close failure used to abort doctor after a
+    // successful count when close ran outside this function's catch.
     if (fd !== undefined) {
-      fs.closeSync(fd);
+      try {
+        fs.closeSync(fd);
+      } catch {
+        // ignore close failures; the advisory line count already completed or failed soft
+      }
     }
   }
 }

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -255,24 +255,42 @@ function addUserRwx(mode: number): number {
   return perms | 0o700;
 }
 
+const JSONL_LINE_COUNT_CHUNK_BYTES = 64 * 1024;
+
+// Doctor only needs a line count for the main-session transcript warning.
+// Stream fixed-size chunks so a multi-hundred-MB JSONL cannot force a full-file string alloc.
 function countJsonlLines(filePath: string): number {
+  let fd: number | undefined;
   try {
-    const raw = fs.readFileSync(filePath, "utf-8");
-    if (!raw) {
-      return 0;
-    }
+    fd = fs.openSync(filePath, "r");
+    const buffer = Buffer.allocUnsafe(JSONL_LINE_COUNT_CHUNK_BYTES);
     let count = 0;
-    for (const char of raw) {
-      if (char === "\n") {
-        count += 1;
+    let lastByte: number | undefined;
+    while (true) {
+      const bytesRead = fs.readSync(fd, buffer, 0, buffer.length, null);
+      if (bytesRead === 0) {
+        break;
+      }
+      for (let i = 0; i < bytesRead; i += 1) {
+        const byte = buffer[i];
+        if (byte === 0x0a) {
+          count += 1;
+        }
+        lastByte = byte;
       }
     }
-    if (!raw.endsWith("\n")) {
+    // Match prior UTF-8 string counting: a non-empty file without a trailing newline
+    // still contributes one line.
+    if (lastByte !== undefined && lastByte !== 0x0a) {
       count += 1;
     }
     return count;
   } catch {
     return 0;
+  } finally {
+    if (fd !== undefined) {
+      fs.closeSync(fd);
+    }
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

`openclaw doctor` state integrity counted main-session JSONL transcript lines by
`fs.readFileSync` + walking every character. A multi-hundred-MB transcript forced
the whole file into one UTF-8 string before the `lineCount <= 1` warning could
run, so doctor could spike RSS to roughly the transcript size.

## Why This Change Was Made

Replace the full-file string read with a fixed-size sync chunk reader
(`openSync` + `readSync`) that counts `0x0a` bytes and preserves the old
trailing-newline rule for the final incomplete line. Close failures stay inside
the helper so an uncommon `closeSync` error cannot abort doctor after a
successful count.

## User Impact

**Before:** A large main transcript could make `openclaw doctor` allocate a
full-file string just to count lines. A close failure after chunked counting
could also abort the doctor command.

**After:** Line counting streams 64 KiB chunks, so doctor keeps the
single-line warning without buffering the whole transcript, and close errors
remain fail-soft.

## Evidence

- Changed: `src/commands/doctor-state-integrity.ts`,
  `src/commands/doctor-state-integrity.test.ts`
- Production path: `noteStateIntegrity` → main transcript exists →
  `countJsonlLines(transcriptPath)` → `lineCount <= 1` warning
- Compatibility: empty / missing / single-line / multi-line semantics unchanged;
  only the read strategy and close fail-soft boundary change

## Real behavior proof

### Behavior or issue addressed

Isolated `openclaw doctor --non-interactive --yes` against a one-line main
transcript prints the State integrity warning; the same command against an
8 × 64 KiB multi-chunk transcript does not.

### Canonical reachability path

`openclaw doctor` → `noteStateIntegrity` → resolve main session transcript →
`countJsonlLines` (chunked `readSync`) → optional
`Main session transcript has only … line` warning

### Shared helper / provider constraint check

Local to doctor state integrity; no new config/env surface. Chunk size matches
the existing doctor JSONL reader constant family (64 KiB).

### Real environment tested

Local trusted source checkout at PR head; Node 22.23.1; isolated
`OPENCLAW_STATE_DIR` / `OPENCLAW_CONFIG_PATH` / `HOME` under `/tmp`; CLI via
`node scripts/run-node.mjs doctor --non-interactive --yes` after local build.

### Exact steps or command run after this patch

```bash
# one-line
PROOF=$(mktemp -d /tmp/openclaw-doctor-jsonl-proof-XXXXXX)
STATE=$PROOF/state; HOME_DIR=$PROOF/home; CONFIG=$PROOF/openclaw.json
mkdir -p "$HOME_DIR" "$STATE/agents/main/sessions"
printf '%s\n' '{"agents":{"list":[{"id":"main","default":true}]}}' > "$CONFIG"
printf '%s' '{"type":"session"}' > "$STATE/agents/main/sessions/short-main.jsonl"
printf '%s\n' '{"agent:main:main":{"sessionId":"short-main","updatedAt":1700000000000}}' \
  > "$STATE/agents/main/sessions/sessions.json"
HOME=$HOME_DIR OPENCLAW_HOME=$HOME_DIR OPENCLAW_STATE_DIR=$STATE \
  OPENCLAW_CONFIG_PATH=$CONFIG CI=true \
  node scripts/run-node.mjs doctor --non-interactive --yes

# multi-chunk (8 × 64 KiB lines; ~512 KiB)
# rewrite sessions.json to chunked-main.jsonl, then rerun the same doctor command
```

Focused regression (closeSync fail-soft):

```bash
node scripts/run-vitest.mjs src/commands/doctor-state-integrity.test.ts \
  -t "multi-chunk|only one line|closeSync" --reporter=verbose
```

### Evidence after fix

Redacted CLI (one-line transcript):

```text
◇  State integrity ────────────────────────────────────────────────────────╮
│  - Main session transcript has only 1 line. Session history may not be   │
│    appending.                                                            │
├──────────────────────────────────────────────────────────────────────────╯
```

Redacted CLI (multi-chunk transcript; same doctor command, no single-line warning):

```text
◇  State integrity ────────────────────────────────────────────────────────╮
│  - OAuth dir not present                                                 │
│    (.../state/credentials).                                              │
│  - Multiple state directories detected. ...                              │
│                                                                          │
├──────────────────────────────────────────────────────────────────────────╯
```

Focused tests:

```text
✓ counts a multi-chunk main transcript without readFileSync
✓ still warns when the main transcript has only one line
✓ keeps line counting fail-soft when closeSync throws
 Test Files  1 passed (1)
      Tests  3 passed | 33 skipped (36)
```

### Observed result after fix

Real `openclaw doctor` prints the one-line State integrity warning and omits it
for a multi-chunk main transcript. `closeSync` failures no longer escape the
count helper.

AI-assisted: yes. I reviewed and understand the change.
