### PR TITLE
fix(doctor): bound session snapshot store reads with size cap

### DIFF
--- a/src/commands/doctor-session-snapshots.test.ts
+++ b/src/commands/doctor-session-snapshots.test.ts
@@ -1,4 +1,5 @@
 // Doctor session snapshot tests cover session snapshot validation and repair guidance.
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -1085,5 +1086,35 @@ describe("doctor session snapshot repair (shouldRepair)", () => {
       shouldRepair: true,
     });
     expect(note).not.toHaveBeenCalled();
+  });
+
+  it("skips oversized session stores instead of reading them into memory", async () => {
+    const storePath = path.join(root, "state", "agents", "main", "sessions", "huge-sessions.json");
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    const fd = await fs.open(storePath, "w");
+    try {
+      const chunk = Buffer.alloc(1024 * 1024, 0x61);
+      for (let i = 0; i < 17; i += 1) {
+        await fd.write(chunk);
+      }
+    } finally {
+      await fd.close();
+    }
+    const readFileSyncSpy = vi.spyOn(fsSync, "readFileSync");
+    try {
+      const issues = await detectSessionSnapshotHealthIssues({
+        storePaths: [storePath],
+        bundledSkillsDir,
+      });
+      expect(issues).toEqual([]);
+      expect(
+        readFileSyncSpy.mock.calls.some((call) => {
+          const target = call[0];
+          return typeof target === "string" && path.resolve(target) === path.resolve(storePath);
+        }),
+      ).toBe(false);
+    } finally {
+      readFileSyncSpy.mockRestore();
+    }
   });
 });

--- a/src/commands/doctor-session-snapshots.test.ts
+++ b/src/commands/doctor-session-snapshots.test.ts
@@ -1088,7 +1088,7 @@ describe("doctor session snapshot repair (shouldRepair)", () => {
     expect(note).not.toHaveBeenCalled();
   });
 
-  it("skips oversized session stores instead of reading them into memory", async () => {
+  it("reports oversized session stores without reading them into memory", async () => {
     const storePath = path.join(root, "state", "agents", "main", "sessions", "huge-sessions.json");
     await fs.mkdir(path.dirname(storePath), { recursive: true });
     const fd = await fs.open(storePath, "w");
@@ -1106,7 +1106,19 @@ describe("doctor session snapshot repair (shouldRepair)", () => {
         storePaths: [storePath],
         bundledSkillsDir,
       });
-      expect(issues).toEqual([]);
+      expect(issues).toEqual([
+        {
+          kind: "store-too-large",
+          storePath,
+          size: 17 * 1024 * 1024,
+          maxBytes: 16 * 1024 * 1024,
+        },
+      ]);
+      expect(sessionSnapshotIssueToHealthFinding(issues[0]!)).toMatchObject({
+        severity: "warn",
+        message: expect.stringContaining("too large to scan"),
+        path: storePath,
+      });
       expect(
         readFileSyncSpy.mock.calls.some((call) => {
           const target = call[0];
@@ -1116,5 +1128,14 @@ describe("doctor session snapshot repair (shouldRepair)", () => {
     } finally {
       readFileSyncSpy.mockRestore();
     }
+
+    await noteSessionSnapshotHealth({
+      storePaths: [storePath],
+      bundledSkillsDir,
+    });
+    expect(note).toHaveBeenCalledWith(
+      expect.stringContaining("Skipped oversized session store"),
+      "Session snapshots",
+    );
   });
 });

--- a/src/commands/doctor-session-snapshots.ts
+++ b/src/commands/doctor-session-snapshots.ts
@@ -38,9 +38,25 @@ type StaleSessionSnapshotPathFinding = {
   expectedPath: string;
 };
 
-type SessionSnapshotHealthIssue = StaleSessionSnapshotPathFinding & {
+type StaleSessionSnapshotHealthIssue = StaleSessionSnapshotPathFinding & {
   storePath: string;
+  kind: "stale-path";
 };
+
+type OversizedSessionSnapshotHealthIssue = {
+  kind: "store-too-large";
+  storePath: string;
+  size: number;
+  maxBytes: number;
+};
+
+type SessionSnapshotHealthIssue =
+  | StaleSessionSnapshotHealthIssue
+  | OversizedSessionSnapshotHealthIssue;
+
+function isOversizedStoreError(error: unknown): error is Error {
+  return error instanceof Error && error.message.includes("file too large");
+}
 
 function resolveSessionSnapshotBundledSkillsDir(params?: {
   bundledSkillsDir?: string;
@@ -379,7 +395,16 @@ export async function detectSessionSnapshotHealthIssues(params?: {
     let store: Record<string, SessionEntry>;
     try {
       store = loadSessionStoreForSnapshotScan(storePath);
-    } catch {
+    } catch (error) {
+      if (isOversizedStoreError(error)) {
+        const storeStat = fs.statSync(storePath, { throwIfNoEntry: false });
+        issues.push({
+          kind: "store-too-large",
+          storePath,
+          size: storeStat?.size ?? 0,
+          maxBytes: MAX_SNAPSHOT_STORE_BYTES,
+        });
+      }
       continue;
     }
     const findings = scanSessionStoreForStaleRuntimeSnapshotPaths({
@@ -389,6 +414,7 @@ export async function detectSessionSnapshotHealthIssues(params?: {
     });
     for (const finding of findings) {
       issues.push({
+        kind: "stale-path",
         sessionKey: finding.sessionKey,
         field: finding.field,
         cachedPath: finding.cachedPath,
@@ -403,6 +429,17 @@ export async function detectSessionSnapshotHealthIssues(params?: {
 export function sessionSnapshotIssueToHealthFinding(
   issue: SessionSnapshotHealthIssue,
 ): HealthFinding {
+  if (issue.kind === "store-too-large") {
+    return {
+      checkId: SESSION_SNAPSHOTS_CHECK_ID,
+      severity: "warn",
+      message: `Session store is too large to scan for stale snapshot paths (${issue.size} bytes; max ${issue.maxBytes}).`,
+      path: issue.storePath,
+      requirement: `Keep session stores under ${issue.maxBytes} bytes for doctor snapshot health scans.`,
+      fixHint:
+        "Split or prune the oversized sessions.json, then re-run `openclaw doctor` to resume snapshot-path health checks.",
+    };
+  }
   return {
     checkId: SESSION_SNAPSHOTS_CHECK_ID,
     severity: "info",
@@ -418,6 +455,14 @@ export function sessionSnapshotIssueToHealthFinding(
 export function sessionSnapshotIssueToRepairEffect(
   issue: SessionSnapshotHealthIssue,
 ): HealthRepairEffect {
+  if (issue.kind === "store-too-large") {
+    return {
+      kind: "file",
+      action: "would-skip-oversized-session-store",
+      target: issue.storePath,
+      dryRunSafe: true,
+    };
+  }
   return {
     kind: "file",
     action: "would-rewrite-session-snapshot-path",
@@ -545,10 +590,17 @@ export async function noteSessionSnapshotHealth(params?: {
     try {
       store = loadSessionStoreForSnapshotScan(storePath);
     } catch (err) {
-      note(
-        `- Failed to inspect session snapshot metadata in ${shortenHomePath(storePath)}: ${String(err)}`,
-        "Session snapshots",
-      );
+      if (isOversizedStoreError(err)) {
+        note(
+          `- Skipped oversized session store ${shortenHomePath(storePath)} (${err.message}). Snapshot-path health was not scanned.`,
+          "Session snapshots",
+        );
+      } else {
+        note(
+          `- Failed to inspect session snapshot metadata in ${shortenHomePath(storePath)}: ${String(err)}`,
+          "Session snapshots",
+        );
+      }
       continue;
     }
     const findings = scanSessionStoreForStaleRuntimeSnapshotPaths({

--- a/src/commands/doctor-session-snapshots.ts
+++ b/src/commands/doctor-session-snapshots.ts
@@ -17,6 +17,9 @@ import { resolveBundledSkillsDir } from "../skills/loading/bundled-dir.js";
 import { resolveConfigDir, shortenHomePath } from "../utils.js";
 
 const SESSION_SNAPSHOTS_CHECK_ID = "core/doctor/session-snapshots";
+// Session stores are JSON maps of session records. Cap reads so a corrupted or
+// hostile multi-GB store cannot OOM doctor during snapshot scan/repair.
+const MAX_SNAPSHOT_STORE_BYTES = 16 * 1024 * 1024;
 
 type SnapshotPathSource =
   | "skillsSnapshot.prompt"
@@ -332,8 +335,21 @@ function resolveSessionStorePaths(params: {
     .toSorted((a, b) => a.localeCompare(b));
 }
 
+function readSnapshotStoreRaw(storePath: string): string {
+  const storeStat = fs.statSync(storePath, { throwIfNoEntry: false });
+  if (!storeStat?.isFile()) {
+    throw new Error(`${storePath}: not a regular file`);
+  }
+  if (storeStat.size > MAX_SNAPSHOT_STORE_BYTES) {
+    throw new Error(
+      `${storePath}: file too large (${storeStat.size} bytes, max ${MAX_SNAPSHOT_STORE_BYTES})`,
+    );
+  }
+  return fs.readFileSync(storePath, "utf-8");
+}
+
 function loadSessionStoreForSnapshotScan(storePath: string): Record<string, SessionEntry> {
-  const parsed = JSON.parse(fs.readFileSync(storePath, "utf-8")) as unknown;
+  const parsed = JSON.parse(readSnapshotStoreRaw(storePath)) as unknown;
   if (!isRecord(parsed)) {
     return {};
   }
@@ -567,7 +583,7 @@ export async function noteSessionSnapshotHealth(params?: {
         const repairResult = await updateSessionStore(
           storePath,
           async (store) => {
-            const raw = fs.readFileSync(storePath, "utf-8");
+            const raw = readSnapshotStoreRaw(storePath);
             const parsed = JSON.parse(raw) as unknown;
             const rawStore = isRecord(parsed) ? parsed : {};
             const replacements = repairFreshSessionSnapshotPaths({

--- a/src/commands/doctor-session-snapshots.ts
+++ b/src/commands/doctor-session-snapshots.ts
@@ -6,6 +6,7 @@ import { note } from "../../packages/terminal-core/src/note.js";
 import { resolveStateDir } from "../config/paths.js";
 import { hydrateSessionStoreSkillPromptRefs } from "../config/sessions/skill-prompt-blobs.js";
 import { updateSessionStore } from "../config/sessions/store.js";
+import { readFileDescriptorBoundedSync } from "../infra/file-descriptor-read.js";
 import { resolveAllAgentSessionStoreTargetsSync } from "../config/sessions/targets.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -352,16 +353,28 @@ function resolveSessionStorePaths(params: {
 }
 
 function readSnapshotStoreRaw(storePath: string): string {
-  const storeStat = fs.statSync(storePath, { throwIfNoEntry: false });
-  if (!storeStat?.isFile()) {
-    throw new Error(`${storePath}: not a regular file`);
+  // Pin one descriptor, validate that inode, and enforce the byte cap while
+  // reading so a concurrent replace/growth after pathname stat cannot bypass
+  // the promised 16 MiB bound.
+  let fd: number | undefined;
+  try {
+    fd = fs.openSync(storePath, "r");
+    const storeStat = fs.fstatSync(fd);
+    if (!storeStat.isFile()) {
+      throw new Error(`${storePath}: not a regular file`);
+    }
+    if (storeStat.size > MAX_SNAPSHOT_STORE_BYTES) {
+      throw new Error(
+        `${storePath}: file too large (${storeStat.size} bytes, max ${MAX_SNAPSHOT_STORE_BYTES})`,
+      );
+    }
+    const buffer = readFileDescriptorBoundedSync(fd, MAX_SNAPSHOT_STORE_BYTES);
+    return buffer.toString("utf-8");
+  } finally {
+    if (fd !== undefined) {
+      fs.closeSync(fd);
+    }
   }
-  if (storeStat.size > MAX_SNAPSHOT_STORE_BYTES) {
-    throw new Error(
-      `${storePath}: file too large (${storeStat.size} bytes, max ${MAX_SNAPSHOT_STORE_BYTES})`,
-    );
-  }
-  return fs.readFileSync(storePath, "utf-8");
 }
 
 function loadSessionStoreForSnapshotScan(storePath: string): Record<string, SessionEntry> {
@@ -632,6 +645,8 @@ export async function noteSessionSnapshotHealth(params?: {
 
     for (const [storePath, findings] of findingsByStore) {
       try {
+        // Enforce the size bound at the writer's load boundary so growth while
+        // repair was queued cannot allocate above MAX_SNAPSHOT_STORE_BYTES.
         const repairResult = await updateSessionStore(
           storePath,
           async (store) => {
@@ -654,6 +669,7 @@ export async function noteSessionSnapshotHealth(params?: {
           {
             requireWriteSuccess: true,
             skipMaintenance: true,
+            maxBytes: MAX_SNAPSHOT_STORE_BYTES,
             skipSaveWhenResult: (result) => result.replacements === 0,
           },
         );

--- a/src/config/sessions/store-load.ts
+++ b/src/config/sessions/store-load.ts
@@ -1,5 +1,6 @@
 // Session store loading normalizes persisted records, migrations, maintenance, and caches.
 import fs from "node:fs";
+import { readFileDescriptorBoundedSync } from "../../infra/file-descriptor-read.js";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { ChannelRouteRef } from "../../plugin-sdk/channel-route.js";
@@ -41,6 +42,8 @@ import { normalizeSessionRuntimeModelFields, type SessionEntry } from "./types.j
 
 type LoadSessionStoreOptions = {
   skipCache?: boolean;
+  /** When set, refuse to allocate more than this many bytes from disk. */
+  maxBytes?: number;
   maintenanceConfig?: ResolvedSessionMaintenanceConfig;
   runMaintenance?: boolean;
   clone?: boolean;
@@ -392,7 +395,8 @@ export function loadSessionStore(
 ): Record<string, SessionEntry> {
   const shouldHydrateSkillPromptRefs = opts.hydrateSkillPromptRefs !== false;
   const canWriteSessionStoreCache = shouldHydrateSkillPromptRefs;
-  if (!opts.skipCache && isSessionStoreCacheEnabled()) {
+  // A maxBytes caller must not hydrate from the unbounded object cache.
+  if (!opts.skipCache && opts.maxBytes === undefined && isSessionStoreCacheEnabled()) {
     const currentFileStat = getFileStatSnapshot(storePath);
     const cached = readSessionStoreCache({
       storePath,
@@ -413,7 +417,28 @@ export function loadSessionStore(
   const retryBuf = maxReadAttempts > 1 ? new Int32Array(new SharedArrayBuffer(4)) : undefined;
   for (let attempt = 0; attempt < maxReadAttempts; attempt += 1) {
     try {
-      const raw = fs.readFileSync(storePath, "utf-8");
+      const maxBytes = opts?.maxBytes;
+      let raw: string;
+      if (typeof maxBytes === "number" && Number.isFinite(maxBytes) && maxBytes >= 0) {
+        let fd: number | undefined;
+        try {
+          fd = fs.openSync(storePath, "r");
+          const st = fs.fstatSync(fd);
+          if (!st.isFile()) {
+            throw new Error(`${storePath}: not a regular file`);
+          }
+          if (st.size > maxBytes) {
+            throw new Error(`${storePath}: file too large (${st.size} bytes, max ${maxBytes})`);
+          }
+          raw = readFileDescriptorBoundedSync(fd, maxBytes).toString("utf-8");
+        } finally {
+          if (fd !== undefined) {
+            fs.closeSync(fd);
+          }
+        }
+      } else {
+        raw = fs.readFileSync(storePath, "utf-8");
+      }
       if (raw.length === 0 && attempt < maxReadAttempts - 1) {
         Atomics.wait(retryBuf!, 0, 0, 50);
         continue;
@@ -428,6 +453,13 @@ export function loadSessionStore(
       // stale content as current and make future cache hits return old data.
       break;
     } catch (err) {
+      // Size-cap failures are intentional permanent refusals (not transient swap races).
+      if (
+        err instanceof RangeError ||
+        (err instanceof Error && err.message.includes("file too large"))
+      ) {
+        throw err;
+      }
       const code = (err as NodeJS.ErrnoException).code;
       const isPermanentReadError = code === "ENOENT" || code === "EACCES" || code === "EPERM";
       if (isPermanentReadError) {

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -132,6 +132,8 @@ type SaveSessionStoreOptions = {
 type UpdateSessionStoreOptions<T> = SaveSessionStoreOptions & {
   /** Allow a nested mutation only when the caller already owns this store writer lane. */
   reentrant?: boolean;
+  /** Refuse writer hydration when the on-disk store exceeds this many bytes. */
+  maxBytes?: number;
   /**
    * Specialized callers can prove their mutator made no changes through its result.
    * When true, the writer-owned object cache is restored and sessions.json is untouched.
@@ -592,9 +594,14 @@ function storeHasUnsafeUntouchedHydratedSkillPrompts(
   return false;
 }
 
-function loadMutableSessionStoreForWriter(storePath: string): Record<string, SessionEntry> {
+function loadMutableSessionStoreForWriter(
+  storePath: string,
+  opts?: { maxBytes?: number },
+): Record<string, SessionEntry> {
   const currentFileStat = getFileStatSnapshot(storePath);
-  if (isSessionStoreCacheEnabled()) {
+  // Skip the mutable object cache when a byte cap is required so hydration
+  // always enforces the bound against the pinned on-disk bytes.
+  if (opts?.maxBytes === undefined && isSessionStoreCacheEnabled()) {
     const cached = takeMutableSessionStoreCache({
       storePath,
       ...currentFileStat,
@@ -605,7 +612,11 @@ function loadMutableSessionStoreForWriter(storePath: string): Record<string, Ses
       return cached;
     }
   }
-  const store = loadSessionStore(storePath, { skipCache: true, clone: false });
+  const store = loadSessionStore(storePath, {
+    skipCache: true,
+    clone: false,
+    ...(opts?.maxBytes !== undefined ? { maxBytes: opts.maxBytes } : {}),
+  });
   writerStoreFileStats.set(store, currentFileStat ?? null);
   writerLockedSessionEntries.set(store, snapshotLockedSessionEntries(store));
   return store;
@@ -947,7 +958,9 @@ export async function updateSessionStore<T>(
   return await runExclusiveSessionStoreWrite(
     storePath,
     async () => {
-      const store = loadMutableSessionStoreForWriter(storePath);
+      const store = loadMutableSessionStoreForWriter(storePath, {
+        maxBytes: opts?.maxBytes,
+      });
       const storeBeforeMutation = opts?.skipSaveWhenResult ? cloneSessionEntries(store) : undefined;
       const result = await mutator(store);
       if (opts?.skipSaveWhenResult?.(result)) {


### PR DESCRIPTION
## What Problem This Solves

Doctor session-snapshot scan/repair loaded session store JSON with unbounded
`fs.readFileSync` at two call sites. A corrupted or hostile multi-GB
`sessions.json` under the user state directory could OOM `openclaw doctor`
before JSON parse or repair logic ran.

Earlier revisions checked size via pathname `statSync` then opened the path
again, and repair hydration could still allocate after a store grew while
queued.

## Why This Change Was Made

1. `readSnapshotStoreRaw` pins one FD (`openSync`/`fstatSync`), enforces the
   16 MiB cap while reading via `readFileDescriptorBoundedSync`, and closes in
   `finally`.
2. Repair passes `maxBytes: MAX_SNAPSHOT_STORE_BYTES` into `updateSessionStore`
   so writer hydration cannot allocate above the bound after queued growth.
3. Oversized stores fail closed with operator-visible Session snapshots notes
   and structured `kind: "store-too-large"` / `would-skip-oversized-session-store`.

## User Impact

**Before:** An oversized session store could force an unbounded sync string
alloc during doctor snapshot health, or bypass a pathname-stat race / grow
while repair waited.

**After:** Stores above 16 MiB are rejected on a pinned descriptor (and at the
writer load boundary). Doctor reports the skip; normal stores continue.

## Evidence

- Changed: `src/commands/doctor-session-snapshots.ts`,
  `src/config/sessions/store-load.ts`, `src/config/sessions/store.ts`
- Production path: `noteSessionSnapshotHealth` →
  `loadSessionStoreForSnapshotScan` / repair `updateSessionStore({ maxBytes })`
  → descriptor-bounded read
- Head: `ec2d1617bce`

## Real behavior proof

### Behavior or issue addressed

A ~17 MiB session store is not fully buffered. Isolated
`openclaw doctor --non-interactive --yes` prints a Session snapshots note that
the store was skipped as oversized. Descriptor-bound + writer `maxBytes` close
the concurrent-growth gaps called out in review.

### Canonical reachability path

`openclaw doctor` → session snapshot health →
`readSnapshotStoreRaw` (pinned FD + bounded read) /
`updateSessionStore(..., { maxBytes })` → skip + warn on overflow

### Shared helper / provider constraint check

Uses `readFileDescriptorBoundedSync`; same 16 MiB campaign cap; no new
config/env keys.

### Real environment tested

Local trusted source checkout at PR head; Node 22.23.1; isolated
`OPENCLAW_STATE_DIR` with a planted 17 MiB `sessions.json`; CLI via
`node scripts/run-node.mjs doctor --non-interactive --yes`.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs src/commands/doctor-session-snapshots.test.ts \
  -t "oversized session stores" --reporter=verbose
```

### Evidence after fix

Redacted CLI previously captured:

```text
◇  Session snapshots ───────────────────────────────────────────────────────────╮
│  - Skipped oversized session store                                            │
│    .../sessions.json: file too large (17825792 bytes, max 16777216).          │
├───────────────────────────────────────────────────────────────────────────────╯
```

### Fix classification

bugfix — resource bound / OOM hardening (descriptor + writer load)

## AI Assistance

AI-assisted implementation and proof.
