### PR TITLE
fix(acp): keep projector boundary tail on a full code point

### DIFF
--- a/src/auto-reply/reply/acp-projector.test.ts
+++ b/src/auto-reply/reply/acp-projector.test.ts
@@ -951,6 +951,17 @@ describe("createAcpReplyProjector", () => {
     });
   });
 
+  it("keeps hidden boundary spacing when the previous visible chunk ends with an emoji", async () => {
+    await runHiddenBoundaryCase({
+      cfgOverrides: createHiddenBoundaryCfg({
+        hiddenBoundarySeparator: "space",
+      }),
+      toolCallId: "call_hidden_emoji_tail",
+      firstText: "fallback👍",
+      expectedText: "fallback👍 I don't",
+    });
+  });
+
   it("does not insert boundary separator for hidden non-tool status updates", async () => {
     const { deliveries, projector } = createProjectorHarness({
       acp: {

--- a/src/auto-reply/reply/acp-projector.ts
+++ b/src/auto-reply/reply/acp-projector.ts
@@ -466,7 +466,9 @@ export function createAcpReplyProjector(params: {
       const accepted = remaining < text.length ? truncateUtf16Safe(text, remaining) : text;
       if (accepted.length > 0) {
         emittedOutputChars += accepted.length;
-        lastVisibleOutputTail = accepted.slice(-1);
+        // Code-point tail: slice(-1) can leave a lone UTF-16 surrogate after emoji,
+        // which breaks whitespace/separator decisions on the next visible chunk.
+        lastVisibleOutputTail = Array.from(accepted).at(-1);
         if (settings.deliveryMode === "live") {
           liveBufferText += accepted;
           if (shouldFlushLiveBufferOnBoundary(liveBufferText)) {


### PR DESCRIPTION
## What Problem This Solves

ACP live projector stored `lastVisibleOutputTail = accepted.slice(-1)` for
hidden-boundary spacing. When the previous visible chunk ended with an emoji
(for example 👍), `slice(-1)` kept a lone UTF-16 surrogate. The next separator
decision then used a broken tail and could skip the intended space boundary.

## Why This Change Was Made

Store the last Unicode code point via `Array.from(accepted).at(-1)` so surrogate
pairs stay intact. This matches the projector's existing UTF-16-safe truncation
helpers without changing separator policy.

## User Impact

**Before:** Visible text after a hidden tool update could lose its boundary
space when the prior chunk ended with an emoji.

**After:** Emoji-terminated chunks keep a full code-point tail, so
`hiddenBoundarySeparator=space` still inserts a space.

## Evidence

- Changed: `src/auto-reply/reply/acp-projector.ts`,
  `src/auto-reply/reply/acp-projector.test.ts`
- Production path: `createAcpReplyProjector` → visible `text_delta` →
  `lastVisibleOutputTail` → `shouldInsertSeparator` after hidden tool events
- Compatibility: ASCII / newline boundary cases unchanged

## Real behavior proof

### Behavior or issue addressed

After visible text ending in 👍, a hidden tool update, then more text, the
projected output is `fallback👍 I don't` (space preserved).

### Canonical reachability path

ACP stream events → `createAcpReplyProjector.onEvent(text_delta)` → set
`lastVisibleOutputTail` → hidden `tool_call` → next `text_delta` →
`shouldInsertSeparator({ previousTail })` → deliver combined block text

### Shared helper / provider constraint check

No new API; uses code-point iteration consistent with nearby
`truncateUtf16Safe` usage.

### Real environment tested

Local trusted source checkout; focused Vitest on the projector harness.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs src/auto-reply/reply/acp-projector.test.ts \
  -t "ends with an emoji" --reporter=verbose
```

### Evidence after fix

```text
✓ keeps hidden boundary spacing when the previous visible chunk ends with an emoji 74ms
 Test Files  1 passed (1)
      Tests  1 passed | 28 skipped (29)
```

### Observed result after fix

Emoji-terminated previous tails no longer break the space separator after
hidden tool updates.

AI-assisted: yes. I reviewed and understand the change.
