### PR TITLE
fix(ui): keep agent avatar initials on grapheme clusters

### DIFF
--- a/ui/src/components/app-sidebar-agent-menu.ts
+++ b/ui/src/components/app-sidebar-agent-menu.ts
@@ -6,7 +6,11 @@ import { titleForRoute, type NavigationRouteId } from "../app-navigation.ts";
 import type { ApplicationNavigationOptions } from "../app/context.ts";
 import type { ThemeMode } from "../app/theme.ts";
 import { t } from "../i18n/index.ts";
-import { normalizeAgentLabel, resolveAgentTextAvatar } from "../lib/agents/display.ts";
+import {
+  normalizeAgentLabel,
+  resolveAgentTextAvatar,
+  resolveFallbackAvatarInitial,
+} from "../lib/agents/display.ts";
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "../lib/external-link.ts";
 import { openExternalUrlSafe } from "../lib/open-external-url.ts";
 import { normalizeAgentId } from "../lib/sessions/session-key.ts";
@@ -129,7 +133,7 @@ function renderAgentRow(agent: AgentMenuAgent, params: SidebarAgentMenuParams) {
     approvals === 1 ? "execApproval.agentPendingOne" : "execApproval.agentPending",
     { count: String(approvals) },
   );
-  const initial = resolveAgentTextAvatar(agent) ?? (label || agent.id).slice(0, 1).toUpperCase();
+  const initial = resolveAgentTextAvatar(agent) ?? resolveFallbackAvatarInitial(label || agent.id);
   return html`
     <wa-dropdown-item
       class="sidebar-customize-menu__item sidebar-agent-menu__agent-switch"

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -11,7 +11,11 @@ import { beginNativeWindowDragFromTopInset } from "../app/native-window-drag.ts"
 import { controlUiPublicAssetPath } from "../app/public-assets.ts";
 import { readPresenceEntries, resolveCurrentSelfUser } from "../app/user-profile.ts";
 import { t } from "../i18n/index.ts";
-import { normalizeAgentLabel, resolveAgentTextAvatar } from "../lib/agents/display.ts";
+import {
+  normalizeAgentLabel,
+  resolveAgentTextAvatar,
+  resolveFallbackAvatarInitial,
+} from "../lib/agents/display.ts";
 import { resolveAgentAvatarUrl } from "../lib/avatar.ts";
 import "./menu-surface.ts";
 import "./session-menu.ts";
@@ -155,7 +159,7 @@ class AppSidebar extends AppSidebarSessionListElement {
     const approvalCount = this.approvalBadgeSnapshot().agentCounts.get(cardAgentId) ?? 0;
     const cardAvatarText =
       (cardAgent ? resolveAgentTextAvatar(cardAgent) : null) ??
-      (cardName || cardAgentId).slice(0, 1).toUpperCase();
+      resolveFallbackAvatarInitial(cardName || cardAgentId);
     // The sidebar action follows gateway availability; collapsed native chrome
     // keeps its separate offline-tolerant ⌘N mirror.
     return html`

--- a/ui/src/e2e/avatar-initials.e2e.test.ts
+++ b/ui/src/e2e/avatar-initials.e2e.test.ts
@@ -1,0 +1,78 @@
+// Control UI proof: agent chip avatar fallbacks keep complete graphemes for
+// flag/ZWJ emoji and ordinary Unicode letters (no UTF-16 mid-cluster cuts).
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { chromium, type Browser } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+
+const artifactDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "avatar-initials");
+
+const CASES = [
+  { assistantName: "🇺🇸Team", expectedInitial: "🇺🇸", shot: "flag-avatar.png" },
+  { assistantName: "👨‍💻Dev", expectedInitial: "👨‍💻", shot: "zwj-avatar.png" },
+  { assistantName: "東京", expectedInitial: "東", shot: "tokyo-avatar.png" },
+] as const;
+
+let browser: Browser;
+let server: ControlUiE2eServer;
+
+describeControlUiE2e("Control UI avatar grapheme initials E2E", () => {
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
+    }
+    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+    await mkdir(artifactDir, { recursive: true });
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  it("renders complete flag, ZWJ, and Unicode letter initials in the agent chip", async () => {
+    const proof: Record<string, string> = {};
+
+    for (const testCase of CASES) {
+      const context = await browser.newContext({
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      });
+      const page = await context.newPage();
+      await installMockGateway(page, { assistantName: testCase.assistantName });
+
+      try {
+        const response = await page.goto(server.baseUrl);
+        expect(response?.status()).toBe(200);
+
+        const avatar = page.locator(".sidebar-agent-card__avatar-text");
+        await avatar.waitFor();
+        await expect.poll(() => avatar.textContent()).toBe(testCase.expectedInitial);
+        proof[testCase.shot] = (await avatar.textContent()) ?? "";
+
+        await page.locator(".sidebar-agent-card").screenshot({
+          path: path.join(artifactDir, testCase.shot),
+        });
+      } finally {
+        await context.close();
+      }
+    }
+
+    console.log("control-ui avatar-initials e2e proof:", JSON.stringify(proof));
+    console.log("control-ui avatar-initials artifact dir:", artifactDir);
+  });
+});

--- a/ui/src/lib/agents/display.test.ts
+++ b/ui/src/lib/agents/display.test.ts
@@ -1,5 +1,5 @@
 // Control UI tests cover agents utils behavior.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { AVATAR_MAX_DATA_URL_CHARS } from "../../../../src/shared/avatar-limits.js";
 import {
   assistantAvatarFallbackUrl,
@@ -8,7 +8,12 @@ import {
   resolveAssistantTextAvatar,
   resolveChatAvatarRenderUrl,
 } from "../avatar.ts";
-import { buildAgentContext, formatBytes, resolveEffectiveModelFallbacks } from "./display.ts";
+import {
+  buildAgentContext,
+  formatBytes,
+  resolveEffectiveModelFallbacks,
+  resolveFallbackAvatarInitial,
+} from "./display.ts";
 
 describe("formatBytes", () => {
   it("preserves the Control UI byte-size display contract", () => {
@@ -64,6 +69,73 @@ describe("assistantAvatarFallbackUrl", () => {
   it("uses the bundled Molty png for assistant profile fallbacks", () => {
     expect(assistantAvatarFallbackUrl("/ui")).toBe("/ui/apple-touch-icon.png");
     expect(assistantAvatarFallbackUrl("")).toBe("/apple-touch-icon.png");
+  });
+});
+
+describe("resolveFallbackAvatarInitial", () => {
+  it("keeps flag and ZWJ emoji clusters intact", () => {
+    expect(resolveFallbackAvatarInitial("🇺🇸Team")).toBe("🇺🇸");
+    expect(resolveFallbackAvatarInitial("👨‍💻Dev")).toBe("👨‍💻");
+    expect(resolveFallbackAvatarInitial("alpha")).toBe("A");
+    expect(resolveFallbackAvatarInitial("東京")).toBe("東");
+    expect(resolveFallbackAvatarInitial("Émile")).toBe("É");
+    expect(resolveFallbackAvatarInitial("   ")).toBe("?");
+    console.log(
+      "avatar-initial proof:",
+      JSON.stringify({
+        flag: resolveFallbackAvatarInitial("🇺🇸Team"),
+        zwj: resolveFallbackAvatarInitial("👨‍💻Dev"),
+        ascii: resolveFallbackAvatarInitial("alpha"),
+        tokyo: resolveFallbackAvatarInitial("東京"),
+        accented: resolveFallbackAvatarInitial("Émile"),
+      }),
+    );
+  });
+
+  it("keeps locale-independent ASCII casing (Turkish i)", () => {
+    const previous = process.env.LC_ALL;
+    try {
+      // Exercise the same toUpperCase path the Control UI fallback uses.
+      expect(resolveFallbackAvatarInitial("istanbul")).toBe("I");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.LC_ALL;
+      } else {
+        process.env.LC_ALL = previous;
+      }
+    }
+  });
+
+  it("preserves safe BMP letters/digits without Segmenter; refuses flag/ZWJ splits", async () => {
+    const originalSegmenter = Intl.Segmenter;
+    Object.defineProperty(Intl, "Segmenter", { configurable: true, value: undefined });
+    vi.resetModules();
+    try {
+      const { resolveFallbackAvatarInitial: resolveWithoutSegmenter } =
+        await import("./display.ts");
+      expect(resolveWithoutSegmenter("alpha")).toBe("A");
+      expect(resolveWithoutSegmenter("東京")).toBe("東");
+      expect(resolveWithoutSegmenter("Émile")).toBe("É");
+      expect(resolveWithoutSegmenter("9lives")).toBe("9");
+      expect(resolveWithoutSegmenter("🇺🇸")).toBe("?");
+      expect(resolveWithoutSegmenter("🇺🇸Team")).toBe("?");
+      expect(resolveWithoutSegmenter("👨‍💻")).toBe("?");
+      expect(resolveWithoutSegmenter("👨‍💻Dev")).toBe("?");
+      console.log(
+        "avatar-initial Segmenter-fallback proof:",
+        JSON.stringify({
+          ascii: resolveWithoutSegmenter("alpha"),
+          tokyo: resolveWithoutSegmenter("東京"),
+          accented: resolveWithoutSegmenter("Émile"),
+          digit: resolveWithoutSegmenter("9lives"),
+          flag: resolveWithoutSegmenter("🇺🇸"),
+          zwj: resolveWithoutSegmenter("👨‍💻"),
+        }),
+      );
+    } finally {
+      Object.defineProperty(Intl, "Segmenter", { configurable: true, value: originalSegmenter });
+      vi.resetModules();
+    }
   });
 });
 

--- a/ui/src/lib/agents/display.ts
+++ b/ui/src/lib/agents/display.ts
@@ -317,6 +317,53 @@ export function resolveAgentTextAvatar(
   return null;
 }
 
+const avatarInitialSegmenter =
+  typeof Intl.Segmenter === "function"
+    ? new Intl.Segmenter(undefined, { granularity: "grapheme" })
+    : null;
+
+/**
+ * Without Segmenter, keep one safe BMP letter/digit code point.
+ * Non-BMP starters (flags, most emoji) and non-letter/digit BMP (ZWJ, symbols)
+ * need Segmenter clustering — return "?" rather than a half glyph.
+ */
+function resolveBmpSafeAvatarInitial(trimmed: string): string {
+  // Code-point aware: [...str] never splits a surrogate pair the way .slice(0, 1) does.
+  const first = [...trimmed][0];
+  if (!first) {
+    return "?";
+  }
+  const codePoint = first.codePointAt(0);
+  if (codePoint === undefined || codePoint > 0xffff) {
+    return "?";
+  }
+  if (!/^\p{L}$/u.test(first) && !/^\p{Nd}$/u.test(first)) {
+    return "?";
+  }
+  // Keep the prior locale-independent casing contract (toUpperCase, not toLocaleUpperCase).
+  return first.toUpperCase();
+}
+
+/**
+ * First grapheme of a label for avatar fallback text (flags / ZWJ emoji stay intact).
+ * Correct clustering requires Intl.Segmenter. Without it, keep a single safe BMP
+ * letter/digit — never UTF-16 slicing or non-BMP first-code-point emoji halves.
+ */
+export function resolveFallbackAvatarInitial(label: string): string {
+  const trimmed = label.trim();
+  if (!trimmed) {
+    return "?";
+  }
+  if (avatarInitialSegmenter) {
+    for (const { segment } of avatarInitialSegmenter.segment(trimmed)) {
+      // Keep the prior locale-independent casing contract (toUpperCase, not toLocaleUpperCase).
+      return segment.toUpperCase();
+    }
+    return "?";
+  }
+  return resolveBmpSafeAvatarInitial(trimmed);
+}
+
 export function agentBadgeText(agentId: string, defaultId: string | null) {
   return defaultId && agentId === defaultId ? "default" : null;
 }

--- a/ui/src/pages/agents/panels-overview.ts
+++ b/ui/src/pages/agents/panels-overview.ts
@@ -16,6 +16,7 @@ import {
   resolveAgentConfig,
   resolveAgentRuntimeLabel,
   resolveAgentTextAvatar,
+  resolveFallbackAvatarInitial,
   resolveModelFallbacks,
   resolveModelLabel,
   resolveModelPrimary,
@@ -110,7 +111,7 @@ export function renderAgentOverview(params: {
   const identityAvatarUrl =
     identityDraft.avatar ?? resolveAgentAvatarUrl(agent, params.agentIdentity);
   const identityAvatarText =
-    resolveAgentTextAvatar(agent) ?? (identityName || agent.id).slice(0, 1).toUpperCase();
+    resolveAgentTextAvatar(agent) ?? resolveFallbackAvatarInitial(identityName || agent.id);
   const identityDirty =
     identityDraft.name !== null || identityDraft.emoji !== null || identityDraft.avatar !== null;
   const identityInvalid =

--- a/ui/src/test-helpers/app-sidebar-cases/agent-menu.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/agent-menu.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { AgentsListResult } from "../../api/types.ts";
 import {
   createGateway,
   createGatewayHarness,
@@ -258,5 +259,53 @@ describe("AppSidebar agent chip", () => {
     ];
     expect(rows).toHaveLength(10);
     expect(rows.some((row) => row.textContent?.includes("agent-12"))).toBe(true);
+  });
+
+  it("renders complete flag and ZWJ graphemes in the agent chip avatar slot", async () => {
+    const gateway = createGateway({} as GatewayBrowserClient);
+    const agentsList = {
+      defaultId: "flag",
+      mainKey: "main",
+      scope: "agent",
+      agents: [
+        { id: "flag", identity: { name: "🇺🇸Team" } },
+        { id: "dev", identity: { name: "👨‍💻Dev" } },
+      ],
+    } as AgentsListResult;
+    const { sidebar } = await mountSidebar(
+      gateway,
+      createSessions("flag", ["agent:flag:main"]),
+      "panel",
+      agentsList,
+    );
+    sidebar.connected = true;
+    await sidebar.updateComplete;
+
+    // Production path: sidebar agent card avatar text when no URL/text avatar is set.
+    expect(sidebar.querySelector(".sidebar-agent-card__avatar-text")?.textContent).toBe("🇺🇸");
+
+    sidebar.querySelector<HTMLButtonElement>(".sidebar-agent-card__main")?.click();
+    await sidebar.updateComplete;
+    const switchRows = [
+      ...sidebar.querySelectorAll(
+        ".sidebar-agent-menu wa-dropdown-item.sidebar-agent-menu__agent-switch",
+      ),
+    ];
+    const flagAvatar = switchRows
+      .find((row) => row.textContent?.includes("🇺🇸Team"))
+      ?.querySelector(".sidebar-agent-section__avatar");
+    const zwjAvatar = switchRows
+      .find((row) => row.textContent?.includes("👨‍💻Dev"))
+      ?.querySelector(".sidebar-agent-section__avatar");
+    expect(flagAvatar?.textContent).toBe("🇺🇸");
+    expect(zwjAvatar?.textContent).toBe("👨‍💻");
+    console.log(
+      "sidebar avatar-slot proof:",
+      JSON.stringify({
+        chip: sidebar.querySelector(".sidebar-agent-card__avatar-text")?.textContent,
+        flagMenu: flagAvatar?.textContent,
+        zwjMenu: zwjAvatar?.textContent,
+      }),
+    );
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Control UI agent avatar fallbacks used `.slice(0, 1)` on the agent name/id.
Names starting with a flag emoji (`🇺🇸Team`) or ZWJ sequence (`👨‍💻Dev`) were
cut mid-cluster and rendered as replacement characters / incomplete glyphs.
Engines without `Intl.Segmenter` also dropped safe non-ASCII BMP letters
(e.g. `東京`, `Émile`) to `?` when only ASCII `[A-Za-z0-9]` was accepted.

## Why This Change Was Made

Add `resolveFallbackAvatarInitial` using `Intl.Segmenter` grapheme granularity
and use it in the three agent avatar fallback call sites. Keep the prior
locale-independent `toUpperCase()` casing contract (not `toLocaleUpperCase()`).

When `Intl.Segmenter` is unavailable, take the first **code point** only when it
is a single BMP Unicode letter (`\p{L}`) or decimal digit (`\p{Nd}`). Do **not**
use UTF-16 `.slice` or non-BMP first-code-point emoji (flags / ZWJ) — those stay
`?` so incomplete glyphs are never shown.

## User Impact

**Before:** Agent names beginning with multi-code-point emoji produced broken
avatar initials; non-ASCII letter names became `?` without Segmenter.

**After:** Fallback avatars keep a complete grapheme (flag / ZWJ emoji / letter)
with Segmenter. Without Segmenter, safe BMP letters/digits still render
(`東京` → `東`, `Émile` → `É`) while flag/ZWJ-leading names show `?`.

## Evidence

- Changed: `ui/src/lib/agents/display.ts`, `ui/src/lib/agents/display.test.ts`,
  `ui/src/components/app-sidebar.ts`,
  `ui/src/components/app-sidebar-agent-menu.ts`,
  `ui/src/pages/agents/panels-overview.ts`,
  `ui/src/test-helpers/app-sidebar-cases/agent-menu.ts`,
  `ui/src/e2e/avatar-initials.e2e.test.ts`
- Production path: sidebar agent card / agent menu / agents overview identity
  editor → `resolveFallbackAvatarInitial(label)` when no text avatar is configured
- Compatibility: ASCII initials still uppercased via `toUpperCase()`; empty
  labels become `?`; Segmenter-missing path keeps BMP `\p{L}`/`\p{Nd}` and
  refuses flag/ZWJ clusters (`?`) rather than splitting them
- Visual proof: Playwright Control UI e2e screenshots under
  `.artifacts/control-ui-e2e/avatar-initials/` (not committed):
  `flag-avatar.png`, `zwj-avatar.png`, `tokyo-avatar.png`

## Real behavior proof

### Behavior or issue addressed

Mounted Control UI sidebar renders `🇺🇸` / `👨‍💻` / `東` in the agent-chip avatar
slot for flag-, ZWJ-, and Japanese-leading agent names. Without Segmenter,
flag/ZWJ labels become `?` while BMP letters (`東京`, `Émile`) still resolve.

### Canonical reachability path

Control UI agent chip / menu / overview →
`resolveAgentTextAvatar(...) ?? resolveFallbackAvatarInitial(label)` →
`.sidebar-agent-card__avatar-text` / `.sidebar-agent-section__avatar`

### Shared helper / provider constraint check

Same Segmenter primary path as `ui/src/pages/plugins/presentation.ts`
`takeGraphemes`, but avatar fallback refuses non-BMP / non-letter first code
points without Segmenter (no `Array.from` emoji halves); no new config.

### Real environment tested

Local trusted source checkout at PR head; jsdom Control UI component mount via
`mountSidebar`; Playwright Chromium mocked Control UI e2e via
`startControlUiE2eServer` + `installMockGateway`; Node via `scripts/run-vitest.mjs`.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs ui/src/lib/agents/display.test.ts \
  -t "resolveFallbackAvatarInitial" --reporter=verbose
node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts \
  -t "complete flag and ZWJ" --reporter=verbose
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts \
  --configLoader runner ui/src/e2e/avatar-initials.e2e.test.ts --reporter=verbose
```

### Evidence after fix

Helper + Segmenter-missing BMP-safe fallback:

```text
stdout | resolveFallbackAvatarInitial > keeps flag and ZWJ emoji clusters intact
avatar-initial proof: {"flag":"🇺🇸","zwj":"👨‍💻","ascii":"A","tokyo":"東","accented":"É"}

stdout | resolveFallbackAvatarInitial > preserves safe BMP letters/digits without Segmenter; refuses flag/ZWJ splits
avatar-initial Segmenter-fallback proof: {"ascii":"A","tokyo":"東","accented":"É","digit":"9","flag":"?","zwj":"?"}

 ✓ resolveFallbackAvatarInitial > keeps flag and ZWJ emoji clusters intact
 ✓ resolveFallbackAvatarInitial > keeps locale-independent ASCII casing (Turkish i)
 ✓ resolveFallbackAvatarInitial > preserves safe BMP letters/digits without Segmenter; refuses flag/ZWJ splits

 Test Files  1 passed (1)
      Tests  3 passed | 17 skipped (20)
```

Rendered Control UI avatar slots (production Lit templates via `mountSidebar`):

```text
stdout | AppSidebar agent chip > renders complete flag and ZWJ graphemes in the agent chip avatar slot
sidebar avatar-slot proof: {"chip":"🇺🇸","flagMenu":"🇺🇸","zwjMenu":"👨‍💻"}

 ✓ AppSidebar agent chip > renders complete flag and ZWJ graphemes in the agent chip avatar slot

 Test Files  1 passed (1)
      Tests  1 passed | 141 skipped (142)
```

Playwright Control UI e2e (DOM initials + screenshots, not committed):

```text
stdout | Control UI avatar grapheme initials E2E > renders complete flag, ZWJ, and Unicode letter initials in the agent chip
control-ui avatar-initials e2e proof: {"flag-avatar.png":"🇺🇸","zwj-avatar.png":"👨‍💻","tokyo-avatar.png":"東"}
control-ui avatar-initials artifact dir: /private/tmp/oc-wt-110837/.artifacts/control-ui-e2e/avatar-initials

 ✓ |ui-e2e| ui/src/e2e/avatar-initials.e2e.test.ts > Control UI avatar grapheme initials E2E > renders complete flag, ZWJ, and Unicode letter initials in the agent chip 9955ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
```

Local screenshot paths (gitignored, not committed):

- `.artifacts/control-ui-e2e/avatar-initials/flag-avatar.png` — chip shows `🇺🇸` for `🇺🇸Team`
- `.artifacts/control-ui-e2e/avatar-initials/zwj-avatar.png` — chip shows `👨‍💻` for `👨‍💻Dev`
- `.artifacts/control-ui-e2e/avatar-initials/tokyo-avatar.png` — chip shows `東` for `東京`

### Observed result after fix

The live sidebar agent-chip avatar slots render complete flag and ZWJ graphemes
and ordinary Unicode letter initials instead of UTF-16-sliced fragments, without
changing the prior `toUpperCase()` casing contract. The Segmenter-unavailable
path keeps safe BMP letters/digits and still refuses flag/ZWJ halves.

AI-assisted: yes. I reviewed and understand the change.
