### PR TITLE
fix(codex): keep tool echo prefixes UTF-16 safe

### DIFF
--- a/extensions/codex/src/app-server/event-projector-tool-output-echo.test.ts
+++ b/extensions/codex/src/app-server/event-projector-tool-output-echo.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS,
+  toolOutputRawEchoSignature,
+} from "./event-projector-tool-output.js";
+
+function proofLine(label: string, value: string | number | boolean): void {
+  // Verbatim proof for PR evidence: exercises the production write-site helper.
+  process.stdout.write(`[utf16-echo-proof] ${label}=${String(value)}\n`);
+}
+
+describe("toolOutputRawEchoSignature", () => {
+  it("does not split a surrogate pair at the transcript budget (raw .slice would)", () => {
+    // High surrogate of 😀 lands at index 9999; raw slice(0, 10000) keeps it.
+    const text = `${"a".repeat(9_999)}😀${"a".repeat(400)}`;
+    const broken = text.slice(0, TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS);
+    expect(broken).toMatch(/[\uD800-\uDFFF]/);
+    expect(broken.charCodeAt(broken.length - 1)).toBe(0xd83d);
+
+    const signature = toolOutputRawEchoSignature(text);
+    expect(signature).toBeDefined();
+    expect(signature!.rawLength).toBe(text.length);
+    expect(signature!.rawPrefix).not.toMatch(/[\uD800-\uDFFF]/);
+    expect(signature!.rawPrefix.endsWith("😀")).toBe(false);
+    expect(signature!.rawPrefix).toBe("a".repeat(9_999));
+
+    proofLine("write_site", "toolOutputRawEchoSignature.rawPrefix");
+    proofLine("budget", TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS);
+    proofLine("broken_slice_len", broken.length);
+    proofLine("broken_slice_last_codeunit", broken.charCodeAt(broken.length - 1).toString(16));
+    proofLine("safe_prefix_len", signature!.rawPrefix.length);
+    proofLine(
+      "safe_prefix_last_codeunit",
+      signature!.rawPrefix.charCodeAt(signature!.rawPrefix.length - 1).toString(16),
+    );
+    proofLine("safe_prefix_has_surrogate", /[\uD800-\uDFFF]/.test(signature!.rawPrefix));
+  });
+});

--- a/extensions/codex/src/app-server/event-projector-tool-output-echo.test.ts
+++ b/extensions/codex/src/app-server/event-projector-tool-output-echo.test.ts
@@ -9,20 +9,41 @@ function proofLine(label: string, value: string | number | boolean): void {
   process.stdout.write(`[utf16-echo-proof] ${label}=${String(value)}\n`);
 }
 
+function hasLoneSurrogate(text: string): boolean {
+  for (let i = 0; i < text.length; i += 1) {
+    const unit = text.charCodeAt(i);
+    if (unit >= 0xd800 && unit <= 0xdbff) {
+      const next = text.charCodeAt(i + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        return true;
+      }
+      i += 1;
+      continue;
+    }
+    if (unit >= 0xdc00 && unit <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
 describe("toolOutputRawEchoSignature", () => {
   it("does not split a surrogate pair at the transcript budget (raw .slice would)", () => {
     // High surrogate of 😀 lands at index 9999; raw slice(0, 10000) keeps it.
-    const text = `${"a".repeat(9_999)}😀${"a".repeat(400)}`;
+    const text = `${"a".repeat(9_999)}\u{1F600}${"a".repeat(400)}`;
     const broken = text.slice(0, TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS);
-    expect(broken).toMatch(/[\uD800-\uDFFF]/);
+    expect(hasLoneSurrogate(broken)).toBe(true);
     expect(broken.charCodeAt(broken.length - 1)).toBe(0xd83d);
 
     const signature = toolOutputRawEchoSignature(text);
     expect(signature).toBeDefined();
     expect(signature!.rawLength).toBe(text.length);
-    expect(signature!.rawPrefix).not.toMatch(/[\uD800-\uDFFF]/);
-    expect(signature!.rawPrefix.endsWith("😀")).toBe(false);
-    expect(signature!.rawPrefix).toBe("a".repeat(9_999));
+    // Prefer full scalar at the cutoff: no lone surrogate, but keep the emoji so a
+    // distinct same-length assistant reply cannot falsely match.
+    expect(hasLoneSurrogate(signature!.rawPrefix)).toBe(false);
+    expect(signature!.rawPrefix.endsWith("\u{1F600}")).toBe(true);
+    expect(signature!.rawPrefix).toBe(`${"a".repeat(9_999)}\u{1F600}`);
+    expect(signature!.rawPrefix.length).toBe(TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS + 1);
 
     proofLine("write_site", "toolOutputRawEchoSignature.rawPrefix");
     proofLine("budget", TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS);
@@ -33,6 +54,20 @@ describe("toolOutputRawEchoSignature", () => {
       "safe_prefix_last_codeunit",
       signature!.rawPrefix.charCodeAt(signature!.rawPrefix.length - 1).toString(16),
     );
-    proofLine("safe_prefix_has_surrogate", /[\uD800-\uDFFF]/.test(signature!.rawPrefix));
+    proofLine("safe_prefix_has_lone_surrogate", hasLoneSurrogate(signature!.rawPrefix));
+    proofLine("safe_prefix_ends_with_emoji", signature!.rawPrefix.endsWith("\u{1F600}"));
+  });
+
+  it("keeps a boundary discriminator so distinct same-length text does not match", () => {
+    const toolOutput = `${"a".repeat(9_999)}\u{1F600}${"a".repeat(400)}`;
+    const signature = toolOutputRawEchoSignature(toolOutput)!;
+    const distinct = `${"a".repeat(9_999)}b${"a".repeat(toolOutput.length - 10_000)}`;
+    expect(distinct.length).toBe(toolOutput.length);
+    // Backed-off prefix of only a×9999 would falsely match; full-scalar prefix does not.
+    expect(distinct.startsWith(signature.rawPrefix)).toBe(false);
+    expect(toolOutput.startsWith(signature.rawPrefix)).toBe(true);
+    proofLine("discriminator_case", "distinct-same-length-no-match");
+    proofLine("distinct_starts_with_prefix", distinct.startsWith(signature.rawPrefix));
+    proofLine("echo_starts_with_prefix", toolOutput.startsWith(signature.rawPrefix));
   });
 });

--- a/extensions/codex/src/app-server/event-projector-tool-output.ts
+++ b/extensions/codex/src/app-server/event-projector-tool-output.ts
@@ -99,7 +99,9 @@ export function toolOutputRawEchoSignature(
   }
   return {
     rawLength: trimmed.length,
-    rawPrefix: trimmed.slice(0, TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS),
+    // Same UTF-16 budget as transcript truncation: a raw .slice can land inside
+    // a surrogate pair and poison echo-prefix matching / suppression.
+    rawPrefix: truncateUtf16Safe(trimmed, TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS),
   };
 }
 

--- a/extensions/codex/src/app-server/event-projector-tool-output.ts
+++ b/extensions/codex/src/app-server/event-projector-tool-output.ts
@@ -3,6 +3,37 @@ import {
   formatToolProgressOutput,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+
+function isHighSurrogate(codeUnit: number): boolean {
+  return codeUnit >= 0xd800 && codeUnit <= 0xdbff;
+}
+
+function isLowSurrogate(codeUnit: number): boolean {
+  return codeUnit >= 0xdc00 && codeUnit <= 0xdfff;
+}
+
+/**
+ * Echo-prefix truncation that stays UTF-16-safe while retaining a boundary
+ * discriminator. Unlike truncateUtf16Safe (which backs off when the budget
+ * lands mid-surrogate), this includes the full scalar so matchesEcho cannot
+ * falsely suppress distinct same-length assistant text that only shares the
+ * shortened ASCII prefix.
+ */
+export function truncateUtf16SafeEchoPrefix(input: string, maxLen: number): string {
+  const limit = Math.max(0, Math.floor(maxLen));
+  if (input.length <= limit) {
+    return input;
+  }
+  if (
+    limit > 0 &&
+    limit < input.length &&
+    isHighSurrogate(input.charCodeAt(limit - 1)) &&
+    isLowSurrogate(input.charCodeAt(limit))
+  ) {
+    return input.slice(0, limit + 1);
+  }
+  return input.slice(0, limit);
+}
 import { readString } from "./event-projector-values.js";
 import { isJsonObject, type CodexThreadItem } from "./protocol.js";
 
@@ -99,9 +130,10 @@ export function toolOutputRawEchoSignature(
   }
   return {
     rawLength: trimmed.length,
-    // Same UTF-16 budget as transcript truncation: a raw .slice can land inside
-    // a surrogate pair and poison echo-prefix matching / suppression.
-    rawPrefix: truncateUtf16Safe(trimmed, TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS),
+    // Same UTF-16 budget as transcript truncation, but prefer a full scalar at
+    // the cutoff so echo matching keeps a boundary discriminator (raw .slice
+    // would leave a lone surrogate; truncateUtf16Safe would drop the scalar).
+    rawPrefix: truncateUtf16SafeEchoPrefix(trimmed, TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS),
   };
 }
 

--- a/extensions/codex/src/app-server/event-projector-tool-progress.ts
+++ b/extensions/codex/src/app-server/event-projector-tool-progress.ts
@@ -531,7 +531,9 @@ export class CodexToolProgressProjection {
     ) {
       const next: ToolProgressRawSignature = {
         length: rawLength,
-        prefix: rawPrefix.slice(0, TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS),
+        // Cap with truncateUtf16Safe so emoji/CJK at the budget edge cannot
+        // leave a lone surrogate in the stored echo prefix.
+        prefix: truncateUtf16Safe(rawPrefix, TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS),
       };
       if (signature.streamedDisplay) {
         existing.streamedRawSignature = next;

--- a/extensions/codex/src/app-server/event-projector-tool-progress.ts
+++ b/extensions/codex/src/app-server/event-projector-tool-progress.ts
@@ -32,6 +32,7 @@ import {
   ToolOutputAccumulator,
   toolOutputRawEchoSignature,
   truncateToolTranscriptText,
+  truncateUtf16SafeEchoPrefix,
 } from "./event-projector-tool-output.js";
 import { readString } from "./event-projector-values.js";
 import type {
@@ -531,9 +532,9 @@ export class CodexToolProgressProjection {
     ) {
       const next: ToolProgressRawSignature = {
         length: rawLength,
-        // Cap with truncateUtf16Safe so emoji/CJK at the budget edge cannot
-        // leave a lone surrogate in the stored echo prefix.
-        prefix: truncateUtf16Safe(rawPrefix, TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS),
+        // Cap UTF-16-safe while keeping a full scalar at the budget edge so
+        // matchesEcho retains a boundary discriminator (no lone surrogate).
+        prefix: truncateUtf16SafeEchoPrefix(rawPrefix, TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS),
       };
       if (signature.streamedDisplay) {
         existing.streamedRawSignature = next;

--- a/extensions/codex/src/app-server/event-projector.progress-echo.test.ts
+++ b/extensions/codex/src/app-server/event-projector.progress-echo.test.ts
@@ -357,6 +357,71 @@ describe("CodexAppServerEventProjector tool progress echo filtering", () => {
     expect(JSON.stringify(result.messagesSnapshot)).not.toContain("tail-should-not-appear");
   });
 
+  it("keeps aggregate echo prefixes UTF-16 safe at the transcript budget via projector write sites", async () => {
+    const projector = await createProjector();
+    // Surrogate pair straddles TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS (10_000): a raw
+    // .slice would leave a lone high surrogate in both echo-prefix writers.
+    const asciiPrefix = "a".repeat(9_999);
+    const aggregatedOutput = `${asciiPrefix}😀${"a".repeat(400)}`;
+    const brokenSlice = aggregatedOutput.slice(0, 10_000);
+
+    await projector.handleNotification(
+      turnCompleted([
+        {
+          type: "commandExecution",
+          id: "cmd-aggregate-utf16-echo",
+          command: "printf output",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "completed",
+          commandActions: [],
+          aggregatedOutput,
+          exitCode: 0,
+          durationMs: 42,
+        },
+      ]),
+    );
+
+    // Production path: turn/completed → rememberCommandAggregateOutputEcho →
+    // toolOutputRawEchoSignature (write site 1) → rememberEcho prefix cap (write site 2).
+    const echoState = (
+      projector as unknown as {
+        toolProgressProjection: {
+          echoesByItem: Map<string, { rawSignatures: Array<{ length: number; prefix: string }> }>;
+        };
+      }
+    ).toolProgressProjection.echoesByItem;
+    const signatures = echoState.get("cmd-aggregate-utf16-echo")?.rawSignatures ?? [];
+    expect(signatures.length).toBeGreaterThan(0);
+    expect(brokenSlice.charCodeAt(brokenSlice.length - 1)).toBe(0xd83d);
+
+    for (const signature of signatures) {
+      expect(signature.prefix).not.toMatch(/[\uD800-\uDFFF]/);
+      expect(signature.prefix.endsWith("😀")).toBe(false);
+      expect(signature.prefix).toBe(asciiPrefix);
+      expect(signature.length).toBe(aggregatedOutput.length);
+      process.stdout.write(
+        `[utf16-echo-proof] write_sites=toolOutputRawEchoSignature+rememberEcho\n`,
+      );
+      process.stdout.write(
+        `[utf16-echo-proof] broken_slice_last_codeunit=${brokenSlice
+          .charCodeAt(brokenSlice.length - 1)
+          .toString(16)}\n`,
+      );
+      process.stdout.write(`[utf16-echo-proof] stored_prefix_len=${signature.prefix.length}\n`);
+      process.stdout.write(
+        `[utf16-echo-proof] stored_prefix_last_codeunit=${signature.prefix
+          .charCodeAt(signature.prefix.length - 1)
+          .toString(16)}\n`,
+      );
+      process.stdout.write(
+        `[utf16-echo-proof] stored_prefix_has_surrogate=${/[\uD800-\uDFFF]/.test(signature.prefix)}\n`,
+      );
+      process.stdout.write(`[utf16-echo-proof] stored_raw_length=${signature.length}\n`);
+    }
+  });
+
   it("keeps final answers that only start with a streamed tool-output prefix", async () => {
     const projector = await createProjector();
     const rawOutput = "s".repeat(12_345);

--- a/extensions/codex/src/app-server/event-projector.progress-echo.test.ts
+++ b/extensions/codex/src/app-server/event-projector.progress-echo.test.ts
@@ -18,6 +18,25 @@ import {
 
 registerCodexEventProjectorTestLifecycle();
 
+
+function hasLoneSurrogate(text: string): boolean {
+  for (let i = 0; i < text.length; i += 1) {
+    const unit = text.charCodeAt(i);
+    if (unit >= 0xd800 && unit <= 0xdbff) {
+      const next = text.charCodeAt(i + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        return true;
+      }
+      i += 1;
+      continue;
+    }
+    if (unit >= 0xdc00 && unit <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
 describe("CodexAppServerEventProjector tool progress echo filtering", () => {
   it("does not promote repeated tool progress text to the final assistant reply", async () => {
     const onToolResult = vi.fn();
@@ -397,9 +416,10 @@ describe("CodexAppServerEventProjector tool progress echo filtering", () => {
     expect(brokenSlice.charCodeAt(brokenSlice.length - 1)).toBe(0xd83d);
 
     for (const signature of signatures) {
-      expect(signature.prefix).not.toMatch(/[\uD800-\uDFFF]/);
-      expect(signature.prefix.endsWith("😀")).toBe(false);
-      expect(signature.prefix).toBe(asciiPrefix);
+      expect(hasLoneSurrogate(signature.prefix)).toBe(false);
+      expect(signature.prefix.endsWith("😀")).toBe(true);
+      expect(signature.prefix).toBe(`${asciiPrefix}😀`);
+      expect(signature.prefix.length).toBe(10_001);
       expect(signature.length).toBe(aggregatedOutput.length);
       process.stdout.write(
         `[utf16-echo-proof] write_sites=toolOutputRawEchoSignature+rememberEcho\n`,
@@ -416,10 +436,67 @@ describe("CodexAppServerEventProjector tool progress echo filtering", () => {
           .toString(16)}\n`,
       );
       process.stdout.write(
-        `[utf16-echo-proof] stored_prefix_has_surrogate=${/[\uD800-\uDFFF]/.test(signature.prefix)}\n`,
+        `[utf16-echo-proof] stored_prefix_has_lone_surrogate=${hasLoneSurrogate(signature.prefix)}\n`,
+      );
+      process.stdout.write(
+        `[utf16-echo-proof] stored_prefix_ends_with_emoji=${signature.prefix.endsWith("😀")}\n`,
       );
       process.stdout.write(`[utf16-echo-proof] stored_raw_length=${signature.length}\n`);
     }
+  });
+
+  it("retains distinct same-length assistant text at the UTF-16 echo budget via projector caller", async () => {
+    const projector = await createProjector();
+    const asciiPrefix = "a".repeat(9_999);
+    const aggregatedOutput = `${asciiPrefix}😀${"a".repeat(400)}`;
+    // Same UTF-16 length, differs at the former lone-surrogate cutoff.
+    const distinctAssistant = `${asciiPrefix}b${"a".repeat(aggregatedOutput.length - 10_000)}`;
+    expect(distinctAssistant.length).toBe(aggregatedOutput.length);
+
+    await projector.handleNotification(
+      turnCompleted([
+        {
+          type: "commandExecution",
+          id: "cmd-aggregate-utf16-discriminator",
+          command: "printf output",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "completed",
+          commandActions: [],
+          aggregatedOutput,
+          exitCode: 0,
+          durationMs: 42,
+        },
+      ]),
+    );
+
+    const progress = (
+      projector as unknown as {
+        toolProgressProjection: { matchesEcho: (text: string) => boolean };
+      }
+    ).toolProgressProjection;
+
+    expect(progress.matchesEcho(aggregatedOutput)).toBe(true);
+    expect(progress.matchesEcho(distinctAssistant)).toBe(false);
+
+    await projector.handleNotification(
+      turnCompleted([{ type: "agentMessage", id: "msg-distinct", text: distinctAssistant }]),
+    );
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+    expect(result.assistantTexts).toEqual([distinctAssistant]);
+    process.stdout.write(
+      `[utf16-echo-proof] caller_path=turn/completed+matchesEcho+assistant retention\n`,
+    );
+    process.stdout.write(
+      `[utf16-echo-proof] echo_matches_tool_output=${progress.matchesEcho(aggregatedOutput)}\n`,
+    );
+    process.stdout.write(
+      `[utf16-echo-proof] echo_matches_distinct=${progress.matchesEcho(distinctAssistant)}\n`,
+    );
+    process.stdout.write(
+      `[utf16-echo-proof] assistant_retained=${result.assistantTexts.includes(distinctAssistant)}\n`,
+    );
   });
 
   it("keeps final answers that only start with a streamed tool-output prefix", async () => {


### PR DESCRIPTION
## What Problem This Solves

Codex native tool-progress echo signatures truncated raw tool output with
`String.prototype.slice`. At the 10_000-char transcript budget, an emoji
surrogate pair can land on the cut and leave a lone UTF-16 code unit in the
stored echo prefix. That corrupts prefix matching and can wrongly suppress (or
fail to suppress) later assistant/tool echoes.

A follow-up regression: plain `truncateUtf16Safe` backs off one code unit at a
surrogate boundary, dropping the boundary discriminator. `matchesEcho` then
treats any equal-length assistant text that shares the shortened ASCII prefix
as an echo, falsely suppressing distinct same-length replies.

Sibling transcript helpers already use UTF-16-safe truncation; echo prefixes
need the discriminator-preserving variant.

## Why This Change Was Made

Introduce `truncateUtf16SafeEchoPrefix` and use it in both echo-prefix writers:

- `toolOutputRawEchoSignature` (aggregate/raw signature)
- `rememberEcho` stored `prefix` cap

At a mid-surrogate budget cut, include the full scalar (length `budget+1`) so
echo matching retains a discriminator. Add caller-path regressions through
`turn/completed` → `rememberEcho`, including a distinct same-length non-echo
retention case.

## User Impact

**Before:** Tool-stream echo dedupe prefixes could split surrogate pairs, or
drop the cutoff scalar and falsely suppress distinct same-length assistant text.

**After:** Echo prefixes stay on whole code points and keep a boundary
discriminator; distinct same-length assistant text is retained.

## Evidence

- Changed: `extensions/codex/src/app-server/event-projector-tool-output.ts`,
  `extensions/codex/src/app-server/event-projector-tool-progress.ts`,
  `extensions/codex/src/app-server/event-projector.progress-echo.test.ts`,
  `extensions/codex/src/app-server/event-projector-tool-output-echo.test.ts`
- Production path: Codex app-server projector →
  `rememberCommandAggregateOutputEcho` → `truncateUtf16SafeEchoPrefix` /
  `rememberEcho`
- Head: `3abc16f6dca`

## Real behavior proof

### Behavior or issue addressed

At budget 10_000 with `"a"*9999 + "😀" + …`:

- raw `text.slice(0, 10000)` ends with lone high surrogate `0xD83D`
- `truncateUtf16Safe` would store only `"a"*9999` (discriminator lost)
- `truncateUtf16SafeEchoPrefix` stores `"a"*9999 + "😀"` (length 10001)
- distinct same-length assistant text beginning `"a"*9999 + "b…"` is retained

### Canonical reachability path

`turnCompleted(commandExecution.aggregatedOutput)` →
`rememberCommandAggregateOutputEcho` → `toolOutputRawEchoSignature` →
`truncateUtf16SafeEchoPrefix` → `rememberEcho`

### Shared helper / provider constraint check

New echo-specific helper; transcript truncation continues to use
`truncateUtf16Safe` where shortening without a discriminator is correct.

### Real environment tested

Local trusted checkout at PR head `3abc16f6dca`; Vitest projector caller path
(exact write sites). Live Codex app-server session was not run in this
environment.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs \
  extensions/codex/src/app-server/event-projector-tool-output-echo.test.ts \
  extensions/codex/src/app-server/event-projector.progress-echo.test.ts \
  --reporter=verbose
```

### Evidence after fix

Caller-path coverage added for:

- UTF-16-safe prefix at the transcript budget via projector write sites
- retention of distinct same-length assistant text when the cutoff scalar is
  kept as the discriminator

### What was not tested

Live Codex app-server session against a real model with emoji tool output.
Proof is the production projector caller + both echo-prefix write sites.

### Fix classification

bugfix — Unicode / echo-prefix correctness + false-suppression regression

## AI Assistance

AI-assisted implementation and proof.
