### PR TITLE
fix(vault): bound success-path Vault JSON response bodies

### DIFF
--- a/extensions/vault/src/secret-ref-resolver.test.ts
+++ b/extensions/vault/src/secret-ref-resolver.test.ts
@@ -748,4 +748,82 @@ describe("vault SecretRef resolver", () => {
       },
     });
   });
+
+  it("rejects oversized success-path Vault JSON before buffering the full body", async () => {
+    const VAULT_JSON_MAX_BYTES = 16 * 1024 * 1024;
+    let bytesWritten = 0;
+    let clientCancelled = false;
+    const server = createServer((_request, response) => {
+      response.writeHead(200, { "Content-Type": "application/json" });
+      // Stream without Content-Length so the client must bound while reading.
+      response.write('{"data":{"data":{"apiKey":"');
+      bytesWritten += 26;
+      const chunk = Buffer.alloc(64 * 1024, 0x78);
+      const writeMore = () => {
+        if (response.destroyed || response.writableEnded) {
+          clientCancelled = true;
+          return;
+        }
+        if (bytesWritten >= 24 * 1024 * 1024) {
+          response.write('"}}}');
+          response.end();
+          return;
+        }
+        const ok = response.write(chunk);
+        bytesWritten += chunk.length;
+        if (!ok) {
+          response.once("drain", writeMore);
+          return;
+        }
+        setImmediate(writeMore);
+      };
+      response.on("close", () => {
+        if (!response.writableFinished) {
+          clientCancelled = true;
+        }
+      });
+      writeMore();
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    servers.push({
+      close: () =>
+        new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+          server.closeAllConnections();
+        }),
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("fixture server did not bind to a TCP port");
+    }
+
+    const result = await runResolver({
+      request: {
+        protocolVersion: 1,
+        provider: "vault",
+        ids: ["providers/openai/apiKey"],
+      },
+      env: {
+        VAULT_ADDR: `http://127.0.0.1:${address.port}`,
+        VAULT_TOKEN: "not-a-real-auth-header",
+      },
+      timeoutMs: 30_000,
+    });
+
+    expect(result).toMatchObject({ code: 0, stderr: "", timedOut: false });
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      protocolVersion: 1,
+      values: {},
+      errors: {
+        "providers/openai/apiKey": {
+          message: expect.stringContaining(`exceeds ${VAULT_JSON_MAX_BYTES} bytes`),
+        },
+      },
+    });
+    // Client cancel + backpressure should stop well under the full 24 MiB stream.
+    expect(clientCancelled || bytesWritten < 20 * 1024 * 1024).toBe(true);
+    expect(bytesWritten).toBeGreaterThan(VAULT_JSON_MAX_BYTES);
+  });
 });

--- a/extensions/vault/src/secret-ref-resolver.test.ts
+++ b/extensions/vault/src/secret-ref-resolver.test.ts
@@ -996,4 +996,82 @@ describe("vault SecretRef resolver", () => {
       },
     });
   });
+  it("rejects oversized success-path Vault JSON before buffering the full body", async () => {
+    const VAULT_JSON_MAX_BYTES = 16 * 1024 * 1024;
+    let bytesWritten = 0;
+    let clientCancelled = false;
+    const server = createServer((_request, response) => {
+      response.writeHead(200, { "Content-Type": "application/json" });
+      // Stream without Content-Length so the client must bound while reading.
+      response.write('{"data":{"data":{"apiKey":"');
+      bytesWritten += 26;
+      const chunk = Buffer.alloc(64 * 1024, 0x78);
+      const writeMore = () => {
+        if (response.destroyed || response.writableEnded) {
+          clientCancelled = true;
+          return;
+        }
+        if (bytesWritten >= 24 * 1024 * 1024) {
+          response.write('"}}}');
+          response.end();
+          return;
+        }
+        const ok = response.write(chunk);
+        bytesWritten += chunk.length;
+        if (!ok) {
+          response.once("drain", writeMore);
+          return;
+        }
+        setImmediate(writeMore);
+      };
+      response.on("close", () => {
+        if (!response.writableFinished) {
+          clientCancelled = true;
+        }
+      });
+      writeMore();
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    servers.push({
+      close: () =>
+        new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+          server.closeAllConnections();
+        }),
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("fixture server did not bind to a TCP port");
+    }
+
+    const result = await runResolver({
+      request: {
+        protocolVersion: 1,
+        provider: "vault",
+        ids: ["providers/openai/apiKey"],
+      },
+      env: {
+        VAULT_ADDR: `http://127.0.0.1:${address.port}`,
+        VAULT_TOKEN: "not-a-real-auth-header",
+      },
+      timeoutMs: 30_000,
+    });
+
+    expect(result).toMatchObject({ code: 0, stderr: "", timedOut: false });
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      protocolVersion: 1,
+      values: {},
+      errors: {
+        "providers/openai/apiKey": {
+          message: expect.stringContaining(`exceeds ${VAULT_JSON_MAX_BYTES} bytes`),
+        },
+      },
+    });
+    // Client cancel + backpressure should stop well under the full 24 MiB stream.
+    expect(clientCancelled || bytesWritten < 20 * 1024 * 1024).toBe(true);
+    expect(bytesWritten).toBeGreaterThan(VAULT_JSON_MAX_BYTES);
+  });
+
 });

--- a/extensions/vault/vault-secret-ref-resolver.js
+++ b/extensions/vault/vault-secret-ref-resolver.js
@@ -5,6 +5,60 @@ import { parseVaultSecretId } from "./vault-secret-id.js";
 
 const KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/token";
 const VAULT_FETCH_TIMEOUT_MS = 5000;
+// Secret payloads are small; keep the same 16 MiB campaign cap used by
+// readProviderJsonResponse so a hostile/misbehaving Vault cannot OOM the
+// SecretRef helper subprocess via an unbounded success-path response.json().
+const VAULT_JSON_MAX_BYTES = 16 * 1024 * 1024;
+
+async function cancelResponseBody(response) {
+  try {
+    await response.body?.cancel();
+  } catch {
+    // Best-effort: body may already be locked or closed.
+  }
+}
+
+async function readVaultJsonResponse(response) {
+  if (!response.ok) {
+    await cancelResponseBody(response);
+    return undefined;
+  }
+  const contentLengthHeader = response.headers.get("content-length");
+  if (contentLengthHeader != null) {
+    const contentLength = Number(contentLengthHeader);
+    if (Number.isFinite(contentLength) && contentLength > VAULT_JSON_MAX_BYTES) {
+      await cancelResponseBody(response);
+      throw new Error(`Vault response exceeds ${VAULT_JSON_MAX_BYTES} bytes.`);
+    }
+  }
+  if (!response.body) {
+    const text = await response.text();
+    if (Buffer.byteLength(text, "utf8") > VAULT_JSON_MAX_BYTES) {
+      throw new Error(`Vault response exceeds ${VAULT_JSON_MAX_BYTES} bytes.`);
+    }
+    return text ? JSON.parse(text) : undefined;
+  }
+  const reader = response.body.getReader();
+  const chunks = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    total += value.byteLength;
+    if (total > VAULT_JSON_MAX_BYTES) {
+      await reader.cancel().catch(() => undefined);
+      throw new Error(`Vault response exceeds ${VAULT_JSON_MAX_BYTES} bytes.`);
+    }
+    chunks.push(value);
+  }
+  if (chunks.length === 0) {
+    return undefined;
+  }
+  const bytes = Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)));
+  return JSON.parse(bytes.toString("utf8"));
+}
 
 function readStdin() {
   return new Promise((resolve, reject) => {
@@ -156,7 +210,7 @@ async function fetchVault(baseUrl, url, init) {
     });
     return {
       response,
-      payload: response.ok ? await response.json() : undefined,
+      payload: await readVaultJsonResponse(response),
     };
   } finally {
     clearTimeout(timeout);

--- a/extensions/vault/vault-secret-ref-resolver.js
+++ b/extensions/vault/vault-secret-ref-resolver.js
@@ -6,6 +6,57 @@ import { parseVaultSecretId } from "./vault-secret-id.js";
 const KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/token";
 const VAULT_FETCH_TIMEOUT_MS = 5000;
 const VAULT_ERROR_BODY_MAX_BYTES = 64 * 1024;
+// Secret payloads are small; keep the same 16 MiB campaign cap used by
+// readProviderJsonResponse so a hostile/misbehaving Vault cannot OOM the
+// SecretRef helper subprocess via an unbounded success-path response.json().
+const VAULT_JSON_MAX_BYTES = 16 * 1024 * 1024;
+
+async function cancelResponseBody(response) {
+  try {
+    await response.body?.cancel();
+  } catch {
+    // Best-effort: body may already be locked or closed.
+  }
+}
+
+async function readVaultSuccessJsonResponse(response) {
+  const contentLengthHeader = response.headers.get("content-length");
+  if (contentLengthHeader != null) {
+    const contentLength = Number(contentLengthHeader);
+    if (Number.isFinite(contentLength) && contentLength > VAULT_JSON_MAX_BYTES) {
+      await cancelResponseBody(response);
+      throw new Error(`Vault response exceeds ${VAULT_JSON_MAX_BYTES} bytes.`);
+    }
+  }
+  if (!response.body) {
+    const text = await response.text();
+    if (Buffer.byteLength(text, "utf8") > VAULT_JSON_MAX_BYTES) {
+      throw new Error(`Vault response exceeds ${VAULT_JSON_MAX_BYTES} bytes.`);
+    }
+    return text ? JSON.parse(text) : undefined;
+  }
+  const reader = response.body.getReader();
+  const chunks = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    total += value.byteLength;
+    if (total > VAULT_JSON_MAX_BYTES) {
+      await reader.cancel().catch(() => undefined);
+      throw new Error(`Vault response exceeds ${VAULT_JSON_MAX_BYTES} bytes.`);
+    }
+    chunks.push(value);
+  }
+  if (chunks.length === 0) {
+    return undefined;
+  }
+  const bytes = Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)));
+  return JSON.parse(bytes.toString("utf8"));
+}
+
 
 class VaultProviderError extends Error {}
 class VaultForbiddenError extends Error {}
@@ -201,7 +252,9 @@ async function fetchVault(baseUrl, url, init) {
     });
     return {
       response,
-      payload: response.ok ? await response.json() : await readVaultErrorPayload(response),
+      payload: response.ok
+        ? await readVaultSuccessJsonResponse(response)
+        : await readVaultErrorPayload(response),
     };
   } finally {
     clearTimeout(timeout);


### PR DESCRIPTION
## What Problem This Solves

The Vault SecretRef helper subprocess (`vault-secret-ref-resolver.js`) parsed
successful HTTP bodies with unbounded `response.json()`. A hostile or buggy
Vault (or MITM on `VAULT_ADDR`) can stream a huge JSON body and OOM the helper
process. Sibling work only cancelled unread bodies on non-ok responses; the
success path stayed unbounded.

## Why This Change Was Made

Replace success-path `response.json()` with `readVaultSuccessJsonResponse`:
Content-Length pre-check, streamed read capped at `VAULT_JSON_MAX_BYTES`
(16 MiB), cancel on overflow. Keep main's existing 64 KiB
`readVaultErrorPayload` path for non-OK responses so invalid-token / ACL
classification still works.

## User Impact

**Before:** A large ok Vault JSON body could grow without bound in the SecretRef
helper subprocess.

**After:** Bodies over 16 MiB are rejected with a clear error; small KV reads
still succeed; non-OK error payloads remain classified via the 64 KiB bound.

## Evidence

- Changed: `extensions/vault/vault-secret-ref-resolver.js`,
  `extensions/vault/src/secret-ref-resolver.test.ts`
- Production path: exec SecretRef → `fetchVault` →
  `readVaultSuccessJsonResponse` / `readVaultErrorPayload`
- Head: `01b378b5a3b` (rebased onto current main)

## Real behavior proof

### Behavior or issue addressed

Oversized success-path Vault JSON is rejected near the 16 MiB cap instead of
being fully buffered via `response.json()`, while non-OK payloads stay on the
64 KiB error reader.

### Canonical reachability path

`runResolver` child process → `fetchVault` →
`readVaultSuccessJsonResponse` (stream, 16 MiB) or `readVaultErrorPayload`
(64 KiB) → per-id protocol response

### Shared helper / provider constraint check

Standalone exec helper cannot import built `openclaw` dist; implements the same
16 MiB campaign bound locally.

### Real environment tested

Local trusted checkout; real `node:http` fixture streaming ~24 MiB without
Content-Length; Node v22.23.1; PR head `01b378b5a3b`.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs extensions/vault/src/secret-ref-resolver.test.ts \
  -t "rejects oversized success-path|reads KV v2|invalid" --reporter=verbose
```

### Evidence after fix

```text
✓ reads KV v2 secrets from Vault using path and field ids
✓ rejects oversized success-path Vault JSON before buffering the full body
```

Resolver returns per-id error containing `exceeds 16777216 bytes`; small KV v2
reads still return values; non-OK classification preserved.

### What was not tested

Live HashiCorp Vault cluster returning a deliberately oversized body.

### Fix classification

bugfix — resource bound / OOM hardening

## AI Assistance

AI-assisted implementation and proof.
