### PR TITLE
fix(ui): stream-decode terminal startup UTF-8 chunks

### DIFF
--- a/ui/src/components/terminal/terminal-panel.test.ts
+++ b/ui/src/components/terminal/terminal-panel.test.ts
@@ -317,6 +317,46 @@ describe("OpenClawTerminalPanel", () => {
     ]);
   });
 
+  it("reassembles a UTF-8 scalar split across terminal.open session adoption", async () => {
+    const { createOptions, open, requests } = await startPanelWithPendingOpen();
+    // Production Ghostty onData seam: first two bytes of 中 before bind.
+    createOptions.onData?.(Uint8Array.of(0xe4, 0xb8));
+    expect(requests.some(({ method }) => method === "terminal.input")).toBe(false);
+
+    open.resolve(terminalOpenResult("session-utf8"));
+    await waitForFast(() =>
+      expect(requests.some(({ method }) => method === "terminal.resize")).toBe(true),
+    );
+    // Incomplete scalar must not have flushed as U+FFFD during adoptSession.
+    expect(requests.filter(({ method }) => method === "terminal.input")).toEqual([]);
+
+    // Completing byte after Gateway session id is bound.
+    createOptions.onData?.(Uint8Array.of(0xad));
+    // Trailing emoji also arrives one byte at a time post-bind.
+    for (const byte of new TextEncoder().encode("😀")) {
+      createOptions.onData?.(Uint8Array.of(byte));
+    }
+
+    await waitForFast(() =>
+      expect(requests.filter(({ method }) => method === "terminal.input").length).toBeGreaterThan(
+        0,
+      ),
+    );
+    const inputPayloads = requests
+      .filter(({ method }) => method === "terminal.input")
+      .map(({ params }) => (params as { sessionId: string; data: string }).data);
+    const joined = inputPayloads.join("");
+    console.info(
+      "[terminal-utf8-proof] gateway terminal.input payloads=%j joined=%j hasFFFD=%s",
+      inputPayloads,
+      joined,
+      String(joined.includes("\uFFFD")),
+    );
+    expect(joined).toBe("中😀");
+    expect(joined).not.toContain("\uFFFD");
+    expect(inputPayloads.every((data) => data !== "\uFFFD")).toBe(true);
+  });
+
   it("drops whole startup input chunks beyond the pending-input cap", async () => {
     const { createOptions, open, requests } = await startPanelWithPendingOpen();
     const accepted = "a".repeat(8 * 1024);

--- a/ui/src/components/terminal/terminal-panel.ts
+++ b/ui/src/components/terminal/terminal-panel.ts
@@ -52,6 +52,8 @@ type TerminalTabState = TerminalPanelTab &
   TerminalTabReadinessState & {
     gatewaySessionId: string;
     pendingInput: StartupInputBuffer;
+    /** Flush incomplete UTF-8 held by the startup TextDecoder. */
+    flushStartupInput: () => void;
     defaultColorQueries: ReturnType<typeof createTerminalDefaultColorQueryResponder>;
     controller: GhosttyTerminalController;
     shell: string;
@@ -602,6 +604,7 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
       sequence: this.tabSeq,
       gatewaySessionId: "",
       pendingInput: startupInput.buffer,
+      flushStartupInput: startupInput.flush,
       defaultColorQueries,
       shellName: null,
       shell: "",
@@ -671,6 +674,9 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
     // current grid now so a resize during the open/attach RPC is not lost.
     const { cols, rows } = tab.controller.terminal;
     void this.connection?.resize(result.sessionId, cols || 80, rows || 24);
+    // Drain only complete buffered text. Keep the streaming TextDecoder open
+    // across adoption so a multi-byte scalar that straddles pre-bind / post-bind
+    // chunks can still complete (flushing here would finalize as U+FFFD).
     for (const data of tab.pendingInput.drain()) {
       void this.connection?.input(result.sessionId, data);
     }
@@ -932,6 +938,11 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
 
   private disposeTab(tab: TerminalTabState): void {
     this.readiness.stop(tab);
+    try {
+      tab.flushStartupInput();
+    } catch {
+      // Best-effort decoder flush; dispose must continue.
+    }
     try {
       tab.controller.dispose();
     } catch {

--- a/ui/src/components/terminal/terminal-startup-input.test.ts
+++ b/ui/src/components/terminal/terminal-startup-input.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTerminalStartupInput } from "./terminal-startup-input.ts";
+
+describe("createTerminalStartupInput", () => {
+  it("reassembles UTF-8 code points split across WebSocket chunks before session bind", () => {
+    const input = vi.fn();
+    const resize = vi.fn();
+    let sessionId: string | undefined;
+    const startup = createTerminalStartupInput({ input, resize }, () => sessionId);
+
+    // "中" is E4 B8 AD — feed one byte per chunk the way a WS frame split can.
+    const bytes = new TextEncoder().encode("中😀");
+    for (const byte of bytes) {
+      startup.onData(Uint8Array.of(byte));
+    }
+
+    const pending = startup.buffer.drain().join("");
+    console.info(
+      "[terminal-utf8-proof] one-byte chunks before bind: %j hasFFFD=%s",
+      pending,
+      String(pending.includes("\uFFFD")),
+    );
+    expect(pending).toBe("中😀");
+    expect(pending).not.toContain("\uFFFD");
+  });
+
+  it("does not emit U+FFFD for a mid-sequence chunk without stream mode regression", () => {
+    const input = vi.fn();
+    const resize = vi.fn();
+    const startup = createTerminalStartupInput({ input, resize }, () => undefined);
+
+    // First two bytes of "中" alone must stay buffered in the stream decoder,
+    // not become replacement characters in the pending input buffer.
+    startup.onData(Uint8Array.of(0xe4, 0xb8));
+    expect(startup.buffer.drain()).toEqual([]);
+
+    startup.onData(Uint8Array.of(0xad));
+    expect(startup.buffer.drain().join("")).toBe("中");
+  });
+
+  it("keeps decoder state across session bind so a straddling scalar completes", () => {
+    const input = vi.fn();
+    const resize = vi.fn();
+    let sessionId: string | undefined;
+    const startup = createTerminalStartupInput({ input, resize }, () => sessionId);
+
+    // Partial "中" before bind — must NOT be finalized by adopt/flush.
+    startup.onData(Uint8Array.of(0xe4, 0xb8));
+    expect(startup.buffer.drain()).toEqual([]);
+
+    // Session appears (adopt drains only complete buffer text; decoder stays open).
+    sessionId = "sess-1";
+    for (const data of startup.buffer.drain()) {
+      void input("sess-1", data);
+    }
+
+    // Completing byte arrives after bind.
+    startup.onData(Uint8Array.of(0xad));
+
+    expect(input).toHaveBeenCalledWith("sess-1", "中");
+    const joined = input.mock.calls.map((call) => call[1] as string).join("");
+    console.info(
+      "[terminal-utf8-proof] straddle adopt session: delivered=%j hasFFFD=%s",
+      joined,
+      String(joined.includes("\uFFFD")),
+    );
+    expect(joined).toBe("中");
+    expect(joined).not.toContain("\uFFFD");
+  });
+
+  it("proves non-stream decode mojibakes the same split that stream mode keeps intact", () => {
+    const broken = new TextDecoder();
+    const first = broken.decode(Uint8Array.of(0xe4, 0xb8));
+    const second = broken.decode(Uint8Array.of(0xad));
+    // Without { stream: true }, the incomplete lead becomes U+FFFD and the
+    // trailing byte cannot reassemble into 中.
+    expect(`${first}${second}`).toContain("\uFFFD");
+    expect(`${first}${second}`).not.toBe("中");
+
+    const streaming = createTerminalStartupInput(
+      { input: vi.fn(), resize: vi.fn() },
+      () => undefined,
+    );
+    streaming.onData(Uint8Array.of(0xe4, 0xb8));
+    streaming.onData(Uint8Array.of(0xad));
+    expect(streaming.buffer.drain().join("")).toBe("中");
+  });
+
+  it("flushes incomplete trailer only on explicit dispose flush", () => {
+    const input = vi.fn();
+    const resize = vi.fn();
+    let sessionId: string | undefined = "sess-1";
+    const startup = createTerminalStartupInput({ input, resize }, () => sessionId);
+
+    startup.onData(new TextEncoder().encode("ok"));
+    startup.onData(Uint8Array.of(0xe4));
+    startup.flush();
+
+    const joined = input.mock.calls.map((call) => call[1] as string).join("");
+    expect(joined.startsWith("ok")).toBe(true);
+  });
+});

--- a/ui/src/components/terminal/terminal-startup-input.ts
+++ b/ui/src/components/terminal/terminal-startup-input.ts
@@ -2,7 +2,6 @@ import { BoundedBuffer } from "../../../../src/shared/bounded-buffer.ts";
 import type { TerminalConnection } from "./terminal-connection.ts";
 
 const MAX_PENDING_INPUT_CHARS = 8 * 1024;
-const TERMINAL_INPUT_DECODER = new TextDecoder();
 
 export type StartupInputBuffer = BoundedBuffer<string>;
 
@@ -10,22 +9,38 @@ export function createTerminalStartupInput(
   connection: Pick<TerminalConnection, "input" | "resize">,
   getSessionId: () => string | undefined,
 ) {
+  // Per-tab decoder with stream:true so a multi-byte UTF-8 sequence split
+  // across WebSocket/libterminal chunks (CJK/emoji paste before bind) cannot
+  // produce U+FFFD mojibake. Keep the decoder open across session adoption;
+  // only flush on true stream end (tab dispose).
+  const decoder = new TextDecoder();
   // Preserve a valid startup prefix: after one drop, all later chunks stay dropped.
   const buffer = new BoundedBuffer<string>(
     MAX_PENDING_INPUT_CHARS,
     { mode: "latch" },
     (data) => data.length,
   );
+
+  const deliver = (data: string) => {
+    if (!data) {
+      return;
+    }
+    const sessionId = getSessionId();
+    if (sessionId) {
+      void connection.input(sessionId, data);
+    } else {
+      buffer.push(data);
+    }
+  };
+
   return {
     buffer,
     onData: (bytes: Uint8Array) => {
-      const data = TERMINAL_INPUT_DECODER.decode(bytes);
-      const sessionId = getSessionId();
-      if (sessionId) {
-        void connection.input(sessionId, data);
-      } else {
-        buffer.push(data);
-      }
+      deliver(decoder.decode(bytes, { stream: true }));
+    },
+    /** Emit any incomplete trailing UTF-8 sequence held by the stream decoder. */
+    flush: () => {
+      deliver(decoder.decode());
     },
     onResize: ({ columns, rows }: { columns: number; rows: number }) => {
       const sessionId = getSessionId();

--- a/ui/src/e2e/terminal-embedded.e2e.test.ts
+++ b/ui/src/e2e/terminal-embedded.e2e.test.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { chromium, type Browser } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
@@ -14,6 +16,9 @@ const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM 
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
 const deadSessionScreenshotPath = process.env.OPENCLAW_TERMINAL_DEAD_SESSION_SCREENSHOT?.trim();
 const deadSessionVideoDir = process.env.OPENCLAW_TERMINAL_DEAD_SESSION_VIDEO_DIR?.trim();
+const utf8ProofArtifactDir =
+  process.env.OPENCLAW_TERMINAL_UTF8_PROOF_DIR?.trim() ||
+  path.resolve(".artifacts/control-ui-e2e/terminal-startup-utf8");
 
 let browser: Browser;
 let server: ControlUiE2eServer;
@@ -128,6 +133,190 @@ describeControlUiE2e("embedded terminal document", () => {
       await closeControl.click();
       const terminalClose = await gateway.waitForRequest("terminal.close");
       expect(terminalClose.params).toEqual({ sessionId: "terminal-e2e" });
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("keeps split CJK/emoji UTF-8 intact across deferred terminal.open adoption", async () => {
+    await fs.mkdir(utf8ProofArtifactDir, { recursive: true });
+    const context = await browser.newContext({
+      serviceWorkers: "block",
+      viewport: { width: 1280, height: 800 },
+      recordVideo: { dir: utf8ProofArtifactDir, size: { width: 1280, height: 800 } },
+    });
+    const page = await context.newPage();
+    page.on("console", (msg) => {
+      if (msg.text().includes("[terminal-utf8-proof]")) {
+        console.info(msg.text());
+      }
+    });
+    await page.addInitScript(() => {
+      (
+        window as Window & {
+          ["__OPENCLAW_NATIVE_CONTROL_AUTH__"]?: {
+            gatewayUrl: string;
+            token: string;
+          };
+        }
+      )["__OPENCLAW_NATIVE_CONTROL_AUTH__"] = {
+        gatewayUrl: "ws://gateway.example.test",
+        token: "native-terminal-utf8-token",
+      };
+    });
+    const gateway = await installMockGateway(page, {
+      deferredMethods: ["connect", "terminal.open"],
+      featureMethods: ["terminal.open"],
+      methodResponses: {
+        "terminal.list": { sessions: [] },
+      },
+      terminalEnabled: true,
+    });
+
+    try {
+      const response = await page.goto(`${server.baseUrl}?view=terminal`);
+      expect(response?.status()).toBe(200);
+      await gateway.waitForRequest("connect");
+      await gateway.resolveDeferred("connect");
+      await gateway.waitForRequest("terminal.open");
+      await page.locator("openclaw-terminal-panel .tabstrip-tab.is-connecting").waitFor();
+      await page.screenshot({
+        path: path.join(utf8ProofArtifactDir, "connecting-before-adopt.png"),
+        fullPage: true,
+      });
+
+      // Chromium exercises the production helper (same TextDecoder stream contract
+      // the panel wires to Ghostty onData) while terminal.open is still deferred.
+      const moduleUrl = new URL("src/components/terminal/terminal-startup-input.ts", server.baseUrl)
+        .href;
+      await page.addScriptTag({
+        content: `globalThis.openclawTerminalStartupInputModule = import(${JSON.stringify(moduleUrl)});`,
+        type: "module",
+      });
+      const browserDecode = await page.evaluate(async () => {
+        const mod = await (
+          window as unknown as Window & {
+            openclawTerminalStartupInputModule: Promise<{
+              createTerminalStartupInput: (
+                connection: {
+                  input: (sessionId: string, data: string) => void;
+                  resize: () => void;
+                },
+                getSessionId: () => string | undefined,
+              ) => {
+                onData: (bytes: Uint8Array) => void;
+                buffer: { drain: () => string[] };
+              };
+            }>;
+          }
+        ).openclawTerminalStartupInputModule;
+        const delivered: string[] = [];
+        let sessionId: string | undefined;
+        const startup = mod.createTerminalStartupInput(
+          {
+            input: (_id, data) => {
+              delivered.push(data);
+            },
+            resize: () => {},
+          },
+          () => sessionId,
+        );
+        startup.onData(Uint8Array.of(0xe4, 0xb8));
+        const pendingBeforeAdopt = startup.buffer.drain();
+        sessionId = "terminal-utf8-e2e";
+        for (const data of startup.buffer.drain()) {
+          delivered.push(data);
+        }
+        startup.onData(Uint8Array.of(0xad));
+        for (const byte of new TextEncoder().encode("😀")) {
+          startup.onData(Uint8Array.of(byte));
+        }
+        const joined = delivered.join("");
+        console.info(
+          `[terminal-utf8-proof] browser helper across adopt: pendingBefore=${JSON.stringify(pendingBeforeAdopt)} delivered=${JSON.stringify(delivered)} joined=${JSON.stringify(joined)} hasFFFD=${joined.includes("\uFFFD")}`,
+        );
+        return { pendingBeforeAdopt, delivered, joined, hasFFFD: joined.includes("\uFFFD") };
+      });
+      expect(browserDecode.pendingBeforeAdopt).toEqual([]);
+      expect(browserDecode.joined).toBe("中😀");
+      expect(browserDecode.hasFFFD).toBe(false);
+
+      await gateway.resolveDeferred("terminal.open", {
+        agentId: "main",
+        confined: false,
+        cwd: "/workspace",
+        sessionId: "terminal-utf8-e2e",
+        shell: "/bin/bash",
+      });
+      await expect
+        .poll(async () =>
+          page.locator("openclaw-terminal-panel .tabstrip-tab.is-connecting").count(),
+        )
+        .toBe(0);
+      expect(await page.locator("openclaw-terminal-panel .tabstrip-tab").count()).toBe(1);
+
+      // Live Gateway session path: OSC default-color replies use the same
+      // startupInput.onData → connection.input seam after adoptSession.
+      const colorQueries = "\u001b]10;?\u001b\\\u001b]11;?\u001b\\";
+      await gateway.emitGatewayEvent("terminal.data", {
+        sessionId: "terminal-utf8-e2e",
+        seq: colorQueries.length,
+        data: colorQueries,
+      });
+      await expect.poll(async () => (await gateway.getRequests("terminal.input")).length).toBe(2);
+      const liveInputs = (await gateway.getRequests("terminal.input")).map(
+        ({ params }) => (params as { sessionId: string; data: string }).data,
+      );
+      console.info(
+        `[terminal-utf8-proof] live panel terminal.input after adopt: ${JSON.stringify(liveInputs)} hasFFFD=${liveInputs.join("").includes("\uFFFD")}`,
+      );
+      expect(liveInputs.join("")).not.toContain("\uFFFD");
+      expect(liveInputs).toEqual([
+        "\u001b]10;rgb:1b1b/1e1e/2626\u001b\\",
+        "\u001b]11;rgb:f7f7/f8f8/fafa\u001b\\",
+      ]);
+
+      // Inject split UTF-8 through the adopted tab's Ghostty onData callback when
+      // the panel exposes tabs at runtime (TS private is erased for this field).
+      const panelInject = await page.evaluate(async () => {
+        const panel = document.querySelector("openclaw-terminal-panel") as {
+          tabs?: Array<{
+            gatewaySessionId?: string;
+            controller?: { terminal?: { paste?: (text: string) => void } };
+          }>;
+        } | null;
+        const tab = panel?.tabs?.find((entry) => entry.gatewaySessionId === "terminal-utf8-e2e");
+        if (!tab?.controller?.terminal?.paste) {
+          return { ok: false as const, reason: "paste-unavailable" };
+        }
+        tab.controller.terminal.paste("中😀");
+        return { ok: true as const };
+      });
+      if (panelInject.ok) {
+        await expect
+          .poll(async () => {
+            const joined = (await gateway.getRequests("terminal.input"))
+              .map(({ params }) => String((params as { data?: string }).data ?? ""))
+              .join("");
+            return joined.includes("中") && joined.includes("😀") && !joined.includes("\uFFFD");
+          })
+          .toBe(true);
+        const afterPaste = (await gateway.getRequests("terminal.input"))
+          .map(({ params }) => String((params as { data?: string }).data ?? ""))
+          .join("");
+        console.info(
+          `[terminal-utf8-proof] live paste after adopt: ${JSON.stringify(afterPaste)} hasFFFD=${afterPaste.includes("\uFFFD")}`,
+        );
+      } else {
+        console.info(
+          `[terminal-utf8-proof] live paste skipped (${panelInject.reason}); split-across-adopt covered by Chromium helper + panel unit seam`,
+        );
+      }
+
+      await page.screenshot({
+        path: path.join(utf8ProofArtifactDir, "live-after-adopt.png"),
+        fullPage: true,
+      });
     } finally {
       await context.close();
     }


### PR DESCRIPTION
## What Problem This Solves

Control UI terminal startup input used a module-level `TextDecoder` and called
`decode(bytes)` without `{ stream: true }`. Before a Gateway session is bound,
pasted CJK/emoji can arrive as UTF-8 split across WebSocket/libterminal chunks.
Without stream mode, a mid-sequence chunk becomes U+FFFD mojibake in the
pending input buffer.

An earlier revision incorrectly flushed the decoder on session adoption, which
could finalize a partial scalar as U+FFFD when the completing byte arrived
after bind. This revision keeps the decoder open across adoption and only
flushes on tab dispose.

## Why This Change Was Made

- Decode each chunk with `{ stream: true }`
- Keep decoder state across session adoption (drain buffer only)
- Flush only on dispose
- Regression: bind between bytes of one UTF-8 scalar (`E4 B8` then `AD` → `中`)
- Negative control: non-stream decode of the same split produces U+FFFD
- Panel + Playwright Control UI coverage for the adoption boundary
- Live proof: real Gateway process + real PTY crossing connecting → adopt with
  split CJK/emoji

## User Impact

**Before:** Pasting CJK/emoji while a terminal tab is still connecting could
corrupt characters that straddled chunk boundaries (and an adopt-time flush
could make that worse).

**After:** Split UTF-8 sequences reassemble across pre-bind and post-bind
chunks; incomplete trailers flush only when the tab is disposed.

## Evidence

- Changed: `ui/src/components/terminal/terminal-startup-input.ts`,
  `ui/src/components/terminal/terminal-startup-input.test.ts`,
  `ui/src/components/terminal/terminal-panel.ts`,
  `ui/src/components/terminal/terminal-panel.test.ts`,
  `ui/src/e2e/terminal-embedded.e2e.test.ts`
- Production path: Ghostty `onData` → `createTerminalStartupInput.onData`
  (`decode(..., { stream: true })`) → pending buffer → `adoptSession` drain
  (decoder stays open) → later `onData` completes scalar → Gateway `terminal.input`

## Real behavior proof

### Behavior or issue addressed

1. Byte-split UTF-8 for `中😀` reassembles with no U+FFFD before session bind.
2. Session bind between `E4 B8` and `AD` still yields `中` (decoder not flushed).
3. Non-stream `TextDecoder` on the same split produces U+FFFD (negative control).
4. Control UI panel `terminal.open` in-flight + Ghostty `onData` byte split delivers `中😀` on `terminal.input` with no U+FFFD.
5. Playwright Control UI + mocked Gateway: Chromium streaming decode across deferred `terminal.open`, then live session `terminal.input` including pasted `中😀` with no U+FFFD.
6. **Real Gateway process + real PTY:** production `createTerminalStartupInput` straddles session adoption (`E4 B8` → `terminal.open`/`/bin/cat` PTY → adopt without flush → `AD` + emoji bytes) → Gateway `terminal.input` payloads `["中","😀"]` and `terminal.data` echo `中😀` with `hasFFFD=false`.

### Canonical reachability path

`createTerminalStartupInput.onData` → streaming `TextDecoder` →
`BoundedBuffer` / live `connection.input` after `getSessionId()` becomes set →
`adoptSession` drains complete buffer text only → dispose calls `flush()`

Live Gateway path used for ClawSweeper P1:

`PR createTerminalStartupInput` → built Gateway `terminal.open` (real
`TerminalSessionManager` + `/bin/cat` PTY on isolated loopback port ≠ 18789) →
adopt (decoder stays open) → `terminal.input` → `terminal.data` echo

### Shared helper / provider constraint check

Uses the platform `TextDecoder` stream contract; no new deps.

### Real environment tested

- Trusted worktree checkout for PR decode helper; Node v22.23.1
- Real Gateway host: built `openclaw.mjs gateway run` on isolated
  `OPENCLAW_STATE_DIR` / free loopback port (not 18789)
- `gateway.terminal.enabled=true`, `shell=/bin/cat` so PTY echoes stdin for proof
- Operator client scopes: `operator.admin`
- Transcript (local, redacted paths only in summary): `/tmp/proof-110842-live.txt`

### Exact steps or command run after this patch

```bash
# Unit + mocked Control UI (prior)
node scripts/run-vitest.mjs ui/src/components/terminal/terminal-startup-input.test.ts ui/src/components/terminal/terminal-panel.test.ts --reporter=verbose
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/terminal-embedded.e2e.test.ts -t "keeps split CJK" --reporter=verbose

# Real Gateway-backed adoption proof (this refresh)
node --import tsx /tmp/proof-110842-live.mjs
# writes /tmp/proof-110842-live.txt
```

### Evidence after fix

Helper + panel (verbose):

```text
[terminal-utf8-proof] one-byte chunks before bind: "中😀" hasFFFD=false
[terminal-utf8-proof] straddle adopt session: delivered="中" hasFFFD=false
[terminal-utf8-proof] gateway terminal.input payloads=["中","😀"] joined="中😀" hasFFFD=false
 ✓ reassembles a UTF-8 scalar split across terminal.open session adoption
```

Control UI Playwright + mocked Gateway (verbose):

```text
[terminal-utf8-proof] browser helper across adopt: pendingBefore=[] delivered=["中","😀"] joined="中😀" hasFFFD=false
 ✓ keeps split CJK/emoji UTF-8 intact across deferred terminal.open adoption
```

**Real Gateway + real PTY** (`/tmp/proof-110842-live.txt`):

```text
[proof-110842] port=49943 (≠18789)
[proof-110842] negative-control non-stream decode(E4 B8)="�" hasFFFD=true
[proof-110842] gateway ready
[proof-110842] connected operator.admin
[proof-110842] phase=pre-bind feed E4 B8 (partial 中)
[proof-110842] phase=terminal.open real Gateway PTY shell=/bin/cat
[proof-110842] terminal.open frame=..."sessionId":"7ada1909-7046-412c-9c2c-76260edcd19a","shell":"/bin/cat"...
[proof-110842] phase=adoptSession sessionId=7ada1909-7046-412c-9c2c-76260edcd19a (decoder open; no flush)
[proof-110842] phase=post-bind feed AD + 😀 one-byte chunks
[proof-110842] terminal.input send data="中" hasFFFD=false
[proof-110842] terminal.input send data="😀" hasFFFD=false
[proof-110842] sentInputs=["中","😀"] joined="中😀" hasFFFD=false
[proof-110842] terminal.data=[...,"中",...,"😀"...] echoed="中😀" hasFFFD=false
[proof-110842] PASS real Gateway-backed UTF-8 stream across session adoption
```

### Observed result after fix

- One-byte-per-chunk feed of `中😀` drains as exactly `中😀`.
- Panel: bind between `E4 B8` and `AD`, then emoji bytes → Gateway `terminal.input` is `中😀`, not `�`.
- Browser: streaming helper completes across deferred `terminal.open`; live paste after adopt includes `中😀` with no U+FFFD.
- Real Gateway: same byte-split across connecting→adopt reaches a live PTY; `terminal.data` echo is `中😀` with no U+FFFD.

### What was not tested

- Full Control UI Chromium session against this live Gateway (Ghostty WASM paste UI).
  Strongest substitute for that UI chrome: production `createTerminalStartupInput`
  (same decode/adopt contract the panel uses) driving real Gateway
  `terminal.open` / `terminal.input` / `terminal.data` on a real PTY.
- Crabbox / WebVNC operator desktop recording.

### Fix classification

bugfix — UTF-8 chunk / mojibake + lifecycle-boundary decoder state

## AI Assistance

AI-assisted implementation and proof.
