### PR TITLE
fix(qqbot): log tool media failures after block replies

### DIFF
--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
@@ -776,6 +776,99 @@ describe("dispatchOutbound", () => {
     }
   });
 
+  it("logs tool media send failures after a block response instead of swallowing them", async () => {
+    const logError = vi.fn();
+    // outbound.sendMedia catches sender throws into result.error; the old empty
+    // catch around this path swallowed both throws and result.error silently.
+    sendMediaMock.mockRejectedValueOnce(new Error("upload exploded"));
+    const runtime = makeRuntime({
+      onDispatch: async ({ deliver }) => {
+        await deliver({ text: "final answer" }, { kind: "block" });
+        await deliver({ mediaUrl: "https://example.com/tool-image.png" }, { kind: "tool" });
+      },
+    });
+
+    await dispatchOutbound(makeInbound(), {
+      runtime,
+      cfg: {},
+      account: { ...account, config: { streaming: { mode: "off" } } },
+      log: { error: logError, info: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+    });
+
+    expect(sendMediaMock).toHaveBeenCalled();
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining("Tool media send error after block response: upload exploded"),
+    );
+  });
+
+  it("keeps agent-scoped media roots on post-block tool media while logging send errors", async () => {
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qqbot-post-block-root-"));
+    try {
+      const filePath = path.join(tmpRoot, "tool-report.docx");
+      await fs.writeFile(filePath, Buffer.from("report"));
+      const realFilePath = await fs.realpath(filePath);
+      const logError = vi.fn();
+      sendMediaMock.mockRejectedValueOnce(new Error("upload exploded"));
+      const runtime = makeRuntime({
+        onDispatch: async ({ deliver }) => {
+          await deliver({ text: "final answer" }, { kind: "block" });
+          await deliver({ mediaUrl: filePath }, { kind: "tool" });
+        },
+      });
+
+      await dispatchOutbound(
+        makeInbound({
+          route: {
+            sessionKey: "qqbot:c2c:user-openid",
+            accountId: "qq-main",
+            agentId: "agent-1",
+          },
+        }),
+        {
+          runtime,
+          cfg: { agents: { list: [{ id: "agent-1", workspace: tmpRoot }] } },
+          account: { ...account, config: { streaming: { mode: "off" } } },
+          log: { error: logError, info: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+        },
+      );
+
+      // Real outbound.sendMedia consumes gatewayMediaContext (mediaLocalRoots /
+      // workspaceDir) before calling the sender; a resolved workspace-local
+      // path proves the shared helper still spreads that context.
+      const senderArgs = sendMediaMock.mock.calls[0]?.[0] as {
+        kind?: string;
+        source?: { localPath?: string };
+        target?: { id?: string; type?: string };
+      };
+      const realWorkspaceRoot = await fs.realpath(tmpRoot);
+      const logged = String(logError.mock.calls[0]?.[0] ?? "");
+      // eslint-disable-next-line no-console -- proof artifact for PR Evidence
+      console.log(
+        "qqbot post-block tool-media proof:",
+        JSON.stringify({
+          kind: senderArgs?.kind,
+          localPath: senderArgs?.source?.localPath,
+          underWorkspace: senderArgs?.source?.localPath?.startsWith(`${realWorkspaceRoot}/`),
+          target: senderArgs?.target,
+          logged,
+        }),
+      );
+      expect(sendMediaMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: "file",
+          source: { localPath: realFilePath },
+          target: { id: "user-openid", type: "c2c" },
+        }),
+      );
+      expect(senderArgs?.source?.localPath?.startsWith(`${realWorkspaceRoot}/`)).toBe(true);
+      expect(logError).toHaveBeenCalledWith(
+        expect.stringContaining("Tool media send error after block response: upload exploded"),
+      );
+    } finally {
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
   it("threads agent scoped media roots through gateway QQBOT_PAYLOAD replies", async () => {
     const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qqbot-payload-root-"));
     try {

--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
@@ -519,18 +519,14 @@ export async function dispatchOutbound(
               if (hasBlockResponse && toolMediaUrls.length > 0) {
                 const urlsToSend = [...toolMediaUrls];
                 toolMediaUrls.length = 0;
+                // Reuse the tool-media helper: empty catch used to swallow both
+                // thrown failures and result.error, so the turn looked successful
+                // while tool images/files never reached QQ.
                 for (const mediaUrl of urlsToSend) {
-                  try {
-                    await sendMedia({
-                      to: qualifiedTarget,
-                      text: "",
-                      mediaUrl,
-                      accountId: account.accountId,
-                      replyToId: event.messageId,
-                      account,
-                      ...gatewayMediaContext,
-                    });
-                  } catch {}
+                  await sendToolMediaWithTimeout(mediaUrl, {
+                    resultError: "Tool media send error after block response",
+                    thrownError: "Tool media send failed after block response",
+                  });
                 }
                 return;
               }


### PR DESCRIPTION
## What Problem This Solves

When QQBot had already delivered a block reply and later flushed tool-collected
media URLs, `outbound-dispatch.ts` wrapped `sendMedia` in an empty `catch {}`
and ignored `result.error`. Upload/send failures were silent: the turn looked
successful while tool images/files never reached the user.

## Why This Change Was Made

Reuse `sendToolMediaWithTimeout` for the post-block tool-media flush so thrown
failures and `result.error` are logged with the same timeout/budget behavior
as the tool-only path. That helper already closes over and forwards
`...gatewayMediaContext` (workspaceDir / mediaLocalRoots) into `sendMedia`.

## User Impact

**Before:** Tool media after a visible block reply could fail with no log.

**After:** Failures are logged
(`Tool media send error after block response: …`) while agent-scoped local
media roots still resolve through `gatewayMediaContext`.

## Evidence

- Changed: `extensions/qqbot/src/engine/gateway/outbound-dispatch.ts`,
  `extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts`
- Production path: `deliver(block)` → `deliver(tool mediaUrl)` →
  `hasBlockResponse && toolMediaUrls` → `sendToolMediaWithTimeout` →
  `sendMedia({ ...gatewayMediaContext })` → `log.error` on failure
- Helper contract (unchanged, cited for prior P1):
  `sendToolMediaWithTimeout` at
  `extensions/qqbot/src/engine/gateway/outbound-dispatch.ts` spreads
  `...gatewayMediaContext` on every `sendMedia` call (same as main). Prior
  ClawSweeper “helper drops context” finding does not match this head.

## Real behavior proof

### Behavior or issue addressed

1. Rejected post-block `sendMedia` is logged (no empty catch).
2. Agent-scoped local tool media after a block still resolves under the
   agent workspace (proves `gatewayMediaContext` still reaches real
   `outbound.sendMedia` before the sender).
3. The same path logs when the sender rejects.

### Canonical reachability path

`dispatchOutbound` → buffered block deliver → tool media deliver →
`sendToolMediaWithTimeout` (closes over `gatewayMediaContext`) →
real `outbound.sendMedia` path-resolution → sender → `log.error`

### Shared helper / provider constraint check

Reuses existing `sendToolMediaWithTimeout` (already spreads
`...gatewayMediaContext`). No send-contract narrowing versus the previous
direct `sendMedia({ ...gatewayMediaContext })` call.

### Real environment tested

Local trusted checkout; production `dispatchOutbound` caller with a real
temp workspace file. Sender is mocked at the QQ upload boundary (no live
QQ Bot app credentials in this environment). Node focused Vitest.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts -t "keeps agent-scoped media roots on post-block" --reporter=verbose
```

### Evidence after fix

```text
qqbot post-block tool-media proof: {"kind":"file","localPath":"/private/var/folders/.../qqbot-post-block-root-.../tool-report.docx","underWorkspace":true,"target":{"type":"c2c","id":"user-openid"},"logged":"Tool media send error after block response: upload exploded"}

✓ keeps agent-scoped media roots on post-block tool media while logging send errors 201ms
 Test Files  1 passed (1)
      Tests  1 passed | 45 skipped (46)
```

### Observed result after fix

- `underWorkspace: true` — resolved `localPath` is under the agent workspace,
  so helper context still reaches path resolution.
- `log.error` receives
  `Tool media send error after block response: upload exploded`.

### Remaining gap (honest)

No credentialed live QQ Bot Open Platform upload was run. Proof is the
production `dispatchOutbound` → real outbound media resolution → sender
boundary with a workspace-local file and logged failure. Live transport
bytes would need a real QQ appId/secret.
