### PR TITLE
feat(qqbot): preserve inbound messages through gateway restarts

### DIFF
--- a/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
@@ -351,7 +351,9 @@ describe("GatewayConnection disconnect status", () => {
       await vi.waitFor(() => expect(createQQWSClientMock).toHaveBeenCalledTimes(1));
 
       controller.abort();
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
 
       expect(unhandledRejections).toStrictEqual([]);
       resolveSocket(ws);

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
@@ -314,6 +314,53 @@ describe("GatewayConnection disconnect status", () => {
     expect(flushRefIndex).toHaveBeenCalledTimes(1);
   });
 
+  it("observes shutdown rejection while the initial connection is pending", async () => {
+    vi.useRealTimers();
+    const cleanupError = new Error("ingress stop failed");
+    const ws = new FakeWebSocket();
+    let resolveSocket!: (socket: FakeWebSocket) => void;
+    createQQWSClientMock.mockReturnValue(
+      new Promise<FakeWebSocket>((resolve) => {
+        resolveSocket = resolve;
+      }),
+    );
+    const controller = new AbortController();
+    const connection = new GatewayConnection({
+      account: makeAccount(),
+      abortSignal: controller.signal,
+      cfg: {},
+      runtime: {} as GatewayPluginRuntime,
+      adapters: {} as EngineAdapters,
+      handleMessage: async () => {},
+      createIngressMonitor: () => ({
+        receive: vi.fn(async () => {}),
+        stop: vi.fn(async () => {
+          throw cleanupError;
+        }),
+        waitForIdle: vi.fn(async () => {}),
+      }),
+    });
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledRejections.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandledRejection);
+
+    try {
+      const started = connection.start();
+      await vi.waitFor(() => expect(createQQWSClientMock).toHaveBeenCalledTimes(1));
+
+      controller.abort();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(unhandledRejections).toStrictEqual([]);
+      resolveSocket(ws);
+      await expect(started).rejects.toBe(cleanupError);
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection);
+    }
+  });
+
   it("terminates the socket when durable admission fails closed", async () => {
     const admissionError = new QQBotIngressAdmissionError("sqlite unavailable");
     const receive = vi.fn(async () => {

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
@@ -3,8 +3,9 @@ import { EventEmitter } from "node:events";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { EngineAdapters } from "../adapter/index.js";
-import { MAX_RECONNECT_ATTEMPTS } from "./constants.js";
+import { GatewayEvent, GatewayOp, MAX_RECONNECT_ATTEMPTS } from "./constants.js";
 import { GatewayConnection } from "./gateway-connection.js";
+import { QQBotIngressAdmissionError, type QQBotIngressMonitor } from "./ingress.js";
 import type { GatewayAccount, GatewayPluginRuntime } from "./types.js";
 
 const createQQWSClientMock = vi.hoisted(() => vi.fn());
@@ -44,7 +45,16 @@ vi.mock("../commands/slash-command-handler.js", () => ({
 class FakeWebSocket extends EventEmitter {
   readyState = 3; // CLOSED — keeps cleanup() from re-entering close()
   close = vi.fn();
+  terminate = vi.fn();
   send = vi.fn();
+}
+
+function createNoopIngressMonitor() {
+  return {
+    receive: vi.fn(async () => {}),
+    stop: vi.fn(async () => {}),
+    waitForIdle: vi.fn(async () => {}),
+  };
 }
 
 function makeAccount(): GatewayAccount {
@@ -57,7 +67,11 @@ function makeAccount(): GatewayAccount {
   };
 }
 
-async function startConnection(params: { onDisconnected?: (info: unknown) => void }) {
+async function startConnection(params: {
+  onDisconnected?: (info: unknown) => void;
+  onError?: (error: Error) => void;
+  createIngressMonitor?: () => QQBotIngressMonitor;
+}) {
   const ws = new FakeWebSocket();
   createQQWSClientMock.mockResolvedValue(ws);
   const controller = new AbortController();
@@ -68,7 +82,10 @@ async function startConnection(params: { onDisconnected?: (info: unknown) => voi
     runtime: {} as GatewayPluginRuntime,
     adapters: {} as EngineAdapters,
     handleMessage: async () => {},
+    createIngressMonitor: createNoopIngressMonitor,
+    ...(params.createIngressMonitor ? { createIngressMonitor: params.createIngressMonitor } : {}),
     onDisconnected: params.onDisconnected,
+    onError: params.onError,
   });
   const started = connection.start();
   await vi.waitFor(() => {
@@ -123,6 +140,7 @@ describe("GatewayConnection disconnect status", () => {
       runtime: {} as GatewayPluginRuntime,
       adapters: {} as EngineAdapters,
       handleMessage: async () => {},
+      createIngressMonitor: createNoopIngressMonitor,
       onDisconnected,
     });
     const started = connection.start();
@@ -168,6 +186,7 @@ describe("GatewayConnection disconnect status", () => {
       runtime: {} as GatewayPluginRuntime,
       adapters: {} as EngineAdapters,
       handleMessage: async () => {},
+      createIngressMonitor: createNoopIngressMonitor,
       onDisconnected,
     });
     const started = connection.start();
@@ -179,9 +198,11 @@ describe("GatewayConnection disconnect status", () => {
     // replacement is scheduled, then becomes live.
     staleWs.emit("open");
     staleWs.emit("message", JSON.stringify({ op: 7 }));
-    expect(onDisconnected).toHaveBeenCalledWith({
-      reason: "server requested reconnect",
-      fatal: false,
+    await vi.waitFor(() => {
+      expect(onDisconnected).toHaveBeenCalledWith({
+        reason: "server requested reconnect",
+        fatal: false,
+      });
     });
     await vi.advanceTimersByTimeAsync(1_100);
     await vi.waitFor(() => {
@@ -211,6 +232,7 @@ describe("GatewayConnection disconnect status", () => {
       runtime: {} as GatewayPluginRuntime,
       adapters: {} as EngineAdapters,
       handleMessage: async () => {},
+      createIngressMonitor: createNoopIngressMonitor,
       onDisconnected,
     });
     const started = connection.start();
@@ -220,9 +242,11 @@ describe("GatewayConnection disconnect status", () => {
 
     staleWs.emit("open");
     staleWs.emit("message", JSON.stringify({ op: 7 }));
-    expect(onDisconnected).toHaveBeenCalledWith({
-      reason: "server requested reconnect",
-      fatal: false,
+    await vi.waitFor(() => {
+      expect(onDisconnected).toHaveBeenCalledWith({
+        reason: "server requested reconnect",
+        fatal: false,
+      });
     });
     staleWs.emit("close", 1006, Buffer.from(""));
 
@@ -243,9 +267,11 @@ describe("GatewayConnection disconnect status", () => {
     ws.emit("open");
     ws.emit("message", JSON.stringify({ op: 9, d: false }));
 
-    expect(onDisconnected).toHaveBeenCalledWith({
-      reason: "session invalidated",
-      fatal: false,
+    await vi.waitFor(() => {
+      expect(onDisconnected).toHaveBeenCalledWith({
+        reason: "session invalidated",
+        fatal: false,
+      });
     });
 
     controller.abort();
@@ -260,6 +286,43 @@ describe("GatewayConnection disconnect status", () => {
     ws.emit("close", 1000, Buffer.from(""));
 
     expect(onDisconnected).not.toHaveBeenCalled();
+    await started;
+  });
+
+  it("terminates the socket when durable admission fails closed", async () => {
+    const admissionError = new QQBotIngressAdmissionError("sqlite unavailable");
+    const receive = vi.fn(async () => {
+      throw admissionError;
+    });
+    const onError = vi.fn();
+    const { ws, controller, started } = await startConnection({
+      onError,
+      createIngressMonitor: () => ({
+        receive,
+        stop: vi.fn(async () => {}),
+        waitForIdle: vi.fn(async () => {}),
+      }),
+    });
+
+    const event = JSON.stringify({
+      op: GatewayOp.DISPATCH,
+      t: GatewayEvent.C2C_MESSAGE_CREATE,
+      d: {
+        id: "message-1",
+        content: "hello",
+        timestamp: "2026-07-18T12:00:00Z",
+        author: { user_openid: "user-1" },
+      },
+    });
+    ws.emit("message", event);
+    ws.emit("message", event);
+
+    await vi.waitFor(() => expect(ws.terminate).toHaveBeenCalledTimes(1));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(receive).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(admissionError);
+    controller.abort();
     await started;
   });
 });

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.test.ts
@@ -3,6 +3,9 @@ import { EventEmitter } from "node:events";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { EngineAdapters } from "../adapter/index.js";
+import { stopBackgroundTokenRefresh } from "../messaging/sender.js";
+import { flushRefIndex } from "../ref/store.js";
+import { flushKnownUsers } from "../session/known-users.js";
 import { GatewayEvent, GatewayOp, MAX_RECONNECT_ATTEMPTS } from "./constants.js";
 import { GatewayConnection } from "./gateway-connection.js";
 import { QQBotIngressAdmissionError, type QQBotIngressMonitor } from "./ingress.js";
@@ -287,6 +290,28 @@ describe("GatewayConnection disconnect status", () => {
 
     expect(onDisconnected).not.toHaveBeenCalled();
     await started;
+  });
+
+  it("continues shutdown cleanup and rejects when one cleanup step fails", async () => {
+    const cleanupError = new Error("ingress stop failed");
+    const stop = vi.fn(async () => {
+      throw cleanupError;
+    });
+    const { controller, started } = await startConnection({
+      createIngressMonitor: () => ({
+        receive: vi.fn(async () => {}),
+        stop,
+        waitForIdle: vi.fn(async () => {}),
+      }),
+    });
+
+    controller.abort();
+
+    await expect(started).rejects.toBe(cleanupError);
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(stopBackgroundTokenRefresh).toHaveBeenCalledWith("test-app");
+    expect(flushKnownUsers).toHaveBeenCalledTimes(1);
+    expect(flushRefIndex).toHaveBeenCalledTimes(1);
   });
 
   it("terminates the socket when durable admission fails closed", async () => {

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.ts
@@ -182,6 +182,8 @@ export class GatewayConnection {
       };
     }
     msg.turnAdoptionLifecycle = lifecycle;
+    // Fleet at-least-once contract: a crash after slash-command side effects but before the
+    // completion tombstone can replay the command, matching complete-at-adoption behavior.
     const result = await trySlashCommand(msg, slashCtx);
     if (result === "handled") {
       return { kind: "completed" };

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.ts
@@ -20,9 +20,22 @@ import type { InteractionEvent } from "../types.js";
 import { decodeGatewayMessageData } from "./codec.js";
 import { FULL_INTENTS, RATE_LIMIT_DELAY, GatewayOp } from "./constants.js";
 import { dispatchEvent } from "./event-dispatcher.js";
+import { isQQBotTurnEventType } from "./ingress-envelope.js";
+import {
+  createQQBotIngressMonitor,
+  QQBotIngressAdmissionError,
+  type QQBotIngressDispatchResult,
+  type QQBotIngressMonitor,
+} from "./ingress.js";
 import { createMessageQueue, type QueuedMessage } from "./message-queue.js";
 import { ReconnectState } from "./reconnect.js";
-import type { GatewayAccount, EngineLogger, GatewayPluginRuntime, WSPayload } from "./types.js";
+import type {
+  GatewayAccount,
+  EngineLogger,
+  GatewayPluginRuntime,
+  QQBotIngressLifecycle,
+  WSPayload,
+} from "./types.js";
 import { createQQWSClient } from "./ws-client.js";
 
 interface GatewayConnectionContext {
@@ -38,6 +51,7 @@ interface GatewayConnectionContext {
   onDisconnected?: (info: { reason?: string; fatal?: boolean }) => void;
   handleMessage: (event: QueuedMessage) => Promise<void>;
   onInteraction?: (event: InteractionEvent) => void;
+  createIngressMonitor?: typeof createQQBotIngressMonitor;
 }
 
 export class GatewayConnection {
@@ -49,6 +63,10 @@ export class GatewayConnection {
   private isConnecting = false;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private shouldRefreshToken = false;
+  private ingress: QQBotIngressMonitor | undefined;
+  private socketMessageTail: Promise<void> = Promise.resolve();
+  private shutdownTask: Promise<void> | undefined;
+  private readonly failedIngressSockets = new WeakSet<WebSocket>();
 
   private readonly reconnect: ReconnectState;
   private readonly msgQueue;
@@ -66,11 +84,27 @@ export class GatewayConnection {
 
   async start(): Promise<void> {
     this.restoreSession();
-    this.registerAbortHandler();
-    await this.connect();
-    return new Promise<void>((resolve) => {
-      this.ctx.abortSignal.addEventListener("abort", () => resolve());
+    this.msgQueue.startProcessor(this.ctx.handleMessage);
+    const slashCtx = this.createSlashCommandContext();
+    const createIngressMonitor = this.ctx.createIngressMonitor ?? createQQBotIngressMonitor;
+    this.ingress = createIngressMonitor({
+      accountId: this.ctx.account.accountId,
+      runtime: this.ctx.runtime,
+      log: this.ctx.log,
+      dispatch: (message, lifecycle) => this.dispatchIngressMessage(message, lifecycle, slashCtx),
     });
+    const stopped = new Promise<void>((resolve) => {
+      const stop = () => void this.shutdown().finally(resolve);
+      if (this.ctx.abortSignal.aborted) {
+        stop();
+        return;
+      }
+      this.ctx.abortSignal.addEventListener("abort", stop, { once: true });
+    });
+    if (!this.isAborted) {
+      await this.connect();
+    }
+    await stopped;
   }
 
   private restoreSession(): void {
@@ -99,19 +133,74 @@ export class GatewayConnection {
     });
   }
 
-  private registerAbortHandler(): void {
-    const { account, abortSignal, log: _log } = this.ctx;
-    abortSignal.addEventListener("abort", () => {
+  private shutdown(): Promise<void> {
+    this.shutdownTask ??= (async () => {
+      const { account } = this.ctx;
       this.isAborted = true;
       if (this.reconnectTimer) {
         clearTimeout(this.reconnectTimer);
         this.reconnectTimer = null;
       }
       this.cleanup();
+      await this.ingress?.stop();
+      await this.socketMessageTail;
+      await this.msgQueue.stop();
       stopBackgroundTokenRefresh(account.appId);
       flushKnownUsers();
       flushRefIndex();
-    });
+    })();
+    return this.shutdownTask;
+  }
+
+  private createSlashCommandContext(): SlashCommandHandlerContext {
+    const { account, cfg, log, adapters } = this.ctx;
+    return {
+      account,
+      cfg,
+      log,
+      getMessagePeerId: (msg) => this.msgQueue.getMessagePeerId(msg),
+      getQueueSnapshot: (peerId) => this.msgQueue.getSnapshot(peerId),
+      resolveCommandAuthorized: (params) =>
+        adapters.access.resolveSlashCommandAuthorization({
+          cfg,
+          accountId: account.accountId,
+          ...params,
+        }),
+    };
+  }
+
+  private async dispatchIngressMessage(
+    msg: QueuedMessage,
+    lifecycle: QQBotIngressLifecycle,
+    slashCtx: SlashCommandHandlerContext,
+  ): Promise<QQBotIngressDispatchResult> {
+    if (this.isAborted || lifecycle.abortSignal.aborted) {
+      return {
+        kind: "failed-retryable",
+        error:
+          lifecycle.abortSignal.reason ?? this.ctx.abortSignal.reason ?? new Error("QQBot stopped"),
+      };
+    }
+    msg.turnAdoptionLifecycle = lifecycle;
+    const result = await trySlashCommand(msg, slashCtx);
+    if (result === "handled") {
+      return { kind: "completed" };
+    }
+    if (this.isAborted || lifecycle.abortSignal.aborted) {
+      return {
+        kind: "failed-retryable",
+        error:
+          lifecycle.abortSignal.reason ?? this.ctx.abortSignal.reason ?? new Error("QQBot stopped"),
+      };
+    }
+    if (result === "urgent") {
+      const peerId = this.msgQueue.getMessagePeerId(msg);
+      this.msgQueue.clearUserQueue(peerId);
+      this.msgQueue.executeImmediate(msg);
+    } else {
+      this.msgQueue.enqueue(msg);
+    }
+    return { kind: "deferred" };
   }
 
   private cleanup(): void {
@@ -180,108 +269,33 @@ export class GatewayConnection {
       });
       this.currentWs = ws;
 
-      const slashCtx: SlashCommandHandlerContext = {
-        account,
-        cfg: this.ctx.cfg,
-        log,
-        getMessagePeerId: (msg) => this.msgQueue.getMessagePeerId(msg),
-        getQueueSnapshot: (peerId) => this.msgQueue.getSnapshot(peerId),
-        resolveCommandAuthorized: (params) =>
-          this.ctx.adapters.access.resolveSlashCommandAuthorization({
-            cfg: this.ctx.cfg,
-            accountId: account.accountId,
-            ...params,
-          }),
-      };
-
-      const trySlashCommandOrEnqueue = async (msg: QueuedMessage): Promise<void> => {
-        const result = await trySlashCommand(msg, slashCtx);
-        if (result === "enqueue") {
-          this.msgQueue.enqueue(msg);
-        } else if (result === "urgent") {
-          const peerId = this.msgQueue.getMessagePeerId(msg);
-          this.msgQueue.clearUserQueue(peerId);
-          this.msgQueue.executeImmediate(msg);
-        }
-        // "handled" — command executed, nothing to queue.
-      };
-
       // ---- WebSocket: open ----
       ws.on("open", () => {
         log?.info(`WebSocket connected`);
         this.isConnecting = false;
         this.reconnect.onConnected();
-        this.msgQueue.startProcessor(this.ctx.handleMessage);
         startBackgroundTokenRefresh(account.appId, account.clientSecret, { log });
       });
 
       // ---- WebSocket: message ----
       ws.on("message", (data) => {
-        try {
-          const rawData = decodeGatewayMessageData(data);
-          const payload = JSON.parse(rawData) as WSPayload;
-          const { op, d, s, t } = payload;
-
-          if (s) {
-            this.lastSeq = s;
-            this.saveCurrentSession();
-          }
-
-          switch (op) {
-            case GatewayOp.HELLO:
-              this.handleHello(ws, d, accessToken);
-              break;
-
-            case GatewayOp.DISPATCH: {
-              log?.debug?.(`Dispatch event: t=${t}, d=${JSON.stringify(d)}`);
-              const result = dispatchEvent(t ?? "", d, account.accountId, log);
-              if (result.action === "ready") {
-                this.sessionId = result.sessionId;
-                this.saveCurrentSession();
-                this.ctx.onReady?.(result.data);
-              } else if (result.action === "resumed") {
-                (this.ctx.onResumed ?? this.ctx.onReady)?.(result.data);
-                this.saveCurrentSession();
-              } else if (result.action === "interaction") {
-                this.ctx.onInteraction?.(result.event);
-              } else if (result.action === "message") {
-                void trySlashCommandOrEnqueue(result.msg);
+        this.socketMessageTail = this.socketMessageTail
+          .then(() => this.handleSocketMessage(ws, data, accessToken))
+          .catch((error: unknown) => {
+            const message = error instanceof Error ? error.message : String(error);
+            if (error instanceof QQBotIngressAdmissionError) {
+              log?.error(`Durable ingress failed; terminating gateway socket: ${message}`);
+              this.ctx.onError?.(error);
+              if (this.currentWs === ws) {
+                // Fence callbacks already queued behind the failed append before
+                // terminate emits close and starts the reconnect path.
+                this.failedIngressSockets.add(ws);
+                ws.terminate();
               }
-              break;
+              return;
             }
-
-            case GatewayOp.HEARTBEAT_ACK:
-              break;
-
-            case GatewayOp.RECONNECT:
-              this.ctx.onDisconnected?.({
-                reason: "server requested reconnect",
-                fatal: false,
-              });
-              this.cleanup();
-              this.scheduleReconnect();
-              break;
-
-            case GatewayOp.INVALID_SESSION: {
-              const canResume = d as boolean;
-              this.ctx.onDisconnected?.({
-                reason: canResume ? "session resume rejected" : "session invalidated",
-                fatal: false,
-              });
-              if (!canResume) {
-                this.sessionId = null;
-                this.lastSeq = null;
-                clearSession(account.accountId);
-                this.shouldRefreshToken = true;
-              }
-              this.cleanup();
-              this.scheduleReconnect(3000);
-              break;
-            }
-          }
-        } catch (err) {
-          log?.error(`Message parse error: ${err instanceof Error ? err.message : String(err)}`);
-        }
+            log?.error(`Message parse error: ${message}`);
+          });
       });
 
       // ---- WebSocket: close ----
@@ -311,6 +325,84 @@ export class GatewayConnection {
       } else {
         this.scheduleReconnect();
       }
+    }
+  }
+
+  private async handleSocketMessage(
+    ws: WebSocket,
+    data: unknown,
+    accessToken: string,
+  ): Promise<void> {
+    if (this.isAborted || this.currentWs !== ws || this.failedIngressSockets.has(ws)) {
+      return;
+    }
+    const rawData = decodeGatewayMessageData(data);
+    const payload = JSON.parse(rawData) as WSPayload;
+    const { op, d, s, t } = payload;
+    let saveAfterDispatch = false;
+
+    switch (op) {
+      case GatewayOp.HELLO:
+        this.handleHello(ws, d, accessToken);
+        break;
+
+      case GatewayOp.DISPATCH: {
+        this.ctx.log?.debug?.(`Dispatch event: t=${t}, d=${JSON.stringify(d)}`);
+        if (isQQBotTurnEventType(t)) {
+          if (!this.ingress) {
+            throw new Error("QQBot ingress monitor is unavailable.");
+          }
+          // Resume sequence advances only after the raw turn is durable.
+          await this.ingress.receive(rawData);
+        } else {
+          const result = dispatchEvent(t ?? "", d, this.ctx.account.accountId, this.ctx.log);
+          if (result.action === "ready") {
+            this.sessionId = result.sessionId;
+            saveAfterDispatch = true;
+            this.ctx.onReady?.(result.data);
+          } else if (result.action === "resumed") {
+            (this.ctx.onResumed ?? this.ctx.onReady)?.(result.data);
+            saveAfterDispatch = true;
+          } else if (result.action === "interaction") {
+            this.ctx.onInteraction?.(result.event);
+          }
+        }
+        break;
+      }
+
+      case GatewayOp.HEARTBEAT_ACK:
+        break;
+
+      case GatewayOp.RECONNECT:
+        this.ctx.onDisconnected?.({ reason: "server requested reconnect", fatal: false });
+        this.cleanup();
+        this.scheduleReconnect();
+        break;
+
+      case GatewayOp.INVALID_SESSION: {
+        const canResume = d as boolean;
+        this.ctx.onDisconnected?.({
+          reason: canResume ? "session resume rejected" : "session invalidated",
+          fatal: false,
+        });
+        if (!canResume) {
+          this.sessionId = null;
+          this.lastSeq = null;
+          clearSession(this.ctx.account.accountId);
+          this.shouldRefreshToken = true;
+        }
+        this.cleanup();
+        this.scheduleReconnect(3000);
+        break;
+      }
+    }
+
+    if (typeof s === "number") {
+      this.lastSeq = s;
+      saveAfterDispatch = true;
+    }
+    if (saveAfterDispatch) {
+      this.saveCurrentSession();
     }
   }
 

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.ts
@@ -101,10 +101,18 @@ export class GatewayConnection {
       }
       this.ctx.abortSignal.addEventListener("abort", stop, { once: true });
     });
+    // Observe shutdown immediately: abort can reject while the initial connection is still pending.
+    const stoppedResult = stopped.then(
+      () => ({ ok: true as const }),
+      (error: unknown) => ({ ok: false as const, error }),
+    );
     if (!this.isAborted) {
       await this.connect();
     }
-    await stopped;
+    const result = await stoppedResult;
+    if (!result.ok) {
+      throw result.error;
+    }
   }
 
   private restoreSession(): void {

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.ts
@@ -93,8 +93,8 @@ export class GatewayConnection {
       log: this.ctx.log,
       dispatch: (message, lifecycle) => this.dispatchIngressMessage(message, lifecycle, slashCtx),
     });
-    const stopped = new Promise<void>((resolve) => {
-      const stop = () => void this.shutdown().finally(resolve);
+    const stopped = new Promise<void>((resolve, reject) => {
+      const stop = () => void this.shutdown().then(resolve, reject);
       if (this.ctx.abortSignal.aborted) {
         stop();
         return;
@@ -136,18 +136,36 @@ export class GatewayConnection {
   private shutdown(): Promise<void> {
     this.shutdownTask ??= (async () => {
       const { account } = this.ctx;
+      const errors: unknown[] = [];
+      const runCleanup = async (
+        label: string,
+        cleanup: () => void | Promise<void>,
+      ): Promise<void> => {
+        try {
+          await cleanup();
+        } catch (error) {
+          errors.push(error);
+          this.ctx.log?.error(`QQBot gateway shutdown ${label} failed: ${String(error)}`);
+        }
+      };
       this.isAborted = true;
       if (this.reconnectTimer) {
         clearTimeout(this.reconnectTimer);
         this.reconnectTimer = null;
       }
-      this.cleanup();
-      await this.ingress?.stop();
-      await this.socketMessageTail;
-      await this.msgQueue.stop();
-      stopBackgroundTokenRefresh(account.appId);
-      flushKnownUsers();
-      flushRefIndex();
+      await runCleanup("socket cleanup", () => this.cleanup());
+      await runCleanup("ingress stop", () => this.ingress?.stop());
+      await runCleanup("socket drain", () => this.socketMessageTail);
+      await runCleanup("message queue stop", () => this.msgQueue.stop());
+      await runCleanup("token refresh stop", () => stopBackgroundTokenRefresh(account.appId));
+      await runCleanup("known-user flush", () => flushKnownUsers());
+      await runCleanup("reference-index flush", () => flushRefIndex());
+      if (errors.length === 1) {
+        throw errors[0];
+      }
+      if (errors.length > 1) {
+        throw new AggregateError(errors, "QQBot gateway shutdown failed.");
+      }
     })();
     return this.shutdownTask;
   }

--- a/extensions/qqbot/src/engine/gateway/gateway.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway.ts
@@ -106,6 +106,10 @@ export async function startGateway(ctx: CoreGatewayContext): Promise<void> {
 
   // ---- 7. Message handler ----
   const handleMessage = async (event: QueuedMessage): Promise<void> => {
+    if (event.turnAdoptionLifecycle?.abortSignal.aborted) {
+      await event.turnAdoptionLifecycle.onAbandoned();
+      return;
+    }
     log?.info(`Processing message from ${event.senderId}: ${event.content}`, {
       accountId: account.accountId,
       messageId: event.messageId,
@@ -142,6 +146,7 @@ export async function startGateway(ctx: CoreGatewayContext): Promise<void> {
         blockReason: inbound.blockReason,
       });
       inbound.typing.keepAlive?.stop();
+      await event.turnAdoptionLifecycle?.onAdopted();
       return;
     }
 
@@ -163,6 +168,7 @@ export async function startGateway(ctx: CoreGatewayContext): Promise<void> {
           },
         );
         inbound.typing.keepAlive?.stop();
+        await event.turnAdoptionLifecycle?.onAdopted();
         return;
       }
       log?.info(
@@ -175,6 +181,7 @@ export async function startGateway(ctx: CoreGatewayContext): Promise<void> {
         },
       );
       inbound.typing.keepAlive?.stop();
+      await event.turnAdoptionLifecycle?.onAdopted();
       return;
     }
 
@@ -212,6 +219,7 @@ export async function startGateway(ctx: CoreGatewayContext): Promise<void> {
         },
       );
       inbound.typing.keepAlive?.stop();
+      await event.turnAdoptionLifecycle?.onAdopted();
       return;
     }
 
@@ -227,6 +235,9 @@ export async function startGateway(ctx: CoreGatewayContext): Promise<void> {
       );
     } catch (err) {
       log?.error(`Message processing failed: ${err instanceof Error ? err.message : String(err)}`);
+      if (event.turnAdoptionLifecycle) {
+        throw err;
+      }
     } finally {
       inbound.typing.keepAlive?.stop();
       if (event.type === "group" && event.groupOpenid && inbound.group) {

--- a/extensions/qqbot/src/engine/gateway/inbound-pipeline.self-echo.test.ts
+++ b/extensions/qqbot/src/engine/gateway/inbound-pipeline.self-echo.test.ts
@@ -74,6 +74,11 @@ const emptyAllowlist: QQBotInboundAccess["state"]["allowlists"]["dm"] = {
 
 function makeRuntime(): GatewayPluginRuntime {
   return {
+    state: {
+      openChannelIngressQueue: () => {
+        throw new Error("unexpected durable ingress access");
+      },
+    },
     channel: {
       activity: { record: vi.fn() },
       routing: {

--- a/extensions/qqbot/src/engine/gateway/ingress-envelope.ts
+++ b/extensions/qqbot/src/engine/gateway/ingress-envelope.ts
@@ -1,0 +1,130 @@
+// QQBot plugin module validates raw gateway envelopes for durable ingress.
+import { GatewayEvent, GatewayOp } from "./constants.js";
+import type { WSPayload } from "./types.js";
+
+const QQBOT_TURN_EVENT_TYPES = new Set<string>([
+  GatewayEvent.C2C_MESSAGE_CREATE,
+  GatewayEvent.AT_MESSAGE_CREATE,
+  GatewayEvent.DIRECT_MESSAGE_CREATE,
+  GatewayEvent.GROUP_AT_MESSAGE_CREATE,
+  GatewayEvent.GROUP_MESSAGE_CREATE,
+]);
+
+export class QQBotIngressPayloadError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "QQBotIngressPayloadError";
+  }
+}
+
+type QQBotIngressEnvelopeFacts = {
+  eventId: string;
+  eventType: string;
+  laneKey: string;
+  payload: WSPayload;
+};
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function record(value: unknown, field: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new QQBotIngressPayloadError(`QQBot gateway event is missing ${field}.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requiredString(value: unknown, field: string): string {
+  const normalized = nonEmptyString(value);
+  if (!normalized) {
+    throw new QQBotIngressPayloadError(`QQBot gateway event is missing ${field}.`);
+  }
+  return normalized;
+}
+
+function parseRawEnvelope(rawEnvelope: string): WSPayload {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawEnvelope);
+  } catch (error) {
+    throw new QQBotIngressPayloadError("QQBot gateway envelope contains invalid JSON.", {
+      cause: error,
+    });
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new QQBotIngressPayloadError("QQBot gateway envelope must be an object.");
+  }
+  return parsed as WSPayload;
+}
+
+export function isQQBotTurnEventType(eventType: string | undefined): boolean {
+  return eventType !== undefined && QQBOT_TURN_EVENT_TYPES.has(eventType);
+}
+
+export function inspectQQBotIngressEnvelope(rawEnvelope: string): QQBotIngressEnvelopeFacts | null {
+  const payload = parseRawEnvelope(rawEnvelope);
+  if (payload.op !== GatewayOp.DISPATCH || !isQQBotTurnEventType(payload.t)) {
+    return null;
+  }
+  const eventType = requiredString(payload.t, "t");
+  const data = record(payload.d, "d");
+  // Message id, not the outer delivery id: QQ can expose one logical group
+  // post through the @ and full-message create variants with distinct envelope
+  // ids. Both variants carry the same stable data.id.
+  const eventId = `message:${requiredString(data.id, "d.id")}`;
+
+  if (eventType === GatewayEvent.C2C_MESSAGE_CREATE) {
+    const author = record(data.author, "d.author");
+    return {
+      eventId,
+      eventType,
+      laneKey: `user:${requiredString(author.user_openid, "d.author.user_openid")}`,
+      payload,
+    };
+  }
+  if (eventType === GatewayEvent.AT_MESSAGE_CREATE) {
+    return {
+      eventId,
+      eventType,
+      laneKey: `channel:${requiredString(data.channel_id, "d.channel_id")}`,
+      payload,
+    };
+  }
+  if (eventType === GatewayEvent.DIRECT_MESSAGE_CREATE) {
+    const author = record(data.author, "d.author");
+    return {
+      eventId,
+      eventType,
+      laneKey: `user:${requiredString(author.id, "d.author.id")}`,
+      payload,
+    };
+  }
+  const author = record(data.author, "d.author");
+  requiredString(author.member_openid, "d.author.member_openid");
+  return {
+    eventId,
+    eventType,
+    laneKey: `group:${requiredString(data.group_openid, "d.group_openid")}`,
+    payload,
+  };
+}
+
+export function parseQQBotClaimedEnvelope(params: {
+  rawEnvelope: string;
+  claimedId: string;
+  claimedLaneKey?: string;
+}): QQBotIngressEnvelopeFacts {
+  const facts = inspectQQBotIngressEnvelope(params.rawEnvelope);
+  if (!facts) {
+    throw new QQBotIngressPayloadError(
+      `QQBot ingress row ${params.claimedId} is not a turn-producing create event.`,
+    );
+  }
+  if (facts.eventId !== params.claimedId || facts.laneKey !== params.claimedLaneKey) {
+    throw new QQBotIngressPayloadError(
+      `QQBot ingress row ${params.claimedId} changed identity after durable admission.`,
+    );
+  }
+  return facts;
+}

--- a/extensions/qqbot/src/engine/gateway/ingress-errors.ts
+++ b/extensions/qqbot/src/engine/gateway/ingress-errors.ts
@@ -1,0 +1,26 @@
+// QQBot plugin module classifies durable ingress failures.
+export function isQQBotAuthenticationFailure(error: unknown): boolean {
+  let current: unknown = error;
+  const seen = new Set<unknown>();
+  while (current && typeof current === "object" && !seen.has(current)) {
+    seen.add(current);
+    const candidate = current as {
+      httpStatus?: unknown;
+      status?: unknown;
+      statusCode?: unknown;
+      cause?: unknown;
+    };
+    if (
+      candidate.httpStatus === 401 ||
+      candidate.httpStatus === 403 ||
+      candidate.status === 401 ||
+      candidate.status === 403 ||
+      candidate.statusCode === 401 ||
+      candidate.statusCode === 403
+    ) {
+      return true;
+    }
+    current = candidate.cause;
+  }
+  return false;
+}

--- a/extensions/qqbot/src/engine/gateway/ingress.test-support.ts
+++ b/extensions/qqbot/src/engine/gateway/ingress.test-support.ts
@@ -1,0 +1,75 @@
+// QQBot durable ingress test helpers own isolated persistent queue state.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  closeOpenClawStateDatabaseForTest,
+  createChannelIngressQueueForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { GatewayEvent, GatewayOp } from "./constants.js";
+
+export type QQBotTestIngressPayload = {
+  version: 1;
+  receivedAt: number;
+  rawEnvelope: string;
+};
+
+export function qqC2CEnvelope(params: {
+  messageId: string;
+  deliveryId?: string;
+  userId?: string;
+  sequence?: number;
+}): string {
+  return JSON.stringify({
+    op: GatewayOp.DISPATCH,
+    id: params.deliveryId ?? `delivery-${params.messageId}`,
+    s: params.sequence ?? 1,
+    t: GatewayEvent.C2C_MESSAGE_CREATE,
+    d: {
+      id: params.messageId,
+      content: "hello",
+      timestamp: "2026-07-18T12:00:00Z",
+      author: { user_openid: params.userId ?? "user-1" },
+    },
+  });
+}
+
+export function qqGroupEnvelope(params: {
+  messageId: string;
+  deliveryId: string;
+  eventType: typeof GatewayEvent.GROUP_AT_MESSAGE_CREATE | typeof GatewayEvent.GROUP_MESSAGE_CREATE;
+}): string {
+  return JSON.stringify({
+    op: GatewayOp.DISPATCH,
+    id: params.deliveryId,
+    s: 1,
+    t: params.eventType,
+    d: {
+      id: params.messageId,
+      content: "hello group",
+      timestamp: "2026-07-18T12:00:00Z",
+      author: { member_openid: "member-1" },
+      group_openid: "group-1",
+    },
+  });
+}
+
+export async function withQQBotIngressQueue<T>(
+  run: (
+    queue: ReturnType<typeof createChannelIngressQueueForTests<QQBotTestIngressPayload>>,
+  ) => Promise<T>,
+): Promise<T> {
+  const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-qqbot-ingress-"));
+  const stateDir = await fs.realpath(created);
+  const queue = createChannelIngressQueueForTests<QQBotTestIngressPayload>({
+    channelId: "qqbot",
+    accountId: "default",
+    stateDir,
+  });
+  try {
+    return await run(queue);
+  } finally {
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  }
+}

--- a/extensions/qqbot/src/engine/gateway/ingress.test-support.ts
+++ b/extensions/qqbot/src/engine/gateway/ingress.test-support.ts
@@ -1,11 +1,11 @@
 // QQBot durable ingress test helpers own isolated persistent queue state.
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import {
   closeOpenClawStateDatabaseForTest,
   createChannelIngressQueueForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { GatewayEvent, GatewayOp } from "./constants.js";
 
 export type QQBotTestIngressPayload = {
@@ -59,7 +59,9 @@ export async function withQQBotIngressQueue<T>(
     queue: ReturnType<typeof createChannelIngressQueueForTests<QQBotTestIngressPayload>>,
   ) => Promise<T>,
 ): Promise<T> {
-  const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-qqbot-ingress-"));
+  const created = await fs.mkdtemp(
+    path.join(resolvePreferredOpenClawTmpDir(), "openclaw-qqbot-ingress-"),
+  );
   const stateDir = await fs.realpath(created);
   const queue = createChannelIngressQueueForTests<QQBotTestIngressPayload>({
     channelId: "qqbot",

--- a/extensions/qqbot/src/engine/gateway/ingress.test.ts
+++ b/extensions/qqbot/src/engine/gateway/ingress.test.ts
@@ -1,0 +1,258 @@
+// QQBot durable ingress tests cover raw admission, recovery, and twin parity.
+import type { ChannelIngressQueue } from "openclaw/plugin-sdk/channel-outbound";
+import { closeOpenClawStateDatabaseForTest } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GatewayEvent } from "./constants.js";
+import { createQQBotIngressMonitor } from "./ingress.js";
+import {
+  qqC2CEnvelope,
+  qqGroupEnvelope,
+  type QQBotTestIngressPayload,
+  withQQBotIngressQueue,
+} from "./ingress.test-support.js";
+
+type QQBotIngressDispatch = Parameters<typeof createQQBotIngressMonitor>[0]["dispatch"];
+
+function createDeferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
+
+function startMonitor(
+  queue: ChannelIngressQueue<QQBotTestIngressPayload>,
+  dispatch: QQBotIngressDispatch,
+) {
+  return createQQBotIngressMonitor({
+    accountId: "default",
+    queue,
+    dispatch,
+    pollIntervalMs: 10,
+    adoptionStallTimeoutMs: 5_000,
+  });
+}
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  vi.restoreAllMocks();
+});
+
+describe("QQBot durable ingress", () => {
+  it("does not stage or dispatch before the raw envelope is durable", async () => {
+    await withQQBotIngressQueue(async (queue) => {
+      const appendGate = createDeferred();
+      const enqueue = vi.fn(async (...args: Parameters<typeof queue.enqueue>) => {
+        await appendGate.promise;
+        return await queue.enqueue(...args);
+      });
+      const gatedQueue = { ...queue, enqueue };
+      const dispatch = vi.fn(async (_message, lifecycle) => {
+        await lifecycle.onAdopted();
+      });
+      const monitor = startMonitor(gatedQueue, dispatch);
+      try {
+        const admitted = monitor.receive(qqC2CEnvelope({ messageId: "durable-first" }));
+        await vi.waitFor(() => expect(enqueue).toHaveBeenCalledTimes(1));
+        expect(dispatch).not.toHaveBeenCalled();
+
+        appendGate.resolve();
+        await admitted;
+        await vi.waitFor(() => expect(dispatch).toHaveBeenCalledTimes(1));
+      } finally {
+        await monitor.stop();
+      }
+    });
+  });
+
+  it("recovers an uncompleted row with a fresh drain and dispatches exactly once", async () => {
+    await withQQBotIngressQueue(async (queue) => {
+      const firstDispatch = vi.fn(async () => ({ kind: "deferred" as const }));
+      const first = startMonitor(queue, firstDispatch);
+      await first.receive(qqC2CEnvelope({ messageId: "restart" }));
+      await vi.waitFor(() => expect(firstDispatch).toHaveBeenCalledTimes(1));
+      await first.stop();
+
+      const recoveredDispatch = vi.fn(async (_message, lifecycle) => {
+        await lifecycle.onAdopted();
+      });
+      const recovered = startMonitor(queue, recoveredDispatch);
+      try {
+        await vi.waitFor(() => expect(recoveredDispatch).toHaveBeenCalledTimes(1));
+        await recovered.waitForIdle();
+        expect(recoveredDispatch).toHaveBeenCalledTimes(1);
+      } finally {
+        await recovered.stop();
+      }
+    });
+  });
+
+  it("keeps a completion tombstone so a duplicate cannot dispatch twice", async () => {
+    await withQQBotIngressQueue(async (queue) => {
+      const dispatch = vi.fn(async (_message, lifecycle) => {
+        await lifecycle.onAdopted();
+      });
+      const monitor = startMonitor(queue, dispatch);
+      try {
+        const envelope = qqC2CEnvelope({ messageId: "completed" });
+        await monitor.receive(envelope);
+        await vi.waitFor(() => expect(dispatch).toHaveBeenCalledTimes(1));
+        await monitor.receive(envelope);
+        await monitor.waitForIdle();
+        expect(dispatch).toHaveBeenCalledTimes(1);
+      } finally {
+        await monitor.stop();
+      }
+    });
+  });
+
+  it("deduplicates group @ and full-message twins by stable message id", async () => {
+    await withQQBotIngressQueue(async (queue) => {
+      const dispatch = vi.fn(async (_message, lifecycle) => {
+        await lifecycle.onAdopted();
+      });
+      const monitor = startMonitor(queue, dispatch);
+      try {
+        await Promise.all([
+          monitor.receive(
+            qqGroupEnvelope({
+              messageId: "logical-twin",
+              deliveryId: "delivery-at",
+              eventType: GatewayEvent.GROUP_AT_MESSAGE_CREATE,
+            }),
+          ),
+          monitor.receive(
+            qqGroupEnvelope({
+              messageId: "logical-twin",
+              deliveryId: "delivery-full",
+              eventType: GatewayEvent.GROUP_MESSAGE_CREATE,
+            }),
+          ),
+        ]);
+        await vi.waitFor(() => expect(dispatch).toHaveBeenCalledTimes(1));
+      } finally {
+        await monitor.stop();
+      }
+    });
+  });
+
+  it("preserves arrival order across an append retry backoff", async () => {
+    await withQQBotIngressQueue(async (queue) => {
+      let failFirst = true;
+      const enqueue = queue.enqueue.bind(queue);
+      queue.enqueue = async (...args) => {
+        if (failFirst) {
+          failFirst = false;
+          throw new Error("sqlite busy");
+        }
+        return await enqueue(...args);
+      };
+      const dispatched: string[] = [];
+      const monitor = startMonitor(queue, async (message, lifecycle) => {
+        dispatched.push(message.messageId);
+        await lifecycle.onAdopted();
+      });
+      try {
+        await Promise.all([
+          monitor.receive(qqC2CEnvelope({ messageId: "first", sequence: 1 })),
+          monitor.receive(qqC2CEnvelope({ messageId: "second", sequence: 2 })),
+        ]);
+        await vi.waitFor(() => expect(dispatched).toEqual(["first", "second"]));
+      } finally {
+        await monitor.stop();
+      }
+    });
+  });
+
+  it("does not dispatch from a pump racing stop through async prune", async () => {
+    await withQQBotIngressQueue(async (queue) => {
+      const pruneGate = createDeferred();
+      const pruneStarted = createDeferred();
+      const prune = queue.prune.bind(queue);
+      queue.prune = async (...args) => {
+        pruneStarted.resolve();
+        await pruneGate.promise;
+        return await prune(...args);
+      };
+      const dispatch = vi.fn();
+      const monitor = startMonitor(queue, dispatch);
+      await pruneStarted.promise;
+      await monitor.receive(qqC2CEnvelope({ messageId: "stop-race" }));
+
+      const stopping = monitor.stop();
+      pruneGate.resolve();
+      await stopping;
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+  });
+
+  it("stores the exact raw envelope in the user conversation lane", async () => {
+    await withQQBotIngressQueue(async (queue) => {
+      const dispatch = vi.fn(async () => ({ kind: "deferred" as const }));
+      const monitor = startMonitor(queue, dispatch);
+      const rawEnvelope = qqC2CEnvelope({ messageId: "raw", userId: "user-raw" });
+      try {
+        await monitor.receive(rawEnvelope);
+        await vi.waitFor(() => expect(dispatch).toHaveBeenCalledTimes(1));
+        expect(await queue.listClaims()).toEqual([
+          expect.objectContaining({
+            id: "message:raw",
+            laneKey: "user:user-raw",
+            payload: expect.objectContaining({ rawEnvelope }),
+          }),
+        ]);
+      } finally {
+        await monitor.stop();
+      }
+    });
+  });
+
+  it("dead-letters malformed persisted envelopes without retry", async () => {
+    await withQQBotIngressQueue(async (queue) => {
+      await queue.enqueue(
+        "message:malformed",
+        { version: 1, receivedAt: 1, rawEnvelope: "{" },
+        { receivedAt: 1, laneKey: "user:user-1" },
+      );
+      const dispatch = vi.fn();
+      const monitor = startMonitor(queue, dispatch);
+      try {
+        await vi.waitFor(async () => {
+          const verdict = await queue.enqueue("message:malformed", {
+            version: 1,
+            receivedAt: 1,
+            rawEnvelope: "{}",
+          });
+          expect(verdict.kind).toBe("failed");
+        });
+        expect(dispatch).not.toHaveBeenCalled();
+      } finally {
+        await monitor.stop();
+      }
+    });
+  });
+
+  it("dead-letters permanent QQ authentication failures", async () => {
+    await withQQBotIngressQueue(async (queue) => {
+      const dispatch = vi.fn(async () => {
+        throw Object.assign(new Error("QQ API unauthorized"), { httpStatus: 401 });
+      });
+      const monitor = startMonitor(queue, dispatch);
+      try {
+        await monitor.receive(qqC2CEnvelope({ messageId: "auth" }));
+        await vi.waitFor(async () => {
+          const verdict = await queue.enqueue("message:auth", {
+            version: 1,
+            receivedAt: 1,
+            rawEnvelope: "{}",
+          });
+          expect(verdict.kind).toBe("failed");
+        });
+        expect(dispatch).toHaveBeenCalledTimes(1);
+      } finally {
+        await monitor.stop();
+      }
+    });
+  });
+});

--- a/extensions/qqbot/src/engine/gateway/ingress.ts
+++ b/extensions/qqbot/src/engine/gateway/ingress.ts
@@ -1,0 +1,276 @@
+// QQBot plugin module owns raw gateway-envelope durable ingress and replay.
+import {
+  createChannelIngressDrain,
+  DEFAULT_INGRESS_ADOPTION_STALL_MS,
+  DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
+  DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
+  type ChannelIngressDrain,
+  type ChannelIngressQueue,
+} from "openclaw/plugin-sdk/channel-outbound";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { dispatchEvent } from "./event-dispatcher.js";
+import {
+  inspectQQBotIngressEnvelope,
+  parseQQBotClaimedEnvelope,
+  QQBotIngressPayloadError,
+} from "./ingress-envelope.js";
+import type { QueuedMessage } from "./message-queue.js";
+import type { EngineLogger, GatewayPluginRuntime, QQBotIngressLifecycle } from "./types.js";
+
+const QQBOT_INGRESS_PAYLOAD_VERSION = 1;
+const QQBOT_INGRESS_POLL_INTERVAL_MS = 1_000;
+const QQBOT_INGRESS_PRUNE_INTERVAL_MS = 60 * 60 * 1_000;
+const QQBOT_INGRESS_COMPLETED_TTL_MS = 30 * 24 * 60 * 60 * 1_000;
+const QQBOT_INGRESS_COMPLETED_MAX_ENTRIES = 20_000;
+const QQBOT_INGRESS_FAILED_TTL_MS = 30 * 24 * 60 * 60 * 1_000;
+const QQBOT_INGRESS_FAILED_MAX_ENTRIES = 20_000;
+
+type QQBotIngressPayload = {
+  version: 1;
+  receivedAt: number;
+  rawEnvelope: string;
+};
+
+export type QQBotIngressDispatchResult =
+  | { kind: "completed" }
+  | { kind: "deferred" }
+  | { kind: "failed-retryable"; error: unknown };
+
+type QQBotIngressDispatch = (
+  message: QueuedMessage,
+  lifecycle: QQBotIngressLifecycle,
+) => Promise<QQBotIngressDispatchResult | void> | QQBotIngressDispatchResult | void;
+
+export class QQBotIngressAdmissionError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "QQBotIngressAdmissionError";
+  }
+}
+
+function isQQBotAuthenticationFailure(error: unknown): boolean {
+  let current: unknown = error;
+  const seen = new Set<unknown>();
+  while (current && typeof current === "object" && !seen.has(current)) {
+    seen.add(current);
+    const candidate = current as {
+      httpStatus?: unknown;
+      status?: unknown;
+      statusCode?: unknown;
+      cause?: unknown;
+    };
+    if (
+      candidate.httpStatus === 401 ||
+      candidate.httpStatus === 403 ||
+      candidate.status === 401 ||
+      candidate.status === 403 ||
+      candidate.statusCode === 401 ||
+      candidate.statusCode === 403
+    ) {
+      return true;
+    }
+    current = candidate.cause;
+  }
+  return false;
+}
+
+export type QQBotIngressMonitor = {
+  receive: (rawEnvelope: string) => Promise<void>;
+  stop: () => Promise<void>;
+  waitForIdle: () => Promise<void>;
+};
+
+export function createQQBotIngressMonitor(options: {
+  accountId: string;
+  runtime?: Pick<GatewayPluginRuntime, "state">;
+  queue?: ChannelIngressQueue<QQBotIngressPayload>;
+  dispatch: QQBotIngressDispatch;
+  log?: EngineLogger;
+  pollIntervalMs?: number;
+  adoptionStallTimeoutMs?: number;
+}): QQBotIngressMonitor {
+  let queue = options.queue;
+  let drain: ChannelIngressDrain | undefined;
+  let running = true;
+  let requested = false;
+  let pumping: Promise<void> | undefined;
+  let lastPrunedAt = 0;
+
+  const getQueue = (): ChannelIngressQueue<QQBotIngressPayload> => {
+    if (!queue) {
+      if (!options.runtime) {
+        throw new Error("QQBot ingress runtime is unavailable.");
+      }
+      queue = options.runtime.state.openChannelIngressQueue<QQBotIngressPayload>({
+        accountId: options.accountId,
+      });
+    }
+    return queue;
+  };
+
+  const getDrain = (): ChannelIngressDrain => {
+    drain ??= createChannelIngressDrain<QQBotIngressPayload>({
+      queue: getQueue(),
+      orderBy: "received",
+      adoptionStallTimeoutMs: options.adoptionStallTimeoutMs ?? DEFAULT_INGRESS_ADOPTION_STALL_MS,
+      retryPolicy: {
+        maxAttempts: DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
+        deadLetterMinAgeMs: DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
+      },
+      resolveNonRetryableFailure: (error) => {
+        if (error instanceof QQBotIngressPayloadError) {
+          return { reason: "invalid-event", message: error.message };
+        }
+        if (isQQBotAuthenticationFailure(error)) {
+          return { reason: "authentication-failed", message: formatErrorMessage(error) };
+        }
+        return null;
+      },
+      onLog: (message) => options.log?.error(`QQBot ingress: ${message}`),
+      dispatchClaimedEvent: async (claimed, lifecycle) => {
+        if (claimed.payload.version !== QQBOT_INGRESS_PAYLOAD_VERSION) {
+          throw new QQBotIngressPayloadError("QQBot ingress payload version is unsupported.");
+        }
+        const facts = parseQQBotClaimedEnvelope({
+          rawEnvelope: claimed.payload.rawEnvelope,
+          claimedId: claimed.id,
+          claimedLaneKey: claimed.laneKey,
+        });
+        // Stage mapping stays claim-side. Receive stores the exact transport envelope.
+        const mapped = dispatchEvent(
+          facts.eventType,
+          facts.payload.d,
+          options.accountId,
+          options.log,
+        );
+        if (mapped.action !== "message") {
+          throw new QQBotIngressPayloadError(
+            `QQBot ingress row ${claimed.id} no longer maps to a message turn.`,
+          );
+        }
+        return await options.dispatch(mapped.msg, lifecycle);
+      },
+    });
+    return drain;
+  };
+
+  const pruneIfDue = async (): Promise<void> => {
+    const now = Date.now();
+    if (now - lastPrunedAt < QQBOT_INGRESS_PRUNE_INTERVAL_MS) {
+      return;
+    }
+    await getQueue().prune({
+      completedTtlMs: QQBOT_INGRESS_COMPLETED_TTL_MS,
+      completedMaxEntries: QQBOT_INGRESS_COMPLETED_MAX_ENTRIES,
+      failedTtlMs: QQBOT_INGRESS_FAILED_TTL_MS,
+      failedMaxEntries: QQBOT_INGRESS_FAILED_MAX_ENTRIES,
+      now,
+    });
+    lastPrunedAt = now;
+  };
+
+  const runPump = async (): Promise<void> => {
+    try {
+      for (;;) {
+        requested = false;
+        await pruneIfDue();
+        if (!running) {
+          break;
+        }
+        const activeDrain = getDrain();
+        const { started } = await activeDrain.drainOnce();
+        await activeDrain.waitForIdle();
+        if (!running || (!requested && started === 0)) {
+          break;
+        }
+      }
+    } catch (error) {
+      options.log?.error(`QQBot ingress drain failed: ${formatErrorMessage(error)}`);
+    } finally {
+      pumping = undefined;
+      if (running && requested) {
+        requestDrain();
+      }
+    }
+  };
+
+  const requestDrain = (): void => {
+    requested = true;
+    if (!running || pumping) {
+      return;
+    }
+    pumping = runPump();
+  };
+
+  const timer = setInterval(requestDrain, options.pollIntervalMs ?? QQBOT_INGRESS_POLL_INTERVAL_MS);
+  timer.unref?.();
+  requestDrain();
+
+  // Socket callbacks can overlap. One admission tail preserves receive order
+  // when an earlier append is sleeping through bounded retry backoff.
+  let admissionTail: Promise<void> = Promise.resolve();
+
+  const admitOnce = async (rawEnvelope: string): Promise<void> => {
+    const facts = inspectQQBotIngressEnvelope(rawEnvelope);
+    if (!facts) {
+      return;
+    }
+    const receivedAt = Date.now();
+    let lastError: unknown;
+    for (const delayMs of [0, 100, 300]) {
+      if (delayMs > 0) {
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, delayMs);
+        });
+      }
+      try {
+        await getQueue().enqueue(
+          facts.eventId,
+          {
+            version: QQBOT_INGRESS_PAYLOAD_VERSION,
+            receivedAt,
+            rawEnvelope,
+          },
+          { receivedAt, laneKey: facts.laneKey },
+        );
+        requestDrain();
+        return;
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    throw new QQBotIngressAdmissionError("QQBot durable ingress append failed.", {
+      cause: lastError,
+    });
+  };
+
+  return {
+    receive: (rawEnvelope) => {
+      if (!running) {
+        return Promise.reject(new Error("QQBot ingress monitor is stopped."));
+      }
+      const admission = admissionTail.then(() => admitOnce(rawEnvelope));
+      admissionTail = admission.catch(() => undefined);
+      return admission;
+    },
+    stop: async () => {
+      running = false;
+      clearInterval(timer);
+      await admissionTail;
+      drain?.dispose();
+      await pumping;
+      drain?.dispose();
+      await drain?.waitForIdle();
+    },
+    waitForIdle: async () => {
+      for (;;) {
+        const activePump = pumping;
+        if (!activePump) {
+          break;
+        }
+        await activePump;
+      }
+      await drain?.waitForIdle();
+    },
+  };
+}

--- a/extensions/qqbot/src/engine/gateway/ingress.ts
+++ b/extensions/qqbot/src/engine/gateway/ingress.ts
@@ -14,6 +14,7 @@ import {
   parseQQBotClaimedEnvelope,
   QQBotIngressPayloadError,
 } from "./ingress-envelope.js";
+import { isQQBotAuthenticationFailure } from "./ingress-errors.js";
 import type { QueuedMessage } from "./message-queue.js";
 import type { EngineLogger, GatewayPluginRuntime, QQBotIngressLifecycle } from "./types.js";
 
@@ -46,32 +47,6 @@ export class QQBotIngressAdmissionError extends Error {
     super(message, options);
     this.name = "QQBotIngressAdmissionError";
   }
-}
-
-function isQQBotAuthenticationFailure(error: unknown): boolean {
-  let current: unknown = error;
-  const seen = new Set<unknown>();
-  while (current && typeof current === "object" && !seen.has(current)) {
-    seen.add(current);
-    const candidate = current as {
-      httpStatus?: unknown;
-      status?: unknown;
-      statusCode?: unknown;
-      cause?: unknown;
-    };
-    if (
-      candidate.httpStatus === 401 ||
-      candidate.httpStatus === 403 ||
-      candidate.status === 401 ||
-      candidate.status === 403 ||
-      candidate.statusCode === 401 ||
-      candidate.statusCode === 403
-    ) {
-      return true;
-    }
-    current = candidate.cause;
-  }
-  return false;
 }
 
 export type QQBotIngressMonitor = {

--- a/extensions/qqbot/src/engine/gateway/message-queue-ingress.test.ts
+++ b/extensions/qqbot/src/engine/gateway/message-queue-ingress.test.ts
@@ -1,5 +1,6 @@
 // QQBot queue ingress tests cover merged lifecycle fan-out and shutdown release.
 import { describe, expect, it, vi } from "vitest";
+import { buildQQBotMergedIngressLifecycle } from "./message-queue-ingress.js";
 import { createMessageQueue, type QueuedMessage } from "./message-queue.js";
 import type { QQBotIngressLifecycle } from "./types.js";
 
@@ -58,6 +59,49 @@ describe("QQBot message queue ingress lifecycle", () => {
       expect(first.adopted).toHaveBeenCalledTimes(1);
       expect(second.adopted).toHaveBeenCalledTimes(1);
     });
+    await queue.stop();
+  });
+
+  it("settles every merged claim when one adoption callback fails", async () => {
+    const adoptionError = new Error("first adoption failed");
+    const first = testLifecycle();
+    const second = testLifecycle();
+    first.adopted.mockRejectedValueOnce(adoptionError);
+    const lifecycle = buildQQBotMergedIngressLifecycle([
+      groupMessage("first", first.lifecycle),
+      groupMessage("second", second.lifecycle),
+    ]);
+
+    await expect(lifecycle?.onAdopted()).rejects.toBe(adoptionError);
+    expect(first.adopted).toHaveBeenCalledTimes(1);
+    expect(second.adopted).toHaveBeenCalledTimes(1);
+  });
+
+  it("settles every merged claim when one abandonment callback fails", async () => {
+    const abandonmentError = new Error("first abandonment failed");
+    const first = testLifecycle();
+    const second = testLifecycle();
+    first.abandoned.mockRejectedValueOnce(abandonmentError);
+    const lifecycle = buildQQBotMergedIngressLifecycle([
+      groupMessage("first", first.lifecycle),
+      groupMessage("second", second.lifecycle),
+    ]);
+
+    await expect(lifecycle?.onAbandoned()).rejects.toBe(abandonmentError);
+    expect(first.abandoned).toHaveBeenCalledTimes(1);
+    expect(second.abandoned).toHaveBeenCalledTimes(1);
+  });
+
+  it("tombstones deferred permanent auth failures instead of releasing them", async () => {
+    const tracked = testLifecycle();
+    const queue = createMessageQueue({ accountId: "default", isAborted: () => false });
+    queue.startProcessor(async () => {
+      throw Object.assign(new Error("unauthorized"), { httpStatus: 401 });
+    });
+    queue.enqueue(groupMessage("auth-failure", tracked.lifecycle));
+
+    await vi.waitFor(() => expect(tracked.adopted).toHaveBeenCalledTimes(1));
+    expect(tracked.abandoned).not.toHaveBeenCalled();
     await queue.stop();
   });
 

--- a/extensions/qqbot/src/engine/gateway/message-queue-ingress.test.ts
+++ b/extensions/qqbot/src/engine/gateway/message-queue-ingress.test.ts
@@ -1,0 +1,85 @@
+// QQBot queue ingress tests cover merged lifecycle fan-out and shutdown release.
+import { describe, expect, it, vi } from "vitest";
+import { createMessageQueue, type QueuedMessage } from "./message-queue.js";
+import type { QQBotIngressLifecycle } from "./types.js";
+
+function groupMessage(messageId: string, lifecycle?: QQBotIngressLifecycle): QueuedMessage {
+  return {
+    type: "group",
+    senderId: "member-1",
+    content: messageId,
+    messageId,
+    timestamp: "2026-07-18T12:00:00Z",
+    groupOpenid: "group-1",
+    ...(lifecycle ? { turnAdoptionLifecycle: lifecycle } : {}),
+  };
+}
+
+function testLifecycle() {
+  const adopted = vi.fn(async () => {});
+  const abandoned = vi.fn(async () => {});
+  return {
+    adopted,
+    abandoned,
+    lifecycle: {
+      abortSignal: new AbortController().signal,
+      onAdopted: adopted,
+      onDeferred: vi.fn(),
+      onAdoptionFinalizing: vi.fn(),
+      onAbandoned: abandoned,
+    } satisfies QQBotIngressLifecycle,
+  };
+}
+
+describe("QQBot message queue ingress lifecycle", () => {
+  it("fans merged-turn adoption out to every constituent claim", async () => {
+    let releaseBlocker!: () => void;
+    const blocker = new Promise<void>((resolve) => {
+      releaseBlocker = resolve;
+    });
+    const first = testLifecycle();
+    const second = testLifecycle();
+    const handler = vi.fn(async (message: QueuedMessage) => {
+      if (message.messageId === "blocker") {
+        await blocker;
+        return;
+      }
+      await message.turnAdoptionLifecycle?.onAdopted();
+    });
+    const queue = createMessageQueue({ accountId: "default", isAborted: () => false });
+    queue.startProcessor(handler);
+    queue.enqueue(groupMessage("blocker"));
+    await vi.waitFor(() => expect(handler).toHaveBeenCalledTimes(1));
+    queue.enqueue(groupMessage("first", first.lifecycle));
+    queue.enqueue(groupMessage("second", second.lifecycle));
+
+    releaseBlocker();
+    await vi.waitFor(() => {
+      expect(first.adopted).toHaveBeenCalledTimes(1);
+      expect(second.adopted).toHaveBeenCalledTimes(1);
+    });
+    await queue.stop();
+  });
+
+  it("releases buffered claims as retryable when shutdown stops the queue", async () => {
+    let releaseBlocker!: () => void;
+    const blocker = new Promise<void>((resolve) => {
+      releaseBlocker = resolve;
+    });
+    const queued = testLifecycle();
+    const queue = createMessageQueue({ accountId: "default", isAborted: () => false });
+    queue.startProcessor(async (message) => {
+      if (message.messageId === "blocker") {
+        await blocker;
+      }
+    });
+    queue.enqueue(groupMessage("blocker"));
+    queue.enqueue(groupMessage("queued", queued.lifecycle));
+
+    const stopping = queue.stop();
+    releaseBlocker();
+    await stopping;
+    expect(queued.abandoned).toHaveBeenCalledTimes(1);
+    expect(queued.adopted).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/qqbot/src/engine/gateway/message-queue-ingress.ts
+++ b/extensions/qqbot/src/engine/gateway/message-queue-ingress.ts
@@ -1,5 +1,4 @@
 // QQBot plugin module fans one merged turn lifecycle across its durable claims.
-import type { QueuedMessage } from "./message-queue.js";
 import type { QQBotIngressLifecycle } from "./types.js";
 
 async function settleAll(
@@ -43,7 +42,7 @@ function notifyAll(
 }
 
 export function buildQQBotMergedIngressLifecycle(
-  messages: readonly QueuedMessage[],
+  messages: readonly { turnAdoptionLifecycle?: QQBotIngressLifecycle }[],
 ): QQBotIngressLifecycle | undefined {
   const lifecycles = messages
     .map((message) => message.turnAdoptionLifecycle)

--- a/extensions/qqbot/src/engine/gateway/message-queue-ingress.ts
+++ b/extensions/qqbot/src/engine/gateway/message-queue-ingress.ts
@@ -2,6 +2,46 @@
 import type { QueuedMessage } from "./message-queue.js";
 import type { QQBotIngressLifecycle } from "./types.js";
 
+async function settleAll(
+  lifecycles: readonly QQBotIngressLifecycle[],
+  label: string,
+  settle: (lifecycle: QQBotIngressLifecycle) => void | Promise<void>,
+): Promise<void> {
+  const results = await Promise.allSettled(
+    lifecycles.map(async (lifecycle) => await settle(lifecycle)),
+  );
+  const errors = results
+    .filter((result): result is PromiseRejectedResult => result.status === "rejected")
+    .map((result) => result.reason);
+  if (errors.length === 1) {
+    throw errors[0];
+  }
+  if (errors.length > 1) {
+    throw new AggregateError(errors, `QQBot merged ingress ${label} failed.`);
+  }
+}
+
+function notifyAll(
+  lifecycles: readonly QQBotIngressLifecycle[],
+  label: string,
+  notify: (lifecycle: QQBotIngressLifecycle) => void,
+): void {
+  const errors: unknown[] = [];
+  for (const lifecycle of lifecycles) {
+    try {
+      notify(lifecycle);
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  if (errors.length === 1) {
+    throw errors[0];
+  }
+  if (errors.length > 1) {
+    throw new AggregateError(errors, `QQBot merged ingress ${label} failed.`);
+  }
+}
+
 export function buildQQBotMergedIngressLifecycle(
   messages: readonly QueuedMessage[],
 ): QQBotIngressLifecycle | undefined {
@@ -17,25 +57,15 @@ export function buildQQBotMergedIngressLifecycle(
   }
   return {
     abortSignal: AbortSignal.any(lifecycles.map((lifecycle) => lifecycle.abortSignal)),
-    onAdopted: async () => {
-      for (const lifecycle of lifecycles) {
-        await lifecycle.onAdopted();
-      }
-    },
+    onAdopted: () => settleAll(lifecycles, "adoption", (lifecycle) => lifecycle.onAdopted()),
     onDeferred: () => {
-      for (const lifecycle of lifecycles) {
-        lifecycle.onDeferred();
-      }
+      notifyAll(lifecycles, "deferral", (lifecycle) => lifecycle.onDeferred());
     },
     onAdoptionFinalizing: () => {
-      for (const lifecycle of lifecycles) {
-        lifecycle.onAdoptionFinalizing();
-      }
+      notifyAll(lifecycles, "adoption finalization", (lifecycle) =>
+        lifecycle.onAdoptionFinalizing(),
+      );
     },
-    onAbandoned: async () => {
-      for (const lifecycle of lifecycles) {
-        await lifecycle.onAbandoned();
-      }
-    },
+    onAbandoned: () => settleAll(lifecycles, "abandonment", (lifecycle) => lifecycle.onAbandoned()),
   };
 }

--- a/extensions/qqbot/src/engine/gateway/message-queue-ingress.ts
+++ b/extensions/qqbot/src/engine/gateway/message-queue-ingress.ts
@@ -1,0 +1,41 @@
+// QQBot plugin module fans one merged turn lifecycle across its durable claims.
+import type { QueuedMessage } from "./message-queue.js";
+import type { QQBotIngressLifecycle } from "./types.js";
+
+export function buildQQBotMergedIngressLifecycle(
+  messages: readonly QueuedMessage[],
+): QQBotIngressLifecycle | undefined {
+  const lifecycles = messages
+    .map((message) => message.turnAdoptionLifecycle)
+    .filter((lifecycle) => lifecycle !== undefined);
+  const [firstLifecycle] = lifecycles;
+  if (!firstLifecycle) {
+    return undefined;
+  }
+  if (lifecycles.length === 1) {
+    return firstLifecycle;
+  }
+  return {
+    abortSignal: AbortSignal.any(lifecycles.map((lifecycle) => lifecycle.abortSignal)),
+    onAdopted: async () => {
+      for (const lifecycle of lifecycles) {
+        await lifecycle.onAdopted();
+      }
+    },
+    onDeferred: () => {
+      for (const lifecycle of lifecycles) {
+        lifecycle.onDeferred();
+      }
+    },
+    onAdoptionFinalizing: () => {
+      for (const lifecycle of lifecycles) {
+        lifecycle.onAdoptionFinalizing();
+      }
+    },
+    onAbandoned: async () => {
+      for (const lifecycle of lifecycles) {
+        await lifecycle.onAbandoned();
+      }
+    },
+  };
+}

--- a/extensions/qqbot/src/engine/gateway/message-queue.ts
+++ b/extensions/qqbot/src/engine/gateway/message-queue.ts
@@ -2,6 +2,8 @@
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { formatErrorMessage } from "../utils/format.js";
+import { buildQQBotMergedIngressLifecycle } from "./message-queue-ingress.js";
+import type { QQBotIngressLifecycle } from "./types.js";
 
 const DEFAULT_GLOBAL_QUEUE_SIZE = 1000;
 const DEFAULT_PER_PEER_QUEUE_SIZE = 20;
@@ -63,6 +65,7 @@ export interface QueuedMessage {
   mentions?: QueuedMention[];
   messageScene?: { source?: string; ext?: string[] };
   merge?: QueuedMergeInfo;
+  turnAdoptionLifecycle?: QQBotIngressLifecycle;
 }
 
 export function isMergedTurn(msg: QueuedMessage): msg is QueuedMessage & {
@@ -99,6 +102,7 @@ interface MessageQueue {
   getMessagePeerId: (msg: QueuedMessage) => string;
   clearUserQueue: (peerId: string) => number;
   executeImmediate: (msg: QueuedMessage) => void;
+  stop: () => Promise<void>;
 }
 
 function isGroupPeer(peerId: string): boolean {
@@ -191,6 +195,7 @@ function mergeGroupMessages(batch: QueuedMessage[]): QueuedMessage {
     mentions: mergedMentions.length > 0 ? mergedMentions : undefined,
     messageScene: last.messageScene,
     merge: { count: batch.length, messages: batch },
+    turnAdoptionLifecycle: buildQQBotMergedIngressLifecycle(batch),
   };
 }
 
@@ -203,8 +208,35 @@ export function createMessageQueue(ctx: MessageQueueContext): MessageQueue {
 
   const userQueues = new Map<string, QueuedMessage[]>();
   const activeUsers = new Set<string>();
+  const activeTasks = new Set<Promise<void>>();
+  const ingressSettlements = new Set<Promise<void>>();
   let handleMessageFnRef: ((msg: QueuedMessage) => Promise<void>) | null = null;
   let totalEnqueued = 0;
+  let stopped = false;
+
+  const trackIngressSettlement = (
+    msg: QueuedMessage,
+    kind: "completed" | "abandoned",
+  ): Promise<void> => {
+    const lifecycle = msg.turnAdoptionLifecycle;
+    if (!lifecycle) {
+      return Promise.resolve();
+    }
+    const settlement = Promise.resolve(
+      kind === "completed" ? lifecycle.onAdopted() : lifecycle.onAbandoned(),
+    )
+      .catch((error: unknown) => {
+        log?.error(`Ingress ${kind} settlement failed: ${formatErrorMessage(error)}`);
+      })
+      .finally(() => ingressSettlements.delete(settlement));
+    ingressSettlements.add(settlement);
+    return settlement;
+  };
+
+  const trackTask = (task: Promise<void>): void => {
+    activeTasks.add(task);
+    void task.finally(() => activeTasks.delete(task));
+  };
 
   const getMessagePeerId = (msg: QueuedMessage): string => {
     if (msg.type === "guild") {
@@ -227,9 +259,14 @@ export function createMessageQueue(ctx: MessageQueueContext): MessageQueue {
   };
 
   const processOne = async (msg: QueuedMessage, peerId: string, label: string): Promise<void> => {
+    if (msg.turnAdoptionLifecycle?.abortSignal.aborted) {
+      await trackIngressSettlement(msg, "abandoned");
+      return;
+    }
     try {
       await handleMessageFnRef!(msg);
     } catch (err) {
+      await trackIngressSettlement(msg, "abandoned");
       log?.error(`${label} error for ${peerId}: ${formatErrorMessage(err)}`);
     }
   };
@@ -296,20 +333,36 @@ export function createMessageQueue(ctx: MessageQueueContext): MessageQueue {
       }
     } finally {
       activeUsers.delete(peerId);
-      userQueues.delete(peerId);
+      if (stopped || ctx.isAborted()) {
+        const abandoned = queue.splice(0);
+        totalEnqueued = Math.max(0, totalEnqueued - abandoned.length);
+        for (const msg of abandoned) {
+          void trackIngressSettlement(msg, "abandoned");
+        }
+        userQueues.delete(peerId);
+      } else if (queue.length === 0) {
+        userQueues.delete(peerId);
+      }
 
       for (const [waitingPeerId, waitingQueue] of userQueues) {
+        if (stopped || ctx.isAborted()) {
+          break;
+        }
         if (activeUsers.size >= maxConcurrentUsers) {
           break;
         }
         if (waitingQueue.length > 0 && !activeUsers.has(waitingPeerId)) {
-          void drainUserQueue(waitingPeerId);
+          trackTask(drainUserQueue(waitingPeerId));
         }
       }
     }
   };
 
   const enqueue = (msg: QueuedMessage): void => {
+    if (stopped) {
+      void trackIngressSettlement(msg, "abandoned");
+      return;
+    }
     const peerId = getMessagePeerId(msg);
     const isGroup = isGroupPeer(peerId);
 
@@ -322,6 +375,9 @@ export function createMessageQueue(ctx: MessageQueueContext): MessageQueue {
     const maxSize = isGroup ? groupQueueSize : peerQueueSize;
     if (queue.length >= maxSize) {
       const dropped = evictOne(queue, isGroup);
+      if (dropped) {
+        void trackIngressSettlement(dropped, "abandoned");
+      }
       totalEnqueued = Math.max(0, totalEnqueued - 1);
       if (isGroup && dropped?.senderIsBot) {
         log?.info(`Queue full for ${peerId}, dropping bot message ${dropped.messageId}`, {
@@ -353,7 +409,7 @@ export function createMessageQueue(ctx: MessageQueueContext): MessageQueue {
       `Message enqueued for ${peerId}, user queue: ${queue.length}, active users: ${activeUsers.size}`,
     );
 
-    void drainUserQueue(peerId);
+    trackTask(drainUserQueue(peerId));
   };
 
   const startProcessor = (handleMessageFn: (msg: QueuedMessage) => Promise<void>): void => {
@@ -383,17 +439,32 @@ export function createMessageQueue(ctx: MessageQueueContext): MessageQueue {
       return 0;
     }
     const droppedCount = queue.length;
-    queue.length = 0;
+    const dropped = queue.splice(0);
     totalEnqueued = Math.max(0, totalEnqueued - droppedCount);
+    for (const msg of dropped) {
+      // Urgent commands intentionally supersede buffered work.
+      void trackIngressSettlement(msg, "completed");
+    }
     return droppedCount;
   };
 
   const executeImmediate = (msg: QueuedMessage): void => {
     if (handleMessageFnRef) {
-      handleMessageFnRef(msg).catch((err: unknown) => {
-        log?.error(`Immediate execution error: ${formatErrorMessage(err)}`);
-      });
+      trackTask(processOne(msg, getMessagePeerId(msg), "Immediate execution"));
     }
+  };
+
+  const stop = async (): Promise<void> => {
+    stopped = true;
+    for (const queue of userQueues.values()) {
+      for (const msg of queue.splice(0)) {
+        void trackIngressSettlement(msg, "abandoned");
+      }
+    }
+    userQueues.clear();
+    totalEnqueued = 0;
+    await Promise.allSettled(activeTasks);
+    await Promise.allSettled(ingressSettlements);
   };
 
   return {
@@ -403,5 +474,6 @@ export function createMessageQueue(ctx: MessageQueueContext): MessageQueue {
     getMessagePeerId,
     clearUserQueue,
     executeImmediate,
+    stop,
   };
 }

--- a/extensions/qqbot/src/engine/gateway/message-queue.ts
+++ b/extensions/qqbot/src/engine/gateway/message-queue.ts
@@ -2,6 +2,7 @@
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { formatErrorMessage } from "../utils/format.js";
+import { isQQBotAuthenticationFailure } from "./ingress-errors.js";
 import { buildQQBotMergedIngressLifecycle } from "./message-queue-ingress.js";
 import type { QQBotIngressLifecycle } from "./types.js";
 
@@ -266,7 +267,10 @@ export function createMessageQueue(ctx: MessageQueueContext): MessageQueue {
     try {
       await handleMessageFnRef!(msg);
     } catch (err) {
-      await trackIngressSettlement(msg, "abandoned");
+      const permanentFailure = isQQBotAuthenticationFailure(err);
+      // Deferred lifecycles cannot return errors to the drain. Permanent auth failures must
+      // tombstone here because releasing them would replay a turn that cannot succeed.
+      await trackIngressSettlement(msg, permanentFailure ? "completed" : "abandoned");
       log?.error(`${label} error for ${peerId}: ${formatErrorMessage(err)}`);
     }
   };

--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
@@ -942,6 +942,55 @@ describe("dispatchOutbound", () => {
     }
   });
 
+  it("keeps durable settlement with a dispatch that outlives the response watchdog", async () => {
+    vi.useFakeTimers();
+    try {
+      const lifecycle = {
+        abortSignal: new AbortController().signal,
+        onAdopted: vi.fn(async () => {}),
+        onDeferred: vi.fn(),
+        onAdoptionFinalizing: vi.fn(),
+        onAbandoned: vi.fn(async () => {}),
+      };
+      const inbound = makeInbound();
+      inbound.event.turnAdoptionLifecycle = lifecycle;
+      const runtime = makeRuntime({
+        onDeliver: async (deliver) => {
+          await new Promise<void>((resolve) => {
+            setTimeout(resolve, 301_000);
+          });
+          await deliver({ text: "late durable answer" }, { kind: "block" });
+        },
+      });
+      let settled = false;
+      const dispatchPromise = dispatchOutbound(inbound, {
+        runtime,
+        cfg: {},
+        account,
+      }).finally(() => {
+        settled = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(300_000);
+
+      expect(settled).toBe(false);
+      expect(lifecycle.onAbandoned).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await dispatchPromise;
+
+      expect(sendTextMock).toHaveBeenCalledWith(
+        expect.anything(),
+        "late durable answer",
+        expect.anything(),
+        expect.anything(),
+      );
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  });
+
   it("marks voice-only inbound as audio without adding voice paths to MediaPaths", async () => {
     let finalized: Record<string, unknown> | undefined;
     const runtime = makeRuntime({ onFinalize: (ctx) => (finalized = ctx) });

--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
@@ -223,6 +223,11 @@ function makeRuntime(params: {
     return { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } };
   });
   return {
+    state: {
+      openChannelIngressQueue: () => {
+        throw new Error("unexpected durable ingress access");
+      },
+    },
     channel: {
       activity: { record: vi.fn() },
       routing: {

--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
@@ -12,6 +12,7 @@
 
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
 import { buildChannelInboundEventContext } from "openclaw/plugin-sdk/channel-inbound";
+import { bindIngressLifecycleToReplyOptions } from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { isSilentReplyPayloadText, SILENT_REPLY_TOKEN } from "openclaw/plugin-sdk/reply-chunking";
 import type { FinalizedMsgContext } from "openclaw/plugin-sdk/reply-runtime";
@@ -675,6 +676,9 @@ export async function dispatchOutbound(
           },
         },
         replyOptions: {
+          ...(event.turnAdoptionLifecycle
+            ? bindIngressLifecycleToReplyOptions(event.turnAdoptionLifecycle)
+            : {}),
           disableBlockStreaming: useOfficialC2cStream
             ? true
             : account.config?.streaming?.mode === "off",
@@ -698,10 +702,13 @@ export async function dispatchOutbound(
 
   try {
     await Promise.race([dispatchPromise, timeoutPromise]);
-  } catch {
+  } catch (error) {
     if (timeoutId) {
       clearTimeout(timeoutId);
       timeoutId = null;
+    }
+    if (event.turnAdoptionLifecycle) {
+      throw error;
     }
   } finally {
     if (timeoutId) {

--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.ts
@@ -283,10 +283,11 @@ export async function dispatchOutbound(
   // a longer configured ceiling (e.g. slow local ollama models) is not
   // silently undercut by a plugin-local 5-minute cap.
   const responseTimeoutMs = resolveResponseTimeoutMs(cfg);
+  const responseTimeoutError = new Error("Response timeout");
   const timeoutPromise = new Promise<void>((_, reject) => {
     timeoutId = setTimeout(() => {
       if (!hasResponse) {
-        reject(new Error("Response timeout"));
+        reject(responseTimeoutError);
       }
     }, responseTimeoutMs);
   });
@@ -707,7 +708,11 @@ export async function dispatchOutbound(
       clearTimeout(timeoutId);
       timeoutId = null;
     }
-    if (event.turnAdoptionLifecycle) {
+    if (error === responseTimeoutError && event.turnAdoptionLifecycle) {
+      // The watchdog cannot cancel a live agent turn. Keep durable settlement with that turn;
+      // releasing here would let a retry overlap its later replies and adoption callback.
+      await dispatchPromise;
+    } else if (event.turnAdoptionLifecycle) {
       throw error;
     }
   } finally {

--- a/extensions/qqbot/src/engine/gateway/stages/access-stage.test.ts
+++ b/extensions/qqbot/src/engine/gateway/stages/access-stage.test.ts
@@ -52,6 +52,11 @@ function buildRuntime(
   resolve: GatewayPluginRuntime["channel"]["routing"]["resolveAgentRoute"],
 ): GatewayPluginRuntime {
   return {
+    state: {
+      openChannelIngressQueue: () => {
+        throw new Error("unexpected durable ingress access");
+      },
+    },
     channel: {
       activity: { record: vi.fn() },
       routing: { resolveAgentRoute: resolve },

--- a/extensions/qqbot/src/engine/gateway/types.ts
+++ b/extensions/qqbot/src/engine/gateway/types.ts
@@ -1,3 +1,4 @@
+import type { ChannelIngressQueue } from "openclaw/plugin-sdk/channel-outbound";
 // Qqbot type declarations define plugin contracts.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
 import type { EngineLogger } from "../types.js";
@@ -7,6 +8,11 @@ import type { GatewayAccount as _GatewayAccount } from "../types.js";
 export type GatewayAccount = _GatewayAccount;
 
 export interface GatewayPluginRuntime {
+  state: {
+    openChannelIngressQueue: <TPayload>(options: {
+      accountId: string;
+    }) => ChannelIngressQueue<TPayload>;
+  };
   channel: {
     activity: {
       record: (params: {
@@ -87,9 +93,19 @@ export type { RefAttachmentSummary } from "../ref/types.js";
 export interface WSPayload {
   op: number;
   d: unknown;
+  /** Stable delivery id on gateway dispatch envelopes. */
+  id?: string;
   s?: number;
   t?: string;
 }
+
+export type QQBotIngressLifecycle = {
+  abortSignal: AbortSignal;
+  onAdopted: () => void | Promise<void>;
+  onDeferred: () => void;
+  onAdoptionFinalizing: () => void;
+  onAbandoned: () => void | Promise<void>;
+};
 
 interface RawMessageAttachment {
   content_type: string;


### PR DESCRIPTION
Related: #109657

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where QQBot users could lose an inbound message when the gateway process stopped after receiving it but before the turn became durable.

## Why This Change Was Made

QQBot now journals the raw gateway envelope before advancing the resumable sequence, then replays it through the shared durable ingress drain with per-conversation serialization, retry/dead-letter handling, and completion at turn adoption. Slash commands retain the fleet-wide at-least-once crash-window contract: a crash after their side effect but before the tombstone can replay them.

## User Impact

QQBot messages accepted by the gateway survive process interruption and resume through the normal turn pipeline after restart. Permanent authentication failures settle terminally instead of replaying forever, while retryable failures remain recoverable.

## Evidence

- Blacksmith Testbox: full `extensions/qqbot` suite — 84 files, 694 tests passed.
- Focused gateway suite — 5 files, 76 tests passed.
- Both dead-code gates passed with zero unused files/exports.
- Oxfmt checked all 14 changed TypeScript files; `git diff --check` passed.
- Exact proof run: https://github.com/openclaw/openclaw/actions/runs/29653215913
