### PR TITLE
fix(ui): number steppers, checkbox accents, and composite-page cleanups across settings

### DIFF
--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -1117,6 +1117,36 @@ async function createChatPickerScenario(): Promise<ControlUiMockGatewayScenario>
       "config.schema": configMocks.schema,
       "sessions.patch": { ok: true },
       "sessions.diff": buildSessionDiffMock(),
+      // The worktrees page assumes the gateway contract shape; without this
+      // fixture the mock's {} fallback surfaces as a TypeError banner.
+      "worktrees.list": {
+        worktrees: [
+          {
+            id: "wt-mock-1",
+            name: "fix-session-icons",
+            repoFingerprint: "a1b2c3d4e5f60718",
+            repoRoot: "/Users/demo/Projects/openclaw",
+            path: "/Users/demo/Projects/openclaw/.openclaw/worktrees/fix-session-icons",
+            branch: "openclaw/fix-session-icons",
+            baseRef: "origin/main",
+            ownerKind: "session",
+            createdAt: baseTime - 3 * 86_400_000,
+            lastActiveAt: baseTime - 2 * 3_600_000,
+          },
+          {
+            id: "wt-mock-2",
+            name: "dashboard-polish",
+            repoFingerprint: "a1b2c3d4e5f60718",
+            repoRoot: "/Users/demo/Projects/openclaw",
+            path: "/Users/demo/Projects/openclaw/.openclaw/worktrees/dashboard-polish",
+            branch: "openclaw/dashboard-polish",
+            baseRef: "origin/main",
+            ownerKind: "manual",
+            createdAt: baseTime - 9 * 86_400_000,
+            lastActiveAt: baseTime - 26 * 3_600_000,
+          },
+        ],
+      },
       "plugins.list": buildPluginCatalogMock(),
       "channels.status": buildChannelsStatusMock(baseTime),
       "wizard.start": channelWizard.start,

--- a/ui/src/components/config-form.render.ts
+++ b/ui/src/components/config-form.render.ts
@@ -20,6 +20,9 @@ type ConfigFormProps = {
   activeSubsection?: string | null;
   /** Inline actions rendered next to the active section heading (e.g. env peek). */
   sectionActions?: TemplateResult;
+  /** Composite pages render custom rows above the form; an empty schema
+   *  section must stay silent there instead of claiming the page is empty. */
+  embedded?: boolean;
   revealSensitive?: boolean;
   isSensitivePathRevealed?: (path: Array<string | number>) => boolean;
   onToggleSensitivePath?: (path: Array<string | number>) => void;
@@ -108,6 +111,9 @@ export function renderConfigForm(props: ConfigFormProps) {
   }
 
   if (filteredEntries.length === 0) {
+    if (props.embedded && !searchQuery) {
+      return nothing;
+    }
     return renderSettingsPage(
       renderSettingsEmpty(
         searchQuery

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -835,6 +835,7 @@ export class ConfigPage extends OpenClawLightDomElement {
           activeSection: "mcp",
           activeSubsection: null,
           showModeToggle: false,
+          embeddedEditor: true,
           navRootLabel: "MCP",
         }),
       });
@@ -856,7 +857,7 @@ export class ConfigPage extends OpenClawLightDomElement {
         onBrowserEnabledToggle: (enabled) =>
           runtimeConfig.patchForm(["browser", "enabled"], enabled),
         onToolProfileChange: (profile) => runtimeConfig.patchForm(["tools", "profile"], profile),
-        editor: renderConfig(props),
+        editor: renderConfig({ ...props, embeddedEditor: true }),
       });
     }
     return renderConfig(props);

--- a/ui/src/pages/config/security.ts
+++ b/ui/src/pages/config/security.ts
@@ -47,7 +47,8 @@ function renderSecurityOverview(props: SecurityViewProps) {
     renderSettingsRow({
       title: t("quickSettings.security.gatewayAuth"),
       control: renderSettingsStatus({
-        kind: gatewayAuth !== "none" ? "ok" : "warn",
+        // "unknown" is a pre-hello placeholder, not a healthy auth mode.
+        kind: gatewayAuth === "none" ? "warn" : gatewayAuth === "unknown" ? "muted" : "ok",
         label: gatewayAuth,
       }),
     }),

--- a/ui/src/pages/config/view.ts
+++ b/ui/src/pages/config/view.ts
@@ -139,6 +139,9 @@ export type ConfigProps = {
   viewState: ConfigViewState;
   rawAvailable?: boolean;
   showModeToggle?: boolean;
+  /** Set when the form renders under a composite page's custom rows; an empty
+   *  schema section stays silent instead of claiming the page is empty. */
+  embeddedEditor?: boolean;
   formValue: Record<string, unknown> | null;
   originalValue: Record<string, unknown> | null;
   activeSection: string | null;
@@ -1889,6 +1892,7 @@ export function renderConfig(props: ConfigProps) {
                       schema: analysis.schema,
                       uiHints: props.uiHints,
                       value: props.formValue,
+                      embedded: props.embeddedEditor === true,
                       rawAvailable,
                       disabled: configBusy || !props.formValue,
                       unsupportedPaths: analysis.unsupportedPaths,

--- a/ui/src/styles/activity.css
+++ b/ui/src/styles/activity.css
@@ -49,7 +49,6 @@
 
 .activity-status-filter input {
   margin: 0;
-  accent-color: var(--accent);
 }
 
 .activity-status-filter:focus-within,

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -634,6 +634,13 @@ select {
   color: inherit;
 }
 
+/* One accent for every native check control; without this, surfaces that
+   forget a local override render the browser's stock blue. */
+input[type="checkbox"],
+input[type="radio"] {
+  accent-color: var(--accent);
+}
+
 input,
 textarea,
 [contenteditable]:not([contenteditable="false"]) {

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1181,7 +1181,6 @@
   margin: 0;
   width: 16px;
   height: 16px;
-  accent-color: var(--accent);
 }
 
 .form-grid {
@@ -2370,7 +2369,6 @@ td.data-table-checkbox-col {
   width: 16px;
   height: 16px;
   margin: 0;
-  accent-color: var(--accent);
   vertical-align: middle;
 }
 
@@ -2492,7 +2490,6 @@ td.data-table-key-col {
 }
 
 .field-inline.checkbox input[type="checkbox"] {
-  accent-color: var(--accent);
 }
 
 /* ===========================================
@@ -4818,7 +4815,6 @@ td.data-table-key-col {
 
 .device-pair-setup__access input {
   margin-top: 2px;
-  accent-color: var(--accent);
 }
 
 .device-pair-setup__access span {

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -226,6 +226,17 @@
   scroll-behavior: smooth;
 }
 
+/* The schema form nests a full settings-page inside this scroller; both carry
+   top padding, which stacks into a dead band between the accordion nav and
+   the first section. Keep one spacing owner. */
+.config-lead + .config-content {
+  padding-top: 0;
+}
+
+.config-content > .settings-page {
+  padding-top: 0;
+}
+
 /* ===========================================
    Appearance custom pickers (theme + text scale)
    =========================================== */

--- a/ui/src/styles/cron.css
+++ b/ui/src/styles/cron.css
@@ -903,7 +903,6 @@
   width: 16px;
   height: 16px;
   margin: 0;
-  accent-color: var(--accent);
 }
 
 /* Run entries: flat list separated by hairlines inside the group. */

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -446,6 +446,15 @@ select.settings-select {
   width: 340px;
 }
 
+/* Number inputs hold short values (ports, counts, limits); the shared 340px
+   text width turns −/+ stepper rows into a stretched bar. */
+.settings-row:not(.settings-row--stacked)
+  .settings-row__control
+  > input[type="number"].settings-input {
+  width: 110px;
+  text-align: center;
+}
+
 /* ── Secret input (inset reveal toggle; no trailing button) ── */
 
 .settings-secret {

--- a/ui/src/styles/workboard.css
+++ b/ui/src/styles/workboard.css
@@ -252,7 +252,6 @@
   width: 15px;
   height: 15px;
   margin: 0;
-  accent-color: var(--accent);
 }
 
 .workboard-draft {


### PR DESCRIPTION
## What Problem This Solves

A visual sweep across all 36 Control UI routes (mock-gateway harness, dark + light) found several surfaces that still looked unstyled or broken:

- Schema-driven number rows (Communications queue limit, Infrastructure port, Worktrees cleanup limits) rendered a full-width text input with the −/+ stepper buttons stranded at opposite ends.
- The Logs level filters rendered stock blue browser checkboxes; six other surfaces each carried their own local `accent-color` override.
- The Advanced page had a dead band between the schema accordion and the Logging section (three stacked top paddings).
- Privacy & Security showed a stray "No settings in this section" under fully populated content, and the Gateway auth row gave "unknown" a green OK dot.
- The Worktrees page crashed with a `TypeError: Cannot read properties of undefined (reading 'toSorted')` banner in the mock harness, which lacks a `worktrees.list` fixture.

## Why This Change Was Made

Each fix lands at the owning boundary: a number-input width cap in the settings design language (steppers become a compact − / value / + cluster); one global `accent-color` rule for check controls in `base.css` with the seven scattered per-surface copies deleted; a single spacing owner for the nested schema-form page; an `embedded` flag on `renderConfigForm` so composite pages (Privacy & Security, MCP) keep an empty schema section silent instead of claiming the page is empty; a muted status dot for the pre-hello "unknown" auth placeholder; and a contract-shaped `worktrees.list` fixture in the mock harness (runtime stays strict).

## User Impact

Settings pages with numeric fields, the Logs filters, the Advanced page, and Privacy & Security all read as designed surfaces now; the dev harness renders the Worktrees page instead of an error banner.

## Evidence

Focused tests: `worktrees-page.test.ts` 18/18, `quick.test.ts` + `settings-search.test.ts` 24/24; `oxfmt`/`oxlint` clean on all 12 touched files. Before/after (dark):

| Page | Before | After |
| --- | --- | --- |
| Communications | ![](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/ui-styling-sweep/settings_communications-before.png) | ![](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/ui-styling-sweep/settings_communications-after.png) |
| Infrastructure | ![](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/ui-styling-sweep/settings_infrastructure-before.png) | ![](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/ui-styling-sweep/settings_infrastructure-after.png) |
| Advanced | ![](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/ui-styling-sweep/settings_advanced-before.png) | ![](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/ui-styling-sweep/settings_advanced-after.png) |
| Privacy & Security | ![](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/ui-styling-sweep/settings_security-before.png) | ![](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/ui-styling-sweep/settings_security-after.png) |
| Logs | ![](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/ui-styling-sweep/logs-before.png) | ![](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/ui-styling-sweep/logs-after.png) |
| Worktrees | ![](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/ui-styling-sweep/worktrees-before.png) | ![](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/ui-styling-sweep/worktrees-after.png) |
