### PR TITLE
fix(gateway): trim audit.list exact-match filter ids

### DIFF
--- a/src/gateway/server-methods/audit.test.ts
+++ b/src/gateway/server-methods/audit.test.ts
@@ -208,4 +208,27 @@ describe("audit gateway methods", () => {
       expect(listAuditEvents).toHaveBeenCalledWith(expect.objectContaining({ cursor: 11 }));
     },
   );
+
+  it.each(["audit.list", "audit.activity.list"] as const)(
+    "trims exact-match filter ids for %s before store lookup",
+    async (method) => {
+      const respond = await runAuditHandler(method, {
+        agentId: " main ",
+        sessionKey: " agent:main:main ",
+        runId: " run-1 ",
+      });
+
+      expect(respond).toHaveBeenCalledWith(true, expect.anything());
+      expect(listAuditEvents).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filters: expect.objectContaining({
+            agentId: "main",
+            sessionKey: "agent:main:main",
+            runId: "run-1",
+            ...(method === "audit.activity.list" ? { includeMessages: true } : {}),
+          }),
+        }),
+      );
+    },
+  );
 });

--- a/src/gateway/server-methods/audit.trim.store.test.ts
+++ b/src/gateway/server-methods/audit.trim.store.test.ts
@@ -1,0 +1,84 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.js";
+import { listAuditEvents, recordAuditEvent } from "../../audit/audit-event-store.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  type OpenClawStateDatabaseOptions,
+} from "../../state/openclaw-state-db.js";
+import { auditHandlers } from "./audit.js";
+
+const tempDirs: string[] = [];
+
+function createDatabaseOptions(): OpenClawStateDatabaseOptions {
+  return { env: { OPENCLAW_STATE_DIR: makeTempDir(tempDirs, "openclaw-audit-trim-") } };
+}
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  delete process.env.OPENCLAW_STATE_DIR;
+});
+
+afterAll(() => {
+  cleanupTempDirs(tempDirs);
+});
+
+describe("audit.list padded filters against a real audit store", () => {
+  it("returns the planted run for padded agentId/runId filters", async () => {
+    const database = createDatabaseOptions();
+    const stateDir = expectDefined(database.env?.OPENCLAW_STATE_DIR, "temp state dir");
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    recordAuditEvent(
+      {
+        sourceId: "audit-trim-run-source",
+        sourceSequence: 1,
+        occurredAt: Date.now(),
+        kind: "agent_run",
+        action: "agent.run.finished",
+        status: "succeeded",
+        actorType: "agent",
+        actorId: "main",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        runId: "run-trim-1",
+      },
+      database,
+    );
+
+    // Negative control: untrimmed filter values miss the planted row at the store.
+    expect(
+      listAuditEvents({
+        limit: 20,
+        filters: { agentId: " main ", runId: " run-trim-1 " },
+        database,
+      }).events,
+    ).toEqual([]);
+
+    const respond = vi.fn();
+    await expectDefined(
+      auditHandlers["audit.list"],
+      "audit.list handler",
+    )({
+      params: {
+        agentId: " main ",
+        sessionKey: " agent:main:main ",
+        runId: " run-trim-1 ",
+      },
+      respond,
+    } as never);
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        events: [
+          expect.objectContaining({
+            agentId: "main",
+            runId: "run-trim-1",
+            action: "agent.run.finished",
+          }),
+        ],
+      }),
+    );
+  });
+});

--- a/src/gateway/server-methods/audit.ts
+++ b/src/gateway/server-methods/audit.ts
@@ -1,4 +1,5 @@
 // Metadata-only operator audit queries over the canonical shared SQLite ledger.
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   ErrorCodes,
   errorShape,
@@ -90,13 +91,16 @@ export const auditHandlers: GatewayRequestHandlers = {
       );
       return;
     }
+    const agentId = normalizeOptionalString(params.agentId);
+    const sessionKey = normalizeOptionalString(params.sessionKey);
+    const runId = normalizeOptionalString(params.runId);
     const page = listAuditEvents({
       limit: Math.min(params.limit ?? DEFAULT_AUDIT_LIST_LIMIT, MAX_AUDIT_LIST_LIMIT),
       ...(parsed.cursor !== undefined ? { cursor: parsed.cursor } : {}),
       filters: {
-        ...(params.agentId ? { agentId: params.agentId } : {}),
-        ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
-        ...(params.runId ? { runId: params.runId } : {}),
+        ...(agentId ? { agentId } : {}),
+        ...(sessionKey ? { sessionKey } : {}),
+        ...(runId ? { runId } : {}),
         ...(params.kind ? { kind: params.kind } : {}),
         ...(params.status ? { status: params.status } : {}),
         ...(params.after !== undefined ? { after: params.after } : {}),
@@ -128,14 +132,17 @@ export const auditHandlers: GatewayRequestHandlers = {
       );
       return;
     }
+    const agentId = normalizeOptionalString(params.agentId);
+    const sessionKey = normalizeOptionalString(params.sessionKey);
+    const runId = normalizeOptionalString(params.runId);
     const page = listAuditEvents({
       limit: Math.min(params.limit ?? DEFAULT_AUDIT_LIST_LIMIT, MAX_AUDIT_LIST_LIMIT),
       ...(parsed.cursor !== undefined ? { cursor: parsed.cursor } : {}),
       filters: {
         includeMessages: true,
-        ...(params.agentId ? { agentId: params.agentId } : {}),
-        ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
-        ...(params.runId ? { runId: params.runId } : {}),
+        ...(agentId ? { agentId } : {}),
+        ...(sessionKey ? { sessionKey } : {}),
+        ...(runId ? { runId } : {}),
         ...(params.kind ? { kind: params.kind } : {}),
         ...(params.status ? { status: params.status } : {}),
         ...(params.direction ? { direction: params.direction } : {}),


### PR DESCRIPTION
## What Problem This Solves

`audit.list` / `audit.activity.list` forwarded `agentId`, `sessionKey`, and
`runId` into exact store filters without trimming. A pasted filter like
`" main "` produced a successful empty page even when matching events existed.

## Why This Change Was Made

Normalize those exact-match filters with `normalizeOptionalString` before
`listAuditEvents`, matching the same file's existing cursor `.trim()` behavior
and other gateway list filters.

## User Impact

**Before:** Padded filter ids returned empty success results.

**After:** Leading/trailing whitespace is stripped so padded filters hit the
same rows as the canonical ids.

## Evidence

- Changed: `src/gateway/server-methods/audit.ts`,
  `src/gateway/server-methods/audit.test.ts`,
  `src/gateway/server-methods/audit.trim.store.test.ts`
- Production path: gateway `audit.list` / `audit.activity.list` handlers →
  normalized filters → `listAuditEvents`
- Compatibility: empty/whitespace-only filters still omit the field

## Real behavior proof

### Behavior or issue addressed

1. Untrimmed store filters miss a planted row (`agentId: " main "` → empty).
2. Production `audit.list` with the same padded filters returns the planted
   `agent.run.finished` event after handler-side trim.

### Canonical reachability path

Real SQLite audit store (`recordAuditEvent`) → Gateway handler
`auditHandlers["audit.list"]` → `normalizeOptionalString` → `listAuditEvents`
(default `OPENCLAW_STATE_DIR`) → respond with matching events

### Shared helper / provider constraint check

Reuses `@openclaw/normalization-core/string-coerce` `normalizeOptionalString`;
no new config/env.

### Real environment tested

Local trusted checkout; temp `OPENCLAW_STATE_DIR`; real OpenClaw state SQLite
audit table (not a mocked `listAuditEvents`). Node via `scripts/run-vitest.mjs`.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs src/gateway/server-methods/audit.trim.store.test.ts --reporter=verbose
```

### Evidence after fix

```text
✓ returns the planted run for padded agentId/runId filters 331ms
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

Negative control: `listAuditEvents({ filters: { agentId: " main ", runId: " run-trim-1 " } })`
returns `[]`. After-fix handler call with the same padded params returns the
planted `agentId: "main"` / `runId: "run-trim-1"` event.

### Observed result after fix

Padded audit filter ids resolve through the production gateway handler against
a real stored audit event.

### What was not tested

Live multi-operator Gateway WebSocket session against a long-lived production
state DB. Proof uses the production handler + real SQLite store under an
isolated state dir.

### Fix classification

bugfix — exact-match filter paste/padding miss

## AI Assistance

AI-assisted implementation and proof.

## Maintainer validation on current main

The sole original contributor commit was refreshed onto clean upstream main after the canonical PTY progress and legacy gateway-startup CI fixes landed. Refreshed exact head `8dd2e18dc03c23bf0608265cca9371e4e3f69e73` preserves @nocodet888-arch original authorship, authored timestamp, commit subject, and stable patch ID `cb4cc62115731047916025980833023929e386c5`.

Maintainer proof runs the actual authenticated production `handleGatewayRequest` dispatcher against a real isolated Kysely/SQLite audit ledger on both unpatched main and the contributor head:

- `audit.list`: padded exact-match agent/session/run IDs return **0 before -> 1 after**.
- `audit.activity.list`: the same padded IDs return **0 before -> 1 after**.
- Main-agent and other-agent exact queries stay isolated; whitespace-only filters equal already-authorized unfiltered visibility.
- Missing `operator.read` remains **FORBIDDEN**; node-role calls remain denied.
- **17/17** focused handler/SQLite/protocol tests pass; targeted formatting and fresh Sol **xhigh** autoreview are clean.

Existing detailed proof: https://github.com/openclaw/openclaw/pull/110847#issuecomment-5151074544

Full hosted CI on this exact contributor head is required before landing.