### PR TITLE
fix(gateway): accept padded device pairing request IDs

### DIFF
--- a/src/gateway/server-methods/devices.test.ts
+++ b/src/gateway/server-methods/devices.test.ts
@@ -984,6 +984,71 @@ describe("deviceHandlers", () => {
     expectRespondedErrorMessage(opts, "device pairing approval denied");
   });
 
+  it("trims whitespace around device.pair.approve requestId before lookup", async () => {
+    approveDevicePairingMock.mockResolvedValue({
+      status: "approved",
+      requestId: "req-2",
+      device: {
+        deviceId: "device-2",
+        publicKey: "pk-2",
+        approvedAtMs: 200,
+        createdAtMs: 150,
+      },
+    });
+    const opts = createOptions(
+      "device.pair.approve",
+      { requestId: " req-2 " },
+      {
+        client: createClient(["operator.admin"], "device-1", {
+          isDeviceTokenAuth: true,
+        }),
+      },
+    );
+
+    await expectDefined(
+      deviceHandlers["device.pair.approve"],
+      'deviceHandlers["device.pair.approve"] test invariant',
+    )(opts);
+
+    expect(getPendingDevicePairingMock).not.toHaveBeenCalled();
+    expect(approveDevicePairingMock).toHaveBeenCalledWith("req-2", {
+      callerScopes: ["operator.admin"],
+    });
+    expect(opts.respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ requestId: "req-2" }),
+      undefined,
+    );
+  });
+
+  it("trims whitespace around device.pair.reject requestId before lookup", async () => {
+    rejectDevicePairingMock.mockResolvedValue({
+      requestId: "req-2",
+      deviceId: "device-2",
+    });
+    const opts = createOptions(
+      "device.pair.reject",
+      { requestId: " req-2 " },
+      {
+        client: createClient(["operator.admin"], "device-1", {
+          isDeviceTokenAuth: true,
+        }),
+      },
+    );
+
+    await expectDefined(
+      deviceHandlers["device.pair.reject"],
+      'deviceHandlers["device.pair.reject"] test invariant',
+    )(opts);
+
+    expect(rejectDevicePairingMock).toHaveBeenCalledWith("req-2");
+    expect(opts.respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ requestId: "req-2", deviceId: "device-2" }),
+      undefined,
+    );
+  });
+
   it("allows admins to approve another device", async () => {
     approveDevicePairingMock.mockResolvedValue({
       status: "approved",

--- a/src/gateway/server-methods/devices.ts
+++ b/src/gateway/server-methods/devices.ts
@@ -264,7 +264,9 @@ export const deviceHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const { requestId } = params as { requestId: string };
+    // Match gateway.suspend.prepare / deviceId trimming: pasted requestIds often
+    // carry surrounding whitespace and must still hit the pending-pairing key.
+    const requestId = (params as { requestId: string }).requestId.trim();
     const authz = resolveDeviceSessionAuthz(client);
     if (!authz.isAdminCaller) {
       const pending = await getPendingDevicePairing(requestId);
@@ -369,7 +371,7 @@ export const deviceHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const { requestId } = params as { requestId: string };
+    const requestId = (params as { requestId: string }).requestId.trim();
     const authz = resolveDeviceSessionAuthz(client);
     if (authz.callerDeviceId && !authz.isAdminCaller) {
       const pending = await getPendingDevicePairing(requestId);


### PR DESCRIPTION
## What Problem This Solves

Users calling device-pair approval or rejection with whitespace around a valid pending request ID receive a false lookup failure. The same request succeeds when its ID has no padding.

## Why This Change Was Made

Normalize the request ID once at the Gateway boundary so ownership checks, mutations, responses, and notifications use the same canonical ID. Stored pairing keys and authorization rules stay unchanged. Node pairing remains tracked separately in #141286.

## User Impact

Pasted device-pair request IDs now work with leading or trailing whitespace. Unknown IDs, malformed input, cross-device requests, and insufficient permissions remain rejected.

## Evidence

- Real signed WebSocket handshakes created the pending requests; the public devices list supplied their IDs.
- On pinned main, padded approval/rejection failed while the same canonical IDs succeeded.
- On the candidate, both padded operations succeeded, returned and broadcast canonical IDs, and the approved device reconnected.
- All 22 public refusal controls preserved the pending requests, including device-token ownership and scope checks.
- An independent run with fresh generated identities confirmed those results.
- All 26 focused handler tests passed. The four padded variants failed on the original handlers. Formatting, focused lint, and line-count/assertion guards passed.

AI-assisted.
