### PR TITLE
fix(gateway): trim agents.workspace relative paths

### DIFF
--- a/src/gateway/server-methods/agents-workspace.test.ts
+++ b/src/gateway/server-methods/agents-workspace.test.ts
@@ -123,6 +123,33 @@ describe("agents.workspace RPC handlers", () => {
     ]);
   });
 
+  it("trims whitespace around workspace list and get paths", async () => {
+    const listed = expectOkPayload(
+      await invokeWorkspaceHandler("agents.workspace.list", {
+        agentId: "main",
+        path: " src ",
+      }),
+    );
+    expect(listed.path).toBe("src");
+    expect(listed.entries.map((entry: Record<string, unknown>) => entry.path)).toEqual([
+      "src/index.ts",
+      "src/util.ts",
+    ]);
+
+    const got = expectOkPayload(
+      await invokeWorkspaceHandler("agents.workspace.get", {
+        agentId: "main",
+        path: " notes.md ",
+      }),
+    );
+    expect(got.file).toMatchObject({
+      path: "notes.md",
+      name: "notes.md",
+      encoding: "utf8",
+      content: "# Notes\n",
+    });
+  });
+
   it("paginates large directories deterministically", async () => {
     for (let index = 0; index < 12; index += 1) {
       writeWorkspaceFile(workspaceRoot, `bulk/file-${String(index).padStart(2, "0")}.txt`, "x");

--- a/src/gateway/server-methods/agents-workspace.ts
+++ b/src/gateway/server-methods/agents-workspace.ts
@@ -76,7 +76,8 @@ function resolveWorkspaceScopeOrRespond(
     return null;
   }
   const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
-  const rawPath = params.path ?? "";
+  // Exact relative lookups; UI/paste padding must not turn a real file into not-found.
+  const rawPath = typeof params.path === "string" ? params.path.trim() : "";
   const portablePath = rawPath.replaceAll("\\", "/");
   if (path.posix.isAbsolute(portablePath) || path.win32.isAbsolute(rawPath)) {
     respond(
@@ -88,13 +89,13 @@ function resolveWorkspaceScopeOrRespond(
     );
     return null;
   }
-  const browserPath = normalizeRelativePath(params.path);
+  const browserPath = normalizeRelativePath(rawPath);
   if (!resolveWorkspacePath(workspaceDir, browserPath || ".")) {
     respond(
       false,
       undefined,
       workspaceError("workspace_path_invalid", "path escapes the agent workspace", {
-        path: params.path ?? "",
+        path: rawPath,
       }),
     );
     return null;


### PR DESCRIPTION
## What Problem This Solves

`agents.workspace.list` / `agents.workspace.get` used `params.path ?? ""`
without trimming. A pasted path like `" src "` or `" notes.md "` failed as
not found / invalid even when the workspace file existed.

## Why This Change Was Made

Trim the relative path once in `resolveWorkspaceScopeOrRespond` before absolute
checks and `normalizeRelativePath`, so both list and get share the same
boundary.

## User Impact

**Before:** Padded workspace-relative paths missed real files/directories.

**After:** Leading/trailing whitespace is ignored for relative path lookup.

## Evidence

- Changed: `src/gateway/server-methods/agents-workspace.ts`,
  `src/gateway/server-methods/agents-workspace.test.ts`
- Production path: `agents.workspace.list` / `agents.workspace.get` →
  `resolveWorkspaceScopeOrRespond` → trimmed path → list/get
- Compatibility: absolute / escape rejection still uses the trimmed path;
  empty remains root for list

## Real behavior proof

### Behavior or issue addressed

Production workspace handlers list `" src "` as `src` and read
`" notes.md "` as the real UTF-8 file contents.

### Canonical reachability path

Gateway RPC `agents.workspace.list` / `agents.workspace.get` →
`resolveWorkspaceScopeOrRespond` (trim) → workspace fs helpers → respond

### Shared helper / provider constraint check

Scope-local trim; no new config/env. Absolute-path and escape guards retained.

### Real environment tested

Local trusted source checkout; real temp workspace files; Vitest invokes the
production `agentsWorkspaceHandlers` methods.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs src/gateway/server-methods/agents-workspace.test.ts \
  -t "trims whitespace around workspace" --reporter=verbose
```

### Evidence after fix

```text
✓ trims whitespace around workspace list and get paths
 Test Files  2 passed (2)
      Tests  2 passed | 36 skipped (38)
```

List returned `path: "src"` with `src/index.ts` / `src/util.ts`; get returned
`file.path: "notes.md"` with content `# Notes\n`.

### Observed result after fix

Padded workspace paths resolve through the production list/get handlers.

AI-assisted: yes. I reviewed and understand the change.
