### PR TITLE
fix(ci): bound mantis-discord-smoke git fetches with timeout

### DIFF
--- a/.github/workflows/mantis-discord-smoke.yml
+++ b/.github/workflows/mantis-discord-smoke.yml
@@ -85,14 +85,14 @@ jobs:
           selected_revision="$(git rev-parse HEAD)"
           trusted_reason=""
 
-          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          timeout --signal=TERM --kill-after=10s 120s git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
 
           if git merge-base --is-ancestor "$selected_revision" refs/remotes/origin/main; then
             trusted_reason="main-ancestor"
           elif git tag --points-at "$selected_revision" | grep -Eq '^v'; then
             trusted_reason="release-tag"
           elif [[ "$INPUT_REF" =~ ^release/[0-9]{4}\.[0-9]+\.[0-9]+$ ]]; then
-            git fetch --no-tags origin "+refs/heads/${INPUT_REF}:refs/remotes/origin/${INPUT_REF}"
+            timeout --signal=TERM --kill-after=10s 120s git fetch --no-tags origin "+refs/heads/${INPUT_REF}:refs/remotes/origin/${INPUT_REF}"
             release_branch_sha="$(git rev-parse "refs/remotes/origin/${INPUT_REF}")"
             if [[ "$selected_revision" == "$release_branch_sha" ]]; then
               trusted_reason="release-branch-head"

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -3240,6 +3240,20 @@ describe("ci workflow guards", () => {
     }
   });
 
+  it("bounds mantis discord smoke validation git fetches", () => {
+    const workflowPath = ".github/workflows/mantis-discord-smoke.yml";
+    const source = readFileSync(workflowPath, "utf8");
+    const gitFetchLines = source.split("\n").filter((line) => line.includes("git fetch"));
+
+    expect(gitFetchLines, workflowPath).toHaveLength(2);
+    expect(
+      gitFetchLines.every((line) =>
+        line.trimStart().startsWith("timeout --signal=TERM --kill-after=10s 120s git fetch"),
+      ),
+      workflowPath,
+    ).toBe(true);
+  });
+
   it("bounds release ref validation fetches across checkout auth modes", () => {
     const resolveTargetSteps = readReleaseChecksWorkflow().jobs.resolve_target.steps;
 


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Related: #110279, #110281, #110028, #110282, #109176, #108940

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where the `mantis-discord-smoke` workflow could remain stuck in either of its two `git fetch` steps until the job timeout when the Git transport stalls. This blocks Mantis Discord smoke runs and wastes the QA runner.

## Why This Change Was Made

Both `git fetch` commands in the `validate_selected_ref` job now run through the repository's bounded process pattern: a 120-second deadline, followed by a 10-second termination grace period. This matches the pattern already applied to Mantis Crabbox workflows in #108940 and recently to `plugin-npm-release` in #110279. All ref-trust validation logic, merge-base checks, and non-network operations are unchanged.

The two fetch locations: the main ref fetch used for the main-ancestor trust check (L88), and the release-branch ref fetch used for the release-branch-head trust check (L95).

## User Impact

Maintainers get prompt, actionable failures instead of losing a Mantis Discord smoke runner for the full job timeout when the Git transport stalls.

## Evidence

**Controlled stalled-fetch runtime proof (the timeout wrapper actually kills a stalled git fetch).** A local TCP server that accepts connections but never responds was stood up to emulate a stalled git endpoint. A bare repo was pointed at it, then the exact production wrapper form (`timeout --signal=TERM --kill-after=10s <DURATION>`) was used to run `git fetch`. The wrapper sent TERM and killed the stalled fetch, returning exit code 124 — the same status the production `validate_selected_ref` job would observe on a real stall. (A 5s deadline is used here instead of the production 120s so the mechanism is observable quickly; the kill mechanism, signal, and exit code are identical to the production command.)

```
=== Controlled stalled-fetch proof for PR #110851 ===
Production pattern guarded: timeout --signal=TERM --kill-after=10s 120s git fetch
(production deadline is 120s; a 5s deadline is used here to demonstrate the mechanism quickly)
Command under test: timeout --signal=TERM --kill-after=10s 5s git fetch --no-tags origin
Expected: killed after 5s, exit code 124

Exit code: 124 (124 = timeout wrapper killed the stalled git fetch)
Elapsed: 6 seconds
=== Proof: timeout wrapper kills stalled git fetch in 6s (exit code 124) ===
```

This directly demonstrates the bounded-process mechanism requested in review: TERM delivery, timeout status 124, and the failure surfacing fast instead of consuming the full job timeout.

**Source-contract guard on the production workflow:** the test `bounds mantis discord smoke validation git fetches` in `test/scripts/ci-workflow-guards.test.ts` reads the actual production workflow YAML from disk (`readFileSync(".github/workflows/mantis-discord-smoke.yml")`) and asserts the `timeout --signal=TERM --kill-after=10s 120s` wrapper is present on every `git fetch` line. Because the test reads the real, deployed CI config file, it fails the moment the timeout wrapper is removed from the production workflow.

**Source-contract guard on the production workflow:** the test `bounds mantis discord smoke validation git fetches` in `test/scripts/ci-workflow-guards.test.ts` reads the actual production workflow YAML from disk (`readFileSync(".github/workflows/mantis-discord-smoke.yml")`) and asserts the `timeout --signal=TERM --kill-after=10s 120s` wrapper is present on every `git fetch` line. Because the test reads the real, deployed CI config file, it fails the moment the timeout wrapper is removed from the production workflow.

The test asserts two concrete properties of the live workflow YAML:
1. Exactly two `git fetch` lines exist in the workflow source (the main ref fetch at L88 and the release-branch ref fetch at L95, both in the `Validate selected ref` step of the `validate_selected_ref` job).
2. Every `git fetch` line includes the `timeout --signal=TERM --kill-after=10s 120s` prefix, so each command is actually wrapped by the bounded-process timeout.

**Focused regression (red -> green):**

- `bounds mantis discord smoke validation git fetches` fails on the unmodified workflow (neither `git fetch` line carries the `timeout` prefix, so `gitFetchLines.every(...).toBe(true)` fails with `expected false to be true`) and passes after the fix.

```
$ pnpm exec vitest run test/scripts/ci-workflow-guards.test.ts \
    -t "bounds mantis discord smoke validation git fetches"
 ✓ tooling  ../scripts/ci-workflow-guards.test.ts (88 tests | 87 skipped) 24ms
 Test Files  1 passed (1)
      Tests  1 passed | 87 skipped (88)
```

Red confirmation (workflow reverted to unbounded `git fetch`): the same assertion fails because neither `git fetch` line includes the `timeout --signal=TERM --kill-after=10s 120s` prefix. This demonstrates the test is a faithful guard: it fails when the production timeout wrapper is missing.

**Format check:** `pnpm exec oxfmt --check` passed for both changed files.

**Scope:** only `.github/workflows/mantis-discord-smoke.yml` (lines 88 and 95) and `test/scripts/ci-workflow-guards.test.ts` (one new `it` block) are changed.
