### PR TITLE
fix(models): report accurate limits in OpenRouter scans

### DIFF
--- a/src/agents/model-scan.test.ts
+++ b/src/agents/model-scan.test.ts
@@ -74,11 +74,113 @@ describe("scanOpenRouterModels", () => {
     if (byPricing === undefined) {
       throw new Error("Expected pricing-based model result.");
     }
+    expect(byPricing.contextLength).toBe(16_384);
+    expect(byPricing.maxCompletionTokens).toBe(1024);
     expect(byPricing.supportsToolsMeta).toBe(true);
     expect(byPricing.supportedParametersCount).toBe(3);
     expect(byPricing.isFree).toBe(true);
     expect(byPricing.tool.skipped).toBe(true);
     expect(byPricing.image.skipped).toBe(true);
+  });
+
+  it("uses OpenRouter top-provider limits for scan metadata", async () => {
+    const fetchImpl = createFetchFixture({
+      data: [
+        {
+          id: "acme/provider-limited:free",
+          name: "Provider Limited",
+          context_length: 32_768,
+          top_provider: {
+            context_length: 16_384,
+            max_completion_tokens: 4096,
+          },
+          supported_parameters: [],
+          pricing: { prompt: "0", completion: "0" },
+        },
+      ],
+    });
+
+    const [result] = await scanOpenRouterModels({
+      fetchImpl,
+      probe: false,
+    });
+
+    expect(result?.contextLength).toBe(16_384);
+    expect(result?.maxCompletionTokens).toBe(4096);
+  });
+
+  it("falls back when top-provider limits are malformed", async () => {
+    for (const topProvider of [
+      { context_length: 0, max_completion_tokens: 0 },
+      { context_length: -1, max_completion_tokens: -1 },
+      { context_length: 8192.5, max_completion_tokens: 8192.5 },
+      {
+        context_length: Number.MAX_SAFE_INTEGER + 1,
+        max_completion_tokens: Number.MAX_SAFE_INTEGER + 1,
+      },
+      { context_length: "8192", max_completion_tokens: "1024" },
+      { context_length: null, max_completion_tokens: null },
+    ]) {
+      const fetchImpl = createFetchFixture({
+        data: [
+          {
+            id: "acme/provider-limited:free",
+            name: "Provider Limited",
+            context_length: 32_768,
+            max_completion_tokens: 4096,
+            top_provider: topProvider,
+            supported_parameters: [],
+            pricing: { prompt: "0", completion: "0" },
+          },
+        ],
+      });
+
+      const [result] = await scanOpenRouterModels({ fetchImpl, probe: false });
+
+      expect(result?.contextLength).toBe(32_768);
+      expect(result?.maxCompletionTokens).toBe(4096);
+    }
+  });
+
+  it("mixes provider context length with a top-level completion cap", async () => {
+    const fetchImpl = createFetchFixture({
+      data: [
+        {
+          id: "acme/provider-limited:free",
+          name: "Provider Limited",
+          context_length: 32_768,
+          max_completion_tokens: 4096,
+          top_provider: { context_length: 16_384, max_completion_tokens: 0 },
+          supported_parameters: [],
+          pricing: { prompt: "0", completion: "0" },
+        },
+      ],
+    });
+
+    const [result] = await scanOpenRouterModels({ fetchImpl, probe: false });
+
+    expect(result?.contextLength).toBe(16_384);
+    expect(result?.maxCompletionTokens).toBe(4096);
+  });
+
+  it("falls back to top-level max_output_tokens", async () => {
+    const fetchImpl = createFetchFixture({
+      data: [
+        {
+          id: "acme/output-limited:free",
+          name: "Output Limited",
+          context_length: 32_768,
+          max_output_tokens: 2048,
+          top_provider: { max_completion_tokens: 0 },
+          supported_parameters: [],
+          pricing: { prompt: "0", completion: "0" },
+        },
+      ],
+    });
+
+    const [result] = await scanOpenRouterModels({ fetchImpl, probe: false });
+
+    expect(result?.maxCompletionTokens).toBe(2048);
   });
 
   it("drops out-of-range OpenRouter created_at timestamps", async () => {

--- a/src/agents/model-scan.ts
+++ b/src/agents/model-scan.ts
@@ -5,8 +5,10 @@ import { registerBuiltInApiProviders } from "@openclaw/ai/providers";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import {
   asDateTimestampMs,
+  asPositiveSafeInteger,
   resolveTimerTimeoutMs,
 } from "@openclaw/normalization-core/number-coercion";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -233,20 +235,18 @@ async function fetchOpenRouterModels(
               return null;
             }
             const name = typeof obj.name === "string" && obj.name.trim() ? obj.name.trim() : id;
+            const topProvider = asOptionalRecord(obj.top_provider);
 
             const contextLength =
-              typeof obj.context_length === "number" && Number.isFinite(obj.context_length)
-                ? obj.context_length
-                : null;
+              asPositiveSafeInteger(topProvider?.context_length) ??
+              asPositiveSafeInteger(obj.context_length) ??
+              null;
 
             const maxCompletionTokens =
-              typeof obj.max_completion_tokens === "number" &&
-              Number.isFinite(obj.max_completion_tokens)
-                ? obj.max_completion_tokens
-                : typeof obj.max_output_tokens === "number" &&
-                    Number.isFinite(obj.max_output_tokens)
-                  ? obj.max_output_tokens
-                  : null;
+              asPositiveSafeInteger(topProvider?.max_completion_tokens) ??
+              asPositiveSafeInteger(obj.max_completion_tokens) ??
+              asPositiveSafeInteger(obj.max_output_tokens) ??
+              null;
 
             const supportedParameters = Array.isArray(obj.supported_parameters)
               ? normalizeStringEntries(


### PR DESCRIPTION
## What problem this solves

`openclaw models scan` read only OpenRouter's catalog-wide context and output
limits. When the primary provider published smaller limits under
`top_provider`, scan output could overstate the metadata used for display and
optional capability probes.

## Canonical fix

- Prefer positive safe-integer limits from `top_provider`.
- Fall back independently to valid catalog-wide `context_length`,
  `max_completion_tokens`, and `max_output_tokens`.
- Reuse the same precedence and validation already owned by
  `extensions/openrouter/provider-catalog.ts`.

`top_provider` describes OpenRouter's primary-provider configuration; it is not
a guarantee that every routed request will use one fixed provider.

No config, Plugin SDK, protocol, persistence, migration, or feature surface
changes.

## Evidence

Exact rewritten head: `d3c9ac59bbb95539d76b1dd06b58b130fa9bd74f`

- Real public no-key/no-probe scan proof:
  - Before: `google/gemma-4-26b-a4b-it:free` reported catalog context
    `262144` and no completion cap.
  - Live OpenRouter metadata reported primary-provider context `131072` and
    completion cap `32768`.
  - After: the same scan reported context `131072` and completion cap `32768`.
- Four focused suites: 51/51 passed.
- Regression coverage includes provider precedence; zero, negative,
  fractional, unsafe, string, and null provider values; independent fallback;
  and `max_output_tokens`.
- Scoped formatting, direct touched-file oxlint, and `git diff --check`: clean.
- Autoreview on the patch-equivalent pre-rebase commit found no actionable
  issues; correctness confidence 0.99; TruffleHog clean.
- The single commit is based on current `main`
  `a67c52611e5768ffe89dc2c4eea0cea0e26e34e6`.

## Scope

Production delta: `+10/-10` (net zero) in `src/agents/model-scan.ts`.
Tests add 102 lines.

Changelog not required: this corrects existing internal catalog normalization
without changing commands or configuration.
