### PR TITLE
fix(auto-reply): notify users when Codex session changes

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution-terminal-failures.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-terminal-failures.test.ts
@@ -653,6 +653,34 @@ describe("runAgentTurnWithFallback: terminal failures", () => {
     },
   );
 
+  it("surfaces stale Codex session generations in groups instead of staying silent", async () => {
+    state.runWithModelFallbackMock.mockRejectedValueOnce(
+      new Error("Codex session generation is no longer current: secret-session-id"),
+    );
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      ...createMinimalRunAgentTurnParams({
+        sessionCtx: {
+          Provider: "telegram",
+          Surface: "telegram",
+          ChatType: "group",
+          MessageSid: "msg",
+        } as unknown as TemplateContext,
+      }),
+    });
+
+    expect(result.kind).toBe("final");
+    if (result.kind !== "final") {
+      throw new Error("expected final reply");
+    }
+    expect(result.payload.text).not.toBe(SILENT_REPLY_TOKEN);
+    expect(result.payload.text).toBe(
+      "⚠️ This Codex session changed before your message could run. Please send it again.",
+    );
+    expect(result.payload.text).not.toContain("secret-session-id");
+  });
+
   it("forwards sanitized generic errors on external chat channels when verbose is on", async () => {
     state.runEmbeddedAgentMock.mockRejectedValueOnce(
       new Error("INVALID_ARGUMENT: some other failure"),

--- a/src/auto-reply/reply/agent-runner-failure-reply.ts
+++ b/src/auto-reply/reply/agent-runner-failure-reply.ts
@@ -221,9 +221,14 @@ const CODEX_APP_SERVER_CLIENT_CLOSED_BEFORE_REPLY_RE =
   /\bcodex app-server client closed before turn completed\b/iu;
 const CODEX_APP_SERVER_TURN_COMPLETION_IDLE_TIMEOUT_RE =
   /\bcodex app-server turn idle timed out waiting for turn\/completed\b/iu;
+const CODEX_SESSION_GENERATION_NOT_CURRENT_RE =
+  /\bcodex session generation is no longer current\b/iu;
 
 function buildCodexAppServerFailureText(message: string): string | null {
   const normalizedMessage = collapseRepeatedFailureDetail(message);
+  if (CODEX_SESSION_GENERATION_NOT_CURRENT_RE.test(normalizedMessage)) {
+    return "⚠️ This Codex session changed before your message could run. Please send it again.";
+  }
   if (CODEX_APP_SERVER_CLIENT_CLOSED_BEFORE_REPLY_RE.test(normalizedMessage)) {
     return "⚠️ Codex app-server connection closed before this turn finished. OpenClaw retried once when the stdio turn was still replay-safe; please try again if this keeps happening.";
   }


### PR DESCRIPTION
Related: #106957, #108769

## What Problem This Solves

Fixes an issue where channel users could receive no reply when another gateway or session transition superseded the Codex session generation before their message ran. The agent runner logged `Embedded agent failed before reply`, but the generation error was treated as generic; normal group failure policy then converted the reply to `NO_REPLY`.

## Why This Change Was Made

Classify the stable Codex generation-fence error as a known terminal failure and return a short, redacted retry prompt. This is intentionally not a durable-ingress retry: the channel claim is completed when the turn is adopted, before Codex starts, and replaying an adopted turn can duplicate side effects. The same in-flight turn also keeps the stale physical session ID, so retrying that run cannot reclaim the authoritative generation.

Codex app-server identifies resume/start operations by thread ID and rejoins running threads only inside its current process; it exposes no cross-process generation token. OpenClaw therefore continues to own and enforce this fence. See [`ThreadResumeParams`](https://github.com/openai/codex/blob/b8b61bc692517adcd18622df260f2ddd80635122/codex-rs/app-server-protocol/src/protocol/v2/thread.rs#L310-L324), [`TurnStartParams`](https://github.com/openai/codex/blob/b8b61bc692517adcd18622df260f2ddd80635122/codex-rs/app-server-protocol/src/protocol/v2/turn.rs#L71-L75), and the process-local running-thread lookup in [`thread_processor.rs`](https://github.com/openai/codex/blob/b8b61bc692517adcd18622df260f2ddd80635122/codex-rs/app-server/src/request_processors/thread_processor.rs#L3296-L3344).

## User Impact

Instead of silence, users now receive: `⚠️ This Codex session changed before your message could run. Please send it again.` The physical session identifier is never exposed. The underlying generation fence and no-replay behavior are unchanged.

Release-note context: fixes silent channel drops when a Codex session generation changes before an adopted turn starts.

## Evidence

- Blacksmith Testbox `tbx_01kxv416r7z3df45ydepkhzvy7`: focused terminal-failure suite passed 20/20; full changed gate passed (format, boundaries, production/test typechecks, lint, and guards). [Run](https://github.com/openclaw/openclaw/actions/runs/29653800465)
- Regression covers a Telegram group turn, asserts a non-silent final reply, exact actionable copy, and session-ID redaction.
- Fresh uncommitted autoreview: clean, correctness confidence 0.97.
- Live two-gateway/channel proof was not run: no deterministic source-blind fixture exists without an approved private channel or internal state injection.

AI-assisted: implementation and review performed with Codex.
