### PR TITLE
fix(auth): bound auth-profile source JSON probe reads

### DIFF
--- a/src/agents/auth-profiles/source-check.test.ts
+++ b/src/agents/auth-profiles/source-check.test.ts
@@ -4,6 +4,8 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { hasAuthProfileStoreSourceForProvider } from "./source-check.js";
 
+const TEST_MAX_AUTH_PROFILE_SOURCE_JSON_BYTES = 1024 * 1024;
+
 describe("hasAuthProfileStoreSourceForProvider", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
@@ -120,6 +122,39 @@ describe("hasAuthProfileStoreSourceForProvider", () => {
       },
     });
 
+    expect(hasAuthProfileStoreSourceForProvider("openai", agentDir)).toBe(false);
+  });
+
+  it("treats oversized auth-profiles.json as no usable provider source", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-source-"));
+    const stateDir = path.join(root, "state");
+    const agentDir = path.join(root, "agent");
+    await fs.mkdir(agentDir, { recursive: true });
+    await fs.mkdir(stateDir, { recursive: true });
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+
+    const storePath = path.join(agentDir, "auth-profiles.json");
+    const usablePrefix =
+      '{"version":1,"profiles":{"openai:default":{"type":"api_key","provider":"openai","key":"sk-test"},"pad":"';
+    const handle = await fs.open(storePath, "w");
+    try {
+      await handle.writeFile(usablePrefix);
+      const remaining =
+        TEST_MAX_AUTH_PROFILE_SOURCE_JSON_BYTES + 1 - Buffer.byteLength(usablePrefix, "utf8");
+      const chunk = Buffer.alloc(64 * 1024, 0x61);
+      let written = 0;
+      while (written < remaining) {
+        const next = chunk.subarray(0, Math.min(chunk.length, remaining - written));
+        await handle.write(next);
+        written += next.length;
+      }
+      await handle.writeFile('"}}');
+    } finally {
+      await handle.close();
+    }
+
+    const stat = await fs.stat(storePath);
+    expect(stat.size).toBeGreaterThan(TEST_MAX_AUTH_PROFILE_SOURCE_JSON_BYTES);
     expect(hasAuthProfileStoreSourceForProvider("openai", agentDir)).toBe(false);
   });
 });

--- a/src/agents/auth-profiles/source-check.ts
+++ b/src/agents/auth-profiles/source-check.ts
@@ -3,6 +3,7 @@
  * These checks intentionally avoid loading secret-bearing credential payloads.
  */
 import fs from "node:fs";
+import { readRegularFileSync } from "../../infra/regular-file.js";
 import { evaluateStoredCredentialEligibility } from "./credential-state.js";
 import {
   resolveAuthStatePath,
@@ -17,6 +18,11 @@ import {
 import { readPersistedAuthProfileStateRaw, readPersistedAuthProfileStoreRaw } from "./sqlite.js";
 import type { AuthProfileCredential, AuthProfileStore } from "./types.js";
 
+// Auth-profile JSON probes are existence/eligibility checks, not full store
+// loads. Cap the read so a hostile or corrupted auth-profiles.json / auth.json
+// cannot force an unbounded buffer into the probe path.
+const MAX_AUTH_PROFILE_SOURCE_JSON_BYTES = 1024 * 1024;
+
 // Auth-profile source checks look at runtime snapshots, JSON compatibility
 // files, legacy files, and SQLite stores without materializing secret values.
 function hasStoredAuthProfileFiles(agentDir?: string): boolean {
@@ -29,7 +35,12 @@ function hasStoredAuthProfileFiles(agentDir?: string): boolean {
 
 function readJsonFile(pathname: string): unknown {
   try {
-    return JSON.parse(fs.readFileSync(pathname, "utf8")) as unknown;
+    const resolvedPath = fs.realpathSync(pathname);
+    const { buffer } = readRegularFileSync({
+      filePath: resolvedPath,
+      maxBytes: MAX_AUTH_PROFILE_SOURCE_JSON_BYTES,
+    });
+    return JSON.parse(buffer.toString("utf8")) as unknown;
   } catch {
     return null;
   }


### PR DESCRIPTION
## What Problem This Solves

`hasAuthProfileStoreSourceForProvider` probes local `auth-profiles.json` /
legacy `auth.json` with unbounded `fs.readFileSync` + `JSON.parse`. A hostile
or corrupted store under the agent dir can force an unbounded buffer into this
read-only eligibility path (doctor/status/auth routing probes).

## Why This Change Was Made

Bound the JSON probe through `readRegularFileSync` after `realpath`, with a
1 MiB cap (same order as other auth/config probe reads). Oversized or unreadable
files fail closed as "no usable provider source", matching parse failures.

## User Impact

**Before:** An oversized `auth-profiles.json` / `auth.json` could be fully
buffered during provider-source probes.

**After:** Stores over 1 MiB are treated as absent for the probe; normal-sized
credential stores still count as usable sources.

## Evidence

- Changed: `src/agents/auth-profiles/source-check.ts`,
  `src/agents/auth-profiles/source-check.test.ts`
- Production path: `hasAuthProfileStoreSourceForProvider` → `readJsonFile` →
  `realpath` + `readRegularFileSync({ maxBytes: 1 MiB })` → JSON parse /
  eligibility
- Sibling pattern: `#110589` skill-file audit bound via `readRegularFile`;
  identity file uses the same helper with a size cap

## Real behavior proof

### Behavior or issue addressed

Oversized `auth-profiles.json` no longer counts as a usable provider source and
is rejected by the size gate before a full unbounded buffer is accepted.

### Canonical reachability path

`hasAuthProfileStoreSourceForProvider(provider, agentDir)` → `readJsonFile` on
`resolveAuthStorePath(agentDir)` → bounded regular-file read → fail closed

### Shared helper / provider constraint check

Uses shared `readRegularFileSync` from `src/infra/regular-file.js`
(`@openclaw/fs-safe`), which rejects when `stat.size > maxBytes` before the
bounded body read.

### Real environment tested

Local trusted worktree; real tempfile `auth-profiles.json` larger than 1 MiB
with a usable-looking credential prefix; Node v22.23.1.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs src/agents/auth-profiles/source-check.test.ts --reporter=verbose
```

### Evidence after fix

```text
✓ |agents| src/agents/auth-profiles/source-check.test.ts > hasAuthProfileStoreSourceForProvider > counts provider-specific usable credentials 84ms
✓ |agents| src/agents/auth-profiles/source-check.test.ts > hasAuthProfileStoreSourceForProvider > counts legacy auth stores with alias fields and fallback providers 1ms
✓ |agents| src/agents/auth-profiles/source-check.test.ts > hasAuthProfileStoreSourceForProvider > ignores malformed provider fields instead of throwing 2ms
✓ |agents| src/agents/auth-profiles/source-check.test.ts > hasAuthProfileStoreSourceForProvider > does not count profile ids that are bound to a different credential provider 1ms
✓ |agents| src/agents/auth-profiles/source-check.test.ts > hasAuthProfileStoreSourceForProvider > honors configured profile order constraints 2ms
✓ |agents| src/agents/auth-profiles/source-check.test.ts > hasAuthProfileStoreSourceForProvider > treats explicit empty profile order as no usable profile 1ms
✓ |agents| src/agents/auth-profiles/source-check.test.ts > hasAuthProfileStoreSourceForProvider > does not count empty provider profiles as credential evidence 1ms
✓ |agents| src/agents/auth-profiles/source-check.test.ts > hasAuthProfileStoreSourceForProvider > does not count expired token profiles as credential evidence 2ms
✓ |agents| src/agents/auth-profiles/source-check.test.ts > hasAuthProfileStoreSourceForProvider > treats oversized auth-profiles.json as no usable provider source 2ms

 Test Files  1 passed (1)
      Tests  9 passed (9)
```

### Observed result after fix

Oversized store (~1 MiB+) with an embedded usable `openai` credential prefix
returns `false` in 2ms; normal-sized stores still return `true`.

### What was not tested

Live gateway doctor/status UI path against a deliberately oversized store on a
running operator install.

### Fix classification

bugfix — resource bound / OOM hardening

## AI Assistance

AI-assisted implementation and proof.
