### PR TITLE
fix(release): plugin npm preflight no longer hangs on stalled registries

### DIFF
--- a/scripts/lib/plugin-npm-release.ts
+++ b/scripts/lib/plugin-npm-release.ts
@@ -644,6 +644,10 @@ export function assertPluginReleaseVersionFloors(
 
 export type NpmLatestVersionResolver = (packageName: string) => string;
 
+function isNpmViewTimeoutError(error: unknown): error is Error & { code: "ETIMEDOUT" } {
+  return error instanceof Error && "code" in error && error.code === "ETIMEDOUT";
+}
+
 function runNpmView(args: string[]): string {
   const tempDir = mkdtempSync(join(tmpdir(), "openclaw-plugin-npm-view-"));
   const userconfigPath = join(tempDir, "npmrc");
@@ -658,10 +662,13 @@ function runNpmView(args: string[]): string {
         timeout: PLUGIN_NPM_VIEW_TIMEOUT_MS,
       }).trim();
     } catch (error) {
-      if (error instanceof Error && "code" in error && error.code === "ETIMEDOUT") {
-        throw new Error(`npm view timed out after ${PLUGIN_NPM_VIEW_TIMEOUT_MS}ms.`, {
-          cause: error,
-        });
+      if (isNpmViewTimeoutError(error)) {
+        throw Object.assign(
+          new Error(`npm view timed out after ${PLUGIN_NPM_VIEW_TIMEOUT_MS}ms.`, {
+            cause: error,
+          }),
+          { code: "ETIMEDOUT" as const },
+        );
       }
       throw error;
     }
@@ -733,7 +740,10 @@ function isPluginVersionPublished(packageName: string, version: string): boolean
   try {
     runNpmView([`${packageName}@${version}`, "version"]);
     return true;
-  } catch {
+  } catch (error) {
+    if (isNpmViewTimeoutError(error)) {
+      throw error;
+    }
     return false;
   }
 }

--- a/scripts/lib/plugin-npm-release.ts
+++ b/scripts/lib/plugin-npm-release.ts
@@ -112,6 +112,7 @@ type PublishablePluginPackageCandidate<TPackageJson extends PluginPackageJson = 
   };
 
 export const OPENCLAW_PLUGIN_NPM_REPOSITORY_URL = "https://github.com/openclaw/openclaw";
+const PLUGIN_NPM_VIEW_TIMEOUT_MS = 60_000;
 
 export function collectRequiredLatestDependencies(packageJson: PluginPackageJson): {
   dependencies: RequiredLatestDependency[];
@@ -649,10 +650,21 @@ function runNpmView(args: string[]): string {
   writeFileSync(userconfigPath, "");
 
   try {
-    return execFileSync("npm", ["view", ...args, "--userconfig", userconfigPath], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "pipe"],
-    }).trim();
+    try {
+      return execFileSync("npm", ["view", ...args, "--userconfig", userconfigPath], {
+        encoding: "utf8",
+        killSignal: "SIGKILL",
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: PLUGIN_NPM_VIEW_TIMEOUT_MS,
+      }).trim();
+    } catch (error) {
+      if (error instanceof Error && "code" in error && error.code === "ETIMEDOUT") {
+        throw new Error(`npm view timed out after ${PLUGIN_NPM_VIEW_TIMEOUT_MS}ms.`, {
+          cause: error,
+        });
+      }
+      throw error;
+    }
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
   }

--- a/test/plugin-npm-release.test.ts
+++ b/test/plugin-npm-release.test.ts
@@ -7,6 +7,7 @@ import { collectClawHubPublishablePluginPackages } from "../scripts/lib/plugin-c
 import {
   collectChangedExtensionIdsFromPaths,
   collectPluginReleaseDependencyFreshnessErrors,
+  collectPluginReleasePlan,
   collectPluginReleaseVersionFloorErrors,
   collectPublishablePluginPackages,
   collectPublishablePluginPackageErrors,
@@ -493,6 +494,48 @@ describe("collectPluginReleaseDependencyFreshnessErrors", () => {
     expect(collectPluginReleaseDependencyFreshnessErrors([plugin])).toEqual([
       "@openclaw/codex@2026.6.11: could not resolve npm latest for @openai/codex: npm view timed out after 60000ms.",
     ]);
+  });
+});
+
+describe("collectPluginReleasePlan", () => {
+  it("fails closed when the published-version lookup times out", () => {
+    const repoDir = makeTempRepoRoot(tempDirs, "openclaw-plugin-npm-release-");
+    mkdirSync(join(repoDir, "extensions", "demo-plugin"), { recursive: true });
+    writePluginReadme(repoDir, "demo-plugin");
+    writeJsonFile(join(repoDir, "extensions", "demo-plugin", "package.json"), {
+      name: "@openclaw/demo-plugin",
+      version: "2026.4.10",
+      type: "module",
+      repository: {
+        type: "git",
+        url: OPENCLAW_PLUGIN_NPM_REPOSITORY_URL,
+      },
+      openclaw: {
+        extensions: ["./index.ts"],
+        ...externalPluginContract("2026.4.10"),
+        install: {
+          npmSpec: "@openclaw/demo-plugin",
+        },
+        release: {
+          publishToNpm: true,
+        },
+      },
+    });
+    childProcessMock.execFileSyncOverride = ((command: string, args?: readonly string[]) => {
+      expect(command).toBe("npm");
+      expect(args).toEqual([
+        "view",
+        "@openclaw/demo-plugin@2026.4.10",
+        "version",
+        "--userconfig",
+        expect.stringContaining("openclaw-plugin-npm-view-"),
+      ]);
+      throw Object.assign(new Error("spawnSync npm ETIMEDOUT"), { code: "ETIMEDOUT" });
+    }) as ExecFileSync;
+
+    expect(() => collectPluginReleasePlan({ rootDir: repoDir })).toThrow(
+      "npm view timed out after 60000ms.",
+    );
   });
 });
 

--- a/test/plugin-npm-release.test.ts
+++ b/test/plugin-npm-release.test.ts
@@ -2,7 +2,7 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { bundledPluginFile, bundledPluginRoot } from "openclaw/plugin-sdk/test-fixtures";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { collectClawHubPublishablePluginPackages } from "../scripts/lib/plugin-clawhub-release.ts";
 import {
   collectChangedExtensionIdsFromPaths,
@@ -21,9 +21,27 @@ import {
 } from "../scripts/lib/plugin-npm-release.ts";
 import { cleanupTempDirs, makeTempRepoRoot, writeJsonFile } from "./helpers/temp-repo.js";
 
+type ExecFileSync = typeof import("node:child_process").execFileSync;
+
+const childProcessMock = vi.hoisted(() => ({
+  execFileSyncOverride: undefined as ExecFileSync | undefined,
+}));
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  const execFileSync = ((...args: unknown[]) => {
+    const implementation = (childProcessMock.execFileSyncOverride ?? actual.execFileSync) as (
+      ...args: unknown[]
+    ) => unknown;
+    return implementation(...args);
+  }) as ExecFileSync;
+  return { ...actual, execFileSync };
+});
+
 const tempDirs: string[] = [];
 
 afterEach(() => {
+  childProcessMock.execFileSyncOverride = undefined;
   cleanupTempDirs(tempDirs);
 });
 
@@ -447,6 +465,33 @@ describe("collectPluginReleaseDependencyFreshnessErrors", () => {
       }),
     ).toEqual([
       "@openclaw/codex@2026.6.11: could not resolve npm latest for @openai/codex: registry unavailable",
+    ]);
+  });
+
+  it("fails closed when the npm latest lookup times out", () => {
+    childProcessMock.execFileSyncOverride = ((
+      command: string,
+      args?: readonly string[],
+      options?: unknown,
+    ) => {
+      expect(command).toBe("npm");
+      expect(args).toEqual([
+        "view",
+        "@openai/codex",
+        "dist-tags.latest",
+        "--json",
+        "--userconfig",
+        expect.stringContaining("openclaw-plugin-npm-view-"),
+      ]);
+      expect(options).toMatchObject({
+        killSignal: "SIGKILL",
+        timeout: 60_000,
+      });
+      throw Object.assign(new Error("spawnSync npm ETIMEDOUT"), { code: "ETIMEDOUT" });
+    }) as ExecFileSync;
+
+    expect(collectPluginReleaseDependencyFreshnessErrors([plugin])).toEqual([
+      "@openclaw/codex@2026.6.11: could not resolve npm latest for @openai/codex: npm view timed out after 60000ms.",
     ]);
   });
 });

--- a/test/plugin-npm-release.test.ts
+++ b/test/plugin-npm-release.test.ts
@@ -489,7 +489,7 @@ describe("collectPluginReleaseDependencyFreshnessErrors", () => {
         timeout: 60_000,
       });
       throw Object.assign(new Error("spawnSync npm ETIMEDOUT"), { code: "ETIMEDOUT" });
-    }) as ExecFileSync;
+    }) as unknown as ExecFileSync;
 
     expect(collectPluginReleaseDependencyFreshnessErrors([plugin])).toEqual([
       "@openclaw/codex@2026.6.11: could not resolve npm latest for @openai/codex: npm view timed out after 60000ms.",
@@ -531,7 +531,7 @@ describe("collectPluginReleasePlan", () => {
         expect.stringContaining("openclaw-plugin-npm-view-"),
       ]);
       throw Object.assign(new Error("spawnSync npm ETIMEDOUT"), { code: "ETIMEDOUT" });
-    }) as ExecFileSync;
+    }) as unknown as ExecFileSync;
 
     expect(() => collectPluginReleasePlan({ rootDir: repoDir })).toThrow(
       "npm view timed out after 60000ms.",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the plugin npm release preflight could block indefinitely when the configured registry accepted an npm metadata request but stopped responding while `dist-tags.latest` was being resolved.

## Why This Change Was Made

`runNpmView()` is the canonical launch point for both plugin dependency-freshness queries and published-version checks. It now applies one 60-second subprocess deadline, uses `SIGKILL` when that deadline expires, and converts Node's `ETIMEDOUT` failure into a stable `npm view timed out after 60000ms` diagnostic. Published-version checks propagate that timeout instead of treating an unavailable registry as proof that a package is unpublished.

The change stays inside the private release helper: exported resolver types, plugin metadata, CLI options, release selection, compatibility behavior, and successful registry responses are unchanged. A fresh same-problem open-PR scan found no competing implementation.

## User Impact

Release operators now get a fail-closed, recognizable error after a stalled registry lookup instead of an indefinitely blocked synchronous preflight. Healthy npm registry lookups and existing release-plan behavior remain unchanged.

## Evidence

- Regression red: the new default-resolver test failed because the npm child options lacked both `timeout` and `killSignal`, and the collector surfaced that assertion instead of a timeout diagnostic.
- Regression green: `test/plugin-npm-release.test.ts` passed all 39 tests, including the release-plan published-version timeout path.
- Near-real issue path: temporary publishable plugin fixtures used both production consumers against a local HTTP/1 registry that accepted requests and never responded. Freshness returned after 60,071ms with `npm view timed out after 60000ms`; the published-version release-plan path threw the same error after 60,068ms instead of producing a publish candidate. The outer bounded proof did not time out.
- Static checks: scoped `oxfmt --check` and `oxlint` passed for the changed source and test files.
- CI repair: the first hosted run found TS2352 in the two new overloaded `execFileSync` test mocks. The repair casts those intentionally narrow callbacks through `unknown`; it changes no production code or emitted test behavior. The unrelated compact-shard descendant-output timing failure is left for the repaired hosted head to re-evaluate.
- Validation boundary: repository policy requires fork checkout execution to remain in secretless hosted CI. A sanitized AWS runner was unavailable because no AWS identity could be resolved; local `git diff --check` passed, and the updated GitHub CI run is the authoritative test-types validation.
