### PR TITLE
fix(agents): mid-turn assistant text from claude-cli turns never reaches the channel even with block streaming enabled

### DIFF
--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -2650,7 +2650,11 @@ describe("createCliJsonlStreamingParser", () => {
     });
 
   it("emits completed block segments with message ordinals across tool boundaries", () => {
-    const segments: Array<{ text: string; assistantMessageIndex: number }> = [];
+    const segments: Array<{
+      text: string;
+      assistantMessageIndex: number;
+      assistantBlockIndex: number;
+    }> = [];
     const deltas: Array<{ text: string; delta: string }> = [];
     const parser = createCliJsonlStreamingParser({
       backend: claudeStreamJsonBackend,
@@ -2673,8 +2677,8 @@ describe("createCliJsonlStreamingParser", () => {
     parser.finish();
 
     expect(segments).toEqual([
-      { text: "Inspecting the repo.", assistantMessageIndex: 0 },
-      { text: "Short wrap-up.", assistantMessageIndex: 1 },
+      { text: "Inspecting the repo.", assistantMessageIndex: 0, assistantBlockIndex: 0 },
+      { text: "Short wrap-up.", assistantMessageIndex: 1, assistantBlockIndex: 0 },
     ]);
     // Without a commentary consumer the preview lane still streams per delta.
     expect(deltas).toEqual([
@@ -2685,7 +2689,11 @@ describe("createCliJsonlStreamingParser", () => {
   });
 
   it("emits pre-tool block segments alongside commentary when both consumers are wired", () => {
-    const segments: Array<{ text: string; assistantMessageIndex: number }> = [];
+    const segments: Array<{
+      text: string;
+      assistantMessageIndex: number;
+      assistantBlockIndex: number;
+    }> = [];
     const commentaryTexts: string[] = [];
     const deltas: Array<{ text: string; delta: string }> = [];
     const parser = createCliJsonlStreamingParser({
@@ -2710,14 +2718,18 @@ describe("createCliJsonlStreamingParser", () => {
 
     expect(commentaryTexts).toEqual(["Checking the config."]);
     expect(segments).toEqual([
-      { text: "Checking the config.", assistantMessageIndex: 0 },
-      { text: "Done.", assistantMessageIndex: 1 },
+      { text: "Checking the config.", assistantMessageIndex: 0, assistantBlockIndex: 0 },
+      { text: "Done.", assistantMessageIndex: 1, assistantBlockIndex: 0 },
     ]);
     expect(deltas).toEqual([{ text: "Done.", delta: "Done." }]);
   });
 
   it("splits block segments at text block boundaries within one message", () => {
-    const segments: Array<{ text: string; assistantMessageIndex: number }> = [];
+    const segments: Array<{
+      text: string;
+      assistantMessageIndex: number;
+      assistantBlockIndex: number;
+    }> = [];
     const parser = createCliJsonlStreamingParser({
       backend: claudeStreamJsonBackend,
       providerId: "claude-cli",
@@ -2737,13 +2749,17 @@ describe("createCliJsonlStreamingParser", () => {
     parser.finish();
 
     expect(segments).toEqual([
-      { text: "First block.", assistantMessageIndex: 0 },
-      { text: "Second block.", assistantMessageIndex: 0 },
+      { text: "First block.", assistantMessageIndex: 0, assistantBlockIndex: 0 },
+      { text: "Second block.", assistantMessageIndex: 0, assistantBlockIndex: 1 },
     ]);
   });
 
   it("reports the tail block segment when a result event arrives without message_stop", () => {
-    const segments: Array<{ text: string; assistantMessageIndex: number }> = [];
+    const segments: Array<{
+      text: string;
+      assistantMessageIndex: number;
+      assistantBlockIndex: number;
+    }> = [];
     const parser = createCliJsonlStreamingParser({
       backend: claudeStreamJsonBackend,
       providerId: "claude-cli",
@@ -2760,11 +2776,17 @@ describe("createCliJsonlStreamingParser", () => {
     );
     parser.finish();
 
-    expect(segments).toEqual([{ text: "Tail text.", assistantMessageIndex: 0 }]);
+    expect(segments).toEqual([
+      { text: "Tail text.", assistantMessageIndex: 0, assistantBlockIndex: 0 },
+    ]);
   });
 
   it("flushes the trailing block segment when the stream ends without terminal events", () => {
-    const segments: Array<{ text: string; assistantMessageIndex: number }> = [];
+    const segments: Array<{
+      text: string;
+      assistantMessageIndex: number;
+      assistantBlockIndex: number;
+    }> = [];
     const parser = createCliJsonlStreamingParser({
       backend: claudeStreamJsonBackend,
       providerId: "claude-cli",
@@ -2780,11 +2802,17 @@ describe("createCliJsonlStreamingParser", () => {
     );
     parser.finish();
 
-    expect(segments).toEqual([{ text: "Partial narration.", assistantMessageIndex: 0 }]);
+    expect(segments).toEqual([
+      { text: "Partial narration.", assistantMessageIndex: 0, assistantBlockIndex: 0 },
+    ]);
   });
 
   it("does not emit block segments for the gemini stream-json dialect", () => {
-    const segments: Array<{ text: string; assistantMessageIndex: number }> = [];
+    const segments: Array<{
+      text: string;
+      assistantMessageIndex: number;
+      assistantBlockIndex: number;
+    }> = [];
     const parser = createCliJsonlStreamingParser({
       backend: {
         command: "gemini",
@@ -2808,6 +2836,55 @@ describe("createCliJsonlStreamingParser", () => {
     // Gemini terminal results already include all streamed text, so no segment lane.
     expect(segments).toEqual([]);
     expect(parser.getOutput()?.text).toBe("Gemini text.");
+  });
+
+  it("uses distinct block ordinals for pre-tool and post-tool text within one message", () => {
+    // Claude can emit text → tool_use → text all inside one assistant message,
+    // where both text blocks share the same message ordinal. The block index
+    // must distinguish them so transport rotation does not overwrite the first.
+    const segments: Array<{
+      text: string;
+      assistantMessageIndex: number;
+      assistantBlockIndex: number;
+    }> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: claudeStreamJsonBackend,
+      providerId: "claude-cli",
+      onAssistantDelta: () => undefined,
+      onAssistantBlockText: (segment) => segments.push(segment),
+    });
+
+    parser.push(
+      [
+        JSON.stringify({ type: "init", session_id: "session-text-tool-text" }),
+        // Pre-tool narration in content block 0.
+        textDeltaLine("Let me inspect the config."),
+        // Tool use starts in content block 1 — boundary flushes the pre-tool text.
+        streamEventLine({
+          type: "content_block_start",
+          index: 1,
+          content_block: { type: "tool_use", id: "toolu_proof", name: "Bash", input: {} },
+        }),
+        // Post-tool text in content block 2 (same assistant message, no message_stop yet).
+        streamEventLine({ type: "content_block_start", index: 2, content_block: { type: "text" } }),
+        textDeltaLine("Done — check complete."),
+        streamEventLine({ type: "message_stop" }),
+      ].join("\n") + "\n",
+    );
+    parser.finish();
+
+    expect(segments).toEqual([
+      {
+        text: "Let me inspect the config.",
+        assistantMessageIndex: 0,
+        assistantBlockIndex: 0,
+      },
+      {
+        text: "Done — check complete.",
+        assistantMessageIndex: 0,
+        assistantBlockIndex: 1,
+      },
+    ]);
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -1,6 +1,7 @@
 /** Tests CLI JSON/JSONL output parsing, streamed deltas, and error extraction. */
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
+import type { CliBackendConfig } from "../config/types.js";
 import {
   createCliJsonlStreamingParser,
   extractCliErrorMessage,
@@ -2629,6 +2630,184 @@ describe("createCliJsonlStreamingParser", () => {
     parser.finish();
 
     expect(commentaryTexts).toEqual(["Reading the file now.", "Now searching."]);
+  });
+
+  const claudeStreamJsonBackend = {
+    command: "claude",
+    output: "jsonl",
+    jsonlDialect: "claude-stream-json",
+    sessionIdFields: ["session_id"],
+  } satisfies CliBackendConfig;
+  const streamEventLine = (event: Record<string, unknown>) =>
+    JSON.stringify({ type: "stream_event", event });
+  const textDeltaLine = (text: string) =>
+    streamEventLine({ type: "content_block_delta", delta: { type: "text_delta", text } });
+  const toolUseStartLine = (id: string) =>
+    streamEventLine({
+      type: "content_block_start",
+      index: 1,
+      content_block: { type: "tool_use", id, name: "Read", input: {} },
+    });
+
+  it("emits completed block segments with message ordinals across tool boundaries", () => {
+    const segments: Array<{ text: string; assistantMessageIndex: number }> = [];
+    const deltas: Array<{ text: string; delta: string }> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: claudeStreamJsonBackend,
+      providerId: "claude-cli",
+      onAssistantDelta: (delta) => deltas.push({ text: delta.text, delta: delta.delta }),
+      onAssistantBlockText: (segment) => segments.push(segment),
+    });
+
+    parser.push(
+      [
+        JSON.stringify({ type: "init", session_id: "session-blocks" }),
+        textDeltaLine("Inspecting the repo."),
+        toolUseStartLine("toolu_1"),
+        streamEventLine({ type: "message_stop" }),
+        textDeltaLine("Short wrap-up."),
+        streamEventLine({ type: "message_stop" }),
+        JSON.stringify({ type: "result", result: "Short wrap-up.", session_id: "session-blocks" }),
+      ].join("\n") + "\n",
+    );
+    parser.finish();
+
+    expect(segments).toEqual([
+      { text: "Inspecting the repo.", assistantMessageIndex: 0 },
+      { text: "Short wrap-up.", assistantMessageIndex: 1 },
+    ]);
+    // Without a commentary consumer the preview lane still streams per delta.
+    expect(deltas).toEqual([
+      { text: "Inspecting the repo.", delta: "Inspecting the repo." },
+      { text: "Inspecting the repo.Short wrap-up.", delta: "Short wrap-up." },
+    ]);
+    expect(parser.getOutput()?.text).toBe("Short wrap-up.");
+  });
+
+  it("emits pre-tool block segments alongside commentary when both consumers are wired", () => {
+    const segments: Array<{ text: string; assistantMessageIndex: number }> = [];
+    const commentaryTexts: string[] = [];
+    const deltas: Array<{ text: string; delta: string }> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: claudeStreamJsonBackend,
+      providerId: "claude-cli",
+      onAssistantDelta: (delta) => deltas.push({ text: delta.text, delta: delta.delta }),
+      onCommentaryText: (text) => commentaryTexts.push(text),
+      onAssistantBlockText: (segment) => segments.push(segment),
+    });
+
+    parser.push(
+      [
+        JSON.stringify({ type: "init", session_id: "session-both-lanes" }),
+        textDeltaLine("Checking the config."),
+        toolUseStartLine("toolu_1"),
+        streamEventLine({ type: "message_stop" }),
+        textDeltaLine("Done."),
+        streamEventLine({ type: "message_stop" }),
+      ].join("\n") + "\n",
+    );
+    parser.finish();
+
+    expect(commentaryTexts).toEqual(["Checking the config."]);
+    expect(segments).toEqual([
+      { text: "Checking the config.", assistantMessageIndex: 0 },
+      { text: "Done.", assistantMessageIndex: 1 },
+    ]);
+    expect(deltas).toEqual([{ text: "Done.", delta: "Done." }]);
+  });
+
+  it("splits block segments at text block boundaries within one message", () => {
+    const segments: Array<{ text: string; assistantMessageIndex: number }> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: claudeStreamJsonBackend,
+      providerId: "claude-cli",
+      onAssistantDelta: () => undefined,
+      onAssistantBlockText: (segment) => segments.push(segment),
+    });
+
+    parser.push(
+      [
+        JSON.stringify({ type: "init", session_id: "session-split" }),
+        textDeltaLine("First block."),
+        streamEventLine({ type: "content_block_start", index: 2, content_block: { type: "text" } }),
+        textDeltaLine("Second block."),
+        streamEventLine({ type: "message_stop" }),
+      ].join("\n") + "\n",
+    );
+    parser.finish();
+
+    expect(segments).toEqual([
+      { text: "First block.", assistantMessageIndex: 0 },
+      { text: "Second block.", assistantMessageIndex: 0 },
+    ]);
+  });
+
+  it("reports the tail block segment when a result event arrives without message_stop", () => {
+    const segments: Array<{ text: string; assistantMessageIndex: number }> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: claudeStreamJsonBackend,
+      providerId: "claude-cli",
+      onAssistantDelta: () => undefined,
+      onAssistantBlockText: (segment) => segments.push(segment),
+    });
+
+    parser.push(
+      [
+        JSON.stringify({ type: "init", session_id: "session-tail" }),
+        textDeltaLine("Tail text."),
+        JSON.stringify({ type: "result", result: "Tail text.", session_id: "session-tail" }),
+      ].join("\n") + "\n",
+    );
+    parser.finish();
+
+    expect(segments).toEqual([{ text: "Tail text.", assistantMessageIndex: 0 }]);
+  });
+
+  it("flushes the trailing block segment when the stream ends without terminal events", () => {
+    const segments: Array<{ text: string; assistantMessageIndex: number }> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: claudeStreamJsonBackend,
+      providerId: "claude-cli",
+      onAssistantDelta: () => undefined,
+      onAssistantBlockText: (segment) => segments.push(segment),
+    });
+
+    parser.push(
+      [
+        JSON.stringify({ type: "init", session_id: "session-truncated" }),
+        textDeltaLine("Partial narration."),
+      ].join("\n") + "\n",
+    );
+    parser.finish();
+
+    expect(segments).toEqual([{ text: "Partial narration.", assistantMessageIndex: 0 }]);
+  });
+
+  it("does not emit block segments for the gemini stream-json dialect", () => {
+    const segments: Array<{ text: string; assistantMessageIndex: number }> = [];
+    const parser = createCliJsonlStreamingParser({
+      backend: {
+        command: "gemini",
+        output: "jsonl",
+        jsonlDialect: "gemini-stream-json",
+        sessionIdFields: ["session_id"],
+      },
+      providerId: "google-gemini-cli",
+      onAssistantDelta: () => undefined,
+      onAssistantBlockText: (segment) => segments.push(segment),
+    });
+
+    parser.push(
+      [
+        JSON.stringify({ type: "message", role: "assistant", content: "Gemini text." }),
+        JSON.stringify({ type: "result", status: "success" }),
+      ].join("\n") + "\n",
+    );
+    parser.finish();
+
+    // Gemini terminal results already include all streamed text, so no segment lane.
+    expect(segments).toEqual([]);
+    expect(parser.getOutput()?.text).toBe("Gemini text.");
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -132,6 +132,8 @@ export type CliAssistantBlockDelta = {
   text: string;
   /** Ordinal of the assistant message this segment belongs to (message_stop advances it). */
   assistantMessageIndex: number;
+  /** Zero-based ordinal of this completed text block within the assistant message. */
+  assistantBlockIndex: number;
 };
 
 export type CliPlanUpdate = {
@@ -1248,12 +1250,14 @@ export function createCliJsonlStreamingParser(params: {
   // Marks the assistantText suffix that has not been reported as a completed segment.
   let assistantBlockStart = 0;
   let assistantMessageIndex = 0;
+  let assistantBlockIndex = 0;
   const thinkingTracker = createThinkingTracker();
 
   const emitAssistantBlockSegment = (segmentText: string) => {
     const text = segmentText.trim();
     if (text && wantAssistantBlocks) {
-      params.onAssistantBlockText?.({ text, assistantMessageIndex });
+      params.onAssistantBlockText?.({ text, assistantMessageIndex, assistantBlockIndex });
+      assistantBlockIndex += 1;
     }
   };
 
@@ -1432,6 +1436,7 @@ export function createCliJsonlStreamingParser(params: {
         flushAssistantBlockFromAccumulated();
         if (evt.type === "message_stop") {
           assistantMessageIndex += 1;
+          assistantBlockIndex = 0;
         }
       }
     }

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -127,6 +127,13 @@ export type CliThinkingProgress = {
   progressTokens: number;
 };
 
+/** Completed assistant text segment emitted at Claude stream block boundaries. */
+export type CliAssistantBlockDelta = {
+  text: string;
+  /** Ordinal of the assistant message this segment belongs to (message_stop advances it). */
+  assistantMessageIndex: number;
+};
+
 export type CliPlanUpdate = {
   steps: AgentPlanStep[];
 };
@@ -1211,6 +1218,7 @@ export function createCliJsonlStreamingParser(params: {
   onToolUseStart?: (delta: CliToolUseStartDelta) => void;
   onToolResult?: (delta: CliToolResultDelta) => void;
   onCommentaryText?: (text: string) => void;
+  onAssistantBlockText?: (delta: CliAssistantBlockDelta) => void;
   onSessionId?: (sessionId: string) => void;
   onAssistantMessage?: (message: unknown) => void;
   onUsage?: (usage: CliUsage, terminal: boolean) => void;
@@ -1232,7 +1240,28 @@ export function createCliJsonlStreamingParser(params: {
   // always has a destination; a separate enable flag let it be dropped (#92092).
   const classifyClaudeCommentary =
     Boolean(params.onCommentaryText) && supportsCliJsonlToolEvents(params);
+  // Completed-segment tracking is Claude-dialect only: the Claude terminal result
+  // carries only the final message, so earlier segments need their own durable
+  // path. Other dialects fold all streamed text into the terminal result already.
+  const wantAssistantBlocks =
+    Boolean(params.onAssistantBlockText) && isClaudeStreamJsonDialect(params);
+  // Marks the assistantText suffix that has not been reported as a completed segment.
+  let assistantBlockStart = 0;
+  let assistantMessageIndex = 0;
   const thinkingTracker = createThinkingTracker();
+
+  const emitAssistantBlockSegment = (segmentText: string) => {
+    const text = segmentText.trim();
+    if (text && wantAssistantBlocks) {
+      params.onAssistantBlockText?.({ text, assistantMessageIndex });
+    }
+  };
+
+  const flushAssistantBlockFromAccumulated = () => {
+    const segment = assistantText.slice(assistantBlockStart);
+    assistantBlockStart = assistantText.length;
+    emitAssistantBlockSegment(segment);
+  };
 
   const flushPendingClaudeAssistantText = () => {
     if (!pendingClaudeText) {
@@ -1257,6 +1286,9 @@ export function createCliJsonlStreamingParser(params: {
     pendingClaudeText = "";
     if (text) {
       params.onCommentaryText?.(text);
+      // Commentary-classified text never joins assistantText, so report the
+      // completed pre-tool segment directly instead of via the accumulated marker.
+      emitAssistantBlockSegment(text);
     }
   };
 
@@ -1308,8 +1340,11 @@ export function createCliJsonlStreamingParser(params: {
       return;
     }
 
-    if (classifyClaudeCommentary && parsed.type === "result") {
+    if ((classifyClaudeCommentary || wantAssistantBlocks) && parsed.type === "result") {
       flushPendingClaudeAssistantText();
+      // Terminal result without a preceding message_stop (truncated stream)
+      // still owes the tail segment before result handling below returns.
+      flushAssistantBlockFromAccumulated();
     }
 
     const result = parseClaudeCliJsonlResult({
@@ -1374,16 +1409,30 @@ export function createCliJsonlStreamingParser(params: {
       }
     }
 
-    if (classifyClaudeCommentary && parsed.type === "stream_event" && isRecord(parsed.event)) {
+    if (
+      (classifyClaudeCommentary || wantAssistantBlocks) &&
+      parsed.type === "stream_event" &&
+      isRecord(parsed.event)
+    ) {
       const evt = parsed.event;
       if (
         evt.type === "content_block_start" &&
         isRecord(evt.content_block) &&
         isClaudeToolUseBlockType(evt.content_block.type)
       ) {
-        flushPendingClaudeCommentaryText();
+        if (classifyClaudeCommentary) {
+          flushPendingClaudeCommentaryText();
+        } else {
+          // Without a commentary consumer pre-tool text stays in assistantText;
+          // the tool boundary still completes it as a durable segment.
+          flushAssistantBlockFromAccumulated();
+        }
       } else if (evt.type === "content_block_start" || evt.type === "message_stop") {
         flushPendingClaudeAssistantText();
+        flushAssistantBlockFromAccumulated();
+        if (evt.type === "message_stop") {
+          assistantMessageIndex += 1;
+        }
       }
     }
 
@@ -1527,6 +1576,8 @@ export function createCliJsonlStreamingParser(params: {
       if (classifyClaudeCommentary) {
         flushPendingClaudeAssistantText();
       }
+      // Streams that end without message_stop or result still owe the tail segment.
+      flushAssistantBlockFromAccumulated();
     },
     getErrorText() {
       return parseErrorText || null;

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -29,6 +29,7 @@ import {
   createCliJsonlStreamingParser,
   extractCliErrorMessage,
   parseCliOutput,
+  type CliAssistantBlockDelta,
   type CliOutput,
   type CliUsage,
   type CliStreamJsonOutputLimits,
@@ -1394,6 +1395,7 @@ function createTurn(params: {
     delta: CliToolResultDelta,
   ) => ClaudeLiveToolTerminalOutcome | undefined;
   onCommentaryText?: (text: string) => void;
+  onAssistantBlockText?: (delta: CliAssistantBlockDelta) => void;
   onSessionId?: (sessionId: string) => void;
   onAssistantMessage?: (message: unknown) => void;
   onUsage?: (usage: CliUsage, terminal: boolean) => void;
@@ -1443,6 +1445,7 @@ function createTurn(params: {
         params.onToolResult?.(delta);
       },
       onCommentaryText: params.onCommentaryText,
+      onAssistantBlockText: params.onAssistantBlockText,
       onSessionId: params.onSessionId,
       onAssistantMessage: params.onAssistantMessage,
       onUsage: params.onUsage,
@@ -1542,6 +1545,7 @@ export async function runClaudeLiveSessionTurn(params: {
     delta: CliToolResultDelta,
   ) => ClaudeLiveToolTerminalOutcome | undefined;
   onCommentaryText?: (text: string) => void;
+  onAssistantBlockText?: (delta: CliAssistantBlockDelta) => void;
   onMcpCaptureReady?: (captureKey: string) => void;
   onSessionId?: (sessionId: string) => void;
   onAssistantMessage?: (message: unknown) => void;
@@ -1772,6 +1776,7 @@ export async function runClaudeLiveSessionTurn(params: {
       onToolResult: params.onToolResult,
       resolveToolResultTerminalOutcome: params.resolveToolResultTerminalOutcome,
       onCommentaryText: params.onCommentaryText,
+      onAssistantBlockText: params.onAssistantBlockText,
       onSessionId: params.onSessionId,
       onAssistantMessage: params.onAssistantMessage,
       onUsage: params.onUsage,

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -1529,6 +1529,7 @@ export async function executePreparedCliRun(
         const emitCliAssistantBlockText = ({
           text,
           assistantMessageIndex,
+          assistantBlockIndex: blockIndex,
         }: CliAssistantBlockDelta) => {
           observedCliActivity = true;
           if (!emitLiveEvents) {
@@ -1543,6 +1544,7 @@ export async function executePreparedCliRun(
                 context.backendResolved.textTransforms?.output,
               ),
               assistantMessageIndex,
+              assistantBlockIndex: blockIndex,
             },
           });
         };

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -47,6 +47,7 @@ import {
   createCliJsonlStreamingParser,
   extractCliErrorMessage,
   parseCliOutput,
+  type CliAssistantBlockDelta,
   type CliOutput,
   type CliPlanUpdate,
   type CliStreamingDelta,
@@ -1523,6 +1524,28 @@ export async function executePreparedCliRun(
             },
           });
         };
+        // Completed segments ride the assistant stream without text/delta fields so
+        // preview and transcript consumers (which key on those fields) ignore them.
+        const emitCliAssistantBlockText = ({
+          text,
+          assistantMessageIndex,
+        }: CliAssistantBlockDelta) => {
+          observedCliActivity = true;
+          if (!emitLiveEvents) {
+            return;
+          }
+          emitAgentEvent({
+            runId: params.runId,
+            stream: "assistant",
+            data: {
+              blockText: applyPluginTextReplacements(
+                text,
+                context.backendResolved.textTransforms?.output,
+              ),
+              assistantMessageIndex,
+            },
+          });
+        };
         // Emit-always: thinking reaches the agent-event bus and session archive
         // like the embedded reasoning stream; /reasoning and /verbose gate only
         // presentation. Text stays raw here to match the thinking-stream contract
@@ -1607,6 +1630,10 @@ export async function executePreparedCliRun(
               emitLiveEvents && context.params.emitCommentaryText
                 ? emitCliCommentaryText
                 : undefined,
+            onAssistantBlockText:
+              emitLiveEvents && context.params.emitAssistantBlockText
+                ? emitCliAssistantBlockText
+                : undefined,
             onMcpCaptureReady: beginGatewayCapture,
             cleanup: async () => {
               await fallbackClaudeSkillsPlugin?.cleanup();
@@ -1645,6 +1672,10 @@ export async function executePreparedCliRun(
                 onCommentaryText:
                   emitLiveEvents && context.params.emitCommentaryText
                     ? emitCliCommentaryText
+                    : undefined,
+                onAssistantBlockText:
+                  emitLiveEvents && context.params.emitAssistantBlockText
+                    ? emitCliAssistantBlockText
                     : undefined,
                 onSessionId: (sessionId) => {
                   observeForkSuccessor(sessionId);

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -199,6 +199,8 @@ export type RunCliAgentParams = {
   }) => void;
   replyOperation?: ReplyOperation;
   emitCommentaryText?: boolean;
+  /** Emit completed assistant text segments as agent events for durable block delivery. */
+  emitAssistantBlockText?: boolean;
   /**
    * Close any long-lived CLI live session created for this run after the run
    * finishes. Intended for temporary helper calls that should not keep process

--- a/src/auto-reply/reply/agent-runner-cli-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-cli-candidate.ts
@@ -125,16 +125,27 @@ export async function runCliFallbackCandidate(params: {
   // Durable segment lane: completed CLI text blocks reach the same block-reply
   // handler embedded runs use, so blockStreaming applies to CLI turns and the
   // pipeline's dedupe suppresses the terminal CLI result when already streamed.
+  // Each completed block receives a compound assistant-message identity encoding
+  // both the Claude message ordinal and the within-message block ordinal so the
+  // coalescer flushes on every completed-block boundary and transport rotation
+  // (e.g. Telegram's answer lane) does not overwrite an earlier block with a
+  // later block from the same assistant message.
   const cliBlockReplyHandler = params.presentation.blockReplyHandler;
   const deliverAssistantBlockText =
     turn.blockStreamingEnabled && cliBlockReplyHandler
-      ? async (payload: { text: string; assistantMessageIndex?: number }) => {
+      ? async (payload: {
+          text: string;
+          assistantMessageIndex?: number;
+          assistantBlockIndex?: number;
+        }) => {
+          const effectiveIndex =
+            payload.assistantMessageIndex !== undefined && payload.assistantBlockIndex !== undefined
+              ? payload.assistantMessageIndex * 1000 + payload.assistantBlockIndex
+              : payload.assistantMessageIndex;
           await cliBlockReplyHandler(
             setReplyPayloadMetadata(
               { text: payload.text },
-              payload.assistantMessageIndex !== undefined
-                ? { assistantMessageIndex: payload.assistantMessageIndex }
-                : {},
+              effectiveIndex !== undefined ? { assistantMessageIndex: effectiveIndex } : {},
             ),
           );
         }

--- a/src/auto-reply/reply/agent-runner-cli-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-cli-candidate.ts
@@ -10,6 +10,7 @@ import {
 } from "../../agents/run-termination.js";
 import { withLocalSessionPlacementTurnAdmission } from "../../agents/session-placement-admission.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { setReplyPayloadMetadata } from "../reply-payload.js";
 import type { ThinkLevel } from "../thinking.js";
 import type { ReplyPayload } from "../types.js";
 import {
@@ -35,7 +36,10 @@ import { isReplyOperationRestartAbort } from "./reply-operation-abort.js";
 
 type CliPresentation = Pick<
   ReturnType<typeof createAgentTurnPresentation>,
-  "handlePartialForTyping" | "preparePartialForTyping" | "startPresentationWhileTyping"
+  | "blockReplyHandler"
+  | "handlePartialForTyping"
+  | "preparePartialForTyping"
+  | "startPresentationWhileTyping"
 >;
 
 export async function runCliFallbackCandidate(params: {
@@ -118,6 +122,23 @@ export async function runCliFallbackCandidate(params: {
       await turn.opts?.onToolResult?.(payload);
     },
   });
+  // Durable segment lane: completed CLI text blocks reach the same block-reply
+  // handler embedded runs use, so blockStreaming applies to CLI turns and the
+  // pipeline's dedupe suppresses the terminal CLI result when already streamed.
+  const cliBlockReplyHandler = params.presentation.blockReplyHandler;
+  const deliverAssistantBlockText =
+    turn.blockStreamingEnabled && cliBlockReplyHandler
+      ? async (payload: { text: string; assistantMessageIndex?: number }) => {
+          await cliBlockReplyHandler(
+            setReplyPayloadMetadata(
+              { text: payload.text },
+              payload.assistantMessageIndex !== undefined
+                ? { assistantMessageIndex: payload.assistantMessageIndex }
+                : {},
+            ),
+          );
+        }
+      : undefined;
   const result = await params.timing.measure("cli_run", () =>
     withLocalSessionPlacementTurnAdmission(
       {
@@ -161,6 +182,7 @@ export async function runCliFallbackCandidate(params: {
             );
           },
           onReasoningText: createCliReasoningStreamBridge(turn.opts?.onReasoningStream),
+          onAssistantBlockText: deliverAssistantBlockText,
           onPlanUpdate: turn.opts?.onPlanUpdate,
           onReasoningProgress: async (payload) => {
             await turn.opts?.onReasoningProgress?.(payload);

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
@@ -93,7 +93,11 @@ describe("runCliAgentWithLifecycle", () => {
         emitAgentEvent({
           runId: params.runId,
           stream: "assistant",
-          data: { blockText: "Inspecting the repo.", assistantMessageIndex: 0 },
+          data: {
+            blockText: "Inspecting the repo.",
+            assistantMessageIndex: 0,
+            assistantBlockIndex: 0,
+          },
         });
         emitAgentEvent({
           runId: params.runId,
@@ -103,13 +107,21 @@ describe("runCliAgentWithLifecycle", () => {
         emitAgentEvent({
           runId: params.runId,
           stream: "assistant",
-          data: { blockText: "Short wrap-up.", assistantMessageIndex: 1 },
+          data: {
+            blockText: "Short wrap-up.",
+            assistantMessageIndex: 1,
+            assistantBlockIndex: 0,
+          },
         });
         return { payloads: [{ text: "Short wrap-up." }], meta: { durationMs: 1 } };
       },
     );
     const onAssistantBlockText = vi.fn<
-      (payload: { text: string; assistantMessageIndex?: number }) => Promise<void>
+      (payload: {
+        text: string;
+        assistantMessageIndex?: number;
+        assistantBlockIndex?: number;
+      }) => Promise<void>
     >(async () => undefined);
     const onAssistantText = vi.fn<(text: string) => Promise<void>>(async () => undefined);
 
@@ -132,11 +144,68 @@ describe("runCliAgentWithLifecycle", () => {
     });
 
     expect(onAssistantBlockText.mock.calls.map(([payload]) => payload)).toEqual([
-      { text: "Inspecting the repo.", assistantMessageIndex: 0 },
-      { text: "Short wrap-up.", assistantMessageIndex: 1 },
+      { text: "Inspecting the repo.", assistantMessageIndex: 0, assistantBlockIndex: 0 },
+      { text: "Short wrap-up.", assistantMessageIndex: 1, assistantBlockIndex: 0 },
     ]);
     // Snapshot preview lane stays isolated from block segment events.
     expect(onAssistantText.mock.calls.map(([text]) => text)).toEqual(["Inspecting the repo."]);
+  });
+
+  it("forwards assistantBlockIndex through the bridge including within-message distinction", async () => {
+    cliDispatchState.runCliAgentMock.mockImplementationOnce(
+      async (params: { runId: string; emitAssistantBlockText?: boolean }) => {
+        expect(params.emitAssistantBlockText).toBe(true);
+        // text → tool → text within one assistant message — blocks 0 and 1.
+        emitAgentEvent({
+          runId: params.runId,
+          stream: "assistant",
+          data: {
+            blockText: "Pre-tool narration.",
+            assistantMessageIndex: 0,
+            assistantBlockIndex: 0,
+          },
+        });
+        emitAgentEvent({
+          runId: params.runId,
+          stream: "assistant",
+          data: {
+            blockText: "Post-tool wrap-up.",
+            assistantMessageIndex: 0,
+            assistantBlockIndex: 1,
+          },
+        });
+        return { payloads: [{ text: "Post-tool wrap-up." }], meta: { durationMs: 1 } };
+      },
+    );
+    const onAssistantBlockText = vi.fn<
+      (payload: {
+        text: string;
+        assistantMessageIndex?: number;
+        assistantBlockIndex?: number;
+      }) => Promise<void>
+    >(async () => undefined);
+
+    await runCliAgentWithLifecycle({
+      runId: "run-block-split",
+      provider: "claude-cli",
+      onAssistantBlockText,
+      runParams: {
+        sessionId: "session-1",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp/workspace",
+        prompt: "hello",
+        provider: "claude-cli",
+        model: "claude",
+        thinkLevel: "high",
+        timeoutMs: 1_000,
+        runId: "run-block-split",
+      },
+    });
+
+    expect(onAssistantBlockText.mock.calls.map(([payload]) => payload)).toEqual([
+      { text: "Pre-tool narration.", assistantMessageIndex: 0, assistantBlockIndex: 0 },
+      { text: "Post-tool wrap-up.", assistantMessageIndex: 0, assistantBlockIndex: 1 },
+    ]);
   });
 
   it("suppresses block segment delivery for silent-expected runs", async () => {
@@ -144,7 +213,11 @@ describe("runCliAgentWithLifecycle", () => {
       emitAgentEvent({
         runId: params.runId,
         stream: "assistant",
-        data: { blockText: "Hidden narration.", assistantMessageIndex: 0 },
+        data: {
+          blockText: "Hidden narration.",
+          assistantMessageIndex: 0,
+          assistantBlockIndex: 0,
+        },
       });
       return { payloads: [], meta: { durationMs: 1 } };
     });

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.test.ts
@@ -86,6 +86,91 @@ describe("runCliAgentWithLifecycle", () => {
     });
   });
 
+  it("bridges completed assistant block segments and requests their emission", async () => {
+    cliDispatchState.runCliAgentMock.mockImplementationOnce(
+      async (params: { runId: string; emitAssistantBlockText?: boolean }) => {
+        expect(params.emitAssistantBlockText).toBe(true);
+        emitAgentEvent({
+          runId: params.runId,
+          stream: "assistant",
+          data: { blockText: "Inspecting the repo.", assistantMessageIndex: 0 },
+        });
+        emitAgentEvent({
+          runId: params.runId,
+          stream: "assistant",
+          data: { text: "Inspecting the repo.", delta: "Inspecting the repo." },
+        });
+        emitAgentEvent({
+          runId: params.runId,
+          stream: "assistant",
+          data: { blockText: "Short wrap-up.", assistantMessageIndex: 1 },
+        });
+        return { payloads: [{ text: "Short wrap-up." }], meta: { durationMs: 1 } };
+      },
+    );
+    const onAssistantBlockText = vi.fn<
+      (payload: { text: string; assistantMessageIndex?: number }) => Promise<void>
+    >(async () => undefined);
+    const onAssistantText = vi.fn<(text: string) => Promise<void>>(async () => undefined);
+
+    await runCliAgentWithLifecycle({
+      runId: "run-block-bridge",
+      provider: "claude-cli",
+      onAssistantText,
+      onAssistantBlockText,
+      runParams: {
+        sessionId: "session-1",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp/workspace",
+        prompt: "hello",
+        provider: "claude-cli",
+        model: "claude",
+        thinkLevel: "high",
+        timeoutMs: 1_000,
+        runId: "run-block-bridge",
+      },
+    });
+
+    expect(onAssistantBlockText.mock.calls.map(([payload]) => payload)).toEqual([
+      { text: "Inspecting the repo.", assistantMessageIndex: 0 },
+      { text: "Short wrap-up.", assistantMessageIndex: 1 },
+    ]);
+    // Snapshot preview lane stays isolated from block segment events.
+    expect(onAssistantText.mock.calls.map(([text]) => text)).toEqual(["Inspecting the repo."]);
+  });
+
+  it("suppresses block segment delivery for silent-expected runs", async () => {
+    cliDispatchState.runCliAgentMock.mockImplementationOnce(async (params: { runId: string }) => {
+      emitAgentEvent({
+        runId: params.runId,
+        stream: "assistant",
+        data: { blockText: "Hidden narration.", assistantMessageIndex: 0 },
+      });
+      return { payloads: [], meta: { durationMs: 1 } };
+    });
+    const onAssistantBlockText = vi.fn(async () => undefined);
+
+    await runCliAgentWithLifecycle({
+      runId: "run-block-silent",
+      provider: "claude-cli",
+      suppressAssistantBridge: true,
+      onAssistantBlockText,
+      runParams: {
+        sessionId: "session-1",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp/workspace",
+        prompt: "hello",
+        provider: "claude-cli",
+        model: "claude",
+        thinkLevel: "high",
+        timeoutMs: 1_000,
+        runId: "run-block-silent",
+      },
+    });
+
+    expect(onAssistantBlockText).not.toHaveBeenCalled();
+  });
+
   it("normalizes shipped string-step plan events to pending typed steps", async () => {
     cliDispatchState.runCliAgentMock.mockImplementationOnce(async (params: { runId: string }) => {
       emitAgentEvent({

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.ts
@@ -165,6 +165,7 @@ type CommentaryTextPayload = {
 type AssistantBlockTextPayload = {
   text: string;
   assistantMessageIndex?: number;
+  assistantBlockIndex?: number;
 };
 
 function readAssistantBlockTextPayload(
@@ -174,14 +175,18 @@ function readAssistantBlockTextPayload(
     return undefined;
   }
   const text = evt.data.blockText.trim();
-  const assistantMessageIndex = evt.data.assistantMessageIndex;
   if (!text) {
     return undefined;
   }
+  const assistantMessageIndex = evt.data.assistantMessageIndex;
+  const assistantBlockIndex = evt.data.assistantBlockIndex;
   return {
     text,
     ...(typeof assistantMessageIndex === "number" && Number.isFinite(assistantMessageIndex)
       ? { assistantMessageIndex }
+      : {}),
+    ...(typeof assistantBlockIndex === "number" && Number.isFinite(assistantBlockIndex)
+      ? { assistantBlockIndex }
       : {}),
   };
 }

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.ts
@@ -162,6 +162,30 @@ type CommentaryTextPayload = {
   itemId?: string;
 };
 
+type AssistantBlockTextPayload = {
+  text: string;
+  assistantMessageIndex?: number;
+};
+
+function readAssistantBlockTextPayload(
+  evt: AgentEventPayload,
+): AssistantBlockTextPayload | undefined {
+  if (evt.stream !== "assistant" || typeof evt.data.blockText !== "string") {
+    return undefined;
+  }
+  const text = evt.data.blockText.trim();
+  const assistantMessageIndex = evt.data.assistantMessageIndex;
+  if (!text) {
+    return undefined;
+  }
+  return {
+    text,
+    ...(typeof assistantMessageIndex === "number" && Number.isFinite(assistantMessageIndex)
+      ? { assistantMessageIndex }
+      : {}),
+  };
+}
+
 function readCommentaryTextPayload(evt: AgentEventPayload): CommentaryTextPayload | undefined {
   if (evt.stream !== "item" || evt.data.kind !== "preamble") {
     return undefined;
@@ -423,6 +447,8 @@ type RunCliAgentWithLifecycleParams = {
   onActivity?: () => void;
   preserveProgressCallbackStartOrder?: boolean;
   onAssistantText?: (text: string) => Promise<void>;
+  /** Delivers completed assistant text segments for durable block streaming. */
+  onAssistantBlockText?: (payload: AssistantBlockTextPayload) => Promise<void>;
   onReasoningText?: (payload: ReasoningTextPayload) => Promise<void>;
   onReasoningProgress?: (payload: ReasoningProgressPayload) => Promise<void>;
   onToolEvent?: (payload: CliToolEventPayload) => Promise<void>;
@@ -550,6 +576,13 @@ async function runCliAgentWithLifecycleInternal(
     deliver: params.onAssistantText,
     startOrder: progressStartOrder,
   });
+  const assistantBlockBridge = createAgentEventBridge({
+    runId: params.runId,
+    suppressed: params.suppressAssistantBridge,
+    deliver: params.onAssistantBlockText,
+    startOrder: progressStartOrder,
+    read: readAssistantBlockTextPayload,
+  });
   let finalReasoningText: string | undefined;
   const reasoningBridge = createReasoningTextBridge({
     runId: params.runId,
@@ -592,6 +625,7 @@ async function runCliAgentWithLifecycleInternal(
   const bridges = [
     activityBridge,
     assistantBridge,
+    assistantBlockBridge,
     reasoningBridge,
     reasoningProgressBridge,
     toolBridge,
@@ -604,6 +638,8 @@ async function runCliAgentWithLifecycleInternal(
     const rawResult = await runCliAgent({
       ...params.runParams,
       emitCommentaryText: params.runParams.emitCommentaryText ?? Boolean(params.onCommentaryText),
+      emitAssistantBlockText:
+        params.runParams.emitAssistantBlockText ?? Boolean(params.onAssistantBlockText),
     });
     const restartAbortReason = params.runParams.abortSignal?.reason;
     if (isAgentRunRestartAbortReason(restartAbortReason)) {

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -14,6 +14,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import * as sessionTypesModule from "../../config/sessions.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { loadSessionEntry, replaceSessionEntry } from "../../config/sessions/session-accessor.js";
+import { emitAgentEvent } from "../../infra/agent-events.js";
 import {
   onInternalDiagnosticEvent,
   resetDiagnosticEventsForTest,
@@ -2195,6 +2196,104 @@ describe("runReplyAgent claude-cli routing", () => {
     expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
     expect(runCliAgentMock).toHaveBeenCalledTimes(1);
     expectReplyText(result, "ok");
+  });
+
+  it("streams completed CLI text segments as durable block replies and dedupes the final", async () => {
+    runCliAgentMock.mockImplementationOnce(
+      async (params: { runId: string; emitAssistantBlockText?: boolean }) => {
+        expect(params.emitAssistantBlockText).toBe(true);
+        emitAgentEvent({
+          runId: params.runId,
+          stream: "assistant",
+          data: { blockText: "Reading the config files now.", assistantMessageIndex: 0 },
+        });
+        emitAgentEvent({
+          runId: params.runId,
+          stream: "assistant",
+          data: { blockText: "Short wrap-up.", assistantMessageIndex: 1 },
+        });
+        return {
+          payloads: [{ text: "Short wrap-up." }],
+          meta: {
+            agentMeta: { provider: "claude-cli", model: "opus-4.5" },
+            executionTrace: {
+              winnerProvider: "claude-cli",
+              winnerModel: "opus-4.5",
+              attempts: [],
+              fallbackUsed: false,
+              runner: "cli",
+            },
+          },
+        };
+      },
+    );
+    const blockReplies: Array<string | undefined> = [];
+    const typing = createMockTypingController();
+    const sessionCtx = {
+      Provider: "webchat",
+      OriginatingTo: "session:1",
+      AccountId: "primary",
+      MessageSid: "msg",
+    } as unknown as TemplateContext;
+    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+    const followupRun = {
+      prompt: "hello",
+      summaryLine: "hello",
+      enqueuedAt: Date.now(),
+      run: {
+        sessionId: "session",
+        sessionKey: "main",
+        messageProvider: "webchat",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp",
+        config: { agents: { defaults: { cliBackends: { "claude-cli": {} } } } },
+        skillsSnapshot: {},
+        provider: "claude-cli",
+        model: "opus-4.5",
+        thinkLevel: "low",
+        verboseLevel: "off",
+        elevatedLevel: "off",
+        bashElevated: {
+          enabled: false,
+          allowed: false,
+          defaultLevel: "off",
+        },
+        timeoutMs: 1_000,
+      },
+    } as unknown as FollowupRun;
+
+    const result = await runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: "main",
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      typing,
+      sessionCtx,
+      defaultModel: "claude-cli/opus-4.5",
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: true,
+      resolvedBlockStreamingBreak: "text_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+      opts: {
+        onBlockReply: async (payload: ReplyPayload) => {
+          blockReplies.push(payload.text);
+        },
+      },
+    });
+
+    // Mid-turn narration reaches the channel durably; the terminal CLI result
+    // matches the last streamed segment and must not be delivered again.
+    expect(blockReplies).toEqual(["Reading the config files now.", "Short wrap-up."]);
+    const returnedTexts = (Array.isArray(result) ? result : result ? [result] : []).map(
+      (payload) => payload.text,
+    );
+    expect(returnedTexts).not.toContain("Short wrap-up.");
   });
 
   it("does not leak hook-blocked CLI input in raw trace payloads", async () => {

--- a/src/auto-reply/reply/block-reply-pipeline.test.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.test.ts
@@ -112,6 +112,26 @@ describe("createBlockReplyPipeline dedup with threading", () => {
     );
   });
 
+  it("hasSentPayload matches finals that merge several streamed assistant messages", async () => {
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async () => {},
+      timeoutMs: 5000,
+    });
+
+    pipeline.enqueue(
+      setReplyPayloadMetadata({ text: "Interim findings." }, { assistantMessageIndex: 0 }),
+    );
+    pipeline.enqueue(
+      setReplyPayloadMetadata({ text: "Final wrap-up." }, { assistantMessageIndex: 1 }),
+    );
+    await pipeline.flush({ force: true });
+
+    // CLI terminal results join interim and final result text with a newline.
+    expect(pipeline.hasSentPayload({ text: "Interim findings.\nFinal wrap-up." })).toBe(true);
+    expect(pipeline.hasSentPayload({ text: "Interim findings." })).toBe(true);
+    expect(pipeline.hasSentPayload({ text: "Different text entirely." })).toBe(false);
+  });
+
   it("keeps exact payload evidence separate from streamed text coverage", async () => {
     const pipeline = createBlockReplyPipeline({
       onBlockReply: async () => {},

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -358,7 +358,11 @@ export function createBlockReplyPipeline(params: {
           return true;
         }
       }
-      return false;
+      // CLI terminal results can merge several assistant messages into one
+      // payload (interim result + post-notification result). Full-run fragment
+      // coverage still proves delivery, so compare across messages in send order.
+      const allFragments = Array.from(streamedTextFragmentsByMessage.values()).flat();
+      return allFragments.length > 0 && normalize(allFragments.join("")) === target;
     },
     getSentMediaUrls: () => Array.from(sentMediaUrls),
   };


### PR DESCRIPTION
Closes #110067
Related: #106760

## What Problem This Solves

Fixes an issue where users running agents on the `claude-cli` backend would receive only the final short wrap-up of a multi-tool turn, while the substantive mid-turn assistant text — findings, explanations, and even direct questions to the operator — was silently never delivered to the channel.

The durable channel reply for a CLI-backed turn is the CLI `result` field, which carries only the final assistant message. All earlier completed text blocks reach the gateway in real time, but block streaming (`blockStreamingDefault: "on"` / `*.streaming.block.enabled`) was only wired for the embedded runtime: the CLI dispatch path wires `onAssistantText` into the ephemeral preview lane and pre-tool commentary into the ephemeral progress-draft lane, and nothing feeds the durable block-reply pipeline. The field report in #110067 measured a worst case of 3,221 chars of prose across 7 text blocks reduced to a delivered 373-char final block, with a discarded 1,699-char block containing the actual findings and a question the operator never received. #106760 is the same loss observed through Telegram.

## Why This Change Was Made

The Claude stream-json parser already detects every completed-segment boundary (tool_use `content_block_start`, other `content_block_start`, `message_stop`, terminal `result`); this change adds a completed-segment callback at exactly those existing flush points, tagging each segment with its assistant-message ordinal. Segments ride the existing assistant agent-event stream as `blockText` events — deliberately without `text`/`delta` fields, so every existing consumer (previews, live chat, ws-log, OpenAI-compatible endpoints), which keys on those fields, ignores them; emission is additionally gated on a per-run flag that is only set when a block consumer is wired. A new dispatch bridge delivers the segments through the same `blockReplyHandler` the embedded candidate uses, only when block streaming is enabled for the turn, so all existing gates (silent-run suppression, silent-token stripping, threading, coalescing, pipeline ordering and dedupe) apply unchanged.

The terminal CLI result is deduplicated by the existing final-assembly evidence (`hasSentPayload` exact-content and per-message fragment coverage). One generic gap is closed alongside: the CLI can merge an interim result and a post-notification result into a single terminal payload spanning two assistant messages, which per-message fragment coverage cannot match, so `hasSentPayload` now also compares against all streamed fragments in send order — for per-message finals (the embedded shape) this is unreachable, because any earlier non-empty message makes the full-run concatenation a strict superset of the final message's fragments.

Scope is deliberately bounded to the Claude stream-json dialect: Gemini stream-json and Codex item-based results already fold all streamed text into the terminal result, so those backends have no loss to fix (pinned by a test). Segments deliver at completed-text-block grain in both `blockStreamingBreak` modes; the embedded runtime's flush-before-tool behaves the same way at tool boundaries, which are the dominant CLI segment boundary. The followup queue lane is unchanged: it has no live block lane for the embedded runtime either, and delivers final payloads through `sendRunPayloads` for both runtimes, so runtime parity is preserved there.

## User Impact

With block streaming enabled, agents on `claude-cli` (and any custom `claude-stream-json` CLI backend) now deliver each completed mid-turn text block as a normal durable channel message, exactly as the embedded runtime does and as `docs/concepts/streaming.md` documents. Operators of long multi-tool turns see narration, findings, and questions when they are written instead of losing them; the final wrap-up is not duplicated. Turns with block streaming disabled are unchanged, previews and progress drafts are unchanged, and no config, protocol, or persisted-state shape changes.

## Evidence

### Live behavior proof (production CLI runner, real subprocess, production block pipeline and final assembly)

Driver: the production `runCliAgentWithLifecycle` (real `runCliAgent`, real agent-event bridges) spawns a real child process replaying a protocol-faithful Claude stream-json multi-tool turn (substantive narration + question -> `tool_use` -> tool result -> short wrap-up -> `result` envelope), wired to the production `createBlockReplyDeliveryHandler` + `createBlockReplyPipeline` with block streaming enabled, then through the production `buildReplyPayloads` final assembly. The only substitutions are the channel sink (console logger) and the CLI binary (config-registered stream-json backend pointing at the replay script).

Before (current `main`) — the narration and the question never reach the channel; the only delivered message is the wrap-up:

```
[proof] production CLI runner + fake claude subprocess (claude stream-json)
[agent/cli-backend] cli exec: provider=proof-claude-cli model=default promptChars=48 ...
[agent/cli-backend] cli turn: provider=proof-claude-cli model=default durationMs=1397 ...
[proof] terminal CLI result payload: "Done — config check complete."
[channel] delivered message: "Done — config check complete."
[proof] FINAL: durable channel messages (1) = ["Done — config check complete."]
```

After (this patch) — the completed mid-turn block is delivered durably while the turn runs, and the terminal result is suppressed as already streamed instead of double-delivering:

```
[proof] production CLI runner + fake claude subprocess (claude stream-json)
[agent/cli-backend] cli exec: provider=proof-claude-cli model=default promptChars=48 ...
[channel] delivered message: "I inspected the channel config: the webhook secret is missing and retries are set to 0, which is why deliveries drop. Should I also enable retries while I fix this?"
[channel] delivered message: "Done — config check complete."
[agent/cli-backend] cli turn: provider=proof-claude-cli model=default durationMs=1558 ...
[proof] terminal CLI result payload: "Done — config check complete."
[proof] FINAL: durable channel messages (2) = ["I inspected the channel config: ... Should I also enable retries while I fix this?","Done — config check complete."]
```

### Regression coverage

- `cli-output.test.ts` (6 new): segment emission with message ordinals across tool boundaries; pre-tool segments alongside commentary when both consumers are wired; segment splits at text-block boundaries within one message; tail segment on `result` without `message_stop`; tail segment on truncated streams; no segments for the Gemini dialect.
- `agent-runner-cli-dispatch.test.ts` (2 new): the bridge delivers `blockText` events in order and requests their emission while the snapshot preview lane stays isolated; silent-expected runs suppress block delivery.
- `block-reply-pipeline.test.ts` (1 new): finals that merge several streamed assistant messages are recognized as already sent.
- `agent-runner.misc.runreplyagent.test.ts` (1 new, full `runReplyAgent` integration): completed CLI segments stream as durable block replies and the matching terminal payload is not delivered again.
- Against unfixed `main`, 8 of the 10 new tests fail (the two that pass are the negative-behavior guards: Gemini exclusion and silent-run suppression); all pre-existing tests in the touched files pass unchanged in both states.
- Focused runs on the fix: `node scripts/run-vitest.mjs` -> `cli-output.test.ts` 73 passed, `agent-runner-cli-dispatch.test.ts` 24 passed, `block-reply-pipeline.test.ts` 22 passed, `agent-runner.misc.runreplyagent.test.ts` 76 passed, `followup-runner.test.ts` 150 passed, `agent-runner-execution-cli-progress.test.ts` + `agent-runner-execution-cli-sessions.test.ts` 14 passed, `claude-live-session-policy/execute-output-buffer/execute.supervisor-capture` 48 passed.
- `pnpm tsgo:core`, `pnpm tsgo:core:test`, and `pnpm tsgo:test:src` clean; scoped `scripts/run-oxlint.mjs` and `oxfmt` clean on all touched files; `git diff --check` clean.

### Sibling-surface context

The audit behind this fix checked the other decision surfaces for the same defect family: Gemini stream-json and Codex item-dialect terminal results already include all streamed text (no durable loss; the Gemini exclusion is pinned by a test); the embedded runtime path is untouched and its block delivery is unchanged; the followup queue lane runs both runtimes without a live block lane and is intentionally left symmetric; the `claude-stdio` live-session path shares the same streaming parser and receives the same callback plumbing as the plain spawn path; and the ephemeral preview, reasoning, and commentary progress lanes are unchanged, including their existing gating.