### PR TITLE
fix(agents): count tool-loop vetoes toward no-progress

### DIFF
--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -1151,6 +1151,38 @@ describe("tool-loop-detection", () => {
       }
     });
 
+    it("does not let a tool-loop veto bridge changed send outcomes", () => {
+      const state = createState();
+      const params = { action: "send", target: "feishu:oc_chat", text: "ping" };
+      const config: ToolLoopDetectionConfig = {
+        enabled: true,
+        warningThreshold: 1,
+        criticalThreshold: 2,
+        globalCircuitBreakerThreshold: 2,
+        detectors: {
+          genericRepeat: false,
+          knownPollNoProgress: false,
+          pingPong: false,
+        },
+      };
+
+      recordSend(state, "message", params, { ...sendPayload(0), route: { id: "route-a" } }, 0);
+      recordToolCall(state, "message", params, "message-veto", config);
+      recordToolCallOutcome(state, {
+        toolName: "message",
+        toolParams: params,
+        toolCallId: "message-veto",
+        result: {
+          content: [{ type: "text", text: "blocked" }],
+          details: { status: "blocked", deniedReason: "tool-loop" },
+        },
+        config,
+      });
+      recordSend(state, "message", params, { ...sendPayload(1), route: { id: "route-b" } }, 1);
+
+      expect(detectToolCallLoop(state, "message", params, config).stuck).toBe(false);
+    });
+
     it("still escalates repeated plugin/approval vetoes to a critical loop", () => {
       const state = createState();
       const params = { action: "read", target: "feishu:oc_chat" };

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -1110,6 +1110,47 @@ describe("tool-loop-detection", () => {
       }
     });
 
+    it("counts tool-loop vetoes toward the global breaker after repeated no-progress sends", () => {
+      const state = createState();
+      const params = { action: "send", target: "feishu:oc_chat", text: "ping" };
+      const config: ToolLoopDetectionConfig = {
+        enabled: true,
+        warningThreshold: 1,
+        criticalThreshold: 2,
+        globalCircuitBreakerThreshold: 3,
+        detectors: {
+          genericRepeat: false,
+          knownPollNoProgress: false,
+          pingPong: false,
+        },
+      };
+
+      recordSend(state, "message", params, sendPayload(0), 0);
+      recordSend(state, "message", params, sendPayload(1), 1);
+
+      expect(detectToolCallLoop(state, "message", params, config).stuck).toBe(false);
+
+      recordToolCall(state, "message", params, "message-veto", config);
+      recordToolCallOutcome(state, {
+        toolName: "message",
+        toolParams: params,
+        toolCallId: "message-veto",
+        result: {
+          content: [{ type: "text", text: "blocked" }],
+          details: { status: "blocked", deniedReason: "tool-loop" },
+        },
+        config,
+      });
+
+      const after = detectToolCallLoop(state, "message", params, config);
+      expect(after.stuck).toBe(true);
+      if (after.stuck) {
+        expect(after.level).toBe("critical");
+        expect(after.detector).toBe("global_circuit_breaker");
+        expect(after.count).toBe(3);
+      }
+    });
+
     it("still escalates repeated plugin/approval vetoes to a critical loop", () => {
       const state = createState();
       const params = { action: "read", target: "feishu:oc_chat" };

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -41,6 +41,7 @@ const WARNING_THRESHOLD = 10;
 export const UNKNOWN_TOOL_THRESHOLD = 10;
 const CRITICAL_THRESHOLD = 20;
 const GLOBAL_CIRCUIT_BREAKER_THRESHOLD = 30;
+const LOOP_VETO_RESULT_HASH = "tool-loop-veto";
 const DEFAULT_LOOP_DETECTION_CONFIG = {
   enabled: false,
   historySize: TOOL_CALL_HISTORY_SIZE,
@@ -303,10 +304,10 @@ function hashToolOutcome(
 
   const details = isPlainObject(result.details) ? result.details : {};
   const text = extractTextContent(result);
-  // The loop detector's own veto is not real progress; giving it no result hash keeps a
-  // critical loop block sticky instead of letting the block reset the streak (#89090).
+  // The loop detector's own veto is not real progress; keep a stable sentinel hash so the
+  // record still counts toward no-progress without colliding with ordinary progress.
   if (isLoopVetoResult(details)) {
-    return { resultHash: undefined };
+    return { resultHash: LOOP_VETO_RESULT_HASH };
   }
   if (toolName === "exec") {
     const execHash = hashExecToolOutcome(details, text);
@@ -395,12 +396,16 @@ function getNoProgressStreak(
     if (!record || record.toolName !== toolName || record.argsHash !== argsHash) {
       continue;
     }
+    if (record.resultHash === LOOP_VETO_RESULT_HASH) {
+      streak += 1;
+      continue;
+    }
     if (typeof record.resultHash !== "string" || !record.resultHash) {
       continue;
     }
     if (!latestResultHash) {
       latestResultHash = record.resultHash;
-      streak = 1;
+      streak += 1;
       continue;
     }
     if (record.resultHash !== latestResultHash) {

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -390,6 +390,7 @@ function getNoProgressStreak(
 ): { count: number; latestResultHash?: string } {
   let streak = 0;
   let latestResultHash: string | undefined;
+  let pendingLoopVetoes = 0;
 
   for (let i = history.length - 1; i >= 0; i -= 1) {
     const record = history[i];
@@ -397,7 +398,7 @@ function getNoProgressStreak(
       continue;
     }
     if (record.resultHash === LOOP_VETO_RESULT_HASH) {
-      streak += 1;
+      pendingLoopVetoes += 1;
       continue;
     }
     if (typeof record.resultHash !== "string" || !record.resultHash) {
@@ -405,13 +406,15 @@ function getNoProgressStreak(
     }
     if (!latestResultHash) {
       latestResultHash = record.resultHash;
-      streak += 1;
+      streak += 1 + pendingLoopVetoes;
+      pendingLoopVetoes = 0;
       continue;
     }
     if (record.resultHash !== latestResultHash) {
       break;
     }
-    streak += 1;
+    streak += 1 + pendingLoopVetoes;
+    pendingLoopVetoes = 0;
   }
 
   return { count: streak, latestResultHash };


### PR DESCRIPTION
## What Problem This Solves
Tool-loop veto records were hashless, so repeated no-progress calls could stop advancing the streak before the global circuit breaker threshold.

## Why This Change Was Made
Loop vetoes now use a stable sentinel hash and the no-progress streak logic counts that sentinel as another no-progress step, so the breaker can keep advancing without treating the veto as progress.

## User Impact
Repeated identical no-progress tool calls can now cross the global circuit breaker as intended after a loop veto.

## Evidence
- Current head: `97443f7c4f5718c94713d50c6b79772e1ca53e4c`
- Runtime replay (`node --import tsx --input-type=module -`) at the current head recorded two identical no-progress sends plus a `tool-loop` veto, then separately replayed a changed-result `route-a -> veto -> route-b` boundary. Redacted terminal output:

```json
{
  "head": "97443f7c4f5718c94713d50c6b79772e1ca53e4c",
  "afterVeto": {
    "stuck": true,
    "level": "critical",
    "detector": "global_circuit_breaker",
    "count": 3,
    "message": "CRITICAL: message has repeated identical no-progress outcomes 3 times. Session execution blocked by global circuit breaker to prevent runaway loops.",
    "warningKey": "global:message:message:3b05c0b99ee7dde151c7ed477489c53cde5d058dd3bfd2308e41734be9c1341c:f4c55806aa590d05a2091d6f4d0ea89bfb3bcdf8361e8e45e4a47756d8bde45d"
  },
  "afterBoundary": {
    "stuck": false
  }
}
```

- `node scripts/run-vitest.mjs src/agents/tool-loop-detection.test.ts`: passed 1 Vitest shard, 55 tests.
- `git diff --check`: passed.

Closes #109435

AI-assisted: yes (Codex)