### PR TITLE
fix(ui): show tool input when results precede calls

### DIFF
--- a/ui/src/e2e/chat-tool-turn-outcome.e2e.test.ts
+++ b/ui/src/e2e/chat-tool-turn-outcome.e2e.test.ts
@@ -171,6 +171,48 @@ suite.define(() => {
     await context.close();
   });
 
+  it("shows native tool input when the result sorts before its call", async () => {
+    const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      historyMessages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "call-native",
+              name: "example_tool",
+              arguments: { query: "example" },
+            },
+          ],
+          timestamp: 2,
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call-native",
+          toolName: "example_tool",
+          content: [{ type: "text", text: "Native result payload" }],
+          timestamp: 1,
+        },
+      ],
+    });
+
+    await page.goto(`${suite.server.baseUrl}chat`);
+    const row = page.locator(".chat-tool-msg-summary");
+    await row.waitFor();
+    expect(await row.count()).toBe(1);
+    await row.click();
+    const card = page.locator(".chat-tool-card");
+    await card.waitFor();
+    expect(await card.getByText("query:", { exact: true }).count()).toBe(1);
+    expect(await card.getByText("example", { exact: true }).count()).toBe(1);
+    await card.getByText("Tool output", { exact: true }).waitFor();
+    await card.getByText("Native result payload", { exact: true }).waitFor();
+    await captureToolActivityProof(page, "native-result-before-call-expanded");
+    await context.close();
+  });
+
   it("keeps a message-only turn visible with its first message line", async () => {
     const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
     const page = await context.newPage();

--- a/ui/src/pages/chat/chat-thread-grouping.ts
+++ b/ui/src/pages/chat/chat-thread-grouping.ts
@@ -347,10 +347,8 @@ function resolveToolResultCallId(item: ChatItem): string | undefined {
       }
     }
   }
-  if (resultIds.size > 1) {
-    return undefined;
-  }
-  return resultIds.values().next().value ?? resolveMessageToolUseId(message);
+  const resultId = resultIds.values().next().value;
+  return resultIds.size > 1 ? undefined : (resultId ?? resolveMessageToolUseId(message));
 }
 
 function refreshOpenCallIds(
@@ -363,24 +361,23 @@ function refreshOpenCallIds(
       openCallIndexes.delete(callId);
     }
   }
-  const item = coalesced[callIndex];
-  if (!item) {
-    return;
-  }
-  for (const callId of unresolvedToolCallIds(item)) {
+  for (const callId of unresolvedToolCallIds(coalesced[callIndex]!)) {
     openCallIndexes.set(callId, callIndex);
   }
 }
 
 export function coalesceToolActivityMessages(items: ChatItem[]): ChatItem[] {
   const coalesced: ChatItem[] = [];
+  // Defer backward-pair removal so all call-id indexes stay stable.
+  const suppressedIndexes = new Set<number>();
   // Parallel calls can outnumber any fixed lookback window, so each unresolved
   // call id owns its current transcript item until a non-tool boundary.
   const openCallIndexes = new Map<string, number>();
+  // Keep earlier result slots by call id so later calls can restore complete cards.
+  const openResultIndexes = new Map<string, number>();
   for (const item of items) {
     const resultItems = splitBundledToolResultItems(item);
     const unmatchedResultItems: ChatItem[] = [];
-    let mergedResult = false;
     for (const resultItem of resultItems) {
       const callId = resolveToolResultCallId(resultItem);
       const callIndex = callId ? openCallIndexes.get(callId) : undefined;
@@ -393,16 +390,41 @@ export function coalesceToolActivityMessages(items: ChatItem[]): ChatItem[] {
       }
       coalesced[callIndex] = merged;
       refreshOpenCallIds(openCallIndexes, coalesced, callIndex);
-      mergedResult = true;
     }
-    if (mergedResult) {
-      for (const unmatched of unmatchedResultItems) {
-        coalesced.push(unmatched);
+    const hasMergedResult = unmatchedResultItems.length < resultItems.length;
+    if (hasMergedResult || resultItems.length > 1) {
+      const orphanResults = hasMergedResult ? unmatchedResultItems : resultItems;
+      for (const orphanResult of orphanResults) {
+        const callId = resolveToolResultCallId(orphanResult);
+        if (callId) {
+          openResultIndexes.set(callId, openResultIndexes.get(callId) ?? coalesced.length);
+        }
+        coalesced.push(orphanResult);
       }
       continue;
     }
 
     const unresolvedCallIds = unresolvedToolCallIds(item);
+    let backwardMerged = item;
+    const matchedResultIndexes: number[] = [];
+    for (const callId of unresolvedCallIds) {
+      const resultIndex = openResultIndexes.get(callId);
+      const orphanResult = resultIndex === undefined ? undefined : coalesced[resultIndex];
+      const merged = orphanResult ? mergeToolCallResultPair(backwardMerged, orphanResult) : null;
+      if (merged && resultIndex !== undefined) {
+        backwardMerged = merged;
+        matchedResultIndexes.push(resultIndex);
+        openResultIndexes.delete(callId);
+      }
+    }
+    if (matchedResultIndexes.length > 0) {
+      const resultIndex = Math.min(...matchedResultIndexes);
+      coalesced[resultIndex] = backwardMerged;
+      matchedResultIndexes.forEach((index) => suppressedIndexes.add(index));
+      suppressedIndexes.delete(resultIndex);
+      refreshOpenCallIds(openCallIndexes, coalesced, resultIndex);
+      continue;
+    }
     if (unresolvedCallIds.size === 1) {
       const callId = unresolvedCallIds.values().next().value;
       const previousIndex = callId ? openCallIndexes.get(callId) : undefined;
@@ -424,12 +446,17 @@ export function coalesceToolActivityMessages(items: ChatItem[]): ChatItem[] {
     }
     if (isToolTimelineItem(item)) {
       // Orphan results keep the window open for later siblings.
+      const callId = resolveToolResultCallId(item);
+      if (callId) {
+        openResultIndexes.set(callId, openResultIndexes.get(callId) ?? coalesced.length - 1);
+      }
       continue;
     }
     // Any other content (user text, assistant reply, dividers) closes the run.
     openCallIndexes.clear();
+    openResultIndexes.clear();
   }
-  return coalesced;
+  return coalesced.filter((_, index) => !suppressedIndexes.has(index));
 }
 
 function assistantGroupHasReplyText(group: MessageGroup): boolean {

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -1674,6 +1674,141 @@ describe("buildCachedChatItems", () => {
     });
   });
 
+  it("coalesces a native tool result that sorts before its call", () => {
+    const groups = messageGroups({
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "call-native",
+              name: "example_tool",
+              arguments: { query: "example" },
+            },
+          ],
+          timestamp: 2000,
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call-native",
+          toolName: "example_tool",
+          content: [{ type: "text", text: "Native result" }],
+          timestamp: 1000,
+        },
+      ],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groupAt(groups, 0).messages).toHaveLength(1);
+    const cards = extractToolCards(messageAt(groupAt(groups, 0), 0).message, "native-reversed");
+    expect(cards).toHaveLength(1);
+    expect(cards[0]).toMatchObject({
+      callId: "call-native",
+      args: { query: "example" },
+      outputText: "Native result",
+    });
+  });
+
+  it("pairs earlier-sorted same-name tool results by call id", () => {
+    const groups = messageGroups({
+      messages: [
+        {
+          role: "toolResult",
+          toolCallId: "call-a",
+          toolName: "read",
+          content: [{ type: "text", text: "contents of a" }],
+          timestamp: 1000,
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call-b",
+          toolName: "read",
+          content: [{ type: "text", text: "contents of b" }],
+          timestamp: 1001,
+        },
+        {
+          role: "assistant",
+          content: [
+            { type: "toolCall", id: "call-b", name: "read", arguments: { path: "b.ts" } },
+            { type: "toolCall", id: "call-a", name: "read", arguments: { path: "a.ts" } },
+          ],
+          timestamp: 1002,
+        },
+      ],
+    });
+
+    expect(groups).toHaveLength(1);
+    const cards = groupAt(groups, 0).messages.flatMap((entry, index) =>
+      extractToolCards(entry.message, `native-same-name-${index}`),
+    );
+    expect(cards).toHaveLength(2);
+    expect(cards.find((card) => card.callId === "call-a")).toMatchObject({
+      args: { path: "a.ts" },
+      outputText: "contents of a",
+    });
+    expect(cards.find((card) => card.callId === "call-b")).toMatchObject({
+      args: { path: "b.ts" },
+      outputText: "contents of b",
+    });
+  });
+
+  it("pairs an earlier bundled result message with later calls", () => {
+    const groups = messageGroups({
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "call-a", content: "contents of a" },
+            { type: "tool_result", tool_use_id: "call-b", content: "contents of b" },
+          ],
+          timestamp: 1000,
+        },
+        {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "call-a", name: "read", input: { path: "a.ts" } },
+            { type: "tool_use", id: "call-b", name: "read", input: { path: "b.ts" } },
+          ],
+          timestamp: 1001,
+        },
+      ],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groupAt(groups, 0).messages).toHaveLength(1);
+    const cards = extractToolCards(messageAt(groupAt(groups, 0), 0).message, "bundled-reversed");
+    expect(cards.map((card) => [card.callId, card.args, card.outputText])).toEqual([
+      ["call-a", { path: "a.ts" }, "contents of a"],
+      ["call-b", { path: "b.ts" }, "contents of b"],
+    ]);
+  });
+
+  it("preserves mixed content in an earlier bundled result message", () => {
+    const mixedContent = [
+      { type: "text", text: "Keep this explanation" },
+      { type: "tool_result", tool_use_id: "call-a", content: "contents of a" },
+      { type: "tool_result", tool_use_id: "call-b", content: "contents of b" },
+    ];
+    const groups = messageGroups({
+      messages: [
+        { role: "user", content: mixedContent, timestamp: 1000 },
+        {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "call-a", name: "read", input: { path: "a.ts" } },
+            { type: "tool_use", id: "call-b", name: "read", input: { path: "b.ts" } },
+          ],
+          timestamp: 1001,
+        },
+      ],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groupAt(groups, 0).messages).toHaveLength(2);
+    expect(firstMessageContent(groupAt(groups, 0))).toEqual(mixedContent);
+  });
+
   it("coalesces interleaved parallel call/result pairs by call id", () => {
     const groups = messageGroups({
       messages: [
@@ -1834,6 +1969,29 @@ describe("buildCachedChatItems", () => {
     });
 
     // Call and late result stay separate items around the user turn.
+    expect(groups).toHaveLength(3);
+    expect(groups.map((group) => group.role)).toEqual(["tool", "user", "tool"]);
+  });
+
+  it("does not pair an earlier result across a user message boundary", () => {
+    const groups = messageGroups({
+      messages: [
+        {
+          role: "toolResult",
+          toolCallId: "call-x",
+          toolName: "read",
+          content: [{ type: "toolResult", text: "early result" }],
+          timestamp: 1000,
+        },
+        { role: "user", content: "start a new turn", timestamp: 1001 },
+        {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "call-x", name: "read", input: { path: "x.ts" } }],
+          timestamp: 1002,
+        },
+      ],
+    });
+
     expect(groups).toHaveLength(3);
     expect(groups.map((group) => group.role)).toEqual(["tool", "user", "tool"]);
   });


### PR DESCRIPTION
Closes #110769

## What Problem This Solves

Fixes an issue where users viewing native-runtime tool activity in the Control UI could see the tool output but not the stored tool input when transcript ordering placed a result before its matching call.

## Why This Change Was Made

The transcript coalescing layer now pairs calls and results by their stable call ID in either ordering direction, while preserving non-tool boundaries. It also handles parallel same-name calls and result-only bundles without matching by adjacency or tool name.

## User Impact

Expanded tool cards now show the input arguments together with the corresponding output for affected native-runtime transcripts. Unrelated user messages and mixed-content result messages retain their existing boundaries and content.

## Evidence

### Before

<img width="1200" height="800" alt="Before: split tool input and output cards" src="https://github.com/user-attachments/assets/4c482f44-dbc5-48b8-ae13-38e361a72733" />

The same current-main fixture renders two cards: one output-only card and one input-only card.

### After

<img width="1200" height="800" alt="After: one paired tool card with input and output" src="https://gist.githubusercontent.com/vincentkoc/23c18272c88fe02541bd0f5029f80989/raw/e8facb6a08ddbbcfd564733aa93e44f52318bcd8/native-result-before-call-expanded.png" />

Final-head screenshot artifact: https://gist.github.com/vincentkoc/23c18272c88fe02541bd0f5029f80989

The fixture renders one paired card containing both `query: example` and `Native result payload`.

### Automated validation

Exact head: `a21cbc3e72c85b1d2ea241122750deed0c963580`

- Sanitized direct AWS Crabbox: https://crabbox.openclaw.ai/portal/runs/run_83685bb27083
- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-thread.test.ts` - 175 passed
- Control UI Chrome E2E (`chat-tool-turn-outcome.e2e.test.ts`) - 5 passed
- Final-head screenshot artifact - PNG 1200x800, SHA-256 `bce34d852c482d73e1ca055ed9dea7ff238872dd8cec004d66ae4981a7569fab`
- `pnpm format:check` on all changed files - passed
- `git diff --check origin/main...HEAD` - passed
- `pnpm check:changed` - passed, including max-lines ratchet, core/UI typechecks, and oxlint
- Autoreview - clean, no accepted/actionable findings (0.98 confidence)
- Production LOC: +42/-15; test LOC: +200/-0

Punchcard-Session: silver-orchard-workshop-q1

## AI Assistance Disclosure

This change was implemented with Codex assistance. The contributor reviewed the diff and validation evidence before submission.
