### PR TITLE
fix(ui): defer remembered camera auto-enable until talk reaches listening

### DIFF
--- a/ui/src/pages/chat/chat-realtime.test.ts
+++ b/ui/src/pages/chat/chat-realtime.test.ts
@@ -93,7 +93,7 @@ describe("chat realtime actions", () => {
     expect(loadSettings().talkCameraAutoEnable).toBe(false);
   });
 
-  it("auto-enables camera once when the remembered preference is on", async () => {
+  it("auto-enables camera once after the session reaches listening", async () => {
     saveSettings({ ...loadSettings(), talkCameraAutoEnable: true });
     const state = createState();
     const setVideoEnabled = vi
@@ -103,10 +103,31 @@ describe("chat realtime actions", () => {
     await state.toggleRealtimeTalk();
     const session = inspectSession(state);
     session.callbacks.onVideoCapability?.(true);
-    session.callbacks.onVideoCapability?.(true);
+    await Promise.resolve();
+    expect(setVideoEnabled).not.toHaveBeenCalled();
+
+    session.callbacks.onStatus?.("listening");
+    session.callbacks.onStatus?.("listening");
     await vi.waitFor(() => expect(setVideoEnabled).toHaveBeenCalledOnce());
 
     expect(setVideoEnabled).toHaveBeenCalledWith(true);
+  });
+
+  it("does not touch the camera when the session never reaches listening", async () => {
+    saveSettings({ ...loadSettings(), talkCameraAutoEnable: true });
+    const state = createState();
+    const setVideoEnabled = vi
+      .spyOn(RealtimeTalkSession.prototype, "setVideoEnabled")
+      .mockResolvedValue(undefined);
+
+    await state.toggleRealtimeTalk();
+    const session = inspectSession(state);
+    session.callbacks.onVideoCapability?.(true);
+    session.callbacks.onStatus?.("error", "Microphone access failed");
+    await Promise.resolve();
+
+    expect(setVideoEnabled).not.toHaveBeenCalled();
+    expect(loadSettings().talkCameraAutoEnable).toBe(true);
   });
 
   it.each([undefined, false])(
@@ -119,7 +140,9 @@ describe("chat realtime actions", () => {
         .mockResolvedValue(undefined);
 
       await state.toggleRealtimeTalk();
-      inspectSession(state).callbacks.onVideoCapability?.(true);
+      const session = inspectSession(state);
+      session.callbacks.onVideoCapability?.(true);
+      session.callbacks.onStatus?.("listening");
       await Promise.resolve();
 
       expect(setVideoEnabled).not.toHaveBeenCalled();
@@ -134,7 +157,9 @@ describe("chat realtime actions", () => {
     );
 
     await state.toggleRealtimeTalk();
-    inspectSession(state).callbacks.onVideoCapability?.(true);
+    const failingSession = inspectSession(state);
+    failingSession.callbacks.onVideoCapability?.(true);
+    failingSession.callbacks.onStatus?.("listening");
     await vi.waitFor(() => expect(state.realtimeTalkCameraError).toBe(true));
 
     expect(state.realtimeTalkDetail).toBe("Camera access is blocked");

--- a/ui/src/pages/chat/chat-realtime.ts
+++ b/ui/src/pages/chat/chat-realtime.ts
@@ -170,6 +170,18 @@ export function attachChatRealtimeActions(state: ChatRealtimeState) {
             state.realtimeTalkInputLevel.set(0);
           }
           state.requestUpdate();
+          // Remembered camera intent waits for "listening": capability is reported
+          // before transport start, and acquiring the camera while microphone
+          // startup can still fail would prompt for a call that never happens.
+          if (
+            status === "listening" &&
+            state.realtimeTalkVideoCapable &&
+            autoEnableCamera &&
+            !autoEnableCameraAttempted
+          ) {
+            autoEnableCameraAttempted = true;
+            void setRealtimeTalkCameraEnabled(true, { disableAutoEnableOnFailure: true });
+          }
         },
         onVideoCapability: (capable) => {
           if (state.realtimeTalkSession !== session) {
@@ -177,10 +189,6 @@ export function attachChatRealtimeActions(state: ChatRealtimeState) {
           }
           state.realtimeTalkVideoCapable = capable;
           state.requestUpdate();
-          if (capable && autoEnableCamera && !autoEnableCameraAttempted) {
-            autoEnableCameraAttempted = true;
-            void setRealtimeTalkCameraEnabled(true, { disableAutoEnableOnFailure: true });
-          }
         },
         onInputLevel: (level) => {
           if (state.realtimeTalkSession !== session) {


### PR DESCRIPTION
## What Problem This Solves

Post-merge review finding on #110817 (Codex inline P2 / ClawSweeper P1): the remembered camera preference (`talkCameraAutoEnable`) auto-enabled from the `onVideoCapability` callback, which fires after transport construction but before `transport.start()` completes. If microphone startup then fails, the browser has already shown a camera permission prompt for a call that never becomes usable — and the preference stays true, so the prompt repeats on every attempt.

## Why This Change Was Made

Move the auto-enable trigger from `onVideoCapability` into the `onStatus` handler, firing only when the session first reaches `listening` (microphone acquired, transport live) while video-capable, keeping the once-per-session guard and the persist-false-on-failure loop breaker. `onVideoCapability` now only records capability for the toggle UI.

## User Impact

Starting a talk call with a remembered camera never touches the camera unless the voice call actually connects; a failing microphone no longer produces repeated camera permission prompts.

## Evidence

- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-realtime.test.ts` — 19 tests pass. New/updated coverage: auto-enable waits for `listening` (no camera call on capability alone), fires exactly once across repeated `listening` callbacks, session erroring before `listening` never touches the camera and leaves the preference unchanged; existing failure-persists-false and preference-off cases updated to the new timing.
- Autoreview (Codex gpt-5.6-sol): clean, "patch is correct (0.95)".
- Addresses https://github.com/openclaw/openclaw/pull/110817#discussion (Codex P2) and ClawSweeper's P1 timing risk on #110817.
