### PR TITLE
fix(linux): guard quick chat streaming sends

### DIFF
--- a/apps/linux/ui/quickchat.js
+++ b/apps/linux/ui/quickchat.js
@@ -143,13 +143,17 @@ function setGatewayState(payload) {
 
 function updateSendButton() {
   const empty = !elements.input.value.trim();
-  const streaming = activeReply !== null && !activeReply.terminal;
+  const streaming = replyStreaming();
   elements.send.disabled =
     gatewayState !== "up" || empty || selectingAgent || sending || accepted || streaming;
   elements.send.classList.toggle("sending", sending);
   elements.send.classList.toggle("accepted", accepted);
   elements.sendIcon.textContent = sending ? "" : accepted ? "✓" : "↑";
   elements.input.readOnly = sending || accepted || streaming;
+}
+
+function replyStreaming() {
+  return activeReply !== null && !activeReply.terminal;
 }
 
 function nameHue(name) {
@@ -587,7 +591,7 @@ function reveal() {
 
 async function send(openDashboard) {
   const message = elements.input.value.trim();
-  if (gatewayState !== "up" || !message || selectingAgent || sending || accepted) {
+  if (gatewayState !== "up" || !message || selectingAgent || sending || accepted || replyStreaming()) {
     return;
   }
   sending = true;

--- a/test/linux-quickchat-stream.test.ts
+++ b/test/linux-quickchat-stream.test.ts
@@ -69,6 +69,8 @@ function createQuickChatHarness(): Record<string, any> {
   const browserBindingsEnd = quickchatSource.indexOf("elements.input.addEventListener");
   assert.notEqual(browserBindingsEnd, -1, "quickchat browser binding boundary");
   const elements = new Map();
+  const invokeCalls: string[] = [];
+  const timers: Array<() => void> = [];
   let resolveSend;
   const sendResult = new Promise((resolve) => {
     resolveSend = resolve;
@@ -77,6 +79,7 @@ function createQuickChatHarness(): Record<string, any> {
     __TAURI__: {
       core: {
         invoke(method: string) {
+          invokeCalls.push(method);
           return method === "quickchat_send" ? sendResult : Promise.resolve(null);
         },
       },
@@ -87,7 +90,10 @@ function createQuickChatHarness(): Record<string, any> {
     requestAnimationFrame(callback: () => void) {
       callback();
     },
-    setTimeout: () => 1,
+    setTimeout: (callback: () => void) => {
+      timers.push(callback);
+      return timers.length;
+    },
   };
   const document = {
     body: createFakeElement(),
@@ -100,7 +106,7 @@ function createQuickChatHarness(): Record<string, any> {
       return elements.get(selector);
     },
   };
-  const browserContext: Record<string, any> = { document, window };
+  const browserContext: Record<string, any> = { document, invokeCalls, timers, window };
   vm.runInNewContext(
     `${quickchatSource.slice(0, browserBindingsEnd)}
 this.harness = {
@@ -109,6 +115,13 @@ this.harness = {
   requestHide,
   setGatewayUp() { gatewayState = "up"; },
   setMessage(value) { elements.input.value = value; },
+  quickchatSendCount() { return invokeCalls.filter((method) => method === "quickchat_send").length; },
+  runTimers() {
+    const callbacks = timers.splice(0);
+    for (const callback of callbacks) {
+      callback();
+    }
+  },
   pendingCount() { return pendingChatEvents.length; },
   activeRunId() { return activeReply?.runId ?? null; },
   replyText() { return elements.replyText.textContent; },
@@ -246,6 +259,31 @@ test("pre-ack frames replay once for only the acknowledged run", async () => {
     deltaText: "!",
   });
   assert.equal(harness.replyText(), "right!");
+});
+
+test("active streaming reply blocks duplicate programmatic sends", async () => {
+  const harness = createQuickChatHarness();
+  harness.setGatewayUp();
+  harness.setMessage("hello");
+  const sending = harness.send(false);
+  harness.resolveSend({ sessionKey: "global", agentId: "work", runId: "right-run" });
+  await sending;
+  harness.handleChatEvent({
+    sessionKey: "global",
+    agentId: "work",
+    runId: "right-run",
+    state: "delta",
+    deltaText: "partial",
+  });
+  harness.runTimers();
+  assert.equal(harness.quickchatSendCount(), 1);
+
+  harness.setMessage("second");
+  await harness.send(false);
+
+  assert.equal(harness.quickchatSendCount(), 1);
+  assert.equal(harness.activeRunId(), "right-run");
+  assert.equal(harness.replyText(), "partial");
 });
 
 test("hiding clears buffered pre-ack frames", async () => {


### PR DESCRIPTION
AI-assisted.

## What Problem This Solves
Fixes an issue where Linux Quick Chat could send a second message while a reply was still streaming if the send path was triggered programmatically or by Enter after the UI had already been re-enabled.

## Why This Change Was Made
`send()` now checks the same active streaming reply state that the UI uses to disable the composer, so the reply area stays single-threaded until the current turn finishes.

## User Impact
Quick Chat no longer drops or replaces an in-flight streamed reply when a duplicate send slips past the button state.

## Evidence
Current head: `1ffd8763bb771e4554a845eb4432fcb66566bf55`

- `node --input-type=module -` runtime WebView harness loaded `apps/linux/ui/quickchat.js` at the current head with mocked Tauri `invoke/listen` and DOM event listeners. Observed after the first `quickchat_send` ACK plus streaming delta: `replyStreaming=true`, `sendDisabled=true`, `inputReadOnly=true`, `activeRunId="run-1"`, and `quickchatSendCount=1`. After programmatic `send(false)`, Enter, and send-button click duplicate attempts while streaming, `quickchatSendCount` stayed `1` and the reply text remained `partial reply`. After a terminal `final` event, a second message was accepted and `quickchatSendCount` became `2`.
- `node scripts/run-vitest.mjs test/linux-quickchat-stream.test.ts` -> 1 file passed, 10 tests passed.
- `git diff --check` -> passed.