### PR TITLE
fix(nostr): report relay connections only after they succeed

### DIFF
--- a/extensions/nostr/src/channel.lifecycle.test.ts
+++ b/extensions/nostr/src/channel.lifecycle.test.ts
@@ -94,4 +94,22 @@ describe("nostr gateway lifecycle", () => {
     expect(mocks.startNostrBus).toHaveBeenCalledOnce();
     expect(bus.close).toHaveBeenCalledOnce();
   });
+
+  it("describes configured relays without claiming they are already connected", async () => {
+    const bus = createMockBus();
+    mocks.startNostrBus.mockResolvedValueOnce(bus as never);
+    const abort = new AbortController();
+    const account = buildResolvedNostrAccount({ relays: ["wss://relay.example.com"] });
+    const context = createStartAccountContext({ account, abortSignal: abort.signal });
+
+    const task = startNostrGatewayAccount(context);
+    await vi.waitFor(() => expect(mocks.startNostrBus).toHaveBeenCalledOnce());
+
+    expect(context.log?.info).toHaveBeenCalledWith(
+      "[default] Nostr provider started with 1 configured relay(s)",
+    );
+
+    abort.abort();
+    await task;
+  });
 });

--- a/extensions/nostr/src/gateway.ts
+++ b/extensions/nostr/src/gateway.ts
@@ -252,7 +252,7 @@ export const startNostrGatewayAccount: NostrGatewayStart = async (ctx) => {
       activeBuses.set(account.accountId, bus);
 
       ctx.log?.info?.(
-        `[${account.accountId}] Nostr provider started, connected to ${account.relays.length} relay(s)`,
+        `[${account.accountId}] Nostr provider started with ${account.relays.length} configured relay(s)`,
       );
 
       return {

--- a/extensions/nostr/src/nostr-bus.inbound.test.ts
+++ b/extensions/nostr/src/nostr-bus.inbound.test.ts
@@ -22,6 +22,7 @@ type TestNostrBusState = {
 };
 
 const mockState = vi.hoisted(() => ({
+  pool: null as { onRelayConnectionSuccess?: (relay: string) => void } | null,
   handlers: [] as Array<{
     onevent: (event: Record<string, unknown>) => void | Promise<void>;
     oneose?: () => void;
@@ -49,6 +50,12 @@ const mockState = vi.hoisted(() => ({
 
 vi.mock("nostr-tools", () => {
   class MockSimplePool {
+    onRelayConnectionSuccess?: (relay: string) => void;
+
+    constructor() {
+      mockState.pool = this;
+    }
+
     subscribeMany(
       relays: string[],
       filters: unknown,
@@ -153,6 +160,7 @@ describe("startNostrBus inbound guards", () => {
       },
     } as unknown as PluginRuntime);
     mockState.handlers = [];
+    mockState.pool = null;
     ingressTasks = [];
     mockState.subscribeMany.mockClear();
     mockState.publish.mockReset();
@@ -195,6 +203,23 @@ describe("startNostrBus inbound guards", () => {
         since: 0,
       });
     }
+
+    await bus.close();
+  });
+
+  it("reports successful relay connections through onConnect", async () => {
+    const onConnect = vi.fn();
+    const bus = await startTestNostrBus({
+      privateKey: TEST_HEX_PRIVATE_KEY,
+      relays: ["wss://relay.example"],
+      onMessage: vi.fn(async () => {}),
+      onConnect,
+      onMetric: () => {},
+    });
+
+    expect(mockState.pool?.onRelayConnectionSuccess).toBeTypeOf("function");
+    mockState.pool?.onRelayConnectionSuccess?.("wss://relay.example/");
+    expect(onConnect).toHaveBeenCalledWith("wss://relay.example/");
 
     await bus.close();
   });

--- a/extensions/nostr/src/nostr-bus.inbound.test.ts
+++ b/extensions/nostr/src/nostr-bus.inbound.test.ts
@@ -22,7 +22,6 @@ type TestNostrBusState = {
 };
 
 const mockState = vi.hoisted(() => ({
-  pool: null as { onRelayConnectionSuccess?: (relay: string) => void } | null,
   handlers: [] as Array<{
     onevent: (event: Record<string, unknown>) => void | Promise<void>;
     oneose?: () => void;
@@ -52,10 +51,6 @@ vi.mock("nostr-tools", () => {
   class MockSimplePool {
     onRelayConnectionSuccess?: (relay: string) => void;
 
-    constructor() {
-      mockState.pool = this;
-    }
-
     subscribeMany(
       relays: string[],
       filters: unknown,
@@ -66,6 +61,10 @@ vi.mock("nostr-tools", () => {
       },
     ) {
       mockState.subscribeMany(relays, filters, handlers);
+      const relay = relays[0];
+      if (relay) {
+        this.onRelayConnectionSuccess?.(new URL(relay).toString());
+      }
       mockState.handlers.push(handlers);
       return {
         close: mockState.subscriptionClose,
@@ -160,7 +159,6 @@ describe("startNostrBus inbound guards", () => {
       },
     } as unknown as PluginRuntime);
     mockState.handlers = [];
-    mockState.pool = null;
     ingressTasks = [];
     mockState.subscribeMany.mockClear();
     mockState.publish.mockReset();
@@ -217,8 +215,7 @@ describe("startNostrBus inbound guards", () => {
       onMetric: () => {},
     });
 
-    expect(mockState.pool?.onRelayConnectionSuccess).toBeTypeOf("function");
-    mockState.pool?.onRelayConnectionSuccess?.("wss://relay.example/");
+    expect(onConnect).toHaveBeenCalledOnce();
     expect(onConnect).toHaveBeenCalledWith("wss://relay.example/");
 
     await bus.close();

--- a/extensions/nostr/src/nostr-bus.inbound.test.ts
+++ b/extensions/nostr/src/nostr-bus.inbound.test.ts
@@ -208,8 +208,7 @@ describe("startNostrBus inbound guards", () => {
   it("reports successful relay connections through onConnect", async () => {
     const onConnect = vi.fn();
     const bus = await startTestNostrBus({
-      privateKey: TEST_HEX_PRIVATE_KEY,
-      relays: ["wss://relay.example"],
+      ...buildResolvedNostrAccount({ relays: ["wss://relay.example"] }),
       onMessage: vi.fn(async () => {}),
       onConnect,
       onMetric: () => {},

--- a/extensions/nostr/src/nostr-bus.ts
+++ b/extensions/nostr/src/nostr-bus.ts
@@ -304,6 +304,7 @@ export async function startNostrBus(options: NostrBusOptions): Promise<NostrBusH
   const sk = validatePrivateKey(privateKey);
   const pk = getPublicKey(sk);
   const pool = new SimplePool();
+  pool.onRelayConnectionSuccess = options.onConnect;
   const accountId = options.accountId ?? pk.slice(0, 16);
   const gatewayStartedAt = Math.floor(Date.now() / 1000);
   const guardPolicy = createDirectDmPreCryptoGuardPolicy({


### PR DESCRIPTION
Related: #110007

## What Problem This Solves

Fixes an issue where operators starting a Nostr channel with unavailable relays would see the configured relay count reported as already connected, while successful connections to healthy relays produced no connection log.

## Why This Change Was Made

The startup message now describes the number of configured relays without claiming a connection state. The existing Nostr bus `onConnect` callback is wired to nostr-tools' successful relay connection event, so connection logs are emitted only after the relay WebSocket actually connects. This does not change relay configuration, protocol behavior, or public APIs.

## User Impact

Nostr startup logs now distinguish configuration from live connectivity. Operators can see which relays actually connected and no longer receive a false connected count when a configured relay is unreachable.

## Evidence

- Test-first reproduction on current main: both regressions failed before the fix (the connection callback was unset, and startup still claimed the relay was connected).
- Focused tests: 2 files, 32 tests passed.
- `pnpm test:extension nostr`: 19 files, 227 tests passed.
- `pnpm check:changed -- <four changed Nostr files>`: passed on Node 24.15.0 / SQLite 3.51.3, including format, API baseline, boundaries, production/test typecheck, lint, database rules, and import-cycle checks.
- `git diff --check`: passed.
- One `codex review --base origin/main`: no actionable findings.

Live third-party proof used a fresh temporary Nostr key, the real OpenClaw gateway command path (`node scripts/run-node.mjs --log-level debug gateway run`), public relay `wss://relay.nostr.net`, and an unreachable loopback control relay. A control event was written to and read back from the public relay before the observation. No Co-Claw/coclaw path was used.

Before the fix, OpenClaw reported both configured relays as connected even though neither had produced a successful connection event:

```text
[nostr] [default] Nostr provider started, connected to 2 relay(s)
healthyRelayConnectionObserved: false
unreachableRelayConnectionObserved: false
relayControlDelivered: true
```

After the fix, startup reports configuration only. The healthy third-party relay is logged after its WebSocket connection succeeds, while the unreachable control relay is never logged as connected:

```text
[nostr] [default] Nostr provider started with 2 configured relay(s)
[nostr] [default] Connected to relay: wss://relay.nostr.net/
healthyRelayConnectionObserved: true
unreachableRelayConnectionObserved: false
relayControlDelivered: true
```

Local full `pnpm build` was attempted twice. Both runs reached the unified tsdown phase and were terminated by SIGTERM on this host without compiler diagnostics, including one run with a 4 GiB old-space setting. The final source diff was nevertheless built by OpenClaw's `scripts/run-node.mjs` path and exercised through the live gateway proof above; the complete build is left to CI.
