### PR TITLE
fix(nostr): prefixed targets fail to send

### DIFF
--- a/extensions/nostr/runtime-api.ts
+++ b/extensions/nostr/runtime-api.ts
@@ -2,6 +2,5 @@
 // Keep this barrel thin and aligned with the local extension surface.
 
 export type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-export { missingTargetError } from "openclaw/plugin-sdk/channel-feedback";
 export { getPluginRuntimeGatewayRequestScope } from "openclaw/plugin-sdk/plugin-runtime";
 export type { PluginRuntime } from "openclaw/plugin-sdk/runtime-store";

--- a/extensions/nostr/runtime-api.ts
+++ b/extensions/nostr/runtime-api.ts
@@ -2,5 +2,6 @@
 // Keep this barrel thin and aligned with the local extension surface.
 
 export type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+export { missingTargetError } from "openclaw/plugin-sdk/channel-feedback";
 export { getPluginRuntimeGatewayRequestScope } from "openclaw/plugin-sdk/plugin-runtime";
 export type { PluginRuntime } from "openclaw/plugin-sdk/runtime-store";

--- a/extensions/nostr/src/channel.test.ts
+++ b/extensions/nostr/src/channel.test.ts
@@ -259,14 +259,20 @@ describe("nostrPlugin", () => {
       expect(nostrPlugin.messaging?.targetResolver?.looksLikeId?.(raw, normalized)).toBe(true);
     });
 
-    it("normalizes prefixed targets for direct outbound sends", () => {
+    it.each([
+      { name: "hex", target: TEST_HEX_PUBLIC_KEY },
+      {
+        name: "npub",
+        target: "npub140x77qfrg4ncn27dauqjx3t83x4ummcpydzk0zdtehhszg69v7ystddknj",
+      },
+    ])("normalizes prefixed $name targets for direct outbound sends", ({ target }) => {
       const result = nostrPlugin.outbound?.resolveTarget?.({
         cfg: createConfiguredNostrCfg() as OpenClawConfig,
-        to: `nostr:${TEST_HEX_PUBLIC_KEY}`,
+        to: `nostr:${target}`,
         mode: "explicit",
       });
 
-      expect(result).toEqual({ ok: true, to: TEST_HEX_PUBLIC_KEY });
+      expect(result).toEqual({ ok: true, to: normalizePubkey(target) });
     });
 
     it("preserves the missing-target hint when no outbound target is supplied", () => {

--- a/extensions/nostr/src/channel.test.ts
+++ b/extensions/nostr/src/channel.test.ts
@@ -7,9 +7,11 @@ import {
 import type { WizardPrompter } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../runtime-api.js";
+import { nostrPlugin } from "./channel.js";
 import { nostrSetupWizard } from "./setup-surface.js";
 import {
   TEST_HEX_PRIVATE_KEY,
+  TEST_HEX_PUBLIC_KEY,
   TEST_SETUP_RELAY_URLS,
   buildResolvedNostrAccount,
   createConfiguredNostrCfg,
@@ -228,6 +230,23 @@ describe("nostrPlugin", () => {
 
       expect(normalize(`nostr:${TEST_HEX_PRIVATE_KEY}`)).toBe(TEST_HEX_PRIVATE_KEY);
       expect(normalize(`  nostr:${TEST_HEX_PRIVATE_KEY}  `)).toBe(TEST_HEX_PRIVATE_KEY);
+    });
+
+    it("recognizes prefixed targets after provider normalization", () => {
+      const raw = `nostr:${TEST_HEX_PUBLIC_KEY}`;
+      const normalized = nostrPlugin.messaging?.normalizeTarget?.(raw);
+
+      expect(nostrPlugin.messaging?.targetResolver?.looksLikeId?.(raw, normalized)).toBe(true);
+    });
+
+    it("normalizes prefixed targets for direct outbound sends", () => {
+      const result = nostrPlugin.outbound?.resolveTarget?.({
+        cfg: createConfiguredNostrCfg() as OpenClawConfig,
+        to: `nostr:${TEST_HEX_PUBLIC_KEY}`,
+        mode: "explicit",
+      });
+
+      expect(result).toEqual({ ok: true, to: TEST_HEX_PUBLIC_KEY });
     });
   });
 

--- a/extensions/nostr/src/channel.test.ts
+++ b/extensions/nostr/src/channel.test.ts
@@ -8,6 +8,7 @@ import type { WizardPrompter } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../runtime-api.js";
 import { nostrPlugin } from "./channel.js";
+import { normalizePubkey } from "./nostr-key-utils.js";
 import { nostrSetupWizard } from "./setup-surface.js";
 import {
   TEST_HEX_PRIVATE_KEY,
@@ -203,6 +204,16 @@ describe("nostrPlugin", () => {
       const ids = nostrTestPlugin.config.listAccountIds(cfg);
       expect(ids).toContain("default");
     });
+
+    it("normalizes prefixed npub allowlist entries", () => {
+      const npub = "npub140x77qfrg4ncn27dauqjx3t83x4ummcpydzk0zdtehhszg69v7ystddknj";
+      const formatted = nostrPlugin.config.formatAllowFrom?.({
+        cfg: createConfiguredNostrCfg() as OpenClawConfig,
+        allowFrom: [`nostr:${npub}`],
+      });
+
+      expect(formatted).toEqual([normalizePubkey(npub)]);
+    });
   });
 
   describe("messaging", () => {
@@ -247,6 +258,21 @@ describe("nostrPlugin", () => {
       });
 
       expect(result).toEqual({ ok: true, to: TEST_HEX_PUBLIC_KEY });
+    });
+
+    it("preserves the missing-target hint when no outbound target is supplied", () => {
+      const result = nostrPlugin.outbound?.resolveTarget?.({
+        cfg: createConfiguredNostrCfg() as OpenClawConfig,
+        mode: "explicit",
+      });
+
+      expect(result?.ok).toBe(false);
+      if (!result || result.ok) {
+        throw new Error("expected blank Nostr target to fail");
+      }
+      expect(result.error.message).toBe(
+        "Delivering to Nostr requires target <npub|hex pubkey|nostr:npub...>",
+      );
     });
   });
 

--- a/extensions/nostr/src/channel.test.ts
+++ b/extensions/nostr/src/channel.test.ts
@@ -214,6 +214,15 @@ describe("nostrPlugin", () => {
 
       expect(formatted).toEqual([normalizePubkey(npub)]);
     });
+
+    it("preserves invalid prefixed allowlist entries instead of promoting them to wildcards", () => {
+      const formatted = nostrPlugin.config.formatAllowFrom?.({
+        cfg: createConfiguredNostrCfg() as OpenClawConfig,
+        allowFrom: ["nostr:*"],
+      });
+
+      expect(formatted).toEqual(["nostr:*"]);
+    });
   });
 
   describe("messaging", () => {

--- a/extensions/nostr/src/channel.ts
+++ b/extensions/nostr/src/channel.ts
@@ -18,6 +18,7 @@ import {
   createDefaultChannelRuntimeState,
   DEFAULT_ACCOUNT_ID,
   formatPairingApproveHint,
+  type ChannelOutboundAdapter,
   type ChannelPlugin,
 } from "./channel-api.js";
 import type { NostrProfile } from "./config-schema.js";
@@ -91,6 +92,34 @@ const nostrMessageAdapter = createChannelMessageAdapterFromOutbound({
   outbound: nostrOutboundAdapter,
 });
 
+function stripNostrTargetPrefix(target: string): string {
+  return target.trim().replace(/^nostr:/i, "");
+}
+
+function normalizeNostrTarget(target: string): string {
+  const cleaned = stripNostrTargetPrefix(target);
+  try {
+    return normalizePubkey(cleaned);
+  } catch {
+    return cleaned;
+  }
+}
+
+const nostrPluginOutboundAdapter: ChannelOutboundAdapter = {
+  ...nostrOutboundAdapter,
+  resolveTarget: ({ to }) => {
+    const normalized = normalizeNostrTarget(to ?? "");
+    try {
+      return { ok: true, to: normalizePubkey(normalized) };
+    } catch {
+      return {
+        ok: false,
+        error: new Error("Nostr target must be a 64-character hex pubkey or npub value"),
+      };
+    }
+  },
+};
+
 export const nostrPlugin: ChannelPlugin<ResolvedNostrAccount> = createChatChannelPlugin({
   base: {
     id: "nostr",
@@ -125,18 +154,10 @@ export const nostrPlugin: ChannelPlugin<ResolvedNostrAccount> = createChatChanne
     },
     messaging: {
       targetPrefixes: ["nostr"],
-      normalizeTarget: (target) => {
-        // Strip nostr: prefix if present
-        const cleaned = target.trim().replace(/^nostr:/i, "");
-        try {
-          return normalizePubkey(cleaned);
-        } catch {
-          return cleaned;
-        }
-      },
+      normalizeTarget: normalizeNostrTarget,
       targetResolver: {
-        looksLikeId: (input) => {
-          const trimmed = input.trim();
+        looksLikeId: (input, normalized) => {
+          const trimmed = normalized?.trim() || stripNostrTargetPrefix(input);
           return (
             trimmed.startsWith("npub1") ||
             trimmed.startsWith("NPUB1") ||
@@ -179,7 +200,7 @@ export const nostrPlugin: ChannelPlugin<ResolvedNostrAccount> = createChatChanne
   security: {
     resolveDmPolicy: resolveNostrDmPolicy,
   },
-  outbound: nostrOutboundAdapter,
+  outbound: nostrPluginOutboundAdapter,
 });
 
 /**

--- a/extensions/nostr/src/channel.ts
+++ b/extensions/nostr/src/channel.ts
@@ -12,6 +12,7 @@ import {
 } from "openclaw/plugin-sdk/extension-shared";
 import { createComputedAccountStatusAdapter } from "openclaw/plugin-sdk/status-helpers";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { missingTargetError } from "../runtime-api.js";
 import {
   buildChannelConfigSchema,
   collectStatusIssuesFromLastError,
@@ -40,6 +41,21 @@ import {
   type ResolvedNostrAccount,
 } from "./types.js";
 
+const NOSTR_TARGET_HINT = "<npub|hex pubkey|nostr:npub...>";
+
+function stripNostrTargetPrefix(target: string): string {
+  return target.trim().replace(/^nostr:/i, "");
+}
+
+function normalizeNostrTarget(target: string): string {
+  const cleaned = stripNostrTargetPrefix(target);
+  try {
+    return normalizePubkey(cleaned);
+  } catch {
+    return cleaned;
+  }
+}
+
 const resolveNostrDmPolicy = createScopedDmSecurityResolver<ResolvedNostrAccount>({
   channelKey: "nostr",
   resolvePolicy: (account) => account.config.dmPolicy,
@@ -47,13 +63,7 @@ const resolveNostrDmPolicy = createScopedDmSecurityResolver<ResolvedNostrAccount
   policyPathSuffix: "dmPolicy",
   defaultPolicy: "pairing",
   approveHint: formatPairingApproveHint("nostr"),
-  normalizeEntry: (raw) => {
-    try {
-      return normalizePubkey(raw.trim().replace(/^nostr:/i, ""));
-    } catch {
-      return raw.trim();
-    }
-  },
+  normalizeEntry: normalizeNostrTarget,
 });
 
 const nostrConfigAdapter = createTopLevelChannelConfigAdapter<ResolvedNostrAccount>({
@@ -78,11 +88,7 @@ const nostrConfigAdapter = createTopLevelChannelConfigAdapter<ResolvedNostrAccou
         if (entry === "*") {
           return "*";
         }
-        try {
-          return normalizePubkey(entry);
-        } catch {
-          return entry;
-        }
+        return normalizeNostrTarget(entry);
       })
       .filter(Boolean),
 });
@@ -92,23 +98,17 @@ const nostrMessageAdapter = createChannelMessageAdapterFromOutbound({
   outbound: nostrOutboundAdapter,
 });
 
-function stripNostrTargetPrefix(target: string): string {
-  return target.trim().replace(/^nostr:/i, "");
-}
-
-function normalizeNostrTarget(target: string): string {
-  const cleaned = stripNostrTargetPrefix(target);
-  try {
-    return normalizePubkey(cleaned);
-  } catch {
-    return cleaned;
-  }
-}
-
 const nostrPluginOutboundAdapter: ChannelOutboundAdapter = {
   ...nostrOutboundAdapter,
   resolveTarget: ({ to }) => {
-    const normalized = normalizeNostrTarget(to ?? "");
+    const trimmed = to?.trim() ?? "";
+    if (!trimmed) {
+      return {
+        ok: false,
+        error: missingTargetError("Nostr", NOSTR_TARGET_HINT),
+      };
+    }
+    const normalized = normalizeNostrTarget(trimmed);
     try {
       return { ok: true, to: normalizePubkey(normalized) };
     } catch {
@@ -164,7 +164,7 @@ export const nostrPlugin: ChannelPlugin<ResolvedNostrAccount> = createChatChanne
             /^[0-9a-fA-F]{64}$/.test(trimmed)
           );
         },
-        hint: "<npub|hex pubkey|nostr:npub...>",
+        hint: NOSTR_TARGET_HINT,
       },
       resolveOutboundSessionRoute: (params) => resolveNostrOutboundSessionRoute(params),
     },

--- a/extensions/nostr/src/channel.ts
+++ b/extensions/nostr/src/channel.ts
@@ -5,6 +5,7 @@ import {
   createTopLevelChannelConfigAdapter,
 } from "openclaw/plugin-sdk/channel-config-helpers";
 import { createChatChannelPlugin } from "openclaw/plugin-sdk/channel-core";
+import { missingTargetError } from "openclaw/plugin-sdk/channel-feedback";
 import { createChannelMessageAdapterFromOutbound } from "openclaw/plugin-sdk/channel-outbound";
 import {
   buildPassiveChannelStatusSummary,
@@ -12,7 +13,6 @@ import {
 } from "openclaw/plugin-sdk/extension-shared";
 import { createComputedAccountStatusAdapter } from "openclaw/plugin-sdk/status-helpers";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { missingTargetError } from "../runtime-api.js";
 import {
   buildChannelConfigSchema,
   collectStatusIssuesFromLastError,
@@ -52,7 +52,8 @@ function normalizeNostrTarget(target: string): string {
   try {
     return normalizePubkey(cleaned);
   } catch {
-    return cleaned;
+    // Invalid prefixed tokens must stay distinct from "*" so formatting cannot widen access.
+    return target.trim();
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending a Nostr DM to a documented `nostr:npub...` target would get a pubkey validation error, while the same target without the provider prefix worked.

It also preserves the normal missing-target guidance and consistently normalizes `nostr:`-prefixed Nostr allowlist entries, so documented prefixed identities do not fail closed during command/elevated sender matching.

## Why This Change Was Made

Nostr targets and identity entries are normalized through one plugin-owned boundary before recognition, outbound delivery, or allowlist matching. Missing targets still use the shared channel error with the accepted target forms. The change does not alter relay behavior, Nostr protocol handling, account configuration shape, or pairing policy.

## User Impact

Users can send Nostr DMs with either `npub...`, a 64-character hex pubkey, or the documented `nostr:`-prefixed form. Missing targets retain the actionable hint, and prefixed allowlist identities match the same canonical sender identity as unprefixed entries.

## Evidence

- Original regression proof before the prefix fix: 37 passed, 2 failed in `extensions/nostr/src/channel.test.ts`.
- Reviewer follow-up red proof: 39 passed, 2 failed; the blank target returned the invalid-format error, and `nostr:npub...` remained unnormalized in `formatAllowFrom`.
- Authorization-boundary red proof: 1 failed / 41 passed because an invalid prefixed allowlist token was incorrectly promoted to a wildcard.
- Focused final test on Node 24.15.0: 42 passed.
- Runtime API guardrail on Node 24.15.0: 6 passed.
- Nostr extension suite before the final authorization-boundary follow-up: 19 files passed, 229 tests passed.
- Targeted formatting, syntax lint, and `git diff --check` passed.
- Native Codex review against `origin/main` on the final diff: no correctness findings.
- Live before proof on `wss://relay.nostr.net`: an unprefixed control send succeeded, while the equivalent `nostr:npub...` target was rejected before delivery.
- Live final proof on `wss://relay.nostr.net` at base `e04ea791`: two OpenClaw gateways used temporary test keys; the prefixed send returned event `a017cc5810fb340ae0e3c5e252c7217729ee29beb6efc299dd7145d9d564c996`, the receiving gateway created a Nostr pairing request, and its pairing challenge reached the sending gateway through the same public relay.
