### PR TITLE
fix(browser): stop screenshot vision-failure fallback from injecting raw base64

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -110,6 +110,10 @@ const rootEntries = [
   // Worker-thread and script entrypoints import contracts that production Knip cannot trace.
   "src/agents/compaction-planning.worker.ts!",
   "scripts/print-cli-backend-live-metadata.ts!",
+  "scripts/repro/code-mode-namespace-live.ts!",
+  "scripts/repro/browser-vision-failure-live-handler.ts!",
+  "scripts/repro/tool-schema-hint-bench.ts!",
+  "scripts/repro/tool-surface-live-bench.ts!",
   // Workflow/package-script entrypoints are not imported from production modules.
   "scripts/openclaw-cross-os-release-checks.ts!",
   "scripts/bench-transcript-cursors.ts!",

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -3568,4 +3568,188 @@ describe("browser tool upload inbound media fallback (#83544)", () => {
     expect(gatewayMocks.callGatewayTool).not.toHaveBeenCalled();
   });
 });
+
+// Redacted stand-in for the raw PNG bytes the pre-fix catch path base64-encoded
+// into the tool result. Byte content is irrelevant to the mechanism.
+const SAMPLE_SCREENSHOT_BASE64 = Buffer.from("PNG-SCREENSHOT-BYTES-REDACTED").toString("base64");
+
+type ProofToolResult = { content?: readonly unknown[]; details?: unknown } | undefined;
+
+type ProofSessionMessage =
+  | { role: "user" | "assistant"; content: string }
+  | { role: "toolResult"; toolName: string; result: ProofToolResult };
+
+function proofContentBlockTypes(result: ProofToolResult): string[] {
+  const content = result?.content;
+  if (!Array.isArray(content)) {
+    return [];
+  }
+  return content.map((block) => ((block as { type?: unknown })?.type as string) ?? "unknown");
+}
+
+function countImageContentBlocks(result: ProofToolResult): number {
+  return proofContentBlockTypes(result).filter((type) => type === "image").length;
+}
+
+function proofResultText(result: ProofToolResult): string {
+  const content = result?.content;
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return content
+    .filter(
+      (block): block is { type: "text"; text: string } =>
+        (block as { type?: unknown })?.type === "text",
+    )
+    .map((block) => block.text)
+    .join("\n");
+}
+
+function buildContaminationSession(
+  screenshotResult: ProofToolResult,
+  snapshotResult: ProofToolResult,
+): ProofSessionMessage[] {
+  // A read tool result is always plain text; it is the kind of later result the
+  // reported bug forced into image-analysis framing when a base64 screenshot
+  // survived alongside it in session state (#106703, #105305).
+  const readResult: ProofToolResult = {
+    content: [{ type: "text", text: "status=green\nregion=us-west-2" }],
+    details: { path: "/workspace/deploy-status.txt" },
+  };
+  return [
+    { role: "user", content: "screenshot the dashboard and summarize it" },
+    { role: "toolResult", toolName: "browser:screenshot", result: screenshotResult },
+    { role: "assistant", content: "the configured vision model was unavailable" },
+    { role: "user", content: "now read the deploy status file" },
+    { role: "toolResult", toolName: "read", result: readResult },
+    { role: "assistant", content: "deploy is green" },
+    { role: "user", content: "take a page snapshot" },
+    { role: "toolResult", toolName: "browser:snapshot", result: snapshotResult },
+    { role: "assistant", content: "captured snapshot" },
+  ];
+}
+
+function totalImageContentBlocks(session: ProofSessionMessage[]): number {
+  let total = 0;
+  for (const message of session) {
+    if (message.role === "toolResult") {
+      total += countImageContentBlocks(message.result);
+    }
+  }
+  return total;
+}
+
+function redactBase64ForLog(text: string): string {
+  return text.replace(/[A-Za-z0-9+/]{24,}={0,2}/g, (match) => `${match.slice(0, 12)}…REDACTED`);
+}
+
+function renderRedactedResult(label: string, result: ProofToolResult): string {
+  const types = proofContentBlockTypes(result);
+  const images = countImageContentBlocks(result);
+  const text = redactBase64ForLog(proofResultText(result)).replace(/\n/g, " \\n ");
+  return [
+    `--- ${label} ---`,
+    `content-block types: [${types.join(", ")}]`,
+    `image content blocks: ${images}`,
+    `text: ${text}`,
+  ].join("\n");
+}
+
+function renderRedactedTranscript(session: ProofSessionMessage[]): string {
+  const lines: string[] = ["=== session transcript (redacted) ==="];
+  for (const message of session) {
+    if (message.role === "toolResult") {
+      const types = proofContentBlockTypes(message.result).join(", ");
+      const images = countImageContentBlocks(message.result);
+      lines.push(`toolResult(${message.toolName}): blocks=[${types}] images=${images}`);
+      continue;
+    }
+    lines.push(`${message.role}: ${message.content}`);
+  }
+  lines.push(`total image content blocks across session: ${totalImageContentBlocks(session)}`);
+  return lines.join("\n");
+}
+
+describe("browser screenshot vision-failure session-contamination proof (#106703, #105305)", () => {
+  registerBrowserToolAfterEachReset();
+
+  it("drives the real screenshot handler with configured vision forced to fail and keeps later tool results text-only", async () => {
+    // An image-understanding model is configured, so the real screenshot handler
+    // takes the vision path rather than the raw-image fallback.
+    configMocks.loadConfig.mockReturnValue({
+      browser: {},
+      tools: { media: { image: { models: [{ provider: "openai", model: "gpt-vision" }] } } },
+    } as never);
+    // Force the ONLY vision call to fail (configured provider error). Everything
+    // else runs through the real production browser screenshot handler.
+    toolCommonMocks.describeImageFile.mockRejectedValueOnce(
+      new Error("vision provider unavailable (HTTP 503)"),
+    );
+
+    const tool = createBrowserTool();
+    const screenshotResult = await tool.execute?.("call-screenshot", {
+      action: "screenshot",
+      target: "host",
+      targetId: "tab-dashboard",
+    });
+    // A later tool call through the same real handler (no vision involved).
+    const snapshotResult = await tool.execute?.("call-snapshot", {
+      action: "snapshot",
+      target: "host",
+      targetId: "tab-dashboard",
+    });
+
+    const session = buildContaminationSession(screenshotResult, snapshotResult);
+    console.log(
+      renderRedactedResult("real screenshot handler (configured vision failure)", screenshotResult),
+    );
+    console.log(renderRedactedResult("real snapshot handler (later tool call)", snapshotResult));
+    console.log(renderRedactedTranscript(session));
+
+    // The changed catch path returned text only: no base64 image block that
+    // could persist across turns and contaminate later results.
+    expect(countImageContentBlocks(screenshotResult)).toBe(0);
+    expect(proofResultText(screenshotResult)).toContain("browser screenshot vision failed");
+    expect((screenshotResult?.details as { vision?: { failed?: boolean } })?.vision?.failed).toBe(
+      true,
+    );
+    expect((screenshotResult?.details as { media?: unknown })?.media).toBeUndefined();
+    expect(toolCommonMocks.imageResultFromFile).not.toHaveBeenCalled();
+
+    // The later snapshot result stays text-framed and the whole session carries
+    // zero base64 image blocks.
+    expect(countImageContentBlocks(snapshotResult)).toBe(0);
+    expect(totalImageContentBlocks(session)).toBe(0);
+  });
+
+  it("shows the same handler still emits base64 on the unchanged no-vision path (the pre-fix contamination shape)", async () => {
+    // With no image-understanding model configured, the real handler reaches the
+    // unchanged imageResultFromFile path: the exact base64 tool-result shape the
+    // pre-fix catch block produced and that pruneProcessedHistoryImages preserves
+    // for recent turns. This confirms the mechanism is real and that the fix only
+    // neutralizes the configured-vision-failure catch.
+    configMocks.loadConfig.mockReturnValue({ browser: {} } as never);
+    toolCommonMocks.imageResultFromFile.mockResolvedValueOnce({
+      content: [
+        { type: "text", text: "browser:screenshot" },
+        { type: "image", data: SAMPLE_SCREENSHOT_BASE64, mimeType: "image/png" },
+      ],
+      details: { path: "/tmp/test.png", media: { outbound: false } },
+    });
+
+    const tool = createBrowserTool();
+    const rawImageResult = await tool.execute?.("call-screenshot-nofix-shape", {
+      action: "screenshot",
+      target: "host",
+      targetId: "tab-dashboard",
+    });
+
+    console.log(
+      renderRedactedResult("no-vision path (unchanged) screenshot result", rawImageResult),
+    );
+
+    expect(countImageContentBlocks(rawImageResult)).toBe(1);
+    expect(toolCommonMocks.imageResultFromFile).toHaveBeenCalledOnce();
+  });
+});
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -3678,7 +3678,11 @@ describe("browser screenshot vision-failure session-contamination proof (#106703
     // takes the vision path rather than the raw-image fallback.
     configMocks.loadConfig.mockReturnValue({
       browser: {},
-      tools: { media: { image: { models: [{ provider: "openai", model: "gpt-vision" }] } } },
+      tools: {
+        media: {
+          models: [{ provider: "openai", model: "gpt-vision", capabilities: ["image"] }],
+        },
+      },
     } as never);
     // Force the ONLY vision call to fail (configured provider error). Everything
     // else runs through the real production browser screenshot handler.

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -1,4 +1,7 @@
 // Browser tests cover browser tool plugin behavior.
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { Value } from "typebox/value";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -1606,37 +1609,49 @@ describe("browser tool snapshot maxChars", () => {
   });
 
   it("passes configured image sanitization to screenshot image results", async () => {
-    configMocks.loadConfig.mockReturnValue({
-      browser: {},
-      agents: { defaults: { imageMaxDimensionPx: 2000 } },
-    } as never);
-    toolCommonMocks.imageResultFromFile.mockResolvedValueOnce({
-      content: [{ type: "image", data: "base64", mimeType: "image/png" }],
-      details: { path: "/tmp/test.png" },
-    });
+    // No vision/describe model is configured, so image understanding is skipped
+    // and the screenshot falls back to a raw image result. Use a real temp file
+    // because sanitization reads the screenshot to prepare the understanding
+    // input; a missing path would surface as a vision failure instead.
+    const shotDir = mkdtempSync(join(tmpdir(), "oc-screenshot-"));
+    const shotPath = join(shotDir, "test.png");
+    writeFileSync(shotPath, Buffer.from("screenshot-bytes"));
+    try {
+      configMocks.loadConfig.mockReturnValue({
+        browser: {},
+        agents: { defaults: { imageMaxDimensionPx: 2000 } },
+      } as never);
+      browserActionsMocks.browserScreenshotAction.mockResolvedValueOnce({
+        ok: true,
+        path: shotPath,
+      });
+      toolCommonMocks.imageResultFromFile.mockResolvedValueOnce({
+        content: [{ type: "image", data: "base64", mimeType: "image/png" }],
+        details: { path: shotPath },
+      });
 
-    const tool = createBrowserTool();
-    await tool.execute?.("call-1", {
-      action: "screenshot",
-      target: "host",
-      targetId: "tab-1",
-    });
+      const tool = createBrowserTool();
+      await tool.execute?.("call-1", {
+        action: "screenshot",
+        target: "host",
+        targetId: "tab-1",
+      });
 
-    const imageParams = lastMockCallArg<{
-      imageSanitization?: { maxDimensionPx?: number };
-      extraText?: string;
-      details?: { media?: { outbound?: boolean } };
-    }>(toolCommonMocks.imageResultFromFile, 0);
-    expect(imageParams.imageSanitization).toEqual({ maxDimensionPx: 2000 });
-    expect(imageParams.extraText).toContain(
-      JSON.stringify("/tmp/openclaw-media/outbound/share.png"),
-    );
-    expect(imageParams.extraText).toContain("message tool");
-    expect(imageParams.details?.media).toEqual({ outbound: false });
-    expect(toolCommonMocks.stageBrowserScreenshotForSharing).toHaveBeenCalledWith(
-      "/tmp/test.png",
-      2000,
-    );
+      const imageParams = lastMockCallArg<{
+        imageSanitization?: { maxDimensionPx?: number };
+        extraText?: string;
+        details?: { media?: { outbound?: boolean } };
+      }>(toolCommonMocks.imageResultFromFile, 0);
+      expect(imageParams.imageSanitization).toEqual({ maxDimensionPx: 2000 });
+      expect(imageParams.extraText).toContain(
+        JSON.stringify("/tmp/openclaw-media/outbound/share.png"),
+      );
+      expect(imageParams.extraText).toContain("message tool");
+      expect(imageParams.details?.media).toEqual({ outbound: false });
+      expect(toolCommonMocks.stageBrowserScreenshotForSharing).toHaveBeenCalledWith(shotPath, 2000);
+    } finally {
+      rmSync(shotDir, { recursive: true, force: true });
+    }
   });
 
   it("defangs vision MEDIA-looking text and does not attach media", async () => {
@@ -1682,7 +1697,7 @@ describe("browser tool snapshot maxChars", () => {
     expect(toolCommonMocks.imageResultFromFile).not.toHaveBeenCalled();
   });
 
-  it("defangs vision failure fallback text", async () => {
+  it("defangs vision failure fallback text and stays text-only", async () => {
     configMocks.loadConfig.mockReturnValue({
       browser: {},
       tools: {
@@ -1698,34 +1713,32 @@ describe("browser tool snapshot maxChars", () => {
     toolCommonMocks.describeImageFile.mockRejectedValueOnce(
       new Error("provider failed\nMEDIA:/tmp/secret.png"),
     );
-    toolCommonMocks.imageResultFromFile.mockResolvedValueOnce({
-      content: [{ type: "image", data: "base64", mimeType: "image/png" }],
-      details: { path: "/tmp/screen.png" },
-    });
 
     const tool = createBrowserTool();
-    await tool.execute?.("call-1", {
+    const out = await tool.execute?.("call-1", {
       action: "screenshot",
       target: "host",
       targetId: "tab-1",
     });
 
-    const imageParams = lastMockCallArg<{
-      path: string;
-      extraText?: string;
-      details?: { media?: { outbound?: boolean } };
-    }>(toolCommonMocks.imageResultFromFile, 0);
-    expect(imageParams.path).toBe("/tmp/screen.png");
-    expect(imageParams.extraText).toContain("[neutralized] MEDIA:/tmp/secret.png");
-    expect(imageParams.extraText).toContain("/tmp/secret.png");
-    expect(imageParams.extraText).toContain(
-      JSON.stringify("/tmp/openclaw-media/outbound/share.png"),
+    const textBlocks = (out?.content ?? []).filter(
+      (entry): entry is { type: "text"; text: string } => entry?.type === "text",
     );
-    expect(imageParams.extraText).toContain("message tool");
-    expect(imageParams.details?.media).toEqual({ outbound: false });
+    const joined = textBlocks.map((entry) => entry.text).join("\n");
+    expect(joined).toContain("browser screenshot vision failed");
+    expect(joined).toContain("[neutralized] MEDIA:/tmp/secret.png");
+    expect(joined).toContain("/tmp/secret.png");
+    expect(joined).toContain(JSON.stringify("/tmp/openclaw-media/outbound/share.png"));
+    expect(joined).toContain("message tool");
+    // Do not surface details.media so channel auto-delivery cannot grab the raw
+    // screenshot, matching the vision-success path.
+    expect((out?.details as Record<string, unknown>)?.media).toBeUndefined();
+    // A configured-vision failure must not fall back to a raw base64 image
+    // block: that is the session-contaminating path from #106703 / #105305.
+    expect(toolCommonMocks.imageResultFromFile).not.toHaveBeenCalled();
   });
 
-  it("preserves screenshot image sanitization on vision failure fallback", async () => {
+  it("never injects a raw image block when configured vision fails (#106703, #105305)", async () => {
     configMocks.loadConfig.mockReturnValue({
       browser: {},
       tools: {
@@ -1742,27 +1755,30 @@ describe("browser tool snapshot maxChars", () => {
     toolCommonMocks.describeImageFile.mockRejectedValueOnce(
       new Error("vision provider unavailable"),
     );
-    toolCommonMocks.imageResultFromFile.mockResolvedValueOnce({
-      content: [{ type: "image", data: "base64", mimeType: "image/png" }],
-      details: { path: "/tmp/screen.png" },
-    });
 
     const tool = createBrowserTool();
-    await tool.execute?.("call-1", {
+    const out = await tool.execute?.("call-1", {
       action: "screenshot",
       target: "host",
       targetId: "tab-1",
     });
 
-    const imageParams = lastMockCallArg<{
-      imageSanitization?: { maxDimensionPx?: number };
-      extraText?: string;
-    }>(toolCommonMocks.imageResultFromFile, 0);
-    // Fallback path must carry the same image sanitization the non-vision
-    // screenshot path applies; otherwise configured maxDimensionPx is silently
-    // bypassed whenever vision fails.
-    expect(imageParams.imageSanitization).toEqual({ maxDimensionPx: 1600 });
-    expect(imageParams.extraText).toContain("browser screenshot vision failed");
+    // The tool result carries no image content, so it cannot persist across
+    // turns and force later exec/read/snapshot results into image-analysis
+    // framing (the root cause of the reported session corruption).
+    const imageBlocks = (out?.content ?? []).filter(
+      (entry) => (entry as { type?: string })?.type === "image",
+    );
+    expect(imageBlocks).toHaveLength(0);
+    const textBlocks = (out?.content ?? []).filter(
+      (entry): entry is { type: "text"; text: string } => entry?.type === "text",
+    );
+    expect(textBlocks.length).toBeGreaterThan(0);
+    expect(textBlocks.map((entry) => entry.text).join("\n")).toContain(
+      "browser screenshot vision failed",
+    );
+    expect((out?.details as { vision?: { failed?: boolean } })?.vision?.failed).toBe(true);
+    expect(toolCommonMocks.imageResultFromFile).not.toHaveBeenCalled();
   });
 
   it("keeps the screenshot usable when explicit-share staging fails", async () => {

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -894,19 +894,30 @@ export function createBrowserTool(opts?: {
               };
             }
           } catch (err) {
-            // Fall back to returning the raw image block so the agent loop can
-            // still recover. Provider/runtime error messages are untrusted
-            // input too, so defang line-start final-reply media directives.
+            // A vision/describe model was configured but failed at runtime.
+            // Do NOT fall back to injecting the raw base64 image block here: an
+            // image-bearing tool result persists across turns and forces later
+            // tool results (exec, read, snapshot) into image-analysis framing,
+            // corrupting the session until /new (#106703, #105305). The vision
+            // success path already delivers screenshots as a text description,
+            // so a configured-vision failure stays text-only and keeps the
+            // staged outbound copy available for an explicit message-tool share.
+            // Provider/runtime error messages are untrusted input too, so defang
+            // line-start final-reply media directives.
             const rawReason = err instanceof Error ? err.message : String(err);
             const reason = neutralizeMediaDirectives(rawReason);
-            const extraText = `[browser screenshot vision failed: ${reason}]\n${shareHint}`;
-            return await browserToolDeps.imageResultFromFile({
-              label: "browser:screenshot",
-              path: screenshotPath,
-              extraText,
-              details: screenshotDetails,
-              imageSanitization,
-            });
+            const text = `[browser screenshot vision failed: ${reason}]\n${shareHint}`;
+            return {
+              content: [{ type: "text" as const, text }],
+              details: {
+                ...(result as Record<string, unknown>),
+                // No details.media: the deliverable is a text notice, mirroring
+                // the vision-success path so channel auto-delivery cannot grab
+                // the raw screenshot. Explicit sharing uses the staged outbound
+                // path embedded in the text above.
+                vision: { failed: true, error: reason },
+              },
+            };
           }
           return await browserToolDeps.imageResultFromFile({
             label: "browser:screenshot",

--- a/scripts/repro/browser-vision-failure-live-handler.ts
+++ b/scripts/repro/browser-vision-failure-live-handler.ts
@@ -25,7 +25,10 @@ function contentBlockTypes(result: ToolResult): string[] {
   if (!Array.isArray(content)) {
     return [];
   }
-  return content.map((block) => String((block as { type?: unknown }).type ?? "unknown"));
+  return content.map((block) => {
+    const type = (block as { type?: unknown }).type;
+    return typeof type === "string" ? type : "unknown";
+  });
 }
 
 function countImageBlocks(result: ToolResult): number {
@@ -65,7 +68,7 @@ function renderResult(label: string, result: ToolResult): string {
   if (details?.vision?.failed) {
     lines.push(`details.vision.failed: true`);
     if (details.vision.error) {
-      lines.push(`details.vision.error: ${redactPaths(String(details.vision.error))}`);
+      lines.push(`details.vision.error: ${redactPaths(details.vision.error)}`);
     }
   }
   if ("media" in (details ?? {})) {
@@ -74,8 +77,7 @@ function renderResult(label: string, result: ToolResult): string {
   return lines.join("\n");
 }
 
-function buildConfig(controlPort: number): OpenClawConfig {
-  const gatewayPort = controlPort - 2;
+function buildConfig(gatewayPort: number): OpenClawConfig {
   const chromePath =
     process.env.BROWSER_EXECUTABLE_PATH?.trim() ||
     (process.platform === "darwin"
@@ -88,11 +90,10 @@ function buildConfig(controlPort: number): OpenClawConfig {
       headless: true,
       noSandbox: process.platform === "linux",
       defaultProfile: "openclaw",
-      controlPort,
       executablePath: chromePath,
       profiles: {
         openclaw: {
-          cdpPort: controlPort + 11,
+          cdpPort: gatewayPort + 11,
           color: "#FF4500",
         },
       },
@@ -109,13 +110,21 @@ function buildConfig(controlPort: number): OpenClawConfig {
 
 const PROOF_PAGE_URL = "https://example.com/";
 
+function readTargetId(result: ToolResult): string | undefined {
+  const details = result?.details;
+  if (!details || typeof details !== "object") {
+    return undefined;
+  }
+  const targetId = (details as { targetId?: unknown }).targetId;
+  return typeof targetId === "string" ? targetId : undefined;
+}
+
 async function main(): Promise<void> {
-  const controlPort = await getFreePort();
+  const gatewayPort = await getFreePort();
   const stateRoot = await mkdtemp(path.join(os.tmpdir(), "openclaw-live-handler-proof-"));
-  const cfg = buildConfig(controlPort);
+  const cfg = buildConfig(gatewayPort);
   setRuntimeConfigSnapshot(cfg, cfg);
 
-  let pass = false;
   try {
     const service = await startBrowserControlServiceFromConfig();
     if (!service) {
@@ -145,10 +154,7 @@ async function main(): Promise<void> {
       profile: "openclaw",
       url: PROOF_PAGE_URL,
     });
-    const targetId =
-      typeof (openResult?.details as { targetId?: unknown } | undefined)?.targetId === "string"
-        ? ((openResult?.details as { targetId: string }).targetId ?? undefined)
-        : undefined;
+    const targetId = readTargetId(openResult);
     console.log(`opened tab targetId: ${targetId ?? "(default)"}`);
     console.log(`proof page url: ${PROOF_PAGE_URL}`);
 
@@ -178,7 +184,7 @@ async function main(): Promise<void> {
       (screenshotResult?.details as { vision?: { failed?: boolean } } | undefined)?.vision?.failed,
     );
     const screenshotText = resultText(screenshotResult);
-    pass =
+    const pass =
       screenshotImages === 0 &&
       snapshotImages === 0 &&
       visionFailed &&

--- a/scripts/repro/browser-vision-failure-live-handler.ts
+++ b/scripts/repro/browser-vision-failure-live-handler.ts
@@ -9,14 +9,14 @@
 import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../src/config/config.js";
-import type { OpenClawConfig } from "../../src/config/types.js";
 import { createBrowserTool } from "../../extensions/browser/src/browser-tool.js";
 import { getFreePort } from "../../extensions/browser/src/browser/test-port.js";
 import {
   startBrowserControlServiceFromConfig,
   stopBrowserControlService,
 } from "../../extensions/browser/src/control-service.js";
+import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../src/config/config.js";
+import type { OpenClawConfig } from "../../src/config/types.js";
 
 type ToolResult = { content?: readonly unknown[]; details?: unknown } | undefined;
 
@@ -50,9 +50,7 @@ function resultText(result: ToolResult): string {
 }
 
 function redactPaths(text: string): string {
-  return text
-    .replaceAll(os.homedir(), "[redacted-home]")
-    .replaceAll(os.tmpdir(), "[redacted-tmp]");
+  return text.replaceAll(os.homedir(), "[redacted-home]").replaceAll(os.tmpdir(), "[redacted-tmp]");
 }
 
 function renderResult(label: string, result: ToolResult): string {

--- a/scripts/repro/browser-vision-failure-live-handler.ts
+++ b/scripts/repro/browser-vision-failure-live-handler.ts
@@ -1,0 +1,202 @@
+#!/usr/bin/env -S node --import tsx
+/**
+ * Live proof: real createBrowserTool().execute() screenshot catch + later snapshot
+ * through the in-process browser control service (no vitest mocks).
+ *
+ * Run from repo root:
+ *   pnpm exec tsx scripts/repro/browser-vision-failure-live-handler.ts
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../src/config/config.js";
+import type { OpenClawConfig } from "../../src/config/types.js";
+import { createBrowserTool } from "../../extensions/browser/src/browser-tool.js";
+import { getFreePort } from "../../extensions/browser/src/browser/test-port.js";
+import {
+  startBrowserControlServiceFromConfig,
+  stopBrowserControlService,
+} from "../../extensions/browser/src/control-service.js";
+
+type ToolResult = { content?: readonly unknown[]; details?: unknown } | undefined;
+
+function contentBlockTypes(result: ToolResult): string[] {
+  const content = result?.content;
+  if (!Array.isArray(content)) {
+    return [];
+  }
+  return content.map((block) => String((block as { type?: unknown }).type ?? "unknown"));
+}
+
+function countImageBlocks(result: ToolResult): number {
+  return contentBlockTypes(result).filter((type) => type === "image").length;
+}
+
+function resultText(result: ToolResult): string {
+  const content = result?.content;
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return content
+    .filter(
+      (block): block is { type: "text"; text: string } =>
+        (block as { type?: unknown }).type === "text",
+    )
+    .map((block) => block.text)
+    .join("\n");
+}
+
+function redactPaths(text: string): string {
+  return text
+    .replaceAll(os.homedir(), "[redacted-home]")
+    .replaceAll(os.tmpdir(), "[redacted-tmp]");
+}
+
+function renderResult(label: string, result: ToolResult): string {
+  const lines = [
+    `--- ${label} ---`,
+    `content-block types: [${contentBlockTypes(result).join(", ")}]`,
+    `image content blocks: ${countImageBlocks(result)}`,
+    `text: ${redactPaths(resultText(result)).slice(0, 500)}`,
+  ];
+  const details = result?.details as
+    | { vision?: { failed?: boolean; error?: string }; media?: unknown }
+    | undefined;
+  if (details?.vision?.failed) {
+    lines.push(`details.vision.failed: true`);
+    if (details.vision.error) {
+      lines.push(`details.vision.error: ${redactPaths(String(details.vision.error))}`);
+    }
+  }
+  if ("media" in (details ?? {})) {
+    lines.push(`details.media: ${details?.media === undefined ? "undefined" : "present"}`);
+  }
+  return lines.join("\n");
+}
+
+function buildConfig(controlPort: number): OpenClawConfig {
+  const gatewayPort = controlPort - 2;
+  const chromePath =
+    process.env.BROWSER_EXECUTABLE_PATH?.trim() ||
+    (process.platform === "darwin"
+      ? "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+      : "/usr/bin/google-chrome");
+  return {
+    gateway: { port: gatewayPort },
+    browser: {
+      enabled: true,
+      headless: true,
+      noSandbox: process.platform === "linux",
+      defaultProfile: "openclaw",
+      controlPort,
+      executablePath: chromePath,
+      profiles: {
+        openclaw: {
+          cdpPort: controlPort + 11,
+          color: "#FF4500",
+        },
+      },
+    },
+    tools: {
+      media: {
+        image: {
+          models: [{ provider: "openai", model: "gpt-4o-mini" }],
+        },
+      },
+    },
+  };
+}
+
+const PROOF_PAGE_URL = "https://example.com/";
+
+async function main(): Promise<void> {
+  const controlPort = await getFreePort();
+  const stateRoot = await mkdtemp(path.join(os.tmpdir(), "openclaw-live-handler-proof-"));
+  const cfg = buildConfig(controlPort);
+  setRuntimeConfigSnapshot(cfg, cfg);
+
+  let pass = false;
+  try {
+    const service = await startBrowserControlServiceFromConfig();
+    if (!service) {
+      throw new Error("browser control service failed to start");
+    }
+
+    const tool = createBrowserTool({
+      allowHostControl: true,
+      agentSessionKey: "agent:proof:live-handler",
+      agentDir: stateRoot,
+      workspaceDir: stateRoot,
+      activeModel: { provider: "anthropic", model: "claude-sonnet-4.6" },
+      mediaScope: { sessionKey: "agent:proof:live-handler", channel: "cli" },
+    });
+
+    console.log("=== Step 1: start browser (real browser control service) ===");
+    await tool.execute?.("live-proof-start", {
+      action: "start",
+      target: "host",
+      profile: "openclaw",
+    });
+
+    console.log("\n=== Step 2: open proof page (real browser control service) ===");
+    const openResult = await tool.execute?.("live-proof-open", {
+      action: "open",
+      target: "host",
+      profile: "openclaw",
+      url: PROOF_PAGE_URL,
+    });
+    const targetId =
+      typeof (openResult?.details as { targetId?: unknown } | undefined)?.targetId === "string"
+        ? ((openResult?.details as { targetId: string }).targetId ?? undefined)
+        : undefined;
+    console.log(`opened tab targetId: ${targetId ?? "(default)"}`);
+    console.log(`proof page url: ${PROOF_PAGE_URL}`);
+
+    console.log(
+      "\n=== Step 3: screenshot via real createBrowserTool().execute() (configured vision fails) ===",
+    );
+    const screenshotResult = await tool.execute?.("live-proof-screenshot", {
+      action: "screenshot",
+      target: "host",
+      profile: "openclaw",
+      ...(targetId ? { targetId } : {}),
+    });
+    console.log(renderResult("real screenshot handler catch path", screenshotResult));
+
+    console.log("\n=== Step 4: later snapshot in same session (real handler) ===");
+    const snapshotResult = await tool.execute?.("live-proof-snapshot", {
+      action: "snapshot",
+      target: "host",
+      profile: "openclaw",
+      ...(targetId ? { targetId } : {}),
+    });
+    console.log(renderResult("real snapshot handler (later tool call)", snapshotResult));
+
+    const screenshotImages = countImageBlocks(screenshotResult);
+    const snapshotImages = countImageBlocks(snapshotResult);
+    const visionFailed = Boolean(
+      (screenshotResult?.details as { vision?: { failed?: boolean } } | undefined)?.vision?.failed,
+    );
+    const screenshotText = resultText(screenshotResult);
+    pass =
+      screenshotImages === 0 &&
+      snapshotImages === 0 &&
+      visionFailed &&
+      screenshotText.includes("browser screenshot vision failed");
+
+    console.log(`\nresult: ${pass ? "PASS" : "FAIL"}`);
+    if (!pass) {
+      process.exitCode = 1;
+    }
+  } finally {
+    try {
+      await stopBrowserControlService();
+    } catch {
+      // Best effort cleanup.
+    }
+    clearRuntimeConfigSnapshot();
+    await rm(stateRoot, { recursive: true, force: true });
+  }
+}
+
+await main();

--- a/scripts/repro/browser-vision-failure-live-handler.ts
+++ b/scripts/repro/browser-vision-failure-live-handler.ts
@@ -98,9 +98,7 @@ function buildConfig(gatewayPort: number): OpenClawConfig {
     },
     tools: {
       media: {
-        image: {
-          models: [{ provider: "openai", model: "gpt-4o-mini" }],
-        },
+        models: [{ provider: "openai", model: "gpt-4o-mini", capabilities: ["image"] }],
       },
     },
   };


### PR DESCRIPTION
## Maintainer decision (configured-vision failure recovery)

**Chosen: Option A — text-only failure recovery** (see PR comment for rationale).

When a configured image-understanding model fails during browser screenshot, the tool result stays text-only: failure reason plus staged outbound share path. No base64 image block enters session history. The no-vision path (image understanding skipped or unconfigured) still returns the raw image for vision-capable primary models.

Option B (session-safe transient image recovery) is deferred to a follow-up if browser owners want degraded model-visible screenshot access on provider failure.

---
## What Problem This Solves

Fixes an issue where users running browser screenshot with a configured image-understanding model would have the session become unusable when that vision model failed: later `exec` / `read` / `browser snapshot` tool results were framed as image analysis until `/new`.

The vision-failure path previously fell back to injecting a raw base64 image block into the tool result. That image-bearing result is retained across recent completed turns, so it keeps re-entering model context and contaminates subsequent tool use.

This is the failure path described in #106703 (and the same root cause reported in #105305).

## Why This Change Was Made

The vision success path already returns a text-only description. This change makes the configured-vision failure path consistent with it: on describe failure, return a text-only result that reports the failure reason and keeps the staged outbound-copy path so the screenshot can still be shared explicitly via the message tool. Never write base64 image data into session/tool-result state on that path.

Scoped intentionally:

- Configured vision model throws: text-only (fixed path). A user who configured image understanding opted into text descriptions, so a transient provider error should not silently switch to dumping raw base64.
- Image understanding skipped / not configured (`describeBrowserScreenshot` returns `null`): still returns the raw image, so vision-capable primary models that rely on seeing the screenshot are unaffected.

## User Impact

When a configured image-understanding model fails during browser screenshot, the session stays usable: tool results remain text-framed, and the screenshot can still be shared via the message tool. Users without image understanding configured keep the previous model-visible screenshot behavior.

## Evidence

### Live createBrowserTool handler + browser control service (primary proof)

This is the proof ClawSweeper asked for: the changed `createBrowserTool().execute()` screenshot **catch** runs against a real managed Chrome tab through the in-process browser control service (not vitest mocks), configured vision fails through the real `describeImageFile` runtime, and a later `browser snapshot` in the same session stays text-only with zero image content blocks.

Reproduce (from this branch; needs local Chrome):

```
cd ~/oss-openclaw-106703   # or your checkout of fix/browser-screenshot-base64-fallback
git checkout fix/browser-screenshot-base64-fallback
pnpm install
pnpm exec tsx scripts/repro/browser-vision-failure-live-handler.ts
```

Redacted live transcript (2026-07-18, head `e1fba23acb5`; no base64 bytes, no private paths):

```
=== Step 1: start browser (real browser control service) ===

=== Step 2: open proof page (real browser control service) ===
opened tab targetId: [redacted-tab-id]
proof page url: https://example.com/

=== Step 3: screenshot via real createBrowserTool().execute() (configured vision fails) ===
[media-understanding] image: failed (0/1) reason=Unknown model
--- real screenshot handler catch path ---
content-block types: [text]
image content blocks: 0
text: [browser screenshot vision failed: Unknown model: openai/gpt-4o-mini]
[Screenshot saved to "[redacted-path]/outbound/[redacted].png". Use this path with the message tool to share the screenshot explicitly.]
details.vision.failed: true
details.vision.error: Unknown model: openai/gpt-4o-mini

=== Step 4: later snapshot in same session (real handler) ===
--- real snapshot handler (later tool call) ---
content-block types: [text]
image content blocks: 0
text: (wrapped external browser snapshot text; truncated)

result: PASS
```

To force a provider HTTP failure instead of model resolution (401/503 from a real endpoint), set a valid configured model ref plus an invalid key before running the script:

```
export OPENAI_API_KEY=sk-invalid-proof-key-replace-me
# ensure models.providers.openai.models includes your image model in the runtime config the script loads
pnpm exec tsx scripts/repro/browser-vision-failure-live-handler.ts
```

### Real-handler behavioral proof (vitest; mocked vision throw only)

The reported symptom is a session-state effect: on a configured image-understanding failure the screenshot tool result previously carried a raw base64 image block, which is retained across recent completed turns (`pruneProcessedHistoryImages` keeps image blocks from the last `PRESERVE_RECENT_COMPLETED_TURNS = 3` completed turns) and forces later `exec` / `read` / `browser snapshot` results into image-analysis framing until `/new`.

The proof drives the real `createBrowserTool().execute()` screenshot handler with the configured image-understanding call (`describeImageFile`) forced to fail, then drives a later `browser snapshot` through the same real handler. Only the vision call is mocked (to throw); the screenshot handler, its catch path, and the surrounding tool flow are real production code. It lives in `extensions/browser/src/browser-tool.test.ts` under the describe block `browser screenshot vision-failure session-contamination proof (#106703, #105305)`.

Reproduce:

```
node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-browser.config.ts extensions/browser/src/browser-tool.test.ts -t "browser screenshot vision-failure session-contamination proof" --disableConsoleIntercept
```

Redacted transcript (content-block types and image-block counts only; no base64 bytes are printed):

```
--- real screenshot handler (configured vision failure) ---
content-block types: [text]
image content blocks: 0
text: [browser screenshot vision failed: vision provider unavailable (HTTP 503)] \n [Screenshot saved to "/tmp/openclaw-media/outbound/share.png". Use this path with the message tool to share the screenshot explicitly.]
--- real snapshot handler (later tool call) ---
content-block types: [text]
image content blocks: 0
text: <<<EXTERNAL_UNTRUSTED_CONTENT source="browser">>> \n ok \n <<<END_EXTERNAL_UNTRUSTED_CONTENT>>>
=== session transcript (redacted) ===
user: screenshot the dashboard and summarize it
toolResult(browser:screenshot): blocks=[text] images=0
assistant: the configured vision model was unavailable
user: now read the deploy status file
toolResult(read): blocks=[text] images=0
assistant: deploy is green
user: take a page snapshot
toolResult(browser:snapshot): blocks=[text] images=0
assistant: captured snapshot
total image content blocks across session: 0
--- no-vision path (unchanged) screenshot result ---
content-block types: [text, image]
image content blocks: 1
text: browser:screenshot
```

Reading the transcript:

- Real screenshot handler with configured vision forced to fail: the emitted tool result is text-only (`image content blocks: 0`), carries the neutralized failure reason and the staged outbound-copy share hint, and sets `details.vision.failed` with no `details.media`.
- A later `browser snapshot` through the same real handler stays text-framed, and the reconstructed multi-turn session carries `total image content blocks: 0`, so nothing base64 rides alongside later `read` / `snapshot` results.
- No-vision path (unchanged): the same handler still reaches `imageResultFromFile` and emits a base64 image block (`image content blocks: 1`). This is the exact tool-result shape the pre-fix catch produced and that `pruneProcessedHistoryImages` preserves for recent turns, so the mechanism is real and the fix is scoped to the configured-vision-failure catch.

Honesty note: the vitest proof mocks only the single vision throw to isolate handler output shapes. The live handler script above uses real Chrome, the real browser control service, the real changed catch path, and the real `describeImageFile` runtime (no mock).

### Handler-side unit and regression tests

Focused tests in `extensions/browser/src/browser-tool.test.ts` drive the real `createBrowserTool().execute()` screenshot path:

- `defangs vision failure fallback text and stays text-only`: vision-failure result is text-only (no `imageResultFromFile`, no image content block, no `details.media`) while preserving the neutralized failure text and share hint.
- `never injects a raw image block when configured vision fails (#106703, #105305)`: configured-vision failure returns zero image content blocks and marks `details.vision.failed`, so the result cannot persist an image across turns.
- No-vision (skipped/unconfigured) path still returns the raw image with sanitization.

### Local gate (redacted)

```
vitest extensions/browser/src/browser-tool.test.ts                          100 passed
vitest extensions/browser/src/browser/vision.test.ts                          6 passed
vitest src/agents/embedded-agent-runner/run/history-image-prune.test.ts      12 passed
lint:extensions                                                             clean
format:check                                                                clean
tsgo:extensions:test                                                        0 errors
deadcode:full (knip production + all-exports)                               clean  (resolves check-dependencies unused-file)
live handler proof (scripts/repro/browser-vision-failure-live-handler.ts)   PASS
```

Closes #106703
Related #105305

