### PR TITLE
fix(whatsapp): avoid deprecated access guard collision

### DIFF
--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -1453,7 +1453,7 @@ export async function attachWebInboxToSocket(
     await debouncer.enqueue(inboundMessage);
   };
 
-  const dispatchInboundMessage = async (
+  const processDurableInboundMessage = async (
     msg: WAMessage,
     context: Pick<
       WhatsAppDurableInboundPayload,
@@ -1589,7 +1589,7 @@ export async function attachWebInboxToSocket(
       const remoteJid = msg.key?.remoteJid;
       const id = msg.key?.id;
       return {
-        kind: await dispatchInboundMessage(msg, {
+        kind: await processDurableInboundMessage(msg, {
           ...payload,
           ...(remoteJid && id
             ? { eventId: createWhatsAppDurableInboundMessageId({ remoteJid, id }) }


### PR DESCRIPTION
## What Problem This Solves

Current main fails the deprecated channel access guard because a private WhatsApp durable-ingress helper happens to use the same name as a forbidden caller-owned reply dispatcher API.

## Why This Change Was Made

Rename the private helper and its sole caller to describe its actual owner: processing one durable WhatsApp inbound message before debounce enqueue. The repository guard remains strict.

## User Impact

None. This is an identifier-only refactor with no runtime, API, config, state, or protocol change.

## Evidence

- Deprecated channel access guard passes.
- WhatsApp durable receive and monitor behavior: 102 tests pass.
- Two independent owner-boundary reviews chose rename-only over weakening the guard.
- Autoreview clean at 0.99 confidence.

AI-assisted: Codex identified and repaired the main-branch gate regression while preparing PR #110442.
