### PR TITLE
fix(ui): drop the Subagent prefix from named sidebar threads

### DIFF
--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -166,8 +166,10 @@ export abstract class AppSidebarSessionNavigationElement extends AppSidebarSessi
       }
       return {
         key: row.key,
+        // The sidebar's zone structure already says what forked from what;
+        // a "Subagent:" prefix on named threads is noise (other surfaces keep it).
         label: resolveSessionDisplayName(row.key, row, {
-          includeSubagentPrefix: !isChild,
+          includeSubagentPrefix: false,
         }),
         meta: formatSidebarTimestamp(row.updatedAt),
         subtitle: resolveSessionWorkSubtitle(row),


### PR DESCRIPTION
## What Problem This Solves

Named threads spawned from the main session render in the sidebar as "Subagent: <label>" — the type prefix shouts implementation detail at a row that already sits in the Threads zone, where the hierarchy (Home = root, threads = forks) carries that meaning. Child rows already drop the prefix; promoted top-level threads did not.

## Why This Change Was Made

The sidebar passes `includeSubagentPrefix: false` unconditionally in its row projection. The prefix remains intact for non-sidebar surfaces (search, session tables) where rows appear without zone context. One-line change plus an invariant comment.

## User Impact

A thread the agent named "Lisbon trip planning" reads as exactly that in the sidebar.

## Evidence

- `ui/src/components/app-sidebar.test.ts`: 121/121 green
- `pnpm tsgo:ui` clean; autoreview (codex/gpt-5.6-sol) clean — "patch is correct (0.96)"
