### PR TITLE
fix(ui): collapse doubled sidebar footer divider and enlarge settings gear

### DIFF
--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -933,7 +933,7 @@ html.openclaw-native-web-chrome .shell:not(.shell--mobile-nav) .sidebar-brand .s
 
 .sidebar-shell__footer {
   flex-shrink: 0;
-  padding: 12px 0 0;
+  padding: 4px 0 0;
   border-top: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
 }
 
@@ -2743,13 +2743,13 @@ wa-dropdown.sidebar-session-sort-menu::part(menu) {
   margin-left: auto;
 }
 
-/* Zone 5: product chrome in one slim footer bar. */
+/* Zone 5: product chrome in one slim footer bar. The shell footer's top
+   border is the only divider (and the pet's ledge); no second line here. */
 .sidebar-footer-bar {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 8px 12px 8px;
-  border-top: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+  padding: 6px 12px;
 }
 
 .sidebar-footer-bar__logo {
@@ -2792,8 +2792,8 @@ wa-dropdown.sidebar-session-sort-menu::part(menu) {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
-  height: 24px;
+  width: 28px;
+  height: 28px;
   flex: none;
   border: none;
   border-radius: var(--radius-md);
@@ -2812,8 +2812,8 @@ wa-dropdown.sidebar-session-sort-menu::part(menu) {
 }
 
 .sidebar-footer-bar__settings svg {
-  width: 15px;
-  height: 15px;
+  width: 17px;
+  height: 17px;
   stroke: currentColor;
   fill: none;
   stroke-width: 1.5px;


### PR DESCRIPTION
## What Problem This Solves

The sidebar footer stacked two hairline dividers: `.sidebar-shell__footer` draws a border-top, and `.sidebar-footer-bar` drew a second one right below it. With no attention chips or update card present (the common resting state), the two lines bracketed ~20px of empty space. The settings gear was also undersized: 15px icon in a 24px button, versus 16px for every nav icon and macOS's ~28px minimum hit target.

## Why This Change Was Made

Design nit pass on the sidebar footer (follow-up to the quiet-sidebar program: chrome only where content is hidden or something is wrong). One divider is enough — the shell footer's border stays because it doubles as the lobster pet's ledge (`ui/src/styles/lobster-pet.css` anchors the pet's feet 3px over it). Attention chips are self-bordered pills and need no separator against the logo bar.

## User Impact

- One divider above the footer area instead of two stacked lines; dead vertical space trimmed (footer padding 12px → 4px, bar padding 8px → 6px).
- Warnings (auth expiry, failed cron) sit between the divider and the logo bar with no extra line.
- Settings gear: 17px icon in a 28px hit target (was 15px/24px).
- Theme toggle intentionally stays in the agent menu; the footer bar stays slim.

## Evidence

Mock-harness (`scripts/control-ui-mock-dev.ts`) before/after, 2x scale.

Resting state (no warnings) — the reported double line:

| Before | After |
| --- | --- |
| ![before empty](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-footer-divider/before-empty-light.png) | ![after empty](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-footer-divider/after-empty-light.png) |

With an attention chip:

| Before | After |
| --- | --- |
| ![before chip](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-footer-divider/before-light.png) | ![after chip](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-footer-divider/after-light.png) |

Dark:

| Before | After |
| --- | --- |
| ![before dark](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-footer-divider/before-dark.png) | ![after dark](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-footer-divider/after-dark.png) |

Validation: CSS-only diff in `ui/src/styles/layout.css`; `oxfmt --check` clean, `git diff --check` clean, autoreview (Codex gpt-5.6-sol) clean. Hosted CI on this PR covers the ui lanes.
