### PR TITLE
fix(telegram): local turn tests complete on macOS

### DIFF
--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -64,17 +64,8 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async () => {
       // dispatcher. Assembled turns now dispatch through core's own provider
       // dispatcher, which an extension test cannot intercept; convert each
       // resolved turn to a prepared one that drives the harness dispatcher,
-      // or reply waits never settle and turn tests hang to timeout.
+      // while leaving the outer runner as the sole lifecycle owner.
       const harness = await import("./bot.create-telegram-bot.test-harness.js");
-      const { createPluginRuntimeMock } = await import("openclaw/plugin-sdk/plugin-test-runtime");
-      const dispatchRuntime = createPluginRuntimeMock({
-        channel: {
-          reply: {
-            dispatchReplyWithBufferedBlockDispatcher:
-              harness.dispatchReplyWithBufferedBlockDispatcher,
-          },
-        },
-      });
       const resolveTurn = params.adapter.resolveTurn;
       return await actual.runChannelInboundEvent({
         ...params,
@@ -89,13 +80,19 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async () => {
               resolved;
             return {
               ...plan,
-              runDispatch: async () => {
-                const result = await dispatchRuntime.channel.inbound.dispatch(plan);
-                if (!result.dispatched) {
-                  throw new Error("Telegram harness turn did not dispatch");
-                }
-                return result.dispatchResult;
-              },
+              runDispatch: async () =>
+                await harness.dispatchReplyWithBufferedBlockDispatcher({
+                  ctx: plan.ctxPayload,
+                  cfg: plan.cfg,
+                  dispatcherOptions: {
+                    ...plan.dispatcherOptions,
+                    deliver: plan.delivery.deliver,
+                    onError: plan.delivery.onError,
+                  },
+                  toolsAllow: plan.toolsAllow,
+                  replyOptions: plan.replyOptions,
+                  replyResolver: plan.replyResolver,
+                }),
             } as typeof resolved;
           },
         },

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -1,10 +1,13 @@
+import fs from "node:fs";
 import { rm } from "node:fs/promises";
+import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   clearPluginInteractiveHandlers,
   registerPluginInteractiveHandler,
 } from "openclaw/plugin-sdk/plugin-runtime";
 import {
+  closeOpenClawStateDatabaseForTest,
   createPluginStateKeyedStoreForTests,
   createPluginStateSyncKeyedStoreForTests,
   resetPluginStateStoreForTests,
@@ -12,6 +15,7 @@ import {
 import type { MsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import { listSessionEntries, upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
+import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { mockPinnedHostnameResolution } from "openclaw/plugin-sdk/test-env";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildTelegramApprovalCallbackData } from "./approval-callback-data.js";
@@ -377,6 +381,8 @@ function systemEventOptions(index = 0) {
 }
 
 const ORIGINAL_TZ = process.env.TZ;
+const ORIGINAL_STATE_DIR = process.env.OPENCLAW_STATE_DIR;
+let scopedStateDir: string | undefined;
 
 describe("createTelegramBot", () => {
   beforeAll(async () => {
@@ -384,12 +390,30 @@ describe("createTelegramBot", () => {
   });
   beforeAll(() => {
     process.env.TZ = "UTC";
+    // Isolate persistent state from the operator's real ~/.openclaw: assembled
+    // turns resolve session/agent bindings through the state DB, and an ambient
+    // Codex session binding fails its generation reclaim, so the embedded agent
+    // drops the turn without replying and reply-wait tests hang to timeout.
+    closeOpenClawStateDatabaseForTest();
+    scopedStateDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(resolvePreferredOpenClawTmpDir(), "openclaw-telegram-bot-state-")),
+    );
+    process.env.OPENCLAW_STATE_DIR = scopedStateDir;
   });
   afterAll(() => {
     if (ORIGINAL_TZ === undefined) {
       delete process.env.TZ;
     } else {
       process.env.TZ = ORIGINAL_TZ;
+    }
+    closeOpenClawStateDatabaseForTest();
+    if (ORIGINAL_STATE_DIR === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = ORIGINAL_STATE_DIR;
+    }
+    if (scopedStateDir) {
+      fs.rmSync(scopedStateDir, { recursive: true, force: true });
     }
   });
 

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -66,6 +66,15 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async () => {
       // resolved turn to a prepared one that drives the harness dispatcher,
       // or reply waits never settle and turn tests hang to timeout.
       const harness = await import("./bot.create-telegram-bot.test-harness.js");
+      const { createPluginRuntimeMock } = await import("openclaw/plugin-sdk/plugin-test-runtime");
+      const dispatchRuntime = createPluginRuntimeMock({
+        channel: {
+          reply: {
+            dispatchReplyWithBufferedBlockDispatcher:
+              harness.dispatchReplyWithBufferedBlockDispatcher,
+          },
+        },
+      });
       const resolveTurn = params.adapter.resolveTurn;
       return await actual.runChannelInboundEvent({
         ...params,
@@ -76,17 +85,17 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async () => {
             if (!("route" in resolved) || "runDispatch" in resolved) {
               return resolved;
             }
-            type Assembled = Extract<typeof resolved, { dispatcherOptions: unknown }>;
-            const assembled = resolved as Assembled;
+            const plan: import("openclaw/plugin-sdk/channel-inbound").ChannelInboundTurnPlan =
+              resolved;
             return {
-              ...assembled,
-              runDispatch: async () =>
-                await harness.dispatchReplyWithBufferedBlockDispatcher({
-                  ctx: assembled.ctxPayload,
-                  cfg: assembled.cfg,
-                  dispatcherOptions: assembled.dispatcherOptions,
-                  replyOptions: assembled.replyOptions,
-                } as Parameters<typeof harness.dispatchReplyWithBufferedBlockDispatcher>[0]),
+              ...plan,
+              runDispatch: async () => {
+                const result = await dispatchRuntime.channel.inbound.dispatch(plan);
+                if (!result.dispatched) {
+                  throw new Error("Telegram harness turn did not dispatch");
+                }
+                return result.dispatchResult;
+              },
             } as typeof resolved;
           },
         },

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -52,6 +52,49 @@ vi.mock("openclaw/plugin-sdk/question-gateway-runtime", () => ({
   },
 }));
 
+vi.mock("openclaw/plugin-sdk/channel-inbound", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/channel-inbound")>(
+    "openclaw/plugin-sdk/channel-inbound",
+  );
+  type RunParams = Parameters<typeof actual.runChannelInboundEvent>[0];
+  return {
+    ...actual,
+    runChannelInboundEvent: async (params: RunParams) => {
+      // This file's turn tests were authored against the injected harness
+      // dispatcher. Assembled turns now dispatch through core's own provider
+      // dispatcher, which an extension test cannot intercept; convert each
+      // resolved turn to a prepared one that drives the harness dispatcher,
+      // or reply waits never settle and turn tests hang to timeout.
+      const harness = await import("./bot.create-telegram-bot.test-harness.js");
+      const resolveTurn = params.adapter.resolveTurn;
+      return await actual.runChannelInboundEvent({
+        ...params,
+        adapter: {
+          ...params.adapter,
+          resolveTurn: async (input, eventClass, preflight) => {
+            const resolved = await resolveTurn(input, eventClass, preflight);
+            if (!("route" in resolved) || "runDispatch" in resolved) {
+              return resolved;
+            }
+            type Assembled = Extract<typeof resolved, { dispatcherOptions: unknown }>;
+            const assembled = resolved as Assembled;
+            return {
+              ...assembled,
+              runDispatch: async () =>
+                await harness.dispatchReplyWithBufferedBlockDispatcher({
+                  ctx: assembled.ctxPayload,
+                  cfg: assembled.cfg,
+                  dispatcherOptions: assembled.dispatcherOptions,
+                  replyOptions: assembled.replyOptions,
+                } as Parameters<typeof harness.dispatchReplyWithBufferedBlockDispatcher>[0]),
+            } as typeof resolved;
+          },
+        },
+      });
+    },
+  };
+});
+
 const {
   answerCallbackQuerySpy,
   commandSpy,

--- a/extensions/telegram/src/delivery-trace.test.ts
+++ b/extensions/telegram/src/delivery-trace.test.ts
@@ -1,9 +1,9 @@
 // Telegram delivery trace goldens: replayable wire-level lifecycle recordings.
 //
 // Drives the REAL dispatcher wiring: buildTelegramMessageContext builds the
-// turn context, dispatchTelegramMessage builds its draft lanes and deliver
-// glue, and the injected dispatchReplyWithBufferedBlockDispatcher seam captures
-// the exact dispatcher/reply options the SDK reply dispatcher would consume.
+// turn context, dispatchTelegramMessage builds its draft lanes and delivery
+// glue, and a core turn-runtime mock captures the exact dispatcher/reply options
+// the SDK reply dispatcher would consume.
 // The scripted IN steps stand in for the model loop; OUT events are the grammY
 // Bot API calls (sendMessage / editMessageText / sendChatAction /
 // deleteMessage) observed at a recording API mock with scripted message ids.
@@ -17,9 +17,12 @@ import {
   type DeliveryTraceScenarioName,
   type WireRecorder,
 } from "openclaw/plugin-sdk/channel-contract-testing";
+import * as channelInbound from "openclaw/plugin-sdk/channel-inbound";
+import type { PluginRuntime } from "openclaw/plugin-sdk/core";
+import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-payload";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
-import { describe, it, vi } from "vitest";
+import { afterEach, describe, it, vi } from "vitest";
 import type { TelegramBotDeps } from "./bot-deps.js";
 import {
   baseTelegramMessageContextConfig,
@@ -32,10 +35,10 @@ import { createTelegramSendChatActionHandler } from "./sendchataction-401-backof
 
 type RecordedWireCall = Parameters<WireRecorder["recordWireCall"]>[0];
 type BufferedDispatcherParams = Parameters<
-  TelegramBotDeps["dispatchReplyWithBufferedBlockDispatcher"]
+  PluginRuntime["channel"]["reply"]["dispatchReplyWithBufferedBlockDispatcher"]
 >[0];
 type BufferedDispatcherResult = Awaited<
-  ReturnType<TelegramBotDeps["dispatchReplyWithBufferedBlockDispatcher"]>
+  ReturnType<PluginRuntime["channel"]["reply"]["dispatchReplyWithBufferedBlockDispatcher"]>
 >;
 
 const TRACE_CHAT_ID = 4242;
@@ -135,11 +138,7 @@ function createRecordingTelegramApi(state: TelegramTraceWireState): Bot["api"] {
   return api as unknown as Bot["api"];
 }
 
-function createTraceTelegramDeps(captured: {
-  dispatcherOptions?: BufferedDispatcherParams["dispatcherOptions"];
-  replyOptions?: BufferedDispatcherParams["replyOptions"];
-  resolveDispatch?: (result: BufferedDispatcherResult) => void;
-}): TelegramBotDeps {
+function createTraceTelegramDeps(): TelegramBotDeps {
   return {
     getRuntimeConfig: (() => ({
       config: baseTelegramMessageContextConfig,
@@ -155,17 +154,6 @@ function createTraceTelegramDeps(captured: {
       created: false,
     })) as unknown as TelegramBotDeps["upsertChannelPairingRequest"],
     enqueueSystemEvent: (async () => {}) as unknown as TelegramBotDeps["enqueueSystemEvent"],
-    // The capture seam: dispatchTelegramMessage hands the SDK reply dispatcher
-    // its deliver wiring here; the trace drives those callbacks directly and
-    // resolves this promise at the scripted idle step, exactly where the real
-    // agent loop would settle.
-    dispatchReplyWithBufferedBlockDispatcher: ((params: BufferedDispatcherParams) => {
-      captured.dispatcherOptions = params.dispatcherOptions;
-      captured.replyOptions = params.replyOptions;
-      return new Promise((resolve) => {
-        captured.resolveDispatch = resolve;
-      });
-    }) as TelegramBotDeps["dispatchReplyWithBufferedBlockDispatcher"],
     buildModelsProviderData: (async () => ({
       byProvider: new Map<string, Set<string>>(),
       providers: [],
@@ -216,7 +204,27 @@ async function setupTelegramTrace(recorder: WireRecorder) {
   if (!context) {
     throw new Error("trace context was not built");
   }
-  const captured: Parameters<typeof createTraceTelegramDeps>[0] = {};
+  const captured: {
+    dispatcherOptions?: BufferedDispatcherParams["dispatcherOptions"];
+    replyOptions?: BufferedDispatcherParams["replyOptions"];
+    resolveDispatch?: (result: BufferedDispatcherResult) => void;
+  } = {};
+  const coreRuntime = createPluginRuntimeMock({
+    channel: {
+      reply: {
+        dispatchReplyWithBufferedBlockDispatcher: (params) => {
+          captured.dispatcherOptions = params.dispatcherOptions;
+          captured.replyOptions = params.replyOptions;
+          return new Promise((resolve) => {
+            captured.resolveDispatch = resolve;
+          });
+        },
+      },
+    },
+  });
+  vi.spyOn(channelInbound, "runChannelInboundEvent").mockImplementation((params) =>
+    coreRuntime.channel.inbound.run(params),
+  );
   const dispatchDone = dispatchTelegramMessage({
     context,
     bot: { api } as unknown as Bot,
@@ -228,7 +236,7 @@ async function setupTelegramTrace(recorder: WireRecorder) {
     streamMode: "partial",
     textLimit: TELEGRAM_TEXT_CHUNK_LIMIT,
     telegramCfg: {},
-    telegramDeps: createTraceTelegramDeps(captured),
+    telegramDeps: createTraceTelegramDeps(),
     opts: { token: "trace-token" },
   });
   // Swallow here only to avoid an unhandled rejection warning racing the idle
@@ -316,6 +324,10 @@ async function setupTelegramTrace(recorder: WireRecorder) {
     }
   };
 }
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 const TELEGRAM_TRACE_SCENARIOS: readonly DeliveryTraceScenarioName[] = [
   "streaming-happy",

--- a/extensions/telegram/src/delivery-trace.test.ts
+++ b/extensions/telegram/src/delivery-trace.test.ts
@@ -175,6 +175,9 @@ function createTraceTelegramDeps(captured: CapturedDispatch): TelegramBotDeps {
       created: false,
     })) as unknown as TelegramBotDeps["upsertChannelPairingRequest"],
     enqueueSystemEvent: (async () => {}) as unknown as TelegramBotDeps["enqueueSystemEvent"],
+    dispatchReplyWithBufferedBlockDispatcher: (() => {
+      throw new Error("trace dispatch bypassed the core runtime mock");
+    }) as TelegramBotDeps["dispatchReplyWithBufferedBlockDispatcher"],
     buildModelsProviderData: (async () => ({
       byProvider: new Map<string, Set<string>>(),
       providers: [],

--- a/extensions/telegram/src/delivery-trace.test.ts
+++ b/extensions/telegram/src/delivery-trace.test.ts
@@ -40,6 +40,11 @@ type BufferedDispatcherParams = Parameters<
 type BufferedDispatcherResult = Awaited<
   ReturnType<PluginRuntime["channel"]["reply"]["dispatchReplyWithBufferedBlockDispatcher"]>
 >;
+type CapturedDispatch = {
+  dispatcherOptions?: BufferedDispatcherParams["dispatcherOptions"];
+  replyOptions?: BufferedDispatcherParams["replyOptions"];
+  resolveDispatch?: (result: BufferedDispatcherResult) => void;
+};
 
 const TRACE_CHAT_ID = 4242;
 // The scripted preview-delete dwell (MIN_PREVIEW_DWELL_MS = 4s) plus margin, so
@@ -138,7 +143,23 @@ function createRecordingTelegramApi(state: TelegramTraceWireState): Bot["api"] {
   return api as unknown as Bot["api"];
 }
 
-function createTraceTelegramDeps(): TelegramBotDeps {
+function createTraceTelegramDeps(captured: CapturedDispatch): TelegramBotDeps {
+  const coreRuntime = createPluginRuntimeMock({
+    channel: {
+      reply: {
+        dispatchReplyWithBufferedBlockDispatcher: (params) => {
+          captured.dispatcherOptions = params.dispatcherOptions;
+          captured.replyOptions = params.replyOptions;
+          return new Promise((resolve) => {
+            captured.resolveDispatch = resolve;
+          });
+        },
+      },
+    },
+  });
+  vi.spyOn(channelInbound, "runChannelInboundEvent").mockImplementation((params) =>
+    coreRuntime.channel.inbound.run(params),
+  );
   return {
     getRuntimeConfig: (() => ({
       config: baseTelegramMessageContextConfig,
@@ -204,27 +225,7 @@ async function setupTelegramTrace(recorder: WireRecorder) {
   if (!context) {
     throw new Error("trace context was not built");
   }
-  const captured: {
-    dispatcherOptions?: BufferedDispatcherParams["dispatcherOptions"];
-    replyOptions?: BufferedDispatcherParams["replyOptions"];
-    resolveDispatch?: (result: BufferedDispatcherResult) => void;
-  } = {};
-  const coreRuntime = createPluginRuntimeMock({
-    channel: {
-      reply: {
-        dispatchReplyWithBufferedBlockDispatcher: (params) => {
-          captured.dispatcherOptions = params.dispatcherOptions;
-          captured.replyOptions = params.replyOptions;
-          return new Promise((resolve) => {
-            captured.resolveDispatch = resolve;
-          });
-        },
-      },
-    },
-  });
-  vi.spyOn(channelInbound, "runChannelInboundEvent").mockImplementation((params) =>
-    coreRuntime.channel.inbound.run(params),
-  );
+  const captured: CapturedDispatch = {};
   const dispatchDone = dispatchTelegramMessage({
     context,
     bot: { api } as unknown as Bot,
@@ -236,8 +237,8 @@ async function setupTelegramTrace(recorder: WireRecorder) {
     streamMode: "partial",
     textLimit: TELEGRAM_TEXT_CHUNK_LIMIT,
     telegramCfg: {},
-    telegramDeps: createTraceTelegramDeps(),
-    opts: { token: "test-token" },
+    telegramDeps: createTraceTelegramDeps(captured),
+    opts: { token: "trace-token" },
   });
   // Swallow here only to avoid an unhandled rejection warning racing the idle
   // step; the idle handler awaits dispatchDone and surfaces real failures.

--- a/extensions/telegram/src/delivery-trace.test.ts
+++ b/extensions/telegram/src/delivery-trace.test.ts
@@ -237,7 +237,7 @@ async function setupTelegramTrace(recorder: WireRecorder) {
     textLimit: TELEGRAM_TEXT_CHUNK_LIMIT,
     telegramCfg: {},
     telegramDeps: createTraceTelegramDeps(),
-    opts: { token: "trace-token" },
+    opts: { token: "test-token" },
   });
   // Swallow here only to avoid an unhandled rejection warning racing the idle
   // step; the idle handler awaits dispatchDone and surfaces real failures.


### PR DESCRIPTION
Related: #110095

## What Problem This Solves

Telegram unit tests hang locally on macOS. Turn tests were authored against the injected dispatcher seam that #110095's core-owned turn execution disconnected, leaving CI-green-but-locally-broken test debt.

## Why This Change Was Made

The test harness now scopes bot tests to a fresh OpenClaw state directory and converts assembled Telegram turns into prepared test turns that invoke the injected dispatcher while preserving a single core lifecycle. Delivery-trace tests intercept the core runtime seam directly, preserving their existing goldens. Production code is unchanged.

AI-assisted: Codex was used for implementation, review, and validation. The resulting test-only behavior and lifecycle wiring were manually inspected.

## User Impact

No user-visible runtime change. Telegram maintainers can run the affected unit tests locally on macOS without per-test hangs or ambient operator state leaking into assembled turns.

## Evidence

- Before: the `bot.test.ts` model-pins test timed out at 120 seconds locally.
- After: `node scripts/run-vitest.mjs extensions/telegram/src/bot.test.ts extensions/telegram/src/delivery-trace.test.ts` passes 123/123 tests in about 60 seconds locally; the latest post-rebase run completed the Vitest shard in 65.22 seconds.
- Delivery-trace goldens are unchanged.
- `oxfmt --check` on both touched files passes.
- `git diff --check origin/main...HEAD` passes.
- Both dead-code gates pass with zero entries.
- Mandatory branch autoreview is clean after addressing lifecycle and dispatch-wiring findings.
