### PR TITLE
test(telegram): update shard harness fixtures

### DIFF
--- a/extensions/telegram/src/miniapp/routes.test.ts
+++ b/extensions/telegram/src/miniapp/routes.test.ts
@@ -32,6 +32,7 @@ vi.mock("./url.js", async (importOriginal) => ({
 const { registerTelegramMiniAppRoutes } = await import("./routes.js");
 
 const BOT_TOKEN = "fixture";
+let signedNonceSequence = 0;
 
 class MockResponse {
   statusCode = 200;
@@ -98,9 +99,10 @@ function config(allowFrom: string[] = ["123456"]): OpenClawConfig {
 }
 
 function signedInitData(userId: string, nonce: string): string {
+  signedNonceSequence += 1;
   const params = new URLSearchParams({
     auth_date: String(Math.floor(Date.now() / 1000)),
-    query_id: nonce,
+    query_id: `${nonce}-${signedNonceSequence}`,
     user: JSON.stringify({ id: Number(userId), first_name: "Ayaan" }),
   });
   const entries = [...params.entries()].map(([key, value]) => `${key}=${value}`).toSorted();
@@ -151,7 +153,13 @@ describe("registerTelegramMiniAppRoutes", () => {
     expect(issueDeviceBootstrapToken).toHaveBeenCalledWith({
       profile: {
         roles: ["operator"],
-        scopes: ["operator.approvals", "operator.read", "operator.talk.secrets", "operator.write"],
+        scopes: [
+          "operator.approvals",
+          "operator.questions",
+          "operator.read",
+          "operator.talk.secrets",
+          "operator.write",
+        ],
         purpose: "control-ui",
       },
     });


### PR DESCRIPTION
## Summary

- keep miniapp bootstrap fixtures unique across repeated shard execution
- expect the current operator questions scope

## Proof

- `node scripts/run-vitest.mjs extensions/telegram/src/bot.test.ts extensions/telegram/src/delivery-trace.test.ts extensions/telegram/src/miniapp/routes.test.ts` (129 passed)
- autoreview clean

Completes the remaining attributable `checks-node-extensions-shard-2` fixture failure from Full Release Validation child run 29654680084. Telegram bot and delivery-trace harness repairs landed independently in #110894.
