### PR TITLE
fix(qa): provide live credentials to full profile evidence

### DIFF
--- a/.github/workflows/qa-profile-evidence.yml
+++ b/.github/workflows/qa-profile-evidence.yml
@@ -39,6 +39,12 @@ on:
       OPENAI_API_KEY:
         description: OpenAI API key used by live QA profile scenarios
         required: true
+      OPENCLAW_QA_CONVEX_SITE_URL:
+        description: Optional Convex credential broker URL supplied by qa-live-shared
+        required: false
+      OPENCLAW_QA_CONVEX_SECRET_CI:
+        description: Optional Convex CI credential supplied by qa-live-shared
+        required: false
     outputs:
       artifact_name:
         description: Uploaded QA profile evidence artifact name
@@ -191,7 +197,7 @@ jobs:
     name: Generate QA profile evidence
     needs: validate_selected_ref
     runs-on: blacksmith-8vcpu-ubuntu-2404
-    timeout-minutes: 60
+    timeout-minutes: ${{ inputs.qa_profile == 'all' && 240 || 60 }}
     permissions:
       contents: read
     outputs:
@@ -240,10 +246,33 @@ jobs:
             throw new Error(`Unknown QA profile ${requested}. Available profiles: ${available}`);
           }
 
-          fs.appendFileSync(process.env.GITHUB_OUTPUT, `profile=${profile.id}\n`);
+          fs.appendFileSync(
+            process.env.GITHUB_OUTPUT,
+            `profile=${profile.id}\nchannel_driver=${profile.channelDriver}\n`,
+          );
           NODE
 
           echo "QA profile: \`${QA_PROFILE}\`" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Require live profile credentials
+        if: steps.profile.outputs.channel_driver == 'live'
+        env:
+          OPENCLAW_QA_CONVEX_SITE_URL: ${{ secrets.OPENCLAW_QA_CONVEX_SITE_URL }}
+          OPENCLAW_QA_CONVEX_SECRET_CI: ${{ secrets.OPENCLAW_QA_CONVEX_SECRET_CI }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          require_var() {
+            local name="$1"
+            if [[ -z "${!name:-}" ]]; then
+              echo "Missing required qa-live-shared secret: ${name}" >&2
+              exit 1
+            fi
+          }
+
+          require_var OPENCLAW_QA_CONVEX_SITE_URL
+          require_var OPENCLAW_QA_CONVEX_SECRET_CI
 
       - name: Build private QA runtime
         env:
@@ -258,6 +287,11 @@ jobs:
         env:
           QA_PROFILE: ${{ steps.profile.outputs.profile }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENCLAW_QA_CONVEX_SITE_URL: ${{ secrets.OPENCLAW_QA_CONVEX_SITE_URL }}
+          OPENCLAW_QA_CONVEX_SECRET_CI: ${{ secrets.OPENCLAW_QA_CONVEX_SECRET_CI }}
+          OPENCLAW_QA_CREDENTIAL_ACQUIRE_TIMEOUT_MS: "1800000"
+          OPENCLAW_QA_CREDENTIAL_ROLE: ci
+          OPENCLAW_QA_CREDENTIAL_SOURCE: convex
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the full-taxonomy maturity evidence workflow completed the Matrix partition but then failed when it reached credential-backed live channels, so no aggregate `qa-evidence.json` was produced and scorecard generation could not continue.

## Why This Change Was Made

Live taxonomy profiles now fail fast when the `qa-live-shared` Convex broker contract is unavailable, expose the pooled CI credential source to every live adapter, and give only the explicit `all` profile enough time for the 353-scenario cross-channel run. The taxonomy remains driver-pluggable: the `all` profile still selects the `live` driver, and scenario `channel` requirements remain enforced by that driver.

## User Impact

No end-user product behavior changes. Maintainers can run the full maturity evidence workflow through Matrix, Slack, Telegram, Discord, and WhatsApp instead of failing at the first credential-backed adapter.

AI-assisted: Codex. I reviewed the workflow change and the failed run evidence.

## Evidence

- Failed full maturity run: https://github.com/openclaw/openclaw/actions/runs/29654736854
- Exact evidence job: https://github.com/openclaw/openclaw/actions/runs/29654736854/job/88107338931
- The repaired Matrix partition passed 81/81 in that run before the next partition failed with `Missing OPENCLAW_QA_SLACK_CHANNEL_ID` because the workflow had not selected the Convex credential source.
- `actionlint` 1.7.11 passes for `.github/workflows/qa-profile-evidence.yml`.
- `oxfmt --check` and `git diff --check` pass.
- Autoreview was attempted but its bundle scanner refused the workflow diff because secret-context variable names looked secret-like; no secret values are present in the patch.
