### PR TITLE
fix(skills): distinguish duplicate ClawHub search results by publisher

### DIFF
--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -353,7 +353,7 @@ describe("skills cli commands", () => {
     );
   }
 
-  it("renders installable ClawHub refs in native skill search results", async () => {
+  it("distinguishes duplicate ClawHub skill slugs by owner", async () => {
     searchSkillsFromClawHubMock.mockResolvedValue([
       {
         slug: "calendar",
@@ -363,8 +363,9 @@ describe("skills cli commands", () => {
         version: "1.2.3",
       },
       {
-        slug: "legacy-calendar",
-        displayName: "Legacy Calendar",
+        slug: "calendar",
+        ownerHandle: "work-owner",
+        displayName: "Team Calendar",
       },
     ]);
 
@@ -374,14 +375,43 @@ describe("skills cli commands", () => {
       query: "calendar",
       limit: undefined,
     });
-    expect(
-      runtimeLogs.some((line) => line.includes("@demo-owner/calendar v1.2.3  Calendar")),
-      "owner-qualified search result log",
-    ).toBe(true);
-    expect(
-      runtimeLogs.some((line) => line.includes("legacy-calendar  Legacy Calendar")),
-      "legacy search result log",
-    ).toBe(true);
+    expect(runtimeLogs).toEqual([
+      "@demo-owner/calendar v1.2.3  Calendar  CalDAV helpers",
+      "@work-owner/calendar  Team Calendar",
+    ]);
+  });
+
+  it("keeps bare skill slugs when ClawHub omits the owner", async () => {
+    searchSkillsFromClawHubMock.mockResolvedValue([
+      {
+        slug: "legacy-calendar",
+        displayName: "Legacy Calendar",
+      },
+    ]);
+
+    await runCommand(["skills", "search", "calendar"]);
+
+    expect(runtimeLogs).toEqual(["legacy-calendar  Legacy Calendar"]);
+  });
+
+  it("keeps ClawHub skill search JSON output unchanged", async () => {
+    const results = [
+      {
+        score: 0.9,
+        slug: "calendar",
+        ownerHandle: "demo-owner",
+        displayName: "Calendar",
+        summary: "CalDAV helpers",
+        version: "1.2.3",
+        updatedAt: 1_700_000_000_000,
+      },
+    ];
+    searchSkillsFromClawHubMock.mockResolvedValue(results);
+
+    await runCommand(["skills", "search", "calendar", "--json"]);
+
+    expect(runtimeLogs).toEqual([]);
+    expect(runtimeStdout).toEqual([JSON.stringify({ results }, null, 2)]);
   });
 
   it("rejects partial numeric search limits", async () => {

--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -353,13 +353,18 @@ describe("skills cli commands", () => {
     );
   }
 
-  it("searches ClawHub skills from the native CLI", async () => {
+  it("renders installable ClawHub refs in native skill search results", async () => {
     searchSkillsFromClawHubMock.mockResolvedValue([
       {
         slug: "calendar",
+        ownerHandle: "demo-owner",
         displayName: "Calendar",
         summary: "CalDAV helpers",
         version: "1.2.3",
+      },
+      {
+        slug: "legacy-calendar",
+        displayName: "Legacy Calendar",
       },
     ]);
 
@@ -370,8 +375,12 @@ describe("skills cli commands", () => {
       limit: undefined,
     });
     expect(
-      runtimeLogs.some((line) => line.includes("calendar v1.2.3  Calendar")),
-      "search result log",
+      runtimeLogs.some((line) => line.includes("@demo-owner/calendar v1.2.3  Calendar")),
+      "owner-qualified search result log",
+    ).toBe(true);
+    expect(
+      runtimeLogs.some((line) => line.includes("legacy-calendar  Legacy Calendar")),
+      "legacy search result log",
     ).toBe(true);
   });
 

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -430,9 +430,11 @@ export function registerSkillsCli(program: Command) {
           return;
         }
         for (const entry of results) {
+          const ownerHandle = normalizeOptionalString(entry.ownerHandle);
+          const skillRef = ownerHandle ? `@${ownerHandle}/${entry.slug}` : entry.slug;
           const version = entry.version ? ` v${entry.version}` : "";
           const summary = entry.summary ? `  ${entry.summary}` : "";
-          defaultRuntime.log(`${entry.slug}${version}  ${entry.displayName}${summary}`);
+          defaultRuntime.log(`${skillRef}${version}  ${entry.displayName}${summary}`);
         }
       } catch (err) {
         defaultRuntime.error(String(err));

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -270,6 +270,7 @@ export type ClawHubPackageSearchResult = {
 export type ClawHubSkillSearchResult = {
   score: number;
   slug: string;
+  ownerHandle?: string | null;
   displayName: string;
   summary?: string;
   version?: string;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users searching ClawHub could see multiple indistinguishable results when different publishers used the same skill slug. For example, three live `weather` results were all rendered as `weather  Weather`, so users could not tell which installable skill ref belonged to which publisher.

## Why This Change Was Made

ClawHub's search contract already returns `ownerHandle`, and owner-qualified refs are the canonical input for skill install, update, and verify flows. Human-readable search output now renders `@owner/slug` when that field is available, while preserving the bare-slug fallback for legacy or private registries that omit it. JSON output is unchanged.

## User Impact

Users can distinguish same-slug search results and copy the displayed owner-qualified ref directly into a follow-up OpenClaw command.

## Evidence

- Live third-party before proof against ClawHub:

  ```text
  $ openclaw skills search weather --limit 3
  weather  Weather  Get current weather and forecasts (no API key required).
  weather  Weather  Get current weather and forecasts (no API key required).
  weather  Weather  Query current conditions and 1-10 day weather forecasts ...
  ```

- Live third-party after proof on final head `27dcc69d4e3`:

  ```text
  $ openclaw skills search weather --limit 3
  @steipete/weather  Weather  Get current weather and forecasts (no API key required).
  @legionspace-hackathon/weather  Weather  Get current weather and forecasts (no API key required).
  @lfengwa2/weather  Weather  Query current conditions and 1-10 day weather forecasts ...
  ```

- ClawHub's live search response returned the distinct `ownerHandle` values, and its read-only detail/install resolver endpoints accepted an owner-qualified `calendar` target with HTTP 200.
- Regression test was added first and failed on the missing `@demo-owner/calendar` output before the production change.
- `node scripts/run-vitest.mjs src/cli/skills-cli.commands.test.ts` — 61 passed after the final rebase.
- Local fallback `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_LOCAL_CHECK=1 OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/check-changed.mjs -- src/cli/skills-cli.ts src/cli/skills-cli.commands.test.ts src/infra/clawhub.ts` — passed all `core` and `coreTests` lanes. The normal Blacksmith delegation was unavailable because the installed Crabbox binary failed its basic `--version/--help` sanity check.
- `./node_modules/.bin/oxfmt --check --threads=1 src/cli/skills-cli.ts src/cli/skills-cli.commands.test.ts src/infra/clawhub.ts` — passed.
- `git diff --check` — passed.
- `codex review --base origin/main` — no defects found.

No skill installation or live configuration mutation was performed.


Co-authored-by: 杨浩宇0668001029 <yang.haoyu@xydigit.com>
