### PR TITLE
fix(qqbot): prevent duplicate storage clears after ingress replay

### DIFF
--- a/extensions/qqbot/src/engine/commands/builtin/register-clear-storage.ts
+++ b/extensions/qqbot/src/engine/commands/builtin/register-clear-storage.ts
@@ -83,6 +83,48 @@ function resolveQqbotDownloadsDir(): string {
   return getQQBotMediaPath("downloads");
 }
 
+function clearQqbotDownloads(targetDir: string): string {
+  const files = scanDirectoryFiles(targetDir);
+
+  if (files.length === 0) {
+    return `✅ 目录已为空，无需清理`;
+  }
+
+  let deletedCount = 0;
+  let deletedSize = 0;
+  let failedCount = 0;
+
+  for (const f of files) {
+    try {
+      fs.unlinkSync(f.filePath);
+      deletedCount++;
+      deletedSize += f.size;
+    } catch {
+      failedCount++;
+    }
+  }
+
+  try {
+    removeEmptyDirs(targetDir);
+  } catch {
+    // Non-critical, silently ignore.
+  }
+
+  if (failedCount === 0) {
+    return [
+      `✅ 清理成功`,
+      ``,
+      `已删除 ${deletedCount} 个文件，释放 ${formatBytes(deletedSize)} 磁盘空间。`,
+    ].join("\n");
+  }
+
+  return [
+    `⚠️ 部分清理完成`,
+    ``,
+    `已删除 ${deletedCount} 个文件（${formatBytes(deletedSize)}），${failedCount} 个文件删除失败。`,
+  ].join("\n");
+}
+
 export function registerClearStorageCommands(registry: SlashCommandRegistry): void {
   registry.register({
     name: "bot-clear-storage",
@@ -99,7 +141,7 @@ export function registerClearStorageCommands(registry: SlashCommandRegistry): vo
       ``,
       `⚠️ 仅在私聊中可用。`,
     ].join("\n"),
-    handler: (ctx) => {
+    handler: async (ctx) => {
       const isForce = ctx.args.trim() === "--force";
       const targetDir = resolveQqbotDownloadsDir();
       const displayDir = `~/.openclaw/media/qqbot/downloads`;
@@ -141,45 +183,12 @@ export function registerClearStorageCommands(registry: SlashCommandRegistry): vo
         return lines.join("\n");
       }
 
-      const files = scanDirectoryFiles(targetDir);
-
-      if (files.length === 0) {
-        return `✅ 目录已为空，无需清理`;
+      const run = async () => clearQqbotDownloads(targetDir);
+      if (!ctx.runIngressEffectOnce) {
+        return await run();
       }
-
-      let deletedCount = 0;
-      let deletedSize = 0;
-      let failedCount = 0;
-
-      for (const f of files) {
-        try {
-          fs.unlinkSync(f.filePath);
-          deletedCount++;
-          deletedSize += f.size;
-        } catch {
-          failedCount++;
-        }
-      }
-
-      try {
-        removeEmptyDirs(targetDir);
-      } catch {
-        // Non-critical, silently ignore.
-      }
-
-      if (failedCount === 0) {
-        return [
-          `✅ 清理成功`,
-          ``,
-          `已删除 ${deletedCount} 个文件，释放 ${formatBytes(deletedSize)} 磁盘空间。`,
-        ].join("\n");
-      }
-
-      return [
-        `⚠️ 部分清理完成`,
-        ``,
-        `已删除 ${deletedCount} 个文件（${formatBytes(deletedSize)}），${failedCount} 个文件删除失败。`,
-      ].join("\n");
+      const outcome = await ctx.runIngressEffectOnce({ effect: "clear-storage", run });
+      return outcome.kind === "executed" ? outcome.value : `✅ 此清理请求已经处理，无需重复清理`;
     },
   });
 }

--- a/extensions/qqbot/src/engine/commands/slash-command-effect-once.test.ts
+++ b/extensions/qqbot/src/engine/commands/slash-command-effect-once.test.ts
@@ -1,0 +1,135 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createQQBotIngressEffectOnce } from "../gateway/ingress-effects.js";
+import type { QueuedMessage } from "../gateway/message-queue.js";
+import type { GatewayAccount } from "../gateway/types.js";
+import { sendText } from "../messaging/sender.js";
+import { trySlashCommand, type SlashCommandHandlerContext } from "./slash-command-handler.js";
+
+vi.mock("../messaging/outbound.js", () => ({
+  sendDocument: vi.fn(async () => undefined),
+}));
+
+vi.mock("../messaging/sender.js", () => ({
+  accountToCreds: vi.fn(() => ({ appId: "app", clientSecret: "" })),
+  buildDeliveryTarget: vi.fn(() => ({ targetType: "c2c", targetId: "TRUSTED_OPENID" })),
+  sendText: vi.fn(async () => undefined),
+}));
+
+const queueSnapshot = {
+  totalPending: 0,
+  activeUsers: 0,
+  maxConcurrentUsers: 1,
+  senderPending: 0,
+};
+
+let testRoot = "";
+
+function createAccount(): GatewayAccount {
+  return {
+    accountId: "default",
+    appId: "app",
+    clientSecret: "",
+    markdownSupport: true,
+    config: { allowFrom: ["TRUSTED_OPENID"] },
+  };
+}
+
+function createClearMessage(): QueuedMessage {
+  return {
+    type: "c2c",
+    senderId: "TRUSTED_OPENID",
+    content: "/bot-clear-storage --force",
+    messageId: "clear-1",
+    timestamp: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+function createHandlerContext(): SlashCommandHandlerContext {
+  return {
+    account: createAccount(),
+    cfg: {},
+    getMessagePeerId: () => "c2c:TRUSTED_OPENID",
+    getQueueSnapshot: () => queueSnapshot,
+  };
+}
+
+function createDownload(name: string): string {
+  const downloads = path.join(testRoot, ".openclaw", "media", "qqbot", "downloads");
+  fs.mkdirSync(downloads, { recursive: true });
+  const filePath = path.join(downloads, name);
+  fs.writeFileSync(filePath, "payload", "utf8");
+  return filePath;
+}
+
+beforeEach(() => {
+  resetPluginStateStoreForTests();
+  testRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-qqbot-effect-once-"));
+  const stateDir = path.join(testRoot, "state");
+  fs.mkdirSync(stateDir, { recursive: true });
+  vi.stubEnv("OPENCLAW_HOME", testRoot);
+  vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+  vi.mocked(sendText).mockClear();
+});
+
+afterEach(() => {
+  resetPluginStateStoreForTests();
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+  fs.rmSync(testRoot, { recursive: true, force: true });
+  testRoot = "";
+});
+
+describe("QQBot slash-command ingress effects", () => {
+  it("clears storage once and still replies when the ingress event replays", async () => {
+    const filePath = createDownload("first.txt");
+    const unlink = vi.spyOn(fs, "unlinkSync");
+    const effectOnce = createQQBotIngressEffectOnce({ accountId: "default" });
+    const ingress = { eventId: "message:clear-1", effectOnce };
+
+    await expect(
+      trySlashCommand(createClearMessage(), createHandlerContext(), ingress),
+    ).resolves.toBe("handled");
+    await expect(
+      trySlashCommand(createClearMessage(), createHandlerContext(), ingress),
+    ).resolves.toBe("handled");
+
+    expect(fs.existsSync(filePath)).toBe(false);
+    expect(unlink).toHaveBeenCalledOnce();
+    expect(sendText).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(sendText).mock.calls[0]?.[1]).toContain("清理成功");
+    expect(vi.mocked(sendText).mock.calls[1]?.[1]).toContain("已经处理");
+  });
+
+  it("releases a failed effect so the same ingress event executes on retry", async () => {
+    const filePath = createDownload("retry.txt");
+    const targetDir = path.dirname(filePath);
+    const failure = new Error("scan failed");
+    const realExistsSync = fs.existsSync.bind(fs);
+    let failScan = true;
+    vi.spyOn(fs, "existsSync").mockImplementation((candidate) => {
+      if (String(candidate) === targetDir && failScan) {
+        failScan = false;
+        throw failure;
+      }
+      return realExistsSync(candidate);
+    });
+    const effectOnce = createQQBotIngressEffectOnce({ accountId: "default" });
+    const ingress = { eventId: "message:clear-retry", effectOnce };
+
+    await expect(
+      trySlashCommand(createClearMessage(), createHandlerContext(), ingress),
+    ).rejects.toBe(failure);
+    expect(realExistsSync(filePath)).toBe(true);
+
+    await expect(
+      trySlashCommand(createClearMessage(), createHandlerContext(), ingress),
+    ).resolves.toBe("handled");
+    expect(realExistsSync(filePath)).toBe(false);
+    expect(sendText).toHaveBeenCalledOnce();
+    expect(vi.mocked(sendText).mock.calls[0]?.[1]).toContain("清理成功");
+  });
+});

--- a/extensions/qqbot/src/engine/commands/slash-command-handler.ts
+++ b/extensions/qqbot/src/engine/commands/slash-command-handler.ts
@@ -7,6 +7,7 @@
 
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveGroupCommandLevelFromAccountConfig } from "../config/group.js";
+import type { QQBotIngressEffectOnce } from "../gateway/ingress-effects.js";
 import type { QueuedMessage } from "../gateway/message-queue.js";
 import type { GatewayAccount, EngineLogger } from "../gateway/types.js";
 import { sendDocument } from "../messaging/outbound.js";
@@ -41,6 +42,13 @@ export interface SlashCommandHandlerContext {
 
 const URGENT_COMMANDS = ["/stop"];
 
+class SlashCommandIngressEffectError extends Error {
+  constructor(readonly effectCause: unknown) {
+    super("QQBot slash-command ingress effect failed");
+    this.name = "SlashCommandIngressEffectError";
+  }
+}
+
 // ============ trySlashCommandOrEnqueue ============
 
 /**
@@ -52,6 +60,7 @@ const URGENT_COMMANDS = ["/stop"];
 export async function trySlashCommand(
   msg: QueuedMessage,
   ctx: SlashCommandHandlerContext,
+  ingress?: { eventId: string; effectOnce: QQBotIngressEffectOnce },
 ): Promise<"handled" | "urgent" | "enqueue"> {
   const { account, log } = ctx;
   const content = (msg.content ?? "").trim();
@@ -118,6 +127,17 @@ export async function trySlashCommand(
     commandAuthorized,
     groupCommandLevel,
     queueSnapshot: ctx.getQueueSnapshot(peerId),
+    ...(ingress
+      ? {
+          runIngressEffectOnce: async <T>(params: { effect: string; run: () => Promise<T> }) => {
+            try {
+              return await ingress.effectOnce.runOnce({ eventId: ingress.eventId, ...params });
+            } catch (error) {
+              throw new SlashCommandIngressEffectError(error);
+            }
+          },
+        }
+      : {}),
   };
 
   try {
@@ -175,6 +195,9 @@ export async function trySlashCommand(
 
     return "handled";
   } catch (err) {
+    if (err instanceof SlashCommandIngressEffectError) {
+      throw err.effectCause;
+    }
     log?.error(`Slash command error: ${String(err)}`);
     return "enqueue";
   }

--- a/extensions/qqbot/src/engine/commands/slash-commands.ts
+++ b/extensions/qqbot/src/engine/commands/slash-commands.ts
@@ -49,6 +49,8 @@ export interface SlashCommandContext {
   groupCommandLevel?: QQBotGroupCommandLevel;
   /** Queue snapshot for the current sender. */
   queueSnapshot: QueueSnapshot;
+  /** Durable guard for non-idempotent effects during ingress drain dispatch. */
+  runIngressEffectOnce?: SlashCommandIngressEffectRunner;
 }
 
 /** Queue status snapshot. */
@@ -58,6 +60,11 @@ export interface QueueSnapshot {
   maxConcurrentUsers: number;
   senderPending: number;
 }
+
+type SlashCommandIngressEffectRunner = <T>(params: {
+  effect: string;
+  run: () => Promise<T>;
+}) => Promise<{ kind: "executed"; value: T } | { kind: "replayed" }>;
 
 /** Slash command result: text, a text+file result, or null to skip handling. */
 export type SlashCommandResult = string | SlashCommandFileResult | null;

--- a/extensions/qqbot/src/engine/gateway/gateway-connection.ts
+++ b/extensions/qqbot/src/engine/gateway/gateway-connection.ts
@@ -20,6 +20,7 @@ import type { InteractionEvent } from "../types.js";
 import { decodeGatewayMessageData } from "./codec.js";
 import { FULL_INTENTS, RATE_LIMIT_DELAY, GatewayOp } from "./constants.js";
 import { dispatchEvent } from "./event-dispatcher.js";
+import { createQQBotIngressEffectOnce } from "./ingress-effects.js";
 import { isQQBotTurnEventType } from "./ingress-envelope.js";
 import {
   createQQBotIngressMonitor,
@@ -70,6 +71,7 @@ export class GatewayConnection {
 
   private readonly reconnect: ReconnectState;
   private readonly msgQueue;
+  private readonly ingressEffectOnce;
   private readonly ctx: GatewayConnectionContext;
 
   constructor(ctx: GatewayConnectionContext) {
@@ -79,6 +81,10 @@ export class GatewayConnection {
       accountId: ctx.account.accountId,
       log: ctx.log,
       isAborted: () => this.isAborted,
+    });
+    this.ingressEffectOnce = createQQBotIngressEffectOnce({
+      accountId: ctx.account.accountId,
+      log: ctx.log,
     });
   }
 
@@ -91,7 +97,8 @@ export class GatewayConnection {
       accountId: this.ctx.account.accountId,
       runtime: this.ctx.runtime,
       log: this.ctx.log,
-      dispatch: (message, lifecycle) => this.dispatchIngressMessage(message, lifecycle, slashCtx),
+      dispatch: (message, lifecycle, eventId) =>
+        this.dispatchIngressMessage(message, lifecycle, eventId, slashCtx),
     });
     const stopped = new Promise<void>((resolve, reject) => {
       const stop = () => void this.shutdown().then(resolve, reject);
@@ -198,6 +205,7 @@ export class GatewayConnection {
   private async dispatchIngressMessage(
     msg: QueuedMessage,
     lifecycle: QQBotIngressLifecycle,
+    eventId: string,
     slashCtx: SlashCommandHandlerContext,
   ): Promise<QQBotIngressDispatchResult> {
     if (this.isAborted || lifecycle.abortSignal.aborted) {
@@ -208,9 +216,12 @@ export class GatewayConnection {
       };
     }
     msg.turnAdoptionLifecycle = lifecycle;
-    // Fleet at-least-once contract: a crash after slash-command side effects but before the
-    // completion tombstone can replay the command, matching complete-at-adoption behavior.
-    const result = await trySlashCommand(msg, slashCtx);
+    // Fleet at-least-once contract: a pre-tombstone crash can replay slash commands.
+    // Non-idempotent handlers opt into createIngressEffectOnce through this dispatch context.
+    const result = await trySlashCommand(msg, slashCtx, {
+      eventId,
+      effectOnce: this.ingressEffectOnce,
+    });
     if (result === "handled") {
       return { kind: "completed" };
     }

--- a/extensions/qqbot/src/engine/gateway/ingress-effects.ts
+++ b/extensions/qqbot/src/engine/gateway/ingress-effects.ts
@@ -1,0 +1,21 @@
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { createIngressEffectOnce } from "openclaw/plugin-sdk/ingress-effect-once";
+import { QQBOT_INGRESS_COMPLETED_MAX_ENTRIES, QQBOT_INGRESS_COMPLETED_TTL_MS } from "./ingress.js";
+import type { EngineLogger } from "./types.js";
+
+export type QQBotIngressEffectOnce = ReturnType<typeof createIngressEffectOnce>;
+
+export function createQQBotIngressEffectOnce(params: {
+  accountId: string;
+  log?: EngineLogger;
+}): QQBotIngressEffectOnce {
+  return createIngressEffectOnce({
+    pluginId: "qqbot",
+    namespacePrefix: `qqbot.gateway.${params.accountId}`,
+    ttlMs: QQBOT_INGRESS_COMPLETED_TTL_MS,
+    stateMaxEntries: QQBOT_INGRESS_COMPLETED_MAX_ENTRIES,
+    onDiskError: (error) => {
+      params.log?.error(`QQBot ingress effect state failed: ${formatErrorMessage(error)}`);
+    },
+  });
+}

--- a/extensions/qqbot/src/engine/gateway/ingress.test.ts
+++ b/extensions/qqbot/src/engine/gateway/ingress.test.ts
@@ -189,12 +189,13 @@ describe("QQBot durable ingress", () => {
 
   it("stores the exact raw envelope in the user conversation lane", async () => {
     await withQQBotIngressQueue(async (queue) => {
-      const dispatch = vi.fn(async () => ({ kind: "deferred" as const }));
+      const dispatch = vi.fn<QQBotIngressDispatch>(async () => ({ kind: "deferred" as const }));
       const monitor = startMonitor(queue, dispatch);
       const rawEnvelope = qqC2CEnvelope({ messageId: "raw", userId: "user-raw" });
       try {
         await monitor.receive(rawEnvelope);
         await vi.waitFor(() => expect(dispatch).toHaveBeenCalledTimes(1));
+        expect(dispatch.mock.calls[0]?.[2]).toBe("message:raw");
         expect(await queue.listClaims()).toEqual([
           expect.objectContaining({
             id: "message:raw",

--- a/extensions/qqbot/src/engine/gateway/ingress.ts
+++ b/extensions/qqbot/src/engine/gateway/ingress.ts
@@ -21,8 +21,8 @@ import type { EngineLogger, GatewayPluginRuntime, QQBotIngressLifecycle } from "
 const QQBOT_INGRESS_PAYLOAD_VERSION = 1;
 const QQBOT_INGRESS_POLL_INTERVAL_MS = 1_000;
 const QQBOT_INGRESS_PRUNE_INTERVAL_MS = 60 * 60 * 1_000;
-const QQBOT_INGRESS_COMPLETED_TTL_MS = 30 * 24 * 60 * 60 * 1_000;
-const QQBOT_INGRESS_COMPLETED_MAX_ENTRIES = 20_000;
+export const QQBOT_INGRESS_COMPLETED_TTL_MS = 30 * 24 * 60 * 60 * 1_000;
+export const QQBOT_INGRESS_COMPLETED_MAX_ENTRIES = 20_000;
 const QQBOT_INGRESS_FAILED_TTL_MS = 30 * 24 * 60 * 60 * 1_000;
 const QQBOT_INGRESS_FAILED_MAX_ENTRIES = 20_000;
 
@@ -40,6 +40,7 @@ export type QQBotIngressDispatchResult =
 type QQBotIngressDispatch = (
   message: QueuedMessage,
   lifecycle: QQBotIngressLifecycle,
+  eventId: string,
 ) => Promise<QQBotIngressDispatchResult | void> | QQBotIngressDispatchResult | void;
 
 export class QQBotIngressAdmissionError extends Error {
@@ -123,7 +124,7 @@ export function createQQBotIngressMonitor(options: {
             `QQBot ingress row ${claimed.id} no longer maps to a message turn.`,
           );
         }
-        return await options.dispatch(mapped.msg, lifecycle);
+        return await options.dispatch(mapped.msg, lifecycle, claimed.id);
       },
     });
     return drain;


### PR DESCRIPTION
Related: #109657

Chip context: accepted at-least-once crash-window contract, opt-in exactly-once for non-idempotent effects.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where QQBot users replaying a durably admitted clear-storage slash command after a crash could delete files that arrived after the first execution.

## Why This Change Was Made

QQBot now passes its durable ingress event ID into slash-command dispatch and uses the shared ingress effect guard for the destructive clear-storage operation. The guard is scoped per account, retains claims for the same 30-day window as QQBot ingress tombstones, releases failed effects for retry, and leaves target-state config commands unwrapped.

## User Impact

Replayed clear-storage commands no longer repeat deletion. Users still receive an idempotent confirmation reply on replay, while failed clears remain retryable.

## Evidence

- Full QQBot suite: 85 files, 696 tests passed.
- Focused replay and ingress suites: 2 files, 11 tests passed.
- Existing slash-command and gateway suites: 4 files, 34 tests passed.
- Both unused-file and unused-export dead-code gates passed with zero entries.
- Changed-surface gate passed, including extension and extension-test typechecks, lint, formatting, plugin boundaries, and runtime import-cycle checks.
- Autoreview passed in uncommitted mode and in branch mode against origin/main with no actionable findings.
- oxfmt and git diff --check passed.
