### PR TITLE
fix(discord): prevent voice speaker cache growth

### DIFF
--- a/extensions/discord/src/voice/speaker-context.test.ts
+++ b/extensions/discord/src/voice/speaker-context.test.ts
@@ -55,4 +55,25 @@ describe("DiscordVoiceSpeakerContextResolver", () => {
 
     expect(fetchMember).toHaveBeenCalledTimes(2);
   });
+
+  it("evicts the oldest speaker context after the cache reaches its production bound", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    const fetchMember = vi.fn(async (_guildId: string, userId: string) => ({
+      nickname: userId,
+      roles: [],
+      user: { id: userId, username: userId, globalName: userId },
+    }));
+    const resolver = new DiscordVoiceSpeakerContextResolver({
+      client: createClient(fetchMember),
+    });
+
+    for (let index = 0; index <= 5_000; index += 1) {
+      await resolver.resolveContext("g1", `u${index}`);
+    }
+    await resolver.resolveContext("g1", "u0");
+    await resolver.resolveContext("g1", "u5000");
+
+    expect(fetchMember).toHaveBeenCalledTimes(5_002);
+  });
 });

--- a/extensions/discord/src/voice/speaker-context.ts
+++ b/extensions/discord/src/voice/speaker-context.ts
@@ -8,6 +8,7 @@ import { resolveDiscordOwnerAccess } from "../monitor/allow-list.js";
 import { formatDiscordUserTag } from "../monitor/format.js";
 
 const SPEAKER_CONTEXT_CACHE_TTL_MS = 60_000;
+const SPEAKER_CONTEXT_CACHE_MAX_ENTRIES = 5_000;
 
 type VoiceSpeakerIdentity = {
   id: string;
@@ -136,6 +137,15 @@ export class DiscordVoiceSpeakerContextResolver {
         ...context,
         expiresAt,
       });
+      // Expiry is checked on lookup, so one-time speakers would otherwise remain
+      // for the full voice-manager lifetime even after their entries expire.
+      while (this.cache.size > SPEAKER_CONTEXT_CACHE_MAX_ENTRIES) {
+        const oldestKey = this.cache.keys().next().value;
+        if (oldestKey === undefined) {
+          break;
+        }
+        this.cache.delete(oldestKey);
+      }
     }
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where long-running Discord voice accounts could retain an unbounded number of expired speaker-context entries after encountering many unique speakers.

The cache uses a 60-second TTL, but expiry was only checked when the same guild/user key was looked up again. One-time speakers therefore remained in the voice manager's cache for its entire process lifetime.

## Why This Change Was Made

The Discord voice speaker-context owner now caps the cache at 5,000 entries and evicts the oldest inserted entry when the cap is exceeded. This matches the fixed-TTL ordering: the oldest entry is also the first one due to expire.

The change does not alter the existing 60-second TTL, Discord REST behavior, permission checks, configuration, or public Plugin SDK surfaces.

## User Impact

Discord voice bots that run for long periods or span many guilds no longer accumulate stale speaker identity contexts without a memory bound. Active and recently observed speakers continue to use the existing cache behavior.

## Evidence

Exact commit: `3e9b135b2f619343c619a56b2ca31f4e644bd53c`

Final pre-push checks:

- latest checked `origin/main`: `5fdb0cd24e68cd27c54ec32c821e8d0165b2e7ac`
- current main does not contain a speaker-context cache size bound
- no open PR touches `extensions/discord/src/voice/speaker-context.ts` or its test (all current open-PR pages checked)
- broad open-PR searches for `speaker context cache`, `discord voice cache bound`, and `one-time speakers cache` returned no matches
- author open PR count: 17 (below the repository limit of 20)

### Before: regression proof

The regression drives the public production `resolveContext()` method through 5,001 unique Discord speaker keys, then looks up the oldest key again. On unpatched main, the oldest entry is still cached, so the client lookup count remains 5,001 instead of reaching 5,002.

```text
$ node scripts/run-vitest.mjs extensions/discord/src/voice/speaker-context.test.ts --reporter verbose

 RUN  v4.1.10 /media/vdc/code/ai/github/openclaw-discord-speaker-context-cache-bound

 ✓ ... > reuses cached speaker context for repeated speaker lookups
 ✓ ... > does not cache speaker context when the cache expiry would exceed Date range
 × ... > evicts the oldest speaker context after the cache reaches its production bound
   → expected "vi.fn()" to be called 5002 times, but got 5001 times

 Test Files  1 failed (1)
      Tests  1 failed | 2 passed (3)
   Duration  7.42s
```

### After: focused regression

The final test also re-reads the newest key after the overflow, proving the oldest entry is evicted while a recent entry remains cached.

```text
$ node scripts/run-vitest.mjs extensions/discord/src/voice/speaker-context.test.ts --reporter verbose

 RUN  v4.1.10 /media/vdc/code/ai/github/openclaw-discord-speaker-context-cache-bound

 ✓ ... > reuses cached speaker context for repeated speaker lookups 497ms
 ✓ ... > does not cache speaker context when the cache expiry would exceed Date range 4ms
 ✓ ... > evicts the oldest speaker context after the cache reaches its production bound 165ms

 Test Files  1 passed (1)
      Tests  3 passed (3)
   Duration  9.72s
```

### Adjacent Discord voice coverage

```text
$ node scripts/run-vitest.mjs \
    extensions/discord/src/voice/speaker-context.test.ts \
    extensions/discord/src/voice/participant-context.test.ts \
    --reporter verbose

 Test Files  2 passed (2)
      Tests  5 passed (5)
   Duration  70.68s
```

### Formatting and lint

```text
$ ./node_modules/.bin/oxfmt --check \
    extensions/discord/src/voice/speaker-context.ts \
    extensions/discord/src/voice/speaker-context.test.ts
Checking formatting...

All matched files use the correct format.
Finished in 184ms on 2 files using 8 threads.

$ OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs \
    extensions/discord/src/voice/speaker-context.ts \
    extensions/discord/src/voice/speaker-context.test.ts
# exit 0

$ git diff --check
# exit 0
```

The local `check:changed` fallback passed conflict-marker, max-lines, attribution, wildcard-export, duplicate-coverage, dependency-pin, formatting, Plugin SDK API, deprecated-API, plugin-boundary, package-patch, and temp-creation checks. It then stopped in the repository-wide extension typecheck on existing `packages/net-policy/src/ip.ts` dependency/type mismatches outside this two-file diff. Blacksmith was unavailable locally and direct AWS Crabbox was not authenticated; the PR's exact-head CI is therefore the authoritative typecheck/lint fan-out.

### Review

The repository autoreview helper ran with Codex `gpt-5.6-sol` for approximately 17 minutes, then exited at the model-engine layer with `codex engine failed (1)` before returning findings or a clean verdict. It did not report a code finding. An equivalent manual review covered the changed class, the long-lived `DiscordVoiceManager` owner, voice ingress and participant-roster callers, the Discord entity/thread/presence cache siblings, concurrency behavior, TTL ordering, and adjacent tests.

Best-fix conclusion: keeping the bound inside `DiscordVoiceSpeakerContextResolver` is the narrow owner-boundary fix. A timer/sweep would add lifecycle work, and reusing the REST entity cache would mix different value and invalidation contracts.
