### PR TITLE
feat(ui): distinct Apps icon and pairing shortcut on the Apps page

### DIFF
--- a/ui/src/app-navigation.test.ts
+++ b/ui/src/app-navigation.test.ts
@@ -84,7 +84,7 @@ describe("navigationIconForRoute", () => {
       chat: "messageSquare",
       custodian: "lobster",
       activity: "activity",
-      apps: "smartphone",
+      apps: "layoutGrid",
       approvals: "shieldCheck",
       workboard: "kanban",
       worktrees: "folder",

--- a/ui/src/app-navigation.ts
+++ b/ui/src/app-navigation.ts
@@ -206,7 +206,7 @@ const SETTINGS_TAKEOVER_ROUTES = SETTINGS_NAVIGATION_ROUTES.filter(
 const NAVIGATION_ICONS: NavigationItem = {
   agents: "bot",
   activity: "activity",
-  apps: "smartphone",
+  apps: "layoutGrid",
   approvals: "shieldCheck",
   workboard: "kanban",
   worktrees: "folder",

--- a/ui/src/components/app-sidebar-agent-menu.ts
+++ b/ui/src/components/app-sidebar-agent-menu.ts
@@ -335,7 +335,7 @@ export function renderSidebarAgentMenu(params: SidebarAgentMenuParams) {
           <span class="sidebar-customize-menu__text">${t("nodes.pairing.button")}</span>
         </wa-dropdown-item>
         <wa-dropdown-item class="sidebar-customize-menu__item" value="command:apps">
-          <span slot="icon" class="nav-item__icon" aria-hidden="true">${icons.smartphone}</span>
+          <span slot="icon" class="nav-item__icon" aria-hidden="true">${icons.layoutGrid}</span>
           <span class="sidebar-customize-menu__text">${t("agentChip.getApps")}</span>
         </wa-dropdown-item>
         <wa-dropdown-item

--- a/ui/src/components/command-palette.ts
+++ b/ui/src/components/command-palette.ts
@@ -71,7 +71,7 @@ function getPaletteBaseItems(): PaletteItem[] {
     {
       id: "nav-apps",
       label: t("palette.items.apps"),
-      icon: "smartphone",
+      icon: "layoutGrid",
       category: "navigation",
       action: "nav:apps",
     },

--- a/ui/src/components/icons.ts
+++ b/ui/src/components/icons.ts
@@ -12,6 +12,14 @@ export const icons = {
       <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
     </svg>
   `,
+  layoutGrid: html`
+    <svg viewBox="0 0 24 24">
+      <rect width="7" height="7" x="3" y="3" rx="1" />
+      <rect width="7" height="7" x="14" y="3" rx="1" />
+      <rect width="7" height="7" x="14" y="14" rx="1" />
+      <rect width="7" height="7" x="3" y="14" rx="1" />
+    </svg>
+  `,
   barChart: html`
     <svg viewBox="0 0 24 24">
       <line x1="12" x2="12" y1="20" y2="10" />

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -2085,6 +2085,8 @@ export const en: TranslationMap = {
     heroTagline:
       "Companion apps for your phone, watch, desktop, and browser — plus plugins to extend what your agent can do.",
     sectionMobile: "On your phone",
+    havePhone: "Already have the app?",
+    pairDevice: "Pair your device",
     sectionWatch: "On your wrist",
     sectionDesktop: "On your desktop",
     sectionBrowser: "In your browser",

--- a/ui/src/pages/apps/apps-page.ts
+++ b/ui/src/pages/apps/apps-page.ts
@@ -3,17 +3,37 @@ import { html } from "lit";
 import { titleForRoute } from "../../app-navigation.ts";
 import type { RouteId } from "../../app-route-paths.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
+import { hasOperatorAdminAccess } from "../../app/operator-access.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
+import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import { renderApps } from "./view.ts";
 
 class AppsPage extends OpenClawLightDomElement {
   @consume({ context: applicationContext, subscribe: true })
   private context!: ApplicationContext;
 
+  // Re-render on gateway snapshots so the pairing affordance follows the
+  // connection/admin state, mirroring the agent-menu canPairDevice gate.
+  private readonly subscriptions = new SubscriptionsController(this).watch(
+    () => this.context?.gateway,
+    (gateway, notify) => gateway.subscribe(notify),
+  );
+
+  override disconnectedCallback() {
+    this.subscriptions.clear();
+    super.disconnectedCallback();
+  }
+
   override render() {
+    const gatewaySnapshot = this.context.gateway.snapshot;
+    const canPairDevice =
+      gatewaySnapshot.connected && hasOperatorAdminAccess(gatewaySnapshot.hello?.auth ?? null);
     const body = renderApps({
       onNavigate: (routeId: RouteId) => this.context.navigate(routeId),
+      onPairDevice: canPairDevice
+        ? () => void this.context.overlays.openDevicePairSetup()
+        : undefined,
     });
     return html`
       <section class="content-header">

--- a/ui/src/pages/apps/view.test.ts
+++ b/ui/src/pages/apps/view.test.ts
@@ -30,9 +30,9 @@ describe("renderApps", () => {
     await i18n.setLocale("en");
   });
 
-  function renderIntoContainer(onNavigate = vi.fn()) {
+  function renderIntoContainer(onNavigate = vi.fn(), onPairDevice?: () => void) {
     const container = document.createElement("div");
-    render(renderApps({ onNavigate }), container);
+    render(renderApps({ onNavigate, onPairDevice }), container);
     return container;
   }
 
@@ -77,6 +77,18 @@ describe("renderApps", () => {
     expect(buttons[0]?.textContent).toContain("Open Plugins");
     buttons[0]?.click();
     expect(onNavigate).toHaveBeenCalledExactlyOnceWith("plugins");
+  });
+
+  it("offers device pairing from the phone section only when permitted", () => {
+    const withoutPair = renderIntoContainer();
+    expect(withoutPair.querySelector(".apps-pair-hint")).toBeNull();
+
+    const onPairDevice = vi.fn();
+    const container = renderIntoContainer(vi.fn(), onPairDevice);
+    const hint = container.querySelector(".apps-pair-hint");
+    expect(hint?.textContent).toContain("Already have the app?");
+    hint?.querySelector("button")?.click();
+    expect(onPairDevice).toHaveBeenCalledOnce();
   });
 
   it("badges the watch apps as bundled with their phone apps", () => {

--- a/ui/src/pages/apps/view.ts
+++ b/ui/src/pages/apps/view.ts
@@ -11,6 +11,8 @@ import { appsBrandIcons } from "./brand-icons.ts";
 
 type AppsProps = {
   onNavigate: (routeId: RouteId) => void;
+  /** Opens the device-pairing dialog; absent when the operator cannot pair. */
+  onPairDevice?: () => void;
 };
 
 type AppCardCta =
@@ -258,10 +260,22 @@ function renderAppCard(card: AppCard, props: AppsProps) {
 }
 
 function renderSection(section: AppSection, props: AppsProps) {
+  const pairHint =
+    section.id === "mobile" && props.onPairDevice
+      ? html`
+          <p class="apps-pair-hint">
+            ${t("appsPage.havePhone")}
+            <button type="button" @click=${props.onPairDevice}>
+              ${t("appsPage.pairDevice")}
+            </button>
+          </p>
+        `
+      : nothing;
   return html`
     <section class="apps-section" aria-label=${section.label()}>
       <h2 class="apps-section__heading">${section.label()}</h2>
       <div class="apps-grid">${section.cards.map((card) => renderAppCard(card, props))}</div>
+      ${pairHint}
     </section>
   `;
 }

--- a/ui/src/styles/apps.css
+++ b/ui/src/styles/apps.css
@@ -188,6 +188,33 @@
   box-shadow: var(--focus-ring);
 }
 
+.apps-pair-hint {
+  margin: 10px 2px 0;
+  color: var(--muted);
+  font-size: var(--control-ui-text-sm);
+}
+
+.apps-pair-hint button {
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--text);
+  font: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.apps-pair-hint button:hover {
+  color: var(--text-strong);
+}
+
+.apps-pair-hint button:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+  border-radius: 4px;
+}
+
 .apps-community {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
Related: #110563, #110622

## What Problem This Solves

Two polish gaps from the Apps & extensions rollout: (1) the sidebar agent menu showed the identical smartphone icon for both "Pair mobile device" and "Get the apps", making the rows visually indistinguishable; (2) the install→pair loop only worked one way — the pairing dialog links to the Apps page, but the Apps page offered no path back into pairing after a user installs the phone app.

## Why This Change Was Made

Maintainer feedback on the shipped menu: "we're using the same logo for pairing and get the apps — change the logo, and also have links for pairing in the app page." A grid glyph is the conventional mark for an apps catalog, and the recent icons.ts split (#110682) made room for it under the file-size cap.

## User Impact

"Get the apps" now uses a layout-grid icon everywhere it appears (sidebar nav entry, command palette, agent menu), so it no longer mirrors the pairing row's phone icon. The Apps page's "On your phone" section gains an "Already have the app? Pair your device" shortcut that opens the pairing dialog; it only renders for connected operators with admin access — the same gate as the agent-menu pairing entry — so read-only viewers never see a dead control.

## Evidence

- Live-verified in the mock dev harness: the agent menu shows distinct icons for the two rows; the Apps-page shortcut opens the pairing dialog over the page; the pairing dialog's "Get the apps" link still routes back to `/apps`.
- New view test: pairing hint hidden without the callback, rendered + click-fires with it; nav test updated for the icon; 41 focused tests pass (apps view + app-navigation).
- `pnpm tsgo:ui` green; `pnpm ui:i18n:baseline` + `pnpm ui:i18n:verify` green (two new keys).
- Autoreview (Codex gpt-5.6-sol, xhigh): clean, "no accepted/actionable findings".
