### PR TITLE
fix(cron): preserve flattened condition triggers

### DIFF
--- a/src/agents/tools/cron-tool-canonicalize.ts
+++ b/src/agents/tools/cron-tool-canonicalize.ts
@@ -42,6 +42,7 @@ const CRON_RECOVERABLE_OBJECT_KEYS: ReadonlySet<string> = new Set([
   "displayName",
   "owner",
   "schedule",
+  "trigger",
   "sessionTarget",
   "wakeMode",
   "payload",

--- a/src/agents/tools/cron-tool.flat-params.test.ts
+++ b/src/agents/tools/cron-tool.flat-params.test.ts
@@ -119,6 +119,24 @@ describe("cron tool flat-params", () => {
     });
   });
 
+  it("recovers a flat trigger when adding a job", async () => {
+    const tool = createCronTool(undefined, { callGatewayTool: callGatewayToolMock });
+
+    await tool.execute("call-flat-trigger-add", {
+      action: "add",
+      name: "watcher",
+      schedule: { kind: "every", everyMs: 60_000 },
+      message: "report the change",
+      trigger: { script: "json({ fire: false })", once: true },
+    });
+
+    const [method, _gatewayOpts, params] = firstGatewayToolCall<{
+      trigger?: { script?: string; once?: boolean };
+    }>();
+    expect(method).toBe("cron.add");
+    expect(params.trigger).toEqual({ script: "json({ fire: false })", once: true });
+  });
+
   it("rejects flat on-exit schedule shorthand for add", async () => {
     const tool = createCronTool(undefined, { callGatewayTool: callGatewayToolMock });
 
@@ -242,6 +260,43 @@ describe("cron tool flat-params", () => {
       tz: "America/Los_Angeles",
       staggerMs: 30_000,
     });
+  });
+
+  it("recovers a flat trigger when updating a job", async () => {
+    const tool = createCronTool(undefined, { callGatewayTool: callGatewayToolMock });
+
+    await tool.execute("call-flat-trigger-update", {
+      action: "update",
+      jobId: "job-trigger",
+      trigger: { script: "json({ fire: true })", once: false },
+    });
+
+    const [method, _gatewayOpts, params] = firstGatewayToolCall<{
+      id?: string;
+      patch?: { trigger?: { script?: string; once?: boolean } };
+    }>();
+    expect(method).toBe("cron.update");
+    expect(params).toEqual({
+      id: "job-trigger",
+      patch: { trigger: { script: "json({ fire: true })", once: false } },
+    });
+  });
+
+  it("recovers a flat trigger clear when updating a job", async () => {
+    const tool = createCronTool(undefined, { callGatewayTool: callGatewayToolMock });
+
+    await tool.execute("call-flat-trigger-clear", {
+      action: "update",
+      jobId: "job-trigger",
+      trigger: null,
+    });
+
+    const [method, _gatewayOpts, params] = firstGatewayToolCall<{
+      id?: string;
+      patch?: { trigger?: null };
+    }>();
+    expect(method).toBe("cron.update");
+    expect(params).toEqual({ id: "job-trigger", patch: { trigger: null } });
   });
 
   it("trims trailing whitespace from recognized job object keys (#95407)", async () => {


### PR DESCRIPTION
Closes #110911

## What Problem This Solves

Fixes an issue where users creating condition-watcher cron jobs through models that flatten tool arguments could get an unconditional recurring job instead. The flattened schedule and payload survived recovery, but the trigger and its once-only policy were silently discarded. Trigger-only flat updates also failed.

## Why This Change Was Made

The cron tool now treats `trigger` as a recoverable canonical job field, matching the nested agent-tool schema, gateway protocol, and existing flat recovery behavior. The change preserves trigger objects on add and update, plus explicit `null` clearing, without changing direct gateway or CLI paths.

## User Impact

Model-authored condition watchers retain their guard script and once-only semantics even when a model emits the supported flattened argument shape. Updates can also replace or clear a flattened trigger instead of silently ignoring it.

## Evidence

- Before fix: add regression received `trigger: undefined`; trigger-only update threw `patch required`.
- Focused regression file: 18/18 passed after the fix.
- Stress: 50 consecutive focused suite runs, 900/900 test executions, zero failures.
- Blacksmith Testbox `check:changed`: core production/test types, lint, format, plugin boundaries, import cycles, database-first guard, and related checks passed.
- Live OpenAI (`openai/gpt-5.4`) on isolated gateways:
  - Model-created one-shot and recurring jobs passed natural execution; the one-shot ran once and deleted, the recurring job ran repeatedly and survived gateway restart.
  - Condition watcher passed multiple quiet polls with no run rows, exactly one triggered payload, persisted trigger state, and `once` disarm.
- Autoreview: clean, no accepted/actionable findings; correctness confidence 0.94.

AI-assisted. I reviewed the canonicalization, schema, gateway, runtime, CLI sibling paths, tests, and live behavior.
