### PR TITLE
feat: flow dashboard session activity to main agents

### DIFF
--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -696,6 +696,92 @@ test("sessions.create stores dashboard model, thinking, and parent linkage, and 
   ]);
 });
 
+test.each([undefined, "main"])(
+  "sessions.create parents dashboard sessions to agent main when dmScope is %s",
+  async (dmScope) => {
+    await createSessionStoreDir();
+    testState.sessionConfig = dmScope ? { dmScope } : undefined;
+
+    const created = await directSessionReq<{
+      key?: string;
+      entry?: { parentSessionKey?: string };
+    }>("sessions.create", { agentId: "main" });
+
+    expect(created.ok, JSON.stringify(created.error)).toBe(true);
+    expect(created.payload?.key).toMatch(/^agent:main:dashboard:/);
+    expect(created.payload?.entry?.parentSessionKey).toBe("agent:main:main");
+  },
+);
+
+test("sessions.create preserves an explicit parent under main dmScope", async () => {
+  await createSessionStoreDir();
+  testState.sessionConfig = { dmScope: "main" };
+  await writeSessionStore({
+    entries: {
+      "agent:main:explicit-parent": sessionStoreEntry("sess-explicit-parent"),
+    },
+  });
+
+  const created = await directSessionReq<{
+    key?: string;
+    entry?: { parentSessionKey?: string };
+  }>("sessions.create", {
+    agentId: "main",
+    parentSessionKey: "agent:main:explicit-parent",
+  });
+
+  expect(created.ok, JSON.stringify(created.error)).toBe(true);
+  expect(created.payload?.entry?.parentSessionKey).toBe("agent:main:explicit-parent");
+
+  const reused = await directSessionReq<{
+    entry?: { parentSessionKey?: string };
+  }>("sessions.create", {
+    agentId: "main",
+    key: created.payload?.key,
+  });
+
+  expect(reused.ok, JSON.stringify(reused.error)).toBe(true);
+  expect(reused.payload?.entry?.parentSessionKey).toBe("agent:main:explicit-parent");
+});
+
+test("sessions.create leaves dashboard sessions unparented under per-channel-peer dmScope", async () => {
+  await createSessionStoreDir();
+  testState.sessionConfig = { dmScope: "per-channel-peer" };
+
+  const created = await directSessionReq<{
+    entry?: { parentSessionKey?: string };
+  }>("sessions.create", { agentId: "main" });
+
+  expect(created.ok, JSON.stringify(created.error)).toBe(true);
+  expect(created.payload?.entry?.parentSessionKey).toBeUndefined();
+});
+
+test("sessions.create leaves dashboard sessions unparented under global session scope", async () => {
+  await createSessionStoreDir();
+  testState.sessionConfig = { dmScope: "main", scope: "global" };
+
+  const created = await directSessionReq<{
+    entry?: { parentSessionKey?: string };
+  }>("sessions.create", { agentId: "main" });
+
+  expect(created.ok, JSON.stringify(created.error)).toBe(true);
+  expect(created.payload?.entry?.parentSessionKey).toBeUndefined();
+});
+
+test("sessions.create does not parent the main session to itself", async () => {
+  await createSessionStoreDir();
+  testState.sessionConfig = { dmScope: "main" };
+
+  const created = await directSessionReq<{
+    key?: string;
+    entry?: { parentSessionKey?: string };
+  }>("sessions.create", { agentId: "main", key: "main" });
+
+  expect(created.ok, JSON.stringify(created.error)).toBe(true);
+  expect(created.payload?.key).toBe("agent:main:main");
+  expect(created.payload?.entry?.parentSessionKey).toBeUndefined();
+});
+
 test("sessions.create resolves a catalog target server-side and pins its runtime", async () => {
   const { storePath } = await createSessionStoreDir();
   testState.agentConfig = { model: { primary: "anthropic/claude-opus-4-8" } };

--- a/src/gateway/session-create-service.ts
+++ b/src/gateway/session-create-service.ts
@@ -313,6 +313,18 @@ export async function createGatewaySession(params: {
       error: errorShape(ErrorCodes.INVALID_REQUEST, "fork requires parentSessionKey"),
     };
   }
+  const targetSessionKey = explicitTargetKey ?? buildDashboardSessionKey(agentId);
+  const agentMainSessionKey = resolveAgentMainSessionKey({ cfg: params.cfg, agentId });
+  // Dashboard sessions parent to main for flow-up notices and sidebar threads.
+  // Isolated DM scopes lack the shared watcher; global scope lacks a per-agent main.
+  const dashboardParentSessionKey =
+    !parentSessionKey &&
+    params.fork !== true &&
+    (params.cfg.session?.dmScope ?? "main") === "main" &&
+    params.cfg.session?.scope !== "global" &&
+    targetSessionKey !== agentMainSessionKey
+      ? agentMainSessionKey
+      : undefined;
   let canonicalParentSessionKey: string | undefined;
   let parentSessionEntry: SessionEntry | undefined;
   let parentSelectedAgentId: string | undefined;
@@ -505,7 +517,7 @@ export async function createGatewaySession(params: {
       });
     }
 
-    const key = explicitTargetKey ?? buildDashboardSessionKey(agentId);
+    const key = targetSessionKey;
     const target = resolveGatewaySessionStoreTarget({ cfg: params.cfg, key, agentId });
     const created = await createSessionEntryWithTranscript<ErrorShape>(
       {
@@ -647,22 +659,27 @@ export async function createGatewaySession(params: {
         };
         sessionEntries[target.canonicalKey] = initializedEntry;
         const initialized = { ...patched, entry: initializedEntry };
-        if (!canonicalParentSessionKey) {
+        const storedParentSessionKey =
+          canonicalParentSessionKey ??
+          normalizeOptionalString(initializedEntry.parentSessionKey) ??
+          dashboardParentSessionKey;
+        if (!storedParentSessionKey) {
           return initialized;
         }
         const inheritedSelection =
-          catalogModel || normalizeOptionalString(params.model)
+          !canonicalParentSessionKey || catalogModel || normalizeOptionalString(params.model)
             ? {}
             : inheritSessionSelection(currentParentSessionEntry);
         const entry: SessionEntry = {
           ...initializedEntry,
           ...inheritedSelection,
-          parentSessionKey: canonicalParentSessionKey,
+          parentSessionKey: storedParentSessionKey,
         };
         if (params.fork !== true) {
           return { ...initialized, entry };
         }
-        if (!currentParentSessionEntry || !parentSessionTarget) {
+        const forkParentSessionKey = canonicalParentSessionKey;
+        if (!forkParentSessionKey || !currentParentSessionEntry || !parentSessionTarget) {
           return {
             ok: false,
             error: errorShape(ErrorCodes.UNAVAILABLE, "failed to resolve parent session for fork"),
@@ -688,7 +705,7 @@ export async function createGatewaySession(params: {
         const fork = await forkSessionFromParent({
           parentEntry: currentParentSessionEntry,
           agentId: parentSessionTarget.agentId,
-          parentSessionKey: canonicalParentSessionKey,
+          parentSessionKey: forkParentSessionKey,
           sessionKey: target.canonicalKey,
           storePath: parentSessionTarget.storePath,
           // Keep the fork transcript owned by the child store across agent boundaries.


### PR DESCRIPTION
## What Problem This Solves

Dashboard-created sessions were independent roots. Human turns in those sessions therefore had no producer watcher, so the routed agent's main session did not learn about the activity through the existing session-state watch queue.

## Why This Change Was Made

The dashboard `sessions.create` service now gives otherwise-unparented sessions a metadata-only parent pointing at the routed agent's canonical main session when the effective global `session.dmScope` is `main` (including the unset default). Explicit and previously stored parents remain authoritative; fork creation, isolated DM scopes, global session scope, and creation of the main session itself remain unchanged.

This uses the existing upstream-link model: `parentSessionKey` supplies the watch producer and the Control UI thread relationship without adding config, fork semantics, parent model inheritance, or channel/session creation behavior.

## User Impact

The main agent can now receive coalesced flow-up notices when users continue dashboard-created threads, while those sessions remain visible as top-level Threads in the Control UI.

`sessions_list` default `tree` visibility is additive: its row ownership check already treats `parentSessionKey === requesterSessionKey` as requester-owned. The Control UI navigation filter hides `spawnedBy` rows only, not `parentSessionKey` rows, so dashboard sessions remain sidebar roots.

Release-note context: Dashboard-created sessions now flow activity back to their agent's main session while remaining first-class Control UI threads.

AI-assisted implementation; reviewed and understood.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/server.sessions.create.test.ts src/sessions/session-state-events.test.ts`
  - session create: 48 passed
  - session state events: 28 passed
- `pnpm tsgo:core`
- `git diff origin/main...HEAD --check`
- `autoreview --mode branch --base origin/main`: clean, no accepted/actionable findings
- Blacksmith Testbox: `tbx_01kxv9pccxs0k0zq1hd6wq6s48` ([run](https://github.com/openclaw/openclaw/actions/runs/29657009919))
