### PR TITLE
feat(irc): add durable ingress queue

### DIFF
--- a/extensions/irc/src/client.ts
+++ b/extensions/irc/src/client.ts
@@ -48,6 +48,7 @@ type IrcPrivmsgEvent = {
   senderNick: string;
   senderUser?: string;
   senderHost?: string;
+  connectedNick: string;
   target: string;
   text: string;
   rawLine: string;
@@ -399,6 +400,7 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
               senderNick,
               senderUser: prefix.user ? prefix.user.trim() : undefined,
               senderHost: prefix.host ? prefix.host.trim() : undefined,
+              connectedNick: currentNick,
               target,
               text,
               rawLine,

--- a/extensions/irc/src/client.ts
+++ b/extensions/irc/src/client.ts
@@ -388,7 +388,7 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
       if (line.command === "PRIVMSG") {
         const targetParam = line.params[0];
         const target = targetParam ? targetParam.trim() : "";
-        const text = line.trailing != null ? line.trailing : "";
+        const text = line.trailing ?? line.params[1] ?? "";
         const prefix = parseIrcPrefix(line.prefix);
         const senderNick = prefix.nick ? prefix.nick.trim() : "";
         if (!target || !senderNick || !text.trim()) {

--- a/extensions/irc/src/gateway.ts
+++ b/extensions/irc/src/gateway.ts
@@ -1,5 +1,5 @@
 // Irc plugin module implements gateway behavior.
-import { runStoppablePassiveMonitor } from "openclaw/plugin-sdk/extension-shared";
+import { runPassiveAccountLifecycle } from "openclaw/plugin-sdk/channel-outbound";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/status-helpers";
 import type { ResolvedIrcAccount } from "./accounts.js";
@@ -34,7 +34,7 @@ export async function startIrcGatewayAccount(ctx: {
     `[${account.accountId}] starting IRC provider (${account.host}:${account.port}${account.tls ? " tls" : ""})`,
   );
   const { monitorIrcProvider } = await loadIrcChannelRuntime();
-  await runStoppablePassiveMonitor({
+  await runPassiveAccountLifecycle({
     abortSignal: ctx.abortSignal,
     start: async () =>
       await monitorIrcProvider({
@@ -44,5 +44,8 @@ export async function startIrcGatewayAccount(ctx: {
         abortSignal: ctx.abortSignal,
         statusSink,
       }),
+    stop: async (monitor) => {
+      await monitor.stop();
+    },
   });
 }

--- a/extensions/irc/src/inbound.behavior.test.ts
+++ b/extensions/irc/src/inbound.behavior.test.ts
@@ -3,6 +3,7 @@ import { createPluginRuntimeMock } from "openclaw/plugin-sdk/channel-test-helper
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ResolvedIrcAccount } from "./accounts.js";
 import { handleIrcInbound } from "./inbound.js";
+import type { IrcIngressLifecycle } from "./irc-ingress.js";
 import type { RuntimeEnv } from "./runtime-api.js";
 import { setIrcRuntime } from "./runtime.js";
 import type { CoreConfig, IrcInboundMessage } from "./types.js";
@@ -194,6 +195,48 @@ describe("irc inbound behavior", () => {
       coreRuntime.channel.inbound.dispatchReply as unknown as { mock: { calls: unknown[][] } }
     ).mock.calls[0]?.[0] as { replyPipeline?: unknown } | undefined;
     expect(assembledRequest?.replyPipeline).toEqual({});
+  });
+
+  it("binds durable completion to reply-lane adoption", async () => {
+    const coreRuntime = createPluginRuntimeMock();
+    setIrcRuntime(coreRuntime as never);
+    const onAdopted = vi.fn(async () => undefined);
+    const turnAdoptionLifecycle: IrcIngressLifecycle = {
+      abortSignal: new AbortController().signal,
+      onAdopted,
+      onDeferred: vi.fn(),
+      onAdoptionFinalizing: vi.fn(),
+      onAbandoned: vi.fn(async () => undefined),
+    };
+
+    const result = await handleIrcInbound({
+      message: createMessage(),
+      account: createAccount({
+        config: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          groupPolicy: "allowlist",
+          groupAllowFrom: [],
+        },
+      }),
+      config: { channels: { irc: {} } } as CoreConfig,
+      runtime: createRuntimeEnv(),
+      turnAdoptionLifecycle,
+      sendReply: vi.fn(async () => {}),
+    });
+
+    const dispatchReply = coreRuntime.channel.reply
+      .dispatchReplyWithBufferedBlockDispatcher as unknown as { mock: { calls: unknown[][] } };
+    const replyOptions = (
+      dispatchReply.mock.calls[0]?.[0] as
+        | { replyOptions?: { turnAdoptionLifecycle?: IrcIngressLifecycle } }
+        | undefined
+    )?.replyOptions;
+    expect(replyOptions?.turnAdoptionLifecycle).toEqual(
+      expect.objectContaining({ abortSignal: turnAdoptionLifecycle.abortSignal }),
+    );
+    expect(onAdopted).toHaveBeenCalledOnce();
+    expect(result).toEqual({ kind: "completed" });
   });
 
   it("uses channel:# prefix for group channel From and OriginatingTo fields", async () => {

--- a/extensions/irc/src/inbound.ts
+++ b/extensions/irc/src/inbound.ts
@@ -9,7 +9,10 @@ import {
   createChannelIngressResolver,
   defineStableChannelIngressIdentity,
 } from "openclaw/plugin-sdk/channel-ingress-runtime";
-import { resolveChannelStreamingBlockEnabled } from "openclaw/plugin-sdk/channel-outbound";
+import {
+  bindIngressLifecycleToReplyOptions,
+  resolveChannelStreamingBlockEnabled,
+} from "openclaw/plugin-sdk/channel-outbound";
 import { createChannelPairingController } from "openclaw/plugin-sdk/channel-pairing";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { isDangerousNameMatchingEnabled } from "openclaw/plugin-sdk/dangerous-name-runtime";
@@ -30,6 +33,7 @@ import {
   normalizeStringEntries,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { ResolvedIrcAccount } from "./accounts.js";
+import type { IrcIngressDispatchResult, IrcIngressLifecycle } from "./irc-ingress.js";
 import { buildIrcAllowlistCandidates, normalizeIrcAllowEntry } from "./normalize.js";
 import { resolveIrcGroupMatch, resolveIrcGroupRequireMention } from "./policy.js";
 import { getIrcRuntime } from "./runtime.js";
@@ -198,10 +202,12 @@ export async function handleIrcInbound(params: {
   config: CoreConfig;
   runtime: RuntimeEnv;
   connectedNick?: string;
+  turnAdoptionLifecycle?: IrcIngressLifecycle;
   sendReply?: (target: string, text: string, replyToId?: string) => Promise<void>;
   statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
-}): Promise<void> {
-  const { message, account, config, runtime, connectedNick, statusSink } = params;
+}): Promise<IrcIngressDispatchResult | void> {
+  const { message, account, config, runtime, connectedNick, statusSink, turnAdoptionLifecycle } =
+    params;
   const core = getIrcRuntime();
   const pairing = createChannelPairingController({
     core,
@@ -211,7 +217,13 @@ export async function handleIrcInbound(params: {
 
   const rawBody = message.text?.trim() ?? "";
   if (!rawBody) {
-    return;
+    return { kind: "completed" };
+  }
+  if (turnAdoptionLifecycle?.abortSignal.aborted) {
+    return {
+      kind: "failed-retryable",
+      error: turnAdoptionLifecycle.abortSignal.reason,
+    };
   }
 
   statusSink?.({ lastInboundAt: message.timestamp });
@@ -335,11 +347,11 @@ export async function handleIrcInbound(params: {
       },
     });
     runtime.log?.(`irc: drop DM sender ${senderDisplay} (dmPolicy=${dmPolicy})`);
-    return;
+    return { kind: "completed" };
   }
   if (access.ingress.admission === "skip") {
     runtime.log?.(`irc: drop channel ${message.target} (missing-mention)`);
-    return;
+    return { kind: "completed" };
   }
   if (access.ingress.admission !== "dispatch") {
     if (
@@ -353,7 +365,7 @@ export async function handleIrcInbound(params: {
         reason: "control command (unauthorized)",
         target: senderDisplay,
       });
-      return;
+      return { kind: "completed" };
     }
     if (message.isGroup) {
       if (access.routeAccess.reason === "channel_not_allowlisted") {
@@ -366,7 +378,14 @@ export async function handleIrcInbound(params: {
     } else {
       runtime.log?.(`irc: drop DM sender ${senderDisplay} (dmPolicy=${dmPolicy})`);
     }
-    return;
+    return { kind: "completed" };
+  }
+
+  if (turnAdoptionLifecycle?.abortSignal.aborted) {
+    return {
+      kind: "failed-retryable",
+      error: turnAdoptionLifecycle.abortSignal.reason,
+    };
   }
 
   const channelTarget =
@@ -428,6 +447,27 @@ export async function handleIrcInbound(params: {
     },
   });
 
+  const ingressState: {
+    handoff: "none" | "adopted" | "deferred" | "abandoned";
+  } = { handoff: "none" };
+  const trackedIngressLifecycle = turnAdoptionLifecycle
+    ? {
+        ...turnAdoptionLifecycle,
+        onAdopted: async () => {
+          ingressState.handoff = "adopted";
+          await turnAdoptionLifecycle.onAdopted();
+        },
+        onDeferred: () => {
+          ingressState.handoff = "deferred";
+          turnAdoptionLifecycle.onDeferred();
+        },
+        onAbandoned: async () => {
+          ingressState.handoff = "abandoned";
+          await turnAdoptionLifecycle.onAbandoned();
+        },
+      }
+    : undefined;
+
   await core.channel.inbound.dispatch({
     cfg: config as OpenClawConfig,
     channel: CHANNEL_ID,
@@ -451,6 +491,9 @@ export async function handleIrcInbound(params: {
     },
     replyPipeline: {},
     replyOptions: {
+      ...(trackedIngressLifecycle
+        ? bindIngressLifecycleToReplyOptions(trackedIngressLifecycle)
+        : {}),
       skillFilter: groupMatch.groupConfig?.skills,
       disableBlockStreaming:
         typeof blockStreamingEnabled === "boolean" ? !blockStreamingEnabled : undefined,
@@ -461,4 +504,20 @@ export async function handleIrcInbound(params: {
       },
     },
   });
+
+  if (turnAdoptionLifecycle?.abortSignal.aborted && ingressState.handoff === "none") {
+    return {
+      kind: "failed-retryable",
+      error: turnAdoptionLifecycle.abortSignal.reason,
+    };
+  }
+  if (turnAdoptionLifecycle && ingressState.handoff === "none") {
+    // Terminal core no-dispatch/gate: settle the claim instead of leaving it
+    // watchdog-held. Reply-lane adoption remains the normal completion path.
+    await turnAdoptionLifecycle.onAdopted();
+    ingressState.handoff = "adopted";
+  }
+  return ingressState.handoff === "deferred" || ingressState.handoff === "abandoned"
+    ? { kind: "deferred" }
+    : { kind: "completed" };
 }

--- a/extensions/irc/src/irc-ingress.test.ts
+++ b/extensions/irc/src/irc-ingress.test.ts
@@ -71,9 +71,9 @@ describe("IRC durable ingress", () => {
       const dispatch = vi.fn();
       const ingress = startIngress(failingQueue, dispatch);
       try {
-        await expect(ingress.openConnection("connection-a").accept(CHANNEL_LINE)).rejects.toBe(
-          appendError,
-        );
+        await expect(
+          ingress.openConnection("connection-a").accept(CHANNEL_LINE, "bot"),
+        ).rejects.toBe(appendError);
         expect(failingQueue.enqueue).toHaveBeenCalledTimes(3);
         expect(dispatch).not.toHaveBeenCalled();
       } finally {
@@ -91,7 +91,7 @@ describe("IRC durable ingress", () => {
         dispatch: interruptedDispatch,
         runtime: { error: vi.fn(), log: vi.fn() },
       });
-      await interrupted.openConnection("connection-restart").accept(CHANNEL_LINE);
+      await interrupted.openConnection("connection-restart").accept(CHANNEL_LINE, "receipt-bot");
       expect(await queue.listPending({ limit: "all" })).toEqual([
         expect.objectContaining({
           id: "local:connection-restart:000000000001",
@@ -119,6 +119,7 @@ describe("IRC durable ingress", () => {
           text: "hello",
           isGroup: true,
         });
+        expect(recoveredDispatch.mock.calls[0]?.[2]).toEqual({ connectedNick: "receipt-bot" });
       } finally {
         await recovered.stop();
       }
@@ -132,9 +133,9 @@ describe("IRC durable ingress", () => {
       });
       const ingress = startIngress(queue, dispatch);
       try {
-        await ingress.openConnection("connection-duplicate").accept(CHANNEL_LINE);
+        await ingress.openConnection("connection-duplicate").accept(CHANNEL_LINE, "bot");
         await ingress.waitForIdle();
-        await ingress.openConnection("connection-duplicate").accept(CHANNEL_LINE);
+        await ingress.openConnection("connection-duplicate").accept(CHANNEL_LINE, "bot");
         await ingress.waitForIdle();
         expect(dispatch).toHaveBeenCalledTimes(1);
       } finally {
@@ -153,8 +154,8 @@ describe("IRC durable ingress", () => {
       const ingress = startIngress(queue, dispatch);
       try {
         const connection = ingress.openConnection("connection-identical");
-        await connection.accept(CHANNEL_LINE);
-        await connection.accept(CHANNEL_LINE);
+        await connection.accept(CHANNEL_LINE, "bot");
+        await connection.accept(CHANNEL_LINE, "bot");
         await ingress.waitForIdle();
         expect(messageIds).toEqual([
           "local:connection-identical:000000000001",
@@ -177,7 +178,7 @@ describe("IRC durable ingress", () => {
       try {
         await ingress
           .openConnection("connection-dm")
-          .accept(":Alice!ident@example.org PRIVMSG openclaw-bot :hello");
+          .accept(":Alice!ident@example.org PRIVMSG openclaw-bot :hello", "bot");
         expect(await queue.listPending({ limit: "all" })).toEqual([
           expect.objectContaining({ laneKey: "direct:alice" }),
         ]);
@@ -200,7 +201,7 @@ describe("IRC durable ingress", () => {
       };
       const dispatch = vi.fn();
       const ingress = startIngress(queue, dispatch);
-      const admitting = ingress.openConnection("connection-stop").accept(CHANNEL_LINE);
+      const admitting = ingress.openConnection("connection-stop").accept(CHANNEL_LINE, "bot");
       await admissionStored.promise;
 
       let stopSettled = false;
@@ -223,7 +224,7 @@ describe("IRC durable ingress", () => {
       const dispatch = vi.fn();
       const ingress = startIngress(queue, dispatch);
       try {
-        await ingress.openConnection("connection-bad").accept("not an IRC message");
+        await ingress.openConnection("connection-bad").accept("not an IRC message", "bot");
         await ingress.waitForIdle();
         expect((await queue.enqueue(eventId, {} as IrcIngressPayload)).kind).toBe("failed");
         expect(dispatch).not.toHaveBeenCalled();

--- a/extensions/irc/src/irc-ingress.test.ts
+++ b/extensions/irc/src/irc-ingress.test.ts
@@ -218,6 +218,49 @@ describe("IRC durable ingress", () => {
     });
   });
 
+  it("quiesces an active pump while paused and resumes without charging the next event", async () => {
+    await withQueue(async (queue) => {
+      const dispatchStarted = createDeferred();
+      const releaseDispatch = createDeferred();
+      const dispatch = vi.fn<IrcIngressDispatch>(async (message, lifecycle) => {
+        if (message.messageId.endsWith("000000000001")) {
+          dispatchStarted.resolve();
+          await releaseDispatch.promise;
+        }
+        await lifecycle.onAdopted();
+      });
+      const ingress = startIngress(queue, dispatch);
+      try {
+        const connection = ingress.openConnection("connection-paused");
+        await connection.accept(CHANNEL_LINE, "bot");
+        await dispatchStarted.promise;
+        let pauseSettled = false;
+        const pausing = ingress.pause().then(() => {
+          pauseSettled = true;
+        });
+        await connection.accept(CHANNEL_LINE, "bot");
+        await Promise.resolve();
+        expect(pauseSettled).toBe(false);
+
+        releaseDispatch.resolve();
+        await pausing;
+        expect(dispatch).toHaveBeenCalledOnce();
+        expect(await queue.listPending({ limit: "all" })).toEqual([
+          expect.objectContaining({
+            id: "local:connection-paused:000000000002",
+            attempts: 0,
+          }),
+        ]);
+
+        ingress.start();
+        await ingress.waitForIdle();
+        expect(dispatch).toHaveBeenCalledTimes(2);
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
   it("dead-letters a malformed persisted raw line without dispatch", async () => {
     await withQueue(async (queue) => {
       const eventId = "local:connection-bad:000000000001";

--- a/extensions/irc/src/irc-ingress.test.ts
+++ b/extensions/irc/src/irc-ingress.test.ts
@@ -1,0 +1,255 @@
+// IRC durable ingress tests cover append ordering, local ids, recovery, and tombstones.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  closeOpenClawStateDatabaseForTest,
+  createChannelIngressQueueForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createIrcIngressMonitor } from "./irc-ingress.js";
+
+type IrcIngressQueue = NonNullable<Parameters<typeof createIrcIngressMonitor>[0]["queue"]>;
+type IrcIngressPayload = Parameters<IrcIngressQueue["enqueue"]>[1];
+type IrcIngressDispatch = Parameters<typeof createIrcIngressMonitor>[0]["dispatch"];
+
+const CHANNEL_LINE = ":alice!ident@example.org PRIVMSG #room :hello";
+
+function createQueue(stateDir: string): IrcIngressQueue {
+  return createChannelIngressQueueForTests<IrcIngressPayload>({
+    channelId: "irc",
+    accountId: "default",
+    stateDir,
+  });
+}
+
+async function withQueue<T>(fn: (queue: IrcIngressQueue) => Promise<T>): Promise<T> {
+  const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-irc-ingress-"));
+  const stateDir = await fs.realpath(created);
+  try {
+    return await fn(createQueue(stateDir));
+  } finally {
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  }
+}
+
+function startIngress(queue: IrcIngressQueue, dispatch: IrcIngressDispatch) {
+  const ingress = createIrcIngressMonitor({
+    accountId: "default",
+    queue,
+    dispatch,
+    runtime: { error: vi.fn(), log: vi.fn() },
+    pollIntervalMs: 10,
+    adoptionStallTimeoutMs: 5_000,
+  });
+  ingress.start();
+  return ingress;
+}
+
+function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolvePromise = () => {};
+  const promise = new Promise<void>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return { promise, resolve: resolvePromise };
+}
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  vi.restoreAllMocks();
+});
+
+describe("IRC durable ingress", () => {
+  it("does not dispatch when the durable append fails", async () => {
+    await withQueue(async (queue) => {
+      const appendError = new Error("sqlite unavailable");
+      const failingQueue = {
+        ...queue,
+        enqueue: vi.fn().mockRejectedValue(appendError),
+      } satisfies IrcIngressQueue;
+      const dispatch = vi.fn();
+      const ingress = startIngress(failingQueue, dispatch);
+      try {
+        await expect(ingress.openConnection("connection-a").accept(CHANNEL_LINE)).rejects.toBe(
+          appendError,
+        );
+        expect(failingQueue.enqueue).toHaveBeenCalledTimes(3);
+        expect(dispatch).not.toHaveBeenCalled();
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("recovers a durable pre-dispatch append with a fresh drain exactly once", async () => {
+    await withQueue(async (queue) => {
+      const interruptedDispatch = vi.fn();
+      const interrupted = createIrcIngressMonitor({
+        accountId: "default",
+        queue,
+        dispatch: interruptedDispatch,
+        runtime: { error: vi.fn(), log: vi.fn() },
+      });
+      await interrupted.openConnection("connection-restart").accept(CHANNEL_LINE);
+      expect(await queue.listPending({ limit: "all" })).toEqual([
+        expect.objectContaining({
+          id: "local:connection-restart:000000000001",
+          laneKey: "channel:#room",
+          payload: expect.objectContaining({ rawLine: CHANNEL_LINE }),
+        }),
+      ]);
+      await interrupted.stop();
+      expect(interruptedDispatch).not.toHaveBeenCalled();
+
+      const recoveredDispatch = vi.fn<IrcIngressDispatch>(async (_message, lifecycle) => {
+        await lifecycle.onAdopted();
+      });
+      const recovered = startIngress(queue, recoveredDispatch);
+      try {
+        await recovered.waitForIdle();
+        expect(recoveredDispatch).toHaveBeenCalledTimes(1);
+        expect(recoveredDispatch.mock.calls[0]?.[0]).toMatchObject({
+          messageId: "local:connection-restart:000000000001",
+          target: "#room",
+          rawTarget: "#room",
+          senderNick: "alice",
+          senderUser: "ident",
+          senderHost: "example.org",
+          text: "hello",
+          isGroup: true,
+        });
+      } finally {
+        await recovered.stop();
+      }
+    });
+  });
+
+  it("keeps a completion tombstone for the same local event id", async () => {
+    await withQueue(async (queue) => {
+      const dispatch = vi.fn<IrcIngressDispatch>(async (_message, lifecycle) => {
+        await lifecycle.onAdopted();
+      });
+      const ingress = startIngress(queue, dispatch);
+      try {
+        await ingress.openConnection("connection-duplicate").accept(CHANNEL_LINE);
+        await ingress.waitForIdle();
+        await ingress.openConnection("connection-duplicate").accept(CHANNEL_LINE);
+        await ingress.waitForIdle();
+        expect(dispatch).toHaveBeenCalledTimes(1);
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("assigns distinct monotonic ids to identical lines on one connection", async () => {
+    await withQueue(async (queue) => {
+      const messageIds: string[] = [];
+      const dispatch = vi.fn<IrcIngressDispatch>(async (message, lifecycle) => {
+        messageIds.push(message.messageId);
+        await lifecycle.onAdopted();
+      });
+      const ingress = startIngress(queue, dispatch);
+      try {
+        const connection = ingress.openConnection("connection-identical");
+        await connection.accept(CHANNEL_LINE);
+        await connection.accept(CHANNEL_LINE);
+        await ingress.waitForIdle();
+        expect(messageIds).toEqual([
+          "local:connection-identical:000000000001",
+          "local:connection-identical:000000000002",
+        ]);
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("derives the direct-message lane from the sender nick", async () => {
+    await withQueue(async (queue) => {
+      const ingress = createIrcIngressMonitor({
+        accountId: "default",
+        queue,
+        dispatch: vi.fn(),
+        runtime: { error: vi.fn(), log: vi.fn() },
+      });
+      try {
+        await ingress
+          .openConnection("connection-dm")
+          .accept(":Alice!ident@example.org PRIVMSG openclaw-bot :hello");
+        expect(await queue.listPending({ limit: "all" })).toEqual([
+          expect.objectContaining({ laneKey: "direct:alice" }),
+        ]);
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("waits for an in-flight admission before stop returns", async () => {
+    await withQueue(async (queue) => {
+      const admissionStored = createDeferred();
+      const releaseAdmission = createDeferred();
+      const enqueue = queue.enqueue.bind(queue);
+      queue.enqueue = async (...args) => {
+        const result = await enqueue(...args);
+        admissionStored.resolve();
+        await releaseAdmission.promise;
+        return result;
+      };
+      const dispatch = vi.fn();
+      const ingress = startIngress(queue, dispatch);
+      const admitting = ingress.openConnection("connection-stop").accept(CHANNEL_LINE);
+      await admissionStored.promise;
+
+      let stopSettled = false;
+      const stopping = ingress.stop().then(() => {
+        stopSettled = true;
+      });
+      await Promise.resolve();
+      expect(stopSettled).toBe(false);
+
+      releaseAdmission.resolve();
+      await Promise.all([admitting, stopping]);
+      expect(dispatch).not.toHaveBeenCalled();
+      expect(await queue.listPending({ limit: "all" })).toHaveLength(1);
+    });
+  });
+
+  it("dead-letters a malformed persisted raw line without dispatch", async () => {
+    await withQueue(async (queue) => {
+      const eventId = "local:connection-bad:000000000001";
+      const dispatch = vi.fn();
+      const ingress = startIngress(queue, dispatch);
+      try {
+        await ingress.openConnection("connection-bad").accept("not an IRC message");
+        await ingress.waitForIdle();
+        expect((await queue.enqueue(eventId, {} as IrcIngressPayload)).kind).toBe("failed");
+        expect(dispatch).not.toHaveBeenCalled();
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("does not create a drain when stop wins an async prune race", async () => {
+    await withQueue(async (queue) => {
+      const pruneStarted = createDeferred();
+      const releasePrune = createDeferred();
+      const prune = queue.prune.bind(queue);
+      queue.prune = async (...args) => {
+        pruneStarted.resolve();
+        await releasePrune.promise;
+        return await prune(...args);
+      };
+      const dispatch = vi.fn();
+      const ingress = startIngress(queue, dispatch);
+      await pruneStarted.promise;
+      const stopping = ingress.stop();
+      releasePrune.resolve();
+      await stopping;
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/extensions/irc/src/irc-ingress.test.ts
+++ b/extensions/irc/src/irc-ingress.test.ts
@@ -119,7 +119,10 @@ describe("IRC durable ingress", () => {
           text: "hello",
           isGroup: true,
         });
-        expect(recoveredDispatch.mock.calls[0]?.[2]).toEqual({ connectedNick: "receipt-bot" });
+        expect(recoveredDispatch.mock.calls[0]?.[2]).toEqual({
+          connectedNick: "receipt-bot",
+          connectionEpoch: "connection-restart",
+        });
       } finally {
         await recovered.stop();
       }

--- a/extensions/irc/src/irc-ingress.ts
+++ b/extensions/irc/src/irc-ingress.ts
@@ -25,6 +25,7 @@ type IrcIngressPayload = {
   version: 1;
   eventId: string;
   receivedAt: number;
+  connectedNick: string;
   rawLine: string;
 };
 
@@ -44,6 +45,7 @@ export type IrcIngressDispatchResult =
 type IrcIngressDispatch = (
   message: IrcInboundMessage,
   lifecycle: IrcIngressLifecycle,
+  context: { connectedNick: string },
 ) => Promise<IrcIngressDispatchResult | void> | IrcIngressDispatchResult | void;
 
 class IrcIngressPayloadError extends Error {
@@ -85,7 +87,13 @@ function inspectRawPrivmsg(rawLine: string): {
   };
 }
 
-function parseClaimedMessage(payload: unknown, claimedId: string): IrcInboundMessage {
+function parseClaimedEvent(
+  payload: unknown,
+  claimedId: string,
+): {
+  message: IrcInboundMessage;
+  connectedNick: string;
+} {
   if (
     !payload ||
     typeof payload !== "object" ||
@@ -94,6 +102,8 @@ function parseClaimedMessage(payload: unknown, claimedId: string): IrcInboundMes
     (payload as Partial<IrcIngressPayload>).eventId !== claimedId ||
     !Number.isSafeInteger((payload as Partial<IrcIngressPayload>).receivedAt) ||
     ((payload as Partial<IrcIngressPayload>).receivedAt ?? 0) <= 0 ||
+    typeof (payload as Partial<IrcIngressPayload>).connectedNick !== "string" ||
+    !(payload as Partial<IrcIngressPayload>).connectedNick?.trim() ||
     typeof (payload as Partial<IrcIngressPayload>).rawLine !== "string"
   ) {
     throw new IrcIngressPayloadError(`IRC ingress row ${claimedId} has invalid metadata.`);
@@ -101,9 +111,12 @@ function parseClaimedMessage(payload: unknown, claimedId: string): IrcInboundMes
   const validPayload = payload as IrcIngressPayload;
   const inspected = inspectRawPrivmsg(validPayload.rawLine);
   return {
-    ...inspected.message,
-    messageId: claimedId,
-    timestamp: validPayload.receivedAt,
+    message: {
+      ...inspected.message,
+      messageId: claimedId,
+      timestamp: validPayload.receivedAt,
+    },
+    connectedNick: validPayload.connectedNick.trim(),
   };
 }
 
@@ -114,7 +127,7 @@ function resolveIrcIngressNonRetryableFailure(error: unknown) {
 }
 
 type IrcIngressConnection = {
-  accept: (rawLine: string) => Promise<void>;
+  accept: (rawLine: string, connectedNick: string) => Promise<void>;
 };
 
 export type IrcIngressMonitor = {
@@ -168,10 +181,10 @@ export function createIrcIngressMonitor(options: {
             error: new Error("IRC ingress stopped before dispatch."),
           };
         }
-        const result = await options.dispatch(
-          parseClaimedMessage(record.payload, record.id),
-          lifecycle,
-        );
+        const claimed = parseClaimedEvent(record.payload, record.id);
+        const result = await options.dispatch(claimed.message, lifecycle, {
+          connectedNick: claimed.connectedNick,
+        });
         if (shutdown.signal.aborted && result?.kind !== "deferred") {
           return {
             kind: "failed-retryable",
@@ -237,7 +250,12 @@ export function createIrcIngressMonitor(options: {
     eventId: string;
     rawLine: string;
     receivedAt: number;
+    connectedNick: string;
   }): Promise<void> => {
+    const connectedNick = params.connectedNick.trim();
+    if (!connectedNick) {
+      throw new Error("IRC ingress connected nickname is required.");
+    }
     let laneKey: string;
     try {
       // Receive-time inspection extracts queue metadata only. The persisted
@@ -267,6 +285,7 @@ export function createIrcIngressMonitor(options: {
             version: IRC_INGRESS_PAYLOAD_VERSION,
             eventId: params.eventId,
             receivedAt: params.receivedAt,
+            connectedNick,
             rawLine: params.rawLine,
           },
           { receivedAt: params.receivedAt, laneKey },
@@ -288,7 +307,7 @@ export function createIrcIngressMonitor(options: {
       }
       let sequence = 0;
       return {
-        accept: (rawLine) => {
+        accept: (rawLine, connectedNick) => {
           if (stopped) {
             return Promise.reject(new Error("IRC ingress is stopped."));
           }
@@ -298,7 +317,7 @@ export function createIrcIngressMonitor(options: {
           const eventId = `local:${epoch}:${String(sequence).padStart(12, "0")}`;
           const receivedAt = Date.now();
           const admission = admissionTail.then(async () => {
-            await admitOnce({ eventId, rawLine, receivedAt });
+            await admitOnce({ eventId, rawLine, receivedAt, connectedNick });
           });
           admissionTail = admission.catch(() => undefined);
           return admission;

--- a/extensions/irc/src/irc-ingress.ts
+++ b/extensions/irc/src/irc-ingress.ts
@@ -25,6 +25,7 @@ type IrcIngressPayload = {
   version: 1;
   eventId: string;
   receivedAt: number;
+  connectionEpoch: string;
   connectedNick: string;
   rawLine: string;
 };
@@ -45,7 +46,7 @@ export type IrcIngressDispatchResult =
 type IrcIngressDispatch = (
   message: IrcInboundMessage,
   lifecycle: IrcIngressLifecycle,
-  context: { connectedNick: string },
+  context: { connectedNick: string; connectionEpoch: string },
 ) => Promise<IrcIngressDispatchResult | void> | IrcIngressDispatchResult | void;
 
 class IrcIngressPayloadError extends Error {
@@ -93,6 +94,7 @@ function parseClaimedEvent(
 ): {
   message: IrcInboundMessage;
   connectedNick: string;
+  connectionEpoch: string;
 } {
   if (
     !payload ||
@@ -102,6 +104,8 @@ function parseClaimedEvent(
     (payload as Partial<IrcIngressPayload>).eventId !== claimedId ||
     !Number.isSafeInteger((payload as Partial<IrcIngressPayload>).receivedAt) ||
     ((payload as Partial<IrcIngressPayload>).receivedAt ?? 0) <= 0 ||
+    typeof (payload as Partial<IrcIngressPayload>).connectionEpoch !== "string" ||
+    !(payload as Partial<IrcIngressPayload>).connectionEpoch?.trim() ||
     typeof (payload as Partial<IrcIngressPayload>).connectedNick !== "string" ||
     !(payload as Partial<IrcIngressPayload>).connectedNick?.trim() ||
     typeof (payload as Partial<IrcIngressPayload>).rawLine !== "string"
@@ -117,6 +121,7 @@ function parseClaimedEvent(
       timestamp: validPayload.receivedAt,
     },
     connectedNick: validPayload.connectedNick.trim(),
+    connectionEpoch: validPayload.connectionEpoch.trim(),
   };
 }
 
@@ -127,6 +132,7 @@ function resolveIrcIngressNonRetryableFailure(error: unknown) {
 }
 
 type IrcIngressConnection = {
+  connectionEpoch: string;
   accept: (rawLine: string, connectedNick: string) => Promise<void>;
 };
 
@@ -186,6 +192,7 @@ export function createIrcIngressMonitor(options: {
         const claimed = parseClaimedEvent(record.payload, record.id);
         const result = await options.dispatch(claimed.message, lifecycle, {
           connectedNick: claimed.connectedNick,
+          connectionEpoch: claimed.connectionEpoch,
         });
         if (shutdown.signal.aborted && result?.kind !== "deferred") {
           return {
@@ -269,8 +276,13 @@ export function createIrcIngressMonitor(options: {
     eventId: string;
     rawLine: string;
     receivedAt: number;
+    connectionEpoch: string;
     connectedNick: string;
   }): Promise<void> => {
+    const connectionEpoch = params.connectionEpoch.trim();
+    if (!connectionEpoch) {
+      throw new Error("IRC ingress connection epoch is required.");
+    }
     const connectedNick = params.connectedNick.trim();
     if (!connectedNick) {
       throw new Error("IRC ingress connected nickname is required.");
@@ -304,6 +316,7 @@ export function createIrcIngressMonitor(options: {
             version: IRC_INGRESS_PAYLOAD_VERSION,
             eventId: params.eventId,
             receivedAt: params.receivedAt,
+            connectionEpoch,
             connectedNick,
             rawLine: params.rawLine,
           },
@@ -326,6 +339,7 @@ export function createIrcIngressMonitor(options: {
       }
       let sequence = 0;
       return {
+        connectionEpoch: epoch,
         accept: (rawLine, connectedNick) => {
           if (stopped) {
             return Promise.reject(new Error("IRC ingress is stopped."));
@@ -336,7 +350,13 @@ export function createIrcIngressMonitor(options: {
           const eventId = `local:${epoch}:${String(sequence).padStart(12, "0")}`;
           const receivedAt = Date.now();
           const admission = admissionTail.then(async () => {
-            await admitOnce({ eventId, rawLine, receivedAt, connectedNick });
+            await admitOnce({
+              eventId,
+              rawLine,
+              receivedAt,
+              connectionEpoch: epoch,
+              connectedNick,
+            });
           });
           admissionTail = admission.catch(() => undefined);
           return admission;

--- a/extensions/irc/src/irc-ingress.ts
+++ b/extensions/irc/src/irc-ingress.ts
@@ -64,7 +64,7 @@ function inspectRawPrivmsg(rawLine: string): {
     throw new IrcIngressPayloadError("IRC ingress row is not a PRIVMSG line.");
   }
   const rawTarget = line.params[0]?.trim() ?? "";
-  const text = line.trailing ?? "";
+  const text = line.trailing ?? line.params[1] ?? "";
   const prefix = parseIrcPrefix(line.prefix);
   const senderNick = prefix.nick?.trim() ?? "";
   if (!rawTarget || !senderNick || !text.trim()) {

--- a/extensions/irc/src/irc-ingress.ts
+++ b/extensions/irc/src/irc-ingress.ts
@@ -133,6 +133,7 @@ type IrcIngressConnection = {
 export type IrcIngressMonitor = {
   openConnection: (connectionEpoch?: string) => IrcIngressConnection;
   start: () => void;
+  pause: () => Promise<void>;
   stop: () => Promise<void>;
   waitForIdle: () => Promise<void>;
 };
@@ -152,6 +153,7 @@ export function createIrcIngressMonitor(options: {
   let requested = false;
   let pumping: Promise<void> | undefined;
   let pollTimer: ReturnType<typeof setInterval> | undefined;
+  let pauseTask: Promise<void> | undefined;
   let lastPrunedAt = 0;
   let admissionTail: Promise<void> = Promise.resolve();
   const shutdown = new AbortController();
@@ -246,6 +248,23 @@ export function createIrcIngressMonitor(options: {
     pumping = runPump();
   };
 
+  const pause = (): Promise<void> => {
+    running = false;
+    requested = false;
+    if (pollTimer) {
+      clearInterval(pollTimer);
+      pollTimer = undefined;
+    }
+    const activePump = pumping;
+    if (!activePump) {
+      return Promise.resolve();
+    }
+    pauseTask ??= activePump.finally(() => {
+      pauseTask = undefined;
+    });
+    return pauseTask;
+  };
+
   const admitOnce = async (params: {
     eventId: string;
     rawLine: string;
@@ -338,22 +357,19 @@ export function createIrcIngressMonitor(options: {
       }
       requestDrain();
     },
+    pause,
     stop: async () => {
       if (stopped) {
         await admissionTail;
         return;
       }
       stopped = true;
-      running = false;
-      if (pollTimer) {
-        clearInterval(pollTimer);
-        pollTimer = undefined;
-      }
+      const paused = pause();
       // Every callback accepted before stop must finish its durable append.
       await admissionTail;
       shutdown.abort();
       drain?.dispose();
-      await pumping;
+      await paused;
       // A pump may have created the lazy drain before observing running=false.
       drain?.dispose();
       await drain?.waitForIdle();

--- a/extensions/irc/src/irc-ingress.ts
+++ b/extensions/irc/src/irc-ingress.ts
@@ -1,0 +1,354 @@
+// IRC plugin module owns raw PRIVMSG durable admission and replay draining.
+import { randomUUID } from "node:crypto";
+import {
+  createChannelIngressDrain,
+  DEFAULT_INGRESS_ADOPTION_STALL_MS,
+  DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
+  DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
+  type ChannelIngressDrain,
+  type ChannelIngressQueue,
+} from "openclaw/plugin-sdk/channel-outbound";
+import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { isChannelTarget } from "./normalize.js";
+import { parseIrcLine, parseIrcPrefix } from "./protocol.js";
+import { getIrcRuntime } from "./runtime.js";
+import type { IrcInboundMessage } from "./types.js";
+
+const IRC_INGRESS_PAYLOAD_VERSION = 1;
+const IRC_INGRESS_POLL_INTERVAL_MS = 1_000;
+const IRC_INGRESS_PRUNE_INTERVAL_MS = 60 * 60 * 1_000;
+const IRC_INGRESS_TOMBSTONE_TTL_MS = 30 * 24 * 60 * 60 * 1_000;
+const IRC_INGRESS_TOMBSTONE_MAX_ENTRIES = 1_000;
+
+type IrcIngressPayload = {
+  version: 1;
+  eventId: string;
+  receivedAt: number;
+  rawLine: string;
+};
+
+export type IrcIngressLifecycle = {
+  abortSignal: AbortSignal;
+  onAdopted: () => void | Promise<void>;
+  onDeferred: () => void;
+  onAdoptionFinalizing: () => void;
+  onAbandoned: () => void | Promise<void>;
+};
+
+export type IrcIngressDispatchResult =
+  | { kind: "completed" }
+  | { kind: "deferred" }
+  | { kind: "failed-retryable"; error: unknown };
+
+type IrcIngressDispatch = (
+  message: IrcInboundMessage,
+  lifecycle: IrcIngressLifecycle,
+) => Promise<IrcIngressDispatchResult | void> | IrcIngressDispatchResult | void;
+
+class IrcIngressPayloadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "IrcIngressPayloadError";
+  }
+}
+
+function inspectRawPrivmsg(rawLine: string): {
+  laneKey: string;
+  message: Omit<IrcInboundMessage, "messageId" | "timestamp">;
+} {
+  const line = parseIrcLine(rawLine);
+  if (!line || line.command !== "PRIVMSG") {
+    throw new IrcIngressPayloadError("IRC ingress row is not a PRIVMSG line.");
+  }
+  const rawTarget = line.params[0]?.trim() ?? "";
+  const text = line.trailing ?? "";
+  const prefix = parseIrcPrefix(line.prefix);
+  const senderNick = prefix.nick?.trim() ?? "";
+  if (!rawTarget || !senderNick || !text.trim()) {
+    throw new IrcIngressPayloadError("IRC PRIVMSG line is missing target, sender, or text.");
+  }
+  const isGroup = isChannelTarget(rawTarget);
+  const target = isGroup ? rawTarget : senderNick;
+  const lanePeer = normalizeLowercaseStringOrEmpty(target);
+  return {
+    laneKey: `${isGroup ? "channel" : "direct"}:${lanePeer}`,
+    message: {
+      target,
+      rawTarget,
+      senderNick,
+      senderUser: prefix.user?.trim() || undefined,
+      senderHost: prefix.host?.trim() || undefined,
+      text,
+      isGroup,
+    },
+  };
+}
+
+function parseClaimedMessage(payload: unknown, claimedId: string): IrcInboundMessage {
+  if (
+    !payload ||
+    typeof payload !== "object" ||
+    Array.isArray(payload) ||
+    (payload as Partial<IrcIngressPayload>).version !== IRC_INGRESS_PAYLOAD_VERSION ||
+    (payload as Partial<IrcIngressPayload>).eventId !== claimedId ||
+    !Number.isSafeInteger((payload as Partial<IrcIngressPayload>).receivedAt) ||
+    ((payload as Partial<IrcIngressPayload>).receivedAt ?? 0) <= 0 ||
+    typeof (payload as Partial<IrcIngressPayload>).rawLine !== "string"
+  ) {
+    throw new IrcIngressPayloadError(`IRC ingress row ${claimedId} has invalid metadata.`);
+  }
+  const validPayload = payload as IrcIngressPayload;
+  const inspected = inspectRawPrivmsg(validPayload.rawLine);
+  return {
+    ...inspected.message,
+    messageId: claimedId,
+    timestamp: validPayload.receivedAt,
+  };
+}
+
+function resolveIrcIngressNonRetryableFailure(error: unknown) {
+  return error instanceof IrcIngressPayloadError
+    ? { reason: "invalid-event", message: error.message }
+    : null;
+}
+
+type IrcIngressConnection = {
+  accept: (rawLine: string) => Promise<void>;
+};
+
+export type IrcIngressMonitor = {
+  openConnection: (connectionEpoch?: string) => IrcIngressConnection;
+  start: () => void;
+  stop: () => Promise<void>;
+  waitForIdle: () => Promise<void>;
+};
+
+export function createIrcIngressMonitor(options: {
+  accountId: string;
+  queue?: ChannelIngressQueue<IrcIngressPayload>;
+  dispatch: IrcIngressDispatch;
+  runtime: Pick<RuntimeEnv, "error" | "log">;
+  pollIntervalMs?: number;
+  adoptionStallTimeoutMs?: number;
+}): IrcIngressMonitor {
+  let queue = options.queue;
+  let drain: ChannelIngressDrain | undefined;
+  let running = false;
+  let stopped = false;
+  let requested = false;
+  let pumping: Promise<void> | undefined;
+  let pollTimer: ReturnType<typeof setInterval> | undefined;
+  let lastPrunedAt = 0;
+  let admissionTail: Promise<void> = Promise.resolve();
+  const shutdown = new AbortController();
+
+  const getQueue = (): ChannelIngressQueue<IrcIngressPayload> => {
+    queue ??= getIrcRuntime().state.openChannelIngressQueue<IrcIngressPayload>({
+      accountId: options.accountId,
+    });
+    return queue;
+  };
+
+  const getDrain = (): ChannelIngressDrain => {
+    drain ??= createChannelIngressDrain<IrcIngressPayload>({
+      queue: getQueue(),
+      abortSignal: shutdown.signal,
+      adoptionStallTimeoutMs: options.adoptionStallTimeoutMs ?? DEFAULT_INGRESS_ADOPTION_STALL_MS,
+      retryPolicy: {
+        maxAttempts: DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
+        deadLetterMinAgeMs: DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
+      },
+      resolveNonRetryableFailure: resolveIrcIngressNonRetryableFailure,
+      onLog: (message) => options.runtime.log?.(`irc ${message}`),
+      dispatchClaimedEvent: async (record, lifecycle) => {
+        if (!running || shutdown.signal.aborted || lifecycle.abortSignal.aborted) {
+          return {
+            kind: "failed-retryable",
+            error: new Error("IRC ingress stopped before dispatch."),
+          };
+        }
+        const result = await options.dispatch(
+          parseClaimedMessage(record.payload, record.id),
+          lifecycle,
+        );
+        if (shutdown.signal.aborted && result?.kind !== "deferred") {
+          return {
+            kind: "failed-retryable",
+            error: new Error("IRC ingress stopped during dispatch."),
+          };
+        }
+        return result;
+      },
+    });
+    return drain;
+  };
+
+  const pruneIfDue = async (): Promise<void> => {
+    const now = Date.now();
+    if (now - lastPrunedAt < IRC_INGRESS_PRUNE_INTERVAL_MS) {
+      return;
+    }
+    await getQueue().prune({
+      completedTtlMs: IRC_INGRESS_TOMBSTONE_TTL_MS,
+      completedMaxEntries: IRC_INGRESS_TOMBSTONE_MAX_ENTRIES,
+      failedTtlMs: IRC_INGRESS_TOMBSTONE_TTL_MS,
+      failedMaxEntries: IRC_INGRESS_TOMBSTONE_MAX_ENTRIES,
+      now,
+    });
+    lastPrunedAt = now;
+  };
+
+  const runPump = async (): Promise<void> => {
+    try {
+      for (;;) {
+        requested = false;
+        await pruneIfDue();
+        // stop() can race the async prune; do not lazily create a live drain afterward.
+        if (!running) {
+          break;
+        }
+        const activeDrain = getDrain();
+        const { started } = await activeDrain.drainOnce();
+        await activeDrain.waitForIdle();
+        if (!running || (!requested && started === 0)) {
+          break;
+        }
+      }
+    } catch (error) {
+      options.runtime.error?.(`irc ingress drain failed: ${String(error)}`);
+    } finally {
+      pumping = undefined;
+      if (running && requested) {
+        requestDrain();
+      }
+    }
+  };
+
+  const requestDrain = (): void => {
+    requested = true;
+    if (!running || pumping) {
+      return;
+    }
+    pumping = runPump();
+  };
+
+  const admitOnce = async (params: {
+    eventId: string;
+    rawLine: string;
+    receivedAt: number;
+  }): Promise<void> => {
+    let laneKey: string;
+    try {
+      // Receive-time inspection extracts queue metadata only. The persisted
+      // envelope remains the untouched line and normalization waits for claim.
+      laneKey = inspectRawPrivmsg(params.rawLine).laneKey;
+    } catch (error) {
+      if (!(error instanceof IrcIngressPayloadError)) {
+        throw error;
+      }
+      // Persist malformed accepted input too, so claim-side parsing can apply
+      // the permanent failure classifier instead of losing it before append.
+      laneKey = `invalid:${params.eventId}`;
+    }
+    let lastError: unknown;
+    // IRC cannot nack or replay an accepted line. Retry the durable append before
+    // surfacing the storage failure; later reconnects cannot recover this event.
+    for (const delayMs of [0, 100, 300]) {
+      if (delayMs > 0) {
+        await new Promise((resolve) => {
+          setTimeout(resolve, delayMs);
+        });
+      }
+      try {
+        await getQueue().enqueue(
+          params.eventId,
+          {
+            version: IRC_INGRESS_PAYLOAD_VERSION,
+            eventId: params.eventId,
+            receivedAt: params.receivedAt,
+            rawLine: params.rawLine,
+          },
+          { receivedAt: params.receivedAt, laneKey },
+        );
+        requestDrain();
+        return;
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    throw lastError;
+  };
+
+  return {
+    openConnection: (connectionEpoch = randomUUID()) => {
+      const epoch = connectionEpoch.trim();
+      if (!epoch) {
+        throw new Error("IRC ingress connection epoch is required.");
+      }
+      let sequence = 0;
+      return {
+        accept: (rawLine) => {
+          if (stopped) {
+            return Promise.reject(new Error("IRC ingress is stopped."));
+          }
+          sequence += 1;
+          // IRC supplies no delivery id. This local id is stable after append,
+          // monotonic within one TCP connection, and never derived from content.
+          const eventId = `local:${epoch}:${String(sequence).padStart(12, "0")}`;
+          const receivedAt = Date.now();
+          const admission = admissionTail.then(async () => {
+            await admitOnce({ eventId, rawLine, receivedAt });
+          });
+          admissionTail = admission.catch(() => undefined);
+          return admission;
+        },
+      };
+    },
+    start: () => {
+      if (stopped) {
+        return;
+      }
+      if (!running) {
+        running = true;
+        pollTimer = setInterval(
+          requestDrain,
+          options.pollIntervalMs ?? IRC_INGRESS_POLL_INTERVAL_MS,
+        );
+        pollTimer.unref?.();
+      }
+      requestDrain();
+    },
+    stop: async () => {
+      if (stopped) {
+        await admissionTail;
+        return;
+      }
+      stopped = true;
+      running = false;
+      if (pollTimer) {
+        clearInterval(pollTimer);
+        pollTimer = undefined;
+      }
+      // Every callback accepted before stop must finish its durable append.
+      await admissionTail;
+      shutdown.abort();
+      drain?.dispose();
+      await pumping;
+      // A pump may have created the lazy drain before observing running=false.
+      drain?.dispose();
+      await drain?.waitForIdle();
+    },
+    waitForIdle: async () => {
+      await admissionTail;
+      for (;;) {
+        const activePump = pumping;
+        if (!activePump) {
+          break;
+        }
+        await activePump;
+      }
+      await drain?.waitForIdle();
+    },
+  };
+}

--- a/extensions/irc/src/monitor.test.ts
+++ b/extensions/irc/src/monitor.test.ts
@@ -367,7 +367,7 @@ describe("irc monitor reconnect", () => {
     });
   });
 
-  it("sends a delayed reply through the reconnected client", async () => {
+  it("does not send a delayed private reply through the reconnected client", async () => {
     await withIngressQueue(async (ingressQueue) => {
       let resolvePairing = (_result: { code: string; created: boolean }) => {};
       let markPairingStarted = () => {};
@@ -409,15 +409,15 @@ describe("irc monitor reconnect", () => {
           "expected IRC monitor to establish the replacement connection",
         );
         resolvePairing({ code: "CODE", created: true });
-        await waitForIrcCondition(
-          () =>
-            server.linesByConnection[1]?.some((line) =>
-              line.startsWith("PRIVMSG alice :OpenClaw: access not configured."),
-            ) === true,
-          "expected delayed reply on the replacement connection",
+        await waitForIrcAsyncCondition(
+          async () => (await ingressQueue.listPending({ limit: "all" })).length === 0,
+          "expected the stale private reply to settle",
         );
         expect(
           server.linesByConnection[0]?.some((line) => line.startsWith("PRIVMSG alice :")),
+        ).toBe(false);
+        expect(
+          server.linesByConnection[1]?.some((line) => line.startsWith("PRIVMSG alice :")),
         ).toBe(false);
       } finally {
         resolvePairing({ code: "CODE", created: true });
@@ -505,6 +505,7 @@ describe("irc monitor inbound target", () => {
           version: 1,
           eventId,
           receivedAt,
+          connectionEpoch: "previous-connection",
           connectedNick: "receipt-bot",
           rawLine: ":receipt-bot!ident@example.org PRIVMSG #openclaw :echo",
         },
@@ -533,6 +534,57 @@ describe("irc monitor inbound target", () => {
         await waitForIrcAsyncCondition(
           async () => (await ingressQueue.listPending({ limit: "all" })).length === 0,
           "expected the replayed self echo to settle",
+        );
+        expect(onMessage).not.toHaveBeenCalled();
+      } finally {
+        if (monitor) {
+          await monitor.stop();
+        }
+        await server.close();
+      }
+    });
+  });
+
+  it("does not replay a DM after the accepting connection changed", async () => {
+    await withIngressQueue(async (ingressQueue) => {
+      installMonitorRuntime();
+      const eventId = "local:previous-connection:000000000002";
+      const receivedAt = Date.now();
+      await ingressQueue.enqueue(
+        eventId,
+        {
+          version: 1,
+          eventId,
+          receivedAt,
+          connectionEpoch: "previous-connection",
+          connectedNick: "receipt-bot",
+          rawLine: ":alice!ident@example.org PRIVMSG receipt-bot :private",
+        },
+        { receivedAt, laneKey: "direct:alice" },
+      );
+      const server = await startInboundIrcServer(undefined, "receipt-bot");
+      const onMessage = vi.fn();
+      let monitor: { stop: () => Promise<void> } | undefined;
+      try {
+        monitor = await monitorIrcProvider({
+          config: {
+            channels: {
+              irc: {
+                host: "127.0.0.1",
+                port: server.port,
+                tls: false,
+                nick: "receipt-bot",
+                username: "bot",
+                realname: "OpenClaw",
+              },
+            },
+          } as CoreConfig,
+          ingressQueue,
+          onMessage,
+        });
+        await waitForIrcAsyncCondition(
+          async () => (await ingressQueue.listPending({ limit: "all" })).length === 0,
+          "expected the replayed DM to settle",
         );
         expect(onMessage).not.toHaveBeenCalled();
       } finally {

--- a/extensions/irc/src/monitor.test.ts
+++ b/extensions/irc/src/monitor.test.ts
@@ -25,6 +25,14 @@ type InboundIrcServer = {
   close(): Promise<void>;
 };
 
+type ReconnectingReplyIrcServer = {
+  port: number;
+  linesByConnection: string[][];
+  connectionCount: number;
+  disconnectFirst(): void;
+  close(): Promise<void>;
+};
+
 type IrcIngressQueue = NonNullable<Parameters<typeof createIrcIngressMonitor>[0]["queue"]>;
 type IrcIngressPayload = Parameters<IrcIngressQueue["enqueue"]>[1];
 
@@ -51,6 +59,22 @@ async function waitForIrcCondition(
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (!predicate()) {
+    if (Date.now() >= deadline) {
+      throw new Error(message);
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, 10);
+    });
+  }
+}
+
+async function waitForIrcAsyncCondition(
+  predicate: () => Promise<boolean>,
+  message: string,
+  timeoutMs = 3000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!(await predicate())) {
     if (Date.now() >= deadline) {
       throw new Error(message);
     }
@@ -126,7 +150,10 @@ async function startDisconnectingIrcServer(): Promise<DisconnectingIrcServer> {
   };
 }
 
-async function startInboundIrcServer(target: string): Promise<InboundIrcServer> {
+async function startInboundIrcServer(
+  target?: string,
+  welcomeNick = "bot",
+): Promise<InboundIrcServer> {
   const sockets = new Set<net.Socket>();
   const server = net.createServer((socket) => {
     sockets.add(socket);
@@ -140,10 +167,12 @@ async function startInboundIrcServer(target: string): Promise<InboundIrcServer> 
         buffer = buffer.slice(idx + 1);
         idx = buffer.indexOf("\n");
         if (line.startsWith("USER ")) {
-          socket.write(":server 001 bot :welcome\r\n");
-          setTimeout(() => {
-            socket.write(`:alice!ident@example.org PRIVMSG ${target} :hello\r\n`);
-          }, 20);
+          socket.write(`:server 001 ${welcomeNick} :welcome\r\n`);
+          if (target) {
+            setTimeout(() => {
+              socket.write(`:alice!ident@example.org PRIVMSG ${target} :hello\r\n`);
+            }, 20);
+          }
         }
       }
     });
@@ -180,6 +209,71 @@ async function startInboundIrcServer(target: string): Promise<InboundIrcServer> 
   };
 }
 
+async function startReconnectingReplyIrcServer(): Promise<ReconnectingReplyIrcServer> {
+  const sockets: net.Socket[] = [];
+  const linesByConnection: string[][] = [];
+  const server = net.createServer((socket) => {
+    const connectionIndex = sockets.length;
+    sockets.push(socket);
+    linesByConnection[connectionIndex] = [];
+    socket.setEncoding("utf8");
+    let buffer = "";
+    socket.on("data", (chunk: string) => {
+      buffer += chunk;
+      let idx = buffer.indexOf("\n");
+      while (idx !== -1) {
+        const line = buffer.slice(0, idx).replace(/\r$/, "");
+        buffer = buffer.slice(idx + 1);
+        idx = buffer.indexOf("\n");
+        linesByConnection[connectionIndex]?.push(line);
+        if (line.startsWith("USER ")) {
+          const nick = connectionIndex === 0 ? "receipt-bot" : "reconnected-bot";
+          socket.write(`:server 001 ${nick} :welcome\r\n`);
+          if (connectionIndex === 0) {
+            setTimeout(() => {
+              socket.write(":alice!ident@example.org PRIVMSG receipt-bot :hello\r\n");
+            }, 20);
+          }
+        }
+      }
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("expected loopback IRC server to bind a TCP port");
+  }
+  return {
+    port: address.port,
+    linesByConnection,
+    get connectionCount() {
+      return sockets.length;
+    },
+    disconnectFirst: () => sockets[0]?.destroy(),
+    close: async () => {
+      for (const socket of sockets) {
+        socket.destroy();
+      }
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+    },
+  };
+}
+
 function installMonitorRuntime() {
   setIrcRuntime({
     logging: {
@@ -194,6 +288,35 @@ function installMonitorRuntime() {
     channel: {
       activity: {
         record: vi.fn(),
+      },
+    },
+  } as never);
+}
+
+function installPairingMonitorRuntime(
+  upsertPairingRequest: () => Promise<{ code: string; created: boolean }>,
+) {
+  setIrcRuntime({
+    logging: {
+      shouldLogVerbose: vi.fn(() => false),
+      getChildLogger: vi.fn(() => ({
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      })),
+    },
+    channel: {
+      activity: { record: vi.fn() },
+      pairing: {
+        readAllowFromStore: vi.fn(async () => []),
+        upsertPairingRequest: vi.fn(upsertPairingRequest),
+      },
+      commands: { shouldHandleTextCommands: vi.fn(() => false) },
+      text: { hasControlCommand: vi.fn(() => false) },
+      mentions: {
+        buildMentionRegexes: vi.fn(() => []),
+        matchesMentionPatterns: vi.fn(() => false),
       },
     },
   } as never);
@@ -229,6 +352,68 @@ describe("irc monitor reconnect", () => {
         );
         expect(server.connectionCount).toBeGreaterThanOrEqual(2);
       } finally {
+        if (monitor) {
+          await monitor.stop();
+        }
+        await server.close();
+      }
+    });
+  });
+
+  it("sends a delayed reply through the reconnected client", async () => {
+    await withIngressQueue(async (ingressQueue) => {
+      let resolvePairing = (_result: { code: string; created: boolean }) => {};
+      let markPairingStarted = () => {};
+      const pairingStarted = new Promise<void>((resolve) => {
+        markPairingStarted = resolve;
+      });
+      const pairingResult = new Promise<{ code: string; created: boolean }>((resolve) => {
+        resolvePairing = resolve;
+      });
+      installPairingMonitorRuntime(async () => {
+        markPairingStarted();
+        return await pairingResult;
+      });
+      const server = await startReconnectingReplyIrcServer();
+      let monitor: { stop: () => Promise<void> } | undefined;
+      try {
+        monitor = await monitorIrcProvider({
+          config: {
+            channels: {
+              irc: {
+                host: "127.0.0.1",
+                port: server.port,
+                tls: false,
+                nick: "receipt-bot",
+                username: "bot",
+                realname: "OpenClaw",
+                dmPolicy: "pairing",
+              },
+            },
+          } as CoreConfig,
+          ingressQueue,
+        });
+        await pairingStarted;
+        server.disconnectFirst();
+        await waitForIrcCondition(
+          () =>
+            server.connectionCount >= 2 &&
+            server.linesByConnection[1]?.some((line) => line.startsWith("USER ")) === true,
+          "expected IRC monitor to establish the replacement connection",
+        );
+        resolvePairing({ code: "CODE", created: true });
+        await waitForIrcCondition(
+          () =>
+            server.linesByConnection[1]?.some((line) =>
+              line.startsWith("PRIVMSG alice :OpenClaw: access not configured."),
+            ) === true,
+          "expected delayed reply on the replacement connection",
+        );
+        expect(
+          server.linesByConnection[0]?.some((line) => line.startsWith("PRIVMSG alice :")),
+        ).toBe(false);
+      } finally {
+        resolvePairing({ code: "CODE", created: true });
         if (monitor) {
           await monitor.stop();
         }
@@ -281,6 +466,56 @@ describe("irc monitor inbound target", () => {
           senderNick: "alice",
           text: "hello",
         });
+      } finally {
+        if (monitor) {
+          await monitor.stop();
+        }
+        await server.close();
+      }
+    });
+  });
+
+  it("uses the receipt-time nickname when replaying a self echo", async () => {
+    await withIngressQueue(async (ingressQueue) => {
+      installMonitorRuntime();
+      const eventId = "local:previous-connection:000000000001";
+      const receivedAt = Date.now();
+      await ingressQueue.enqueue(
+        eventId,
+        {
+          version: 1,
+          eventId,
+          receivedAt,
+          connectedNick: "receipt-bot",
+          rawLine: ":receipt-bot!ident@example.org PRIVMSG #openclaw :echo",
+        },
+        { receivedAt, laneKey: "channel:#openclaw" },
+      );
+      const server = await startInboundIrcServer(undefined, "reconnected-bot");
+      const onMessage = vi.fn();
+      let monitor: { stop: () => Promise<void> } | undefined;
+      try {
+        monitor = await monitorIrcProvider({
+          config: {
+            channels: {
+              irc: {
+                host: "127.0.0.1",
+                port: server.port,
+                tls: false,
+                nick: "reconnected-bot",
+                username: "bot",
+                realname: "OpenClaw",
+              },
+            },
+          } as CoreConfig,
+          ingressQueue,
+          onMessage,
+        });
+        await waitForIrcAsyncCondition(
+          async () => (await ingressQueue.listPending({ limit: "all" })).length === 0,
+          "expected the replayed self echo to settle",
+        );
+        expect(onMessage).not.toHaveBeenCalled();
       } finally {
         if (monitor) {
           await monitor.stop();

--- a/extensions/irc/src/monitor.test.ts
+++ b/extensions/irc/src/monitor.test.ts
@@ -1,6 +1,14 @@
 // Irc tests cover monitor plugin behavior.
+import fs from "node:fs/promises";
 import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import {
+  closeOpenClawStateDatabaseForTest,
+  createChannelIngressQueueForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { describe, expect, it, vi } from "vitest";
+import { createIrcIngressMonitor } from "./irc-ingress.js";
 import { monitorIrcProvider } from "./monitor.js";
 import { setIrcRuntime } from "./runtime.js";
 import type { CoreConfig, IrcInboundMessage } from "./types.js";
@@ -16,6 +24,25 @@ type InboundIrcServer = {
   port: number;
   close(): Promise<void>;
 };
+
+type IrcIngressQueue = NonNullable<Parameters<typeof createIrcIngressMonitor>[0]["queue"]>;
+type IrcIngressPayload = Parameters<IrcIngressQueue["enqueue"]>[1];
+
+async function withIngressQueue<T>(fn: (queue: IrcIngressQueue) => Promise<T>): Promise<T> {
+  const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-irc-monitor-"));
+  const stateDir = await fs.realpath(created);
+  const queue = createChannelIngressQueueForTests<IrcIngressPayload>({
+    channelId: "irc",
+    accountId: "default",
+    stateDir,
+  });
+  try {
+    return await fn(queue);
+  } finally {
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  }
+}
 
 async function waitForIrcCondition(
   predicate: () => boolean,
@@ -64,8 +91,12 @@ async function startDisconnectingIrcServer(): Promise<DisconnectingIrcServer> {
     });
   });
 
-  await new Promise<void>((resolve) => {
-    server.listen(0, "127.0.0.1", resolve);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
   });
   const address = server.address();
   if (!address || typeof address === "string") {
@@ -119,8 +150,12 @@ async function startInboundIrcServer(target: string): Promise<InboundIrcServer> 
     socket.on("close", () => sockets.delete(socket));
   });
 
-  await new Promise<void>((resolve) => {
-    server.listen(0, "127.0.0.1", resolve);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
   });
   const address = server.address();
   if (!address || typeof address === "string") {
@@ -166,37 +201,40 @@ function installMonitorRuntime() {
 
 describe("irc monitor reconnect", () => {
   it("reconnects when an established IRC socket closes", async () => {
-    installMonitorRuntime();
-    const server = await startDisconnectingIrcServer();
-    const config = {
-      channels: {
-        irc: {
-          host: "127.0.0.1",
-          port: server.port,
-          tls: false,
-          nick: "bot",
-          username: "bot",
-          realname: "OpenClaw",
-          channels: ["#openclaw"],
+    await withIngressQueue(async (ingressQueue) => {
+      installMonitorRuntime();
+      const server = await startDisconnectingIrcServer();
+      const config = {
+        channels: {
+          irc: {
+            host: "127.0.0.1",
+            port: server.port,
+            tls: false,
+            nick: "bot",
+            username: "bot",
+            realname: "OpenClaw",
+            channels: ["#openclaw"],
+          },
         },
-      },
-    } as CoreConfig;
-    let monitor: { stop: () => void } | undefined;
+      } as CoreConfig;
+      let monitor: { stop: () => Promise<void> } | undefined;
 
-    try {
-      monitor = await monitorIrcProvider({ config });
-      await waitForIrcCondition(
-        () =>
-          server.connectionCount >= 2 &&
-          server.lines.filter((line) => line === "USER bot 0 * :OpenClaw").length >= 2,
-        "expected IRC monitor to reconnect after the first socket closed",
-      );
-
-      expect(server.connectionCount).toBeGreaterThanOrEqual(2);
-    } finally {
-      monitor?.stop();
-      await server.close();
-    }
+      try {
+        monitor = await monitorIrcProvider({ config, ingressQueue });
+        await waitForIrcCondition(
+          () =>
+            server.connectionCount >= 2 &&
+            server.lines.filter((line) => line === "USER bot 0 * :OpenClaw").length >= 2,
+          "expected IRC monitor to reconnect after the first socket closed",
+        );
+        expect(server.connectionCount).toBeGreaterThanOrEqual(2);
+      } finally {
+        if (monitor) {
+          await monitor.stop();
+        }
+        await server.close();
+      }
+    });
   });
 });
 
@@ -213,37 +251,42 @@ describe("irc monitor inbound target", () => {
       expected: { isGroup: false, target: "alice", rawTarget: "openclaw-bot" },
     },
   ])("maps $label targets through the monitor boundary", async ({ serverTarget, expected }) => {
-    installMonitorRuntime();
-    const server = await startInboundIrcServer(serverTarget);
-    const messages: IrcInboundMessage[] = [];
-    let monitor: { stop: () => void } | undefined;
-    try {
-      monitor = await monitorIrcProvider({
-        config: {
-          channels: {
-            irc: {
-              host: "127.0.0.1",
-              port: server.port,
-              tls: false,
-              nick: "bot",
-              username: "bot",
-              realname: "OpenClaw",
+    await withIngressQueue(async (ingressQueue) => {
+      installMonitorRuntime();
+      const server = await startInboundIrcServer(serverTarget);
+      const messages: IrcInboundMessage[] = [];
+      let monitor: { stop: () => Promise<void> } | undefined;
+      try {
+        monitor = await monitorIrcProvider({
+          config: {
+            channels: {
+              irc: {
+                host: "127.0.0.1",
+                port: server.port,
+                tls: false,
+                nick: "bot",
+                username: "bot",
+                realname: "OpenClaw",
+              },
             },
+          } as CoreConfig,
+          ingressQueue,
+          onMessage: (message) => {
+            messages.push(message);
           },
-        } as CoreConfig,
-        onMessage: (message) => {
-          messages.push(message);
-        },
-      });
-      await waitForIrcCondition(() => messages.length === 1, "expected one inbound IRC message");
-      expect(messages[0]).toMatchObject({
-        ...expected,
-        senderNick: "alice",
-        text: "hello",
-      });
-    } finally {
-      monitor?.stop();
-      await server.close();
-    }
+        });
+        await waitForIrcCondition(() => messages.length === 1, "expected one inbound IRC message");
+        expect(messages[0]).toMatchObject({
+          ...expected,
+          senderNick: "alice",
+          text: "hello",
+        });
+      } finally {
+        if (monitor) {
+          await monitor.stop();
+        }
+        await server.close();
+      }
+    });
   });
 });

--- a/extensions/irc/src/monitor.test.ts
+++ b/extensions/irc/src/monitor.test.ts
@@ -154,6 +154,7 @@ async function startInboundIrcServer(
   target?: string,
   welcomeNick = "bot",
   colonlessBody = false,
+  senderNick = "alice",
 ): Promise<InboundIrcServer> {
   const sockets = new Set<net.Socket>();
   const server = net.createServer((socket) => {
@@ -172,7 +173,9 @@ async function startInboundIrcServer(
           if (target) {
             setTimeout(() => {
               const bodySeparator = colonlessBody ? " " : " :";
-              socket.write(`:alice!ident@example.org PRIVMSG ${target}${bodySeparator}hello\r\n`);
+              socket.write(
+                `:${senderNick}!ident@example.org PRIVMSG ${target}${bodySeparator}hello\r\n`,
+              );
             }, 20);
           }
         }
@@ -277,6 +280,7 @@ async function startReconnectingReplyIrcServer(): Promise<ReconnectingReplyIrcSe
 }
 
 function installMonitorRuntime() {
+  const activityRecord = vi.fn();
   setIrcRuntime({
     logging: {
       shouldLogVerbose: vi.fn(() => false),
@@ -289,10 +293,11 @@ function installMonitorRuntime() {
     },
     channel: {
       activity: {
-        record: vi.fn(),
+        record: activityRecord,
       },
     },
   } as never);
+  return activityRecord;
 }
 
 function installPairingMonitorRuntime(
@@ -530,6 +535,50 @@ describe("irc monitor inbound target", () => {
           "expected the replayed self echo to settle",
         );
         expect(onMessage).not.toHaveBeenCalled();
+      } finally {
+        if (monitor) {
+          await monitor.stop();
+        }
+        await server.close();
+      }
+    });
+  });
+
+  it("does not record receipt-time self echoes as inbound activity", async () => {
+    await withIngressQueue(async (ingressQueue) => {
+      const activityRecord = installMonitorRuntime();
+      const enqueueSpy = vi.spyOn(ingressQueue, "enqueue");
+      const server = await startInboundIrcServer("#openclaw", "bot", false, "bot");
+      const onMessage = vi.fn();
+      let monitor: { stop: () => Promise<void> } | undefined;
+      try {
+        monitor = await monitorIrcProvider({
+          config: {
+            channels: {
+              irc: {
+                host: "127.0.0.1",
+                port: server.port,
+                tls: false,
+                nick: "bot",
+                username: "bot",
+                realname: "OpenClaw",
+              },
+            },
+          } as CoreConfig,
+          ingressQueue,
+          onMessage,
+        });
+        await waitForIrcCondition(
+          () => enqueueSpy.mock.calls.length === 1,
+          "expected the receipt-time self echo to enter ingress",
+        );
+        await enqueueSpy.mock.results[0]?.value;
+        await waitForIrcAsyncCondition(
+          async () => (await ingressQueue.listPending({ limit: "all" })).length === 0,
+          "expected the receipt-time self echo to settle",
+        );
+        expect(onMessage).not.toHaveBeenCalled();
+        expect(activityRecord).not.toHaveBeenCalled();
       } finally {
         if (monitor) {
           await monitor.stop();

--- a/extensions/irc/src/monitor.test.ts
+++ b/extensions/irc/src/monitor.test.ts
@@ -153,6 +153,7 @@ async function startDisconnectingIrcServer(): Promise<DisconnectingIrcServer> {
 async function startInboundIrcServer(
   target?: string,
   welcomeNick = "bot",
+  colonlessBody = false,
 ): Promise<InboundIrcServer> {
   const sockets = new Set<net.Socket>();
   const server = net.createServer((socket) => {
@@ -170,7 +171,8 @@ async function startInboundIrcServer(
           socket.write(`:server 001 ${welcomeNick} :welcome\r\n`);
           if (target) {
             setTimeout(() => {
-              socket.write(`:alice!ident@example.org PRIVMSG ${target} :hello\r\n`);
+              const bodySeparator = colonlessBody ? " " : " :";
+              socket.write(`:alice!ident@example.org PRIVMSG ${target}${bodySeparator}hello\r\n`);
             }, 20);
           }
         }
@@ -435,45 +437,57 @@ describe("irc monitor inbound target", () => {
       serverTarget: "openclaw-bot",
       expected: { isGroup: false, target: "alice", rawTarget: "openclaw-bot" },
     },
-  ])("maps $label targets through the monitor boundary", async ({ serverTarget, expected }) => {
-    await withIngressQueue(async (ingressQueue) => {
-      installMonitorRuntime();
-      const server = await startInboundIrcServer(serverTarget);
-      const messages: IrcInboundMessage[] = [];
-      let monitor: { stop: () => Promise<void> } | undefined;
-      try {
-        monitor = await monitorIrcProvider({
-          config: {
-            channels: {
-              irc: {
-                host: "127.0.0.1",
-                port: server.port,
-                tls: false,
-                nick: "bot",
-                username: "bot",
-                realname: "OpenClaw",
+    {
+      label: "channel with a colonless body",
+      serverTarget: "#openclaw",
+      colonlessBody: true,
+      expected: { isGroup: true, target: "#openclaw", rawTarget: "#openclaw" },
+    },
+  ])(
+    "maps $label targets through the monitor boundary",
+    async ({ serverTarget, colonlessBody, expected }) => {
+      await withIngressQueue(async (ingressQueue) => {
+        installMonitorRuntime();
+        const server = await startInboundIrcServer(serverTarget, "bot", colonlessBody);
+        const messages: IrcInboundMessage[] = [];
+        let monitor: { stop: () => Promise<void> } | undefined;
+        try {
+          monitor = await monitorIrcProvider({
+            config: {
+              channels: {
+                irc: {
+                  host: "127.0.0.1",
+                  port: server.port,
+                  tls: false,
+                  nick: "bot",
+                  username: "bot",
+                  realname: "OpenClaw",
+                },
               },
+            } as CoreConfig,
+            ingressQueue,
+            onMessage: (message) => {
+              messages.push(message);
             },
-          } as CoreConfig,
-          ingressQueue,
-          onMessage: (message) => {
-            messages.push(message);
-          },
-        });
-        await waitForIrcCondition(() => messages.length === 1, "expected one inbound IRC message");
-        expect(messages[0]).toMatchObject({
-          ...expected,
-          senderNick: "alice",
-          text: "hello",
-        });
-      } finally {
-        if (monitor) {
-          await monitor.stop();
+          });
+          await waitForIrcCondition(
+            () => messages.length === 1,
+            "expected one inbound IRC message",
+          );
+          expect(messages[0]).toMatchObject({
+            ...expected,
+            senderNick: "alice",
+            text: "hello",
+          });
+        } finally {
+          if (monitor) {
+            await monitor.stop();
+          }
+          await server.close();
         }
-        await server.close();
-      }
-    });
-  });
+      });
+    },
+  );
 
   it("uses the receipt-time nickname when replaying a self echo", async () => {
     await withIngressQueue(async (ingressQueue) => {

--- a/extensions/irc/src/monitor.ts
+++ b/extensions/irc/src/monitor.ts
@@ -171,6 +171,12 @@ export async function monitorIrcProvider(
         },
         onPrivmsg: async (event) => {
           await ingressConnection.accept(event.rawLine, event.connectedNick);
+          if (
+            normalizeLowercaseStringOrEmpty(event.senderNick) ===
+            normalizeLowercaseStringOrEmpty(event.connectedNick)
+          ) {
+            return;
+          }
           core.channel.activity.record({
             channel: "irc",
             accountId: account.accountId,

--- a/extensions/irc/src/monitor.ts
+++ b/extensions/irc/src/monitor.ts
@@ -53,6 +53,7 @@ export async function monitorIrcProvider(
   });
 
   let client: IrcClient | null = null;
+  let activeConnectionEpoch: string | null = null;
   let ingressPause: Promise<void> = Promise.resolve();
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   let stopped = false;
@@ -75,7 +76,7 @@ export async function monitorIrcProvider(
     dispatch: async (
       message,
       turnAdoptionLifecycle: IrcIngressLifecycle,
-      context: { connectedNick: string },
+      context: { connectedNick: string; connectionEpoch: string },
     ) => {
       const activeClient = client;
       if (!activeClient || stopped || monitorAbort.signal.aborted) {
@@ -88,6 +89,14 @@ export async function monitorIrcProvider(
         normalizeLowercaseStringOrEmpty(message.senderNick) ===
         normalizeLowercaseStringOrEmpty(context.connectedNick)
       ) {
+        return { kind: "completed" };
+      }
+      // IRC nicknames can change owners between connections. Channel replay is
+      // safe, but a stale DM recipient cannot be revalidated after reconnect.
+      if (!message.isGroup && context.connectionEpoch !== activeConnectionEpoch) {
+        logger.warn?.(
+          `[${account.accountId}] dropping replayed IRC DM after the connection changed`,
+        );
         return { kind: "completed" };
       }
       if (opts.onMessage) {
@@ -105,6 +114,9 @@ export async function monitorIrcProvider(
           const replyClient = client;
           if (!replyClient || !replyClient.isReady() || stopped || monitorAbort.signal.aborted) {
             throw new Error("IRC transport disconnected before reply send.");
+          }
+          if (!message.isGroup && context.connectionEpoch !== activeConnectionEpoch) {
+            throw new Error("IRC connection changed before private reply send.");
           }
           replyClient.sendPrivmsg(target, text);
           opts.statusSink?.({ lastOutboundAt: Date.now() });
@@ -163,6 +175,9 @@ export async function monitorIrcProvider(
             return;
           }
           ingressPause = ingress.pause();
+          if (activeConnectionEpoch === ingressConnection.connectionEpoch) {
+            activeConnectionEpoch = null;
+          }
           client = null;
           logger.warn?.(
             `[${account.accountId}] IRC connection closed; reconnecting in ${IRC_MONITOR_RECONNECT_DELAY_MS}ms`,
@@ -191,8 +206,12 @@ export async function monitorIrcProvider(
       return;
     }
     client = nextClient;
+    activeConnectionEpoch = ingressConnection.connectionEpoch;
     await ingressPause;
     if (client !== nextClient || !nextClient.isReady()) {
+      if (activeConnectionEpoch === ingressConnection.connectionEpoch) {
+        activeConnectionEpoch = null;
+      }
       return;
     }
     ingress.start();
@@ -227,6 +246,7 @@ export async function monitorIrcProvider(
         }
         client?.quit("shutdown");
         client = null;
+        activeConnectionEpoch = null;
         await ingress.stop();
       })();
       return stopTask;

--- a/extensions/irc/src/monitor.ts
+++ b/extensions/irc/src/monitor.ts
@@ -71,7 +71,11 @@ export async function monitorIrcProvider(
     accountId: account.accountId,
     runtime,
     ...(opts.ingressQueue ? { queue: opts.ingressQueue } : {}),
-    dispatch: async (message, turnAdoptionLifecycle: IrcIngressLifecycle) => {
+    dispatch: async (
+      message,
+      turnAdoptionLifecycle: IrcIngressLifecycle,
+      context: { connectedNick: string },
+    ) => {
       const activeClient = client;
       if (!activeClient || stopped || monitorAbort.signal.aborted) {
         return {
@@ -81,7 +85,7 @@ export async function monitorIrcProvider(
       }
       if (
         normalizeLowercaseStringOrEmpty(message.senderNick) ===
-        normalizeLowercaseStringOrEmpty(activeClient.nick)
+        normalizeLowercaseStringOrEmpty(context.connectedNick)
       ) {
         return { kind: "completed" };
       }
@@ -94,10 +98,14 @@ export async function monitorIrcProvider(
         account,
         config: cfg,
         runtime,
-        connectedNick: activeClient.nick,
+        connectedNick: context.connectedNick,
         turnAdoptionLifecycle,
         sendReply: async (target, text) => {
-          activeClient.sendPrivmsg(target, text);
+          const replyClient = client;
+          if (!replyClient || !replyClient.isReady() || stopped || monitorAbort.signal.aborted) {
+            throw new Error("IRC transport disconnected before reply send.");
+          }
+          replyClient.sendPrivmsg(target, text);
           opts.statusSink?.({ lastOutboundAt: Date.now() });
           core.channel.activity.record({
             channel: "irc",
@@ -160,7 +168,7 @@ export async function monitorIrcProvider(
           scheduleReconnect();
         },
         onPrivmsg: async (event) => {
-          await ingressConnection.accept(event.rawLine);
+          await ingressConnection.accept(event.rawLine, event.connectedNick);
           core.channel.activity.record({
             channel: "irc",
             accountId: account.accountId,

--- a/extensions/irc/src/monitor.ts
+++ b/extensions/irc/src/monitor.ts
@@ -5,8 +5,11 @@ import { resolveIrcAccount } from "./accounts.js";
 import { connectIrcClient, type IrcClient } from "./client.js";
 import { buildIrcConnectOptions } from "./connect-options.js";
 import { handleIrcInbound } from "./inbound.js";
-import { isChannelTarget } from "./normalize.js";
-import { makeIrcMessageId } from "./protocol.js";
+import {
+  createIrcIngressMonitor,
+  type IrcIngressLifecycle,
+  type IrcIngressMonitor,
+} from "./irc-ingress.js";
 import type { RuntimeEnv } from "./runtime-api.js";
 import { getIrcRuntime } from "./runtime.js";
 import type { CoreConfig, IrcInboundMessage } from "./types.js";
@@ -18,25 +21,14 @@ type IrcMonitorOptions = {
   abortSignal?: AbortSignal;
   statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
   onMessage?: (message: IrcInboundMessage, client: IrcClient) => void | Promise<void>;
+  ingressQueue?: NonNullable<Parameters<typeof createIrcIngressMonitor>[0]["queue"]>;
 };
 
 const IRC_MONITOR_RECONNECT_DELAY_MS = 1000;
 
-function resolveIrcInboundTarget(params: { target: string; senderNick: string }): {
-  isGroup: boolean;
-  target: string;
-  rawTarget: string;
-} {
-  const rawTarget = params.target;
-  const isGroup = isChannelTarget(rawTarget);
-  if (isGroup) {
-    return { isGroup: true, target: rawTarget, rawTarget };
-  }
-  const senderNick = params.senderNick.trim();
-  return { isGroup: false, target: senderNick || rawTarget, rawTarget };
-}
-
-export async function monitorIrcProvider(opts: IrcMonitorOptions): Promise<{ stop: () => void }> {
+export async function monitorIrcProvider(
+  opts: IrcMonitorOptions,
+): Promise<{ stop: () => Promise<void> }> {
   const core = getIrcRuntime();
   const cfg = opts.config ?? (core.config.current() as CoreConfig);
   const account = resolveIrcAccount({
@@ -75,6 +67,49 @@ export async function monitorIrcProvider(opts: IrcMonitorOptions): Promise<{ sto
     }
   }
 
+  const ingress: IrcIngressMonitor = createIrcIngressMonitor({
+    accountId: account.accountId,
+    runtime,
+    ...(opts.ingressQueue ? { queue: opts.ingressQueue } : {}),
+    dispatch: async (message, turnAdoptionLifecycle: IrcIngressLifecycle) => {
+      const activeClient = client;
+      if (!activeClient || stopped || monitorAbort.signal.aborted) {
+        return {
+          kind: "failed-retryable",
+          error: new Error("IRC transport disconnected before ingress dispatch."),
+        };
+      }
+      if (
+        normalizeLowercaseStringOrEmpty(message.senderNick) ===
+        normalizeLowercaseStringOrEmpty(activeClient.nick)
+      ) {
+        return { kind: "completed" };
+      }
+      if (opts.onMessage) {
+        await opts.onMessage(message, activeClient);
+        return { kind: "completed" };
+      }
+      return await handleIrcInbound({
+        message,
+        account,
+        config: cfg,
+        runtime,
+        connectedNick: activeClient.nick,
+        turnAdoptionLifecycle,
+        sendReply: async (target, text) => {
+          activeClient.sendPrivmsg(target, text);
+          opts.statusSink?.({ lastOutboundAt: Date.now() });
+          core.channel.activity.record({
+            channel: "irc",
+            accountId: account.accountId,
+            direction: "outbound",
+          });
+        },
+        statusSink: opts.statusSink,
+      });
+    },
+  });
+
   function scheduleReconnect() {
     if (stopped || monitorAbort.signal.aborted || reconnectTimer) {
       return;
@@ -96,6 +131,7 @@ export async function monitorIrcProvider(opts: IrcMonitorOptions): Promise<{ sto
     if (stopped || monitorAbort.signal.aborted) {
       return;
     }
+    const ingressConnection = ingress.openConnection();
     const nextClient = await connectIrcClient(
       buildIrcConnectOptions(account, {
         channels: account.config.channels,
@@ -124,60 +160,12 @@ export async function monitorIrcProvider(opts: IrcMonitorOptions): Promise<{ sto
           scheduleReconnect();
         },
         onPrivmsg: async (event) => {
-          if (!client) {
-            return;
-          }
-          if (
-            normalizeLowercaseStringOrEmpty(event.senderNick) ===
-            normalizeLowercaseStringOrEmpty(client.nick)
-          ) {
-            return;
-          }
-
-          const inboundTarget = resolveIrcInboundTarget({
-            target: event.target,
-            senderNick: event.senderNick,
-          });
-          const message: IrcInboundMessage = {
-            messageId: makeIrcMessageId(),
-            target: inboundTarget.target,
-            rawTarget: inboundTarget.rawTarget,
-            senderNick: event.senderNick,
-            senderUser: event.senderUser,
-            senderHost: event.senderHost,
-            text: event.text,
-            timestamp: Date.now(),
-            isGroup: inboundTarget.isGroup,
-          };
-
+          await ingressConnection.accept(event.rawLine);
           core.channel.activity.record({
             channel: "irc",
             accountId: account.accountId,
             direction: "inbound",
-            at: message.timestamp,
-          });
-
-          if (opts.onMessage) {
-            await opts.onMessage(message, client);
-            return;
-          }
-
-          await handleIrcInbound({
-            message,
-            account,
-            config: cfg,
-            runtime,
-            connectedNick: client.nick,
-            sendReply: async (target, text) => {
-              client?.sendPrivmsg(target, text);
-              opts.statusSink?.({ lastOutboundAt: Date.now() });
-              core.channel.activity.record({
-                channel: "irc",
-                accountId: account.accountId,
-                direction: "outbound",
-              });
-            },
-            statusSink: opts.statusSink,
+            at: Date.now(),
           });
         },
       }),
@@ -187,28 +175,41 @@ export async function monitorIrcProvider(opts: IrcMonitorOptions): Promise<{ sto
       return;
     }
     client = nextClient;
+    ingress.start();
 
     logger.info(
       `[${account.accountId}] connected to ${account.host}:${account.port}${account.tls ? " (tls)" : ""} as ${nextClient.nick}`,
     );
   }
 
-  await connect();
+  try {
+    await connect();
+  } catch (error) {
+    removeAbortListener?.();
+    removeAbortListener = null;
+    await ingress.stop();
+    throw error;
+  }
 
+  let stopTask: Promise<void> | undefined;
   return {
     stop: () => {
-      stopped = true;
-      removeAbortListener?.();
-      removeAbortListener = null;
-      if (!monitorAbort.signal.aborted) {
-        monitorAbort.abort();
-      }
-      if (reconnectTimer) {
-        clearTimeout(reconnectTimer);
-        reconnectTimer = null;
-      }
-      client?.quit("shutdown");
-      client = null;
+      stopTask ??= (async () => {
+        stopped = true;
+        removeAbortListener?.();
+        removeAbortListener = null;
+        if (!monitorAbort.signal.aborted) {
+          monitorAbort.abort();
+        }
+        if (reconnectTimer) {
+          clearTimeout(reconnectTimer);
+          reconnectTimer = null;
+        }
+        client?.quit("shutdown");
+        client = null;
+        await ingress.stop();
+      })();
+      return stopTask;
     },
   };
 }

--- a/extensions/irc/src/monitor.ts
+++ b/extensions/irc/src/monitor.ts
@@ -53,6 +53,7 @@ export async function monitorIrcProvider(
   });
 
   let client: IrcClient | null = null;
+  let ingressPause: Promise<void> = Promise.resolve();
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   let stopped = false;
   const monitorAbort = new AbortController();
@@ -161,6 +162,7 @@ export async function monitorIrcProvider(
           if (stopped || monitorAbort.signal.aborted) {
             return;
           }
+          ingressPause = ingress.pause();
           client = null;
           logger.warn?.(
             `[${account.accountId}] IRC connection closed; reconnecting in ${IRC_MONITOR_RECONNECT_DELAY_MS}ms`,
@@ -183,6 +185,10 @@ export async function monitorIrcProvider(
       return;
     }
     client = nextClient;
+    await ingressPause;
+    if (client !== nextClient || !nextClient.isReady()) {
+      return;
+    }
     ingress.start();
 
     logger.info(


### PR DESCRIPTION
## What Problem This Solves

IRC messages were dispatched directly from the socket callback. A process crash after socket acceptance but before dispatch could lose the message with no recovery path.

Important transport caveat: IRC does not redeliver after socket acceptance; dedupe tombstones are near-inert. The durable queue's value is crash-window durability between accept and dispatch, with local restart recovery.

## Why This Change Was Made

This routes accepted PRIVMSG lines through the shared durable channel-ingress queue, preserves receipt-time connection context, serializes same-lane work, and coordinates draining with reconnect and shutdown.

IRC nick ownership is not stable across connections. Direct messages therefore fail closed when the accepting connection changes; channel messages remain recoverable after reconnect or local restart.

## User Impact

IRC channel traffic survives the local accept-to-dispatch crash window and resumes from the local queue after restart. Colonless PRIVMSG bodies remain accepted. Self echoes stay suppressed and do not affect inbound activity metrics.

This does not provide transport-level replay or exactly-once command side effects. A crash after side effects but before queue completion can repeat work under the accepted at-least-once contract.

## Evidence

- IRC extension suite: 20 files, 117 tests passed, including real socket reconnect, colonless PRIVMSG, pause/resume, self-echo, restart recovery, and cross-connection DM safety cases.
- Dead-code full gates: dependency, unused-file, and unused-export scans passed with zero entries on Blacksmith Testbox tbx_01kxv9vfbrvbj7m5d783h7n1z9.
- Blacksmith proof: https://github.com/openclaw/openclaw/actions/runs/29657098983
- oxfmt check passed on all 8 touched IRC files.
- git diff --check passed.
- Mandatory branch autoreview passed with no accepted or actionable findings.
