### PR TITLE
feat: add LLMTR provider for Turkey-hosted and global models

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -566,6 +566,11 @@
       - any-glob-to-any-file:
           - "extensions/litellm/**"
           - "docs/providers/litellm.md"
+"extensions: llmtr":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/llmtr/**"
+          - "docs/providers/llmtr.md"
 "extensions: openai":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -1512,6 +1512,14 @@
     "target": "NovitaAI"
   },
   {
+    "source": "LLMTR",
+    "target": "LLMTR"
+  },
+  {
+    "source": "LLMTR (multi-vendor gateway)",
+    "target": "LLMTR（多厂商网关）"
+  },
+  {
     "source": "Onboard",
     "target": "引导设置"
   },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1542,6 +1542,7 @@
                   "providers/inworld",
                   "providers/kilocode",
                   "providers/litellm",
+                  "providers/llmtr",
                   "providers/lmstudio",
                   "providers/longcat",
                   "providers/meta",

--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -78,7 +78,7 @@ Each entry lists the package, distribution route, and description.
 
 - **[crabbox](/plugins/reference/crabbox)** (`@openclaw/crabbox-provider`) - included in OpenClaw. Cloud worker provider backed by the Crabbox CLI.
 
-- **[cua-computer](/plugins/reference/cua-computer)** (`@openclaw/cua-computer`) - included in OpenClaw. Experimental CUA Driver SDK computer control for Windows and Linux node hosts.
+- **[cua-computer](/plugins/reference/cua-computer)** (`@openclaw/cua-computer`) - included in OpenClaw. Experimental CUA Driver computer control for macOS, Windows, and Linux node hosts.
 
 - **[deepgram](/plugins/reference/deepgram)** (`@openclaw/deepgram-provider`) - included in OpenClaw. Adds media understanding provider support. Adds realtime transcription provider support.
 
@@ -172,7 +172,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Official external packages
 
-90 plugins
+91 plugins
 
 - **[acpx](/plugins/reference/acpx)** (`@openclaw/acpx`) - npm; ClawHub. OpenClaw ACP runtime backend with plugin-owned session and transport management.
 
@@ -259,6 +259,8 @@ Each entry lists the package, distribution route, and description.
 - **[line](/plugins/reference/line)** (`@openclaw/line`) - npm; ClawHub. OpenClaw LINE channel plugin for LINE Bot API chats.
 
 - **[llama-cpp](/plugins/reference/llama-cpp)** (`@openclaw/llama-cpp-provider`) - npm; ClawHub. Managed local llama.cpp server for GGUF chat and embeddings.
+
+- **[llmtr](/plugins/reference/llmtr)** (`@openclaw/llmtr-provider`) - npm; ClawHub: `clawhub:@openclaw/llmtr-provider`. OpenClaw LLMTR provider plugin.
 
 - **[lobster](/plugins/reference/lobster)** (`@openclaw/lobster`) - npm; ClawHub. Lobster workflow tool plugin for typed pipelines and resumable approvals.
 

--- a/docs/plugins/reference.md
+++ b/docs/plugins/reference.md
@@ -16,5 +16,5 @@ Regenerate it with:
 pnpm plugins:inventory:gen
 ```
 
-Use [Plugin inventory](/plugins/plugin-inventory) to browse all 149
+Use [Plugin inventory](/plugins/plugin-inventory) to browse all 150
 generated plugin reference pages by distribution, package, and description.

--- a/docs/plugins/reference/cua-computer.md
+++ b/docs/plugins/reference/cua-computer.md
@@ -1,5 +1,5 @@
 ---
-summary: "Experimental CUA Driver SDK computer control for Windows and Linux node hosts."
+summary: "Experimental CUA Driver computer control for macOS, Windows, and Linux node hosts."
 read_when:
   - You are installing, configuring, or auditing the cua-computer plugin
 title: "Cua Computer plugin"
@@ -7,7 +7,7 @@ title: "Cua Computer plugin"
 
 # Cua Computer plugin
 
-Experimental CUA Driver SDK computer control for Windows and Linux node hosts.
+Experimental CUA Driver computer control for macOS, Windows, and Linux node hosts.
 
 ## Distribution
 

--- a/docs/plugins/reference/llmtr.md
+++ b/docs/plugins/reference/llmtr.md
@@ -1,0 +1,23 @@
+---
+summary: "OpenClaw LLMTR provider plugin."
+read_when:
+  - You are installing, configuring, or auditing the llmtr plugin
+title: "LLMTR plugin"
+---
+
+# LLMTR plugin
+
+OpenClaw LLMTR provider plugin.
+
+## Distribution
+
+- Package: `@openclaw/llmtr-provider`
+- Install route: npm; ClawHub: `clawhub:@openclaw/llmtr-provider`
+
+## Surface
+
+providers: `llmtr`
+
+## Related docs
+
+- [llmtr](/providers/llmtr)

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -53,6 +53,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 - [inferrs (local models)](/providers/inferrs)
 - [Kilocode](/providers/kilocode)
 - [LiteLLM (unified gateway)](/providers/litellm)
+- [LLMTR (multi-vendor gateway)](/providers/llmtr)
 - [LM Studio (local models)](/providers/lmstudio)
 - [LongCat](/providers/longcat)
 - [MiniMax](/providers/minimax)

--- a/docs/providers/llmtr.md
+++ b/docs/providers/llmtr.md
@@ -1,0 +1,155 @@
+---
+summary: "Use LLMTR's OpenAI-compatible AI gateway with OpenClaw"
+read_when:
+  - You want one key covering Anthropic, OpenAI, Google, Qwen, DeepSeek and more
+  - You need Turkish data residency or Turkish-language models
+  - You need the LLMTR provider id, key, or endpoint
+title: "LLMTR"
+---
+
+LLMTR is an OpenAI-compatible AI gateway that serves over 230 models behind a
+single API key: global passthrough routes across Anthropic, OpenAI, Google,
+Qwen, Z.AI, Mistral, DeepSeek, MiniMax, Moonshot, Meta, NVIDIA and others, plus
+a Turkey-hosted set for workloads that need Turkish data residency or
+Turkish-language models. OpenClaw provides LLMTR through the official external
+`@openclaw/llmtr-provider` plugin. Model refs use the
+`llmtr/anthropic/claude-sonnet-5` form.
+
+Turkey-hosted routes are named `llmtr/<name>` upstream, so their refs collapse
+to a single prefix: the Trendyol model is `llmtr/trendyol-asure-12b`, not
+`llmtr/llmtr/trendyol-asure-12b`.
+
+## Setup
+
+Install the plugin and restart the Gateway:
+
+```bash
+openclaw plugins install @openclaw/llmtr-provider
+openclaw gateway restart
+```
+
+Create an API key at [llmtr.com](https://llmtr.com), then run:
+
+```bash
+openclaw onboard --auth-choice llmtr-api-key
+```
+
+Or set:
+
+```bash
+export LLMTR_API_KEY="<your-llmtr-api-key>" # pragma: allowlist secret
+```
+
+## Defaults
+
+| Setting       | Value                             |
+| ------------- | --------------------------------- |
+| Plugin        | `@openclaw/llmtr-provider`        |
+| Provider id   | `llmtr`                           |
+| Base URL      | `https://llmtr.com/v1`            |
+| Env var       | `LLMTR_API_KEY`                   |
+| Default model | `llmtr/anthropic/claude-sonnet-5` |
+
+## Model catalog
+
+The plugin refreshes its catalog from `GET /v1/models` and keeps only routes
+whose `supported_operations` include `CHAT_COMPLETIONS`, so embedding-only
+(`voyageai`, `llmtr/embeddinggemma-300m`), image (`recraft`, `krea`) and
+`/v1/responses`-only routes never appear. Context windows, output caps,
+modalities, pricing and reasoning support come from the same response. A
+snapshot ships with the plugin as the offline fallback.
+
+```bash
+openclaw models list --provider llmtr
+```
+
+Turkey-hosted:
+
+- `llmtr/gemma-4`
+- `llmtr/qwen3-5-4b`
+- `llmtr/qwen3-6-35b`
+- `llmtr/trendyol-asure-12b`
+- `llmtr/muse-glimmer-30b-tr`
+- `llmtr/magibu-11b-v8`
+- `llmtr/medgemma-4b`
+
+Global passthrough (snapshot selection):
+
+- `llmtr/anthropic/claude-opus-5`, `claude-sonnet-5`, `claude-opus-4.8`,
+  `claude-haiku-4.5`
+- `llmtr/openai/gpt-5.4`, `gpt-5.4-mini`, `gpt-5.2`
+- `llmtr/google/gemini-3.7-flash`, `gemini-3.5-flash`,
+  `gemini-3.1-pro-preview`
+- `llmtr/zai/glm-5.2`, `glm-5.1`, `glm-5`, `glm-5-turbo`, `glm-4.7`, `glm-4.6`,
+  `glm-4.6v` (vision)
+- `llmtr/qwen/qwen3.7-max`, `qwen3.7-plus`, `qwen3.6-flash`, `qwen3.5-plus`,
+  `qwen3-coder-plus`
+- `llmtr/deepseek/deepseek-v4-pro`, `deepseek-v4-flash`, `deepseek-reasoner`,
+  `deepseek-chat`
+- `llmtr/moonshot/kimi-k3`, `kimi-k2.7-code`, `kimi-k2.6`
+- `llmtr/minimax/minimax-m3`, `minimax-m2.7`, `minimax-m2.7-highspeed`,
+  `minimax-m2.5`, `minimax-m2.5-highspeed`
+- `llmtr/mistral/mistral-large-latest`, `mistral-medium-latest`
+- `llmtr/meta/muse-spark-1.2`, `llama-3.3-70b-instruct`
+- `llmtr/stepfun/step-3.7-flash`, `llmtr/mimo/mimo-v2.5-pro`,
+  `llmtr/kwaikat/kat-coder-pro-v2.5`,
+  `llmtr/nvidia/nemotron-3-super-120b-a12b`
+
+## Using a model that is not in the snapshot
+
+Discovery surfaces every chat-capable route the gateway serves, so the snapshot
+list above is a floor rather than a limit. To pin a route explicitly — or to
+override a published value — add it under `models.providers.llmtr.models`:
+
+```json
+{
+  "models": {
+    "providers": {
+      "llmtr": {
+        "models": [{ "id": "perplexity/sonar-pro", "contextWindow": 131072, "maxTokens": 32768 }]
+      }
+    }
+  }
+}
+```
+
+Check `supported_operations` in `curl https://llmtr.com/v1/models` first: models
+LLMTR serves solely through `/v1/responses` reject chat-completions requests, as
+do embedding, image, video, and audio routes.
+
+## When to choose LLMTR
+
+- One account and key covering Anthropic, OpenAI, Google, Qwen, DeepSeek,
+  Z.AI, MiniMax, Moonshot and more, with a shared credit balance.
+- Turkish data residency, or Turkish-language models such as Trendyol Asure
+  and Muse Glimmer.
+- A gateway fallback beside OpenRouter or direct vendor APIs.
+
+Choose a direct vendor provider when you need vendor-native request
+parameters, prompt caching, or support contracts — LLMTR adds a platform
+margin on credit purchases and normalizes requests through its own gateway.
+Some routes also advertise a narrower parameter set than the vendor's own API;
+`supported_parameters` in `GET /v1/models` is authoritative, and the plugin
+only declares reasoning support for routes that accept a reasoning parameter.
+
+## Troubleshooting
+
+- `401`/`403`: verify the key in the LLMTR dashboard and re-run
+  `openclaw onboard --auth-choice llmtr-api-key` if the stored profile is
+  stale.
+- Errors naming a route that used to work: LLMTR retires routes, and retired
+  ids drop out of `GET /v1/models` before they stop answering. `llmtr/sincap`
+  and `llmtr/trendyol-7b` are both gone from the catalog;
+  `llmtr/trendyol-asure-12b` replaces the latter. Use the ids from
+  `openclaw models list --provider llmtr`.
+- A model appears on llmtr.com but not in OpenClaw: it is most likely a
+  `/v1/responses`-only or non-chat route. Confirm with
+  `curl https://llmtr.com/v1/models` and check `supported_operations`.
+- `502` or idle timeouts on Turkey-hosted `llmtr/*` routes: these are hosted
+  on smaller capacity and can be temporarily unavailable. Retry, or fall back
+  to a global route; the same key serves both.
+
+## Related
+
+- [Model providers](/concepts/model-providers)
+- [Provider directory](/providers/index)

--- a/docs/providers/llmtr.md
+++ b/docs/providers/llmtr.md
@@ -75,25 +75,48 @@ Turkey-hosted:
 
 Global passthrough (snapshot selection):
 
-- `llmtr/anthropic/claude-opus-5`, `claude-sonnet-5`, `claude-opus-4.8`,
-  `claude-haiku-4.5`
-- `llmtr/openai/gpt-5.4`, `gpt-5.4-mini`, `gpt-5.2`
-- `llmtr/google/gemini-3.7-flash`, `gemini-3.5-flash`,
-  `gemini-3.1-pro-preview`
-- `llmtr/zai/glm-5.2`, `glm-5.1`, `glm-5`, `glm-5-turbo`, `glm-4.7`, `glm-4.6`,
-  `glm-4.6v` (vision)
-- `llmtr/qwen/qwen3.7-max`, `qwen3.7-plus`, `qwen3.6-flash`, `qwen3.5-plus`,
-  `qwen3-coder-plus`
-- `llmtr/deepseek/deepseek-v4-pro`, `deepseek-v4-flash`, `deepseek-reasoner`,
-  `deepseek-chat`
-- `llmtr/moonshot/kimi-k3`, `kimi-k2.7-code`, `kimi-k2.6`
-- `llmtr/minimax/minimax-m3`, `minimax-m2.7`, `minimax-m2.7-highspeed`,
-  `minimax-m2.5`, `minimax-m2.5-highspeed`
-- `llmtr/mistral/mistral-large-latest`, `mistral-medium-latest`
-- `llmtr/meta/muse-spark-1.2`, `llama-3.3-70b-instruct`
-- `llmtr/stepfun/step-3.7-flash`, `llmtr/mimo/mimo-v2.5-pro`,
-  `llmtr/kwaikat/kat-coder-pro-v2.5`,
-  `llmtr/nvidia/nemotron-3-super-120b-a12b`
+- `llmtr/anthropic/claude-opus-5`
+- `llmtr/anthropic/claude-sonnet-5`
+- `llmtr/anthropic/claude-opus-4.8`
+- `llmtr/anthropic/claude-haiku-4.5`
+- `llmtr/openai/gpt-5.4`
+- `llmtr/openai/gpt-5.4-mini`
+- `llmtr/openai/gpt-5.2`
+- `llmtr/google/gemini-3.7-flash`
+- `llmtr/google/gemini-3.5-flash`
+- `llmtr/google/gemini-3.1-pro-preview`
+- `llmtr/zai/glm-5.2`
+- `llmtr/zai/glm-5.1`
+- `llmtr/zai/glm-5`
+- `llmtr/zai/glm-5-turbo`
+- `llmtr/zai/glm-4.7`
+- `llmtr/zai/glm-4.6`
+- `llmtr/zai/glm-4.6v` (vision)
+- `llmtr/qwen/qwen3.7-max`
+- `llmtr/qwen/qwen3.7-plus`
+- `llmtr/qwen/qwen3.6-flash`
+- `llmtr/qwen/qwen3.5-plus`
+- `llmtr/qwen/qwen3-coder-plus`
+- `llmtr/deepseek/deepseek-v4-pro`
+- `llmtr/deepseek/deepseek-v4-flash`
+- `llmtr/deepseek/deepseek-reasoner`
+- `llmtr/deepseek/deepseek-chat`
+- `llmtr/moonshot/kimi-k3`
+- `llmtr/moonshot/kimi-k2.7-code`
+- `llmtr/moonshot/kimi-k2.6`
+- `llmtr/minimax/minimax-m3`
+- `llmtr/minimax/minimax-m2.7`
+- `llmtr/minimax/minimax-m2.7-highspeed`
+- `llmtr/minimax/minimax-m2.5`
+- `llmtr/minimax/minimax-m2.5-highspeed`
+- `llmtr/mistral/mistral-large-latest`
+- `llmtr/mistral/mistral-medium-latest`
+- `llmtr/meta/muse-spark-1.2`
+- `llmtr/meta/llama-3.3-70b-instruct`
+- `llmtr/stepfun/step-3.7-flash`
+- `llmtr/mimo/mimo-v2.5-pro`
+- `llmtr/kwaikat/kat-coder-pro-v2.5`
+- `llmtr/nvidia/nemotron-3-super-120b-a12b`
 
 ## Using a model that is not in the snapshot
 

--- a/extensions/llmtr/README.md
+++ b/extensions/llmtr/README.md
@@ -1,0 +1,20 @@
+# OpenClaw LLMTR provider
+
+Official OpenClaw provider plugin for LLMTR, an OpenAI-compatible AI gateway
+that serves global vendor models alongside Turkey-hosted models behind one API
+key.
+
+## Install
+
+```sh
+openclaw plugins install @openclaw/llmtr-provider
+openclaw gateway restart
+```
+
+Configure `LLMTR_API_KEY`, then select a model such as
+`llmtr/anthropic/claude-sonnet-5` or `llmtr/trendyol-asure-12b`.
+
+## Docs
+
+See `docs/providers/llmtr.md` in the OpenClaw repository, or the published docs
+at `https://docs.openclaw.ai/providers/llmtr`.

--- a/extensions/llmtr/index.test.ts
+++ b/extensions/llmtr/index.test.ts
@@ -1,0 +1,151 @@
+// LLMTR tests cover plugin registration and model discovery filtering.
+import { registerSingleProviderPlugin } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getCachedLiveProviderModelRows = vi.fn();
+
+vi.mock("openclaw/plugin-sdk/provider-catalog-live-runtime", async () => {
+  // Keep the real LiveModelCatalogHttpError: models.ts branches on `instanceof`.
+  const actual = await vi.importActual<
+    typeof import("openclaw/plugin-sdk/provider-catalog-live-runtime")
+  >("openclaw/plugin-sdk/provider-catalog-live-runtime");
+  return { ...actual, getCachedLiveProviderModelRows };
+});
+
+const { discoverLlmtrModels, LLMTR_BASE_URL } = await import("./models.js");
+const plugin = (await import("./index.js")).default;
+
+function requireCatalogProvider(
+  result:
+    | { provider: { baseUrl?: string; models?: Array<{ id: string }> } }
+    | { providers: Record<string, unknown> }
+    | null
+    | undefined,
+): { baseUrl?: string; models?: Array<{ id: string }> } {
+  if (!result || !("provider" in result)) {
+    throw new Error("single provider catalog result missing");
+  }
+  return result.provider;
+}
+
+function modelRow(id: string, operations: string[], overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    object: "model",
+    owned_by: id.split("/")[0],
+    supported_operations: operations,
+    ...overrides,
+  };
+}
+
+describe("llmtr provider plugin", () => {
+  beforeEach(() => {
+    getCachedLiveProviderModelRows.mockReset();
+  });
+
+  it("registers LLMTR as an OpenAI-compatible provider", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+
+    expect(provider.id).toBe("llmtr");
+    expect(provider.envVars).toEqual(["LLMTR_API_KEY"]);
+    expect(provider.auth?.map((method) => method.id)).toEqual(["api-key"]);
+
+    const result = await provider.staticCatalog?.run({
+      config: {},
+      env: {},
+      resolveProviderApiKey: () => ({}),
+    } as never);
+    const catalogProvider = requireCatalogProvider(result);
+    expect(catalogProvider.baseUrl).toBe(LLMTR_BASE_URL);
+
+    const ids = catalogProvider.models?.map((model) => model.id) ?? [];
+    // The catalog ships Turkey-hosted routes plus the global passthrough
+    // selection. Turkey-hosted routes are literally `llmtr/<name>` upstream, so
+    // the vendor prefix must survive normalization even though it repeats the
+    // provider id (`modelKey` collapses the ref back to
+    // `llmtr/trendyol-asure-12b`).
+    expect(ids).toContain("llmtr/trendyol-asure-12b");
+    expect(ids).toContain("anthropic/claude-sonnet-5");
+    expect(ids).toContain("zai/glm-5.2");
+    expect(ids).toContain("minimax/minimax-m3");
+    // Both dropped out of GET /v1/models upstream; trendyol-asure-12b replaces
+    // trendyol-7b.
+    expect(ids).not.toContain("llmtr/sincap");
+    expect(ids).not.toContain("llmtr/trendyol-7b");
+    // Non-chat routes must never reach the catalog.
+    expect(ids).not.toContain("llmtr/embeddinggemma-300m");
+  });
+
+  it("drops discovered models that cannot serve chat completions", async () => {
+    getCachedLiveProviderModelRows.mockResolvedValue([
+      modelRow("llmtr/trendyol-asure-12b", ["CHAT_COMPLETIONS"]),
+      modelRow("openai/gpt-5.5", ["RESPONSES"]),
+      modelRow("llmtr/embeddinggemma-300m", ["EMBEDDINGS"]),
+      modelRow("voyageai/voyage-3.5", ["EMBEDDINGS"]),
+      modelRow("recraft/recraft-v3", ["IMAGES"]),
+      modelRow("google/gemini-3.5-flash", ["CHAT_COMPLETIONS", "RESPONSES"]),
+    ]);
+
+    const ids = (await discoverLlmtrModels("key")).map((model) => model.id);
+
+    expect(ids).toEqual(["llmtr/trendyol-asure-12b", "google/gemini-3.5-flash"]);
+  });
+
+  it("builds discovered models from the metadata the gateway publishes", async () => {
+    getCachedLiveProviderModelRows.mockResolvedValue([
+      modelRow("zai/glm-5.2", ["CHAT_COMPLETIONS"], {
+        name: "GLM-5.2",
+        context_length: 1000000,
+        top_provider: { max_completion_tokens: 131072 },
+        architecture: { input_modalities: ["text"] },
+        pricing: { prompt: "0.00000126", completion: "0.00000396" },
+        supported_parameters: ["reasoning", "reasoning_effort", "tools"],
+      }),
+      modelRow("minimax/minimax-m3", ["CHAT_COMPLETIONS"], {
+        context_length: 1000000,
+        // Output caps above the window would let the request exceed it.
+        top_provider: { max_completion_tokens: 2000000 },
+        architecture: { input_modalities: ["text", "image", "file", "video"] },
+        supported_parameters: ["tools"],
+      }),
+      modelRow("acme/unknown", ["CHAT_COMPLETIONS"]),
+    ]);
+
+    const models = await discoverLlmtrModels("key");
+    const glm = models.find((model) => model.id === "zai/glm-5.2");
+    const minimax = models.find((model) => model.id === "minimax/minimax-m3");
+    const bare = models.find((model) => model.id === "acme/unknown");
+
+    expect(glm?.name).toBe("GLM-5.2");
+    expect(glm?.contextWindow).toBe(1000000);
+    expect(glm?.maxTokens).toBe(131072);
+    expect(glm?.reasoning).toBe(true);
+    // `pricing` is USD per token; catalog cost is USD per million tokens.
+    expect(glm?.cost.input).toBe(1.26);
+    expect(glm?.cost.output).toBe(3.96);
+
+    // `file` is not an OpenClaw modality, and maxTokens is clamped to the window.
+    expect(minimax?.input).toEqual(["text", "image", "video"]);
+    expect(minimax?.maxTokens).toBe(1000000);
+    expect(minimax?.reasoning).toBe(false);
+
+    // A row without metadata still lands on conservative defaults.
+    expect(bare?.contextWindow).toBe(32768);
+    expect(bare?.maxTokens).toBe(8192);
+    expect(bare?.input).toEqual(["text"]);
+
+    // LLMTR returns usage on streamed responses; every path must carry the flag.
+    for (const model of models) {
+      expect(model.compat?.supportsUsageInStreaming).toBe(true);
+    }
+  });
+
+  it("falls back to the bundled catalog when discovery fails", async () => {
+    getCachedLiveProviderModelRows.mockRejectedValue(new Error("network down"));
+
+    const ids = (await discoverLlmtrModels()).map((model) => model.id);
+
+    expect(ids).toContain("llmtr/trendyol-asure-12b");
+    expect(ids).toContain("anthropic/claude-sonnet-5");
+  });
+});

--- a/extensions/llmtr/index.ts
+++ b/extensions/llmtr/index.ts
@@ -1,0 +1,49 @@
+// LLMTR plugin entrypoint registers its OpenClaw integration.
+import { readConfiguredProviderCatalogEntries } from "openclaw/plugin-sdk/provider-catalog-shared";
+import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
+import { buildProviderReplayFamilyHooks } from "openclaw/plugin-sdk/provider-model-shared";
+import { buildProviderToolCompatFamilyHooks } from "openclaw/plugin-sdk/provider-tools";
+import { LLMTR_DEFAULT_MODEL_REF } from "./models.js";
+import { buildLlmtrProvider, buildStaticLlmtrProvider } from "./provider-catalog.js";
+
+const PROVIDER_ID = "llmtr";
+
+export default defineSingleProviderPluginEntry({
+  id: PROVIDER_ID,
+  name: "LLMTR Provider",
+  description: "OpenClaw LLMTR provider plugin",
+  provider: {
+    label: "LLMTR",
+    docsPath: "/providers/llmtr",
+    envVars: ["LLMTR_API_KEY"],
+    auth: [
+      {
+        methodId: "api-key",
+        label: "LLMTR API key",
+        hint: "OpenAI-compatible AI gateway with Turkey-hosted routes",
+        optionKey: "llmtrApiKey",
+        flagName: "--llmtr-api-key",
+        envVar: "LLMTR_API_KEY",
+        promptMessage: "Enter LLMTR API key",
+        defaultModel: LLMTR_DEFAULT_MODEL_REF,
+        noteTitle: "LLMTR",
+        noteMessage: "Manage API keys at https://llmtr.com/dashboard",
+      },
+    ],
+    catalog: {
+      buildProvider: buildLlmtrProvider,
+      buildStaticProvider: buildStaticLlmtrProvider,
+      allowExplicitBaseUrl: true,
+    },
+    augmentModelCatalog: ({ config }) =>
+      readConfiguredProviderCatalogEntries({
+        config,
+        providerId: PROVIDER_ID,
+      }),
+    ...buildProviderReplayFamilyHooks({
+      family: "openai-compatible",
+      dropReasoningFromHistory: false,
+    }),
+    ...buildProviderToolCompatFamilyHooks("openai"),
+  },
+});

--- a/extensions/llmtr/models.ts
+++ b/extensions/llmtr/models.ts
@@ -1,0 +1,216 @@
+/**
+ * LLMTR model catalog, static model definitions, and dynamic model discovery.
+ */
+import {
+  getCachedLiveProviderModelRows,
+  LiveModelCatalogHttpError,
+} from "openclaw/plugin-sdk/provider-catalog-live-runtime";
+import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
+import { ssrfPolicyFromHttpBaseUrlAllowedHostname } from "openclaw/plugin-sdk/ssrf-runtime";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
+
+const log = createSubsystemLogger("llmtr-models");
+
+const LLMTR_MANIFEST_PROVIDER = buildManifestModelProviderConfig({
+  providerId: "llmtr",
+  catalog: manifest.modelCatalog.providers.llmtr,
+});
+
+/** Base URL for the LLMTR OpenAI-compatible gateway. */
+export const LLMTR_BASE_URL = LLMTR_MANIFEST_PROVIDER.baseUrl;
+/** Default LLMTR model id used for onboarding. */
+const LLMTR_DEFAULT_MODEL_ID = "anthropic/claude-sonnet-5";
+/** Default LLMTR model ref used for onboarding. */
+export const LLMTR_DEFAULT_MODEL_REF = `llmtr/${LLMTR_DEFAULT_MODEL_ID}`;
+
+/**
+ * Last-resort sizing for a discovered row that publishes no `context_length`.
+ * Under-declaring the window truncates history early instead of failing the
+ * request upstream.
+ */
+const LLMTR_DEFAULT_CONTEXT_WINDOW = 32768;
+const LLMTR_DEFAULT_MAX_TOKENS = 8192;
+
+/** Bundled fallback LLMTR model catalog, normalized from the plugin manifest. */
+export const LLMTR_MODEL_CATALOG: ModelDefinitionConfig[] = LLMTR_MANIFEST_PROVIDER.models;
+
+/** Adds LLMTR provider compat metadata to one model catalog entry. */
+export function buildLlmtrModelDefinition(model: ModelDefinitionConfig): ModelDefinitionConfig {
+  return {
+    ...model,
+    api: "openai-completions",
+    compat: {
+      ...model.compat,
+      // Verified live: LLMTR honours stream_options.include_usage and emits a
+      // final usage block on streamed responses. Declaring false here would
+      // make every streamed turn report zero token usage.
+      supportsUsageInStreaming: true,
+    },
+  };
+}
+
+interface LlmtrModelEntry {
+  id?: unknown;
+  name?: unknown;
+  owned_by?: unknown;
+  supported_operations?: unknown;
+  context_length?: unknown;
+  architecture?: { input_modalities?: unknown } | null;
+  pricing?: Record<string, unknown> | null;
+  top_provider?: { max_completion_tokens?: unknown } | null;
+  supported_parameters?: unknown;
+  reasoning?: { mandatory?: unknown; default_enabled?: unknown } | null;
+}
+
+const CACHE_TTL = 5 * 60 * 1000;
+
+/**
+ * LLMTR routes Responses-only models (OpenAI gpt-5.5+/codex, Grok 4.x, Qwen VL)
+ * to `/v1/responses`. This plugin speaks `openai-completions`, so advertising
+ * them would surface models that reject every request we can send.
+ */
+const CHAT_COMPLETIONS_OPERATION = "CHAT_COMPLETIONS";
+
+function supportsChatCompletions(entry: LlmtrModelEntry): boolean {
+  return (
+    Array.isArray(entry.supported_operations) &&
+    entry.supported_operations.includes(CHAT_COMPLETIONS_OPERATION)
+  );
+}
+
+async function fetchLlmtrModelRows(apiKey?: string): Promise<readonly unknown[]> {
+  return await getCachedLiveProviderModelRows({
+    providerId: "llmtr",
+    endpoint: `${LLMTR_BASE_URL}/models`,
+    discoveryApiKey: apiKey,
+    timeoutMs: 10_000,
+    ttlMs: CACHE_TTL,
+    buildRequestHeaders: ({ discoveryApiKey }) => ({
+      Accept: "application/json",
+      ...(discoveryApiKey ? { Authorization: `Bearer ${discoveryApiKey}` } : {}),
+    }),
+    policy: ssrfPolicyFromHttpBaseUrlAllowedHostname(LLMTR_BASE_URL),
+    auditContext: "llmtr-model-discovery",
+  });
+}
+
+const MODEL_INPUT_MODALITIES = ["text", "image", "video", "audio"] as const;
+type ModelInputModality = (typeof MODEL_INPUT_MODALITIES)[number];
+
+function readPositiveInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : undefined;
+}
+
+/** `pricing` is USD per token; catalog `cost` is USD per million tokens. */
+function perMillionTokenCost(value: unknown): number {
+  const perToken = typeof value === "string" ? Number(value) : value;
+  if (typeof perToken !== "number" || !Number.isFinite(perToken) || perToken <= 0) {
+    return 0;
+  }
+  return Math.round(perToken * 1_000_000 * 1e6) / 1e6;
+}
+
+function readInputModalities(entry: LlmtrModelEntry): ModelInputModality[] {
+  const declared = entry.architecture?.input_modalities;
+  if (!Array.isArray(declared)) {
+    return ["text"];
+  }
+  // `file` is advertised alongside the modalities OpenClaw routes on; drop it.
+  const modalities = MODEL_INPUT_MODALITIES.filter((modality) => declared.includes(modality));
+  return modalities.length > 0 ? [...modalities] : ["text"];
+}
+
+/**
+ * Only routes that advertise a reasoning parameter accept OpenClaw's thinking
+ * controls; the gateway rejects them elsewhere.
+ */
+function supportsReasoning(entry: LlmtrModelEntry): boolean {
+  const parameters = Array.isArray(entry.supported_parameters) ? entry.supported_parameters : [];
+  return (
+    parameters.includes("reasoning") ||
+    parameters.includes("reasoning_effort") ||
+    entry.reasoning?.mandatory === true ||
+    entry.reasoning?.default_enabled === true
+  );
+}
+
+/**
+ * Builds a catalog entry from the discovery row. `/v1/models` publishes
+ * `context_length`, `top_provider.max_completion_tokens`, modalities, pricing
+ * and reasoning support, so live metadata wins over the bundled snapshot, which
+ * only fills gaps the gateway leaves empty.
+ */
+function buildDiscoveredModel(
+  id: string,
+  entry: LlmtrModelEntry,
+  curated: ModelDefinitionConfig | undefined,
+): ModelDefinitionConfig {
+  const contextWindow =
+    readPositiveInteger(entry.context_length) ??
+    curated?.contextWindow ??
+    LLMTR_DEFAULT_CONTEXT_WINDOW;
+  const declaredMaxTokens =
+    readPositiveInteger(entry.top_provider?.max_completion_tokens) ??
+    curated?.maxTokens ??
+    LLMTR_DEFAULT_MAX_TOKENS;
+  return buildLlmtrModelDefinition({
+    id,
+    name: normalizeOptionalString(entry.name) ?? curated?.name ?? id,
+    reasoning: supportsReasoning(entry),
+    input: readInputModalities(entry),
+    contextWindow,
+    maxTokens: Math.min(declaredMaxTokens, contextWindow),
+    cost: {
+      input: perMillionTokenCost(entry.pricing?.prompt),
+      output: perMillionTokenCost(entry.pricing?.completion),
+      cacheRead: perMillionTokenCost(entry.pricing?.input_cache_read),
+      cacheWrite: perMillionTokenCost(entry.pricing?.input_cache_write),
+    },
+  });
+}
+
+/** Discovers LLMTR models dynamically, falling back to the bundled static catalog. */
+export async function discoverLlmtrModels(apiKey?: string): Promise<ModelDefinitionConfig[]> {
+  const trimmedKey = normalizeOptionalString(apiKey) ?? "";
+  const staticCatalog = () => LLMTR_MODEL_CATALOG.map(buildLlmtrModelDefinition);
+  const curatedById = new Map(LLMTR_MODEL_CATALOG.map((model) => [model.id, model]));
+
+  try {
+    const rows = await fetchLlmtrModelRows(trimmedKey || undefined);
+    if (rows.length === 0) {
+      log.warn("No models in response, using static catalog");
+      return staticCatalog();
+    }
+
+    const seen = new Set<string>();
+    const models: ModelDefinitionConfig[] = [];
+
+    for (const entry of rows as LlmtrModelEntry[]) {
+      const id = normalizeOptionalString(entry?.id) ?? "";
+      if (!id || seen.has(id) || !supportsChatCompletions(entry)) {
+        continue;
+      }
+      seen.add(id);
+      models.push(buildDiscoveredModel(id, entry, curatedById.get(id)));
+    }
+
+    if (models.length === 0) {
+      log.warn("No chat-completions models in response, using static catalog");
+      return staticCatalog();
+    }
+    return models;
+  } catch (error) {
+    if (error instanceof LiveModelCatalogHttpError && error.status === 401 && trimmedKey) {
+      // LLMTR serves /v1/models unauthenticated; retry keyless so a bad key
+      // still yields the public catalog instead of the frozen bundled one.
+      return await discoverLlmtrModels(undefined);
+    }
+    log.warn(`Discovery failed: ${String(error)}, using static catalog`);
+    return staticCatalog();
+  }
+}

--- a/extensions/llmtr/openclaw.plugin.json
+++ b/extensions/llmtr/openclaw.plugin.json
@@ -1,0 +1,915 @@
+{
+  "id": "llmtr",
+  "name": "LLMTR",
+  "description": "OpenClaw LLMTR provider plugin.",
+  "activation": {
+    "onStartup": false
+  },
+  "enabledByDefault": true,
+  "providers": [
+    "llmtr"
+  ],
+  "providerRequest": {
+    "providers": {
+      "llmtr": {
+        "family": "openai"
+      }
+    }
+  },
+  "modelIdNormalization": {
+    "providers": {
+      "llmtr": {
+        "prefixWhenBare": "llmtr"
+      }
+    }
+  },
+  "setup": {
+    "providers": [
+      {
+        "id": "llmtr",
+        "envVars": [
+          "LLMTR_API_KEY"
+        ]
+      }
+    ]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "llmtr",
+      "method": "api-key",
+      "choiceId": "llmtr-api-key",
+      "appGuidedSecret": true,
+      "choiceLabel": "LLMTR API key",
+      "choiceHint": "OpenAI-compatible AI gateway with Turkey-hosted routes",
+      "groupId": "llmtr",
+      "groupLabel": "LLMTR",
+      "groupHint": "OpenAI-compatible AI gateway with Turkey-hosted routes",
+      "optionKey": "llmtrApiKey",
+      "cliFlag": "--llmtr-api-key",
+      "cliOption": "--llmtr-api-key <key>",
+      "cliDescription": "LLMTR API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  },
+  "modelCatalog": {
+    "providers": {
+      "llmtr": {
+        "baseUrl": "https://llmtr.com/v1",
+        "api": "openai-completions",
+        "models": [
+          {
+            "id": "llmtr/gemma-4",
+            "name": "Gemma 4 (LLMTR)",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "contextWindow": 131072,
+            "maxTokens": 131072,
+            "cost": {
+              "input": 2,
+              "output": 5,
+              "cacheRead": 0.5,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "llmtr/qwen3-5-4b",
+            "name": "Qwen 3.5 4B (LLMTR)",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "contextWindow": 131072,
+            "maxTokens": 131072,
+            "cost": {
+              "input": 1,
+              "output": 3,
+              "cacheRead": 0.25,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "llmtr/qwen3-6-35b",
+            "name": "Qwen 3.6 35B-A3B (LLMTR)",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "contextWindow": 16384,
+            "maxTokens": 16384,
+            "cost": {
+              "input": 5,
+              "output": 10,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "llmtr/trendyol-asure-12b",
+            "name": "Trendyol Asure 12B (LLMTR)",
+            "reasoning": false,
+            "input": [
+              "text",
+              "image"
+            ],
+            "contextWindow": 40960,
+            "maxTokens": 40960,
+            "cost": {
+              "input": 0.1,
+              "output": 0.5,
+              "cacheRead": 0.025,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "llmtr/muse-glimmer-30b-tr",
+            "name": "Muse Glimmer 30B (Türkiye) (LLMTR)",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "contextWindow": 131072,
+            "maxTokens": 131072,
+            "cost": {
+              "input": 2,
+              "output": 5,
+              "cacheRead": 0.5,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "llmtr/magibu-11b-v8",
+            "name": "Magibu 11B v8 (LLMTR)",
+            "reasoning": false,
+            "input": [
+              "text"
+            ],
+            "contextWindow": 8192,
+            "maxTokens": 8192,
+            "cost": {
+              "input": 0.1,
+              "output": 0.5,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "llmtr/medgemma-4b",
+            "name": "MedGemma 4B (LLMTR)",
+            "reasoning": false,
+            "input": [
+              "text",
+              "image"
+            ],
+            "contextWindow": 8192,
+            "maxTokens": 8192,
+            "cost": {
+              "input": 3,
+              "output": 5,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "anthropic/claude-opus-5",
+            "name": "Claude Opus 5 (Anthropic)",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "contextWindow": 1000000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 5,
+              "output": 25,
+              "cacheRead": 0.5,
+              "cacheWrite": 6.25
+            },
+            "compat": {
+              "codeMode": "capable"
+            }
+          },
+          {
+            "id": "anthropic/claude-sonnet-5",
+            "name": "Claude Sonnet 5 (Anthropic)",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "contextWindow": 1000000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 2,
+              "output": 10,
+              "cacheRead": 0.2,
+              "cacheWrite": 2.5
+            },
+            "compat": {
+              "codeMode": "capable"
+            }
+          },
+          {
+            "id": "anthropic/claude-opus-4.8",
+            "name": "Claude Opus 4.8 (Anthropic)",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "contextWindow": 1000000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 5,
+              "output": 25,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "anthropic/claude-haiku-4.5",
+            "name": "Claude Haiku 4.5 (Anthropic)",
+            "reasoning": false,
+            "input": [
+              "text",
+              "image"
+            ],
+            "contextWindow": 200000,
+            "maxTokens": 64000,
+            "cost": {
+              "input": 1,
+              "output": 5,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "openai/gpt-5.4",
+            "name": "GPT-5.4 (OpenAI)",
+            "reasoning": false,
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "contextWindow": 272000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 2.5,
+              "output": 15,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "openai/gpt-5.4-mini",
+            "name": "GPT-5.4 mini (OpenAI)",
+            "reasoning": false,
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "contextWindow": 128000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 0.75,
+              "output": 4.5,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "openai/gpt-5.2",
+            "name": "GPT-5.2 (OpenAI)",
+            "reasoning": false,
+            "input": [
+              "text",
+              "image",
+              "audio"
+            ],
+            "contextWindow": 128000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 1.75,
+              "output": 14,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "google/gemini-3.7-flash",
+            "name": "Gemini 3.7 Flash (Google)",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video"
+            ],
+            "contextWindow": 1048576,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 0.75,
+              "output": 3.75,
+              "cacheRead": 0.075,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "google/gemini-3.5-flash",
+            "name": "Gemini 3.5 Flash (Google)",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video"
+            ],
+            "contextWindow": 1048576,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 1.5,
+              "output": 9,
+              "cacheRead": 0.15,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "google/gemini-3.1-pro-preview",
+            "name": "Gemini 3.1 Pro Preview (Google)",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video"
+            ],
+            "contextWindow": 1048576,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 2,
+              "output": 12,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "zai/glm-5.2",
+            "name": "GLM-5.2 (Z.AI)",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "contextWindow": 1000000,
+            "maxTokens": 131072,
+            "cost": {
+              "input": 1.26,
+              "output": 3.96,
+              "cacheRead": 0.234,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "codeMode": "capable"
+            }
+          },
+          {
+            "id": "zai/glm-5.1",
+            "name": "GLM-5.1 (Z.AI)",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "contextWindow": 128000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 1.26,
+              "output": 3.96,
+              "cacheRead": 0.234,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "codeMode": "capable"
+            }
+          },
+          {
+            "id": "zai/glm-5",
+            "name": "GLM-5 (Z.AI)",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "contextWindow": 128000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 0.9,
+              "output": 2.88,
+              "cacheRead": 0.18,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "zai/glm-5-turbo",
+            "name": "GLM-5-Turbo (Z.AI)",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "contextWindow": 128000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 1.08,
+              "output": 3.6,
+              "cacheRead": 0.216,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "zai/glm-4.7",
+            "name": "GLM-4.7 (Z.AI)",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "contextWindow": 128000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 0.6,
+              "output": 2.2,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "zai/glm-4.6",
+            "name": "GLM-4.6 (Z.AI)",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "contextWindow": 128000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 0.6,
+              "output": 2.2,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "zai/glm-4.6v",
+            "name": "GLM-4.6V (Z.AI)",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "contextWindow": 128000,
+            "maxTokens": 32768,
+            "cost": {
+              "input": 0.3,
+              "output": 0.9,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "qwen/qwen3.7-max",
+            "name": "Qwen3.7-Max (Qwen)",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "contextWindow": 256000,
+            "maxTokens": 131072,
+            "cost": {
+              "input": 2.5,
+              "output": 7.5,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "qwen/qwen3.7-plus",
+            "name": "Qwen3.7-Plus (Qwen)",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "contextWindow": 1000000,
+            "maxTokens": 131072,
+            "cost": {
+              "input": 0.4,
+              "output": 1.6,
+              "cacheRead": 0.04,
+              "cacheWrite": 0.5
+            }
+          },
+          {
+            "id": "qwen/qwen3.6-flash",
+            "name": "Qwen3.6-Flash (Qwen)",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "contextWindow": 1000000,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 0.25,
+              "output": 1.5,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "qwen/qwen3.5-plus",
+            "name": "Qwen3.5-Plus (Qwen)",
+            "reasoning": false,
+            "input": [
+              "text"
+            ],
+            "contextWindow": 1000000,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 0.4,
+              "output": 2.4,
+              "cacheRead": 0.04,
+              "cacheWrite": 0.5
+            }
+          },
+          {
+            "id": "qwen/qwen3-coder-plus",
+            "name": "Qwen3-Coder-Plus (Qwen)",
+            "reasoning": false,
+            "input": [
+              "text"
+            ],
+            "contextWindow": 1000000,
+            "maxTokens": 65536,
+            "cost": {
+              "input": 1,
+              "output": 5,
+              "cacheRead": 0.1,
+              "cacheWrite": 1.25
+            }
+          },
+          {
+            "id": "deepseek/deepseek-v4-pro",
+            "name": "DeepSeek V4 Pro (DeepSeek)",
+            "reasoning": false,
+            "input": [
+              "text"
+            ],
+            "contextWindow": 1000000,
+            "maxTokens": 393216,
+            "cost": {
+              "input": 0.435,
+              "output": 0.87,
+              "cacheRead": 0.003625,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "codeMode": "capable"
+            }
+          },
+          {
+            "id": "deepseek/deepseek-v4-flash",
+            "name": "DeepSeek V4 Flash (DeepSeek)",
+            "reasoning": false,
+            "input": [
+              "text"
+            ],
+            "contextWindow": 1000000,
+            "maxTokens": 393216,
+            "cost": {
+              "input": 0.14,
+              "output": 0.28,
+              "cacheRead": 0.0028,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "codeMode": "capable"
+            }
+          },
+          {
+            "id": "deepseek/deepseek-reasoner",
+            "name": "DeepSeek R1 (DeepSeek)",
+            "reasoning": false,
+            "input": [
+              "text"
+            ],
+            "contextWindow": 1000000,
+            "maxTokens": 393216,
+            "cost": {
+              "input": 0.14,
+              "output": 0.28,
+              "cacheRead": 0.0028,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "deepseek/deepseek-chat",
+            "name": "DeepSeek Chat (DeepSeek)",
+            "reasoning": false,
+            "input": [
+              "text"
+            ],
+            "contextWindow": 1000000,
+            "maxTokens": 393216,
+            "cost": {
+              "input": 0.14,
+              "output": 0.28,
+              "cacheRead": 0.0028,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "moonshot/kimi-k3",
+            "name": "Kimi K3 (Moonshot)",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "contextWindow": 1048576,
+            "maxTokens": 1048576,
+            "cost": {
+              "input": 3,
+              "output": 15,
+              "cacheRead": 0.3,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "codeMode": "capable"
+            }
+          },
+          {
+            "id": "moonshot/kimi-k2.7-code",
+            "name": "Kimi K2.7 Code (Moonshot)",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "contextWindow": 262144,
+            "maxTokens": 262144,
+            "cost": {
+              "input": 0.95,
+              "output": 4,
+              "cacheRead": 0.19,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "moonshot/kimi-k2.6",
+            "name": "Kimi K2.6 (Moonshot)",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "contextWindow": 256000,
+            "maxTokens": 256000,
+            "cost": {
+              "input": 0.95,
+              "output": 4,
+              "cacheRead": 0.16,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "minimax/minimax-m3",
+            "name": "MiniMax M3 (MiniMax)",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "contextWindow": 1000000,
+            "maxTokens": 524288,
+            "cost": {
+              "input": 0.6,
+              "output": 2.4,
+              "cacheRead": 0.12,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "minimax/minimax-m2.7",
+            "name": "MiniMax M2.7 (MiniMax)",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "contextWindow": 204800,
+            "maxTokens": 196608,
+            "cost": {
+              "input": 0.3,
+              "output": 1.2,
+              "cacheRead": 0.06,
+              "cacheWrite": 0.375
+            }
+          },
+          {
+            "id": "minimax/minimax-m2.7-highspeed",
+            "name": "MiniMax M2.7 Highspeed (MiniMax)",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "contextWindow": 204800,
+            "maxTokens": 196608,
+            "cost": {
+              "input": 0.6,
+              "output": 2.4,
+              "cacheRead": 0.06,
+              "cacheWrite": 0.375
+            }
+          },
+          {
+            "id": "minimax/minimax-m2.5",
+            "name": "MiniMax M2.5 (MiniMax)",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "contextWindow": 204800,
+            "maxTokens": 196608,
+            "cost": {
+              "input": 0.3,
+              "output": 1.2,
+              "cacheRead": 0.03,
+              "cacheWrite": 0.375
+            }
+          },
+          {
+            "id": "minimax/minimax-m2.5-highspeed",
+            "name": "MiniMax M2.5 Highspeed (MiniMax)",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "contextWindow": 204800,
+            "maxTokens": 196608,
+            "cost": {
+              "input": 0.6,
+              "output": 2.4,
+              "cacheRead": 0.03,
+              "cacheWrite": 0.375
+            }
+          },
+          {
+            "id": "stepfun/step-3.7-flash",
+            "name": "Step 3.7 Flash (StepFun)",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "contextWindow": 256000,
+            "maxTokens": 256000,
+            "cost": {
+              "input": 0.2,
+              "output": 1.15,
+              "cacheRead": 0.04,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "mimo/mimo-v2.5-pro",
+            "name": "MiMo V2.5 Pro (MiMo)",
+            "reasoning": false,
+            "input": [
+              "text"
+            ],
+            "contextWindow": 1000000,
+            "maxTokens": 131072,
+            "cost": {
+              "input": 0.435,
+              "output": 0.87,
+              "cacheRead": 0.0036,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "kwaikat/kat-coder-pro-v2.5",
+            "name": "KwaiKAT: KAT-Coder-Pro V2.5 (KwaiKAT)",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "contextWindow": 262144,
+            "maxTokens": 262144,
+            "cost": {
+              "input": 0.74,
+              "output": 2.96,
+              "cacheRead": 0.15,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "meta/muse-spark-1.2",
+            "name": "Muse Spark 1.2 (Meta)",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image",
+              "video"
+            ],
+            "contextWindow": 1048576,
+            "maxTokens": 1048576,
+            "cost": {
+              "input": 1.25,
+              "output": 4.25,
+              "cacheRead": 0.15,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "meta/llama-3.3-70b-instruct",
+            "name": "Llama 3.3 70B Instruct (Meta)",
+            "reasoning": false,
+            "input": [
+              "text"
+            ],
+            "contextWindow": 131072,
+            "maxTokens": 32768,
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "nvidia/nemotron-3-super-120b-a12b",
+            "name": "Nemotron 3 Super 120B A12B (NVIDIA)",
+            "reasoning": false,
+            "input": [
+              "text"
+            ],
+            "contextWindow": 1000000,
+            "maxTokens": 1000000,
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "mistral/mistral-large-latest",
+            "name": "Mistral Large 3 (Mistral)",
+            "reasoning": false,
+            "input": [
+              "text",
+              "image"
+            ],
+            "contextWindow": 256000,
+            "maxTokens": 256000,
+            "cost": {
+              "input": 0.5,
+              "output": 1.5,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "mistral/mistral-medium-latest",
+            "name": "Mistral Medium 3.1 (Mistral)",
+            "reasoning": false,
+            "input": [
+              "text",
+              "image"
+            ],
+            "contextWindow": 128000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 0.4,
+              "output": 2,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/extensions/llmtr/package.json
+++ b/extensions/llmtr/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@openclaw/llmtr-provider",
+  "version": "2026.8.1",
+  "description": "OpenClaw LLMTR provider plugin",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/openclaw/openclaw"
+  },
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "install": {
+      "clawhubSpec": "clawhub:@openclaw/llmtr-provider",
+      "npmSpec": "@openclaw/llmtr-provider",
+      "defaultChoice": "npm",
+      "minHostVersion": ">=2026.8.1"
+    },
+    "compat": {
+      "pluginApi": ">=2026.8.1"
+    },
+    "build": {
+      "openclawVersion": "2026.8.1",
+      "bundledDist": false
+    },
+    "release": {
+      "publishToClawHub": true,
+      "publishToNpm": true
+    }
+  }
+}

--- a/extensions/llmtr/provider-catalog.ts
+++ b/extensions/llmtr/provider-catalog.ts
@@ -1,0 +1,31 @@
+/**
+ * LLMTR provider builders for static and dynamically discovered catalogs.
+ */
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  LLMTR_BASE_URL,
+  LLMTR_MODEL_CATALOG,
+  buildLlmtrModelDefinition,
+  discoverLlmtrModels,
+} from "./models.js";
+
+/** Builds the static LLMTR provider catalog from bundled model metadata. */
+export function buildStaticLlmtrProvider(): ModelProviderConfig {
+  return {
+    baseUrl: LLMTR_BASE_URL,
+    api: "openai-completions",
+    models: LLMTR_MODEL_CATALOG.map(buildLlmtrModelDefinition),
+  };
+}
+
+/**
+ * Builds the LLMTR provider with dynamic model discovery, falling back to the
+ * bundled catalog when the gateway is unreachable.
+ */
+export async function buildLlmtrProvider(apiKey?: string): Promise<ModelProviderConfig> {
+  return {
+    baseUrl: LLMTR_BASE_URL,
+    api: "openai-completions",
+    models: await discoverLlmtrModels(apiKey),
+  };
+}

--- a/extensions/llmtr/tsconfig.json
+++ b/extensions/llmtr/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json"
+}

--- a/package.json
+++ b/package.json
@@ -295,6 +295,7 @@
     "!dist/extensions/kimi-coding/**",
     "!dist/extensions/line/**",
     "!dist/extensions/llama-cpp/**",
+    "!dist/extensions/llmtr/**",
     "!dist/extensions/lobster/**",
     "!dist/extensions/longcat/**",
     "!dist/extensions/mattermost/**",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1145,6 +1145,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/llmtr:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/lmstudio: {}
 
   extensions/lobster:

--- a/scripts/generate-plugin-inventory-doc.mts
+++ b/scripts/generate-plugin-inventory-doc.mts
@@ -181,6 +181,7 @@ function humanizeId(value: string) {
     ["line", "LINE"],
     ["litellm", "LiteLLM"],
     ["llm", "LLM"],
+    ["llmtr", "LLMTR"],
     ["lmstudio", "LM Studio"],
     ["longcat", "LongCat"],
     ["mdns", "mDNS"],

--- a/scripts/lib/official-external-provider-catalog.json
+++ b/scripts/lib/official-external-provider-catalog.json
@@ -2465,6 +2465,49 @@
           "minHostVersion": ">=2026.6.9"
         }
       }
+    },
+    {
+      "name": "@openclaw/llmtr-provider",
+      "description": "OpenClaw LLMTR provider plugin",
+      "source": "official",
+      "kind": "provider",
+      "openclaw": {
+        "plugin": {
+          "id": "llmtr",
+          "label": "LLMTR"
+        },
+        "providers": [
+          {
+            "id": "llmtr",
+            "name": "LLMTR",
+            "docs": "/providers/llmtr",
+            "categories": ["cloud", "llm"],
+            "envVars": ["LLMTR_API_KEY"],
+            "authChoices": [
+              {
+                "method": "api-key",
+                "choiceId": "llmtr-api-key",
+                "choiceLabel": "LLMTR API key",
+                "choiceHint": "OpenAI-compatible AI gateway with Turkey-hosted routes",
+                "groupId": "llmtr",
+                "groupLabel": "LLMTR",
+                "groupHint": "OpenAI-compatible AI gateway with Turkey-hosted routes",
+                "optionKey": "llmtrApiKey",
+                "cliFlag": "--llmtr-api-key",
+                "cliOption": "--llmtr-api-key <key>",
+                "cliDescription": "LLMTR API key",
+                "onboardingScopes": ["text-inference"]
+              }
+            ]
+          }
+        ],
+        "install": {
+          "clawhubSpec": "clawhub:@openclaw/llmtr-provider",
+          "npmSpec": "@openclaw/llmtr-provider",
+          "defaultChoice": "npm",
+          "minHostVersion": ">=2026.8.1"
+        }
+      }
     }
   ]
 }

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -487,6 +487,7 @@ const BUILT_IN_MODEL_PROVIDER_OVERLAY_IDS = new Set([
   "kimi",
   "kimi-coding",
   "litellm",
+  "llmtr",
   "lmstudio",
   "meta",
   "microsoft-foundry",


### PR DESCRIPTION
Closes #110915

## What Problem This Solves

OpenClaw cannot reach Turkish-hosted models, and has no single-key route to the
mixed vendor set behind [LLMTR](https://llmtr.com) — an OpenAI-compatible AI
gateway serving over 230 models: global passthrough routes across Anthropic,
OpenAI, Google, Qwen, Z.AI, Mistral, DeepSeek, MiniMax, Moonshot, Meta and
NVIDIA, plus a Turkey-hosted set for workloads that need Turkish data residency
or Turkish-language models.

LLMTR does answer a generic OpenAI-compatible base URL, so this provider is not
about making requests work at all. It is about three things a generic
passthrough cannot do:

1. **Chat-capability filtering.** LLMTR also serves embeddings (`voyageai`,
   `llmtr/embeddinggemma-300m`), image routes (`recraft`, `krea`) and
   `/v1/responses`-only models. Advertising those surfaces models that reject
   every request the `openai-completions` path can send. Discovery keeps only
   rows whose `supported_operations` include `CHAT_COMPLETIONS`.
2. **Correct model metadata.** `GET /v1/models` publishes `context_length`,
   `top_provider.max_completion_tokens`, `architecture.input_modalities`,
   `pricing` and `supported_parameters`. The provider maps those into the
   catalog, so context windows, output caps, modalities, cost and reasoning
   support match the gateway instead of being guessed.
3. **Ref shape and auth ergonomics.** Turkey-hosted routes are named
   `llmtr/<name>` upstream, so the ref collapses to `llmtr/trendyol-asure-12b`.
   The manifest handles that through the existing
   `modelIdNormalization.prefixWhenBare` seam rather than new core code, and the
   key goes through the normal provider auth flow.

## Distribution

This ships as an **official external plugin**, matching `@openclaw/novita-provider`
and `@openclaw/longcat-provider`:

- `openclaw.build.bundledDist: false` plus `!dist/extensions/llmtr/**` in the
  root `files`, so it is not in core dist and adds no enabled-by-default auth
  surface.
- `openclaw.release.publishToNpm` / `publishToClawHub`, `openclaw.install`
  (`npm` default, `clawhub:@openclaw/llmtr-provider`), and
  `openclaw.compat.pluginApi` / `openclaw.build.openclawVersion`.
- A mirrored entry in `scripts/lib/official-external-provider-catalog.json` so
  the provider, its env var and its auth choice are discoverable before install.

## User Impact

```bash
openclaw plugins install @openclaw/llmtr-provider
openclaw gateway restart
export LLMTR_API_KEY=...
openclaw agent --local --model llmtr/zai/glm-5.2 -m "..."
```

Existing users are unaffected: nothing installs by default, and no shipped
provider, config shape, or default changes.

## Core Touchpoints

Four lines outside the plugin and its docs:

- `src/config/zod-schema.core.ts` — `llmtr` in the provider-overlay id set, so
  the documented `models.providers.llmtr` config validates (`chutes`, `novita`
  and `stepfun` are listed the same way).
- `scripts/generate-plugin-inventory-doc.mts` — `llmtr` → `LLMTR` in the
  brand-casing map used by the generated reference pages.
- `.github/labeler.yml`, root `package.json` `files`.

`docs/plugins/plugin-inventory.md`, `docs/plugins/reference.md` and
`docs/plugins/reference/llmtr.md` are `pnpm plugins:inventory:gen` output. That
run also refreshes two `cua-computer` lines that were already stale on `main`
before this branch.

## Evidence

**Catalog verified against the live gateway on 2026-08-16.** Every shipped id
was checked against `GET /v1/models` for presence and `CHAT_COMPLETIONS`
support; context windows, output caps, modalities and pricing are taken from
that response rather than hand-entered.

**Streaming usage.** LLMTR honours `stream_options: {include_usage: true}`;
a streamed completion returns
`{"prompt_tokens":15,"completion_tokens":2,"total_tokens":17}`. The provider
therefore declares `supportsUsageInStreaming: true`. See the comment below for
why this changed.

**Agent turns completed end-to-end** (verified on the earlier revision of this
branch; the runtime path is unchanged by the packaging conversion):

```
model-fetch start    provider=llmtr api=openai-completions model=zai/glm-5.1
                     url=https://llmtr.com/v1/chat/completions
model-fetch response provider=llmtr status=200 elapsedMs=7176
run ended with stopReason=stop
```

Same for `llmtr/anthropic/claude-sonnet-5`. Tool-calling round-trip through the
full agent stack on `deepseek/deepseek-v4-pro`: two model calls, tool executed,
correct final answer, `stopReason=stop`.

**Checks (local, this revision):**

- `pnpm test:extension llmtr` — 4 passed.
- `pnpm test:contracts:plugins` — 1009 passed, 33 failed. All 33 are Windows
  SQLite `EBUSY` teardown errors in `host-hooks` / `session-attachments` /
  `session-entry-projection`, which reproduce on a clean checkout of `main` and
  touch no surface in this PR.
- `pnpm tsgo:core`, `tsgo:ui`, `tsgo:extensions`, `tsgo:extensions:test`,
  `tsgo:scripts` — clean.
- `pnpm lint:core`, `lint:extensions`, `format:check` — clean.
- `pnpm docs:check-mdx`, `docs:check-links`, `docs:check-i18n-glossary`,
  `plugins:inventory:check`, `plugins:sync:check` — clean.
- `src/plugins/official-external-provider-endpoints.test.ts` (3),
  `src/plugins/official-external-plugin-catalog.test.ts` (80),
  `src/plugins/contracts/shared-upstream-model.contract.test.ts` (3) — passed.
- `pnpm deadcode:full` — the `llmtr` finding from the earlier revision is fixed.
  It still reports `src/config/docs-config-examples.ts` as an unused file, which
  reproduces identically on a clean checkout of `main`.

## Known Gaps

- The lockfile diff cannot be avoided. `extensions/*` is a pnpm workspace glob,
  so any new plugin directory adds an importer stanza. The diff here is six
  lines and a `workspace:*` link to `@openclaw/plugin-sdk`; it resolves no new
  third-party package. `dependency-guard` still fires on the file's presence.
- Some Turkey-hosted `llmtr/*` routes intermittently return `502` or time out.
  That is upstream capacity, not this integration; it is documented in the
  provider doc's troubleshooting section.
- The shipped catalog is a snapshot for offline fallback; live discovery is the
  authority and surfaces every chat-capable route the gateway serves.


## Real behaviour proof (current head, external package)

ClawSweeper asked for current-head external-package installation/loading plus a
live completion after the externalization change. The earlier transcript in this
PR predated that change, so here is a fresh run against the externalized plugin.

The plugin sources were built into a standalone publishable package and
installed the way an operator would, rather than being loaded from the repo
tree. Host: released `openclaw@2026.7.1-2`.

**Build and pack**

```
$ npm run typecheck && npm test
  tsc --noEmit                       (clean)
  Test Files  1 passed (1)
       Tests  4 passed (4)

$ npm run build
  dist/index.js  29.4kb

$ npm pack
  name:          openclaw-llmtr-provider
  version:       1.1.0
  package size:  13.2 kB
  unpacked size: 74.7 kB
  total files:   8
```

**Install**

```
$ openclaw plugins install ./openclaw-llmtr-provider-1.1.0.tgz
Extracting openclaw-llmtr-provider-1.1.0.tgz…
Plugin manifest id "llmtr" differs from npm package name
  "openclaw-llmtr-provider"; using manifest id as the config key.
Installing to <state>/extensions/llmtr…
Linked peerDependency "openclaw" -> <host>/node_modules/openclaw
Installed plugin: llmtr
Restart the gateway to load plugins.
```

**Load**

```
$ openclaw plugins list
┌──────────┬───────┬──────────┬─────────┬────────────────────────────┬─────────┐
│ Name     │ ID    │ Format   │ Status  │ Source                     │ Version │
│ LLMTR    │ llmtr │ openclaw │ enabled │ global:llmtr/dist/index.js │ 1.1.0   │
└──────────┴───────┴──────────┴─────────┴────────────────────────────┴─────────┘

$ openclaw plugins doctor
No plugin issues detected.
```

Note it resolves under `global:` (the state-dir extensions root), not from
`dist/extensions` — i.e. it is genuinely loading as an external package and not
out of core dist.

**Catalog**

```
$ openclaw models list
llmtr/anthropic/claude-haiku-4.5    text        200k   default
llmtr/anthropic/claude-opus-4.8     text+image  1000k
llmtr/anthropic/claude-opus-5       text+image  1000k
llmtr/anthropic/claude-sonnet-5     text+image  1000k
llmtr/deepseek/deepseek-v4-pro      text        1000k
llmtr/google/gemini-3.5-flash       text+image  1049k
llmtr/gemma-4                       text+image   131k
… (truncated)
```

**Live completion** (API key redacted; it is read from `LLMTR_API_KEY`)

```
$ openclaw agent --local --model llmtr/anthropic/claude-haiku-4.5 \
    -m "Reply with exactly: LLMTR-PLUGIN-OK"

[model-fetch] start    provider=llmtr api=openai-completions
              model=anthropic/claude-haiku-4.5 method=POST
              url=https://llmtr.com/v1/chat/completions policy=custom
[model-fetch] response provider=llmtr status=200 elapsedMs=1088
              contentType=text/event-stream; charset=utf-8
LLMTR-PLUGIN-OK
[agent] run 17a4ed75 ended with stopReason=stop
```

One thing worth surfacing rather than trimming from the transcript: with
`plugins.allow` unset, OpenClaw warns that discovered non-bundled plugins may
auto-load and points at `plugins.allow` as the explicit trust step. That warning
is correct and is the expected posture for an on-demand external provider; the
provider doc should tell operators to set it. Flagging it here rather than
quietly configuring it away.

**On distribution.** ClawSweeper recommends community ClawHub distribution over
an official `@openclaw` catalog entry. The package proven above is published
from an owned repository at
https://github.com/knowhy-co/openclaw-llmtr-provider, so that path exists and
works today regardless of what is decided here. This PR is left open for the
maintainers' call on the official catalog entry; happy to strip the catalog and
first-party doc registration down to whatever shape you prefer.


### Exact-artifact proof

The proof above was for a community-owned package built from the same sources.
Exact-artifact proof for `@openclaw/llmtr-provider@2026.8.1` — this branch's own
package name and version, on an `openclaw@2026.8.1-beta.2` host — is in
[this comment](https://github.com/openclaw/openclaw/pull/110917#issuecomment-5307242691):
install, load (`enabled`, `global:llmtr/dist/index.js`, `2026.8.1`),
`plugins doctor` clean, and a live completion returning HTTP 200 over SSE in
648 ms.

Two findings from producing it, both detailed in that comment:

- A raw `npm pack` of `extensions/llmtr` is not installable — the host requires
  compiled output for a TypeScript entry. This is not a defect in this branch:
  the published `@openclaw/longcat-provider` tarball shows the release pipeline
  adds `dist/**` and a `files` field while leaving `extensions: ["./index.ts"]`
  untouched. The artifact above replicates that.
- `minHostVersion` is `>=2026.8.1`, which no published host satisfies today
  (installing on current stable is refused). `longcat` uses `>=2026.6.8`. Happy
  to lower it to match if that is the intended policy.
