### PR TITLE
test(memory-wiki): allow agent isolation proof to finish

### DIFF
--- a/extensions/memory-wiki/src/agent-vault-isolation.test.ts
+++ b/extensions/memory-wiki/src/agent-vault-isolation.test.ts
@@ -263,5 +263,5 @@ describe("agent-scoped memory-wiki tools", () => {
     } finally {
       clearMemoryPluginState();
     }
-  });
+  }, 240_000);
 });


### PR DESCRIPTION
## Summary

- give the memory-wiki agent-vault isolation integration proof a test-specific 240s timeout
- preserve all existing isolation assertions and production behavior

## Why

Plugin prerelease validation run 29657197620 timed out this test at the shared 120s limit under extension-shard load. The retry continued after Vitest teardown and then observed the compiled-cache owner being cleared. A concurrent exact-SHA recovery passed the same shard, confirming load-sensitive runtime rather than a behavior regression.

## Proof

- `node scripts/run-vitest.mjs extensions/memory-wiki/src/agent-vault-isolation.test.ts` (1/1 passed; test runtime 94.11s)
- autoreview clean (0.98)

Changelog not required: test-only reliability fix.
