### PR TITLE
fix(test): CLI startup budget checks can hang indefinitely

### DIFF
--- a/scripts/bench-cli-startup.ts
+++ b/scripts/bench-cli-startup.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { expectDefined } from "../packages/normalization-core/src/expect.js";
 import { parseStrictIntegerOption } from "./lib/dev-tooling-safety.ts";
+import { terminateManagedChild } from "./lib/managed-child-process.mjs";
 
 type CommandCase = {
   id: string;
@@ -111,6 +112,9 @@ const TIMEOUT_KILL_GRACE_MS = resolveTimeoutKillGraceMs(process.env);
 const PROCESS_GROUP_EXIT_POLL_MS = 25;
 const DEFAULT_ENTRY = "openclaw.mjs";
 const MAX_RSS_MARKER = "__OPENCLAW_MAX_RSS_KB__=";
+const activeSampleProcesses = new Set<ReturnType<typeof spawn>>();
+const activeTempDirs = new Set<string>();
+let benchmarkShutdownPromise: Promise<never> | null = null;
 
 function resolveTimeoutKillGraceMs(env: NodeJS.ProcessEnv): number {
   const raw = env.VITEST ? env.OPENCLAW_TEST_CLI_STARTUP_TIMEOUT_KILL_GRACE_MS : undefined;
@@ -710,6 +714,71 @@ function appendLimited(current: string, chunk: Buffer | string, maxLength: numbe
   return next.length > maxLength ? next.slice(next.length - maxLength) : next;
 }
 
+function removeTrackedTempDir(tempDir: string): void {
+  activeTempDirs.delete(tempDir);
+  rmSync(tempDir, { recursive: true, force: true });
+}
+
+function installBenchmarkSignalCleanup(): () => void {
+  const signalHandlers = new Map<NodeJS.Signals, () => void>();
+  let shutdownChildren: Array<ReturnType<typeof spawn>> = [];
+
+  const removeHandlers = () => {
+    for (const [signal, handler] of signalHandlers) {
+      process.off(signal, handler);
+    }
+    signalHandlers.clear();
+  };
+
+  const forceKillShutdownChildren = () => {
+    for (const child of shutdownChildren) {
+      signalSampleProcess(child, "SIGKILL", process.platform !== "win32");
+    }
+  };
+
+  const beginShutdown = (signal: NodeJS.Signals) => {
+    if (benchmarkShutdownPromise) {
+      forceKillShutdownChildren();
+      return;
+    }
+    shutdownChildren = [...activeSampleProcesses];
+    benchmarkShutdownPromise = (async (): Promise<never> => {
+      for (const child of shutdownChildren) {
+        signalSampleProcess(child, signal, process.platform !== "win32");
+      }
+      // The budget wrapper reserves two final grace periods: drain after the cooperative signal,
+      // then reap the forced sample group before the benchmark leader exits.
+      await Promise.all(
+        shutdownChildren.map((child) =>
+          waitForSampleProcessGroupExit(child, process.platform !== "win32", TIMEOUT_KILL_GRACE_MS),
+        ),
+      );
+      forceKillShutdownChildren();
+      for (const tempDir of activeTempDirs) {
+        removeTrackedTempDir(tempDir);
+      }
+      await Promise.all(
+        shutdownChildren.map((child) =>
+          waitForSampleProcessGroupExit(child, process.platform !== "win32", TIMEOUT_KILL_GRACE_MS),
+        ),
+      );
+      removeHandlers();
+      process.kill(process.pid, signal);
+      return await new Promise<never>(() => {});
+    })();
+  };
+
+  const signals: NodeJS.Signals[] =
+    process.platform === "win32" ? ["SIGINT", "SIGTERM"] : ["SIGHUP", "SIGINT", "SIGTERM"];
+  for (const signal of signals) {
+    const handler = () => beginShutdown(signal);
+    signalHandlers.set(signal, handler);
+    process.on(signal, handler);
+  }
+
+  return removeHandlers;
+}
+
 async function runSample(params: {
   entry: string;
   commandCase: CommandCase;
@@ -719,6 +788,7 @@ async function runSample(params: {
   rssHookPath: string;
 }): Promise<Sample> {
   const runRoot = mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-bench-home-"));
+  activeTempDirs.add(runRoot);
   const stateDir = path.join(runRoot, ".openclaw");
   const configPath = path.join(stateDir, "openclaw.json");
   const configFixture = buildConfigFixture(params.commandCase);
@@ -744,10 +814,11 @@ async function runSample(params: {
   let timedOut = false;
   let forceKillAt: number | null = null;
   let forceKillTimer: ReturnType<typeof setTimeout> | null = null;
+  let activeProc: ReturnType<typeof spawn> | null = null;
   const maxOutputLength = 32 * 1024 * 1024;
 
   try {
-    return await new Promise<Sample>((resolve) => {
+    const completedSample = await new Promise<Sample>((resolve) => {
       const useProcessGroup = process.platform !== "win32";
       const proc = spawn(process.execPath, nodeArgs, {
         cwd: process.cwd(),
@@ -765,6 +836,8 @@ async function runSample(params: {
         },
         stdio: ["ignore", "pipe", "pipe"],
       });
+      activeProc = proc;
+      activeSampleProcesses.add(proc);
 
       const finish = (sample: Omit<Sample, "ms" | "firstOutputMs" | "maxRssMb">) => {
         if (settled) {
@@ -848,8 +921,15 @@ async function runSample(params: {
         complete();
       });
     });
+    if (benchmarkShutdownPromise) {
+      return await benchmarkShutdownPromise;
+    }
+    return completedSample;
   } finally {
-    rmSync(runRoot, { recursive: true, force: true });
+    if (activeProc) {
+      activeSampleProcesses.delete(activeProc);
+    }
+    removeTrackedTempDir(runRoot);
   }
 }
 
@@ -878,15 +958,15 @@ function signalSampleProcess(
   signal: NodeJS.Signals,
   useProcessGroup: boolean,
 ): void {
+  if (!useProcessGroup) {
+    terminateManagedChild(proc, signal, { platform: "win32" });
+    return;
+  }
   if (!proc.pid) {
     return;
   }
   try {
-    if (useProcessGroup) {
-      process.kill(-proc.pid, signal);
-    } else {
-      proc.kill(signal);
-    }
+    process.kill(-proc.pid, signal);
   } catch (error) {
     const code = (error as NodeJS.ErrnoException | undefined)?.code;
     if (code !== "ESRCH" && code !== "EPERM") {
@@ -1218,7 +1298,9 @@ async function main(): Promise<void> {
     printDelta(baseline, candidate);
     return;
   }
+  const removeSignalHandlers = installBenchmarkSignalCleanup();
   const tmpDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-bench-"));
+  activeTempDirs.add(tmpDir);
   const rssHookPath = buildRssHook(tmpDir);
   try {
     const primary = await buildSuiteResult({
@@ -1292,7 +1374,8 @@ async function main(): Promise<void> {
       }
     }
   } finally {
-    rmSync(tmpDir, { recursive: true, force: true });
+    removeTrackedTempDir(tmpDir);
+    removeSignalHandlers();
   }
 }
 

--- a/scripts/test-cli-startup-bench-budget.mjs
+++ b/scripts/test-cli-startup-bench-budget.mjs
@@ -1,9 +1,10 @@
 // Compares CLI startup benchmark reports against checked-in budgets.
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import fs from "node:fs";
 import { resolveCliStartupBuildTimeoutMs } from "./ensure-cli-startup-build.mjs";
 import { booleanFlag, intFlag, parseFlagArgs, stringFlag } from "./lib/arg-utils.mjs";
 import { budgetFloatFlag, readBudgetEnvNumber } from "./lib/budget-number-args.mjs";
+import { terminateManagedChild } from "./lib/managed-child-process.mjs";
 import { readJsonFile } from "./test-report-utils.mjs";
 
 const CLI_STARTUP_BENCH_FIXTURE_PATH = "test/fixtures/cli-startup-bench.json";
@@ -35,10 +36,117 @@ function resolveBenchmarkDeadlineMs(options, env) {
   const sampleLifecycleMs = options.timeoutMs + cleanupGraceMs * 2;
   const totalRunsPerCase = options.runs + options.warmup;
   // The current all preset has 43 cases. Keep headroom for case growth and for module/report
-  // teardown while preserving both cleanup waits used by each timed-out sample.
+  // teardown while preserving both cleanup waits used by each timed-out sample. The final two
+  // grace periods let the benchmark reap an active detached sample before its own group is forced.
   return clampTimerTimeoutMs(
-    BENCHMARK_CASE_DEADLINE_CAP * totalRunsPerCase * sampleLifecycleMs + cleanupGraceMs,
+    BENCHMARK_CASE_DEADLINE_CAP * totalRunsPerCase * sampleLifecycleMs + cleanupGraceMs * 2,
   );
+}
+
+function isProcessGroupAlive(child) {
+  if (process.platform === "win32" || !child.pid) {
+    return false;
+  }
+  try {
+    process.kill(-child.pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+function runCommandWithDeadline(args, options) {
+  const terminationGraceMs = options.terminationGraceMs;
+  const executionTimeoutMs = clampTimerTimeoutMs(options.deadlineMs - terminationGraceMs);
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, args, {
+      cwd: process.cwd(),
+      detached: process.platform !== "win32",
+      stdio: "inherit",
+      env: process.env,
+    });
+    let settled = false;
+    let timedOut = false;
+    let parentSignal = null;
+    let forceKillTimer = null;
+    const signalHandlers = new Map();
+
+    const removeSignalHandlers = () => {
+      for (const [signal, handler] of signalHandlers) {
+        process.off(signal, handler);
+      }
+      signalHandlers.clear();
+    };
+    const clearTimers = () => {
+      clearTimeout(executionTimer);
+      if (forceKillTimer) {
+        clearTimeout(forceKillTimer);
+      }
+    };
+    const finish = (result) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimers();
+      removeSignalHandlers();
+      if (parentSignal) {
+        process.kill(process.pid, parentSignal);
+        return;
+      }
+      resolve(result);
+    };
+    const timeoutResult = () => ({
+      error: undefined,
+      signal: "SIGKILL",
+      status: 1,
+      timedOut: true,
+    });
+    const forceKill = () => {
+      terminateManagedChild(child, "SIGKILL");
+      finish(timeoutResult());
+    };
+    const beginTermination = (signal, { fromTimeout = false } = {}) => {
+      if (timedOut || parentSignal) {
+        forceKill();
+        return;
+      }
+      timedOut = fromTimeout;
+      if (!fromTimeout) {
+        parentSignal = signal;
+      }
+      terminateManagedChild(child, signal);
+      forceKillTimer = setTimeout(forceKill, terminationGraceMs);
+      forceKillTimer.unref?.();
+    };
+
+    const executionTimer = setTimeout(
+      () => beginTermination("SIGTERM", { fromTimeout: true }),
+      executionTimeoutMs,
+    );
+    executionTimer.unref?.();
+
+    const forwardedSignals =
+      process.platform === "win32" ? ["SIGINT", "SIGTERM"] : ["SIGHUP", "SIGINT", "SIGTERM"];
+    for (const signal of forwardedSignals) {
+      const handler = () => beginTermination(signal);
+      signalHandlers.set(signal, handler);
+      process.on(signal, handler);
+    }
+
+    child.once("error", (error) => {
+      finish({ error, signal: null, status: null, timedOut });
+    });
+    child.once("close", (status, signal) => {
+      if (!timedOut && !parentSignal) {
+        finish({ error: undefined, signal, status: status ?? (signal ? 1 : 0), timedOut: false });
+        return;
+      }
+      if (!isProcessGroupAlive(child)) {
+        finish(timeoutResult());
+      }
+    });
+  });
 }
 
 function formatMs(value) {
@@ -137,17 +245,21 @@ if (shouldAutoSkipNonCanonicalBaselineChecks && !opts.skipBaseline) {
   };
 }
 
-function resolveCurrentReportPath() {
+async function resolveCurrentReportPath() {
   if (opts.report) {
     return opts.report;
   }
-  const build = spawnSync(process.execPath, ["scripts/ensure-cli-startup-build.mjs"], {
-    cwd: process.cwd(),
-    stdio: "inherit",
-    env: process.env,
-    killSignal: "SIGKILL",
-    timeout: resolveBuildDeadlineMs(process.env),
+  const cleanupGraceMs = resolveBenchmarkCleanupGraceMs(process.env);
+  const buildDeadlineMs = resolveBuildDeadlineMs(process.env);
+  const build = await runCommandWithDeadline(["scripts/ensure-cli-startup-build.mjs"], {
+    deadlineMs: buildDeadlineMs,
+    terminationGraceMs: cleanupGraceMs,
   });
+  if (build.timedOut) {
+    console.error(`[test-cli-startup-bench-budget] build timed out after ${buildDeadlineMs}ms`);
+  } else if (build.error) {
+    console.error(build.error instanceof Error ? build.error.message : String(build.error));
+  }
   if (build.status !== 0) {
     process.exit(build.status ?? 1);
   }
@@ -170,13 +282,18 @@ function resolveCurrentReportPath() {
     "--output",
     reportPath,
   ];
-  const run = spawnSync(process.execPath, args, {
-    cwd: process.cwd(),
-    stdio: "inherit",
-    env: process.env,
-    killSignal: "SIGKILL",
-    timeout: resolveBenchmarkDeadlineMs(opts, process.env),
+  const benchmarkDeadlineMs = resolveBenchmarkDeadlineMs(opts, process.env);
+  const run = await runCommandWithDeadline(args, {
+    deadlineMs: benchmarkDeadlineMs,
+    terminationGraceMs: cleanupGraceMs * 2,
   });
+  if (run.timedOut) {
+    console.error(
+      `[test-cli-startup-bench-budget] benchmark timed out after ${benchmarkDeadlineMs}ms`,
+    );
+  } else if (run.error) {
+    console.error(run.error instanceof Error ? run.error.message : String(run.error));
+  }
   if (run.status !== 0) {
     process.exit(run.status ?? 1);
   }
@@ -188,7 +305,7 @@ function indexCases(report) {
 }
 
 const baseline = readJsonFile(opts.baseline);
-const current = readJsonFile(resolveCurrentReportPath());
+const current = readJsonFile(await resolveCurrentReportPath());
 const baselineCases = indexCases(baseline);
 const currentCases = indexCases(current);
 const shouldRequireEveryBaselineCase = opts.preset === "all";

--- a/scripts/test-cli-startup-bench-budget.mjs
+++ b/scripts/test-cli-startup-bench-budget.mjs
@@ -1,11 +1,45 @@
 // Compares CLI startup benchmark reports against checked-in budgets.
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import { resolveCliStartupBuildTimeoutMs } from "./ensure-cli-startup-build.mjs";
 import { booleanFlag, intFlag, parseFlagArgs, stringFlag } from "./lib/arg-utils.mjs";
 import { budgetFloatFlag, readBudgetEnvNumber } from "./lib/budget-number-args.mjs";
 import { readJsonFile } from "./test-report-utils.mjs";
 
 const CLI_STARTUP_BENCH_FIXTURE_PATH = "test/fixtures/cli-startup-bench.json";
+const BENCHMARK_CASE_DEADLINE_CAP = 50;
+const DEFAULT_BENCHMARK_CLEANUP_GRACE_MS = 1_000;
+const MAX_TIMER_TIMEOUT_MS = 2_147_000_000;
+
+function clampTimerTimeoutMs(value) {
+  return Math.min(Math.max(Math.floor(value), 1), MAX_TIMER_TIMEOUT_MS);
+}
+
+function resolveBenchmarkCleanupGraceMs(env) {
+  const raw = env.VITEST ? env.OPENCLAW_TEST_CLI_STARTUP_TIMEOUT_KILL_GRACE_MS : undefined;
+  if (!raw || !/^\d+$/u.test(raw)) {
+    return DEFAULT_BENCHMARK_CLEANUP_GRACE_MS;
+  }
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) ? parsed : DEFAULT_BENCHMARK_CLEANUP_GRACE_MS;
+}
+
+function resolveBuildDeadlineMs(env) {
+  return clampTimerTimeoutMs(
+    resolveCliStartupBuildTimeoutMs(env) + resolveBenchmarkCleanupGraceMs(env),
+  );
+}
+
+function resolveBenchmarkDeadlineMs(options, env) {
+  const cleanupGraceMs = resolveBenchmarkCleanupGraceMs(env);
+  const sampleLifecycleMs = options.timeoutMs + cleanupGraceMs * 2;
+  const totalRunsPerCase = options.runs + options.warmup;
+  // The current all preset has 43 cases. Keep headroom for case growth and for module/report
+  // teardown while preserving both cleanup waits used by each timed-out sample.
+  return clampTimerTimeoutMs(
+    BENCHMARK_CASE_DEADLINE_CAP * totalRunsPerCase * sampleLifecycleMs + cleanupGraceMs,
+  );
+}
 
 function formatMs(value) {
   return `${value.toFixed(1)}ms`;
@@ -111,6 +145,8 @@ function resolveCurrentReportPath() {
     cwd: process.cwd(),
     stdio: "inherit",
     env: process.env,
+    killSignal: "SIGKILL",
+    timeout: resolveBuildDeadlineMs(process.env),
   });
   if (build.status !== 0) {
     process.exit(build.status ?? 1);
@@ -138,6 +174,8 @@ function resolveCurrentReportPath() {
     cwd: process.cwd(),
     stdio: "inherit",
     env: process.env,
+    killSignal: "SIGKILL",
+    timeout: resolveBenchmarkDeadlineMs(opts, process.env),
   });
   if (run.status !== 0) {
     process.exit(run.status ?? 1);

--- a/test/scripts/bench-cli-startup.test.ts
+++ b/test/scripts/bench-cli-startup.test.ts
@@ -169,7 +169,7 @@ describe("bench-cli-startup", () => {
             "--warmup",
             "0",
             "--timeout-ms",
-            "100",
+            "1000",
             "--json",
           ],
           {

--- a/test/scripts/bench-cli-startup.test.ts
+++ b/test/scripts/bench-cli-startup.test.ts
@@ -9,12 +9,37 @@ import { withEnv } from "../../src/test-utils/env.js";
 import { createTempDirTracker } from "../helpers/temp-dir.js";
 
 function isProcessAlive(pid: number): boolean {
+  if (process.platform === "linux") {
+    try {
+      // Bounded test supervisors can retain an already-killed orphan as a zombie until the shard
+      // exits; treat that state as terminated for process-cleanup assertions.
+      const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+      const commandEnd = stat.lastIndexOf(")");
+      if (commandEnd >= 0 && stat.slice(commandEnd + 2).startsWith("Z")) {
+        return false;
+      }
+    } catch {
+      return false;
+    }
+  }
   try {
     process.kill(pid, 0);
     return true;
   } catch {
     return false;
   }
+}
+
+function waitForProcessExit(pid: number, timeoutMs: number): boolean {
+  const deadlineAt = Date.now() + timeoutMs;
+  const waitBuffer = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+  while (Date.now() < deadlineAt) {
+    if (!isProcessAlive(pid)) {
+      return true;
+    }
+    Atomics.wait(waitBuffer, 0, 0, 25);
+  }
+  return !isProcessAlive(pid);
 }
 
 describe("bench-cli-startup", () => {
@@ -163,7 +188,7 @@ describe("bench-cli-startup", () => {
         expect(result.status).toBe(1);
         expect(result.signal).toBeNull();
         expect(result.stderr).toContain("version sample 1: timed out");
-        expect(isProcessAlive(childPid)).toBe(false);
+        expect(waitForProcessExit(childPid, 1_000)).toBe(true);
       } finally {
         if (childPid !== undefined && isProcessAlive(childPid)) {
           process.kill(childPid, "SIGKILL");

--- a/test/scripts/cli-startup-bench-spawner.test.ts
+++ b/test/scripts/cli-startup-bench-spawner.test.ts
@@ -5,18 +5,16 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 
-const SCRIPT_PATHS = [
-  "scripts/test-cli-startup-bench-budget.mjs",
-  "scripts/test-update-cli-startup-bench.mjs",
-];
-
 describe("CLI startup benchmark script spawners", () => {
   it("use the active Node executable for benchmark child processes", () => {
-    for (const scriptPath of SCRIPT_PATHS) {
+    for (const [scriptPath, invocation] of [
+      ["scripts/test-cli-startup-bench-budget.mjs", "spawn(process.execPath, args"],
+      ["scripts/test-update-cli-startup-bench.mjs", "spawnSync(process.execPath, args"],
+    ] as const) {
       const source = fs.readFileSync(path.resolve(process.cwd(), scriptPath), "utf8");
 
-      expect(source).toContain("spawnSync(process.execPath, args");
-      expect(source).not.toContain('spawnSync("node", args');
+      expect(source).toContain(invocation);
+      expect(source).not.toContain('("node", args');
     }
   });
 
@@ -26,9 +24,7 @@ describe("CLI startup benchmark script spawners", () => {
       "utf8",
     );
 
-    expect(source).toContain(
-      'spawnSync(process.execPath, ["scripts/ensure-cli-startup-build.mjs"]',
-    );
+    expect(source).toContain('runCommandWithDeadline(["scripts/ensure-cli-startup-build.mjs"]');
     expect(source.indexOf("scripts/ensure-cli-startup-build.mjs")).toBeLessThan(
       source.indexOf("scripts/bench-cli-startup.ts"),
     );

--- a/test/scripts/test-cli-startup-bench-budget.test.ts
+++ b/test/scripts/test-cli-startup-bench-budget.test.ts
@@ -1,0 +1,124 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const SCRIPT_PATH = "scripts/test-cli-startup-bench-budget.mjs";
+const TEST_BACKSTOP_MS = process.env.CI ? 8_000 : 4_000;
+
+type SpawnCall = {
+  args: string[];
+  call: number;
+  killSignal?: string;
+  timeout?: number;
+};
+
+function runWithResidentSpawn(hangOnCall: number): {
+  calls: SpawnCall[];
+  result: ReturnType<typeof spawnSync>;
+} {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-startup-budget-deadline-"));
+  const callsPath = path.join(tempDir, "spawn-calls.jsonl");
+  const preloadPath = path.join(tempDir, "mock-spawn-sync.cjs");
+  writeFileSync(
+    preloadPath,
+    [
+      'const childProcess = require("node:child_process");',
+      'const fs = require("node:fs");',
+      'const { syncBuiltinESMExports } = require("node:module");',
+      "const originalSpawnSync = childProcess.spawnSync;",
+      "let call = 0;",
+      "childProcess.spawnSync = (command, args, options = {}) => {",
+      "  call += 1;",
+      "  fs.appendFileSync(",
+      "    process.env.OPENCLAW_TEST_SPAWN_CALLS_PATH,",
+      "    `${JSON.stringify({ call, args, timeout: options.timeout, killSignal: options.killSignal })}\\n`,",
+      "  );",
+      "  if (call < Number(process.env.OPENCLAW_TEST_HANG_ON_SPAWN_CALL)) {",
+      "    return { error: undefined, output: [null, null, null], pid: 1, signal: null, status: 0, stderr: null, stdout: null };",
+      "  }",
+      "  return originalSpawnSync(",
+      "    process.execPath,",
+      '    ["--eval", "setInterval(() => {}, 1000)"],',
+      "    options,",
+      "  );",
+      "};",
+      "syncBuiltinESMExports();",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--require",
+        preloadPath,
+        SCRIPT_PATH,
+        "--preset",
+        "all",
+        "--runs",
+        "2",
+        "--warmup",
+        "3",
+        "--timeout-ms",
+        "1",
+      ],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          OPENCLAW_CLI_STARTUP_BUILD_TIMEOUT_MS: "1",
+          OPENCLAW_TEST_CLI_STARTUP_TIMEOUT_KILL_GRACE_MS: "2",
+          OPENCLAW_TEST_HANG_ON_SPAWN_CALL: String(hangOnCall),
+          OPENCLAW_TEST_SPAWN_CALLS_PATH: callsPath,
+          VITEST: "1",
+        },
+        killSignal: "SIGKILL",
+        timeout: TEST_BACKSTOP_MS,
+      },
+    );
+    const calls = readFileSync(callsPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as SpawnCall);
+    return { calls, result };
+  } finally {
+    rmSync(tempDir, { force: true, recursive: true });
+  }
+}
+
+describe("test-cli-startup-bench-budget deadlines", () => {
+  it("bounds a stalled build child before the test backstop", () => {
+    const { calls, result } = runWithResidentSpawn(1);
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(1);
+    expect(calls).toEqual([
+      expect.objectContaining({
+        call: 1,
+        killSignal: "SIGKILL",
+        timeout: 3,
+      }),
+    ]);
+  });
+
+  it("bounds the whole benchmark after build success before the test backstop", () => {
+    const { calls, result } = runWithResidentSpawn(2);
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(1);
+    expect(calls).toHaveLength(2);
+    expect(calls[1]).toEqual(
+      expect.objectContaining({
+        call: 2,
+        killSignal: "SIGKILL",
+        timeout: 1_252,
+      }),
+    );
+  });
+});

--- a/test/scripts/test-cli-startup-bench-budget.test.ts
+++ b/test/scripts/test-cli-startup-bench-budget.test.ts
@@ -1,46 +1,72 @@
-import { spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import os from "node:os";
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const SCRIPT_PATH = "scripts/test-cli-startup-bench-budget.mjs";
 const TEST_BACKSTOP_MS = process.env.CI ? 8_000 : 4_000;
+const BENCHMARK_START_BACKSTOP_MS = process.env.CI ? 20_000 : 12_000;
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+async function waitForCondition(condition: () => boolean, timeoutMs: number): Promise<boolean> {
+  const deadlineAt = Date.now() + timeoutMs;
+  while (Date.now() < deadlineAt) {
+    if (condition()) {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  return condition();
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
 
 type SpawnCall = {
   args: string[];
   call: number;
-  killSignal?: string;
-  timeout?: number;
+  detached?: boolean;
 };
 
 function runWithResidentSpawn(hangOnCall: number): {
   calls: SpawnCall[];
   result: ReturnType<typeof spawnSync>;
 } {
-  const tempDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-startup-budget-deadline-"));
+  const tempDir = tempDirs.make("openclaw-startup-budget-deadline-");
   const callsPath = path.join(tempDir, "spawn-calls.jsonl");
-  const preloadPath = path.join(tempDir, "mock-spawn-sync.cjs");
+  const preloadPath = path.join(tempDir, "mock-spawn.cjs");
   writeFileSync(
     preloadPath,
     [
       'const childProcess = require("node:child_process");',
+      'const { EventEmitter } = require("node:events");',
       'const fs = require("node:fs");',
       'const { syncBuiltinESMExports } = require("node:module");',
-      "const originalSpawnSync = childProcess.spawnSync;",
+      "const originalSpawn = childProcess.spawn;",
       "let call = 0;",
-      "childProcess.spawnSync = (command, args, options = {}) => {",
+      "childProcess.spawn = (command, args, options = {}) => {",
       "  call += 1;",
       "  fs.appendFileSync(",
       "    process.env.OPENCLAW_TEST_SPAWN_CALLS_PATH,",
-      "    `${JSON.stringify({ call, args, timeout: options.timeout, killSignal: options.killSignal })}\\n`,",
+      "    `${JSON.stringify({ call, args, detached: options.detached })}\\n`,",
       "  );",
       "  if (call < Number(process.env.OPENCLAW_TEST_HANG_ON_SPAWN_CALL)) {",
-      "    return { error: undefined, output: [null, null, null], pid: 1, signal: null, status: 0, stderr: null, stdout: null };",
+      "    const child = new EventEmitter();",
+      "    child.kill = () => true;",
+      "    child.pid = undefined;",
+      '    process.nextTick(() => child.emit("close", 0, null));',
+      "    return child;",
       "  }",
-      "  return originalSpawnSync(",
+      "  return originalSpawn(",
       "    process.execPath,",
-      '    ["--eval", "setInterval(() => {}, 1000)"],',
+      '    ["--eval", "process.on(\\"SIGTERM\\", () => {}); setInterval(() => {}, 1000)"],',
       "    options,",
       "  );",
       "};",
@@ -98,11 +124,12 @@ describe("test-cli-startup-bench-budget deadlines", () => {
 
     expect(result.error).toBeUndefined();
     expect(result.status).toBe(1);
+    expect(result.stderr).toContain("build timed out after 3ms");
     expect(calls).toEqual([
       expect.objectContaining({
+        args: ["scripts/ensure-cli-startup-build.mjs"],
         call: 1,
-        killSignal: "SIGKILL",
-        timeout: 3,
+        detached: process.platform !== "win32",
       }),
     ]);
   });
@@ -112,13 +139,105 @@ describe("test-cli-startup-bench-budget deadlines", () => {
 
     expect(result.error).toBeUndefined();
     expect(result.status).toBe(1);
+    expect(result.stderr).toContain("benchmark timed out after 1254ms");
     expect(calls).toHaveLength(2);
     expect(calls[1]).toEqual(
       expect.objectContaining({
         call: 2,
-        killSignal: "SIGKILL",
-        timeout: 1_252,
+        detached: process.platform !== "win32",
       }),
     );
   });
+
+  it.runIf(process.platform !== "win32")(
+    "cleans an active detached sample when the benchmark is terminated",
+    async () => {
+      const tempDir = tempDirs.make("openclaw-startup-budget-cleanup-");
+      const samplePidPath = path.join(tempDir, "sample.pid");
+      const entryPath = path.join(tempDir, "resident-entry.mjs");
+      const reportPath = path.join(tempDir, "report.json");
+      writeFileSync(
+        entryPath,
+        [
+          'import { writeFileSync } from "node:fs";',
+          `writeFileSync(${JSON.stringify(samplePidPath)}, JSON.stringify({ pid: process.pid, runRoot: process.env.OPENCLAW_HOME }));`,
+          'process.on("SIGTERM", () => {});',
+          "setInterval(() => {}, 1000);",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+
+      let benchmarkPid = 0;
+      let samplePid = 0;
+      let sampleRunRoot = "";
+      try {
+        const benchmark = spawn(
+          process.execPath,
+          [
+            "--import",
+            "tsx",
+            "scripts/bench-cli-startup.ts",
+            "--entry",
+            entryPath,
+            "--case",
+            "version",
+            "--runs",
+            "1",
+            "--warmup",
+            "0",
+            "--timeout-ms",
+            "10000",
+            "--output",
+            reportPath,
+          ],
+          {
+            cwd: process.cwd(),
+            detached: true,
+            env: {
+              ...process.env,
+              OPENCLAW_TEST_CLI_STARTUP_TIMEOUT_KILL_GRACE_MS: "50",
+              VITEST: "1",
+            },
+            stdio: "ignore",
+          },
+        );
+        benchmarkPid = benchmark.pid ?? 0;
+        expect(benchmarkPid).toBeGreaterThan(0);
+        expect(
+          await waitForCondition(() => existsSync(samplePidPath), BENCHMARK_START_BACKSTOP_MS),
+        ).toBe(true);
+        const sampleState = JSON.parse(readFileSync(samplePidPath, "utf8")) as {
+          pid: number;
+          runRoot: string;
+        };
+        samplePid = sampleState.pid;
+        sampleRunRoot = sampleState.runRoot;
+        expect(samplePid).toBeGreaterThan(0);
+        expect(isProcessAlive(samplePid)).toBe(true);
+        expect(existsSync(sampleRunRoot)).toBe(true);
+
+        process.kill(-benchmarkPid, "SIGTERM");
+        expect(
+          await waitForCondition(
+            () => benchmark.exitCode !== null || benchmark.signalCode !== null,
+            TEST_BACKSTOP_MS,
+          ),
+        ).toBe(true);
+        expect(await waitForCondition(() => !isProcessAlive(samplePid), 1_000)).toBe(true);
+        expect(existsSync(sampleRunRoot)).toBe(false);
+      } finally {
+        if (samplePid > 0 && isProcessAlive(samplePid)) {
+          process.kill(-samplePid, "SIGKILL");
+        }
+        if (benchmarkPid > 0 && isProcessAlive(benchmarkPid)) {
+          process.kill(-benchmarkPid, "SIGKILL");
+        }
+        if (sampleRunRoot) {
+          rmSync(sampleRunRoot, { force: true, recursive: true });
+        }
+        rmSync(tempDir, { force: true, recursive: true });
+      }
+    },
+  );
 });


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where CI jobs and developers running the CLI startup budget check could hang
indefinitely if either the prerequisite build or the outer benchmark process stopped making
progress. The existing `--timeout-ms` flag only bounded individual benchmark samples, so it did
not cover build execution, benchmark module loading, the full runs/warmups workload, or teardown.

## Why This Change Was Made

The startup budget wrapper now owns separate deadlines for its build and benchmark child trees.
Each deadline first requests cooperative termination and then force-kills the managed process
group. The build deadline reuses the existing CLI startup build timeout plus cleanup grace; the
benchmark deadline scales across measured runs and warmups and reserves cleanup time for every
sample and for an active detached sample at outer shutdown. This fixes the source process-lifecycle
boundary without changing benchmark flags, report schemas, fixtures, or OpenClaw runtime behavior.

## User Impact

Startup budget validation now fails with a bounded nonzero exit instead of occupying a CI worker
or developer terminal indefinitely. Deadline termination also cleans active benchmark samples and
their temporary state instead of leaving orphan processes behind. Successful runs continue to use
the same inputs and produce the same reports.

## Evidence

- Before the fix, both deadline regressions reached their 4-second test backstop. A separate red
  regression also showed that terminating the benchmark leader left its detached sample alive.
- Focused and adjacent process-lifecycle suites: 29/29 tests passed, including real detached-sample
  and temporary-directory cleanup.
- Issue-path process proof: the resident build scenario exited in 80ms with a 3ms total deadline;
  the resident benchmark scenario exited in 1358ms with a 1254ms total deadline covering two runs,
  three warmups, per-run timeout cleanup, and final process-tree cleanup. Neither reached the
  4-second backstop.
- A real benchmark with an active detached sample shut down in 1684ms; the sample was gone and its
  temporary run root had been removed before the proof returned.
- Changed-surface checks passed, including formatting, script declarations, test-root typecheck,
  dependency guards, and script lint. Blacksmith Testbox was unavailable because its local CLI was
  not installed, so the trusted pinned-main checkout ran the same gates locally.
