### PR TITLE
fix(huggingface): discover models when HTTP proxy is required

### DIFF
--- a/extensions/huggingface/models.proxy.test.ts
+++ b/extensions/huggingface/models.proxy.test.ts
@@ -1,0 +1,49 @@
+// Hugging Face proxy tests cover the live model discovery transport policy.
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>()),
+  fetchWithSsrFGuard: fetchWithSsrFGuardMock,
+}));
+
+import { discoverHuggingfaceModels } from "./models.js";
+
+const ORIGINAL_VITEST = process.env.VITEST;
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+
+function restoreEnv(key: "VITEST" | "NODE_ENV", value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}
+
+afterEach(() => {
+  restoreEnv("VITEST", ORIGINAL_VITEST);
+  restoreEnv("NODE_ENV", ORIGINAL_NODE_ENV);
+  fetchWithSsrFGuardMock.mockReset();
+  vi.restoreAllMocks();
+});
+
+describe("Hugging Face model discovery proxy policy", () => {
+  it("allows the guarded official catalog request to use an eligible HTTP proxy", async () => {
+    process.env.VITEST = "false";
+    process.env.NODE_ENV = "development";
+    const response = new Response("unavailable", { status: 503 });
+    const release = vi.fn(async () => undefined);
+    fetchWithSsrFGuardMock.mockResolvedValue({ response, release });
+
+    await discoverHuggingfaceModels("hf_test_token");
+
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "trusted_env_proxy",
+        url: "https://router.huggingface.co/v1/models",
+      }),
+    );
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/huggingface/models.ts
+++ b/extensions/huggingface/models.ts
@@ -1,4 +1,5 @@
 // Huggingface plugin module implements models behavior.
+import { withTrustedEnvProxyGuardedFetchMode } from "openclaw/plugin-sdk/fetch-runtime";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-types";
@@ -139,19 +140,21 @@ export async function discoverHuggingfaceModels(
 
   try {
     const requestTimeoutMs = resolveTimerTimeoutMs(timeoutMs, HUGGINGFACE_DISCOVERY_TIMEOUT_MS);
-    const { response, release } = await fetchWithSsrFGuard({
-      url: `${HUGGINGFACE_BASE_URL}/models`,
-      init: {
-        signal: AbortSignal.timeout(requestTimeoutMs),
-        headers: {
-          Authorization: `Bearer ${trimmedKey}`,
-          "Content-Type": "application/json",
+    const { response, release } = await fetchWithSsrFGuard(
+      withTrustedEnvProxyGuardedFetchMode({
+        url: `${HUGGINGFACE_BASE_URL}/models`,
+        init: {
+          signal: AbortSignal.timeout(requestTimeoutMs),
+          headers: {
+            Authorization: `Bearer ${trimmedKey}`,
+            "Content-Type": "application/json",
+          },
         },
-      },
-      timeoutMs: requestTimeoutMs,
-      policy: ssrfPolicyFromHttpBaseUrlAllowedHostname(HUGGINGFACE_BASE_URL),
-      auditContext: "huggingface-model-discovery",
-    });
+        timeoutMs: requestTimeoutMs,
+        policy: ssrfPolicyFromHttpBaseUrlAllowedHostname(HUGGINGFACE_BASE_URL),
+        auditContext: "huggingface-model-discovery",
+      }),
+    );
     try {
       if (!response.ok) {
         await response.body?.cancel().catch(() => undefined);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users whose outbound HTTPS access requires an HTTP(S) proxy would wait through the Hugging Face model-discovery window and then see only the 3 static fallback models in `openclaw models list --all --provider huggingface`.

## Why This Change Was Made

The fixed Hugging Face official catalog request now uses the existing trusted environment-proxy guarded-fetch preset. The existing SSRF hostname policy, timeout, bounded response parsing, `NO_PROXY`/direct behavior, static fallback, and response release remain unchanged.

## User Impact

OpenClaw can now discover the live Hugging Face model catalog in proxy-required environments instead of silently falling back to the small static catalog.

## Evidence

- TDD red: the new regression test failed against the original production call because the guarded request did not select `mode: "trusted_env_proxy"`.
- Focused green: 2 Hugging Face test files, 13 tests passed.
- Extension lane: `pnpm test:extension huggingface` — 3 test files, 14 tests passed.
- Repository gate: `pnpm check:changed` passed.
- Live before (Linux, Node 24.15.0, isolated state, random test-only token, required HTTPS proxy): `pnpm openclaw models list --all --provider huggingface --plain` completed with only the 3 static fallback models after the configured 30-second discovery window.
- Third-party control: a direct request through the same proxy to Hugging Face's official `https://router.huggingface.co/v1/models` returned HTTP 200 with 124 models.
- Live after (same OpenClaw command and environment, final code): OpenClaw listed 124 Hugging Face models, matching the official third-party response.
- No-proxy control: after clearing all HTTP(S)/ALL proxy variables, OpenClaw still safely fell back to the same 3 static models.
- `codex review --base origin/main`: no findings.
