### PR TITLE
fix(ui): show tool input when native result sorts before its call

### DIFF
--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -867,6 +867,116 @@ describe("buildCachedChatItems", () => {
     });
   });
 
+  it("coalesces a native tool result that sorts before its call", () => {
+    const groups = messageGroups({
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "call-native",
+              name: "example_tool",
+              arguments: { query: "example" },
+            },
+          ],
+          timestamp: 2000,
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call-native",
+          toolName: "example_tool",
+          content: [{ type: "text", text: "Native result" }],
+          timestamp: 1000,
+        },
+      ],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groupAt(groups, 0).messages).toHaveLength(1);
+    const cards = extractToolCards(messageAt(groupAt(groups, 0), 0).message, "native-reversed");
+    expect(cards).toHaveLength(1);
+    expect(cards[0]).toMatchObject({
+      callId: "call-native",
+      args: { query: "example" },
+      outputText: "Native result",
+    });
+  });
+
+  it("pairs earlier-sorted same-name tool results by call id", () => {
+    const groups = messageGroups({
+      messages: [
+        {
+          role: "toolResult",
+          toolCallId: "call-a",
+          toolName: "read",
+          content: [{ type: "text", text: "contents of a" }],
+          timestamp: 1000,
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call-b",
+          toolName: "read",
+          content: [{ type: "text", text: "contents of b" }],
+          timestamp: 1001,
+        },
+        {
+          role: "assistant",
+          content: [
+            { type: "toolCall", id: "call-b", name: "read", arguments: { path: "b.ts" } },
+            { type: "toolCall", id: "call-a", name: "read", arguments: { path: "a.ts" } },
+          ],
+          timestamp: 1002,
+        },
+      ],
+    });
+
+    expect(groups).toHaveLength(1);
+    const cards = groupAt(groups, 0).messages.flatMap((entry, index) =>
+      extractToolCards(entry.message, `native-same-name-${index}`),
+    );
+    expect(cards).toHaveLength(2);
+    expect(cards.find((card) => card.callId === "call-a")).toMatchObject({
+      args: { path: "a.ts" },
+      outputText: "contents of a",
+    });
+    expect(cards.find((card) => card.callId === "call-b")).toMatchObject({
+      args: { path: "b.ts" },
+      outputText: "contents of b",
+    });
+  });
+
+  it("pairs an earlier bundled result message with later calls", () => {
+    const groups = messageGroups({
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "call-a", content: "contents of a" },
+            { type: "tool_result", tool_use_id: "call-b", content: "contents of b" },
+          ],
+          timestamp: 1000,
+        },
+        {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "call-a", name: "read", input: { path: "a.ts" } },
+            { type: "tool_use", id: "call-b", name: "read", input: { path: "b.ts" } },
+          ],
+          timestamp: 1001,
+        },
+      ],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groupAt(groups, 0).messages).toHaveLength(1);
+    const cards = extractToolCards(messageAt(groupAt(groups, 0), 0).message, "bundled-reversed");
+    expect(cards.map((card) => [card.callId, card.args, card.outputText])).toEqual([
+      ["call-a", { path: "a.ts" }, "contents of a"],
+      ["call-b", { path: "b.ts" }, "contents of b"],
+    ]);
+  });
+
   it("coalesces interleaved parallel call/result pairs by call id", () => {
     const groups = messageGroups({
       messages: [

--- a/ui/src/pages/chat/chat-thread.ts
+++ b/ui/src/pages/chat/chat-thread.ts
@@ -699,9 +699,21 @@ function refreshOpenCallIds(
 
 function coalesceToolActivityMessages(items: ChatItem[]): ChatItem[] {
   const coalesced: ChatItem[] = [];
+  // Backward pairing can replace several earlier result slots with one
+  // multi-call item. Defer removal so all call-id indexes stay stable.
+  const suppressedIndexes = new Set<number>();
   // Parallel calls can outnumber any fixed lookback window, so each unresolved
   // call id owns its current transcript item until a non-tool boundary.
   const openCallIndexes = new Map<string, number>();
+  // Timestamp ordering can place a persisted result before its call. Keep the
+  // orphan's slot by call id so a later call can restore the complete card.
+  const openResultIndexes = new Map<string, number>();
+  const registerOrphanResult = (resultItem: ChatItem, index: number) => {
+    const callId = resolveToolResultCallId(resultItem);
+    if (callId && !openResultIndexes.has(callId)) {
+      openResultIndexes.set(callId, index);
+    }
+  };
   for (const item of items) {
     const resultItems = splitBundledToolResultItems(item);
     const unmatchedResultItems: ChatItem[] = [];
@@ -723,11 +735,45 @@ function coalesceToolActivityMessages(items: ChatItem[]): ChatItem[] {
     if (mergedResult) {
       for (const unmatched of unmatchedResultItems) {
         coalesced.push(unmatched);
+        registerOrphanResult(unmatched, coalesced.length - 1);
+      }
+      continue;
+    }
+    if (resultItems.length > 1) {
+      // Keep bundled orphan results addressable by their individual call ids;
+      // the later calls may arrive together or as separate messages.
+      for (const resultItem of resultItems) {
+        coalesced.push(resultItem);
+        registerOrphanResult(resultItem, coalesced.length - 1);
       }
       continue;
     }
 
     const unresolvedCallIds = unresolvedToolCallIds(item);
+    let backwardMerged = item;
+    const matchedResultIndexes: number[] = [];
+    for (const callId of unresolvedCallIds) {
+      const resultIndex = openResultIndexes.get(callId);
+      const orphanResult = resultIndex === undefined ? undefined : coalesced[resultIndex];
+      const merged = orphanResult ? mergeToolCallResultPair(backwardMerged, orphanResult) : null;
+      if (!merged || resultIndex === undefined) {
+        continue;
+      }
+      backwardMerged = merged;
+      matchedResultIndexes.push(resultIndex);
+      openResultIndexes.delete(callId);
+    }
+    if (matchedResultIndexes.length > 0) {
+      const resultIndex = Math.min(...matchedResultIndexes);
+      coalesced[resultIndex] = backwardMerged;
+      for (const matchedIndex of matchedResultIndexes) {
+        if (matchedIndex !== resultIndex) {
+          suppressedIndexes.add(matchedIndex);
+        }
+      }
+      refreshOpenCallIds(openCallIndexes, coalesced, resultIndex);
+      continue;
+    }
     if (unresolvedCallIds.size === 1) {
       const callId = unresolvedCallIds.values().next().value;
       const previousIndex = callId ? openCallIndexes.get(callId) : undefined;
@@ -749,12 +795,14 @@ function coalesceToolActivityMessages(items: ChatItem[]): ChatItem[] {
     }
     if (isToolTimelineItem(item)) {
       // Orphan results keep the window open for later siblings.
+      registerOrphanResult(item, coalesced.length - 1);
       continue;
     }
     // Any other content (user text, assistant reply, dividers) closes the run.
     openCallIndexes.clear();
+    openResultIndexes.clear();
   }
-  return coalesced;
+  return coalesced.filter((_, index) => !suppressedIndexes.has(index));
 }
 
 function assistantGroupHasReplyText(group: MessageGroup): boolean {


### PR DESCRIPTION
## Summary

Fixes #110769 — in the Control UI chat view, tool cards rendered only the "Tool output" section and never a "Tool input" section, even though the tool call's `arguments` were present in the stored session transcript.

## Root cause

`coalesceToolActivityMessages` (ui/src/pages/chat/chat-thread.ts) paired a tool result with its call only when both landed in the same message or the call preceded the result. For native-runtime transcripts (the `anthropic-messages` API), the assistant `toolCall` and the separate `toolResult` message are distinct messages that can appear in either timestamp order. A result that sorts before its matching call was therefore rendered as an output-only card — `inputText` derived from `toolCall.arguments` was empty, so the "Tool input" section was skipped.

## Fix

The coalescing layer now keeps orphan result slots indexed by their stable call id (`openResultIndexes`) and restores the complete card when the later call arrives. This pairs:
- a single native result that sorts before its call,
- parallel same-name calls/results addressed by call id, and
- earlier bundled result messages delivered with later calls,

without relying on adjacency or tool name, while preserving non-tool boundaries and mixed-content result messages (existing grouping and content retained).

## Validation

- Targeted unit suite: `pnpm exec vitest run src/pages/chat/chat-thread.test.ts` — 120 passed (includes 3 new regression tests for the reversed-order, same-name, and bundled-result cases).
- `oxfmt --check` and `oxlint` clean on both changed files.

## Note on parallel work

This is an independent implementation of the same fix as #110868 (open at time of writing, by another contributor). I authored it against current `main` and added regression coverage; opening it so maintainers can compare approaches. Happy to withdraw in favor of #110868 if that is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)