### PR TITLE
fix(gateway): honor scopes for WebChat session mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- **Gateway session mutation authorization:** authorize WebChat and other Gateway clients by negotiated operator scopes instead of client ID or mode, so approved clients can manage sessions without impersonating Control UI.
 - **External gateway supervision:** add `OPENCLAW_SUPERVISOR_MODE=external` for lifecycle owners such as OCM, preserving verified restart and deferral behavior without exposing native service authority, blocking native service mutation and self-update, and providing a versioned atomic restart-handoff consume contract. Thanks @shakkernerd.
 - **ClickClack guided setup:** configure ClickClack from `openclaw onboard` or `openclaw channels add clickclack` with URL, token, and workspace prompts, default-account env fallback, nonfatal live connection validation, and gateway-aware next steps that connect automatically when OpenClaw is already running. Thanks @shakkernerd.
 - **ClickClack command menus:** publish each bot's native OpenClaw commands to ClickClack composer autocomplete at gateway startup, with per-account opt-out and nonfatal compatibility handling for older tokens and servers. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Gateway session mutation authorization:** authorize WebChat and other Gateway clients by negotiated operator scopes instead of client ID or mode, so approved clients can manage sessions without impersonating Control UI.
 - **External gateway supervision:** add `OPENCLAW_SUPERVISOR_MODE=external` for lifecycle owners such as OCM, preserving verified restart and deferral behavior without exposing native service authority, blocking native service mutation and self-update, and providing a versioned atomic restart-handoff consume contract. Thanks @shakkernerd.
 - **ClickClack guided setup:** configure ClickClack from `openclaw onboard` or `openclaw channels add clickclack` with URL, token, and workspace prompts, default-account env fallback, nonfatal live connection validation, and gateway-aware next steps that connect automatically when OpenClaw is already running. Thanks @shakkernerd.
 - **ClickClack command menus:** publish each bot's native OpenClaw commands to ClickClack composer autocomplete at gateway startup, with per-account opt-out and nonfatal compatibility handling for older tokens and servers. Thanks @shakkernerd.

--- a/docs/gateway/operator-scopes.md
+++ b/docs/gateway/operator-scopes.md
@@ -58,6 +58,11 @@ the concrete thing being approved or mutated:
 This lets lower-scope operators perform low-risk pairing actions without
 making all pairing approval admin-only.
 
+Session mutation RPCs are authorized by their negotiated operator scopes,
+independent of the connecting client's `client.id` or `client.mode`. Client
+identity can still affect connection and device-auth policy, but it neither
+grants nor removes session mutation authority.
+
 ## Device pairing approvals
 
 Device pairing records are the durable source of approved roles and scopes.

--- a/src/gateway/server-methods/sessions-compact.ts
+++ b/src/gateway/server-methods/sessions-compact.ts
@@ -35,7 +35,6 @@ import {
 import {
   emitSessionOperation,
   loadAccessorSessionEntryForGatewayTarget,
-  rejectWebchatSessionMutation,
   requireSessionKey,
   resolveGatewaySessionTargetFromKey,
 } from "./sessions-shared.js";
@@ -43,7 +42,7 @@ import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
 export const sessionCompactHandlers: GatewayRequestHandlers = {
-  "sessions.compact": async ({ params, respond, context, client, isWebchatConnect }) => {
+  "sessions.compact": async ({ params, respond, context }) => {
     if (!assertValidParams(params, validateSessionsCompactParams, "sessions.compact", respond)) {
       return;
     }
@@ -52,10 +51,6 @@ export const sessionCompactHandlers: GatewayRequestHandlers = {
     if (!key) {
       return;
     }
-    if (rejectWebchatSessionMutation({ action: "compact", client, isWebchatConnect, respond })) {
-      return;
-    }
-
     const maxLines =
       typeof p.maxLines === "number" && Number.isFinite(p.maxLines)
         ? Math.max(1, Math.floor(p.maxLines))

--- a/src/gateway/server-methods/sessions-compaction-checkpoints.ts
+++ b/src/gateway/server-methods/sessions-compaction-checkpoints.ts
@@ -24,7 +24,6 @@ import { emitSessionsChanged } from "./session-change-event.js";
 import { interruptSessionRunIfActive } from "./sessions-messaging.js";
 import {
   loadAccessorSessionEntryForGatewayTarget,
-  rejectWebchatSessionMutation,
   requireSessionKey,
   resolveSessionWorkerPlacementMutationError,
   respondSessionWorkerPlacementMutationError,
@@ -38,7 +37,7 @@ const MODEL_SELECTION_LOCKED_CHECKPOINT_MESSAGE =
   "Checkpoint branch and restore are unavailable while model selection is locked.";
 
 export const sessionCheckpointHandlers: GatewayRequestHandlers = {
-  "sessions.compaction.branch": async ({ params, respond, context, client, isWebchatConnect }) => {
+  "sessions.compaction.branch": async ({ params, respond, context }) => {
     if (
       !assertValidParams(
         params,
@@ -52,9 +51,6 @@ export const sessionCheckpointHandlers: GatewayRequestHandlers = {
     const p = params;
     const key = requireSessionKey(p.key, respond);
     if (!key) {
-      return;
-    }
-    if (rejectWebchatSessionMutation({ action: "branch", client, isWebchatConnect, respond })) {
       return;
     }
     const checkpointId =
@@ -182,9 +178,6 @@ export const sessionCheckpointHandlers: GatewayRequestHandlers = {
     const p = params;
     const key = requireSessionKey(p.key, respond);
     if (!key) {
-      return;
-    }
-    if (rejectWebchatSessionMutation({ action: "restore", client, isWebchatConnect, respond })) {
       return;
     }
     const checkpointId =

--- a/src/gateway/server-methods/sessions-delete.ts
+++ b/src/gateway/server-methods/sessions-delete.ts
@@ -32,7 +32,6 @@ import {
   loadAccessorSessionEntryForGatewayTarget,
   loadSessionsRuntimeModule,
   rejectPluginRuntimeDeleteMismatch,
-  rejectWebchatSessionMutation,
   requireSessionKey,
   resolveGatewaySessionTargetFromKey,
   resolveSessionWorkerPlacementMutationError,
@@ -52,10 +51,6 @@ export const sessionDeleteHandlers: GatewayRequestHandlers = {
     if (!key) {
       return;
     }
-    if (rejectWebchatSessionMutation({ action: "delete", client, isWebchatConnect, respond })) {
-      return;
-    }
-
     const cfg = context.getRuntimeConfig();
     const requestedAgent = resolveRequestedGlobalAgentId(cfg, key, p.agentId);
     if (!requestedAgent.ok) {

--- a/src/gateway/server-methods/sessions-dispatch.ts
+++ b/src/gateway/server-methods/sessions-dispatch.ts
@@ -17,22 +17,18 @@ import {
 import {
   isWorkerDispatchInputError,
   loadAccessorSessionEntryForGatewayTarget,
-  rejectWebchatSessionMutation,
   requireSessionKey,
 } from "./sessions-shared.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
 export const sessionDispatchHandlers: GatewayRequestHandlers = {
-  "sessions.dispatch": async ({ params, respond, context, client, isWebchatConnect }) => {
+  "sessions.dispatch": async ({ params, respond, context }) => {
     if (!assertValidParams(params, validateSessionsDispatchParams, "sessions.dispatch", respond)) {
       return;
     }
     const key = requireSessionKey(params.key, respond);
     if (!key) {
-      return;
-    }
-    if (rejectWebchatSessionMutation({ action: "dispatch", client, isWebchatConnect, respond })) {
       return;
     }
     const dispatchService = context.workerPlacementDispatchService;
@@ -163,15 +159,12 @@ export const sessionDispatchHandlers: GatewayRequestHandlers = {
       );
     }
   },
-  "sessions.reclaim": async ({ params, respond, context, client, isWebchatConnect }) => {
+  "sessions.reclaim": async ({ params, respond, context }) => {
     if (!assertValidParams(params, validateSessionsReclaimParams, "sessions.reclaim", respond)) {
       return;
     }
     const key = requireSessionKey(params.key, respond);
     if (!key) {
-      return;
-    }
-    if (rejectWebchatSessionMutation({ action: "reclaim", client, isWebchatConnect, respond })) {
       return;
     }
     const placementService = context.workerPlacementDispatchService;

--- a/src/gateway/server-methods/sessions-mutations.ts
+++ b/src/gateway/server-methods/sessions-mutations.ts
@@ -39,7 +39,6 @@ import { emitSessionsChanged } from "./session-change-event.js";
 import {
   isAgentMainSessionKey,
   loadSessionsRuntimeModule,
-  rejectWebchatSessionMutation,
   requireSessionKey,
   resolveGatewaySessionTargetFromKey,
   resolveSessionWorkerPlacementPatchError,
@@ -49,7 +48,7 @@ import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
 export const sessionMutationHandlers: GatewayRequestHandlers = {
-  "sessions.patch": async ({ params, respond, context, client, isWebchatConnect }) => {
+  "sessions.patch": async ({ params, respond, context, client }) => {
     if (!assertValidParams(params, validateSessionsPatchParams, "sessions.patch", respond)) {
       return;
     }
@@ -58,10 +57,6 @@ export const sessionMutationHandlers: GatewayRequestHandlers = {
     if (!key) {
       return;
     }
-    if (rejectWebchatSessionMutation({ action: "patch", client, isWebchatConnect, respond })) {
-      return;
-    }
-
     const cfg = context.getRuntimeConfig();
     const requestedAgent = resolveRequestedGlobalAgentId(cfg, key, p.agentId);
     if (!requestedAgent.ok) {
@@ -315,7 +310,7 @@ export const sessionMutationHandlers: GatewayRequestHandlers = {
       reason: "patch",
     });
   },
-  "sessions.pluginPatch": async ({ params, respond, context, client, isWebchatConnect }) => {
+  "sessions.pluginPatch": async ({ params, respond, context, client }) => {
     if (
       !assertValidParams(params, validateSessionsPluginPatchParams, "sessions.pluginPatch", respond)
     ) {
@@ -323,9 +318,6 @@ export const sessionMutationHandlers: GatewayRequestHandlers = {
     }
     const key = requireSessionKey(params.key, respond);
     if (!key) {
-      return;
-    }
-    if (rejectWebchatSessionMutation({ action: "patch", client, isWebchatConnect, respond })) {
       return;
     }
     const scopes = Array.isArray(client?.connect.scopes) ? client.connect.scopes : [];

--- a/src/gateway/server-methods/sessions-rewind.ts
+++ b/src/gateway/server-methods/sessions-rewind.ts
@@ -31,7 +31,6 @@ import { hasVisibleActiveSessionRun } from "./session-active-runs.js";
 import { emitSessionsChanged } from "./session-change-event.js";
 import {
   loadAccessorSessionEntryForGatewayTarget,
-  rejectWebchatSessionMutation,
   resolveSessionWorkerPlacementMutationError,
   respondSessionWorkerPlacementMutationError,
 } from "./sessions-shared.js";
@@ -145,7 +144,7 @@ async function mutateSessionAtMessage(
   options: GatewayRequestHandlerOptions,
   action: MessageCutAction,
 ): Promise<void> {
-  const { params, respond, context, client, isWebchatConnect } = options;
+  const { params, respond, context } = options;
   const sessionKey = typeof params.sessionKey === "string" ? params.sessionKey.trim() : "";
   const entryId =
     action === "switch"
@@ -155,16 +154,6 @@ async function mutateSessionAtMessage(
       : typeof params.entryId === "string"
         ? params.entryId.trim()
         : "";
-  if (
-    rejectWebchatSessionMutation({
-      action,
-      client,
-      isWebchatConnect,
-      respond,
-    })
-  ) {
-    return;
-  }
   const cfg = context.getRuntimeConfig();
   const requestedAgent = resolveRequestedGlobalAgentId(
     cfg,

--- a/src/gateway/server-methods/sessions-shared.ts
+++ b/src/gateway/server-methods/sessions-shared.ts
@@ -1,6 +1,5 @@
 // Shared session-handler target resolution and mutation guards.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { GATEWAY_CLIENT_IDS } from "../../../packages/gateway-protocol/src/client-info.js";
 import {
   ErrorCodes,
   errorShape,
@@ -275,39 +274,6 @@ export function emitSessionOperation(
     connIds,
     { dropIfSlow: true },
   );
-}
-
-export function rejectWebchatSessionMutation(params: {
-  action:
-    | "patch"
-    | "delete"
-    | "compact"
-    | "branch"
-    | "restore"
-    | "rewind"
-    | "fork"
-    | "switch"
-    | "dispatch"
-    | "reclaim";
-  client: GatewayClient | null;
-  isWebchatConnect: (params: GatewayClient["connect"] | null | undefined) => boolean;
-  respond: RespondFn;
-}): boolean {
-  if (!params.client?.connect || !params.isWebchatConnect(params.client.connect)) {
-    return false;
-  }
-  if (params.client.connect.client.id === GATEWAY_CLIENT_IDS.CONTROL_UI) {
-    return false;
-  }
-  params.respond(
-    false,
-    undefined,
-    errorShape(
-      ErrorCodes.INVALID_REQUEST,
-      `webchat clients cannot ${params.action} sessions; use chat.send for session-scoped updates`,
-    ),
-  );
-  return true;
 }
 
 export function isWorkerDispatchInputError(error: unknown): boolean {

--- a/src/gateway/server.sessions.permissions-hooks.test.ts
+++ b/src/gateway/server.sessions.permissions-hooks.test.ts
@@ -32,9 +32,12 @@ import {
 const { createSessionStoreDir, openClient, getHarness } = setupGatewaySessionsTestHarness();
 type PermissionClient = NonNullable<Parameters<typeof connectWebchatClient>[0]["client"]>;
 
-async function openPermissionClient(client: Pick<PermissionClient, "id" | "mode">) {
+async function openPermissionClient(
+  client: Pick<PermissionClient, "id" | "mode"> & { scopes?: string[] },
+) {
   return await connectWebchatClient({
     port: getHarness().port,
+    scopes: client.scopes,
     client: {
       id: client.id,
       version: "1.0.0",
@@ -96,52 +99,89 @@ async function createPermissionCheckpointStore() {
   return { storePath };
 }
 
-test("webchat clients cannot mutate sessions", async () => {
+test("webchat session mutations follow operator scope policy", async () => {
   const { storePath } = await createPermissionCheckpointStore();
 
   const ws = await openPermissionClient({
     id: GATEWAY_CLIENT_IDS.WEBCHAT_UI,
     mode: GATEWAY_CLIENT_MODES.UI,
+    scopes: ["operator.read"],
   });
 
-  const patched = await rpcReq(ws, "sessions.patch", {
-    key: "agent:main:discord:group:dev",
-    label: "should-fail",
-  });
-  expect(patched.ok).toBe(false);
-  expect(patched.error?.message ?? "").toMatch(/webchat clients cannot patch sessions/i);
+  const deniedMutations = [
+    {
+      method: "sessions.patch",
+      params: { key: "agent:main:discord:group:dev", label: "should-fail" },
+      missingScope: "operator.write",
+    },
+    {
+      method: "sessions.delete",
+      params: { key: "agent:main:discord:group:dev" },
+      missingScope: "operator.admin",
+    },
+    {
+      method: "sessions.compact",
+      params: { key: "main", maxLines: 3 },
+      missingScope: "operator.admin",
+    },
+    {
+      method: "sessions.compaction.branch",
+      params: { key: "main", checkpointId: "checkpoint-1" },
+      missingScope: "operator.write",
+    },
+    {
+      method: "sessions.compaction.restore",
+      params: { key: "main", checkpointId: "checkpoint-1" },
+      missingScope: "operator.admin",
+    },
+    {
+      method: "sessions.branches.switch",
+      params: { sessionKey: "agent:main:main", leafEntryId: "entry-1" },
+      missingScope: "operator.admin",
+    },
+    {
+      method: "sessions.rewind",
+      params: { sessionKey: "agent:main:main", entryId: "entry-1" },
+      missingScope: "operator.admin",
+    },
+    {
+      method: "sessions.fork",
+      params: { sessionKey: "agent:main:main", entryId: "entry-1" },
+      missingScope: "operator.write",
+    },
+    {
+      method: "sessions.dispatch",
+      params: { key: "agent:main:main", profileId: "test" },
+      missingScope: "operator.admin",
+    },
+    {
+      method: "sessions.reclaim",
+      params: { key: "agent:main:main" },
+      missingScope: "operator.admin",
+    },
+    {
+      method: "sessions.pluginPatch",
+      params: {
+        key: "agent:main:main",
+        pluginId: "test-plugin",
+        namespace: "test",
+        value: true,
+      },
+      missingScope: "operator.admin",
+    },
+  ];
 
-  const deleted = await rpcReq(ws, "sessions.delete", {
-    key: "agent:main:discord:group:dev",
-  });
-  expect(deleted.ok).toBe(false);
-  expect(deleted.error?.message ?? "").toMatch(/webchat clients cannot delete sessions/i);
+  for (const mutation of deniedMutations) {
+    const result = await rpcReq(ws, mutation.method, mutation.params);
+    expect(result.ok, mutation.method).toBe(false);
+    expect(result.error?.message, mutation.method).toBe(`missing scope: ${mutation.missingScope}`);
+  }
 
-  const compacted = await rpcReq(ws, "sessions.compact", {
-    key: "main",
-    maxLines: 3,
-  });
-  expect(compacted.ok).toBe(false);
-  expect(compacted.error?.message ?? "").toMatch(/webchat clients cannot compact sessions/i);
-
-  const branched = await rpcReq(ws, "sessions.compaction.branch", {
-    key: "main",
-    checkpointId: "checkpoint-1",
-  });
-  expect(branched.ok).toBe(false);
-  expect(branched.error?.message ?? "").toMatch(/webchat clients cannot branch sessions/i);
   expect(
     listSessionEntries({ storePath })
       .map(({ sessionKey }) => sessionKey)
       .toSorted(),
   ).toEqual(["agent:main:discord:group:dev", "agent:main:main"]);
-
-  const restored = await rpcReq(ws, "sessions.compaction.restore", {
-    key: "main",
-    checkpointId: "checkpoint-1",
-  });
-  expect(restored.ok).toBe(false);
-  expect(restored.error?.message ?? "").toMatch(/webchat clients cannot restore sessions/i);
 
   ws.close();
 });
@@ -186,7 +226,7 @@ test("session:patch hook fires with correct context", async () => {
   ws.close();
 });
 
-test("session:patch hook does not fire for webchat clients", async () => {
+test("session:patch hook does not fire after scope rejection", async () => {
   const dir = makeTempDir(permHookTempDirs, "openclaw-sessions-webchat-hook-");
   const storePath = path.join(dir, "sessions.json");
   testState.sessionStorePath = storePath;
@@ -202,6 +242,7 @@ test("session:patch hook does not fire for webchat clients", async () => {
   const ws = await openPermissionClient({
     id: GATEWAY_CLIENT_IDS.WEBCHAT_UI,
     mode: GATEWAY_CLIENT_MODES.UI,
+    scopes: ["operator.read"],
   });
 
   const patched = await rpcReq(ws, "sessions.patch", {
@@ -327,11 +368,12 @@ test("session:patch hook mutations cannot change the response path", async () =>
   ws.close();
 });
 
-test("control-ui client can mutate sessions even in webchat mode", async () => {
+test("admin-scoped webchat client can mutate sessions", async () => {
   const { storePath } = await createPermissionCheckpointStore();
   const ws = await openPermissionClient({
-    id: GATEWAY_CLIENT_IDS.CONTROL_UI,
+    id: GATEWAY_CLIENT_IDS.WEBCHAT_UI,
     mode: GATEWAY_CLIENT_MODES.WEBCHAT,
+    scopes: ["operator.admin"],
   });
 
   const branched = await rpcReq<{

--- a/src/gateway/test-helpers.server.ts
+++ b/src/gateway/test-helpers.server.ts
@@ -1181,6 +1181,7 @@ export async function connectWebchatClient(params: {
   port: number;
   origin?: string;
   client?: NonNullable<Parameters<typeof connectReq>[1]>["client"];
+  scopes?: string[];
 }): Promise<WebSocket> {
   const origin = params.origin ?? `http://127.0.0.1:${params.port}`;
   const ws = new WebSocket(`ws://127.0.0.1:${params.port}`, {
@@ -1203,6 +1204,7 @@ export async function connectWebchatClient(params: {
     ws.once("error", onError);
   });
   await connectOk(ws, {
+    scopes: params.scopes,
     client:
       params.client ??
       ({


### PR DESCRIPTION
Closes #110930

## What Problem This Solves

Fixes an issue where custom WebChat clients with approved operator scopes could
not patch, delete, compact, branch, restore, rewind, fork, switch, dispatch, or
reclaim sessions. The blanket WebChat restriction made client identity act as a
second authorization layer and encouraged clients to impersonate Control UI.

## Why This Change Was Made

Session mutations now use the existing centralized method-scope policy,
including parameter-aware patch and delete checks. Client ID and mode no longer
grant or remove mutation authority. Connection admission, device pairing, scope
approval, and `gateway.controlUi.dangerouslyDisableDeviceAuth` are unchanged.

## User Impact

Approved third-party WebChat clients can manage sessions with their negotiated
operator scopes. Lower-scope clients receive the same structured missing-scope
errors as other Gateway clients.

## Evidence

- Blacksmith Testbox at `6e20935154a76cd43f433f42df1a7a19006125b6`:
  `server.sessions.permissions-hooks` plus `method-scopes`, 132/132 tests passed.
- Blacksmith Testbox `pnpm check:changed`: core and core-test typechecks, changed
  formatting, core lint, import-cycle checks, plugin boundaries, and security
  guards passed.
- The Gateway integration test verifies read-scoped WebChat rejection across
  every formerly identity-blocked mutation, unchanged session state after
  rejection, and successful persisted branch/delete mutations for an
  admin-scoped WebChat client.
