### PR TITLE
refactor(ui): render Ask OpenClaw chat through the shared chat presentation layer

### DIFF
--- a/ui/src/e2e/custodian-event-nudge.e2e.test.ts
+++ b/ui/src/e2e/custodian-event-nudge.e2e.test.ts
@@ -120,7 +120,7 @@ describeControlUiE2e("Control UI custodian event nudge mocked Gateway E2E", () =
         message: "what happened with telegram?",
         sessionId: "e2e-custodian",
       });
-      await page.getByText("what happened with telegram?", { exact: true }).waitFor();
+      await page.locator(".chat-group.user", { hasText: "what happened with telegram?" }).waitFor();
       expect(await nudge.count()).toBe(0);
 
       await gateway.emitGatewayEvent("health", {

--- a/ui/src/pages/custodian/custodian-page.test.ts
+++ b/ui/src/pages/custodian/custodian-page.test.ts
@@ -156,7 +156,7 @@ describe("custodian page", () => {
       .fn()
       .mockResolvedValueOnce({
         sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
-        reply: "Welcome aboard.",
+        reply: "Welcome **aboard**.",
         action: "none",
         question,
       })
@@ -170,12 +170,16 @@ describe("custodian page", () => {
 
     await waitForFast(() => expect(request).toHaveBeenCalledOnce());
     await page.updateComplete;
+    const assistantGroup = page.querySelector<HTMLElement>(".chat-group.assistant")!;
+    expect(assistantGroup.querySelector("strong")?.textContent).toBe("aboard");
+    expect(assistantGroup.querySelector(".chat-avatar.assistant")?.textContent?.trim()).toBe("OC");
     const card = page.querySelector("openclaw-option-card")!;
     await card.updateComplete;
     expect(page.querySelector(".option-card__choice--recommended")?.textContent).toContain(
       "Talk to my agent",
     );
-    page.querySelector<HTMLButtonElement>('[data-option-value="Connect WhatsApp"]')!.click();
+    const connectOption = page.querySelectorAll<HTMLButtonElement>("[data-option-value]")[1]!;
+    connectOption.click();
 
     await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
     await page.updateComplete;
@@ -186,10 +190,9 @@ describe("custodian page", () => {
       welcomeVariant: "onboarding",
       message: "connect whatsapp",
     });
-    expect(page.textContent).toContain("Connect WhatsApp");
-    expect(
-      page.querySelector<HTMLButtonElement>('[data-option-value="Connect WhatsApp"]')?.disabled,
-    ).toBe(true);
+    const userGroup = page.querySelector<HTMLElement>(".chat-group.user")!;
+    expect(userGroup.textContent).toContain("Connect WhatsApp");
+    expect(connectOption.disabled).toBe(true);
   });
 
   it("keeps failed sensitive replies masked for correction and retry", async () => {
@@ -207,17 +210,17 @@ describe("custodian page", () => {
     await waitForFast(() => expect(request).toHaveBeenCalledOnce());
     await page.updateComplete;
     const input = page.querySelector<HTMLInputElement>(
-      '.custodian__composer input[type="password"]',
+      '.agent-chat__composer-combobox input[type="password"]',
     )!;
     input.value = "test-token-placeholder";
     input.dispatchEvent(new InputEvent("input", { bubbles: true }));
     await page.updateComplete;
-    page.querySelector<HTMLButtonElement>(".custodian__composer button")!.click();
+    page.querySelector<HTMLButtonElement>(".chat-send-btn")!.click();
 
     await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
     await waitForFast(() => expect(page.querySelector('[role="alert"]')).not.toBeNull());
     await page.updateComplete;
-    expect(page.querySelector('.custodian__composer input[type="password"]')).not.toBeNull();
+    expect(input.isConnected).toBe(true);
     expect(page.textContent).toContain("Sensitive reply sent");
     expect(page.innerHTML).not.toContain("test-token-placeholder");
   });
@@ -437,7 +440,7 @@ describe("custodian page", () => {
     composer.value = "test-token-placeholder";
     composer.dispatchEvent(new InputEvent("input", { bubbles: true }));
     await page.updateComplete;
-    page.querySelector<HTMLButtonElement>(".custodian__composer button")!.click();
+    page.querySelector<HTMLButtonElement>(".chat-send-btn")!.click();
     await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
 
     setGatewayDeviceToken("test-token-placeholder");
@@ -471,7 +474,7 @@ describe("custodian page", () => {
     composer.value = "install everything";
     composer.dispatchEvent(new Event("input"));
     await page.updateComplete;
-    page.querySelector<HTMLButtonElement>(".custodian__composer button")!.click();
+    page.querySelector<HTMLButtonElement>(".chat-send-btn")!.click();
 
     await waitForFast(() =>
       expect(page.querySelector('[role="alert"]')?.textContent).toContain("gateway timeout"),
@@ -502,7 +505,7 @@ describe("custodian page", () => {
     composer.value = sensitiveValue;
     composer.dispatchEvent(new Event("input"));
     await page.updateComplete;
-    page.querySelector<HTMLButtonElement>(".custodian__composer button")!.click();
+    page.querySelector<HTMLButtonElement>(".chat-send-btn")!.click();
 
     await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
     expect(request.mock.calls[1]?.[1]).toMatchObject({ message: sensitiveValue });
@@ -569,16 +572,21 @@ describe("custodian page", () => {
     const { page } = await mountPage(context);
     await waitForFast(() => expect(request).toHaveBeenCalledOnce());
     await page.updateComplete;
-    const input = page.querySelector<HTMLTextAreaElement>(".custodian__composer textarea")!;
-    input.value = "Something else";
+    const input = page.querySelector<HTMLTextAreaElement>(
+      ".agent-chat__composer-combobox textarea",
+    )!;
+    input.value = "**Something** else";
     input.dispatchEvent(new InputEvent("input", { bubbles: true }));
     await page.updateComplete;
 
-    page.querySelector<HTMLButtonElement>(".custodian__composer button")!.click();
+    page.querySelector<HTMLButtonElement>(".chat-send-btn")!.click();
 
     await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
     await page.updateComplete;
-    expect(request.mock.calls[1]?.[1]).toMatchObject({ message: "Something else" });
+    expect(request.mock.calls[1]?.[1]).toMatchObject({ message: "**Something** else" });
+    // Parity with the regular chat: user turns run through the same markdown pipeline.
+    const sentGroup = page.querySelector<HTMLElement>(".chat-group.user")!;
+    expect(sentGroup.querySelector("strong")?.textContent).toBe("Something");
     expect(page.querySelector<HTMLButtonElement>('[data-option-value="Ask first"]')?.disabled).toBe(
       true,
     );
@@ -603,7 +611,7 @@ describe("custodian page", () => {
     composer.value = "status";
     composer.dispatchEvent(new Event("input"));
     await page.updateComplete;
-    page.querySelector<HTMLButtonElement>(".custodian__composer button")!.click();
+    page.querySelector<HTMLButtonElement>(".chat-send-btn")!.click();
     await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
     expect(request.mock.calls[1]?.[1]).not.toHaveProperty("welcomeVariant");
     expect(request.mock.calls[1]?.[1]).toMatchObject({ message: "status" });

--- a/ui/src/pages/custodian/custodian-page.ts
+++ b/ui/src/pages/custodian/custodian-page.ts
@@ -2,17 +2,22 @@ import { consume } from "@lit/context";
 import type { SystemAgentChatParams, SystemAgentChatResult } from "@openclaw/gateway-protocol";
 import { html, nothing, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
-import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
+import { icons } from "../../components/icons.ts";
 import "../../components/option-card.ts";
-import { toSanitizedMarkdownHtml } from "../../components/markdown.ts";
 import { t } from "../../i18n/index.ts";
+import type { MessageGroup } from "../../lib/chat/chat-types.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { searchForSession } from "../../lib/sessions/navigation.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
+import "../../styles/chat/grouped.css";
+import "../../styles/chat/layout.css";
+import "../../styles/chat/text.css";
 import "../../styles/custodian.css";
+import { renderChatAvatar } from "../chat/chat-avatar.ts";
+import { renderMessageGroup } from "../chat/components/chat-message.ts";
 import { classifyCustodianEventNudge, type CustodianEventNudge } from "./event-nudge.ts";
 import { parseCustodianQuestion, type CustodianStructuredQuestion } from "./structured-question.ts";
 
@@ -22,8 +27,21 @@ type CustodianMessage = {
   id: number;
   role: "assistant" | "user";
   text: string;
+  at: number;
   question: CustodianStructuredQuestion | null;
 };
+
+function toMessageGroup(message: CustodianMessage): MessageGroup {
+  const key = `msg-${message.id}`;
+  return {
+    kind: "group",
+    key,
+    role: message.role,
+    messages: [{ message: { role: message.role, content: message.text }, key }],
+    timestamp: message.at,
+    isStreaming: false,
+  };
+}
 
 function createSessionId(): string {
   if (typeof crypto.randomUUID === "function") {
@@ -193,6 +211,7 @@ export class CustodianPage extends OpenClawLightDomElement {
         id: this.nextMessageId++,
         role: "assistant",
         text: reply,
+        at: Date.now(),
         question,
       },
     ];
@@ -259,7 +278,13 @@ export class CustodianPage extends OpenClawLightDomElement {
     this.retireQuestions();
     this.messages = [
       ...this.messages,
-      { id: this.nextMessageId++, role: "user", text: displayText, question: null },
+      {
+        id: this.nextMessageId++,
+        role: "user",
+        text: displayText,
+        at: Date.now(),
+        question: null,
+      },
     ];
     this.input = "";
     void this.requestReply(client, {
@@ -399,16 +424,15 @@ export class CustodianPage extends OpenClawLightDomElement {
             const showQuestion =
               message.question !== null && !this.dismissedQuestions.has(questionKey);
             return html`
-              <article class=${`custodian__message custodian__message--${message.role}`}>
-                ${message.text
-                  ? html`<div class="custodian__message-text chat-text">
-                      ${message.role === "assistant"
-                        ? unsafeHTML(toSanitizedMarkdownHtml(message.text))
-                        : message.text}
-                    </div>`
-                  : nothing}
-                ${showQuestion
-                  ? html`<openclaw-option-card
+              ${renderMessageGroup(toMessageGroup(message), {
+                showReasoning: false,
+                showToolCalls: false,
+                assistantName: t("custodian.title"),
+                assistantAvatar: "OC",
+              })}
+              ${showQuestion
+                ? html`<div class="custodian__option-card">
+                    <openclaw-option-card
                       .props=${{
                         header: message.question!.header,
                         question: message.question!.question,
@@ -425,15 +449,18 @@ export class CustodianPage extends OpenClawLightDomElement {
                         onSelect: (label: string) => this.answerQuestion(message, label),
                         onSkip: () => this.dismissQuestion(message),
                       }}
-                    ></openclaw-option-card>`
-                  : nothing}
-              </article>
+                    ></openclaw-option-card>
+                  </div>`
+                : nothing}
             `;
           })}
           ${this.sending
-            ? html`<div class="custodian__thinking" role="status">
-                <span></span><span></span><span></span>
-                <span class="sr-only">${t("custodian.thinking")}</span>
+            ? html`<div class="chat-group assistant custodian__thinking-row" role="status">
+                ${renderChatAvatar("assistant", { name: t("custodian.title"), avatar: "OC" })}
+                <div class="chat-group-messages custodian__thinking">
+                  <span></span><span></span><span></span>
+                  <span class="sr-only">${t("custodian.thinking")}</span>
+                </div>
               </div>`
             : nothing}
           ${this.error
@@ -448,40 +475,51 @@ export class CustodianPage extends OpenClawLightDomElement {
             : nothing}
         </div>
 
-        <div class="custodian__composer">
-          ${this.sensitive
-            ? html`<input
-                type="password"
-                .value=${this.input}
-                autocomplete="off"
-                placeholder=${t("custodian.sensitivePlaceholder")}
-                aria-label=${t("custodian.sensitivePlaceholder")}
-                ?disabled=${!this.activeClient || !this.chatAvailable || this.sending}
-                @input=${(event: Event) => (this.input = (event.target as HTMLInputElement).value)}
-                @keydown=${(event: KeyboardEvent) => this.handleComposerKeydown(event)}
-              />`
-            : html`<textarea
-                rows="1"
-                .value=${this.input}
-                autocomplete="on"
-                placeholder=${t("custodian.placeholder")}
-                aria-label=${t("custodian.placeholder")}
-                ?disabled=${!this.activeClient || !this.chatAvailable || this.sending}
-                @input=${(event: Event) =>
-                  (this.input = (event.target as HTMLTextAreaElement).value)}
-                @keydown=${(event: KeyboardEvent) => this.handleComposerKeydown(event)}
-              ></textarea>`}
-          <button
-            class="btn primary"
-            type="button"
-            ?disabled=${!this.input.trim() ||
-            !this.activeClient ||
-            !this.chatAvailable ||
-            this.sending}
-            @click=${() => this.send()}
-          >
-            ${t("custodian.send")}
-          </button>
+        <div class="agent-chat__composer-shell">
+          <div class="agent-chat__input">
+            <div class="agent-chat__composer-input-row">
+              <div class="agent-chat__composer-combobox">
+                ${this.sensitive
+                  ? html`<input
+                      type="password"
+                      .value=${this.input}
+                      autocomplete="off"
+                      placeholder=${t("custodian.sensitivePlaceholder")}
+                      aria-label=${t("custodian.sensitivePlaceholder")}
+                      ?disabled=${!this.activeClient || !this.chatAvailable || this.sending}
+                      @input=${(event: Event) =>
+                        (this.input = (event.target as HTMLInputElement).value)}
+                      @keydown=${(event: KeyboardEvent) => this.handleComposerKeydown(event)}
+                    />`
+                  : html`<textarea
+                      rows="1"
+                      .value=${this.input}
+                      autocomplete="on"
+                      placeholder=${t("custodian.placeholder")}
+                      aria-label=${t("custodian.placeholder")}
+                      ?disabled=${!this.activeClient || !this.chatAvailable || this.sending}
+                      @input=${(event: Event) =>
+                        (this.input = (event.target as HTMLTextAreaElement).value)}
+                      @keydown=${(event: KeyboardEvent) => this.handleComposerKeydown(event)}
+                    ></textarea>`}
+              </div>
+              <div class="agent-chat__composer-actions">
+                <button
+                  class="chat-send-btn"
+                  type="button"
+                  aria-label=${t("custodian.send")}
+                  ?disabled=${!this.input.trim() ||
+                  !this.activeClient ||
+                  !this.chatAvailable ||
+                  this.sending}
+                  @click=${() => this.send()}
+                >
+                  ${icons.arrowUp}
+                  <span class="agent-chat__control-label">${t("custodian.send")}</span>
+                </button>
+              </div>
+            </div>
+          </div>
         </div>
       </section>
     `;

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1592,7 +1592,7 @@ openclaw-chat-page {
   border: 0;
 }
 
-.agent-chat__composer-combobox > textarea {
+.agent-chat__composer-combobox > :is(textarea, input) {
   width: 100%;
   min-height: 36px;
   max-height: calc(7em + 24px);
@@ -1609,16 +1609,16 @@ openclaw-chat-page {
   box-sizing: border-box;
 }
 
-.agent-chat__composer-combobox > textarea:focus-visible {
+.agent-chat__composer-combobox > :is(textarea, input):focus-visible {
   box-shadow: none;
 }
 
-.agent-chat__composer-combobox > textarea::placeholder {
+.agent-chat__composer-combobox > :is(textarea, input)::placeholder {
   color: var(--muted);
 }
 
 @media (hover: none) and (pointer: coarse) {
-  .agent-chat__composer-combobox > textarea {
+  .agent-chat__composer-combobox > :is(textarea, input) {
     font-size: var(--control-ui-input-text-size);
   }
 }
@@ -2406,7 +2406,7 @@ openclaw-chat-page {
 }
 
 @media (min-width: 1600px) {
-  .agent-chat__composer-combobox > textarea {
+  .agent-chat__composer-combobox > :is(textarea, input) {
     max-height: calc(7em + 12px);
   }
 
@@ -2447,7 +2447,7 @@ openclaw-chat-page {
     align-self: stretch;
   }
 
-  .agent-chat__composer-combobox > textarea {
+  .agent-chat__composer-combobox > :is(textarea, input) {
     flex: 1 1 auto;
     min-height: 44px;
     max-height: calc(7em + var(--chat-box-inset) + var(--chat-box-inset));
@@ -2563,7 +2563,7 @@ openclaw-chat-page {
     background: var(--card);
   }
 
-  .agent-chat__composer-combobox > textarea {
+  .agent-chat__composer-combobox > :is(textarea, input) {
     min-height: 48px;
     max-height: 56px;
     overflow-y: auto;
@@ -3899,7 +3899,7 @@ openclaw-chat-page {
     gap: 6px;
   }
 
-  .agent-chat__composer-shell:has(.agent-chat__composer-combobox > textarea:focus) {
+  .agent-chat__composer-shell:has(.agent-chat__composer-combobox > :is(textarea, input):focus) {
     margin-bottom: 0;
   }
 
@@ -3919,7 +3919,7 @@ openclaw-chat-page {
     margin-bottom: calc(14px + max(var(--safe-area-bottom), 34px));
   }
 
-  .agent-chat__composer-shell:has(.agent-chat__composer-combobox > textarea:focus) {
+  .agent-chat__composer-shell:has(.agent-chat__composer-combobox > :is(textarea, input):focus) {
     margin-bottom: 0;
   }
 }

--- a/ui/src/styles/custodian.css
+++ b/ui/src/styles/custodian.css
@@ -58,13 +58,8 @@
   display: flex;
   min-height: 0;
   flex-direction: column;
-  gap: 16px;
   overflow-y: auto;
   padding: 24px 2px;
-}
-
-.custodian__message {
-  width: min(680px, 90%);
 }
 
 .custodian__nudge {
@@ -121,39 +116,19 @@
   color: var(--text-strong);
 }
 
-.custodian__message--assistant {
-  align-self: flex-start;
-}
-
-.custodian__message--user {
-  align-self: flex-end;
-  padding: 10px 14px;
-  border-radius: 16px 16px 4px 16px;
-  background: var(--accent);
-  color: var(--primary-foreground);
-}
-
-.custodian__message-text > :first-child {
-  margin-top: 0;
-}
-
-.custodian__message-text > :last-child {
-  margin-bottom: 0;
-}
-
-.custodian__message openclaw-option-card {
-  display: block;
-  margin-top: 14px;
+.custodian__option-card {
+  /* Left offset = avatar column (36px) + group gap (10px) so cards align with
+     the message text column, not the avatar gutter. */
+  margin: -12px 16px 14px 46px;
 }
 
 .custodian__thinking {
   display: flex;
+  flex-direction: row;
   align-items: center;
   gap: 5px;
   width: fit-content;
-  padding: 10px 12px;
-  border-radius: var(--radius-full);
-  background: var(--bg-elevated);
+  padding: 10px 0;
 }
 
 .custodian__thinking > span:not(.sr-only) {
@@ -184,31 +159,6 @@
   color: var(--danger);
 }
 
-.custodian__composer {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 10px;
-  padding-top: 14px;
-  border-top: 1px solid var(--border-subtle);
-}
-
-.custodian__composer :is(input, textarea) {
-  min-height: 44px;
-  max-height: 140px;
-  resize: vertical;
-  padding: 11px 13px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  background: var(--bg-elevated);
-  color: var(--text);
-  font: inherit;
-}
-
-.custodian__composer :is(input, textarea):focus-visible {
-  outline: none;
-  box-shadow: var(--focus-ring);
-}
-
 @keyframes custodian-thinking {
   to {
     opacity: 0.35;
@@ -228,9 +178,11 @@
   .custodian__identity p {
     display: none;
   }
+}
 
-  .custodian__message {
-    width: 96%;
+@media (max-width: 400px) {
+  .custodian__option-card {
+    margin-left: 0;
   }
 }
 


### PR DESCRIPTION
Related: #110896

## What Problem This Solves

The Ask OpenClaw page (Setup chat / custodian, Settings → Ask OpenClaw and the first-run onboarding surface) hand-rolled its own message bubbles, markdown rendering, thinking indicator, and composer. It looked visibly worse than the regular chat — no avatars, no sender/timestamp affordances, a bare textarea + "Send" button — and duplicated presentation code the chat page already owns.

## Why This Change Was Made

Part 1 of #110896. The custodian now renders through the regular chat's presentation layer:

- Messages render via the shared `renderMessageGroup` (`ui/src/pages/chat/components/chat-message.ts`) with tool calls and reasoning display disabled — bringing avatars ("OC" text avatar), the shared markdown pipeline with code-block copy chrome, hover sender/timestamp footers, and copy-as-markdown for free.
- The composer reuses the chat composer's shell classes (`.agent-chat__composer-shell` / `__composer-combobox`) so the input and round send button are visually identical to the regular chat; the custodian keeps its minimal behavior (Enter-to-send, sensitive password mode, no attachments/model/talk controls).
- User turns now run through the same markdown pipeline as the regular chat (parity was the point of the change; previously they were interpolated as plain text).
- The bespoke bubble/composer CSS in `ui/src/styles/custodian.css` is deleted; `ui/src/styles/chat/layout.css` composer selectors were widened from `> textarea` to `> :is(textarea, input)` (the chat combobox's only direct child is a textarea, so regular chat is unaffected).
- Custodian-owned behavior is unchanged: connection-scoped sessions, idempotent-retry rules, sensitive masking, structured option cards, event nudges, open-agent/exit routing.

Net diff: −2 lines with behavior parity gained.

## User Impact

The Setup/Ask OpenClaw chat looks and feels like the regular chat (same bubbles, avatars, markdown, composer), minus features that don't apply there. No protocol or backend changes; macOS/Android/TUI surfaces unaffected.

| Before | After |
| --- | --- |
| ![thread before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/custodian-shared-chat/thread-before.png) | ![thread after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/custodian-shared-chat/thread-after.png) |
| ![nudge before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/custodian-shared-chat/nudge-before.png) | ![nudge after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/custodian-shared-chat/nudge-after.png) |

## Evidence

- `fnm exec --using v24.15.0 -- node scripts/run-vitest.mjs ui/src/pages/custodian` — 3 files, 36 tests passed (includes new assertions: assistant markdown through the shared pipeline, user-turn markdown parity, OC avatar).
- `ui/src/components/settings-sidebar.test.ts` — 6 tests passed.
- Mocked-gateway Playwright e2e `ui/src/e2e/custodian-event-nudge.e2e.test.ts` passed locally with `OPENCLAW_CAPTURE_UI_PROOF=1`; screenshots below are from that run.
- Autoreview (codex/gpt-5.6-sol, xhigh): clean, no accepted/actionable findings.
