### PR TITLE
fix(test): voice-call closed-loop tests no longer wait indefinitely

### DIFF
--- a/scripts/lib/managed-child-process.d.mts
+++ b/scripts/lib/managed-child-process.d.mts
@@ -1,3 +1,5 @@
+export const MANAGED_COMMAND_TIMEOUT_CODE: "OPENCLAW_MANAGED_COMMAND_TIMEOUT";
+
 /**
  * Return conventional shell exit code for a signal.
  *
@@ -35,6 +37,7 @@ export function terminateManagedChild(
  *   platform?: NodeJS.Platform;
  *   comSpec?: string;
  *   onReady?: (child: import("node:child_process").ChildProcess) => void;
+ *   timeoutMs?: number;
  * }} options
  * @returns {Promise<number>}
  */
@@ -49,6 +52,7 @@ export function runManagedCommand({
   windowsVerbatimArguments,
   comSpec,
   onReady,
+  timeoutMs,
 }: {
   bin: string;
   args?: string[];
@@ -60,6 +64,7 @@ export function runManagedCommand({
   platform?: NodeJS.Platform;
   comSpec?: string;
   onReady?: (child: import("node:child_process").ChildProcess) => void;
+  timeoutMs?: number;
 }): Promise<number>;
 /**
  * @param {{

--- a/scripts/lib/managed-child-process.mjs
+++ b/scripts/lib/managed-child-process.mjs
@@ -6,6 +6,7 @@ import { resolveWindowsTaskkillPath } from "./windows-taskkill.mjs";
 
 const FORWARDED_SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP"];
 const FORCE_KILL_DELAY_MS = 5_000;
+const MAX_MANAGED_COMMAND_TIMEOUT_MS = 2_147_000_000;
 export const MANAGED_COMMAND_TIMEOUT_CODE = "OPENCLAW_MANAGED_COMMAND_TIMEOUT";
 const managedChildren = new Set();
 const signalHandlers = new Map();
@@ -103,8 +104,15 @@ export async function runManagedCommand({
   onReady,
   timeoutMs,
 }) {
-  if (timeoutMs !== undefined && (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0)) {
-    throw new TypeError("managed command timeoutMs must be a positive integer");
+  if (
+    timeoutMs !== undefined &&
+    (!Number.isSafeInteger(timeoutMs) ||
+      timeoutMs <= 0 ||
+      timeoutMs > MAX_MANAGED_COMMAND_TIMEOUT_MS)
+  ) {
+    throw new TypeError(
+      `managed command timeoutMs must be a positive integer no greater than ${MAX_MANAGED_COMMAND_TIMEOUT_MS}`,
+    );
   }
   const spawnSpec = createManagedCommandSpawnSpec({
     bin,

--- a/scripts/lib/managed-child-process.mjs
+++ b/scripts/lib/managed-child-process.mjs
@@ -6,6 +6,7 @@ import { resolveWindowsTaskkillPath } from "./windows-taskkill.mjs";
 
 const FORWARDED_SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP"];
 const FORCE_KILL_DELAY_MS = 5_000;
+export const MANAGED_COMMAND_TIMEOUT_CODE = "OPENCLAW_MANAGED_COMMAND_TIMEOUT";
 const managedChildren = new Set();
 const signalHandlers = new Map();
 
@@ -85,6 +86,7 @@ export function terminateManagedChild(
  *   platform?: NodeJS.Platform;
  *   comSpec?: string;
  *   onReady?: (child: import("node:child_process").ChildProcess) => void;
+ *   timeoutMs?: number;
  * }} options
  * @returns {Promise<number>}
  */
@@ -99,7 +101,11 @@ export async function runManagedCommand({
   windowsVerbatimArguments,
   comSpec,
   onReady,
+  timeoutMs,
 }) {
+  if (timeoutMs !== undefined && (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0)) {
+    throw new TypeError("managed command timeoutMs must be a positive integer");
+  }
   const spawnSpec = createManagedCommandSpawnSpec({
     bin,
     args,
@@ -116,19 +122,40 @@ export async function runManagedCommand({
     child,
     forceKillTimer: null,
     receivedSignal: null,
+    timedOut: false,
   };
   addManagedChild(managedChild);
   onReady?.(child);
+  const timeoutTimer =
+    timeoutMs === undefined
+      ? null
+      : setTimeout(() => {
+          managedChild.timedOut = true;
+          terminateManagedChild(child, "SIGTERM", { platform });
+          managedChild.forceKillTimer ??= setTimeout(() => {
+            terminateManagedChild(child, "SIGKILL", { platform });
+          }, FORCE_KILL_DELAY_MS);
+        }, timeoutMs);
 
   try {
     return await new Promise((resolve, reject) => {
       child.once("error", reject);
       child.once("close", (status, signal) => {
+        if (timeoutTimer) {
+          clearTimeout(timeoutTimer);
+        }
         if (managedChild.forceKillTimer) {
           clearTimeout(managedChild.forceKillTimer);
         }
-        if (managedChild.receivedSignal) {
-          terminateManagedChild(child, "SIGKILL");
+        if (managedChild.receivedSignal || managedChild.timedOut) {
+          terminateManagedChild(child, "SIGKILL", { platform });
+        }
+        if (managedChild.timedOut) {
+          const error = new Error(`managed command timed out after ${timeoutMs}ms`);
+          error.code = MANAGED_COMMAND_TIMEOUT_CODE;
+          error.timeoutMs = timeoutMs;
+          reject(error);
+          return;
         }
         resolve(
           managedChild.receivedSignal
@@ -140,6 +167,12 @@ export async function runManagedCommand({
       });
     });
   } finally {
+    if (timeoutTimer) {
+      clearTimeout(timeoutTimer);
+    }
+    if (managedChild.forceKillTimer) {
+      clearTimeout(managedChild.forceKillTimer);
+    }
     removeManagedChild(managedChild);
   }
 }
@@ -151,6 +184,7 @@ export async function runManagedCommand({
  *   child: import("node:child_process").ChildProcess;
  *   forceKillTimer: ReturnType<typeof setTimeout> | null;
  *   receivedSignal: string | null;
+ *   timedOut: boolean;
  * }} managedChild
  */
 function addManagedChild(managedChild) {
@@ -165,6 +199,7 @@ function addManagedChild(managedChild) {
  *   child: import("node:child_process").ChildProcess;
  *   forceKillTimer: ReturnType<typeof setTimeout> | null;
  *   receivedSignal: string | null;
+ *   timedOut: boolean;
  * }} managedChild
  */
 function removeManagedChild(managedChild) {

--- a/scripts/test-voicecall-closedloop.mjs
+++ b/scripts/test-voicecall-closedloop.mjs
@@ -1,26 +1,33 @@
 #!/usr/bin/env node
 
 // Runs the closed-loop voice-call test slice through the repo Vitest wrapper.
-import { execFileSync } from "node:child_process";
 import { bundledPluginFile } from "./lib/bundled-plugin-paths.mjs";
+import { MANAGED_COMMAND_TIMEOUT_CODE, runManagedCommand } from "./lib/managed-child-process.mjs";
 
 const testFiles = [
-  bundledPluginFile("voice-call", "src/manager.test.ts"),
+  bundledPluginFile("voice-call", "src/manager.closed-loop.test.ts"),
   bundledPluginFile("voice-call", "src/media-stream.test.ts"),
-  "src/plugins/voice-call.plugin.test.ts",
+  bundledPluginFile("voice-call", "index.test.ts"),
 ];
 const args = ["run", "--config", "vitest.config.ts", ...testFiles, "--maxWorkers=1"];
 // The nested runner resets its watchdog on output, so this slice also needs a wall-clock limit.
 const totalDeadlineMs = 10 * 60 * 1000;
 
 try {
-  execFileSync(process.execPath, ["scripts/run-vitest.mjs", ...args], {
-    killSignal: "SIGTERM",
+  process.exitCode = await runManagedCommand({
+    args: ["scripts/run-vitest.mjs", ...args],
+    bin: process.execPath,
+    shell: false,
     stdio: "inherit",
-    timeout: totalDeadlineMs,
+    timeoutMs: totalDeadlineMs,
   });
 } catch (error) {
-  if (!error || typeof error !== "object" || !("code" in error) || error.code !== "ETIMEDOUT") {
+  if (
+    !error ||
+    typeof error !== "object" ||
+    !("code" in error) ||
+    error.code !== MANAGED_COMMAND_TIMEOUT_CODE
+  ) {
     throw error;
   }
   throw new Error(

--- a/scripts/test-voicecall-closedloop.mjs
+++ b/scripts/test-voicecall-closedloop.mjs
@@ -4,16 +4,31 @@
 import { execFileSync } from "node:child_process";
 import { bundledPluginFile } from "./lib/bundled-plugin-paths.mjs";
 
-const args = [
-  "run",
-  "--config",
-  "vitest.config.ts",
+const testFiles = [
   bundledPluginFile("voice-call", "src/manager.test.ts"),
   bundledPluginFile("voice-call", "src/media-stream.test.ts"),
   "src/plugins/voice-call.plugin.test.ts",
-  "--maxWorkers=1",
 ];
+const args = ["run", "--config", "vitest.config.ts", ...testFiles, "--maxWorkers=1"];
+// The nested runner resets its watchdog on output, so this slice also needs a wall-clock limit.
+const totalDeadlineMs = 10 * 60 * 1000;
 
-execFileSync(process.execPath, ["scripts/run-vitest.mjs", ...args], {
-  stdio: "inherit",
-});
+try {
+  execFileSync(process.execPath, ["scripts/run-vitest.mjs", ...args], {
+    killSignal: "SIGTERM",
+    stdio: "inherit",
+    timeout: totalDeadlineMs,
+  });
+} catch (error) {
+  if (!error || typeof error !== "object" || !("code" in error) || error.code !== "ETIMEDOUT") {
+    throw error;
+  }
+  throw new Error(
+    [
+      `closed-loop voice-call test slice timed out after ${totalDeadlineMs}ms`,
+      "Target test files:",
+      ...testFiles.map((file) => `  - ${file}`),
+    ].join("\n"),
+    { cause: error },
+  );
+}

--- a/test/scripts/managed-child-process.test.ts
+++ b/test/scripts/managed-child-process.test.ts
@@ -7,6 +7,7 @@ import { pathToFileURL } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import {
   createManagedCommandSpawnSpec,
+  MANAGED_COMMAND_TIMEOUT_CODE,
   runManagedCommand,
   signalExitCode,
   terminateManagedChild,
@@ -304,6 +305,65 @@ import { runManagedCommand } from ${JSON.stringify(helperUrl)};
       }
     },
   );
+
+  posixIt("force-cleans descendants when a managed command deadline expires", async () => {
+    const dir = createTempDir("openclaw-managed-timeout-");
+    const childPath = path.join(dir, "child.mjs");
+    const childPidPath = path.join(dir, "child.pid");
+    const descendantPidPath = path.join(dir, "descendant.pid");
+
+    fs.writeFileSync(
+      childPath,
+      `
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+
+const descendant = spawn(process.execPath, [
+  "-e",
+  "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);",
+], { stdio: "ignore" });
+fs.writeFileSync(process.argv[2], String(process.pid));
+fs.writeFileSync(process.argv[3], String(descendant.pid));
+process.on("SIGTERM", () => process.exit(0));
+setInterval(() => {}, 1_000);
+`,
+      "utf8",
+    );
+
+    let childPid = 0;
+    let descendantPid = 0;
+    const command = runManagedCommand({
+      args: [childPath, childPidPath, descendantPidPath],
+      bin: process.execPath,
+      onReady: (child) => {
+        childPid = expectProcessPid(child.pid);
+      },
+      shell: false,
+      stdio: "ignore",
+      timeoutMs: 500,
+    });
+
+    try {
+      await waitFor(() => fs.existsSync(descendantPidPath));
+      descendantPid = Number(fs.readFileSync(descendantPidPath, "utf8"));
+      expect(isProcessAlive(childPid)).toBe(true);
+      expect(isProcessAlive(descendantPid)).toBe(true);
+
+      await expect(command).rejects.toMatchObject({
+        code: MANAGED_COMMAND_TIMEOUT_CODE,
+        timeoutMs: 500,
+      });
+      await waitFor(() => !isProcessAlive(childPid), 1_500);
+      await waitFor(() => !isProcessAlive(descendantPid), 1_500);
+    } finally {
+      if (childPid && isProcessAlive(childPid)) {
+        process.kill(childPid, "SIGKILL");
+      }
+      if (descendantPid && isProcessAlive(descendantPid)) {
+        process.kill(descendantPid, "SIGKILL");
+      }
+    }
+  });
 });
 
 async function waitFor(condition: () => boolean, timeoutMs = 3_000) {
@@ -325,8 +385,18 @@ async function waitForClose(child: ReturnType<typeof spawn>) {
 function isProcessAlive(pid: number) {
   try {
     process.kill(pid, 0);
-    return true;
   } catch {
     return false;
   }
+  if (process.platform === "linux") {
+    try {
+      const state = fs.readFileSync(`/proc/${pid}/stat`, "utf8").split(") ")[1]?.[0];
+      if (state === "Z") {
+        return false;
+      }
+    } catch {
+      return false;
+    }
+  }
+  return true;
 }

--- a/test/scripts/managed-child-process.test.ts
+++ b/test/scripts/managed-child-process.test.ts
@@ -222,6 +222,20 @@ describe("managed-child-process", () => {
     }
   });
 
+  it("rejects deadlines above the Node-safe timer bound", async () => {
+    await expect(
+      runManagedCommand({
+        args: ["-e", "setInterval(() => {}, 1_000)"],
+        bin: process.execPath,
+        shell: false,
+        stdio: "ignore",
+        timeoutMs: 2_147_000_001,
+      }),
+    ).rejects.toThrow(
+      "managed command timeoutMs must be a positive integer no greater than 2147000000",
+    );
+  });
+
   posixIt(
     "kills managed child process group descendants when the runner is terminated",
     async () => {

--- a/test/scripts/test-voicecall-closedloop.test.ts
+++ b/test/scripts/test-voicecall-closedloop.test.ts
@@ -1,4 +1,6 @@
 import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const MANAGED_COMMAND_TIMEOUT_CODE = "OPENCLAW_MANAGED_COMMAND_TIMEOUT";
@@ -7,6 +9,7 @@ const expectedTestFiles = [
   "extensions/voice-call/src/media-stream.test.ts",
   "extensions/voice-call/index.test.ts",
 ];
+const scriptUrl = pathToFileURL(path.resolve("scripts/test-voicecall-closedloop.mjs")).href;
 const { execFileSyncMock, runManagedCommandMock } = vi.hoisted(() => ({
   execFileSyncMock: vi.fn(),
   runManagedCommandMock: vi.fn(),
@@ -43,7 +46,7 @@ describe("test-voicecall-closedloop", () => {
   });
 
   it("runs the current three-file slice through the managed total deadline", async () => {
-    await import("../../scripts/test-voicecall-closedloop.mjs");
+    await import(scriptUrl);
 
     expect(execFileSyncMock).not.toHaveBeenCalled();
     expect(runManagedCommandMock).toHaveBeenCalledOnce();
@@ -73,7 +76,7 @@ describe("test-voicecall-closedloop", () => {
       }),
     );
 
-    const error = await import("../../scripts/test-voicecall-closedloop.mjs").then(
+    const error = await import(scriptUrl).then(
       () => undefined,
       (cause: unknown) => cause,
     );

--- a/test/scripts/test-voicecall-closedloop.test.ts
+++ b/test/scripts/test-voicecall-closedloop.test.ts
@@ -1,8 +1,15 @@
-import type { ExecFileSyncOptions } from "node:child_process";
+import fs from "node:fs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { execFileSyncMock } = vi.hoisted(() => ({
+const MANAGED_COMMAND_TIMEOUT_CODE = "OPENCLAW_MANAGED_COMMAND_TIMEOUT";
+const expectedTestFiles = [
+  "extensions/voice-call/src/manager.closed-loop.test.ts",
+  "extensions/voice-call/src/media-stream.test.ts",
+  "extensions/voice-call/index.test.ts",
+];
+const { execFileSyncMock, runManagedCommandMock } = vi.hoisted(() => ({
   execFileSyncMock: vi.fn(),
+  runManagedCommandMock: vi.fn(),
 }));
 
 vi.mock("node:child_process", async () => {
@@ -13,21 +20,57 @@ vi.mock("node:child_process", async () => {
   };
 });
 
+vi.mock("../../scripts/lib/managed-child-process.mjs", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../scripts/lib/managed-child-process.mjs")
+  >("../../scripts/lib/managed-child-process.mjs");
+  return {
+    ...actual,
+    MANAGED_COMMAND_TIMEOUT_CODE,
+    runManagedCommand: runManagedCommandMock,
+  };
+});
+
 describe("test-voicecall-closedloop", () => {
   beforeEach(() => {
     vi.resetModules();
     execFileSyncMock.mockReset();
+    execFileSyncMock.mockImplementation(() => {
+      throw new Error("legacy execFileSync path was used");
+    });
+    runManagedCommandMock.mockReset();
+    runManagedCommandMock.mockResolvedValue(0);
   });
 
-  it("enforces a total deadline and reports all target test files", async () => {
-    const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
-    execFileSyncMock.mockImplementation(
-      (_command: string, _args: readonly string[], options: ExecFileSyncOptions) =>
-        actual.execFileSync(process.execPath, ["--eval", "setInterval(() => {}, 1_000)"], {
-          ...options,
-          stdio: "ignore",
-          timeout: 50,
-        }),
+  it("runs the current three-file slice through the managed total deadline", async () => {
+    await import("../../scripts/test-voicecall-closedloop.mjs");
+
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+    expect(runManagedCommandMock).toHaveBeenCalledOnce();
+    expect(runManagedCommandMock).toHaveBeenCalledWith({
+      args: [
+        "scripts/run-vitest.mjs",
+        "run",
+        "--config",
+        "vitest.config.ts",
+        ...expectedTestFiles,
+        "--maxWorkers=1",
+      ],
+      bin: process.execPath,
+      shell: false,
+      stdio: "inherit",
+      timeoutMs: 10 * 60 * 1000,
+    });
+    for (const file of expectedTestFiles) {
+      expect(fs.existsSync(file), file).toBe(true);
+    }
+  });
+
+  it("reports every selected file when the total deadline expires", async () => {
+    runManagedCommandMock.mockRejectedValue(
+      Object.assign(new Error("managed command timed out"), {
+        code: MANAGED_COMMAND_TIMEOUT_CODE,
+      }),
     );
 
     const error = await import("../../scripts/test-voicecall-closedloop.mjs").then(
@@ -35,15 +78,10 @@ describe("test-voicecall-closedloop", () => {
       (cause: unknown) => cause,
     );
 
-    expect(execFileSyncMock).toHaveBeenCalledOnce();
-    expect(execFileSyncMock.mock.calls[0]?.[2]).toMatchObject({
-      killSignal: "SIGTERM",
-      timeout: 10 * 60 * 1000,
-    });
     expect(error).toBeInstanceOf(Error);
     expect((error as Error).message).toContain("closed-loop voice-call test slice timed out");
-    expect((error as Error).message).toContain("extensions/voice-call/src/manager.test.ts");
-    expect((error as Error).message).toContain("extensions/voice-call/src/media-stream.test.ts");
-    expect((error as Error).message).toContain("src/plugins/voice-call.plugin.test.ts");
+    for (const file of expectedTestFiles) {
+      expect((error as Error).message).toContain(file);
+    }
   });
 });

--- a/test/scripts/test-voicecall-closedloop.test.ts
+++ b/test/scripts/test-voicecall-closedloop.test.ts
@@ -1,0 +1,49 @@
+import type { ExecFileSyncOptions } from "node:child_process";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { execFileSyncMock } = vi.hoisted(() => ({
+  execFileSyncMock: vi.fn(),
+}));
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    execFileSync: execFileSyncMock,
+  };
+});
+
+describe("test-voicecall-closedloop", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    execFileSyncMock.mockReset();
+  });
+
+  it("enforces a total deadline and reports all target test files", async () => {
+    const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+    execFileSyncMock.mockImplementation(
+      (_command: string, _args: readonly string[], options: ExecFileSyncOptions) =>
+        actual.execFileSync(process.execPath, ["--eval", "setInterval(() => {}, 1_000)"], {
+          ...options,
+          stdio: "ignore",
+          timeout: 50,
+        }),
+    );
+
+    const error = await import("../../scripts/test-voicecall-closedloop.mjs").then(
+      () => undefined,
+      (cause: unknown) => cause,
+    );
+
+    expect(execFileSyncMock).toHaveBeenCalledOnce();
+    expect(execFileSyncMock.mock.calls[0]?.[2]).toMatchObject({
+      killSignal: "SIGTERM",
+      timeout: 10 * 60 * 1000,
+    });
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("closed-loop voice-call test slice timed out");
+    expect((error as Error).message).toContain("extensions/voice-call/src/manager.test.ts");
+    expect((error as Error).message).toContain("extensions/voice-call/src/media-stream.test.ts");
+    expect((error as Error).message).toContain("src/plugins/voice-call.plugin.test.ts");
+  });
+});


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where developers running `pnpm test:voicecall:closedloop` could wait indefinitely when the nested Vitest runner remained alive while continuing to produce output. The shared no-output watchdog does not cover that active-but-stuck condition.

## Why This Change Was Made

The dedicated voice-call wrapper now runs the three current closed-loop test files through the shared cross-platform managed-child owner with a 10-minute wall-clock deadline. On timeout it first requests graceful termination, then force-cleans the owned process tree if needed, and reports every selected test file.

## User Impact

The dedicated command now either completes normally or stops after 10 minutes with an actionable list of the three affected test files instead of waiting forever. Its slice also points at the current manager, media-stream, and extension test files. Other Vitest entry points and product runtime behavior are unaffected.

## Evidence

- Before the fix, the dedicated command could wait indefinitely when its nested runner stayed alive and kept producing output, so the shared no-output watchdog never fired.
- The focused managed-process and wrapper regressions pass 13/13 tests, covering the 600000ms deadline, rejection above Node's safe timer bound, graceful and forced process-tree cleanup, timeout diagnostics, and all three selected files.
- The actual dedicated slice passes 73/73 tests across the manager closed-loop, media-stream, and extension test files.
- The repository script-declaration gate reports all 234 runtime/declaration contracts match, including the new managed timeout constant and option.
- A bounded near-real CLI run used the committed wrapper with an output-producing persistent runner and a descendant that resisted graceful termination. It exited after 600139ms with the expected timeout, named all three selected files, and left the descendant stopped.
- The protected test-root typecheck is left to CI because the local validation environment could not attest the required cgroup resource envelope.
- Gateway startup is not applicable because the affected surface is the repository test CLI and its child-process lifetime.
