### PR TITLE
fix(android): move device identity key into encrypted storage

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeApp.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeApp.kt
@@ -116,7 +116,7 @@ class NodeApp : Application() {
       database.close()
     }
     prefs.clearGatewayCredentials(gatewayId)
-    val deviceId = DeviceIdentityStore(this).loadOrCreate().deviceId
+    val deviceId = DeviceIdentityStore.withPrefs(this, prefs).loadOrCreate().deviceId
     val deviceAuthStore = DeviceAuthStore(prefs)
     deviceAuthStore.clearToken(gatewayId, deviceId, "node")
     deviceAuthStore.clearToken(gatewayId, deviceId, "operator")

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -633,7 +633,7 @@ class NodeRuntime private constructor(
   val gateways: StateFlow<List<GatewayEndpoint>> = discovery.gateways
   val discoveryStatusText: StateFlow<String> = discovery.statusText
 
-  private val identityStore = DeviceIdentityStore(appContext)
+  private val identityStore = DeviceIdentityStore.withPrefs(appContext, prefs)
   private var connectedEndpoint: GatewayEndpoint? = null
   private var activeGatewayAuth: GatewayConnectAuth? = null
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
@@ -527,6 +527,8 @@ class SecurePrefs(
     securePrefs.edit { putString(key, value) }
   }
 
+  // KTX edit(commit = true) discards commit's Boolean; the identity migration fails closed on it.
+  @Suppress("UseKtx")
   internal fun putStringSynchronously(
     key: String,
     value: String,

--- a/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
@@ -527,6 +527,11 @@ class SecurePrefs(
     securePrefs.edit { putString(key, value) }
   }
 
+  internal fun putStringSynchronously(
+    key: String,
+    value: String,
+  ): Boolean = securePrefs.edit().putString(key, value).commit()
+
   fun remove(key: String) {
     securePrefs.edit { remove(key) }
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/DeviceIdentityStore.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/DeviceIdentityStore.kt
@@ -1,5 +1,6 @@
 package ai.openclaw.app.gateway
 
+import ai.openclaw.app.SecurePrefs
 import android.content.Context
 import android.util.Base64
 import kotlinx.serialization.Serializable
@@ -17,11 +18,14 @@ data class DeviceIdentity(
 )
 
 /** Owns device identity generation, persistence, and auth payload signatures. */
-class DeviceIdentityStore(
+class DeviceIdentityStore private constructor(
   context: Context,
+  private val prefs: SecurePrefs,
 ) {
+  constructor(context: Context) : this(context, SecurePrefs(context))
+
   private val json = Json { ignoreUnknownKeys = true }
-  private val identityFile = File(context.filesDir, "openclaw/identity/device.json")
+  private val legacyIdentityFile = File(context.filesDir, "openclaw/identity/device.json")
 
   @Volatile private var cachedIdentity: DeviceIdentity? = null
 
@@ -29,6 +33,7 @@ class DeviceIdentityStore(
   @Synchronized
   fun loadOrCreate(): DeviceIdentity {
     cachedIdentity?.let { return it }
+    migrateLegacyIdentity()
     val existing = load()
     if (existing != null) {
       val derived = deriveDeviceId(existing.publicKeyRawBase64)
@@ -120,12 +125,11 @@ class DeviceIdentityStore(
       null
     }
 
-  private fun load(): DeviceIdentity? = readIdentity(identityFile)
+  private fun load(): DeviceIdentity? = readIdentity(prefs.getString(identityKey))
 
-  private fun readIdentity(file: File): DeviceIdentity? {
+  private fun readIdentity(raw: String?): DeviceIdentity? {
     return try {
-      if (!file.exists()) return null
-      val raw = file.readText(Charsets.UTF_8)
+      if (raw == null) return null
       val decoded = json.decodeFromString(DeviceIdentity.serializer(), raw)
       if (decoded.deviceId.isBlank() ||
         decoded.publicKeyRawBase64.isBlank() ||
@@ -140,13 +144,30 @@ class DeviceIdentityStore(
     }
   }
 
+  private fun migrateLegacyIdentity() {
+    if (!legacyIdentityFile.exists()) return
+    val legacy =
+      runCatching { legacyIdentityFile.readText(Charsets.UTF_8) }
+        .getOrNull()
+        ?.let(::readIdentity)
+    if (legacy == null) {
+      legacyIdentityFile.delete()
+      return
+    }
+
+    save(legacy)
+    check(load() == legacy) { "Failed to migrate device identity to secure storage" }
+    // Delete plaintext after verified import so secure prefs remain the only identity owner.
+    // A fallback would expose the key again and can restore stale identity, breaking gateway pairing.
+    check(legacyIdentityFile.delete() || !legacyIdentityFile.exists()) {
+      "Failed to delete legacy device identity"
+    }
+  }
+
   private fun save(identity: DeviceIdentity) {
-    try {
-      identityFile.parentFile?.mkdirs()
-      val encoded = json.encodeToString(DeviceIdentity.serializer(), identity)
-      identityFile.writeText(encoded, Charsets.UTF_8)
-    } catch (_: Throwable) {
-      // best-effort only
+    val encoded = json.encodeToString(DeviceIdentity.serializer(), identity)
+    check(prefs.putStringSynchronously(identityKey, encoded)) {
+      "Failed to persist device identity"
     }
   }
 
@@ -206,6 +227,12 @@ class DeviceIdentityStore(
     )
 
   companion object {
+    private const val identityKey = "device.identity"
     private val HEX = "0123456789abcdef".toCharArray()
+
+    internal fun withPrefs(
+      context: Context,
+      prefs: SecurePrefs,
+    ): DeviceIdentityStore = DeviceIdentityStore(context, prefs)
   }
 }

--- a/apps/android/app/src/main/res/xml/network_security_config.xml
+++ b/apps/android/app/src/main/res/xml/network_security_config.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config xmlns:tools="http://schemas.android.com/tools">
-  <!-- This app is primarily used on a trusted tailnet; allow cleartext for every endpoint. -->
+  <!--
+    Private LAN gateway addresses are user-selected and cannot be expressed as NSC domain rules.
+    OkHttp enforces NSC for ws://, so a false base-config would break arbitrary RFC1918 gateways.
+    GatewayHostSecurity is therefore the enforcement point for cleartext gateway scope.
+  -->
   <base-config cleartextTrafficPermitted="true" tools:ignore="InsecureBaseConfiguration" />
 </network-security-config>

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -370,7 +370,7 @@ class GatewayBootstrapAuthTest {
       )
     val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
     val runtime = NodeRuntime(app, prefs)
-    val deviceId = DeviceIdentityStore(app).loadOrCreate().deviceId
+    val deviceId = DeviceIdentityStore.withPrefs(app, prefs).loadOrCreate().deviceId
     val endpoint = GatewayEndpoint.manual(host = "127.0.0.1", port = 18789)
     DeviceAuthStore(prefs).saveToken(endpoint.stableId, deviceId, "operator", "bootstrap-operator-token")
 
@@ -726,7 +726,7 @@ class GatewayBootstrapAuthTest {
         )
       val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
       val runtime = NodeRuntime(app, prefs)
-      val deviceId = DeviceIdentityStore(app).loadOrCreate().deviceId
+      val deviceId = DeviceIdentityStore.withPrefs(app, prefs).loadOrCreate().deviceId
       val authStore = DeviceAuthStore(prefs)
       val target = GatewayEndpoint.manual("target.example", 18789).stableId
       val other = GatewayEndpoint.manual("other.example", 18789).stableId

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/DeviceIdentityStoreTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/DeviceIdentityStoreTest.kt
@@ -1,0 +1,80 @@
+package ai.openclaw.app.gateway
+
+import ai.openclaw.app.SecurePrefs
+import android.content.Context
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import java.io.File
+import java.util.UUID
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class DeviceIdentityStoreTest {
+  private val app get() = RuntimeEnvironment.getApplication()
+  private val legacyFile get() = File(app.filesDir, "openclaw/identity/device.json")
+
+  @Before
+  fun setUp() {
+    legacyFile.delete()
+  }
+
+  @After
+  fun tearDown() {
+    legacyFile.delete()
+  }
+
+  @Test
+  fun migratesLegacyIdentityAndKeepsItStableAcrossReopen() {
+    val backing = newBackingPrefs()
+    val prefs = SecurePrefs(app, securePrefsOverride = backing)
+    val seed = DeviceIdentityStore.withPrefs(app, prefs).loadOrCreate()
+    backing.edit().clear().commit()
+    legacyFile.parentFile?.mkdirs()
+    legacyFile.writeText(Json.encodeToString(seed), Charsets.UTF_8)
+
+    val migrated = DeviceIdentityStore.withPrefs(app, prefs).loadOrCreate()
+
+    assertEquals(seed, migrated)
+    assertFalse(legacyFile.exists())
+    assertEquals(migrated, DeviceIdentityStore.withPrefs(app, prefs).loadOrCreate())
+  }
+
+  @Test
+  fun freshInstallPersistsIdentityOnlyInSecurePrefs() {
+    val backing = newBackingPrefs()
+    val prefs = SecurePrefs(app, securePrefsOverride = backing)
+
+    val created = DeviceIdentityStore.withPrefs(app, prefs).loadOrCreate()
+
+    assertFalse(legacyFile.exists())
+    assertEquals(created, DeviceIdentityStore.withPrefs(app, prefs).loadOrCreate())
+  }
+
+  @Test
+  fun corruptedLegacyFileIsDeletedAndReplacedWithStableIdentity() {
+    val backing = newBackingPrefs()
+    val prefs = SecurePrefs(app, securePrefsOverride = backing)
+    legacyFile.parentFile?.mkdirs()
+    legacyFile.writeText("{not-json", Charsets.UTF_8)
+
+    val regenerated = DeviceIdentityStore.withPrefs(app, prefs).loadOrCreate()
+
+    assertFalse(legacyFile.exists())
+    assertEquals(regenerated, DeviceIdentityStore.withPrefs(app, prefs).loadOrCreate())
+  }
+
+  private fun newBackingPrefs() =
+    app.getSharedPreferences(
+      "device-identity-test-${UUID.randomUUID()}",
+      Context.MODE_PRIVATE,
+    )
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/DeviceIdentityTestSupport.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/DeviceIdentityTestSupport.kt
@@ -1,0 +1,16 @@
+package ai.openclaw.app.gateway
+
+import ai.openclaw.app.SecurePrefs
+import android.content.Context
+
+internal fun testDeviceIdentityStore(context: Context): DeviceIdentityStore {
+  val backing =
+    context.getSharedPreferences(
+      "openclaw.node.secure.test.device-identity",
+      Context.MODE_PRIVATE,
+    )
+  return DeviceIdentityStore.withPrefs(
+    context,
+    SecurePrefs(context, securePrefsOverride = backing),
+  )
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionCustomHeadersTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionCustomHeadersTest.kt
@@ -113,7 +113,7 @@ class GatewaySessionCustomHeadersTest {
       val session =
         GatewaySession(
           scope = scope,
-          identityStore = DeviceIdentityStore(app),
+          identityStore = testDeviceIdentityStore(app),
           deviceAuthStore = NoopDeviceAuthStore(),
           onConnected = { if (!connected.isCompleted) connected.complete(Unit) },
           onDisconnected = {},

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
@@ -525,7 +525,7 @@ class GatewaySessionInvokeTest {
         ) { GatewaySession.InvokeResult.ok("""{"handled":true}""") }
 
       try {
-        val deviceId = DeviceIdentityStore(RuntimeEnvironment.getApplication()).loadOrCreate().deviceId
+        val deviceId = testDeviceIdentityStore(RuntimeEnvironment.getApplication()).loadOrCreate().deviceId
         harness.deviceAuthStore.saveToken(gatewayIdForPort(server.port), deviceId, "node", "device-token")
 
         connectNodeSession(
@@ -569,7 +569,7 @@ class GatewaySessionInvokeTest {
         ) { GatewaySession.InvokeResult.ok("""{"handled":true}""") }
 
       try {
-        val deviceId = DeviceIdentityStore(RuntimeEnvironment.getApplication()).loadOrCreate().deviceId
+        val deviceId = testDeviceIdentityStore(RuntimeEnvironment.getApplication()).loadOrCreate().deviceId
         harness.deviceAuthStore.saveToken(
           gatewayId = gatewayIdForPort(server.port),
           deviceId = deviceId,
@@ -709,7 +709,7 @@ class GatewaySessionInvokeTest {
         ) { GatewaySession.InvokeResult.ok("""{"handled":true}""") }
 
       try {
-        val deviceId = DeviceIdentityStore(RuntimeEnvironment.getApplication()).loadOrCreate().deviceId
+        val deviceId = testDeviceIdentityStore(RuntimeEnvironment.getApplication()).loadOrCreate().deviceId
         harness.deviceAuthStore.saveToken(gatewayIdForPort(server.port), deviceId, "node", "stored-device-token")
 
         connectNodeSession(
@@ -767,7 +767,7 @@ class GatewaySessionInvokeTest {
         )
         awaitConnectedOrThrow(connected, lastDisconnect, server)
 
-        val deviceId = DeviceIdentityStore(RuntimeEnvironment.getApplication()).loadOrCreate().deviceId
+        val deviceId = testDeviceIdentityStore(RuntimeEnvironment.getApplication()).loadOrCreate().deviceId
         assertEquals("shared-node-token", harness.deviceAuthStore.loadToken(gatewayIdForPort(server.port), deviceId, "node"))
         assertNull(harness.deviceAuthStore.loadToken(gatewayIdForPort(server.port), deviceId, "operator"))
       } finally {
@@ -812,7 +812,7 @@ class GatewaySessionInvokeTest {
         )
         awaitConnectedOrThrow(connected, lastDisconnect, server)
 
-        val deviceId = DeviceIdentityStore(RuntimeEnvironment.getApplication()).loadOrCreate().deviceId
+        val deviceId = testDeviceIdentityStore(RuntimeEnvironment.getApplication()).loadOrCreate().deviceId
         val nodeEntry = harness.deviceAuthStore.loadEntry(gatewayIdForPort(server.port), deviceId, "node")
         val operatorEntry = harness.deviceAuthStore.loadEntry(gatewayIdForPort(server.port), deviceId, "operator")
         assertEquals("bootstrap-node-token", nodeEntry?.token)
@@ -870,7 +870,7 @@ class GatewaySessionInvokeTest {
         )
         awaitConnectedOrThrow(connected, lastDisconnect, server)
 
-        val deviceId = DeviceIdentityStore(RuntimeEnvironment.getApplication()).loadOrCreate().deviceId
+        val deviceId = testDeviceIdentityStore(RuntimeEnvironment.getApplication()).loadOrCreate().deviceId
         assertEquals("shared-node-token", harness.deviceAuthStore.loadToken(gatewayIdForPort(server.port), deviceId, "node"))
         assertNull(harness.deviceAuthStore.loadToken(gatewayIdForPort(server.port), deviceId, "operator"))
       } finally {
@@ -1328,7 +1328,7 @@ class GatewaySessionInvokeTest {
     val session =
       GatewaySession(
         scope = CoroutineScope(sessionJob + Dispatchers.Default),
-        identityStore = DeviceIdentityStore(app),
+        identityStore = testDeviceIdentityStore(app),
         deviceAuthStore = deviceAuthStore,
         onConnected = {
           if (!connected.isCompleted) connected.complete(Unit)

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
@@ -1001,7 +1001,7 @@ class GatewaySessionReconnectTest {
     val session =
       GatewaySession(
         scope = CoroutineScope(sessionJob + Dispatchers.Default),
-        identityStore = DeviceIdentityStore(app),
+        identityStore = testDeviceIdentityStore(app),
         deviceAuthStore = deviceAuthStore,
         onConnected = { summary ->
           onConnected()

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/DebugHandlerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/DebugHandlerTest.kt
@@ -1,6 +1,6 @@
 package ai.openclaw.app.node
 
-import ai.openclaw.app.gateway.DeviceIdentityStore
+import ai.openclaw.app.gateway.testDeviceIdentityStore
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -26,7 +26,7 @@ class DebugHandlerTest : NodeHandlerRobolectricTest() {
     val context = appContext()
     File(context.cacheDir, "camera_debug.log").writeText(raw)
 
-    val result = DebugHandler(context, DeviceIdentityStore(context)).handleLogs()
+    val result = DebugHandler(context, testDeviceIdentityStore(context)).handleLogs()
 
     assertTrue(result.ok)
     val logs =

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/InvokeDispatcherTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/InvokeDispatcherTest.kt
@@ -1,7 +1,7 @@
 package ai.openclaw.app.node
 
-import ai.openclaw.app.gateway.DeviceIdentityStore
 import ai.openclaw.app.gateway.GatewaySession
+import ai.openclaw.app.gateway.testDeviceIdentityStore
 import ai.openclaw.app.protocol.OpenClawCallLogCommand
 import ai.openclaw.app.protocol.OpenClawCameraCommand
 import ai.openclaw.app.protocol.OpenClawCanvasCommand
@@ -373,7 +373,7 @@ class InvokeDispatcherTest {
           canvas = canvas,
           json = Json { ignoreUnknownKeys = true },
         ),
-      debugHandler = DebugHandler(appContext, DeviceIdentityStore(appContext)),
+      debugHandler = DebugHandler(appContext, testDeviceIdentityStore(appContext)),
       callLogHandler = CallLogHandler.forTesting(appContext, InvokeDispatcherFakeCallLogDataSource()),
       isForeground = { isForeground },
       cameraEnabled = { cameraEnabled },

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -2,9 +2,9 @@ package ai.openclaw.app.voice
 
 import ai.openclaw.app.gateway.DeviceAuthEntry
 import ai.openclaw.app.gateway.DeviceAuthTokenStore
-import ai.openclaw.app.gateway.DeviceIdentityStore
 import ai.openclaw.app.gateway.GatewayRequestRejected
 import ai.openclaw.app.gateway.GatewaySession
+import ai.openclaw.app.gateway.testDeviceIdentityStore
 import ai.openclaw.app.i18n.NativeText
 import ai.openclaw.app.i18n.nativeText
 import ai.openclaw.app.i18n.verbatimText
@@ -1043,7 +1043,7 @@ class TalkModeManagerTest {
     val session =
       GatewaySession(
         scope = CoroutineScope(sessionJob + Dispatchers.Default),
-        identityStore = DeviceIdentityStore(app),
+        identityStore = testDeviceIdentityStore(app),
         deviceAuthStore = InMemoryDeviceAuthStore(),
         onConnected = {},
         onDisconnected = {},


### PR DESCRIPTION
## What Problem This Solves

The Android app stored its Ed25519 device identity (the private key that signs gateway device-auth payloads) as plaintext JSON in `filesDir` (`openclaw/identity/device.json`). Only `allowBackup="false"` in the manifest kept that key out of Google cloud backup — a single manifest flag flip away from shipping the signing key off-device. Separately, the global cleartext allowance in `network_security_config.xml` was undocumented, making it look like an oversight rather than a decision.

## Why This Change Was Made

Defense in depth for the device identity: the key now lives in `EncryptedSharedPreferences` (same `SecurePrefs` infrastructure that already protects gateway tokens), so at-rest exposure no longer hinges on a single manifest flag. A one-time migration imports the legacy `device.json` with a synchronous write, readback verification, and then deletes the plaintext file — no fallback reader remains, so encrypted prefs are the only identity owner afterwards. Corrupt legacy files regenerate a fresh identity, matching the previous behavior (corrupt JSON was already treated as absent). Persistence failures now fail closed instead of silently continuing with an unpersisted identity.

For the cleartext scope: Android NSC domain rules cannot express user-selected RFC1918 gateway endpoints, and OkHttp enforces `NetworkSecurityPolicy` for `ws://`, so flipping the base-config to `false` would break LAN gateway connections outright. That constraint is now documented in the config itself, with `GatewayHostSecurity` called out as the code-level cleartext gate (loopback/mDNS/private ranges only).

## User Impact

No user-visible behavior change. Existing installs keep their device identity (and gateway pairings) through the migration; fresh installs generate the identity directly into encrypted storage.

## Evidence

- `:app:testPlayDebugUnitTest` and `:app:testThirdPartyDebugUnitTest` for `DeviceIdentityStoreTest` (migration, fresh install, corrupt legacy): green on both flavors.
- `:app:compilePlayDebugKotlin` + `:app:compileThirdPartyDebugKotlin`: green.
- `:app:ktlintCheck`: green.
- Structured autoreview: clean (single reported finding — a claimed Robolectric generic-inference compile error — rejected as factually wrong: `RuntimeEnvironment.getApplication()` is non-generic and the test source compiles and passes on both flavors).
- OkHttp/NSC enforcement claim verified against OkHttp 5.4.0 `AndroidPlatform`/`RealRoutePlanner` sources and the Android NSC documentation.
