### PR TITLE
feat(android): accept audio and document attachments via share sheet and composer

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -523,7 +523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 201,
+      "line": 218,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainActivity.kt",
       "source": "Too many shares are waiting to be added.",
       "surface": "android",
@@ -531,7 +531,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 322,
+      "line": 341,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainActivity.kt",
       "source": "OPENCLAW",
       "surface": "android",
@@ -539,7 +539,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 466,
+      "line": 465,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Searching…",
       "surface": "android",
@@ -547,7 +547,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 592,
+      "line": 591,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Mic off",
       "surface": "android",
@@ -555,7 +555,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 606,
+      "line": 605,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Off",
       "surface": "android",
@@ -12051,7 +12051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 323,
+      "line": 327,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Model",
       "surface": "android",
@@ -12059,7 +12059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 416,
+      "line": 450,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Some shared images were omitted or could not be added.",
       "surface": "android",
@@ -12067,7 +12067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 557,
+      "line": 591,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat needs attention",
       "surface": "android",
@@ -12075,7 +12075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 836,
+      "line": 876,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "All",
       "surface": "android",
@@ -12083,7 +12083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 918,
+      "line": 958,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Working",
       "surface": "android",
@@ -12091,7 +12091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 919,
+      "line": 959,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready",
       "surface": "android",
@@ -12099,7 +12099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 920,
+      "line": 960,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Offline",
       "surface": "android",
@@ -12107,7 +12107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 933,
+      "line": 973,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat actions",
       "surface": "android",
@@ -12115,7 +12115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 938,
+      "line": 978,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Refresh chat",
       "surface": "android",
@@ -12123,7 +12123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 946,
+      "line": 986,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Background tasks",
       "surface": "android",
@@ -12131,7 +12131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 967,
+      "line": 1007,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -12139,7 +12139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1114,
+      "line": 1154,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Messages to recover",
       "surface": "android",
@@ -12147,7 +12147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1116,
+      "line": 1156,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows.",
       "surface": "android",
@@ -12155,7 +12155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1144,
+      "line": 1184,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Loading thread",
       "surface": "android",
@@ -12163,7 +12163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1177,
+      "line": 1217,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Jump to latest",
       "surface": "android",
@@ -12171,7 +12171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1207,
+      "line": 1247,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready when you are",
       "surface": "android",
@@ -12179,7 +12179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1211,
+      "line": 1251,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Start with a prompt, or use voice.",
       "surface": "android",
@@ -12187,7 +12187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1213,
+      "line": 1253,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Use the recovery options below to reconnect.",
       "surface": "android",
@@ -12195,7 +12195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1215,
+      "line": 1255,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat is checking Gateway health.",
       "surface": "android",
@@ -12203,7 +12203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1238,
+      "line": 1278,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Fix connection",
       "surface": "android",
@@ -12211,7 +12211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1239,
+      "line": 1279,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Copy diagnostics",
       "surface": "android",
@@ -12219,7 +12219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1298,
+      "line": 1338,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Catch me up",
       "surface": "android",
@@ -12227,7 +12227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1299,
+      "line": 1339,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Summarize recent threads and next steps.",
       "surface": "android",
@@ -12235,7 +12235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1300,
+      "line": 1340,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
       "surface": "android",
@@ -12243,7 +12243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1304,
+      "line": 1344,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Plan the work",
       "surface": "android",
@@ -12251,7 +12251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1305,
+      "line": 1345,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Turn a goal into an actionable checklist.",
       "surface": "android",
@@ -12259,7 +12259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1306,
+      "line": 1346,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Help me turn this goal into a practical checklist: ",
       "surface": "android",
@@ -12267,7 +12267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1310,
+      "line": 1350,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Use this phone",
       "surface": "android",
@@ -12275,7 +12275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1311,
+      "line": 1351,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ask OpenClaw to use Android capabilities.",
       "surface": "android",
@@ -12283,7 +12283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1312,
+      "line": 1352,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "What can you help me do from this phone right now?",
       "surface": "android",
@@ -12291,7 +12291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1377,
+      "line": 1417,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw · Live",
       "surface": "android",
@@ -12299,7 +12299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1378,
+      "line": 1418,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "You",
       "surface": "android",
@@ -12307,7 +12307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1379,
+      "line": 1419,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "System",
       "surface": "android",
@@ -12315,7 +12315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1380,
+      "line": 1420,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -12323,15 +12323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1400,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "Attachment",
-      "surface": "android",
-      "id": "native.android.e695e7b72d13e9e5"
-    },
-    {
-      "kind": "ui-call",
-      "line": 1453,
+      "line": 1493,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Preparing audio…",
       "surface": "android",
@@ -12339,7 +12331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1453,
+      "line": 1493,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Speaking…",
       "surface": "android",
@@ -12347,7 +12339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1474,
+      "line": 1514,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Tools running",
       "surface": "android",
@@ -12355,7 +12347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1476,
+      "line": 1516,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is working",
       "surface": "android",
@@ -12363,7 +12355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1479,
+      "line": 1519,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "+${toolCalls.size - 4} more",
       "surface": "android",
@@ -12371,7 +12363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1489,
+      "line": 1529,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Thinking",
       "surface": "android",
@@ -12379,7 +12371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1490,
+      "line": 1530,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is preparing a response.",
       "surface": "android",
@@ -12387,7 +12379,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1555,
+      "line": 1595,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$completedCount/${steps.size}",
       "surface": "android",
@@ -12395,7 +12387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1562,
+      "line": 1602,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Collapse plan checklist",
       "surface": "android",
@@ -12403,7 +12395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1562,
+      "line": 1602,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Expand plan checklist",
       "surface": "android",
@@ -12411,7 +12403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1693,
+      "line": 1734,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Dismiss shared-image warning",
       "surface": "android",
@@ -12419,7 +12411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1795,
+      "line": 1837,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Stop",
       "surface": "android",
@@ -12427,7 +12419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1893,
+      "line": 1935,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Default",
       "surface": "android",
@@ -12435,7 +12427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1959,
+      "line": 2001,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Pin model",
       "surface": "android",
@@ -12443,7 +12435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1959,
+      "line": 2001,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Unpin model",
       "surface": "android",
@@ -12451,7 +12443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1976,
+      "line": 2018,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "No commands found",
       "surface": "android",
@@ -12459,7 +12451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2018,
+      "line": 2060,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Command",
       "surface": "android",
@@ -12467,7 +12459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2038,
+      "line": 2080,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway offline",
       "surface": "android",
@@ -12475,7 +12467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2084,
+      "line": 2126,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Close thinking level selector",
       "surface": "android",
@@ -12483,7 +12475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2084,
+      "line": 2126,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Open thinking level selector",
       "surface": "android",
@@ -12491,7 +12483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2148,
+      "line": 2191,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attach image",
       "surface": "android",
@@ -12499,7 +12491,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 2179,
+      "line": 2196,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Attachment",
+      "surface": "android",
+      "id": "native.android.e695e7b72d13e9e5"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2227,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Message OpenClaw",
       "surface": "android",
@@ -12507,7 +12507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2208,
+      "line": 2256,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "End Talk",
       "surface": "android",
@@ -12515,7 +12515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2208,
+      "line": 2256,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Start Talk",
       "surface": "android",
@@ -12523,7 +12523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2293,
+      "line": 2341,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Voice note · ${formatVoiceNoteDuration(duration)}",
       "surface": "android",
@@ -12531,7 +12531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2302,
+      "line": 2350,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Remove attachment",
       "surface": "android",
@@ -12539,7 +12539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2314,
+      "line": 2362,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "New chat",
       "surface": "android",
@@ -12547,7 +12547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2323,
+      "line": 2371,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Main",
       "surface": "android",
@@ -12555,7 +12555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2324,
+      "line": 2372,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Current",
       "surface": "android",
@@ -12563,7 +12563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2331,
+      "line": 2379,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$emoji $name",
       "surface": "android",
@@ -12571,7 +12571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2390,
+      "line": 2438,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Send",
       "surface": "android",
@@ -12579,7 +12579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2401,
+      "line": 2449,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat is still checking Gateway health.",
       "surface": "android",
@@ -12587,7 +12587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2402,
+      "line": 2450,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway is offline. Fix the connection below or copy diagnostics.",
       "surface": "android",
@@ -12595,7 +12595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2403,
+      "line": 2451,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway authentication needs attention.",
       "surface": "android",
@@ -12603,7 +12603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2422,
+      "line": 2470,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Context ${(it * 100).roundToInt()}%",
       "surface": "android",
@@ -12611,7 +12611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2423,
+      "line": 2471,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Context --",
       "surface": "android",
@@ -12619,7 +12619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2424,
+      "line": 2472,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$contextLabel · ${contextMeterThinkingLabel(thinkingLevel)}",
       "surface": "android",
@@ -12627,7 +12627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2463,
+      "line": 2511,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Off",
       "surface": "android",
@@ -12635,7 +12635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2464,
+      "line": 2512,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Minimal",
       "surface": "android",
@@ -12643,7 +12643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2465,
+      "line": 2513,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Low",
       "surface": "android",
@@ -12651,7 +12651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2466,
+      "line": 2514,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Medium",
       "surface": "android",
@@ -12659,7 +12659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2467,
+      "line": 2515,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "High",
       "surface": "android",
@@ -12667,7 +12667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2468,
+      "line": 2516,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Xhigh",
       "surface": "android",
@@ -12675,7 +12675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2469,
+      "line": 2517,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Adaptive",
       "surface": "android",
@@ -12683,7 +12683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2470,
+      "line": 2518,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Max",
       "surface": "android",

--- a/apps/.i18n/native/ar.json
+++ b/apps/.i18n/native/ar.json
@@ -7704,11 +7704,6 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.android.e695e7b72d13e9e5",
-      "source": "Attachment",
-      "translated": "مرفق"
-    },
-    {
       "id": "native.android.5aafbef3744d86f3",
       "source": "Preparing audio…",
       "translated": "جارٍ تحضير الصوت…"
@@ -7812,6 +7807,11 @@
       "id": "native.android.623e434c83e3c020",
       "source": "Attach image",
       "translated": "إرفاق صورة"
+    },
+    {
+      "id": "native.android.e695e7b72d13e9e5",
+      "source": "Attachment",
+      "translated": "مرفق"
     },
     {
       "id": "native.android.f1d69eb66c5dfa39",

--- a/apps/.i18n/native/de.json
+++ b/apps/.i18n/native/de.json
@@ -7704,11 +7704,6 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.android.e695e7b72d13e9e5",
-      "source": "Attachment",
-      "translated": "Anhang"
-    },
-    {
       "id": "native.android.5aafbef3744d86f3",
       "source": "Preparing audio…",
       "translated": "Audio wird vorbereitet…"
@@ -7812,6 +7807,11 @@
       "id": "native.android.623e434c83e3c020",
       "source": "Attach image",
       "translated": "Bild anhängen"
+    },
+    {
+      "id": "native.android.e695e7b72d13e9e5",
+      "source": "Attachment",
+      "translated": "Anhang"
     },
     {
       "id": "native.android.f1d69eb66c5dfa39",

--- a/apps/.i18n/native/es.json
+++ b/apps/.i18n/native/es.json
@@ -7704,11 +7704,6 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.android.e695e7b72d13e9e5",
-      "source": "Attachment",
-      "translated": "Archivo adjunto"
-    },
-    {
       "id": "native.android.5aafbef3744d86f3",
       "source": "Preparing audio…",
       "translated": "Preparando audio…"
@@ -7812,6 +7807,11 @@
       "id": "native.android.623e434c83e3c020",
       "source": "Attach image",
       "translated": "Adjuntar imagen"
+    },
+    {
+      "id": "native.android.e695e7b72d13e9e5",
+      "source": "Attachment",
+      "translated": "Archivo adjunto"
     },
     {
       "id": "native.android.f1d69eb66c5dfa39",

--- a/apps/.i18n/native/fa.json
+++ b/apps/.i18n/native/fa.json
@@ -7704,11 +7704,6 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.android.e695e7b72d13e9e5",
-      "source": "Attachment",
-      "translated": "پیوست"
-    },
-    {
       "id": "native.android.5aafbef3744d86f3",
       "source": "Preparing audio…",
       "translated": "در حال آماده‌سازی صدا…"
@@ -7812,6 +7807,11 @@
       "id": "native.android.623e434c83e3c020",
       "source": "Attach image",
       "translated": "پیوست کردن تصویر"
+    },
+    {
+      "id": "native.android.e695e7b72d13e9e5",
+      "source": "Attachment",
+      "translated": "پیوست"
     },
     {
       "id": "native.android.f1d69eb66c5dfa39",

--- a/apps/.i18n/native/fr.json
+++ b/apps/.i18n/native/fr.json
@@ -7704,11 +7704,6 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.android.e695e7b72d13e9e5",
-      "source": "Attachment",
-      "translated": "Pièce jointe"
-    },
-    {
       "id": "native.android.5aafbef3744d86f3",
       "source": "Preparing audio…",
       "translated": "Préparation de l'audio…"
@@ -7812,6 +7807,11 @@
       "id": "native.android.623e434c83e3c020",
       "source": "Attach image",
       "translated": "Joindre une image"
+    },
+    {
+      "id": "native.android.e695e7b72d13e9e5",
+      "source": "Attachment",
+      "translated": "Pièce jointe"
     },
     {
       "id": "native.android.f1d69eb66c5dfa39",

--- a/apps/.i18n/native/hi.json
+++ b/apps/.i18n/native/hi.json
@@ -7704,11 +7704,6 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.android.e695e7b72d13e9e5",
-      "source": "Attachment",
-      "translated": "अटैचमेंट"
-    },
-    {
       "id": "native.android.5aafbef3744d86f3",
       "source": "Preparing audio…",
       "translated": "ऑडियो तैयार किया जा रहा है…"
@@ -7812,6 +7807,11 @@
       "id": "native.android.623e434c83e3c020",
       "source": "Attach image",
       "translated": "छवि संलग्न करें"
+    },
+    {
+      "id": "native.android.e695e7b72d13e9e5",
+      "source": "Attachment",
+      "translated": "अटैचमेंट"
     },
     {
       "id": "native.android.f1d69eb66c5dfa39",

--- a/apps/.i18n/native/id.json
+++ b/apps/.i18n/native/id.json
@@ -7704,11 +7704,6 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.android.e695e7b72d13e9e5",
-      "source": "Attachment",
-      "translated": "Lampiran"
-    },
-    {
       "id": "native.android.5aafbef3744d86f3",
       "source": "Preparing audio…",
       "translated": "Menyiapkan audio…"
@@ -7812,6 +7807,11 @@
       "id": "native.android.623e434c83e3c020",
       "source": "Attach image",
       "translated": "Lampirkan gambar"
+    },
+    {
+      "id": "native.android.e695e7b72d13e9e5",
+      "source": "Attachment",
+      "translated": "Lampiran"
     },
     {
       "id": "native.android.f1d69eb66c5dfa39",

--- a/apps/.i18n/native/it.json
+++ b/apps/.i18n/native/it.json
@@ -7704,11 +7704,6 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.android.e695e7b72d13e9e5",
-      "source": "Attachment",
-      "translated": "Allegato"
-    },
-    {
       "id": "native.android.5aafbef3744d86f3",
       "source": "Preparing audio…",
       "translated": "Preparazione audio…"
@@ -7812,6 +7807,11 @@
       "id": "native.android.623e434c83e3c020",
       "source": "Attach image",
       "translated": "Allega immagine"
+    },
+    {
+      "id": "native.android.e695e7b72d13e9e5",
+      "source": "Attachment",
+      "translated": "Allegato"
     },
     {
       "id": "native.android.f1d69eb66c5dfa39",

--- a/apps/.i18n/native/ja-JP.json
+++ b/apps/.i18n/native/ja-JP.json
@@ -7704,11 +7704,6 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.android.e695e7b72d13e9e5",
-      "source": "Attachment",
-      "translated": "添付ファイル"
-    },
-    {
       "id": "native.android.5aafbef3744d86f3",
       "source": "Preparing audio…",
       "translated": "音声を準備中…"
@@ -7812,6 +7807,11 @@
       "id": "native.android.623e434c83e3c020",
       "source": "Attach image",
       "translated": "画像を添付"
+    },
+    {
+      "id": "native.android.e695e7b72d13e9e5",
+      "source": "Attachment",
+      "translated": "添付ファイル"
     },
     {
       "id": "native.android.f1d69eb66c5dfa39",

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -7704,11 +7704,6 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.android.e695e7b72d13e9e5",
-      "source": "Attachment",
-      "translated": "첨부 파일"
-    },
-    {
       "id": "native.android.5aafbef3744d86f3",
       "source": "Preparing audio…",
       "translated": "오디오 준비 중…"
@@ -7812,6 +7807,11 @@
       "id": "native.android.623e434c83e3c020",
       "source": "Attach image",
       "translated": "이미지 첨부"
+    },
+    {
+      "id": "native.android.e695e7b72d13e9e5",
+      "source": "Attachment",
+      "translated": "첨부 파일"
     },
     {
       "id": "native.android.f1d69eb66c5dfa39",

--- a/apps/.i18n/native/nl.json
+++ b/apps/.i18n/native/nl.json
@@ -7704,11 +7704,6 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.android.e695e7b72d13e9e5",
-      "source": "Attachment",
-      "translated": "Bijlage"
-    },
-    {
       "id": "native.android.5aafbef3744d86f3",
       "source": "Preparing audio…",
       "translated": "Audio voorbereiden…"
@@ -7812,6 +7807,11 @@
       "id": "native.android.623e434c83e3c020",
       "source": "Attach image",
       "translated": "Afbeelding toevoegen"
+    },
+    {
+      "id": "native.android.e695e7b72d13e9e5",
+      "source": "Attachment",
+      "translated": "Bijlage"
     },
     {
       "id": "native.android.f1d69eb66c5dfa39",

--- a/apps/.i18n/native/pl.json
+++ b/apps/.i18n/native/pl.json
@@ -7704,11 +7704,6 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.android.e695e7b72d13e9e5",
-      "source": "Attachment",
-      "translated": "Załącznik"
-    },
-    {
       "id": "native.android.5aafbef3744d86f3",
       "source": "Preparing audio…",
       "translated": "Przygotowywanie dźwięku…"
@@ -7812,6 +7807,11 @@
       "id": "native.android.623e434c83e3c020",
       "source": "Attach image",
       "translated": "Dołącz obraz"
+    },
+    {
+      "id": "native.android.e695e7b72d13e9e5",
+      "source": "Attachment",
+      "translated": "Załącznik"
     },
     {
       "id": "native.android.f1d69eb66c5dfa39",

--- a/apps/.i18n/native/pt-BR.json
+++ b/apps/.i18n/native/pt-BR.json
@@ -7704,11 +7704,6 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.android.e695e7b72d13e9e5",
-      "source": "Attachment",
-      "translated": "Anexo"
-    },
-    {
       "id": "native.android.5aafbef3744d86f3",
       "source": "Preparing audio…",
       "translated": "Preparando áudio…"
@@ -7812,6 +7807,11 @@
       "id": "native.android.623e434c83e3c020",
       "source": "Attach image",
       "translated": "Anexar imagem"
+    },
+    {
+      "id": "native.android.e695e7b72d13e9e5",
+      "source": "Attachment",
+      "translated": "Anexo"
     },
     {
       "id": "native.android.f1d69eb66c5dfa39",

--- a/apps/.i18n/native/ru.json
+++ b/apps/.i18n/native/ru.json
@@ -7704,11 +7704,6 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.android.e695e7b72d13e9e5",
-      "source": "Attachment",
-      "translated": "Вложение"
-    },
-    {
       "id": "native.android.5aafbef3744d86f3",
       "source": "Preparing audio…",
       "translated": "Подготовка аудио…"
@@ -7812,6 +7807,11 @@
       "id": "native.android.623e434c83e3c020",
       "source": "Attach image",
       "translated": "Прикрепить изображение"
+    },
+    {
+      "id": "native.android.e695e7b72d13e9e5",
+      "source": "Attachment",
+      "translated": "Вложение"
     },
     {
       "id": "native.android.f1d69eb66c5dfa39",

--- a/apps/.i18n/native/sv.json
+++ b/apps/.i18n/native/sv.json
@@ -7704,11 +7704,6 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.android.e695e7b72d13e9e5",
-      "source": "Attachment",
-      "translated": "Bilaga"
-    },
-    {
       "id": "native.android.5aafbef3744d86f3",
       "source": "Preparing audio…",
       "translated": "Förbereder ljud…"
@@ -7812,6 +7807,11 @@
       "id": "native.android.623e434c83e3c020",
       "source": "Attach image",
       "translated": "Bifoga bild"
+    },
+    {
+      "id": "native.android.e695e7b72d13e9e5",
+      "source": "Attachment",
+      "translated": "Bilaga"
     },
     {
       "id": "native.android.f1d69eb66c5dfa39",

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -7704,11 +7704,6 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.android.e695e7b72d13e9e5",
-      "source": "Attachment",
-      "translated": "ไฟล์แนบ"
-    },
-    {
       "id": "native.android.5aafbef3744d86f3",
       "source": "Preparing audio…",
       "translated": "กำลังเตรียมเสียง…"
@@ -7812,6 +7807,11 @@
       "id": "native.android.623e434c83e3c020",
       "source": "Attach image",
       "translated": "แนบรูปภาพ"
+    },
+    {
+      "id": "native.android.e695e7b72d13e9e5",
+      "source": "Attachment",
+      "translated": "ไฟล์แนบ"
     },
     {
       "id": "native.android.f1d69eb66c5dfa39",

--- a/apps/.i18n/native/tr.json
+++ b/apps/.i18n/native/tr.json
@@ -7704,11 +7704,6 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.android.e695e7b72d13e9e5",
-      "source": "Attachment",
-      "translated": "Ek"
-    },
-    {
       "id": "native.android.5aafbef3744d86f3",
       "source": "Preparing audio…",
       "translated": "Ses hazırlanıyor…"
@@ -7812,6 +7807,11 @@
       "id": "native.android.623e434c83e3c020",
       "source": "Attach image",
       "translated": "Görsel ekle"
+    },
+    {
+      "id": "native.android.e695e7b72d13e9e5",
+      "source": "Attachment",
+      "translated": "Ek"
     },
     {
       "id": "native.android.f1d69eb66c5dfa39",

--- a/apps/.i18n/native/uk.json
+++ b/apps/.i18n/native/uk.json
@@ -7704,11 +7704,6 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.android.e695e7b72d13e9e5",
-      "source": "Attachment",
-      "translated": "Вкладення"
-    },
-    {
       "id": "native.android.5aafbef3744d86f3",
       "source": "Preparing audio…",
       "translated": "Підготовка аудіо…"
@@ -7812,6 +7807,11 @@
       "id": "native.android.623e434c83e3c020",
       "source": "Attach image",
       "translated": "Прикріпити зображення"
+    },
+    {
+      "id": "native.android.e695e7b72d13e9e5",
+      "source": "Attachment",
+      "translated": "Вкладення"
     },
     {
       "id": "native.android.f1d69eb66c5dfa39",

--- a/apps/.i18n/native/vi.json
+++ b/apps/.i18n/native/vi.json
@@ -7704,11 +7704,6 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.android.e695e7b72d13e9e5",
-      "source": "Attachment",
-      "translated": "Tệp đính kèm"
-    },
-    {
       "id": "native.android.5aafbef3744d86f3",
       "source": "Preparing audio…",
       "translated": "Đang chuẩn bị âm thanh…"
@@ -7812,6 +7807,11 @@
       "id": "native.android.623e434c83e3c020",
       "source": "Attach image",
       "translated": "Đính kèm hình ảnh"
+    },
+    {
+      "id": "native.android.e695e7b72d13e9e5",
+      "source": "Attachment",
+      "translated": "Tệp đính kèm"
     },
     {
       "id": "native.android.f1d69eb66c5dfa39",

--- a/apps/.i18n/native/zh-CN.json
+++ b/apps/.i18n/native/zh-CN.json
@@ -7704,11 +7704,6 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.android.e695e7b72d13e9e5",
-      "source": "Attachment",
-      "translated": "附件"
-    },
-    {
       "id": "native.android.5aafbef3744d86f3",
       "source": "Preparing audio…",
       "translated": "正在准备音频…"
@@ -7812,6 +7807,11 @@
       "id": "native.android.623e434c83e3c020",
       "source": "Attach image",
       "translated": "附加图片"
+    },
+    {
+      "id": "native.android.e695e7b72d13e9e5",
+      "source": "Attachment",
+      "translated": "附件"
     },
     {
       "id": "native.android.f1d69eb66c5dfa39",

--- a/apps/.i18n/native/zh-TW.json
+++ b/apps/.i18n/native/zh-TW.json
@@ -7704,11 +7704,6 @@
       "translated": "OpenClaw"
     },
     {
-      "id": "native.android.e695e7b72d13e9e5",
-      "source": "Attachment",
-      "translated": "附件"
-    },
-    {
       "id": "native.android.5aafbef3744d86f3",
       "source": "Preparing audio…",
       "translated": "正在準備音訊…"
@@ -7812,6 +7807,11 @@
       "id": "native.android.623e434c83e3c020",
       "source": "Attach image",
       "translated": "附加圖片"
+    },
+    {
+      "id": "native.android.e695e7b72d13e9e5",
+      "source": "Attachment",
+      "translated": "附件"
     },
     {
       "id": "native.android.f1d69eb66c5dfa39",

--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -125,6 +125,23 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="image/*" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="audio/*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="application/pdf" />
+                <data android:mimeType="application/vnd.openxmlformats-officedocument.wordprocessingml.document" />
+                <data android:mimeType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" />
+                <data android:mimeType="application/vnd.openxmlformats-officedocument.presentationml.presentation" />
+                <data android:mimeType="text/csv" />
+                <data android:mimeType="text/markdown" />
+            </intent-filter>
         </activity>
     </application>
 </manifest>

--- a/apps/android/app/src/main/java/ai/openclaw/app/AssistantLaunch.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/AssistantLaunch.kt
@@ -4,6 +4,7 @@ import android.content.ContentResolver
 import android.content.Intent
 import android.net.Uri
 import androidx.core.content.IntentCompat
+import java.util.Locale
 
 /** Android Assistant entry point used by manifest-declared app actions. */
 const val actionAskOpenClaw = "ai.openclaw.app.action.ASK_OPENCLAW"
@@ -37,14 +38,40 @@ data class AssistantLaunchRequest(
 /** Shared content staged in chat for user review before sending. */
 data class ShareLaunchRequest(
   val text: String?,
-  val imageUris: List<Uri>,
-  val droppedImageCount: Int,
+  val attachments: List<SharedAttachment>,
+  val droppedAttachmentCount: Int,
 )
 
-private data class SharedImageSelection(
-  val uris: List<Uri>,
+enum class SharedAttachmentKind {
+  Image,
+  Audio,
+  Document,
+}
+
+data class SharedAttachment(
+  val uri: Uri,
+  val kind: SharedAttachmentKind,
+  val mimeType: String,
+)
+
+private data class SharedAttachmentSelection(
+  val attachments: List<SharedAttachment>,
   val droppedCount: Int,
 )
+
+internal val SHARED_ATTACHMENT_MIME_ALLOWLIST =
+  setOf(
+    "image/*",
+    "audio/*",
+    "application/pdf",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    "text/csv",
+    "text/markdown",
+  )
+
+internal val SHARED_AUDIO_DOCUMENT_MIME_TYPES = SHARED_ATTACHMENT_MIME_ALLOWLIST.filterNot { it == "image/*" }.toTypedArray()
 
 /**
  * Parses app-owned navigation actions that should open a specific home tab.
@@ -84,8 +111,11 @@ fun parseAssistantLaunchIntent(intent: Intent?): AssistantLaunchRequest? {
   }
 }
 
-/** Parses Android Sharesheet content without reading external providers on the main thread. */
-fun parseShareLaunchIntent(intent: Intent?): ShareLaunchRequest? {
+/** Parses Android Sharesheet metadata without opening or reading shared payload bytes. */
+fun parseShareLaunchIntent(
+  intent: Intent?,
+  resolveMimeType: (Uri) -> String?,
+): ShareLaunchRequest? {
   val action = intent?.action ?: return null
   if (action != Intent.ACTION_SEND && action != Intent.ACTION_SEND_MULTIPLE) return null
 
@@ -95,25 +125,21 @@ fun parseShareLaunchIntent(intent: Intent?): ShareLaunchRequest? {
       .distinct()
       .joinToString(separator = "\n\n")
       .ifEmpty { null }
-  val imageSelection =
-    if (intent.type?.startsWith("image/", ignoreCase = true) == true) {
-      sharedImageUris(intent, action)
-    } else {
-      SharedImageSelection(uris = emptyList(), droppedCount = 0)
-    }
+  val attachmentSelection = sharedAttachments(intent, action, resolveMimeType)
 
-  if (text == null && imageSelection.uris.isEmpty()) return null
+  if (text == null && attachmentSelection.attachments.isEmpty() && attachmentSelection.droppedCount == 0) return null
   return ShareLaunchRequest(
     text = text,
-    imageUris = imageSelection.uris,
-    droppedImageCount = imageSelection.droppedCount,
+    attachments = attachmentSelection.attachments,
+    droppedAttachmentCount = attachmentSelection.droppedCount,
   )
 }
 
-private fun sharedImageUris(
+private fun sharedAttachments(
   intent: Intent,
   action: String,
-): SharedImageSelection {
+  resolveMimeType: (Uri) -> String?,
+): SharedAttachmentSelection {
   val streamUris =
     when (action) {
       Intent.ACTION_SEND ->
@@ -136,10 +162,57 @@ private fun sharedImageUris(
     (streamUris + clipUris)
       .filter { uri -> uri.scheme.equals(ContentResolver.SCHEME_CONTENT, ignoreCase = true) }
       .distinct()
-  return SharedImageSelection(
-    uris = validUris.take(MAX_SHARED_IMAGE_COUNT),
-    droppedCount = (validUris.size - MAX_SHARED_IMAGE_COUNT).coerceAtLeast(0),
+  val fallbackMimeType =
+    normalizeSharedAttachmentMimeType(intent.type)
+      ?.takeIf(::isStageableSharedAttachmentMimeType)
+  val resolved = mutableListOf<SharedAttachment>()
+  var droppedCount = 0
+  for ((index, uri) in validUris.withIndex()) {
+    if (resolved.size >= MAX_SHARED_ATTACHMENT_COUNT) {
+      droppedCount += validUris.size - index
+      break
+    }
+    val providerMimeType =
+      try {
+        normalizeSharedAttachmentMimeType(resolveMimeType(uri))
+      } catch (_: Exception) {
+        null
+      }
+    val mimeType = providerMimeType ?: fallbackMimeType
+    val kind = sharedAttachmentKindForMimeType(mimeType)
+    if (!isStageableSharedAttachmentMimeType(mimeType) || kind == null) {
+      droppedCount += 1
+      continue
+    }
+    resolved += SharedAttachment(uri = uri, kind = kind, mimeType = requireNotNull(mimeType))
+  }
+  return SharedAttachmentSelection(
+    attachments = resolved,
+    droppedCount = droppedCount,
   )
 }
 
-private const val MAX_SHARED_IMAGE_COUNT = 8
+internal fun sharedAttachmentKindForMimeType(mimeType: String?): SharedAttachmentKind? {
+  val normalized = normalizeSharedAttachmentMimeType(mimeType) ?: return null
+  return when {
+    normalized.startsWith("image/") -> SharedAttachmentKind.Image
+    normalized.startsWith("audio/") -> SharedAttachmentKind.Audio
+    normalized in SHARED_ATTACHMENT_MIME_ALLOWLIST -> SharedAttachmentKind.Document
+    else -> null
+  }
+}
+
+internal fun isStageableSharedAttachmentMimeType(mimeType: String?): Boolean {
+  val normalized = normalizeSharedAttachmentMimeType(mimeType) ?: return false
+  val kind = sharedAttachmentKindForMimeType(normalized) ?: return false
+  return kind == SharedAttachmentKind.Image || !normalized.endsWith("/*")
+}
+
+internal fun normalizeSharedAttachmentMimeType(mimeType: String?): String? =
+  mimeType
+    ?.substringBefore(';')
+    ?.trim()
+    ?.lowercase(Locale.US)
+    ?.takeIf { it.isNotEmpty() }
+
+private const val MAX_SHARED_ATTACHMENT_COUNT = 8

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainActivity.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainActivity.kt
@@ -35,6 +35,9 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
 /**
@@ -47,6 +50,8 @@ class MainActivity : AppCompatActivity() {
   private var didStartViewModelCollectors = false
   private var foreground = false
   private val pendingIntentRouter = MainActivityPendingIntentRouter()
+  private val shareLaunchMutex = Mutex()
+  private val shareLaunchSlots = Semaphore(MAX_PENDING_CHAT_SHARES)
   private val runtimeUiStarter = MainActivityRuntimeUiStarter()
   private var screenshotScene: AndroidScreenshotScene? = null
 
@@ -196,10 +201,24 @@ class MainActivity : AppCompatActivity() {
     viewModel: MainViewModel,
     intent: Intent?,
   ) {
-    parseShareLaunchIntent(intent)?.let { request ->
-      if (!viewModel.handleShareLaunch(request)) {
+    if (intent?.isShareLaunchIntent() == true) {
+      if (!shareLaunchSlots.tryAcquire()) {
         Toast.makeText(this, nativeString("Too many shares are waiting to be added."), Toast.LENGTH_SHORT).show()
+        return
       }
+      val owner = viewModel.captureChatShareOwner()
+      lifecycleScope
+        .launch {
+          shareLaunchMutex.withLock {
+            val request =
+              withContext(Dispatchers.IO) {
+                parseShareLaunchIntent(intent, contentResolver::getType)
+              } ?: return@withLock
+            if (!viewModel.handleShareLaunch(request, owner)) {
+              Toast.makeText(this@MainActivity, nativeString("Too many shares are waiting to be added."), Toast.LENGTH_SHORT).show()
+            }
+          }
+        }.invokeOnCompletion { shareLaunchSlots.release() }
       return
     }
     parseHomeDestinationIntent(intent)?.let { destination ->

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -39,7 +39,6 @@ import ai.openclaw.app.voice.VoiceConversationEntry
 import ai.openclaw.app.voice.VoiceWakePreferences
 import android.Manifest
 import android.app.Application
-import android.net.Uri
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.SavedStateHandle
@@ -114,8 +113,8 @@ internal fun retainRefusedAssistantPrompt(
 data class ChatShareDraft(
   val id: Long,
   val text: String?,
-  val imageUris: List<Uri>,
-  val droppedImageCount: Int,
+  val attachments: List<SharedAttachment>,
+  val droppedAttachmentCount: Int,
 )
 
 internal const val MAX_PENDING_CHAT_SHARES = 16
@@ -925,15 +924,17 @@ class MainViewModel private constructor(
   }
 
   /** Opens shared content as a fresh composer draft; sending still requires an explicit tap. */
-  fun handleShareLaunch(request: ShareLaunchRequest): Boolean {
-    val owner = currentOrProvisionalChatComposerOwner()
+  internal fun handleShareLaunch(
+    request: ShareLaunchRequest,
+    owner: ChatComposerOwner,
+  ): Boolean {
     val accepted =
       chatShareDraftQueue.enqueue(
         ChatShareDraft(
           id = chatShareDraftSeq.incrementAndGet(),
           text = request.text,
-          imageUris = request.imageUris,
-          droppedImageCount = request.droppedImageCount,
+          attachments = request.attachments,
+          droppedAttachmentCount = request.droppedAttachmentCount,
         ),
         owner,
       )
@@ -1586,6 +1587,8 @@ class MainViewModel private constructor(
         sessionKey = chatSessionKey.value,
         mainSessionKey = mainSessionKey.value,
       )
+
+  internal fun captureChatShareOwner(): ChatComposerOwner = currentOrProvisionalChatComposerOwner()
 
   internal fun isCurrentChatComposerOwner(expected: ChatComposerOwner): Boolean =
     (

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt
@@ -3,10 +3,10 @@ package ai.openclaw.app.ui.chat
 import ai.openclaw.app.ChatDraft
 import ai.openclaw.app.ChatDraftPlacement
 import ai.openclaw.app.ChatShareDraft
+import ai.openclaw.app.SharedAttachment
 import ai.openclaw.app.chat.ChatComposerOwner
 import ai.openclaw.app.chat.OUTBOX_MAX_COMMAND_ATTACHMENT_BYTES
 import ai.openclaw.app.chat.VoiceNoteRecorderState
-import android.net.Uri
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.saveable.listSaver
 import kotlinx.coroutines.CancellationException
@@ -381,11 +381,16 @@ internal fun mergeSharedChatText(
 internal data class StagedChatShare(
   val text: String?,
   val attachments: List<PendingAttachment>,
-  val failedImageCount: Int,
-  val droppedImageCount: Int,
+  val failedAttachmentCount: Int,
+  val droppedAttachmentCount: Int,
 )
 
 internal const val CHAT_COMPOSER_MAX_ATTACHMENTS = 8
+
+// Gateway chat attachments default to 20 MiB (images: 6 MiB); Android's outbox further caps audio/documents at 8 MiB.
+internal const val CHAT_COMPOSER_MAX_IMAGE_DECODED_BYTES = 6L * 1024L * 1024L
+internal const val CHAT_COMPOSER_MAX_AUDIO_DECODED_BYTES = OUTBOX_MAX_COMMAND_ATTACHMENT_BYTES
+internal const val CHAT_COMPOSER_MAX_DOCUMENT_DECODED_BYTES = OUTBOX_MAX_COMMAND_ATTACHMENT_BYTES
 internal const val CHAT_COMPOSER_MAX_DECODED_ATTACHMENT_BYTES = OUTBOX_MAX_COMMAND_ATTACHMENT_BYTES
 internal const val CHAT_COMPOSER_MAX_BASE64_CHARS = ((CHAT_COMPOSER_MAX_DECODED_ATTACHMENT_BYTES + 2) / 3) * 4
 internal const val CHAT_COMPOSER_MAX_TOTAL_ATTACHMENTS = 24
@@ -412,10 +417,11 @@ internal fun admitChatAttachments(
   for (candidate in candidates) {
     val candidateBase64Chars = candidate.base64.length.toLong()
     val candidateDecodedBytes = decodedBase64ByteCount(candidate.base64)
+    val withinKind = candidateDecodedBytes <= chatComposerAttachmentDecodedByteLimit(candidate.mimeType)
     val withinCount = currentAttachments.size + accepted.size < maxAttachmentCount
     val withinBase64 = candidateBase64Chars <= maxBase64Chars - base64Chars
     val withinDecoded = candidateDecodedBytes <= maxDecodedBytes - decodedBytes
-    if (withinCount && withinBase64 && withinDecoded) {
+    if (withinKind && withinCount && withinBase64 && withinDecoded) {
       accepted += candidate
       base64Chars += candidateBase64Chars
       decodedBytes += candidateDecodedBytes
@@ -425,6 +431,13 @@ internal fun admitChatAttachments(
   }
   return ChatAttachmentAdmission(accepted = accepted, omittedCount = omittedCount)
 }
+
+internal fun chatComposerAttachmentDecodedByteLimit(mimeType: String): Long =
+  when {
+    mimeType.startsWith("image/", ignoreCase = true) -> CHAT_COMPOSER_MAX_IMAGE_DECODED_BYTES
+    mimeType.startsWith("audio/", ignoreCase = true) -> CHAT_COMPOSER_MAX_AUDIO_DECODED_BYTES
+    else -> CHAT_COMPOSER_MAX_DOCUMENT_DECODED_BYTES
+  }
 
 internal fun decodedBase64ByteCount(base64: String): Long {
   val padding =
@@ -439,29 +452,29 @@ internal fun decodedBase64ByteCount(base64: String): Long {
 /** Loads a complete queue head before any part of it becomes visible in the composer. */
 internal suspend fun stageChatShareDraft(
   draft: ChatShareDraft,
-  loadImage: suspend (Uri) -> PendingAttachment,
+  loadAttachment: suspend (SharedAttachment) -> PendingAttachment,
 ): StagedChatShare {
   val attachments = mutableListOf<PendingAttachment>()
-  var failedImageCount = 0
-  var droppedImageCount = draft.droppedImageCount
-  for (uri in draft.imageUris) {
+  var failedAttachmentCount = 0
+  var droppedAttachmentCount = draft.droppedAttachmentCount
+  for (sharedAttachment in draft.attachments) {
     try {
-      val candidate = loadImage(uri)
+      val candidate = loadAttachment(sharedAttachment)
       val admission = admitChatAttachments(attachments, listOf(candidate))
       attachments += admission.accepted
-      droppedImageCount += admission.omittedCount
+      droppedAttachmentCount += admission.omittedCount
     } catch (error: CancellationException) {
       // Screen disposal must leave the queue head unacknowledged for the next ChatScreen.
       throw error
     } catch (_: Exception) {
-      failedImageCount += 1
+      failedAttachmentCount += 1
     }
   }
   return StagedChatShare(
     text = draft.text,
     attachments = attachments,
-    failedImageCount = failedImageCount,
-    droppedImageCount = droppedImageCount,
+    failedAttachmentCount = failedAttachmentCount,
+    droppedAttachmentCount = droppedAttachmentCount,
   )
 }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposerStateStore.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposerStateStore.kt
@@ -249,6 +249,11 @@ internal class ChatComposerStateStore(
     omitted: Int,
   ) = synchronized(lock) { recordAttachmentOmissionLocked(owner, omitted, ChatComposerAttachmentNotice.Image) }
 
+  fun reportAttachmentOmission(
+    owner: ChatComposerOwner,
+    omitted: Int,
+  ) = synchronized(lock) { recordAttachmentOmissionLocked(owner, omitted, ChatComposerAttachmentNotice.Attachment) }
+
   /** Migrates every state surface and returns aliases owned by external queues. */
   fun resolveAliases(
     to: ChatComposerOwner,

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatImageCodec.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatImageCodec.kt
@@ -1,11 +1,18 @@
 package ai.openclaw.app.ui.chat
 
+import ai.openclaw.app.SharedAttachment
+import ai.openclaw.app.SharedAttachmentKind
 import ai.openclaw.app.chat.CHAT_IMAGE_MAX_BASE64_CHARS
+import ai.openclaw.app.isStageableSharedAttachmentMimeType
 import ai.openclaw.app.node.JpegSizeLimiter
+import ai.openclaw.app.normalizeSharedAttachmentMimeType
+import ai.openclaw.app.sharedAttachmentKindForMimeType
 import android.content.ContentResolver
+import android.database.Cursor
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
+import android.provider.OpenableColumns
 import android.util.Base64
 import android.util.LruCache
 import androidx.core.graphics.scale
@@ -25,6 +32,89 @@ private val decodedBitmapCache =
       value: Bitmap,
     ): Int = value.byteCount.coerceAtLeast(1)
   }
+
+internal fun loadPickedAudioOrDocumentAttachment(
+  resolver: ContentResolver,
+  uri: Uri,
+): PendingAttachment {
+  val mimeType = normalizeSharedAttachmentMimeType(resolver.getType(uri))
+  if (!isStageableSharedAttachmentMimeType(mimeType)) throw IllegalStateException("unsupported attachment")
+  val kind = sharedAttachmentKindForMimeType(mimeType)
+  if (kind == null || kind == SharedAttachmentKind.Image) throw IllegalStateException("unsupported attachment")
+  return loadSharedAttachment(resolver, SharedAttachment(uri = uri, kind = kind, mimeType = requireNotNull(mimeType)))
+}
+
+/** Revalidates provider MIME metadata while the sender grant is live, then loads bounded bytes. */
+internal fun loadSharedAttachment(
+  resolver: ContentResolver,
+  attachment: SharedAttachment,
+): PendingAttachment {
+  val providerMimeType = normalizeSharedAttachmentMimeType(resolver.getType(attachment.uri))
+  val mimeType = providerMimeType ?: attachment.mimeType
+  if (!isStageableSharedAttachmentMimeType(mimeType)) throw IllegalStateException("unsupported attachment")
+  val kind = sharedAttachmentKindForMimeType(mimeType) ?: throw IllegalStateException("unsupported attachment")
+  if (providerMimeType != null && (kind != attachment.kind || mimeType != attachment.mimeType)) {
+    throw IllegalStateException("attachment type changed")
+  }
+  if (kind == SharedAttachmentKind.Image) return loadSizedImageAttachment(resolver, attachment.uri)
+
+  val maxBytes = chatComposerAttachmentDecodedByteLimit(mimeType)
+  val bytes = readBoundedAttachmentBytes(resolver, attachment.uri, maxBytes)
+  return PendingAttachment(
+    id = attachment.uri.toString() + "#" + System.currentTimeMillis(),
+    fileName = sharedAttachmentFileName(resolver, attachment.uri),
+    mimeType = mimeType,
+    base64 = Base64.encodeToString(bytes, Base64.NO_WRAP),
+  )
+}
+
+private fun readBoundedAttachmentBytes(
+  resolver: ContentResolver,
+  uri: Uri,
+  maxBytes: Long,
+): ByteArray {
+  val output = ByteArrayOutputStream()
+  resolver.openInputStream(uri).use { input ->
+    requireNotNull(input) { "attachment unavailable" }
+    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+    var total = 0L
+    while (true) {
+      val count = input.read(buffer)
+      if (count < 0) break
+      total += count
+      if (total > maxBytes) throw IllegalStateException("attachment too large")
+      output.write(buffer, 0, count)
+    }
+  }
+  return output.toByteArray()
+}
+
+private fun sharedAttachmentFileName(
+  resolver: ContentResolver,
+  uri: Uri,
+): String {
+  val displayName =
+    try {
+      resolver
+        .query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
+        ?.use { cursor -> cursor.firstString(OpenableColumns.DISPLAY_NAME) }
+    } catch (_: Exception) {
+      null
+    }
+  val raw = displayName ?: uri.lastPathSegment?.substringAfterLast('/') ?: "attachment"
+  return raw
+    .replace(Regex("[\\p{Cc}/\\\\]"), "_")
+    .trim()
+    .take(128)
+    .ifEmpty { "attachment" }
+}
+
+private fun Cursor.firstString(columnName: String): String? {
+  if (!moveToFirst()) return null
+  val index = getColumnIndex(columnName)
+  if (index < 0 || isNull(index)) return null
+  return getString(index)?.trim()?.takeIf { it.isNotEmpty() }
+}
 
 /** Loads a picked image URI into the bounded JPEG attachment shape sent to chat. */
 internal fun loadSizedImageAttachment(

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -5,6 +5,7 @@ import ai.openclaw.app.GatewayModelSummary
 import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.PendingAssistantAutoSend
 import ai.openclaw.app.R
+import ai.openclaw.app.SHARED_AUDIO_DOCUMENT_MIME_TYPES
 import ai.openclaw.app.chat.ChatCommandEntry
 import ai.openclaw.app.chat.ChatComposerOwner
 import ai.openclaw.app.chat.ChatMessage
@@ -87,6 +88,7 @@ import androidx.compose.material.icons.automirrored.filled.VolumeUp
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowDownward
 import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.AttachFile
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.material.icons.filled.ContentCopy
@@ -273,6 +275,8 @@ fun ChatScreen(
   val inputDrafts = composerState.textDrafts
   val imagePickerOwnerCheckpoint =
     rememberSaveable(saver = ChatComposerMediaCheckpoint.Saver) { ChatComposerMediaCheckpoint() }
+  val filePickerOwnerCheckpoint =
+    rememberSaveable(saver = ChatComposerMediaCheckpoint.Saver) { ChatComposerMediaCheckpoint() }
   val voiceNoteCommitCheckpoint = remember { ChatComposerMediaCheckpoint() }
   val input = inputDrafts[composerOwner]
   val attachmentsByOwner by composerState.attachments.collectAsState()
@@ -371,6 +375,36 @@ fun ChatScreen(
           }
       }
     }
+  val pickAudioOrDocument =
+    rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
+      val lease = filePickerOwnerCheckpoint.consume() ?: return@rememberLauncherForActivityResult
+      if (uri == null) {
+        composerState.cancelMediaAcquisition(lease.authorizationId)
+        return@rememberLauncherForActivityResult
+      }
+      val importOwner =
+        if (shouldMigrateComposerDraft(lease.owner, currentPickerOwner, currentPickerMainSessionKey)) {
+          currentPickerOwner
+        } else {
+          lease.owner
+        }
+      viewModel.importChatComposerAttachments(
+        owner = importOwner,
+        mediaAuthorizationId = lease.authorizationId,
+        mainSessionKey = currentPickerMainSessionKey,
+        expectedCount = 1,
+      ) {
+        listOfNotNull(
+          try {
+            loadPickedAudioOrDocumentAttachment(resolver, uri)
+          } catch (err: CancellationException) {
+            throw err
+          } catch (_: Throwable) {
+            null
+          },
+        )
+      }
+    }
 
   LaunchedEffect(composerOwner) {
     dictationController.cancel()
@@ -457,8 +491,8 @@ fun ChatScreen(
     viewModel.withChatShareDraftLease(share.id, ownerSnapshot) {
       val staged =
         withContext(Dispatchers.IO) {
-          stageChatShareDraft(share) { uri ->
-            loadSizedImageAttachment(resolver, uri)
+          stageChatShareDraft(share) { attachment ->
+            loadSharedAttachment(resolver, attachment)
           }
         }
       if (!viewModel.isCurrentChatComposerOwner(ownerSnapshot)) return@withChatShareDraftLease
@@ -482,9 +516,9 @@ fun ChatScreen(
       inputDrafts[ownerSnapshot] =
         mergeSharedChatText(sharedText = staged.text, currentInput = inputDrafts[ownerSnapshot])
       val admissionOmissions = composerState.addAttachments(ownerSnapshot, staged.attachments)
-      composerState.reportImageOmission(
+      composerState.reportAttachmentOmission(
         ownerSnapshot,
-        staged.failedImageCount + staged.droppedImageCount + admissionOmissions,
+        staged.failedAttachmentCount + staged.droppedAttachmentCount + admissionOmissions,
       )
       viewModel.acknowledgeChatShareDraft(share.id, ownerSnapshot)
     }
@@ -631,6 +665,12 @@ fun ChatScreen(
         val authorizationId = composerState.beginMediaAcquisition(composerOwner) ?: return@ChatComposer
         imagePickerOwnerCheckpoint.begin(composerOwner, authorizationId)
         pickImages.launch("image/*")
+      },
+      onPickAudioOrDocument = {
+        if (!viewModel.isCurrentChatComposerOwner(composerOwner)) return@ChatComposer
+        val authorizationId = composerState.beginMediaAcquisition(composerOwner) ?: return@ChatComposer
+        filePickerOwnerCheckpoint.begin(composerOwner, authorizationId)
+        pickAudioOrDocument.launch(SHARED_AUDIO_DOCUMENT_MIME_TYPES)
       },
       onRemoveAttachment = { id -> composerState.removeAttachments(composerOwner, setOf(id)) },
       voiceNoteState = voiceNoteState,
@@ -1635,6 +1675,7 @@ private fun ChatComposer(
   onThinkingLevelChange: (String) -> Unit,
   onOpenModelPicker: () -> Unit,
   onPickImages: () -> Unit,
+  onPickAudioOrDocument: () -> Unit,
   onRemoveAttachment: (String) -> Unit,
   voiceNoteState: VoiceNoteRecorderState,
   voiceNoteElapsedMs: Long,
@@ -1752,6 +1793,7 @@ private fun ChatComposer(
           value = value,
           onValueChange = onValueChange,
           onPickImages = onPickImages,
+          onPickAudioOrDocument = onPickAudioOrDocument,
           onStartVoiceNote = onStartVoiceNote,
           recordVoiceNoteEnabled = recordVoiceNoteEnabled,
           dictationActive = dictationActive,
@@ -2118,6 +2160,7 @@ private fun ChatInputPill(
   value: String,
   onValueChange: (String) -> Unit,
   onPickImages: () -> Unit,
+  onPickAudioOrDocument: () -> Unit,
   onStartVoiceNote: () -> Unit,
   recordVoiceNoteEnabled: Boolean,
   dictationActive: Boolean,
@@ -2146,6 +2189,11 @@ private fun ChatInputPill(
       Surface(onClick = onPickImages, modifier = Modifier.size(ClawTheme.spacing.touchTarget), shape = CircleShape, color = ClawTheme.colors.surfaceRaised, contentColor = ClawTheme.colors.text) {
         Box(contentAlignment = Alignment.Center) {
           Icon(imageVector = Icons.Default.Add, contentDescription = nativeString("Attach image"), modifier = Modifier.size(20.dp))
+        }
+      }
+      Surface(onClick = onPickAudioOrDocument, modifier = Modifier.size(ClawTheme.spacing.touchTarget), shape = CircleShape, color = ClawTheme.colors.surfaceRaised, contentColor = ClawTheme.colors.text) {
+        Box(contentAlignment = Alignment.Center) {
+          Icon(imageVector = Icons.Default.AttachFile, contentDescription = nativeString("Attachment"), modifier = Modifier.size(20.dp))
         }
       }
       Box(modifier = Modifier.weight(1f)) {

--- a/apps/android/app/src/test/java/ai/openclaw/app/ShareLaunchTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ShareLaunchTest.kt
@@ -21,7 +21,7 @@ class ShareLaunchTest {
   @Test
   fun composesDistinctSubjectAndTextForReview() {
     val parsed =
-      parseShareLaunchIntent(
+      parseShare(
         Intent(Intent.ACTION_SEND)
           .setType("text/plain")
           .putExtra(Intent.EXTRA_SUBJECT, "Article title")
@@ -30,14 +30,14 @@ class ShareLaunchTest {
 
     requireNotNull(parsed)
     assertEquals("Article title\n\nhttps://example.com/article", parsed.text)
-    assertEquals(emptyList<Uri>(), parsed.imageUris)
+    assertEquals(emptyList<SharedAttachment>(), parsed.attachments)
   }
 
   @Test
   fun keepsCaptionAndProviderBackedImage() {
     val image = Uri.parse("content://photos/shared/1")
     val parsed =
-      parseShareLaunchIntent(
+      parseShare(
         Intent(Intent.ACTION_SEND)
           .setType("image/png")
           .putExtra(Intent.EXTRA_TEXT, "What is in this image?")
@@ -46,14 +46,15 @@ class ShareLaunchTest {
 
     requireNotNull(parsed)
     assertEquals("What is in this image?", parsed.text)
-    assertEquals(listOf(image), parsed.imageUris)
+    assertEquals(listOf(image), parsed.attachments.map(SharedAttachment::uri))
+    assertEquals(listOf(SharedAttachmentKind.Image), parsed.attachments.map(SharedAttachment::kind))
   }
 
   @Test
   fun readsProviderBackedImageFromClipData() {
     val image = Uri.parse("content://photos/shared/clip")
     val parsed =
-      parseShareLaunchIntent(
+      parseShare(
         Intent(Intent.ACTION_SEND)
           .setType("IMAGE/PNG")
           .apply {
@@ -62,14 +63,14 @@ class ShareLaunchTest {
       )
 
     requireNotNull(parsed)
-    assertEquals(listOf(image), parsed.imageUris)
+    assertEquals(listOf(image), parsed.attachments.map(SharedAttachment::uri))
   }
 
   @Test
-  fun deduplicatesAndBoundsMultipleImagesAcrossExtrasAndClipData() {
+  fun deduplicatesAndBoundsMultipleAttachmentsAcrossExtrasAndClipData() {
     val images = (1..10).map { index -> Uri.parse("content://photos/shared/$index") }
     val parsed =
-      parseShareLaunchIntent(
+      parseShare(
         Intent(Intent.ACTION_SEND_MULTIPLE)
           .setType("image/jpeg")
           .putParcelableArrayListExtra(Intent.EXTRA_STREAM, ArrayList(images))
@@ -79,29 +80,156 @@ class ShareLaunchTest {
       )
 
     requireNotNull(parsed)
-    assertEquals(images.take(8), parsed.imageUris)
-    assertEquals(2, parsed.droppedImageCount)
+    assertEquals(images.take(8), parsed.attachments.map(SharedAttachment::uri))
+    assertEquals(2, parsed.droppedAttachmentCount)
+  }
+
+  @Test
+  fun acceptsSingleAudioShareWhenProviderMimeIsUnknown() {
+    val audio = Uri.parse("content://media/shared/song")
+    val parsed =
+      parseShare(
+        Intent(Intent.ACTION_SEND)
+          .setType("audio/mpeg")
+          .putExtra(Intent.EXTRA_STREAM, audio),
+      )
+
+    requireNotNull(parsed)
+    assertEquals(listOf(audio), parsed.attachments.map(SharedAttachment::uri))
+    assertEquals(listOf(SharedAttachmentKind.Audio), parsed.attachments.map(SharedAttachment::kind))
+  }
+
+  @Test
+  fun rejectsWildcardAudioWhenProviderMimeIsUnknown() {
+    val audio = Uri.parse("content://media/shared/unknown")
+    val parsed =
+      parseShare(
+        Intent(Intent.ACTION_SEND)
+          .setType("audio/*")
+          .putExtra(Intent.EXTRA_STREAM, audio),
+      )
+
+    requireNotNull(parsed)
+    assertEquals(emptyList<SharedAttachment>(), parsed.attachments)
+    assertEquals(1, parsed.droppedAttachmentCount)
+  }
+
+  @Test
+  fun acceptsMultipleAudioShares() {
+    val audio = (1..3).map { Uri.parse("content://media/shared/$it") }
+    val parsed =
+      parseShare(
+        Intent(Intent.ACTION_SEND_MULTIPLE)
+          .setType("audio/ogg")
+          .putParcelableArrayListExtra(Intent.EXTRA_STREAM, ArrayList(audio)),
+      )
+
+    requireNotNull(parsed)
+    assertEquals(audio, parsed.attachments.map(SharedAttachment::uri))
+    assertTrue(parsed.attachments.all { it.kind == SharedAttachmentKind.Audio })
+  }
+
+  @Test
+  fun acceptsCuratedDocumentShare() {
+    val document = Uri.parse("content://docs/shared/report")
+    val parsed =
+      parseShare(
+        Intent(Intent.ACTION_SEND)
+          .setType("application/pdf")
+          .putExtra(Intent.EXTRA_STREAM, document),
+      )
+
+    requireNotNull(parsed)
+    assertEquals(listOf(SharedAttachmentKind.Document), parsed.attachments.map(SharedAttachment::kind))
+    assertEquals("application/pdf", parsed.attachments.single().mimeType)
+  }
+
+  @Test
+  fun classifiesMixedBatchFromProviderMimeTypes() {
+    val image = Uri.parse("content://mixed/image")
+    val audio = Uri.parse("content://mixed/audio")
+    val document = Uri.parse("content://mixed/document")
+    val mimeTypes =
+      mapOf(
+        image to "image/png",
+        audio to "audio/mpeg",
+        document to "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      )
+    val parsed =
+      parseShare(
+        intent =
+          Intent(Intent.ACTION_SEND_MULTIPLE)
+            .setType("*/*")
+            .putParcelableArrayListExtra(Intent.EXTRA_STREAM, arrayListOf(image, audio, document)),
+        mimeTypes = mimeTypes,
+      )
+
+    requireNotNull(parsed)
+    assertEquals(
+      listOf(SharedAttachmentKind.Image, SharedAttachmentKind.Audio, SharedAttachmentKind.Document),
+      parsed.attachments.map(SharedAttachment::kind),
+    )
+  }
+
+  @Test
+  fun rejectsBlanketApplicationTypeUsingProviderMimeAndReportsDrop() {
+    val payload = Uri.parse("content://files/shared/blob")
+    val parsed =
+      parseShare(
+        intent =
+          Intent(Intent.ACTION_SEND)
+            .setType("application/pdf")
+            .putExtra(Intent.EXTRA_STREAM, payload),
+        mimeTypes = mapOf(payload to "application/octet-stream"),
+      )
+
+    requireNotNull(parsed)
+    assertEquals(emptyList<SharedAttachment>(), parsed.attachments)
+    assertEquals(1, parsed.droppedAttachmentCount)
+  }
+
+  @Test
+  fun unsupportedEntriesDoNotConsumeAttachmentCap() {
+    val unsupported = Uri.parse("content://mixed/unsupported")
+    val documents = (1..8).map { Uri.parse("content://mixed/document/$it") }
+    val mimeTypes =
+      buildMap {
+        put(unsupported, "application/octet-stream")
+        documents.forEach { document -> put(document, "application/pdf") }
+      }
+    val parsed =
+      parseShare(
+        intent =
+          Intent(Intent.ACTION_SEND_MULTIPLE)
+            .setType("*/*")
+            .putParcelableArrayListExtra(Intent.EXTRA_STREAM, ArrayList(listOf(unsupported) + documents)),
+        mimeTypes = mimeTypes,
+      )
+
+    requireNotNull(parsed)
+    assertEquals(documents, parsed.attachments.map(SharedAttachment::uri))
+    assertEquals(1, parsed.droppedAttachmentCount)
   }
 
   @Test
   fun rejectsFileUrisAndEmptyOrUnrelatedIntents() {
     assertNull(
-      parseShareLaunchIntent(
+      parseShare(
         Intent(Intent.ACTION_SEND)
           .setType("image/jpeg")
           .putExtra(Intent.EXTRA_STREAM, Uri.parse("file:///data/data/ai.openclaw.app/private.jpg")),
       ),
     )
-    assertNull(parseShareLaunchIntent(Intent(Intent.ACTION_SEND).setType("text/plain")))
-    assertNull(parseShareLaunchIntent(Intent(Intent.ACTION_VIEW)))
+    assertNull(parseShare(Intent(Intent.ACTION_SEND).setType("text/plain")))
+    assertNull(parseShare(Intent(Intent.ACTION_VIEW)))
   }
 
   @Test
   fun rapidSharesKeepStableHeadUntilMatchingAcknowledgement() {
     val queue = ChatShareDraftQueue(capacity = 2)
     val owner = composerOwner("main", "agent:main:device")
-    val first = ChatShareDraft(id = 1, text = "first", imageUris = emptyList(), droppedImageCount = 0)
-    val second = ChatShareDraft(id = 2, text = "second", imageUris = emptyList(), droppedImageCount = 0)
+    val first = ChatShareDraft(id = 1, text = "first", attachments = emptyList(), droppedAttachmentCount = 0)
+    val second = ChatShareDraft(id = 2, text = "second", attachments = emptyList(), droppedAttachmentCount = 0)
 
     assertTrue(queue.enqueue(first, owner))
     assertTrue(queue.enqueue(second, owner))
@@ -121,8 +249,8 @@ class ShareLaunchTest {
   fun pendingShareQueueIsBoundedWithoutReplacingItsHead() {
     val queue = ChatShareDraftQueue(capacity = 1)
     val owner = composerOwner("main", "agent:main:device")
-    val first = ChatShareDraft(id = 1, text = "first", imageUris = emptyList(), droppedImageCount = 0)
-    val overflow = ChatShareDraft(id = 2, text = "overflow", imageUris = emptyList(), droppedImageCount = 0)
+    val first = ChatShareDraft(id = 1, text = "first", attachments = emptyList(), droppedAttachmentCount = 0)
+    val overflow = ChatShareDraft(id = 2, text = "overflow", attachments = emptyList(), droppedAttachmentCount = 0)
 
     assertTrue(queue.enqueue(first, owner))
     assertFalse(queue.enqueue(overflow, owner))
@@ -136,8 +264,8 @@ class ShareLaunchTest {
       val queue = ChatShareDraftQueue(capacity = 2)
       val ownerA = composerOwner("agent-a", "session-a")
       val ownerB = composerOwner("agent-b", "session-b")
-      val first = ChatShareDraft(id = 1, text = "first", imageUris = emptyList(), droppedImageCount = 0)
-      val second = ChatShareDraft(id = 2, text = "second", imageUris = emptyList(), droppedImageCount = 0)
+      val first = ChatShareDraft(id = 1, text = "first", attachments = emptyList(), droppedAttachmentCount = 0)
+      val second = ChatShareDraft(id = 2, text = "second", attachments = emptyList(), droppedAttachmentCount = 0)
       queue.enqueue(first, ownerA)
       queue.enqueue(second, ownerB)
 
@@ -152,8 +280,8 @@ class ShareLaunchTest {
   fun overlappingActivityLoadersCannotCommitTheSameHead() =
     runBlocking {
       val queue = ChatShareDraftQueue(capacity = 2)
-      val first = ChatShareDraft(id = 1, text = "first", imageUris = emptyList(), droppedImageCount = 0)
-      val next = ChatShareDraft(id = 2, text = "second", imageUris = emptyList(), droppedImageCount = 0)
+      val first = ChatShareDraft(id = 1, text = "first", attachments = emptyList(), droppedAttachmentCount = 0)
+      val next = ChatShareDraft(id = 2, text = "second", attachments = emptyList(), droppedAttachmentCount = 0)
       val owner = composerOwner("main", "agent:main:device")
       queue.enqueue(first, owner)
       queue.enqueue(next, owner)
@@ -188,7 +316,7 @@ class ShareLaunchTest {
   fun claimedShareCannotRetargetAcrossComposerNavigation() =
     runBlocking {
       val queue = ChatShareDraftQueue(capacity = 1)
-      val share = ChatShareDraft(id = 1, text = "private", imageUris = emptyList(), droppedImageCount = 0)
+      val share = ChatShareDraft(id = 1, text = "private", attachments = emptyList(), droppedAttachmentCount = 0)
       val ownerA = composerOwner("agent-a", "session-a")
       val ownerB = composerOwner("agent-b", "session-b")
       val resolvedA = ownerA.copy(sessionKey = "agent:agent-a:device")
@@ -207,7 +335,7 @@ class ShareLaunchTest {
   fun shareOwnerIsCapturedBeforeAnyLoaderRuns() =
     runBlocking {
       val queue = ChatShareDraftQueue(capacity = 1)
-      val share = ChatShareDraft(id = 1, text = "private", imageUris = emptyList(), droppedImageCount = 0)
+      val share = ChatShareDraft(id = 1, text = "private", attachments = emptyList(), droppedAttachmentCount = 0)
       val ownerA = composerOwner("agent-a", "session-a")
       val ownerB = composerOwner("agent-b", "session-b")
 
@@ -223,8 +351,8 @@ class ShareLaunchTest {
       val queue = ChatShareDraftQueue(capacity = 2)
       val ownerA = composerOwner("agent-a", "session-a", gatewayStableId = "gateway-a")
       val ownerB = composerOwner("agent-b", "session-b", gatewayStableId = "gateway-b")
-      val first = ChatShareDraft(id = 1, text = "private a", imageUris = emptyList(), droppedImageCount = 0)
-      val second = ChatShareDraft(id = 2, text = "private b", imageUris = emptyList(), droppedImageCount = 0)
+      val first = ChatShareDraft(id = 1, text = "private a", attachments = emptyList(), droppedAttachmentCount = 0)
+      val second = ChatShareDraft(id = 2, text = "private b", attachments = emptyList(), droppedAttachmentCount = 0)
       queue.enqueue(first, ownerA)
       queue.enqueue(second, ownerB)
 
@@ -245,4 +373,9 @@ class ShareLaunchTest {
       agentId = agentId,
       sessionKey = sessionKey,
     )
+
+  private fun parseShare(
+    intent: Intent,
+    mimeTypes: Map<Uri, String> = emptyMap(),
+  ): ShareLaunchRequest? = parseShareLaunchIntent(intent) { uri -> mimeTypes[uri] }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatComposerDraftTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatComposerDraftTest.kt
@@ -3,6 +3,8 @@ package ai.openclaw.app.ui.chat
 import ai.openclaw.app.ChatDraft
 import ai.openclaw.app.ChatDraftPlacement
 import ai.openclaw.app.ChatShareDraft
+import ai.openclaw.app.SharedAttachment
+import ai.openclaw.app.SharedAttachmentKind
 import ai.openclaw.app.chat.ChatComposerOwner
 import ai.openclaw.app.chat.GatewayDefaultAgentOwner
 import ai.openclaw.app.chat.VoiceNoteRecorderState
@@ -527,8 +529,8 @@ class ChatComposerDraftTest {
       StagedChatShare(
         text = "shared link",
         attachments = listOf(shared),
-        failedImageCount = 0,
-        droppedImageCount = 2,
+        failedAttachmentCount = 0,
+        droppedAttachmentCount = 2,
       )
 
     store.add(owner, listOf(existing))
@@ -536,7 +538,7 @@ class ChatComposerDraftTest {
 
     assertEquals("existing draft\n\nshared link", mergeSharedChatText(staged.text, "existing draft"))
     assertEquals(listOf(existing, shared), store.get(owner))
-    assertEquals(2, staged.failedImageCount + staged.droppedImageCount + omitted)
+    assertEquals(2, staged.failedAttachmentCount + staged.droppedAttachmentCount + omitted)
   }
 
   @Test
@@ -548,20 +550,20 @@ class ChatComposerDraftTest {
         ChatShareDraft(
           id = 1,
           text = "caption",
-          imageUris = listOf(readable, unreadable),
-          droppedImageCount = 0,
+          attachments = listOf(sharedAttachment(readable), sharedAttachment(unreadable)),
+          droppedAttachmentCount = 0,
         )
 
       val staged =
-        stageChatShareDraft(draft) { uri ->
-          if (uri == unreadable) error("provider read failed")
-          pendingAttachment(uri.toString())
+        stageChatShareDraft(draft) { attachment ->
+          if (attachment.uri == unreadable) error("provider read failed")
+          pendingAttachment(attachment.uri.toString())
         }
 
       assertEquals("caption", staged.text)
       assertEquals(listOf(readable.toString()), staged.attachments.map { it.id })
-      assertEquals(1, staged.failedImageCount)
-      assertEquals(0, staged.droppedImageCount)
+      assertEquals(1, staged.failedAttachmentCount)
+      assertEquals(0, staged.droppedAttachmentCount)
     }
 
   @Test
@@ -570,8 +572,8 @@ class ChatComposerDraftTest {
       ChatShareDraft(
         id = 1,
         text = null,
-        imageUris = listOf(Uri.parse("content://photos/slow")),
-        droppedImageCount = 0,
+        attachments = listOf(sharedAttachment(Uri.parse("content://photos/slow"))),
+        droppedAttachmentCount = 0,
       )
 
     assertThrows(CancellationException::class.java) {
@@ -588,19 +590,25 @@ class ChatComposerDraftTest {
       val store = ChatComposerAttachmentStore()
       val current = (1..7).map { pendingAttachment("existing-$it") }
       val uris = (1..3).map { Uri.parse("content://photos/shared/$it") }
-      val draft = ChatShareDraft(id = 1, text = null, imageUris = uris, droppedImageCount = 0)
+      val draft =
+        ChatShareDraft(
+          id = 1,
+          text = null,
+          attachments = uris.map(::sharedAttachment),
+          droppedAttachmentCount = 0,
+        )
 
       val staged =
-        stageChatShareDraft(draft) { uri ->
-          pendingAttachment(uri.toString())
+        stageChatShareDraft(draft) { attachment ->
+          pendingAttachment(attachment.uri.toString())
         }
 
       assertEquals(uris.map(Uri::toString), staged.attachments.map { it.id })
-      assertEquals(0, staged.droppedImageCount)
+      assertEquals(0, staged.droppedAttachmentCount)
       store.add(owner, current)
       val omitted = store.add(owner, staged.attachments)
       assertEquals(CHAT_COMPOSER_MAX_ATTACHMENTS, store.get(owner).size)
-      assertEquals(2, staged.droppedImageCount + omitted)
+      assertEquals(2, staged.droppedAttachmentCount + omitted)
     }
 
   @Test
@@ -611,8 +619,8 @@ class ChatComposerDraftTest {
       StagedChatShare(
         text = null,
         attachments = listOf(pendingAttachment("one"), pendingAttachment("two")),
-        failedImageCount = 0,
-        droppedImageCount = 0,
+        failedAttachmentCount = 0,
+        droppedAttachmentCount = 0,
       )
     val current = (1..7).map { pendingAttachment("existing-$it") }
 
@@ -620,7 +628,7 @@ class ChatComposerDraftTest {
     val omitted = store.add(owner, staged.attachments)
 
     assertEquals(CHAT_COMPOSER_MAX_ATTACHMENTS, store.get(owner).size)
-    assertEquals(1, staged.droppedImageCount + omitted)
+    assertEquals(1, staged.droppedAttachmentCount + omitted)
   }
 
   @Test
@@ -666,9 +674,16 @@ class ChatComposerDraftTest {
   }
 
   @Test
+  fun attachmentAdmissionUsesPerKindDecodedBudgets() {
+    assertEquals(CHAT_COMPOSER_MAX_IMAGE_DECODED_BYTES, chatComposerAttachmentDecodedByteLimit("image/png"))
+    assertEquals(CHAT_COMPOSER_MAX_AUDIO_DECODED_BYTES, chatComposerAttachmentDecodedByteLimit("audio/mpeg"))
+    assertEquals(CHAT_COMPOSER_MAX_DOCUMENT_DECODED_BYTES, chatComposerAttachmentDecodedByteLimit("application/pdf"))
+  }
+
+  @Test
   fun stagedShareCommitsOnlyForMatchingQueueHead() {
-    val current = ChatShareDraft(id = 7, text = "current", imageUris = emptyList(), droppedImageCount = 0)
-    val replacement = ChatShareDraft(id = 8, text = "replacement", imageUris = emptyList(), droppedImageCount = 0)
+    val current = ChatShareDraft(id = 7, text = "current", attachments = emptyList(), droppedAttachmentCount = 0)
+    val replacement = ChatShareDraft(id = 8, text = "replacement", attachments = emptyList(), droppedAttachmentCount = 0)
     val owner = ChatComposerOwner(gatewayStableId = "gateway-a", agentId = "agent-a", sessionKey = "session-a")
 
     assertTrue(canCommitStagedChatShare(current.id, current, owner, owner))
@@ -885,7 +900,7 @@ class ChatComposerDraftTest {
 
   @Test
   fun stagedShareRejectsAReplacementComposerOwner() {
-    val share = ChatShareDraft(id = 7, text = "share", imageUris = emptyList(), droppedImageCount = 0)
+    val share = ChatShareDraft(id = 7, text = "share", attachments = emptyList(), droppedAttachmentCount = 0)
     val owner = ChatComposerOwner(gatewayStableId = "gateway-a", agentId = "agent-a", sessionKey = "session-a")
 
     assertFalse(
@@ -951,5 +966,12 @@ class ChatComposerDraftTest {
       fileName = "$id.jpg",
       mimeType = "image/jpeg",
       base64 = base64,
+    )
+
+  private fun sharedAttachment(uri: Uri): SharedAttachment =
+    SharedAttachment(
+      uri = uri,
+      kind = SharedAttachmentKind.Image,
+      mimeType = "image/jpeg",
     )
 }


### PR DESCRIPTION
## What Problem This Solves

The Android app's share-sheet intake only accepted `text/*` and `image/*`, and the composer could only attach images — even though the send pipeline already supports audio and file attachment types (voice notes prove the audio path) and the gateway happily accepts non-image attachments by offloading them to the media store for agent-side reads. Sharing a PDF, a voice memo, or a CSV from another app into OpenClaw was simply impossible on Android.

## Why This Change Was Made

Close the intake gap without touching the transport: add `ACTION_SEND`/`ACTION_SEND_MULTIPLE` filters for `audio/*` and a curated document set (PDF, the OOXML trio, CSV, Markdown — deliberately not blanket `application/*`), and a document/audio picker next to the existing image picker in the composer.

Intake stays hardened the same way image shares already were, plus new guards where non-image bytes need them:

- code-side mime allowlist (manifest filters are advisory; a hostile sender can lie in `intent.type`) with provider-type revalidation at load time while the URI grant is live — a type that changes between parse and load is rejected;
- `content://`-scheme enforcement, dedupe, and the 8-item cap with dropped-count reporting preserved;
- bounded streaming reads with per-kind size budgets (images keep the JPEG limiter; audio/documents cap at the outbox command attachment limit) and display-name sanitization;
- share parsing moved off the main thread behind a bounded slot queue with the composer-owner captured up front, so owner-migration races behave exactly like the existing image path;
- draft-not-autosend unchanged: shared content stages into the composer and sending still requires an explicit tap.

## User Impact

Android users can now share audio files and documents (PDF, Word, Excel, PowerPoint, CSV, Markdown) into OpenClaw from any app's share sheet, and attach them from inside the chat composer. Oversized or unsupported items are dropped with the same visible notice behavior images use today.

## Evidence

- `:app:testPlayDebugUnitTest` for `ShareLaunchTest` (audio single/multiple, document single, mixed batch, `application/octet-stream` rejection, scheme rejection, caps) and `ChatComposerDraftTest` (per-kind budget admission): green.
- `:app:compilePlayDebugKotlin` + `:app:ktlintCheck`: green.
- Structured autoreview: clean — "consistently extends share parsing, bounded loading, composer admission, owner-safe queueing, and picker support … no concrete regression or exploitable defect."
- Size caps aligned with `OUTBOX_MAX_COMMAND_ATTACHMENT_BYTES` (8 MiB) under the gateway's 20 MB default attachment ceiling (`chat-attachments.ts`).
