### PR TITLE
fix(ci): sweep PRs with unknown mergeability in pr-ci-sweeper

### DIFF
--- a/scripts/github/pr-ci-sweeper.mjs
+++ b/scripts/github/pr-ci-sweeper.mjs
@@ -37,14 +37,13 @@ export function classifyPrForSweep({ pr, ciRuns, botCloseCount, now }) {
     return { action: "skip", reason: "recently-updated" };
   }
   // A conflicted PR legitimately has no merge ref; CI cannot attach until the
-  // author resolves, so re-firing would loop forever.
+  // author resolves, so re-firing would loop forever. Null/unknown mergeability
+  // is NOT skipped: live testing showed dropped-CI PRs stay mergeable=null
+  // indefinitely (the stuck merge-ref computation IS the pathology), and
+  // close/reopen is what un-sticks it. A not-yet-computed conflict costs at
+  // most one budgeted re-fire before the recomputed false skips it.
   if (pr.mergeable === false) {
     return { action: "skip", reason: "merge-conflict" };
-  }
-  // Pending computation resolves by the next hourly sweep; do not close/reopen
-  // on an unknown merge state.
-  if (pr.mergeable === null || pr.mergeable === undefined) {
-    return { action: "skip", reason: "mergeability-pending" };
   }
   // Closing a PR silently cancels enabled auto-merge and reopening does not
   // restore it; leave those PRs (e.g. generated locale refreshes) to a human.
@@ -203,7 +202,7 @@ export async function runPrCiSweeper({ github, context, core, dryRun = false, ap
       fresh.state !== "open" ||
       fresh.head.sha !== pr.head.sha ||
       fresh.auto_merge ||
-      fresh.mergeable !== true
+      fresh.mergeable === false
     ) {
       core.info(`pr-ci-sweeper: #${pr.number} changed during sweep; leaving it alone`);
       continue;

--- a/test/scripts/pr-ci-sweeper.test.ts
+++ b/test/scripts/pr-ci-sweeper.test.ts
@@ -113,9 +113,9 @@ describe("classifyPrForSweep", () => {
       expected: { action: "skip", reason: "refire-budget-exhausted" },
     },
     {
-      name: "skips while mergeability is still computing",
+      name: "re-fires on unknown mergeability (stuck merge-ref IS the pathology)",
       input: { pr: pr({ mergeable: null }), ciRuns: [], botCloseCount: 0, now: NOW },
-      expected: { action: "skip", reason: "mergeability-pending" },
+      expected: { action: "refire", reason: "ci-run-missing" },
     },
   ];
 


### PR DESCRIPTION
## What Problem This Solves

The hourly PR CI sweeper (#110889) never repaired its primary targets. Live verification found three genuinely dropped-CI PRs (#110837, #110776, #110657) skipped as `mergeability-pending` across three consecutive sweeps: their `mergeable` stays `null` / `mergeable_state: "unknown"` indefinitely, so the conservative guard made exactly the PRs the sweeper exists for permanently unsweepable.

## Why This Change Was Made

Probing showed the stuck merge-ref computation IS the pathology: repeated `pulls.get` calls over 16+ seconds never resolve mergeability for dropped-CI PRs, while healthy PRs compute within seconds. Close/reopen is what un-sticks GitHub's merge-ref machinery (validated on four maintainer PRs this week). The classify guard now re-fires on unknown mergeability and keeps skipping computed conflicts (`mergeable: false`); the pre-close revalidation applies the same policy. A not-yet-computed conflict costs at most one budgeted re-fire before the post-reopen recomputation yields `false` and skips it — bounded by the existing per-PR budget of two closes.

## User Impact

The sweeper actually heals dropped PR CI instead of logging skips forever. No other behavior changes.

## Evidence

- Live sweep logs (runs 29657783396, 29659015960): `skip #110837/#110776/#110657 (mergeability-pending)` with zero re-fires despite those heads having zero pull_request CI runs.
- Direct probes: `mergeable: null`, `mergeable_state: "unknown"` persisting across repeated GETs 16+ seconds apart for #110837.
- `node scripts/run-vitest.mjs test/scripts/pr-ci-sweeper.test.ts` — 14 tests pass with the inverted null-mergeability case.
- Structured autoreview (gpt-5.6-sol): clean (0.97).
- Post-merge: live dispatch must show re-fires on the three stuck PRs and CI attaching to their heads.