### PR TITLE
fix: distinct Responses tool-call ids for repeated native Kimi calls

### DIFF
--- a/src/agents/embedded-agent-helpers/openai.test.ts
+++ b/src/agents/embedded-agent-helpers/openai.test.ts
@@ -37,14 +37,22 @@ function buildToolResult(rawId: string): ToolResultMessage {
   };
 }
 
-function toolCallId(message: AgentMessage): string {
-  const content = (message as { content?: Array<{ type?: unknown; id?: unknown }> }).content;
+function toolCallId(message: AgentMessage | undefined): string {
+  const content = (message as { content?: Array<{ type?: unknown; id?: unknown }> } | undefined)
+    ?.content;
   const call = content?.find((block) => block.type === "toolCall");
-  return call?.id as string;
+  if (typeof call?.id !== "string") {
+    throw new Error("expected assistant tool call id");
+  }
+  return call.id;
 }
 
-function toolResultId(message: AgentMessage): string {
-  return (message as { toolCallId?: string }).toolCallId as string;
+function toolResultId(message: AgentMessage | undefined): string {
+  const id = (message as { toolCallId?: unknown } | undefined)?.toolCallId;
+  if (typeof id !== "string") {
+    throw new Error("expected tool result id");
+  }
+  return id;
 }
 
 describe("normalizeOpenAIResponsesToolCallIds", () => {

--- a/src/agents/embedded-agent-helpers/openai.test.ts
+++ b/src/agents/embedded-agent-helpers/openai.test.ts
@@ -13,7 +13,7 @@ const ZERO_USAGE = {
   cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 } as const;
 
-function buildAssistantToolCall(toolCallId: string): AssistantMessage {
+function buildAssistantToolCall(rawId: string): AssistantMessage {
   return {
     role: "assistant",
     api: "openai-responses",
@@ -22,14 +22,14 @@ function buildAssistantToolCall(toolCallId: string): AssistantMessage {
     usage: ZERO_USAGE,
     stopReason: "toolUse",
     timestamp: 0,
-    content: [{ type: "toolCall", id: toolCallId, name: "gateway", arguments: {} }],
+    content: [{ type: "toolCall", id: rawId, name: "gateway", arguments: {} }],
   };
 }
 
-function buildToolResult(toolCallId: string): ToolResultMessage {
+function buildToolResult(rawId: string): ToolResultMessage {
   return {
     role: "toolResult",
-    toolCallId,
+    toolCallId: rawId,
     toolName: "gateway",
     content: [],
     isError: false,

--- a/src/agents/embedded-agent-helpers/openai.test.ts
+++ b/src/agents/embedded-agent-helpers/openai.test.ts
@@ -48,27 +48,69 @@ function toolResultId(message: AgentMessage): string {
 }
 
 describe("normalizeOpenAIResponsesToolCallIds", () => {
-  it("assigns distinct call ids to repeated native Kimi tool calls that share a callId", () => {
-    // Native Kimi ids pair a stable `functions.<tool>:<index>` callId with a
-    // unique `fc_tmp_*` itemId. The same tool called at the same index across
-    // turns (e.g. `gateway` called first every time) previously collided
-    // because only the callId half was hashed, producing identical `call_*`
-    // ids and breaking Responses replay with dangling_tool_call.
+  it("derives a stable id from the complete native pairing", () => {
+    const rawId = "functions.gateway:0|fc_tmp_kegospxl46";
+    const first = normalizeOpenAIResponsesToolCallIds([buildAssistantToolCall(rawId)]);
+    const second = normalizeOpenAIResponsesToolCallIds([buildAssistantToolCall(rawId)]);
+
+    expect(toolCallId(first[0])).toBe(
+      "call_functions_gateway_0_fc_tmp_kegospxl46_8ea5d0ca62|fc_tmp_kegospxl46",
+    );
+    expect(toolCallId(second[0])).toBe(toolCallId(first[0]));
+  });
+
+  it("passes canonical Responses ids through without allocating new messages", () => {
+    const messages: AgentMessage[] = [
+      buildAssistantToolCall("call_gateway_0|fc_gateway_0"),
+      buildToolResult("call_gateway_0|fc_gateway_0"),
+    ];
+
+    expect(normalizeOpenAIResponsesToolCallIds(messages)).toBe(messages);
+  });
+
+  it("assigns distinct call ids to repeated native Kimi calls across turns", () => {
     const messages: AgentMessage[] = [
       buildAssistantToolCall("functions.gateway:0|fc_tmp_kegospxl46"),
       buildToolResult("functions.gateway:0|fc_tmp_kegospxl46"),
+      { role: "user", content: "check again", timestamp: 1 } as AgentMessage,
       buildAssistantToolCall("functions.gateway:0|fc_tmp_btw21n10glg"),
       buildToolResult("functions.gateway:0|fc_tmp_btw21n10glg"),
     ];
 
-    const [firstCall, firstResult, secondCall, secondResult] = normalizeOpenAIResponsesToolCallIds(
-      messages,
-    ) as [AgentMessage, AgentMessage, AgentMessage, AgentMessage];
+    const [firstCall, firstResult, , secondCall, secondResult] =
+      normalizeOpenAIResponsesToolCallIds(messages);
 
     const firstCallId = toolCallId(firstCall);
     const secondCallId = toolCallId(secondCall);
     expect(firstCallId).not.toBe(secondCallId);
     expect(toolResultId(firstResult)).toBe(firstCallId);
     expect(toolResultId(secondResult)).toBe(secondCallId);
+  });
+
+  it("normalizes mixed result aliases and incomplete persisted pairings independently", () => {
+    const pairedId = "functions.gateway:0|fc_tmp_paired";
+    const assistantOnlyId = "functions.read:0|fc_tmp_assistant_only";
+    const resultOnlyId = "functions.exec:0|fc_tmp_result_only";
+    const aliasedResult = {
+      ...buildToolResult(pairedId),
+      toolUseId: pairedId,
+    } as ToolResultMessage & { toolUseId: string };
+    const untouchedUser = { role: "user", content: "continue", timestamp: 1 } as AgentMessage;
+
+    const out = normalizeOpenAIResponsesToolCallIds([
+      aliasedResult as AgentMessage,
+      buildAssistantToolCall(pairedId),
+      untouchedUser,
+      buildAssistantToolCall(assistantOnlyId),
+      buildToolResult(resultOnlyId),
+    ]);
+
+    const normalizedPairedId = toolCallId(out[1]);
+    expect(toolResultId(out[0])).toBe(normalizedPairedId);
+    expect((out[0] as { toolUseId?: string }).toolUseId).toBe(normalizedPairedId);
+    expect(out[2]).toBe(untouchedUser);
+    expect(toolCallId(out[3])).toMatch(/^call_[A-Za-z0-9_-]+\|fc_[A-Za-z0-9_-]+$/);
+    expect(toolResultId(out[4])).toMatch(/^call_[A-Za-z0-9_-]+\|fc_[A-Za-z0-9_-]+$/);
+    expect(toolCallId(out[3])).not.toBe(toolResultId(out[4]));
   });
 });

--- a/src/agents/embedded-agent-helpers/openai.test.ts
+++ b/src/agents/embedded-agent-helpers/openai.test.ts
@@ -1,0 +1,74 @@
+// Covers OpenAI Responses tool-call id normalization for replay safety.
+import type { AssistantMessage, ToolResultMessage } from "openclaw/plugin-sdk/llm";
+import { describe, expect, it } from "vitest";
+import type { AgentMessage } from "../runtime/index.js";
+import { normalizeOpenAIResponsesToolCallIds } from "./openai.js";
+
+const ZERO_USAGE = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+} as const;
+
+function buildAssistantToolCall(toolCallId: string): AssistantMessage {
+  return {
+    role: "assistant",
+    api: "openai-responses",
+    provider: "openrouter",
+    model: "moonshotai/kimi-k2.5",
+    usage: ZERO_USAGE,
+    stopReason: "toolUse",
+    timestamp: 0,
+    content: [{ type: "toolCall", id: toolCallId, name: "gateway", arguments: {} }],
+  };
+}
+
+function buildToolResult(toolCallId: string): ToolResultMessage {
+  return {
+    role: "toolResult",
+    toolCallId,
+    toolName: "gateway",
+    content: [],
+    isError: false,
+    timestamp: 0,
+  };
+}
+
+function toolCallId(message: AgentMessage): string {
+  const content = (message as { content?: Array<{ type?: unknown; id?: unknown }> }).content;
+  const call = content?.find((block) => block.type === "toolCall");
+  return call?.id as string;
+}
+
+function toolResultId(message: AgentMessage): string {
+  return (message as { toolCallId?: string }).toolCallId as string;
+}
+
+describe("normalizeOpenAIResponsesToolCallIds", () => {
+  it("assigns distinct call ids to repeated native Kimi tool calls that share a callId", () => {
+    // Native Kimi ids pair a stable `functions.<tool>:<index>` callId with a
+    // unique `fc_tmp_*` itemId. The same tool called at the same index across
+    // turns (e.g. `gateway` called first every time) previously collided
+    // because only the callId half was hashed, producing identical `call_*`
+    // ids and breaking Responses replay with dangling_tool_call.
+    const messages: AgentMessage[] = [
+      buildAssistantToolCall("functions.gateway:0|fc_tmp_kegospxl46"),
+      buildToolResult("functions.gateway:0|fc_tmp_kegospxl46"),
+      buildAssistantToolCall("functions.gateway:0|fc_tmp_btw21n10glg"),
+      buildToolResult("functions.gateway:0|fc_tmp_btw21n10glg"),
+    ];
+
+    const [firstCall, firstResult, secondCall, secondResult] = normalizeOpenAIResponsesToolCallIds(
+      messages,
+    ) as [AgentMessage, AgentMessage, AgentMessage, AgentMessage];
+
+    const firstCallId = toolCallId(firstCall);
+    const secondCallId = toolCallId(secondCall);
+    expect(firstCallId).not.toBe(secondCallId);
+    expect(toolResultId(firstResult)).toBe(firstCallId);
+    expect(toolResultId(secondResult)).toBe(secondCallId);
+  });
+});

--- a/src/agents/embedded-agent-helpers/openai.ts
+++ b/src/agents/embedded-agent-helpers/openai.ts
@@ -125,7 +125,10 @@ function normalizeOpenAIResponsesIdPart(params: {
 function normalizeOpenAIResponsesFunctionCallId(id: string): string {
   const { callId, itemId } = splitOpenAIFunctionCallPairing(id);
   const normalizedCallId = normalizeOpenAIResponsesIdPart({
-    value: callId,
+    // Hash the full pairing so repeated native ids sharing a `callId` (e.g.
+    // `functions.<tool>:<index>` reused across turns) don't collide into the
+    // same `call_*` id and break Responses replay.
+    value: itemId ? `${callId}|${itemId}` : callId,
     prefix: "call_",
     isValid: (value) => OPENAI_RESPONSES_CALL_ID_RE.test(value),
   });

--- a/src/agents/embedded-agent-runner.openai-tool-id-preservation.test.ts
+++ b/src/agents/embedded-agent-runner.openai-tool-id-preservation.test.ts
@@ -23,7 +23,7 @@ vi.mock(
   async () =>
     await createSanitizeSessionHistoryProviderHookRuntimeMock({
       resolveProviderRuntimePlugin: vi.fn(({ provider }: { provider?: string }) =>
-        provider === "openai"
+        provider === "openai" || provider === "openrouter"
           ? {
               buildReplayPolicy: (context?: { modelApi?: string }) => ({
                 // Completions APIs need strict ids; Responses can preserve richer
@@ -193,5 +193,64 @@ describe("sanitizeSessionHistory openai tool id preservation", () => {
 
     const toolResult = result[1] as { toolCallId?: string };
     expect(toolResult.toolCallId).toBe(toolCall?.id);
+  });
+
+  it("keeps repeated Kimi calls distinct while repairing an incomplete later turn", async () => {
+    const firstRawId = "functions.gateway:0|fc_tmp_first";
+    const secondRawId = "functions.gateway:0|fc_tmp_second";
+    const result = await sanitizeSessionHistory({
+      messages: [
+        castAgentMessage({
+          role: "assistant",
+          content: [{ type: "toolCall", id: firstRawId, name: "gateway", arguments: {} }],
+        }),
+        castAgentMessage({
+          role: "toolResult",
+          toolCallId: firstRawId,
+          toolName: "gateway",
+          content: [{ type: "text", text: "first result" }],
+          isError: false,
+        }),
+        castAgentMessage({ role: "user", content: "check again" }),
+        castAgentMessage({
+          role: "assistant",
+          content: [{ type: "toolCall", id: secondRawId, name: "gateway", arguments: {} }],
+        }),
+        castAgentMessage({ role: "user", content: "continue" }),
+      ],
+      modelApi: "openai-responses",
+      provider: "openrouter",
+      modelId: "moonshotai/kimi-k2.5",
+      sessionManager: makeSessionManager(),
+      sessionId: "test-session",
+    });
+
+    const firstAssistant = result[0] as { content?: Array<{ type?: string; id?: string }> };
+    const secondAssistant = result[3] as { content?: Array<{ type?: string; id?: string }> };
+    const firstCallId = firstAssistant.content?.find((block) => block.type === "toolCall")?.id;
+    const secondCallId = secondAssistant.content?.find((block) => block.type === "toolCall")?.id;
+    expect(firstCallId).toMatch(/^call_[A-Za-z0-9_-]+$/);
+    expect(secondCallId).toMatch(/^call_[A-Za-z0-9_-]+$/);
+    expect(secondCallId).not.toBe(firstCallId);
+    expect(result[1]).toMatchObject({
+      role: "toolResult",
+      toolCallId: firstCallId,
+      isError: false,
+      content: [{ type: "text", text: "first result" }],
+    });
+    expect(result[4]).toMatchObject({
+      role: "toolResult",
+      toolCallId: secondCallId,
+      isError: true,
+      content: [{ type: "text", text: "aborted" }],
+    });
+    expect(result.map((message) => message.role)).toEqual([
+      "assistant",
+      "toolResult",
+      "user",
+      "assistant",
+      "toolResult",
+      "user",
+    ]);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where users on the `openai-responses` API path would stop getting any agent replies at all once a session called the same tool at the same call-index more than once (a common pattern — e.g. a `gateway`/status-check tool invoked first in several separate turns). Every subsequent turn on that session failed before producing a reply, with the gateway logging `invalid_replay_transcript: ... dangling_tool_call toolCallId=call_<hash>`. The session was effectively bricked until manually truncated or reset.

Observed on `moonshotai/kimi-k2.5` via OpenRouter, which is what my agent was routed to at the time. The bug isn't model-specific, though — it's in OpenClaw's own id normalizer for the `openai-responses` wire format, so it reproduces for any model/provider combination that goes through that API shape and reuses native `functions.<tool>:<index>|fc_*`-style ids across turns.

## Why This Change Was Made

`normalizeOpenAIResponsesFunctionCallId` (`src/agents/embedded-agent-helpers/openai.ts`) rewrites native tool-call ids like `functions.gateway:0|fc_tmp_kegospxl46` into `call_*` ids the OpenAI Responses API accepts. It splits the id into a `callId` half (`functions.gateway:0`) and an `itemId` half (`fc_tmp_kegospxl46`), but only hashed the `callId` half when generating the `call_*` id. Since `callId` is just `<toolName>:<callIndexInTurn>`, it repeats across turns whenever the same tool is called at the same position — so every occurrence collapsed to the identical `call_*` id, corrupting replay once two or more calls collided in the same session history.

The fix hashes the full `callId|itemId` pairing (falling back to `callId` alone when there is no `itemId`), so repeated native ids that share a `callId` now normalize to distinct ids while still resolving consistently between the assistant tool-call and its matching tool-result.

## User Impact

Sessions on `openai-responses`-backed providers no longer get permanently stuck after the same tool is called at the same index more than once in a conversation — replies keep working instead of failing on every turn with a replay error.

## Evidence

- [x] Mark as AI-assisted in the PR title or description — root-caused and fixed with an AI coding assistant (Claude Code) after diagnosing the issue on a personal OpenClaw instance; I reviewed and understand the change.

**Full before/after runtime proof (linked artifact):** https://gist.github.com/christiandesantis/b1cee60d56319d2d80013310a0ba9cb8 — verbatim `openclaw logs`/`openclaw sessions list --json`/`openclaw agent --json` output from my own instance: session `agent:main:main` (`980f8d6e-c602-4540-b54d-20602bab3d0f`) status `"failed"` before the patch with the repeated `dangling_tool_call` error, then `"done"` after, plus the `workspace.test.ts` CI-flake repro from below. Nothing in it is sensitive — just error metadata, session/run ids, and JSON structure, no personal data.

**Root cause repro** (standalone, no runtime needed):
```
$ node -e 'console.log(require("crypto").createHash("sha256").update("functions.gateway:0").digest("hex").slice(0,10))'
24933ffc9b
```
This matches the exact `toolCallId` from the failure below — proving the collision is `sha256("functions.gateway:0")`, i.e. the `callId` half alone, independent of which specific call produced it.

**Before fix** — real gateway log from my own OpenClaw instance, `agent:main:main` session, every single turn failing identically:
```
$ openclaw logs
2026-07-18T14:46:46.695-04:00 error diagnostic lane task error: lane=main durationMs=253 error="Error: invalid_replay_transcript: OpenAI Responses replay contains dangling_tool_call toolCallId=call_functions_gateway_0_24933ffc9b at message index 18"
2026-07-18T14:46:46.697-04:00 error diagnostic lane task error: lane=session:agent:main:main durationMs=255 error="Error: invalid_replay_transcript: OpenAI Responses replay contains dangling_tool_call toolCallId=call_functions_gateway_0_24933ffc9b at message index 18"
2026-07-18T14:46:46.701-04:00 error Embedded agent failed before reply: invalid_replay_transcript: OpenAI Responses replay contains dangling_tool_call toolCallId=call_functions_gateway_0_24933ffc9b at message index 18
```
The identical error (same `toolCallId`) repeated on every retry over the following ~10 minutes (14:50:21, 14:50:52, 14:51:25, 14:52:26, 14:54:28) — the session never recovered on its own.

**After fix** — same corrupted session, replayed through the patched code (hotpatched compiled output + gateway restart), triggered via `openclaw agent --session-key "agent:main:main" --agent main -m "..." --json`:
```json
"replayInvalid": false,
"livenessState": "working",
"stopReason": "stop",
"executionTrace": {
  "winnerProvider": "openrouter",
  "winnerModel": "moonshotai/kimi-k3",
  "attempts": [{ "provider": "openrouter", "model": "moonshotai/kimi-k3", "result": "success", "stage": "assistant" }],
  "fallbackUsed": false,
  "runner": "embedded"
}
```
Followed by a clean `openclaw logs` tail with no further `dangling_tool_call`/`invalid_replay_transcript` entries and a normal `run ... ended with stopReason=stop` line — the previously-bricked session now completes turns normally. (The response happened to land on `kimi-k3` since the default model had moved on by the time I re-tested — unrelated to the fix, which is model-agnostic.)

**Automated proof:**
- Added `src/agents/embedded-agent-helpers/openai.test.ts`, a focused regression test asserting two native ids that share a `callId` but differ only in `itemId` now normalize to distinct `call_*` ids, with each `toolResult` still resolving to the matching (now-distinct) `toolCall`.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-helpers/openai.test.ts` — passes.
- `pnpm tsgo:core` and `pnpm tsgo:core:test` — both clean.
- `node scripts/run-oxlint.mjs src/agents/embedded-agent-helpers/openai.ts src/agents/embedded-agent-helpers/openai.test.ts` — 0 warnings, 0 errors (fixed a `no-shadow` finding from the initial version of the test).
- `pnpm format` — clean, no diff beyond the intended change.

- I don't have a shareable session log for the AI-assisted diagnosis/fix (local troubleshooting session, not something I captured for export), happy to describe the exact steps if useful for review.
- `autoreview` skill: not run — it isn't available to me as an external contributor without OpenClaw's internal tooling access.

