### PR TITLE
test: run Codex version contracts on dependency bumps

### DIFF
--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -2281,8 +2281,14 @@ const TEST_HELPER_NORMALIZE_TEXT_TARGETS = [
 ];
 const HAPPY_PATH_PROMPT_SNAPSHOT_HELPER_TEST_TARGETS = ["test/scripts/prompt-snapshots.test.ts"];
 const APPCAST_TEST_TARGETS = ["test/appcast.test.ts", "test/scripts/make-appcast.test.ts"];
+const CODEX_VERSION_CONTRACT_TEST_TARGETS = [
+  "extensions/codex/src/manifest.test.ts",
+  "extensions/openai/openai-provider.test.ts",
+];
 const SOURCE_TEST_TARGETS = new Map([
   ...PRECISE_SOURCE_TEST_TARGETS,
+  ["extensions/codex/package.json", CODEX_VERSION_CONTRACT_TEST_TARGETS],
+  ["extensions/codex/src/app-server/version.ts", CODEX_VERSION_CONTRACT_TEST_TARGETS],
   ["src/test-utils/openclaw-test-state.ts", ["src/test-utils/openclaw-test-state.test.ts"]],
   [
     "src/channels/plugins/contracts/test-helpers/manifest.ts",

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -272,6 +272,19 @@ describe("scripts/test-projects changed-target routing", () => {
     });
   });
 
+  it.each(["extensions/codex/package.json", "extensions/codex/src/app-server/version.ts"])(
+    "routes Codex version changes through cross-plugin contract tests for %s",
+    (changedPath) => {
+      expect(resolveChangedTestTargetPlan([changedPath])).toEqual({
+        mode: "targets",
+        targets: [
+          "extensions/codex/src/manifest.test.ts",
+          "extensions/openai/openai-provider.test.ts",
+        ],
+      });
+    },
+  );
+
   it("routes release wrapper changes through their owner tests", () => {
     expect(resolveChangedTestTargetPlan(["scripts/apple-release-source-check.sh"])).toEqual({
       mode: "targets",


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Codex dependency bumps could skip the cross-plugin test that verifies OpenAI model discovery sends the pinned Codex client version.

## Why This Change Was Made

Codex package and supported-version changes now route through both the Codex manifest pin test and the OpenAI provider client-version contract test. Focused planner coverage locks both source paths to that owner set.

## User Impact

No runtime behavior change. Maintainers get earlier CI failure when a future Codex bump leaves OpenAI discovery metadata stale.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/test-projects.test.ts extensions/codex/src/manifest.test.ts extensions/openai/openai-provider.test.ts`
- 3 shards passed: 211 tooling tests, 1 Codex manifest test, 59 OpenAI provider tests.
- `git diff --check`
- `oxfmt --check` on both changed files.
- Autoreview: no accepted/actionable findings, confidence 0.98.

AI-assisted: yes. Change understood and reviewed.
