### PR TITLE
feat(ui): sidebar rows use full width; actions overlay with a hover fade

### DIFF
--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1939,6 +1939,43 @@ html.openclaw-native-macos
   padding-right: 2px;
 }
 
+/* Resting rows give the title the full sidebar width: the trailing aside
+   overlays the row instead of reserving button width in-flow. It must not
+   intercept clicks on the link tail beneath it — the buttons re-enable
+   their own pointer-events on hover/focus. Child rows keep the in-flow
+   aside because their runtime trail is resting content, not a hover swap. */
+.sidebar-recent-session:not(.sidebar-recent-session--child) > .sidebar-recent-session__aside {
+  position: absolute;
+  top: 50%;
+  right: 2px;
+  transform: translateY(-50%);
+  pointer-events: none;
+}
+
+/* Rows with a child toggle keep it as the rightmost in-flow control; the
+   overlaid actions land just left of it, at the link's right edge — the
+   same link-relative geometry as toggle-less rows, so one mask fits both. */
+.sidebar-recent-session:not(.sidebar-recent-session--child):has(> .sidebar-child-session-toggle)
+  > .sidebar-recent-session__aside {
+  right: 35px;
+}
+
+/* While the actions are surfaced, the link content fades out beneath them.
+   A mask (not a background scrim) keeps the fade correct over rest, hover,
+   active, and selected row backgrounds alike. */
+.sidebar-recent-session:not(.sidebar-recent-session--child):hover > .sidebar-recent-session__link,
+.sidebar-recent-session:not(.sidebar-recent-session--child):focus-within
+  > .sidebar-recent-session__link {
+  mask-image: linear-gradient(to right, black calc(100% - 80px), transparent calc(100% - 52px));
+}
+
+/* Touch keeps the actions permanently visible, so the fade is permanent too. */
+@media (hover: none), (pointer: coarse) {
+  .sidebar-recent-session:not(.sidebar-recent-session--child) > .sidebar-recent-session__link {
+    mask-image: linear-gradient(to right, black calc(100% - 80px), transparent calc(100% - 52px));
+  }
+}
+
 .nav-collapse-toggle {
   width: 36px;
   height: 36px;


### PR DESCRIPTION
## What Problem This Solves

Sidebar session rows permanently reserve the width of the hover-only action cluster (pin + menu, ~50px), so titles truncate — "Home server migr…", "Long running session …" — while the reserved space sits empty at rest. The buttons only matter while hovering; the title matters all the time.

## Why This Change Was Made

CSS-only restructure of the row's trailing aside, scoped to sidebar rows (the shared chat session picker is untouched):

- The aside (relative-time trail + action buttons) now overlays the row absolutely instead of sitting in-flow, so resting titles run to the sidebar edge. It is `pointer-events: none` at rest — clicks on the newly covered link tail pass through; the buttons re-enable their own pointer-events on hover/focus (existing rule).
- While the actions are surfaced (row hover/focus), the link content fades out beneath them with a ~28px mask gradient — a mask rather than a background scrim, so the fade is correct over rest, hover, active, and selected row backgrounds without color matching.
- Rows with a child toggle keep the toggle as the rightmost in-flow control (chevron + count stay legible); the overlaid actions land just left of it, which is the same link-relative geometry as toggle-less rows, so one mask rule fits both.
- Child rows keep the in-flow aside: their runtime trail is resting content, not a hover swap.
- Touch pointers keep actions always visible (existing behavior), so the fade is permanent there.

Leading state chrome (unread dot, run spinner) is unaffected; trailing glyphs (dashboard, badges) fade under the buttons only while the row is hovered.

## User Impact

Sidebar rows show meaningfully more of every title at rest; hovering swaps the tail for the management controls with a soft fade instead of a layout jump.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-row-fade/before-rest.png" alt="Before: rest" width="380"> | <img src="https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-row-fade/after-rest.png" alt="After: rest" width="380"> |
| <img src="https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-row-fade/before-hover-row.png" alt="Before: hover" width="380"> | <img src="https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-row-fade/after-hover-row.png" alt="After: hover" width="380"> |

Hovered row with a child toggle (actions sit left of the chevron + count, title fades beneath them):

<img src="https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-row-fade/after-hover-toggle-row.png" alt="After: hover with child toggle" width="380">

## Evidence

- `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts` — 124 passed (CSS-only change; markup and behavior untouched).
- `oxfmt` clean; screenshots from the deterministic mock harness (`scripts/control-ui-mock-dev.ts`) with simulated Mac web chrome — before-shots from the merge base, after-shots from this branch, identical fixtures.
- Continues the quiet-sidebar program (#110448–#110800, #110933) per maintainer direction.
