### PR TITLE
fix(agents): restore ask_user roundtrip in Gateway chats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Ask-user availability and delivery:** keep `ask_user` available to primary sessions under the default `coding` and chat-only `messaging` tool profiles, and deliver its question prompt even when verbose tool progress is disabled.
 - **Bounded input and provider responses:** cap pasted auth/config input and enforce wall-clock deadlines across generated-media downloads, polling JSON, and failed response details so oversized or slow-drip streams cannot exceed resource budgets (thanks @Pick-cat).
 - **Cloud worker derived workspace caches:** exclude Python caches, dependency trees, and macOS metadata symmetrically from outbound sync and inbound reconciliation so local cache rewrites cannot fence later cloud results or worker reclaim.
 - **Codex model status diagnostics:** report a configured Codex route as unavailable when its harness plugin is disabled, missing, or quarantined, while preserving the separate credential result and making `models status --check` fail instead of silently treating fallback execution as healthy. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Ask-user availability and delivery:** keep `ask_user` available to primary sessions under the default `coding` and chat-only `messaging` tool profiles, and deliver its question prompt even when verbose tool progress is disabled.
 - **Bounded input and provider responses:** cap pasted auth/config input and enforce wall-clock deadlines across generated-media downloads, polling JSON, and failed response details so oversized or slow-drip streams cannot exceed resource budgets (thanks @Pick-cat).
 - **Cloud worker derived workspace caches:** exclude Python caches, dependency trees, and macOS metadata symmetrically from outbound sync and inbound reconciliation so local cache rewrites cannot fence later cloud results or worker reclaim.
 - **Codex model status diagnostics:** report a configured Codex route as unavailable when its harness plugin is disabled, missing, or quarantined, while preserving the separate credential result and making `models status --check` fail instead of silently treating fallback execution as healthy. Thanks @shakkernerd.

--- a/docs/gateway/config-tools.md
+++ b/docs/gateway/config-tools.md
@@ -20,12 +20,12 @@ sidebarTitle: "Tools and custom providers"
 Local onboarding defaults new local configs to `tools.profile: "coding"` when unset (existing explicit profiles are preserved).
 </Note>
 
-| Profile     | Includes                                                                                                                                                                                                                     |
-| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `minimal`   | `session_status` only                                                                                                                                                                                                        |
-| `coding`    | `group:fs`, `group:runtime`, `group:web`, `group:sessions`, `group:memory`, `cron`, `get_goal`, `create_goal`, `update_goal`, `update_plan`, `skill_workshop`, `image`, `image_generate`, `music_generate`, `video_generate` |
-| `messaging` | `group:messaging`, `sessions_list`, `sessions_history`, `sessions_send`, `session_status`                                                                                                                                    |
-| `full`      | No restriction (same as unset)                                                                                                                                                                                               |
+| Profile     | Includes                                                                                                                                                                                                                                 |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `minimal`   | `session_status` only                                                                                                                                                                                                                    |
+| `coding`    | `group:fs`, `group:runtime`, `group:web`, `group:sessions`, `group:memory`, `cron`, `get_goal`, `create_goal`, `update_goal`, `update_plan`, `ask_user`, `skill_workshop`, `image`, `image_generate`, `music_generate`, `video_generate` |
+| `messaging` | `group:messaging`, `sessions_list`, `sessions_history`, `sessions_send`, `session_status`, `ask_user`                                                                                                                                    |
+| `full`      | No restriction (same as unset)                                                                                                                                                                                                           |
 
 `coding` and `messaging` also implicitly allow `bundle-mcp` (configured MCP servers).
 
@@ -42,7 +42,7 @@ Local onboarding defaults new local configs to `tools.profile: "coding"` when un
 | `group:automation` | `heartbeat_respond`, `cron`, `gateway`                                                                                                                |
 | `group:messaging`  | `message`                                                                                                                                             |
 | `group:nodes`      | `nodes`, `computer`                                                                                                                                   |
-| `group:agents`     | `agents_list`, `get_goal`, `create_goal`, `update_goal`, `update_plan`, `skill_workshop`                                                              |
+| `group:agents`     | `agents_list`, `get_goal`, `create_goal`, `update_goal`, `update_plan`, `ask_user`, `skill_workshop`                                                  |
 | `group:media`      | `image`, `image_generate`, `music_generate`, `video_generate`, `tts`                                                                                  |
 | `group:openclaw`   | All built-in tools above except `read`/`write`/`edit`/`apply_patch`/`exec`/`process`/`canvas` (excludes plugin tools)                                 |
 | `group:plugins`    | Tools owned by loaded plugins, including configured MCP servers exposed through `bundle-mcp`                                                          |

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-assistant-text.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-assistant-text.ts
@@ -61,6 +61,16 @@ export function buildAssistantText(
       ? extractLatestToolOutput(input)
       : "");
   const toolJson = parseToolOutputJson(scenarioToolOutput);
+  const structuredToolText = Array.isArray(toolJson?.content)
+    ? toolJson.content
+        .map((entry) =>
+          entry && typeof entry === "object" && !Array.isArray(entry)
+            ? (entry as { text?: unknown }).text
+            : undefined,
+        )
+        .filter((value): value is string => typeof value === "string")
+        .join("\n")
+    : "";
   const userTexts = extractAllUserTexts(input);
   const allInputText = extractAllRequestTexts(input, body);
   const rememberedFact = extractRememberedFact(userTexts);
@@ -328,14 +338,15 @@ export function buildAssistantText(
   ) {
     const targetTool = extractToolSearchTarget(allInputText);
     if (targetTool === "ask_user") {
-      const deploy = /^Deploy:\s*(.+)$/m.exec(toolOutput)?.[1]?.trim();
+      const askUserResult = structuredToolText || toolOutput;
+      const deploy = /^Deploy:\s*(.+)$/m.exec(askUserResult)?.[1]?.trim();
       const checks = /^Checks:\s*(.+)$/m
-        .exec(toolOutput)?.[1]
+        .exec(askUserResult)?.[1]
         ?.split(",")
         .map((value) => value.replace(/\s*\(Recommended\)\s*$/, "").trim())
         .filter(Boolean)
         .join(",");
-      const note = /^Note:\s*(.+)$/m.exec(toolOutput)?.[1]?.trim();
+      const note = /^Note:\s*(.+)$/m.exec(askUserResult)?.[1]?.trim();
       if (deploy && checks && note) {
         return `ASK-USER-ROUNDTRIP-OK | deploy=${deploy} | checks=${checks} | note=${note}`;
       }

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-assistant-text.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-assistant-text.ts
@@ -327,6 +327,19 @@ export function buildAssistantText(
       QA_TOOL_SEARCH_FAILURE_PROMPT_RE.test(allInputText))
   ) {
     const targetTool = extractToolSearchTarget(allInputText);
+    if (targetTool === "ask_user") {
+      const deploy = /^Deploy:\s*(.+)$/m.exec(toolOutput)?.[1]?.trim();
+      const checks = /^Checks:\s*(.+)$/m
+        .exec(toolOutput)?.[1]
+        ?.split(",")
+        .map((value) => value.replace(/\s*\(Recommended\)\s*$/, "").trim())
+        .filter(Boolean)
+        .join(",");
+      const note = /^Note:\s*(.+)$/m.exec(toolOutput)?.[1]?.trim();
+      if (deploy && checks && note) {
+        return `ASK-USER-ROUNDTRIP-OK | deploy=${deploy} | checks=${checks} | note=${note}`;
+      }
+    }
     if (targetTool && toolOutput.includes(targetTool) && toolOutput.includes("FAKE_PLUGIN_OK")) {
       return `FAKE_PLUGIN_OK ${targetTool}`;
     }

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-assistant-text.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-assistant-text.ts
@@ -90,6 +90,11 @@ export function buildAssistantText(
       : "";
   const promptExactReplyDirective = extractExactReplyDirective(prompt);
   const promptExactMarkerDirective = extractExactMarkerDirective(prompt);
+  const allUserText = userTexts.join("\n");
+  const userExactReplyDirective =
+    promptExactReplyDirective ?? extractExactReplyDirective(allUserText);
+  const userExactMarkerDirective =
+    promptExactMarkerDirective ?? extractExactMarkerDirective(allUserText);
   const exactReplyDirective = promptExactReplyDirective ?? extractExactReplyDirective(allInputText);
   const exactMarkerDirective =
     promptExactMarkerDirective ?? extractExactMarkerDirective(allInputText);
@@ -161,11 +166,11 @@ export function buildAssistantText(
   if (/\bmarker\b/i.test(allInputText) && promptExactReplyDirective) {
     return promptExactReplyDirective;
   }
-  if (/\bmarker\b/i.test(allInputText) && exactMarkerDirective) {
-    return exactMarkerDirective;
+  if (/\bmarker\b/i.test(allInputText) && userExactMarkerDirective) {
+    return userExactMarkerDirective;
   }
-  if (/\bmarker\b/i.test(allInputText) && exactReplyDirective) {
-    return exactReplyDirective;
+  if (/\bmarker\b/i.test(allInputText) && userExactReplyDirective) {
+    return userExactReplyDirective;
   }
   if (promptExactReplyDirective) {
     return promptExactReplyDirective;
@@ -331,26 +336,30 @@ export function buildAssistantText(
     }
     return "";
   }
+  const askUserResult = structuredToolText || toolOutput;
+  const askUserDeploy = /^Deploy:\s*(.+)$/m.exec(askUserResult)?.[1]?.trim();
+  const askUserChecks = /^Checks:\s*(.+)$/m
+    .exec(askUserResult)?.[1]
+    ?.split(",")
+    .map((value) => value.replace(/\s*\(Recommended\)\s*$/, "").trim())
+    .filter(Boolean)
+    .join(",");
+  const askUserNote = /^Note:\s*(.+)$/m.exec(askUserResult)?.[1]?.trim();
+  if (
+    toolOutput &&
+    /"status"\s*:\s*"answered"/.test(askUserResult) &&
+    askUserDeploy &&
+    askUserChecks &&
+    askUserNote
+  ) {
+    return `ASK-USER-ROUNDTRIP-OK | deploy=${askUserDeploy} | checks=${askUserChecks} | note=${askUserNote}`;
+  }
   if (
     toolOutput &&
     (QA_TOOL_SEARCH_PROMPT_RE.test(allInputText) ||
       QA_TOOL_SEARCH_FAILURE_PROMPT_RE.test(allInputText))
   ) {
     const targetTool = extractToolSearchTarget(allInputText);
-    if (targetTool === "ask_user") {
-      const askUserResult = structuredToolText || toolOutput;
-      const deploy = /^Deploy:\s*(.+)$/m.exec(askUserResult)?.[1]?.trim();
-      const checks = /^Checks:\s*(.+)$/m
-        .exec(askUserResult)?.[1]
-        ?.split(",")
-        .map((value) => value.replace(/\s*\(Recommended\)\s*$/, "").trim())
-        .filter(Boolean)
-        .join(",");
-      const note = /^Note:\s*(.+)$/m.exec(askUserResult)?.[1]?.trim();
-      if (deploy && checks && note) {
-        return `ASK-USER-ROUNDTRIP-OK | deploy=${deploy} | checks=${checks} | note=${note}`;
-      }
-    }
     if (targetTool && toolOutput.includes(targetTool) && toolOutput.includes("FAKE_PLUGIN_OK")) {
       return `FAKE_PLUGIN_OK ${targetTool}`;
     }

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-assistant-text.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-assistant-text.ts
@@ -96,8 +96,6 @@ export function buildAssistantText(
   const userExactMarkerDirective =
     promptExactMarkerDirective ?? extractExactMarkerDirective(allUserText);
   const exactReplyDirective = promptExactReplyDirective ?? extractExactReplyDirective(allInputText);
-  const exactMarkerDirective =
-    promptExactMarkerDirective ?? extractExactMarkerDirective(allInputText);
   const whatsAppLocationMarker = shouldUseWhatsAppLocationMarker(prompt)
     ? extractWhatsAppLocationMarkerDirective(allInputText)
     : "";

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-tooling.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-tooling.ts
@@ -215,6 +215,42 @@ export function buildQaToolSearchArgs(
   if (targetTool === "message") {
     return { action: "send", message: "runtime parity message fixture" };
   }
+  if (targetTool === "ask_user") {
+    return {
+      questions: [
+        {
+          id: "deploy_target",
+          header: "Deploy",
+          question: "Where should this deploy?",
+          options: [
+            { label: "Staging (Recommended)", description: "Safer default" },
+            { label: "Production", description: "Ship to users" },
+          ],
+        },
+        {
+          id: "checks",
+          header: "Checks",
+          question: "Which checks should run?",
+          options: [
+            { label: "Unit (Recommended)", description: "Fast focused coverage" },
+            { label: "E2E", description: "Full user-path coverage" },
+            { label: "Lint", description: "Static checks" },
+          ],
+          multiSelect: true,
+        },
+        {
+          id: "release_note",
+          header: "Note",
+          question: "Which release note label should be used?",
+          options: [
+            { label: "Routine (Recommended)", description: "Standard release note" },
+            { label: "Urgent", description: "Highlight prominently" },
+          ],
+        },
+      ],
+      timeoutSeconds: 60,
+    };
+  }
   if (targetTool === "session_status") {
     return { sessionKey: "current" };
   }

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -4600,6 +4600,35 @@ describe("qa mock openai server", () => {
     expect(outputText(await response.json())).toBe(`FAKE_PLUGIN_OK ${targetTool}`);
   });
 
+  it("derives ask_user QA summaries from the returned answers", async () => {
+    const server = await startMockServer();
+    const response = await postResponses(server, {
+      stream: false,
+      input: [
+        makeUserInput(
+          "tool search qa check target=ask_user. Ask structured questions, then summarize their actual answers.",
+        ),
+        {
+          type: "function_call_output",
+          call_id: "call_ask_user_1",
+          output: JSON.stringify({
+            content: [
+              {
+                type: "text",
+                text: "Deploy: Canary\nChecks: Lint, Unit (Recommended)\nNote: weekend-only",
+              },
+            ],
+          }),
+        },
+      ],
+    });
+
+    expect(response.status).toBe(200);
+    expect(outputText(await response.json())).toBe(
+      "ASK-USER-ROUNDTRIP-OK | deploy=Canary | checks=Lint,Unit | note=weekend-only",
+    );
+  });
+
   it("plans QA tool-search failure calls with denied-input args", async () => {
     const server = await startMockServer();
 

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -4605,8 +4605,17 @@ describe("qa mock openai server", () => {
     const response = await postResponses(server, {
       stream: false,
       input: [
+        {
+          role: "system",
+          content: [
+            {
+              type: "input_text",
+              text: "Nothing to say: entire reply exactly NO_REPLY",
+            },
+          ],
+        },
         makeUserInput(
-          "tool search qa check target=ask_user. Ask structured questions, then summarize their actual answers.",
+          "QA routing marker: tool search qa check target=ask_user. Ask structured questions, then summarize their actual answers.",
         ),
         {
           type: "function_call_output",
@@ -4615,7 +4624,7 @@ describe("qa mock openai server", () => {
             content: [
               {
                 type: "text",
-                text: "Deploy: Canary\nChecks: Lint, Unit (Recommended)\nNote: weekend-only",
+                text: 'Deploy: Canary\nChecks: Lint, Unit (Recommended)\nNote: weekend-only\n\n{"status":"answered"}',
               },
             ],
           }),

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -164,6 +164,11 @@ async function buildResponsesPayload(
   const toolJson = parseToolOutputJson(scenarioToolOutput);
   const promptExactReplyDirective = extractExactReplyDirective(prompt);
   const promptExactMarkerDirective = extractExactMarkerDirective(prompt);
+  const allUserText = extractAllUserTexts(input).join("\n");
+  const userExactReplyDirective =
+    promptExactReplyDirective ?? extractExactReplyDirective(allUserText);
+  const userExactMarkerDirective =
+    promptExactMarkerDirective ?? extractExactMarkerDirective(allUserText);
   const exactReplyDirective = promptExactReplyDirective ?? extractExactReplyDirective(allInputText);
   const exactMarkerDirective =
     promptExactMarkerDirective ?? extractExactMarkerDirective(allInputText);
@@ -728,11 +733,11 @@ async function buildResponsesPayload(
   if (/\bmarker\b/i.test(allInputText) && promptExactReplyDirective) {
     return buildAssistantEvents(promptExactReplyDirective);
   }
-  if (/\bmarker\b/i.test(allInputText) && exactMarkerDirective) {
-    return buildAssistantEvents(exactMarkerDirective);
+  if (/\bmarker\b/i.test(allInputText) && userExactMarkerDirective) {
+    return buildAssistantEvents(userExactMarkerDirective);
   }
-  if (/\bmarker\b/i.test(allInputText) && exactReplyDirective) {
-    return buildAssistantEvents(exactReplyDirective);
+  if (/\bmarker\b/i.test(allInputText) && userExactReplyDirective) {
+    return buildAssistantEvents(userExactReplyDirective);
   }
   if (QA_SKILL_WORKSHOP_REVIEW_PROMPT_RE.test(allInputText)) {
     return buildAssistantEvents(

--- a/qa/scenarios/runtime/tools/ask-user.yaml
+++ b/qa/scenarios/runtime/tools/ask-user.yaml
@@ -123,7 +123,7 @@ flow:
           saveAs: finalMessage
           args:
             - lambda:
-                expr: "state.getSnapshot().messages.slice(startIndex).find((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === config.conversationId && candidate !== promptMessage && !candidate.text.includes(config.promptNeedle))"
+                expr: "state.getSnapshot().messages.slice(startIndex).find((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === config.conversationId && candidate !== promptMessage && candidate.text.includes(config.expectedFinal))"
             - expr: liveTurnTimeoutMs(env, 45000)
             - expr: "env.providerMode === 'mock-openai' ? 100 : 250"
         - assert:

--- a/qa/scenarios/runtime/tools/ask-user.yaml
+++ b/qa/scenarios/runtime/tools/ask-user.yaml
@@ -123,11 +123,11 @@ flow:
           saveAs: finalMessage
           args:
             - lambda:
-                expr: "state.getSnapshot().messages.slice(startIndex).find((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === config.conversationId && candidate !== promptMessage && candidate.text.includes(config.expectedFinal))"
+                expr: "state.getSnapshot().messages.slice(startIndex).find((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === config.conversationId && candidate !== promptMessage && candidate.text === config.expectedFinal)"
             - expr: liveTurnTimeoutMs(env, 45000)
             - expr: "env.providerMode === 'mock-openai' ? 100 : 250"
         - assert:
-            expr: "finalMessage.text.includes(config.expectedFinal)"
+            expr: "finalMessage.text === config.expectedFinal"
             message:
               expr: "`ask_user resumed with unexpected final text: ${JSON.stringify(finalMessage.text)}`"
         - set: terminalQuestion

--- a/qa/scenarios/runtime/tools/ask-user.yaml
+++ b/qa/scenarios/runtime/tools/ask-user.yaml
@@ -1,0 +1,121 @@
+title: Ask user structured question roundtrip
+
+scenario:
+  id: runtime-tool-ask-user
+  surface: runtime-tool
+  coverage:
+    primary:
+      - tools.ask-user
+    secondary:
+      - channels.qa-channel
+      - gateway.chat-apis
+  objective: Verify the agent can ask three structured questions, pause, receive mixed answer shapes, and resume with the selected values.
+  successCriteria:
+    - The model calls ask_user exactly once with single-select, multi-select, and free-text-capable questions.
+    - QA Channel delivers the structured prompt while the agent run remains blocked.
+    - Gateway resolution resumes the same run with the canonical selected values.
+    - The final reply proves the agent received the selected single, multiple, and free-text answers.
+  docsRefs:
+    - docs/tools/ask-user.md
+    - docs/channels/qa-channel.md
+    - docs/concepts/qa-e2e-automation.md
+  codeRefs:
+    - src/agents/tools/ask-user-tool.ts
+    - src/gateway/server-methods/question.ts
+    - extensions/qa-lab/src/providers/mock-openai/mock-openai-tooling.ts
+    - extensions/qa-lab/src/suite-runtime-agent-process.ts
+  execution:
+    kind: flow
+    summary: Send an inbound chat turn, observe its ask_user prompt through QA Channel, resolve three answer shapes, and verify the resumed final reply.
+    config:
+      conversationId: qa-ask-user-roundtrip
+      promptNeedle: Where should this deploy?
+      expectedFinal: ASK-USER-ROUNDTRIP-OK | deploy=Production | checks=Unit,E2E | note=night-shift
+      prompt: >-
+        Structured question QA check. Call ask_user exactly once with these three questions:
+        deploy_target asks "Where should this deploy?" with Staging (Recommended) first and Production second;
+        checks asks "Which checks should run?" with Unit (Recommended), E2E, and Lint and allows multiple selections;
+        release_note asks "Which release note label should be used?" with Routine (Recommended) and Urgent.
+        Use a 60 second timeout. After the tool returns, read its actual answers and reply on one line
+        using this format: `ASK-USER-ROUNDTRIP-OK | deploy=<deploy_target> | checks=<checks comma-separated without spaces or Recommended suffixes> | note=<release_note>`.
+        Never invent or predict the answers.
+        QA routing marker: tool search qa check target=ask_user.
+
+flow:
+  steps:
+    - name: asks, blocks, resolves, and resumes with structured answers
+      actions:
+        - call: waitForGatewayHealthy
+          args:
+            - ref: env
+            - 60000
+        - call: waitForQaChannelReady
+          args:
+            - ref: env
+            - 60000
+        - call: reset
+        - set: startIndex
+          value:
+            expr: state.getSnapshot().messages.length
+        - sendInbound:
+            conversation:
+              id:
+                ref: config.conversationId
+              kind: direct
+            senderId:
+              ref: config.conversationId
+            senderName: QA Operator
+            text:
+              ref: config.prompt
+        - call: waitForCondition
+          saveAs: pendingQuestion
+          args:
+            - lambda:
+                async: true
+                expr: "(await env.gateway.call('question.list', {})).questions.find((question) => question.status === 'pending' && question.questions.some((entry) => entry.question === config.promptNeedle))"
+            - expr: liveTurnTimeoutMs(env, 45000)
+            - expr: "env.providerMode === 'mock-openai' ? 100 : 250"
+        - call: waitForCondition
+          saveAs: promptMessage
+          args:
+            - lambda:
+                expr: "state.getSnapshot().messages.slice(startIndex).find((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === config.conversationId && candidate.text.includes(config.promptNeedle))"
+            - expr: liveTurnTimeoutMs(env, 45000)
+            - expr: "env.providerMode === 'mock-openai' ? 100 : 250"
+        - assert:
+            expr: "pendingQuestion.questions.length === 3 && pendingQuestion.questions[0].id === 'deploy_target' && pendingQuestion.questions[1].multiSelect === true && pendingQuestion.questions.every((question) => question.isOther === true)"
+            message:
+              expr: "`ask_user question shape drifted: ${JSON.stringify(pendingQuestion.questions)}`"
+        - set: resolution
+          value:
+            expr: >-
+              env.gateway.call('question.resolve', {
+                id: pendingQuestion.id,
+                answers: {
+                  answers: {
+                    deploy_target: { answers: ['Production'] },
+                    checks: { answers: ['Unit (Recommended)', 'E2E'] },
+                    release_note: { answers: ['night-shift'] },
+                  },
+                },
+                resolvedBy: 'qa-lab',
+              })
+        - assert:
+            expr: "resolution.status === 'answered'"
+            message:
+              expr: "`ask_user resolution failed: ${JSON.stringify(resolution)}`"
+        - call: waitForCondition
+          saveAs: finalMessage
+          args:
+            - lambda:
+                expr: "state.getSnapshot().messages.slice(startIndex).filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === config.conversationId && candidate.text.includes(config.expectedFinal)).at(-1)"
+            - expr: liveTurnTimeoutMs(env, 45000)
+            - expr: "env.providerMode === 'mock-openai' ? 100 : 250"
+        - set: terminalQuestion
+          value:
+            expr: "env.gateway.call('question.get', { id: pendingQuestion.id })"
+        - assert:
+            expr: "resolution.status === 'answered' && terminalQuestion.question.status === 'answered'"
+            message:
+              expr: "`ask_user question did not terminalize as answered: ${JSON.stringify({ resolution, terminalQuestion })}`"
+      detailsExpr: finalMessage.text

--- a/qa/scenarios/runtime/tools/ask-user.yaml
+++ b/qa/scenarios/runtime/tools/ask-user.yaml
@@ -54,6 +54,9 @@ flow:
             - ref: env
             - 60000
         - call: reset
+        - set: requestCursorBefore
+          value:
+            expr: "env.mock ? (await fetchJson(`${env.mock.baseUrl}/debug/request-cursor`)).cursor : 0"
         - set: startIndex
           value:
             expr: state.getSnapshot().messages.length
@@ -105,12 +108,28 @@ flow:
             message:
               expr: "`ask_user resolution failed: ${JSON.stringify(resolution)}`"
         - call: waitForCondition
+          saveAs: resumedProviderRequest
+          args:
+            - lambda:
+                async: true
+                expr: "env.mock ? (await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${requestCursorBefore}`)).find((request) => String(request.toolOutput ?? '').includes('Deploy:')) : true"
+            - expr: liveTurnTimeoutMs(env, 45000)
+            - expr: "env.providerMode === 'mock-openai' ? 100 : 250"
+        - assert:
+            expr: "!env.mock || (String(resumedProviderRequest.toolOutput).includes('Production') && String(resumedProviderRequest.toolOutput).includes('Unit (Recommended)') && String(resumedProviderRequest.toolOutput).includes('E2E') && String(resumedProviderRequest.toolOutput).includes('night-shift'))"
+            message:
+              expr: "`ask_user answers did not reach the resumed provider request: ${JSON.stringify({ toolOutput: resumedProviderRequest?.toolOutput })}`"
+        - call: waitForCondition
           saveAs: finalMessage
           args:
             - lambda:
-                expr: "state.getSnapshot().messages.slice(startIndex).filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === config.conversationId && candidate.text.includes(config.expectedFinal)).at(-1)"
+                expr: "state.getSnapshot().messages.slice(startIndex).find((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === config.conversationId && candidate !== promptMessage && !candidate.text.includes(config.promptNeedle))"
             - expr: liveTurnTimeoutMs(env, 45000)
             - expr: "env.providerMode === 'mock-openai' ? 100 : 250"
+        - assert:
+            expr: "finalMessage.text.includes(config.expectedFinal)"
+            message:
+              expr: "`ask_user resumed with unexpected final text: ${JSON.stringify(finalMessage.text)}`"
         - set: terminalQuestion
           value:
             expr: "env.gateway.call('question.get', { id: pendingQuestion.id })"

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -47,6 +47,7 @@ async function activateAskUserPrompt(toolCallId: string, args: unknown) {
   let resolveAnswer: ((value: { status: "cancelled" }) => void) | undefined;
   const tool = createAskUserTool({
     sessionKey: "agent:unit-session",
+    runId: "run-test",
     gatewayCall: async (method, _opts, params) => {
       if (method === "question.request") {
         if (!params || typeof params !== "object" || !("id" in params)) {

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -160,12 +160,13 @@ function buildAskUserPromptPayload(
   args: unknown,
 ) {
   try {
-    const { questions } = normalizeAskUserParams(args);
+    const { questions, timeoutSeconds } = normalizeAskUserParams(args);
     const reservation = reserveAskUserPromptDelivery({
       toolCallId,
       sessionKey,
       runId,
       questions,
+      timeoutSeconds,
     });
     if (!reservation) {
       return undefined;

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -156,11 +156,17 @@ function readUpdatePlanResult(
 function buildAskUserPromptPayload(
   toolCallId: string,
   sessionKey: string | undefined,
+  runId: string,
   args: unknown,
 ) {
   try {
     const { questions } = normalizeAskUserParams(args);
-    const reservation = reserveAskUserPromptDelivery({ toolCallId, sessionKey, questions });
+    const reservation = reserveAskUserPromptDelivery({
+      toolCallId,
+      sessionKey,
+      runId,
+      questions,
+    });
     if (!reservation) {
       return undefined;
     }
@@ -973,11 +979,11 @@ export function handleToolExecutionStart(
   const startToolName = normalizeToolName(evt.toolName);
   const askUserPromptReservation =
     startToolName === "ask_user" && ctx.params.onToolResult
-      ? buildAskUserPromptPayload(evt.toolCallId, ctx.params.sessionKey, evt.args)
+      ? buildAskUserPromptPayload(evt.toolCallId, ctx.params.sessionKey, ctx.params.runId, evt.args)
       : undefined;
   const cancelAskUserPromptReservation = () => {
     if (askUserPromptReservation) {
-      cancelAskUserPromptDelivery(evt.toolCallId, ctx.params.sessionKey);
+      cancelAskUserPromptDelivery(evt.toolCallId, ctx.params.sessionKey, ctx.params.runId);
     }
   };
   const continueAfterBlockReplyFlush = (): void | Promise<void> => {
@@ -1366,7 +1372,7 @@ export async function handleToolExecutionEnd(
   const hideFromChannelProgress = evt.hideFromChannelProgress === true;
   const toolCallId = evt.toolCallId;
   if (toolName === "ask_user") {
-    cancelAskUserPromptDelivery(toolCallId, ctx.params.sessionKey);
+    cancelAskUserPromptDelivery(toolCallId, ctx.params.sessionKey, ctx.params.runId);
   }
   const runId = ctx.params.runId;
   const isError = evt.isError;

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -591,6 +591,7 @@ export function createOpenClawTools(
           createAskUserTool({
             agentId: sessionAgentId,
             sessionKey: options?.runSessionKey ?? options?.agentSessionKey,
+            runId: options?.runId,
           }),
         ]
       : []),

--- a/src/agents/tool-catalog.test.ts
+++ b/src/agents/tool-catalog.test.ts
@@ -58,6 +58,7 @@ describe("tool-catalog", () => {
       "create_goal",
       "update_goal",
       "update_plan",
+      "ask_user",
       "skill_workshop",
       "image",
       "image_generate",
@@ -83,6 +84,7 @@ describe("tool-catalog", () => {
       "subagents",
       "session_status",
       "message",
+      "ask_user",
       "bundle-mcp",
     ]);
     expect(requirePolicyAllow("minimal")).toEqual(["session_status"]);

--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -4,6 +4,7 @@
  * for OpenClaw-owned tools.
  */
 import {
+  ASK_USER_TOOL_DISPLAY_SUMMARY,
   CRON_TOOL_DISPLAY_SUMMARY,
   EXEC_TOOL_DISPLAY_SUMMARY,
   PROCESS_TOOL_DISPLAY_SUMMARY,
@@ -388,6 +389,14 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     description: UPDATE_PLAN_TOOL_DISPLAY_SUMMARY,
     sectionId: "agents",
     profiles: ["coding"],
+    includeInOpenClawGroup: true,
+  },
+  {
+    id: "ask_user",
+    label: "ask_user",
+    description: ASK_USER_TOOL_DISPLAY_SUMMARY,
+    sectionId: "agents",
+    profiles: ["coding", "messaging"],
     includeInOpenClawGroup: true,
   },
   {

--- a/src/agents/tools/ask-user-tool.test.ts
+++ b/src/agents/tools/ask-user-tool.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { UserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.types.js";
 import { steerActiveSessionWithOptionalDeliveryWait } from "../embedded-agent-runner/run/attempt.queue-message.js";
 import {
+  cancelAskUserPromptDelivery,
   createAskUserTool,
   isAskUserPromptActive,
   isAskUserPromptPending,
@@ -143,7 +144,7 @@ describe("ask_user prompt delivery", () => {
     await expect(isAskUserPromptPending(reservation.questionId, gateway.call)).resolves.toBe(false);
   });
 
-  it("retains an active prompt when Gateway revalidation fails transiently", async () => {
+  it("retries a transient Gateway revalidation failure before delivering", async () => {
     const questions = normalizeAskUserParams(validArgs).questions;
     const reservation = reserveAskUserPromptDelivery({
       toolCallId: "call-revalidation-failure",
@@ -153,11 +154,56 @@ describe("ask_user prompt delivery", () => {
     if (!reservation) {
       throw new Error("expected prompt reservation");
     }
+    let attempts = 0;
     const gateway = gatewayStub(async () => {
-      throw new Error("temporary Gateway disconnect");
+      attempts += 1;
+      if (attempts === 1) {
+        throw new Error("temporary Gateway disconnect");
+      }
+      return { questions: [{ id: reservation.questionId, status: "pending" }] };
     });
 
     await expect(isAskUserPromptPending(reservation.questionId, gateway.call)).resolves.toBe(true);
+    expect(attempts).toBe(2);
+  });
+
+  it("drops a prompt when local terminalization wins during Gateway revalidation", async () => {
+    const questions = normalizeAskUserParams(validArgs).questions;
+    const toolCallId = "call-revalidation-terminal";
+    const sessionKey = "agent:main:revalidation-terminal";
+    const reservation = reserveAskUserPromptDelivery({ toolCallId, sessionKey, questions });
+    if (!reservation) {
+      throw new Error("expected prompt reservation");
+    }
+    const gateway = gatewayStub(async () => {
+      cancelAskUserPromptDelivery(toolCallId, sessionKey);
+      return { questions: [{ id: reservation.questionId, status: "pending" }] };
+    });
+
+    await expect(isAskUserPromptPending(reservation.questionId, gateway.call)).resolves.toBe(false);
+  });
+
+  it("expires prompt revalidation while the Gateway lookup remains stalled", async () => {
+    vi.useFakeTimers();
+    try {
+      const questions = normalizeAskUserParams(validArgs).questions;
+      const reservation = reserveAskUserPromptDelivery({
+        toolCallId: "call-revalidation-stalled",
+        sessionKey: "agent:main:revalidation-stalled",
+        questions,
+        timeoutSeconds: 30,
+      });
+      if (!reservation) {
+        throw new Error("expected prompt reservation");
+      }
+      const gateway = gatewayStub(async () => await new Promise(() => {}));
+
+      const pending = isAskUserPromptPending(reservation.questionId, gateway.call);
+      await vi.advanceTimersByTimeAsync(30_000);
+      await expect(pending).resolves.toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("shares prompt readiness across bundled module instances", async () => {

--- a/src/agents/tools/ask-user-tool.test.ts
+++ b/src/agents/tools/ask-user-tool.test.ts
@@ -5,9 +5,11 @@ import { steerActiveSessionWithOptionalDeliveryWait } from "../embedded-agent-ru
 import {
   createAskUserTool,
   isAskUserPromptActive,
+  isAskUserPromptPending,
   normalizeAskUserParams,
   reserveAskUserPromptDelivery,
   settleAskUserPromptDelivery,
+  waitForAskUserPromptReady,
 } from "./ask-user-tool.js";
 import { resetPendingAskUserQuestionsForTest } from "./ask-user-tool.test-support.js";
 
@@ -98,6 +100,116 @@ describe("ask_user normalization", () => {
     ],
   ])("rejects %s", (_name, args, error) => {
     expect(() => normalizeAskUserParams(args)).toThrow(error);
+  });
+});
+
+describe("ask_user prompt delivery", () => {
+  it("uses the Gateway record when the executor has isolated runtime state", async () => {
+    const questions = normalizeAskUserParams(validArgs).questions;
+    const reservation = reserveAskUserPromptDelivery({
+      toolCallId: "call-isolated-runtime",
+      sessionKey: "agent:main:isolated-runtime",
+      questions,
+    });
+    if (!reservation) {
+      throw new Error("expected prompt reservation");
+    }
+    const gateway = gatewayStub(async (method, _opts, params) => {
+      expect(method).toBe("question.list");
+      expect(params).toEqual({});
+      return { questions: [{ id: reservation.questionId, status: "pending" }] };
+    });
+
+    await expect(waitForAskUserPromptReady(reservation.questionId, gateway.call)).resolves.toEqual(
+      questions,
+    );
+    await expect(isAskUserPromptPending(reservation.questionId, gateway.call)).resolves.toBe(true);
+  });
+
+  it("rejects prompt delivery after the Gateway question terminalizes", async () => {
+    const questions = normalizeAskUserParams(validArgs).questions;
+    const reservation = reserveAskUserPromptDelivery({
+      toolCallId: "call-terminal-before-delivery",
+      sessionKey: "agent:main:terminal-before-delivery",
+      questions,
+    });
+    if (!reservation) {
+      throw new Error("expected prompt reservation");
+    }
+    const gateway = gatewayStub(async () => ({
+      questions: [{ id: reservation.questionId, status: "expired" }],
+    }));
+
+    await expect(isAskUserPromptPending(reservation.questionId, gateway.call)).resolves.toBe(false);
+  });
+
+  it("retains an active prompt when Gateway revalidation fails transiently", async () => {
+    const questions = normalizeAskUserParams(validArgs).questions;
+    const reservation = reserveAskUserPromptDelivery({
+      toolCallId: "call-revalidation-failure",
+      sessionKey: "agent:main:revalidation-failure",
+      questions,
+    });
+    if (!reservation) {
+      throw new Error("expected prompt reservation");
+    }
+    const gateway = gatewayStub(async () => {
+      throw new Error("temporary Gateway disconnect");
+    });
+
+    await expect(isAskUserPromptPending(reservation.questionId, gateway.call)).resolves.toBe(true);
+  });
+
+  it("shares prompt readiness across bundled module instances", async () => {
+    const runId = "run-split-module";
+    const toolCallId = "call-split-module";
+    const questions = normalizeAskUserParams(validArgs).questions;
+    const reservation = reserveAskUserPromptDelivery({
+      toolCallId,
+      runId,
+      sessionKey: "agent:main:subscriber-session",
+      questions,
+    });
+    if (!reservation) {
+      throw new Error("expected prompt reservation");
+    }
+    let finishWait: ((value: unknown) => void) | undefined;
+    const gateway = gatewayStub(async (method, _opts, params) => {
+      if (method === "question.request") {
+        return { id: params.id };
+      }
+      if (method === "question.waitAnswer") {
+        return await new Promise((resolve) => {
+          finishWait = resolve;
+        });
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+
+    vi.resetModules();
+    const isolatedModule = await import("./ask-user-tool.js");
+    const pending = isolatedModule
+      .createAskUserTool({
+        runId,
+        sessionKey: "agent:main:executor-session",
+        gatewayCall: gateway.call,
+      })
+      .execute(toolCallId, validArgs);
+    await vi.waitFor(() =>
+      expect(gateway.mock.mock.calls.some(([method]) => method === "question.request")).toBe(true),
+    );
+    let readyQuestions: unknown;
+    void waitForAskUserPromptReady(reservation.questionId).then((value) => {
+      readyQuestions = value;
+    });
+    await vi.waitFor(() => expect(readyQuestions).toEqual(questions));
+
+    settleAskUserPromptDelivery(reservation.questionId);
+    finishWait?.({
+      status: "answered",
+      answers: { answers: { deploy_target: { answers: ["Production"] } } },
+    });
+    await expect(pending).resolves.toMatchObject({ details: { status: "answered" } });
   });
 });
 

--- a/src/agents/tools/ask-user-tool.test.ts
+++ b/src/agents/tools/ask-user-tool.test.ts
@@ -5,7 +5,6 @@ import { steerActiveSessionWithOptionalDeliveryWait } from "../embedded-agent-ru
 import {
   cancelAskUserPromptDelivery,
   createAskUserTool,
-  isAskUserPromptActive,
   isAskUserPromptPending,
   normalizeAskUserParams,
   reserveAskUserPromptDelivery,
@@ -463,7 +462,13 @@ describe("ask_user execution", () => {
     finishRegistration?.({ id: reservation.questionId });
 
     await expect(pending).rejects.toThrow("stop before registration completed");
-    expect(isAskUserPromptActive(reservation.questionId)).toBe(false);
+    expect(
+      reserveAskUserPromptDelivery({
+        toolCallId: "call-after-late-registration-abort",
+        sessionKey,
+        questions: normalizeAskUserParams(validArgs).questions,
+      }),
+    ).toBeDefined();
   });
 
   it("suppresses a stale prompt when an image arrives during registration", async () => {
@@ -668,8 +673,14 @@ describe("ask_user execution", () => {
 
     controller.abort(new Error("stop during delivery"));
 
-    expect(isAskUserPromptActive(reservation.questionId)).toBe(false);
     await expect(pending).rejects.toThrow("stop during delivery");
+    expect(
+      reserveAskUserPromptDelivery({
+        toolCallId: "call-after-delivery-abort",
+        sessionKey,
+        questions: normalizeAskUserParams(validArgs).questions,
+      }),
+    ).toBeDefined();
     expect(gateway.mock).toHaveBeenCalledWith(
       "question.resolve",
       { timeoutMs: 10_000 },

--- a/src/agents/tools/ask-user-tool.ts
+++ b/src/agents/tools/ask-user-tool.ts
@@ -324,7 +324,9 @@ export async function waitForAskUserPromptReady(
       // Registration and local Gateway credentials may still be coming online.
       // Local state can win on the next pass; isolated runtimes retry the record.
     }
-    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 50);
+    });
   }
   return undefined;
 }
@@ -408,11 +410,6 @@ export function settleAskUserPromptDelivery(questionId: string, error?: unknown)
   );
 }
 
-/** Returns whether a question-associated prompt still belongs to a blocking ask_user call. */
-export function isAskUserPromptActive(questionId: string): boolean {
-  return askUserQuestions.has(questionId);
-}
-
 /** Rechecks the Gateway immediately before exposing an answerable prompt. */
 export async function isAskUserPromptPending(
   questionId: string,
@@ -436,10 +433,11 @@ export async function isAskUserPromptPending(
     }
     // Cancellation can win while the Gateway request is in flight. Recheck local
     // ownership before trusting an older remote `pending` snapshot.
+    const currentState = askUserQuestions.get(questionId);
     if (
-      askUserQuestions.get(questionId) !== state ||
-      state.phase.kind === "resolving" ||
-      state.phase.kind === "prompt-failed"
+      currentState !== state ||
+      currentState.phase.kind === "resolving" ||
+      currentState.phase.kind === "prompt-failed"
     ) {
       return false;
     }

--- a/src/agents/tools/ask-user-tool.ts
+++ b/src/agents/tools/ask-user-tool.ts
@@ -87,7 +87,19 @@ type AskUserQuestionState = {
   waiters: Set<() => void>;
 };
 
-const askUserQuestions = new Map<string, AskUserQuestionState>();
+const ASK_USER_QUESTIONS_KEY = Symbol.for("openclaw.askUserQuestions");
+const askUserGlobal = globalThis as Record<PropertyKey, unknown>;
+// Tool execution and subscriber delivery can live in separate production bundles.
+// Keep one process registry or prompt readiness never reaches the delivery waiter.
+const askUserQuestions = (() => {
+  const existing = askUserGlobal[ASK_USER_QUESTIONS_KEY];
+  if (existing instanceof Map) {
+    return existing as Map<string, AskUserQuestionState>;
+  }
+  const questions = new Map<string, AskUserQuestionState>();
+  askUserGlobal[ASK_USER_QUESTIONS_KEY] = questions;
+  return questions;
+})();
 
 type NormalizedAskUserParams = {
   questions: QuestionRequestQuestion[];
@@ -192,8 +204,9 @@ export function normalizeAskUserParams(value: unknown): NormalizedAskUserParams 
 }
 
 /** Stable client-generated gateway question id shared with tool-start delivery. */
-function buildAskUserQuestionId(toolCallId: string, sessionKey?: string): string {
-  const identity = `${sessionKey?.trim() ?? ""}\0${toolCallId}`;
+function buildAskUserQuestionId(toolCallId: string, sessionKey?: string, runId?: string): string {
+  const owner = runId?.trim() || sessionKey?.trim() || "";
+  const identity = `${owner}\0${toolCallId}`;
   return `ask_${createHash("sha256").update(identity).digest("hex").slice(0, 32)}`;
 }
 
@@ -254,13 +267,14 @@ async function waitForQuestionChange(
 export function reserveAskUserPromptDelivery(params: {
   toolCallId: string;
   sessionKey?: string;
+  runId?: string;
   questions: QuestionRequestQuestion[];
 }): { questionId: string } | undefined {
   const sessionKey = askUserSessionKey(params.sessionKey);
   if (findAskUserQuestionForSession(sessionKey)) {
     return undefined;
   }
-  const questionId = buildAskUserQuestionId(params.toolCallId, params.sessionKey);
+  const questionId = buildAskUserQuestionId(params.toolCallId, params.sessionKey, params.runId);
   if (askUserQuestions.has(questionId)) {
     return undefined;
   }
@@ -277,6 +291,7 @@ export function reserveAskUserPromptDelivery(params: {
 /** Waits until policy-accepted tool execution has registered the gateway question. */
 export async function waitForAskUserPromptReady(
   questionId: string,
+  gatewayCall: AskUserGatewayCall = callGatewayTool,
 ): Promise<QuestionRequestQuestion[] | undefined> {
   const state = askUserQuestions.get(questionId);
   if (!state) {
@@ -291,9 +306,48 @@ export async function waitForAskUserPromptReady(
     ) {
       return state.questions;
     }
-    await waitForQuestionChange(state);
+    try {
+      const status = await readAskUserQuestionStatus(questionId, gatewayCall);
+      if (status === "pending") {
+        // The executor may live in another JS realm or process. The Gateway record
+        // is the cross-runtime readiness boundary when local state cannot signal.
+        return state.questions;
+      }
+      if (typeof status === "string") {
+        return undefined;
+      }
+    } catch {
+      // Registration and local Gateway credentials may still be coming online.
+      // Local state can win on the next pass; isolated runtimes retry the record.
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
   }
   return undefined;
+}
+
+async function readAskUserQuestionStatus(
+  questionId: string,
+  gatewayCall: AskUserGatewayCall,
+): Promise<string | undefined> {
+  const result = await gatewayCall("question.list", { timeoutMs: ASK_USER_RPC_GRACE_MS }, {});
+  const questions =
+    result && typeof result === "object" && !Array.isArray(result)
+      ? (result as { questions?: unknown }).questions
+      : undefined;
+  const question = Array.isArray(questions)
+    ? questions.find(
+        (candidate) =>
+          candidate &&
+          typeof candidate === "object" &&
+          !Array.isArray(candidate) &&
+          (candidate as { id?: unknown }).id === questionId,
+      )
+    : undefined;
+  const status =
+    question && typeof question === "object" && !Array.isArray(question)
+      ? (question as { status?: unknown }).status
+      : undefined;
+  return typeof status === "string" ? status : undefined;
 }
 
 /** Opens prompt delivery after question.request succeeds. */
@@ -323,9 +377,30 @@ export function isAskUserPromptActive(questionId: string): boolean {
   return askUserQuestions.has(questionId);
 }
 
+/** Rechecks the Gateway immediately before exposing an answerable prompt. */
+export async function isAskUserPromptPending(
+  questionId: string,
+  gatewayCall: AskUserGatewayCall = callGatewayTool,
+): Promise<boolean> {
+  if (!isAskUserPromptActive(questionId)) {
+    return false;
+  }
+  try {
+    return (await readAskUserQuestionStatus(questionId, gatewayCall)) === "pending";
+  } catch {
+    // A transient lookup failure must not strand the blocking tool. The local
+    // reservation remains the fallback; only a confirmed terminal record drops it.
+    return isAskUserPromptActive(questionId);
+  }
+}
+
 /** Releases a tool-start reservation when policy rejects execution. */
-export function cancelAskUserPromptDelivery(toolCallId: string, sessionKey?: string): void {
-  releaseAskUserQuestion(buildAskUserQuestionId(toolCallId, sessionKey));
+export function cancelAskUserPromptDelivery(
+  toolCallId: string,
+  sessionKey?: string,
+  runId?: string,
+): void {
+  releaseAskUserQuestion(buildAskUserQuestionId(toolCallId, sessionKey, runId));
 }
 
 function answeredResult(questions: readonly QuestionRequestQuestion[], answers: QuestionAnswers) {
@@ -399,6 +474,7 @@ if (process.env.VITEST || process.env.NODE_ENV === "test") {
 export function createAskUserTool(params: {
   agentId?: string;
   sessionKey?: string;
+  runId?: string;
   gatewayCall?: AskUserGatewayCall;
 }): AnyAgentTool {
   const gatewayCall: AskUserGatewayCall = params.gatewayCall ?? callGatewayTool;
@@ -409,7 +485,7 @@ export function createAskUserTool(params: {
     description: describeAskUserTool(),
     parameters: AskUserToolSchema,
     execute: async (toolCallId, args, signal) => {
-      const questionId = buildAskUserQuestionId(toolCallId, params.sessionKey);
+      const questionId = buildAskUserQuestionId(toolCallId, params.sessionKey, params.runId);
       let normalized: NormalizedAskUserParams;
       try {
         signal?.throwIfAborted();

--- a/src/agents/tools/ask-user-tool.ts
+++ b/src/agents/tools/ask-user-tool.ts
@@ -16,6 +16,7 @@ const DEFAULT_ASK_USER_TIMEOUT_SECONDS = 900;
 const MIN_ASK_USER_TIMEOUT_SECONDS = 30;
 const MAX_ASK_USER_TIMEOUT_SECONDS = 3600;
 const ASK_USER_RPC_GRACE_MS = 10_000;
+const ASK_USER_PROMPT_RECHECK_MS = 50;
 const QUESTION_ID_PATTERN = /^[a-z][a-z0-9_]*$/;
 const TERMINAL_QUESTION_ERROR_REASONS = new Set([
   "QUESTION_ALREADY_TERMINAL",
@@ -80,6 +81,7 @@ type AskUserQuestionState = {
   questionId: string;
   sessionKey: string;
   questions: QuestionRequestQuestion[];
+  expiresAtMs: number;
   phase: AskUserQuestionPhase;
   gatewayCall?: AskUserGatewayCall;
   answer?: Promise<QuestionWaitAnswerResult>;
@@ -269,6 +271,7 @@ export function reserveAskUserPromptDelivery(params: {
   sessionKey?: string;
   runId?: string;
   questions: QuestionRequestQuestion[];
+  timeoutSeconds?: number;
 }): { questionId: string } | undefined {
   const sessionKey = askUserSessionKey(params.sessionKey);
   if (findAskUserQuestionForSession(sessionKey)) {
@@ -282,6 +285,7 @@ export function reserveAskUserPromptDelivery(params: {
     questionId,
     sessionKey,
     questions: params.questions,
+    expiresAtMs: Date.now() + (params.timeoutSeconds ?? DEFAULT_ASK_USER_TIMEOUT_SECONDS) * 1_000,
     phase: { kind: "reserved" },
     waiters: new Set(),
   });
@@ -350,6 +354,38 @@ async function readAskUserQuestionStatus(
   return typeof status === "string" ? status : undefined;
 }
 
+type AskUserPromptStatusRead =
+  | { kind: "status"; status: string | undefined }
+  | { kind: "error" }
+  | { kind: "expired" };
+
+async function readAskUserQuestionStatusBeforeExpiry(
+  questionId: string,
+  expiresAtMs: number,
+  gatewayCall: AskUserGatewayCall,
+): Promise<AskUserPromptStatusRead> {
+  const remainingMs = expiresAtMs - Date.now();
+  if (remainingMs <= 0) {
+    return { kind: "expired" };
+  }
+  return await new Promise<AskUserPromptStatusRead>((resolve) => {
+    let settled = false;
+    const finish = (result: AskUserPromptStatusRead) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(expiryTimer);
+      resolve(result);
+    };
+    const expiryTimer = setTimeout(() => finish({ kind: "expired" }), remainingMs);
+    void readAskUserQuestionStatus(questionId, gatewayCall).then(
+      (status) => finish({ kind: "status", status }),
+      () => finish({ kind: "error" }),
+    );
+  });
+}
+
 /** Opens prompt delivery after question.request succeeds. */
 function markAskUserPromptReady(questionId: string, questions: QuestionRequestQuestion[]): void {
   const state = askUserQuestions.get(questionId);
@@ -382,16 +418,50 @@ export async function isAskUserPromptPending(
   questionId: string,
   gatewayCall: AskUserGatewayCall = callGatewayTool,
 ): Promise<boolean> {
-  if (!isAskUserPromptActive(questionId)) {
+  const state = askUserQuestions.get(questionId);
+  if (!state) {
     return false;
   }
-  try {
-    return (await readAskUserQuestionStatus(questionId, gatewayCall)) === "pending";
-  } catch {
-    // A transient lookup failure must not strand the blocking tool. The local
-    // reservation remains the fallback; only a confirmed terminal record drops it.
-    return isAskUserPromptActive(questionId);
+  while (askUserQuestions.get(questionId) === state) {
+    if (state.phase.kind === "resolving" || state.phase.kind === "prompt-failed") {
+      return false;
+    }
+    const read = await readAskUserQuestionStatusBeforeExpiry(
+      questionId,
+      state.expiresAtMs,
+      gatewayCall,
+    );
+    if (read.kind === "expired") {
+      return false;
+    }
+    // Cancellation can win while the Gateway request is in flight. Recheck local
+    // ownership before trusting an older remote `pending` snapshot.
+    if (
+      askUserQuestions.get(questionId) !== state ||
+      state.phase.kind === "resolving" ||
+      state.phase.kind === "prompt-failed"
+    ) {
+      return false;
+    }
+    if (read.kind === "status" && read.status === "pending") {
+      return true;
+    }
+    if (read.kind === "status" && typeof read.status === "string") {
+      return false;
+    }
+    if (read.kind === "error") {
+      // Keep the prompt private until Gateway state is authoritative again.
+      // Failing open here can expose a stale question after remote terminalization.
+    }
+    const remainingMs = state.expiresAtMs - Date.now();
+    if (remainingMs <= 0) {
+      return false;
+    }
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, Math.min(ASK_USER_PROMPT_RECHECK_MS, remainingMs));
+    });
   }
+  return false;
 }
 
 /** Releases a tool-start reservation when policy rejects execution. */
@@ -511,12 +581,14 @@ export function createAskUserTool(params: {
           questionId,
           sessionKey,
           questions: normalized.questions,
+          expiresAtMs: Date.now() + timeoutMs,
           phase: { kind: "registering" },
           gatewayCall,
           waiters: new Set(),
         } satisfies AskUserQuestionState);
       state.sessionKey = sessionKey;
       state.questions = normalized.questions;
+      state.expiresAtMs = Date.now() + timeoutMs;
       state.gatewayCall = gatewayCall;
       transitionAskUserQuestion(state, { kind: "registering" });
       askUserQuestions.set(questionId, state);

--- a/src/auto-reply/reply/dispatch-from-config.routing.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.routing.test-utils.ts
@@ -422,9 +422,12 @@ describe("dispatchReplyFromConfig", () => {
 
     await dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher, replyResolver });
     expect(dispatcher.sendToolResult).toHaveBeenCalledWith(payload);
-    const toolDeliveryOrder = dispatcher.sendToolResult.mock.invocationCallOrder[0];
+    const toolDeliveryOrder =
+      vi.mocked(dispatcher.sendToolResult).mock.invocationCallOrder[0] ?? Number.NEGATIVE_INFINITY;
     expect(
-      dispatcher.waitForIdle.mock.invocationCallOrder.some((order) => order > toolDeliveryOrder),
+      vi
+        .mocked(dispatcher.waitForIdle)
+        .mock.invocationCallOrder.some((order) => order > toolDeliveryOrder),
     ).toBe(true);
   });
 

--- a/src/auto-reply/reply/dispatch-from-config.routing.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.routing.test-utils.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import type { MsgContext } from "../templating.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import {
+  askUserMocks,
   createDispatcher,
   emptyConfig,
   hookMocks,
@@ -400,6 +401,57 @@ describe("dispatchReplyFromConfig", () => {
     await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
     expect(dispatcher.sendToolResult).toHaveBeenCalledWith({ text: "tool output" });
     expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+  });
+
+  it("delivers ask_user prompts when verbose tool progress is disabled", async () => {
+    setNoAbort();
+    const payload = {
+      text: "Question for you: Where should this deploy?",
+      channelData: { askUser: { questionId: "question-owned-by-agent-runtime" } },
+    } satisfies ReplyPayload;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "telegram", ChatType: "direct" });
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      await requireToolResultHandler(opts?.onToolResult)(payload);
+      return undefined;
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher, replyResolver });
+    expect(dispatcher.sendToolResult).toHaveBeenCalledWith(payload);
+    const toolDeliveryOrder = dispatcher.sendToolResult.mock.invocationCallOrder[0];
+    expect(
+      dispatcher.waitForIdle.mock.invocationCallOrder.some((order) => order > toolDeliveryOrder),
+    ).toBe(true);
+  });
+
+  it("drops ask_user prompts that terminalize before dispatcher delivery", async () => {
+    setNoAbort();
+    askUserMocks.isAskUserPromptPending.mockResolvedValue(false);
+    const payload = {
+      text: "Question for you: Where should this deploy?",
+      channelData: { askUser: { questionId: "question-terminal-before-delivery" } },
+    } satisfies ReplyPayload;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "telegram", ChatType: "direct" });
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      await requireToolResultHandler(opts?.onToolResult)(payload);
+      return undefined;
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher, replyResolver });
+
+    expect(askUserMocks.isAskUserPromptPending).toHaveBeenCalledWith(
+      "question-terminal-before-delivery",
+    );
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
   });
 
   it("does not synthesize hidden text-only tool summaries into TTS media", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
+++ b/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
@@ -40,6 +40,9 @@ const mocks = vi.hoisted(() => ({
 const globalMocks = vi.hoisted(() => ({
   logVerbose: vi.fn(),
 }));
+const askUserMocks = vi.hoisted(() => ({
+  isAskUserPromptPending: vi.fn(async () => true),
+}));
 const diagnosticMocks = vi.hoisted(() => ({
   logMessageDispatchCompleted: vi.fn(),
   logMessageDispatchStarted: vi.fn(),
@@ -369,6 +372,7 @@ export {
   acpManagerRuntimeMocks,
   acpMocks,
   agentEventMocks,
+  askUserMocks,
   diagnosticMocks,
   globalMocks,
   hookMocks,
@@ -437,6 +441,10 @@ vi.mock("../../globals.js", async (importOriginal) => {
     logVerbose: globalMocks.logVerbose,
   };
 });
+
+vi.mock("../../agents/tools/ask-user-tool.js", () => ({
+  isAskUserPromptPending: askUserMocks.isAskUserPromptPending,
+}));
 
 vi.mock("../../logging/diagnostic.js", () => ({
   logMessageDispatchCompleted: diagnosticMocks.logMessageDispatchCompleted,
@@ -688,6 +696,7 @@ export function createDispatcher(): ReplyDispatcher {
 }
 
 export function resetPluginTtsAndThreadMocks() {
+  askUserMocks.isAskUserPromptPending.mockReset().mockResolvedValue(true);
   pluginConversationBindingMocks.shownFallbackNoticeBindingIds.clear();
   ttsMocks.state.synthesizeFinalAudio = false;
   ttsMocks.state.synthesizeToolAudio = false;

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -30,7 +30,7 @@ import {
 } from "../../agents/subagent-capabilities.js";
 import { isToolAllowedByPolicies } from "../../agents/tool-policy-match.js";
 import { mergeAlsoAllowPolicy, resolveToolProfilePolicy } from "../../agents/tool-policy.js";
-import { isAskUserPromptActive } from "../../agents/tools/ask-user-tool.js";
+import { isAskUserPromptPending } from "../../agents/tools/ask-user-tool.js";
 import {
   resolveConversationBindingRecord,
   touchConversationBindingRecord,
@@ -1400,13 +1400,13 @@ async function dispatchReplyFromConfigInner(
       const askUser = payload.channelData?.askUser;
       return askUser && typeof askUser === "object" && !Array.isArray(askUser);
     };
-    const isInactiveAskUserPayload = (payload: ReplyPayload) => {
+    const readAskUserQuestionId = (payload: ReplyPayload) => {
       const askUser = payload.channelData?.askUser;
       if (!askUser || typeof askUser !== "object" || Array.isArray(askUser)) {
-        return false;
+        return undefined;
       }
       const questionId = (askUser as { questionId?: unknown }).questionId;
-      return typeof questionId === "string" && !isAskUserPromptActive(questionId);
+      return typeof questionId === "string" ? questionId : undefined;
     };
     const shouldSuppressLateTextOnlyToolProgress = (payload: ReplyPayload) => {
       if (!finalReplyDeliveryStarted) {
@@ -2251,16 +2251,10 @@ async function dispatchReplyFromConfigInner(
                       if (isDispatchOperationAborted()) {
                         return;
                       }
-                      if (isInactiveAskUserPayload(payload)) {
-                        return;
-                      }
                       await waitForPendingDirectBlockReplyDelivery(
                         getDispatchAbortOperation()?.abortSignal,
                       );
                       if (isDispatchOperationAborted()) {
-                        return;
-                      }
-                      if (isInactiveAskUserPayload(payload)) {
                         return;
                       }
                       markInboundDedupeReplayUnsafe();
@@ -2305,7 +2299,8 @@ async function dispatchReplyFromConfigInner(
                       if (
                         shouldSuppressProgressDelivery() &&
                         !isFastModeAutoProgressDelivery &&
-                        !isForcedToolProgress
+                        !isForcedToolProgress &&
+                        !hasAskUserPayload(payload)
                       ) {
                         return;
                       }
@@ -2334,9 +2329,6 @@ async function dispatchReplyFromConfigInner(
                       if (isDispatchOperationAborted()) {
                         return;
                       }
-                      if (isInactiveAskUserPayload(deliveryPayload)) {
-                        return;
-                      }
                       if (
                         shouldSuppressLateTextOnlyToolProgress(deliveryPayload) &&
                         !isFastModeAutoProgressPayload(deliveryPayload) &&
@@ -2354,18 +2346,40 @@ async function dispatchReplyFromConfigInner(
                       ) {
                         const hasMedia =
                           resolveSendableOutboundReplyParts(deliveryPayload).hasMedia;
-                        if (!hasMedia && !hasExecApprovalPayload(deliveryPayload)) {
+                        if (
+                          !hasMedia &&
+                          !hasExecApprovalPayload(deliveryPayload) &&
+                          !hasAskUserPayload(deliveryPayload)
+                        ) {
                           return;
                         }
                       }
                       if (deliveryPayload.isError === true) {
                         markVisibleToolErrorProgress();
                       }
+                      const askUserQuestionId = readAskUserQuestionId(deliveryPayload);
+                      if (
+                        askUserQuestionId !== undefined &&
+                        !(await isAskUserPromptPending(askUserQuestionId))
+                      ) {
+                        return;
+                      }
+                      if (isDispatchOperationAborted()) {
+                        return;
+                      }
                       if (shouldRouteToOriginating) {
                         await sendPayloadAsync(deliveryPayload, undefined, false);
                       } else {
                         markInboundDedupeReplayUnsafe();
-                        dispatcher.sendToolResult(deliveryPayload);
+                        const delivered = dispatcher.sendToolResult(deliveryPayload);
+                        if (delivered && hasAskUserPayload(deliveryPayload)) {
+                          // ask_user blocks until this callback resolves; drain its prompt now
+                          // or the answerable UI can remain queued behind the blocked agent run.
+                          await waitForReplyDispatcherIdle(
+                            dispatcher,
+                            getDispatchAbortOperation()?.abortSignal,
+                          );
+                        }
                       }
                     };
                     return run();

--- a/taxonomy.yaml
+++ b/taxonomy.yaml
@@ -1626,6 +1626,7 @@ surfaces:
                 runtime.codex-native-workspace.read,
                 runtime.prompt-compatibility,
                 runtime.tool-continuity,
+                tools.ask-user,
                 tools.apply-patch,
                 tools.edit,
                 tools.evidence,


### PR DESCRIPTION
Closes #110955

## What Problem This Solves

Fixes an issue where users asking a normal Gateway-hosted agent for a structured decision could find `ask_user` unavailable, never see the pending prompt, or leave the agent run blocked after answering it.

## Why This Change Was Made

The primary agent tool profiles now expose `ask_user`, and prompt delivery shares one run-scoped question identity across the subscriber, executor, Gateway, and channel dispatcher. Delivery rechecks authoritative terminal state before enqueueing, while the QA provider and scenario prove actual answer-driven resumption without leaking expected answers into the prompt.

## User Impact

Gateway chat users can receive a structured single-select, multi-select, or free-text question, answer it through the operator question API or Control UI, and have the same agent run resume with those values. Quiet tool-progress settings no longer hide the prompt.

## Evidence

- Live OpenAI (`openai/gpt-5.6-luna`): `ASK-USER-ROUNDTRIP-OK | deploy=Production | checks=Unit,E2E | note=night-shift`.
- Live WebChat routing: `WEBCHAT-DIRECT-REPLY-OK`; no self-message tool detour.
- Custom Gateway port 61767: `/health` returned `{"ok":true,"status":"live"}` while listening on `127.0.0.1:61767`.
- Fresh Testbox: 571 focused tests passed, private QA build passed, and the real mock Gateway `runtime-tool-ask-user` scenario passed. [Run 29660332327](https://github.com/openclaw/openclaw/actions/runs/29660332327).
- Broad stress pack passed direct chat, group mention routing, thread follow-up, model-switch tool continuity, 20-turn runtime, subagent handoff, cron delivery, and stranded final-reply recovery.
- Control UI Playwright: pending/answered question, multi-select array submission, and answered/expired stepper states all passed; sanitized 1440x900 screenshots captured.
- Autoreview: clean, no accepted/actionable findings.

AI-assisted: yes. I reviewed the implementation and validation evidence.
