### PR TITLE
fix(agents): restore bootstrap retry coverage

### DIFF
--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -1004,14 +1004,11 @@ describe("loadWorkspaceBootstrapFiles", () => {
       content: "# AGENTS.md\n\nkeep me\n",
     });
 
-    const originalReadFileSync = syncFs.readFileSync.bind(syncFs);
-    let readFileSyncCalls = 0;
+    const originalRead = syncFs.read.bind(syncFs);
+    let readCalls = 0;
     let threwTransient = false;
-    const readSpy = vi.spyOn(syncFs, "readFileSync").mockImplementation(((
-      target: unknown,
-      options: unknown,
-    ) => {
-      readFileSyncCalls += 1;
+    const readSpy = vi.spyOn(syncFs, "read").mockImplementation(((...args: unknown[]) => {
+      readCalls += 1;
       if (!threwTransient) {
         threwTransient = true;
         throw Object.assign(new Error("Unknown system error -11: read"), {
@@ -1019,15 +1016,15 @@ describe("loadWorkspaceBootstrapFiles", () => {
           errno: -11,
         });
       }
-      return originalReadFileSync(target as never, options as never);
-    }) as typeof syncFs.readFileSync);
+      return originalRead(...(args as Parameters<typeof syncFs.read>));
+    }) as unknown as typeof syncFs.read);
 
     try {
       const files = await loadWorkspaceBootstrapFiles(tempDir);
       expect(threwTransient).toBe(true);
       // The retry re-opens and reads again, so the failed first read is followed
       // by at least one more successful read.
-      expect(readFileSyncCalls).toBeGreaterThanOrEqual(2);
+      expect(readCalls).toBeGreaterThanOrEqual(2);
       const agents = files.find((file) => file.name === DEFAULT_AGENTS_FILENAME);
       expect(agents?.missing).toBe(false);
       expect(agents?.content).toContain("keep me");
@@ -1044,12 +1041,12 @@ describe("loadWorkspaceBootstrapFiles", () => {
       content: "# AGENTS.md\n",
     });
 
-    const readSpy = vi.spyOn(syncFs, "readFileSync").mockImplementation((() => {
+    const readSpy = vi.spyOn(syncFs, "read").mockImplementation((() => {
       throw Object.assign(new Error("Unknown system error -11: read"), {
         code: "EAGAIN",
         errno: -11,
       });
-    }) as typeof syncFs.readFileSync);
+    }) as unknown as typeof syncFs.read);
 
     try {
       // Unlike the template check, this reader returns an io failure (not a


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the core agent test shard failed after workspace bootstrap reads moved from the synchronous file API to the bounded asynchronous descriptor reader. The two transient-read tests still mocked the retired API, so their fault injection never ran.

## Why This Change Was Made

The tests now intercept the asynchronous descriptor read used by production. They still prove both recovery after one transient failure and the missing-file result after the retry budget is exhausted. Production code is unchanged.

## User Impact

No runtime behavior change. The current-main agent test gate is reliable again and continues covering transient bootstrap read handling.

## Evidence

- Before: `src/agents/workspace.test.ts` failed 2/58 locally and twice in CI run 29660834320.
- After: focused suite passed 58/58.
- Blacksmith Testbox changed gate passed formatting, guards, core-test typecheck, and targeted lint: https://github.com/openclaw/openclaw/actions/runs/29661358249
- Updated-scanner autoreview found no accepted/actionable findings (confidence 0.95).

AI-assisted test repair. I reviewed the production reader contract, test behavior, and resulting diff.
