### PR TITLE
test(telegram): mock core turn dispatcher

### DIFF
--- a/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
@@ -208,6 +208,10 @@ const dispatchReplyHoisted = vi.hoisted(() => ({
       }),
   ),
 }));
+vi.mock("../../../src/auto-reply/reply/provider-dispatcher.js", () => ({
+  dispatchReplyWithBufferedBlockDispatcher:
+    dispatchReplyHoisted.dispatchReplyWithBufferedBlockDispatcher,
+}));
 export const listSkillCommandsForAgents = skillCommandListHoisted.listSkillCommandsForAgents;
 const buildModelsProviderData = modelProviderDataHoisted.buildModelsProviderData;
 export const replySpy = replySpyHoisted.replySpy;


### PR DESCRIPTION
## Summary

- mock the core turn lifecycle provider dispatcher in the Telegram integration harness
- keep Telegram bot tests on the existing hoisted reply double after the core turn refactor
- prevent extension prerelease tests from launching real agent/provider work

## Proof

- isolated regression: 1 passed in 4.6s
- Telegram bot integration file: 122 passed
- exact failed prerelease shard batch: 298 files passed, 4,363 tests passed
- autoreview clean
