### PR TITLE
fix(qa): prevent Matrix E2EE sends from hanging QA runs

### DIFF
--- a/extensions/qa-lab/src/live-transports/matrix/substrate/e2ee-client-internals.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/e2ee-client-internals.ts
@@ -10,6 +10,36 @@ export const MATRIX_QA_E2EE_SYNC_FILTER = {
   },
 };
 
+export async function runMatrixQaE2eeClientOperation<T>(params: {
+  label: string;
+  run: () => Promise<T>;
+  stop: () => void;
+  timeoutMs: number;
+}): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      // Matrix SDK encryption can wait indefinitely after room-key sharing. Stop this
+      // disposable QA client so the scenario can fail and release its worker resources.
+      try {
+        params.stop();
+      } catch {
+        // Preserve the operation timeout as the actionable failure.
+      }
+      reject(new Error(`${params.label} timed out after ${params.timeoutMs}ms`));
+    }, params.timeoutMs);
+    timer.unref();
+  });
+
+  try {
+    return await Promise.race([params.run(), timeout]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
 export function shouldRecordMatrixQaObservedEventUpdate(params: {
   next: MatrixQaObservedEvent;
   previous: MatrixQaObservedEvent | undefined;

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/e2ee-client.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/e2ee-client.test.ts
@@ -2,10 +2,11 @@
 import { mkdtemp, rm, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   MATRIX_QA_E2EE_SYNC_FILTER,
   prepareMatrixQaE2eeStorage,
+  runMatrixQaE2eeClientOperation,
   shouldRecordMatrixQaObservedEventUpdate,
 } from "./e2ee-client-internals.js";
 import { findMatrixQaObservedEventMatch } from "./events.js";
@@ -14,10 +15,38 @@ const testing = {
   MATRIX_QA_E2EE_SYNC_FILTER,
   findMatrixQaObservedEventMatch,
   prepareMatrixQaE2eeStorage,
+  runMatrixQaE2eeClientOperation,
   shouldRecordMatrixQaObservedEventUpdate,
 };
 
 describe("matrix qa e2ee client storage", () => {
+  it("stops a disposable client when an E2EE operation exceeds its scenario timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const stop = vi.fn();
+      const operation = testing.runMatrixQaE2eeClientOperation({
+        label: "Matrix E2EE text send",
+        run: () =>
+          new Promise<string>(() => {
+            // Intentionally pending so the timeout owns settlement.
+          }),
+        stop,
+        timeoutMs: 150_000,
+      });
+      const rejection = expect(operation).rejects.toThrow(
+        "Matrix E2EE text send timed out after 150000ms",
+      );
+
+      await vi.advanceTimersByTimeAsync(150_000);
+
+      await rejection;
+      expect(stop).toHaveBeenCalledOnce();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("filters receipt noise without suppressing room state or timeline events", () => {
     expect(testing.MATRIX_QA_E2EE_SYNC_FILTER).toEqual({
       room: {

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/e2ee-client.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/e2ee-client.ts
@@ -26,6 +26,7 @@ import { buildMatrixQaMessageContent } from "./client-message-content.js";
 import {
   MATRIX_QA_E2EE_SYNC_FILTER,
   prepareMatrixQaE2eeStorage,
+  runMatrixQaE2eeClientOperation,
   shouldRecordMatrixQaObservedEventUpdate,
   type MatrixQaE2eeActorId,
 } from "./e2ee-client-internals.js";
@@ -391,6 +392,13 @@ export async function createMatrixQaE2eeScenarioClient(
     }
     return client.crypto;
   };
+  const runClientOperation = <T>(label: string, run: () => Promise<T>) =>
+    runMatrixQaE2eeClientOperation({
+      label,
+      run,
+      stop: () => client.stopWithoutPersist(),
+      timeoutMs: params.timeoutMs,
+    });
 
   return {
     async acceptVerification(id) {
@@ -452,16 +460,17 @@ export async function createMatrixQaE2eeScenarioClient(
       return await requireCrypto().scanVerificationQr(id, qrDataBase64);
     },
     async sendTextMessage(opts) {
-      return await client.sendMessage(
-        opts.roomId,
-        buildMatrixQaMessageContent(opts) as MessageEventContent,
+      return await runClientOperation("Matrix E2EE text send", () =>
+        client.sendMessage(opts.roomId, buildMatrixQaMessageContent(opts) as MessageEventContent),
       );
     },
     async sendNoticeMessage(opts) {
-      return await client.sendMessage(opts.roomId, {
-        ...buildMatrixQaMessageContent(opts),
-        msgtype: "m.notice",
-      } as MessageEventContent);
+      return await runClientOperation("Matrix E2EE notice send", () =>
+        client.sendMessage(opts.roomId, {
+          ...buildMatrixQaMessageContent(opts),
+          msgtype: "m.notice",
+        } as MessageEventContent),
+      );
     },
     async sendImageMessage(opts) {
       const encrypted = await requireCrypto().encryptMedia(opts.buffer);
@@ -471,19 +480,21 @@ export async function createMatrixQaE2eeScenarioClient(
         opts.fileName,
       );
       const file: EncryptedFile = { url: contentUri, ...encrypted.file };
-      return await client.sendMessage(opts.roomId, {
-        ...buildMatrixQaMessageContent({
-          body: opts.body,
-          mentionUserIds: opts.mentionUserIds,
-        }),
-        file,
-        filename: opts.fileName,
-        info: {
-          mimetype: opts.contentType,
-          size: opts.buffer.byteLength,
-        },
-        msgtype: "m.image",
-      } as MessageEventContent);
+      return await runClientOperation("Matrix E2EE image send", () =>
+        client.sendMessage(opts.roomId, {
+          ...buildMatrixQaMessageContent({
+            body: opts.body,
+            mentionUserIds: opts.mentionUserIds,
+          }),
+          file,
+          filename: opts.fileName,
+          info: {
+            mimetype: opts.contentType,
+            size: opts.buffer.byteLength,
+          },
+          msgtype: "m.image",
+        } as MessageEventContent),
+      );
     },
     async startVerification(id, method) {
       return await requireCrypto().startVerification(id, method);


### PR DESCRIPTION
Related: #110897

## What Problem This Solves

Resolves an operational problem where the full QA evidence workflow could remain active until its job timeout when a Matrix E2EE QA-client send stopped settling after room-key sharing. That blocked complete maturity-scorecard evidence generation and held a CI worker indefinitely.

## Why This Change Was Made

The disposable Matrix QA client now bounds text, notice, and image send calls by the scenario timeout and stops the client before reporting a timeout. Production Matrix behavior and pre-send media preparation are unchanged. A focused fake-timer regression test covers timeout settlement, client shutdown, and timer cleanup.

AI-assisted: Codex diagnosed, implemented, and validated this change; the final patch passed the repository's `autoreview` gate.

## User Impact

Maintainers running Matrix or full-profile QA now get a deterministic scenario failure and worker cleanup instead of a multi-hour hung run. There is no user-facing runtime behavior change.

## Evidence

- Before: [QA Profile Evidence run 29658161693](https://github.com/openclaw/openclaw/actions/runs/29658161693) stopped producing logs in `matrix-e2ee-state-after-missing-encryption` and required cancellation.
- Linux live-transport proof: `matrix-e2ee-state-after-missing-encryption` passed with the real Matrix driver and deterministic mock provider in 42 seconds on [Blacksmith Testbox run 29660828552](https://github.com/openclaw/openclaw/actions/runs/29660828552).
- Focused regression: `node scripts/run-vitest.mjs extensions/qa-lab/src/live-transports/matrix/substrate/e2ee-client.test.ts` — 5/5 passed.
- Dependency/dead-code gate: `pnpm deadcode:full` — passed on [Blacksmith Testbox run 29661929698](https://github.com/openclaw/openclaw/actions/runs/29661929698).
- Changed-surface gate: `pnpm check:changed` — extension production/test typechecks, lint, formatting, boundaries, and import-cycle checks passed on [Blacksmith Testbox run 29661929698](https://github.com/openclaw/openclaw/actions/runs/29661929698).
- Final `autoreview --mode uncommitted`: clean, no accepted/actionable findings.
