### PR TITLE
fix(channels): scope wizard credentials to the selected account

### DIFF
--- a/src/channels/plugins/setup-promotion-keys.ts
+++ b/src/channels/plugins/setup-promotion-keys.ts
@@ -5,6 +5,8 @@ const COMMON_SINGLE_ACCOUNT_PROMOTION_KEYS = [
   "name",
   "token",
   "tokenFile",
+  "botId",
+  "secret",
   "botToken",
   "appToken",
   "account",

--- a/src/channels/plugins/setup-wizard.test.ts
+++ b/src/channels/plugins/setup-wizard.test.ts
@@ -227,6 +227,33 @@ describe("channel setup wizard account scoping", () => {
     expect(queued.confirm).not.toHaveBeenCalled();
   });
 
+  it("migrates stale root credentials when only an empty accounts map exists", async () => {
+    const queued = createQueuedWizardPrompter({
+      confirmValues: [false, false],
+      textValues: ["test-new-bot-id", "mock-secret"],
+    });
+
+    const result = await runSetupWizardConfigure({
+      configure: createConfigure(),
+      cfg: {
+        channels: {
+          demo: { botId: "test-stale-bot-id", secret: "fixture-secret", accounts: {} },
+        },
+      } as OpenClawConfig,
+      prompter: queued.prompter,
+      options: { secretInputMode: "plaintext" as const },
+    });
+
+    const channel = getChannelConfig(result.cfg);
+    expect(channel).not.toHaveProperty("botId");
+    expect(channel).not.toHaveProperty("secret");
+    expect(channel.accounts?.[result.accountId]).toEqual({
+      botId: "test-new-bot-id",
+      secret: "mock-secret",
+    });
+    expect(Object.keys(channel.accounts ?? {})).toEqual([result.accountId]);
+  });
+
   it("replaces credentials only in the selected existing account after rejecting keep", async () => {
     const main = { botId: "test-main-bot-id", secret: "test-secret" };
     const before = JSON.stringify(main);

--- a/src/channels/plugins/setup-wizard.test.ts
+++ b/src/channels/plugins/setup-wizard.test.ts
@@ -244,14 +244,18 @@ describe("channel setup wizard account scoping", () => {
       options: { secretInputMode: "plaintext" as const },
     });
 
+    const accountId = result.accountId;
+    if (!accountId) {
+      throw new Error("expected the wizard to resolve an account id");
+    }
     const channel = getChannelConfig(result.cfg);
     expect(channel).not.toHaveProperty("botId");
     expect(channel).not.toHaveProperty("secret");
-    expect(channel.accounts?.[result.accountId]).toEqual({
+    expect(channel.accounts?.[accountId]).toEqual({
       botId: "test-new-bot-id",
       secret: "mock-secret",
     });
-    expect(Object.keys(channel.accounts ?? {})).toEqual([result.accountId]);
+    expect(Object.keys(channel.accounts ?? {})).toEqual([accountId]);
   });
 
   it("replaces credentials only in the selected existing account after rejecting keep", async () => {

--- a/src/channels/plugins/setup-wizard.test.ts
+++ b/src/channels/plugins/setup-wizard.test.ts
@@ -1,0 +1,334 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../routing/session-key.js";
+import { createChannelTestPluginBase } from "../../test-utils/channel-plugins.js";
+import {
+  createQueuedWizardPrompter,
+  runSetupWizardConfigure,
+} from "../../test-utils/plugin-setup-wizard.js";
+import type { ChannelSetupPlugin, ChannelSetupWizard } from "./setup-wizard-types.js";
+import { buildChannelSetupWizardAdapterFromSetupWizard } from "./setup-wizard.js";
+
+type AccountConfig = {
+  botId?: string;
+  secret?: string;
+  enabled?: boolean;
+  marker?: { keep: string };
+};
+
+type ChannelConfig = AccountConfig & {
+  defaultAccount?: string;
+  accounts?: Record<string, AccountConfig>;
+};
+
+function getChannelConfig(cfg: OpenClawConfig): ChannelConfig {
+  return ((cfg.channels as Record<string, unknown> | undefined)?.demo ?? {}) as ChannelConfig;
+}
+
+function resolveDefaultAccountId(cfg: OpenClawConfig): string {
+  const channel = getChannelConfig(cfg);
+  return normalizeAccountId(
+    channel.defaultAccount ?? Object.keys(channel.accounts ?? {})[0] ?? DEFAULT_ACCOUNT_ID,
+  );
+}
+
+function resolveLegacyAccount(cfg: OpenClawConfig): AccountConfig {
+  const channel = getChannelConfig(cfg);
+  return {
+    ...channel,
+    ...channel.accounts?.[resolveDefaultAccountId(cfg)],
+  };
+}
+
+function setLegacyAccount(cfg: OpenClawConfig, patch: AccountConfig): OpenClawConfig {
+  const channel = getChannelConfig(cfg);
+  if (!channel.accounts) {
+    return {
+      ...cfg,
+      channels: {
+        ...cfg.channels,
+        demo: { ...channel, ...patch },
+      },
+    } as OpenClawConfig;
+  }
+  const accountId = resolveDefaultAccountId(cfg);
+  return {
+    ...cfg,
+    channels: {
+      ...cfg.channels,
+      demo: {
+        ...channel,
+        accounts: {
+          ...channel.accounts,
+          [accountId]: {
+            ...channel.accounts[accountId],
+            ...patch,
+          },
+        },
+      },
+    },
+  } as OpenClawConfig;
+}
+
+function createLegacyPlugin(): ChannelSetupPlugin {
+  return {
+    ...createChannelTestPluginBase({
+      id: "demo",
+      label: "Demo",
+      config: {
+        listAccountIds: (cfg) => {
+          const ids = Object.keys(getChannelConfig(cfg).accounts ?? {});
+          return ids.length > 0 ? ids : [DEFAULT_ACCOUNT_ID];
+        },
+        defaultAccountId: resolveDefaultAccountId,
+      },
+    }),
+    setup: {
+      applyAccountConfig: ({ cfg, input }) =>
+        setLegacyAccount(cfg, {
+          botId: typeof input.token === "string" ? input.token : undefined,
+          secret: typeof input.privateKey === "string" ? input.privateKey : undefined,
+        }),
+    },
+  };
+}
+
+function createLegacyWizard(): ChannelSetupWizard {
+  return {
+    channel: "demo",
+    status: {
+      configuredLabel: "Configured",
+      unconfiguredLabel: "Not configured",
+      resolveConfigured: ({ cfg }) => Boolean(resolveLegacyAccount(cfg).botId),
+    },
+    credentials: [
+      {
+        inputKey: "token",
+        providerHint: "Demo",
+        credentialLabel: "Bot ID",
+        envPrompt: "Use Bot ID from environment?",
+        keepPrompt: "Bot ID already configured. Keep it?",
+        inputPrompt: "Bot ID",
+        inspect: ({ cfg }) => {
+          const botId = resolveLegacyAccount(cfg).botId;
+          return {
+            accountConfigured: Boolean(botId),
+            hasConfiguredValue: Boolean(botId),
+            resolvedValue: botId,
+          };
+        },
+        applySet: ({ cfg, resolvedValue }) => setLegacyAccount(cfg, { botId: resolvedValue }),
+      },
+      {
+        inputKey: "privateKey",
+        providerHint: "Demo",
+        credentialLabel: "Token",
+        envPrompt: "Use token from environment?",
+        keepPrompt: "Token already configured. Keep it?",
+        inputPrompt: "Token",
+        inspect: ({ cfg }) => {
+          const secret = resolveLegacyAccount(cfg).secret;
+          return {
+            accountConfigured: Boolean(secret),
+            hasConfiguredValue: Boolean(secret),
+            resolvedValue: secret,
+          };
+        },
+        applySet: ({ cfg, resolvedValue: secret }) => setLegacyAccount(cfg, { secret }),
+      },
+    ],
+  };
+}
+
+function createConfigure() {
+  return buildChannelSetupWizardAdapterFromSetupWizard({
+    plugin: createLegacyPlugin(),
+    wizard: createLegacyWizard(),
+  }).configure;
+}
+
+describe("channel setup wizard account scoping", () => {
+  it("does not prefill or overwrite the existing account when adding a new account", async () => {
+    const main = {
+      botId: "test-main-bot-id",
+      secret: "test-secret",
+      enabled: false,
+      marker: { keep: "byte-identical" },
+    };
+    const before = JSON.stringify(main);
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["__new__"],
+      textValues: ["alerts", "test-alerts-bot-id", "example-secret"],
+      confirmValues: [false, false],
+    });
+
+    const result = await runSetupWizardConfigure({
+      configure: createConfigure(),
+      cfg: {
+        channels: {
+          demo: {
+            enabled: true,
+            defaultAccount: "main",
+            accounts: { main },
+          },
+        },
+      } as OpenClawConfig,
+      prompter: queued.prompter,
+      shouldPromptAccountIds: true,
+      options: { secretInputMode: "plaintext" as const },
+    });
+
+    const channel = getChannelConfig(result.cfg);
+    expect(result.accountId).toBe("alerts");
+    expect(channel.defaultAccount).toBe("main");
+    expect(JSON.stringify(channel.accounts?.main)).toBe(before);
+    expect(channel.accounts?.alerts).toEqual({
+      botId: "test-alerts-bot-id",
+      secret: "example-secret",
+    });
+    expect(queued.confirm).not.toHaveBeenCalled();
+  });
+
+  it("promotes mixed root credentials before adding another named account", async () => {
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["__new__"],
+      textValues: ["alerts", "test-alerts-bot-id", "example-secret"],
+    });
+
+    const result = await runSetupWizardConfigure({
+      configure: createConfigure(),
+      cfg: {
+        channels: {
+          demo: {
+            defaultAccount: "main",
+            botId: "test-main-bot-id",
+            secret: "test-secret",
+            accounts: { main: { marker: { keep: "mixed-shape" } } },
+          },
+        },
+      } as OpenClawConfig,
+      prompter: queued.prompter,
+      shouldPromptAccountIds: true,
+      options: { secretInputMode: "plaintext" as const },
+    });
+
+    const channel = getChannelConfig(result.cfg);
+    expect(channel).not.toHaveProperty("botId");
+    expect(channel).not.toHaveProperty("secret");
+    expect(channel.defaultAccount).toBe("main");
+    expect(channel.accounts).toEqual({
+      main: {
+        marker: { keep: "mixed-shape" },
+        botId: "test-main-bot-id",
+        secret: "test-secret",
+      },
+      alerts: { botId: "test-alerts-bot-id", secret: "example-secret" },
+    });
+    expect(queued.confirm).not.toHaveBeenCalled();
+  });
+
+  it("replaces credentials only in the selected existing account after rejecting keep", async () => {
+    const main = { botId: "test-main-bot-id", secret: "test-secret" };
+    const before = JSON.stringify(main);
+    const queued = createQueuedWizardPrompter({
+      confirmValues: [false, false],
+      textValues: ["test-new-bot-id", "mock-secret"],
+    });
+
+    const result = await runSetupWizardConfigure({
+      configure: createConfigure(),
+      cfg: {
+        channels: {
+          demo: {
+            defaultAccount: "main",
+            accounts: {
+              main,
+              alerts: { botId: "test-old-bot-id", secret: "fixture-secret" },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      prompter: queued.prompter,
+      accountOverrides: { demo: "alerts" },
+      options: { secretInputMode: "plaintext" as const },
+    });
+
+    const channel = getChannelConfig(result.cfg);
+    expect(channel.defaultAccount).toBe("main");
+    expect(JSON.stringify(channel.accounts?.main)).toBe(before);
+    expect(channel.accounts?.alerts).toEqual({
+      botId: "test-new-bot-id",
+      secret: "mock-secret",
+    });
+    expect(queued.confirm).toHaveBeenCalledTimes(2);
+  });
+
+  it("scopes a named default account when another account is the channel default", async () => {
+    const main = { botId: "test-main-bot-id", secret: "test-secret" };
+    const before = JSON.stringify(main);
+    const queued = createQueuedWizardPrompter({
+      confirmValues: [false, false],
+      textValues: ["test-new-bot-id", "mock-secret"],
+    });
+
+    const result = await runSetupWizardConfigure({
+      configure: createConfigure(),
+      cfg: {
+        channels: {
+          demo: {
+            defaultAccount: "main",
+            accounts: {
+              default: { botId: "test-old-bot-id", secret: "fixture-secret" },
+              main,
+            },
+          },
+        },
+      } as OpenClawConfig,
+      prompter: queued.prompter,
+      accountOverrides: { demo: DEFAULT_ACCOUNT_ID },
+      options: { secretInputMode: "plaintext" as const },
+    });
+
+    const channel = getChannelConfig(result.cfg);
+    expect(channel.defaultAccount).toBe("main");
+    expect(JSON.stringify(channel.accounts?.main)).toBe(before);
+    expect(channel.accounts?.default).toEqual({
+      botId: "test-new-bot-id",
+      secret: "mock-secret",
+    });
+    expect(queued.confirm).toHaveBeenCalledTimes(2);
+  });
+
+  it("promotes root credentials before adding the first named account", async () => {
+    const queued = createQueuedWizardPrompter({
+      selectValues: ["__new__"],
+      textValues: ["alerts", "test-alerts-bot-id", "example-secret"],
+    });
+
+    const result = await runSetupWizardConfigure({
+      configure: createConfigure(),
+      cfg: {
+        channels: {
+          demo: {
+            enabled: true,
+            botId: "test-main-bot-id",
+            secret: "test-secret",
+          },
+        },
+      } as OpenClawConfig,
+      prompter: queued.prompter,
+      shouldPromptAccountIds: true,
+      options: { secretInputMode: "plaintext" as const },
+    });
+
+    const channel = getChannelConfig(result.cfg);
+    expect(channel).not.toHaveProperty("botId");
+    expect(channel).not.toHaveProperty("secret");
+    expect(channel).not.toHaveProperty("defaultAccount");
+    expect(channel.accounts).toEqual({
+      default: { botId: "test-main-bot-id", secret: "test-secret" },
+      alerts: { botId: "test-alerts-bot-id", secret: "example-secret" },
+    });
+    expect(queued.confirm).not.toHaveBeenCalled();
+  });
+});

--- a/src/channels/plugins/setup-wizard.ts
+++ b/src/channels/plugins/setup-wizard.ts
@@ -5,8 +5,9 @@
  */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { DEFAULT_ACCOUNT_ID } from "../../routing/session-key.js";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../routing/session-key.js";
 import { configureChannelAccessWithAllowlist } from "./setup-group-access-configure.js";
+import { moveSingleAccountChannelSectionToDefaultAccount } from "./setup-helpers.js";
 import {
   promptResolvedAllowFrom,
   resolveAccountIdForConfigure,
@@ -31,6 +32,68 @@ export type {
 } from "./setup-wizard-types.js";
 
 type ChannelSetupWizardPlugin = ChannelSetupPlugin;
+
+type ChannelSectionWithAccounts = Record<string, unknown> & {
+  accounts?: Record<string, unknown>;
+  defaultAccount?: string;
+};
+
+function getChannelSection(cfg: OpenClawConfig, channelKey: string): ChannelSectionWithAccounts {
+  const channels = cfg.channels as Record<string, unknown> | undefined;
+  const channel = channels?.[channelKey];
+  return channel && typeof channel === "object" ? (channel as ChannelSectionWithAccounts) : {};
+}
+
+function createWizardAccountScope(params: {
+  cfg: OpenClawConfig;
+  channelKey: string;
+  accountId: string;
+}): { cfg: OpenClawConfig; restore: (cfg: OpenClawConfig) => OpenClawConfig } {
+  const accountId = normalizeAccountId(params.accountId);
+  const initialChannel = getChannelSection(params.cfg, params.channelKey);
+  const hasNamedAccounts = Object.keys(initialChannel.accounts ?? {}).length > 0;
+  if (accountId === DEFAULT_ACCOUNT_ID && !hasNamedAccounts) {
+    return { cfg: params.cfg, restore: (cfg) => cfg };
+  }
+
+  const cfg = moveSingleAccountChannelSectionToDefaultAccount({
+    cfg: params.cfg,
+    channelKey: params.channelKey,
+  });
+  const channel = getChannelSection(cfg, params.channelKey);
+  const previousDefaultAccount = channel.defaultAccount;
+
+  // Some shipped plugins ignore accountId and resolve through defaultAccount.
+  // Scope their callbacks to this wizard run, then restore the operator's default.
+  const scopedCfg = {
+    ...cfg,
+    channels: {
+      ...cfg.channels,
+      [params.channelKey]: {
+        ...channel,
+        defaultAccount: accountId,
+      },
+    },
+  } as OpenClawConfig;
+
+  return {
+    cfg: scopedCfg,
+    restore: (currentCfg) => {
+      const currentChannel = getChannelSection(currentCfg, params.channelKey);
+      const restoredChannel =
+        previousDefaultAccount !== undefined
+          ? { ...currentChannel, defaultAccount: previousDefaultAccount }
+          : (({ defaultAccount: _ignored, ...rest }) => rest)(currentChannel);
+      return {
+        ...currentCfg,
+        channels: {
+          ...currentCfg.channels,
+          [params.channelKey]: restoredChannel,
+        },
+      } as OpenClawConfig;
+    },
+  };
+}
 
 async function buildStatus(
   plugin: ChannelSetupWizardPlugin,
@@ -203,7 +266,12 @@ export function buildChannelSetupWizardAdapterFromSetupWizard(params: {
             defaultAccountId,
           }));
 
-      let next = cfg;
+      const accountScope = createWizardAccountScope({
+        cfg,
+        channelKey: plugin.id,
+        accountId,
+      });
+      let next = accountScope.cfg;
       let credentialValues = collectCredentialValues({
         wizard,
         cfg: next,
@@ -632,7 +700,7 @@ export function buildChannelSetupWizardAdapterFromSetupWizard(params: {
         await prompter.note(wizard.completionNote.lines.join("\n"), wizard.completionNote.title);
       }
 
-      return { cfg: next, accountId };
+      return { cfg: accountScope.restore(next), accountId };
     },
     dmPolicy: wizard.dmPolicy,
     disable: wizard.disable,

--- a/src/channels/plugins/setup-wizard.ts
+++ b/src/channels/plugins/setup-wizard.ts
@@ -51,8 +51,9 @@ function createWizardAccountScope(params: {
 }): { cfg: OpenClawConfig; restore: (cfg: OpenClawConfig) => OpenClawConfig } {
   const accountId = normalizeAccountId(params.accountId);
   const initialChannel = getChannelSection(params.cfg, params.channelKey);
-  const hasNamedAccounts = Object.keys(initialChannel.accounts ?? {}).length > 0;
-  if (accountId === DEFAULT_ACCOUNT_ID && !hasNamedAccounts) {
+  // An existing accounts map — even empty — makes legacy plugins write account-scoped
+  // while root credentials linger; only a truly absent map may skip promotion.
+  if (accountId === DEFAULT_ACCOUNT_ID && initialChannel.accounts === undefined) {
     return { cfg: params.cfg, restore: (cfg) => cfg };
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes #79553. When an operator with an existing channel account selected "Add a new account" in the channel setup wizard, plugins using the accounts schema (observed with the WeCom plugin; the same class applies to any legacy accounts-schema plugin) pre-filled credentials from the existing account and — after answering "No" to "already configured. Keep it?" — **overwrote the existing `accounts.main` credentials** instead of writing the new account. That is silent configuration corruption of a working account.

## Why This Change Was Made

Root cause: `buildChannelSetupWizardAdapterFromSetupWizard` selected an `accountId` but passed unscoped config to the plugin setup callbacks. Legacy accounts-schema callbacks that ignore `accountId` resolve credentials through `defaultAccount`, which still pointed at the existing account — so both the "already configured" inspection and the credential writes hit the wrong account.

The fix scopes the wizard run at the owning boundary (`src/channels/plugins/setup-wizard.ts`): before invoking plugin callbacks it promotes any legacy root-level credentials into the accounts map, points `defaultAccount` at the selected account for the duration of the callbacks (immutably — no shared-state mutation), and restores the operator's original `defaultAccount` on the returned config. An existing-but-empty `accounts: {}` map is treated as account-scoped too, so lingering root credentials are migrated rather than left stale. `botId`/`secret` were added to the generic single-account promotion keys. Telegram's adapter already patches account-aware and is unchanged.

## User Impact

- "Add a new account" no longer overwrites or pre-fills from the existing account; new credentials land only under the new account id.
- Replacing credentials on a selected existing account touches only that account; other accounts stay byte-identical.
- Mixed legacy shapes (root credentials with named or empty accounts maps) are migrated into the accounts map instead of leaving stale root secrets behind.
- No config schema changes, no new flags.

## Evidence

- Regression suite `src/channels/plugins/setup-wizard.test.ts` (new, 6 tests): no-prefill/no-overwrite on add-new, mixed-root promotion, selected-account-only replacement, named `default` account, first named account, empty-accounts-map migration. All pass.
- Sibling suites `setup-helpers.test.ts` + `helpers.test.ts`: 12 tests pass.
- Autoreview (codex `gpt-5.6-sol`, xhigh): clean, "patch is correct (0.87)". An earlier autoreview pass surfaced the empty-accounts-map edge; it is fixed and covered by the regression suite.
- `git diff --check` clean; branch rebased onto current `origin/main`.
