### PR TITLE
docs(agents): draft-then-ready PR creation prevents the merge-ref CI race

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,7 +233,7 @@ Skills own workflows; root owns hard policy and routing.
 - No surprise GH writes: chat must mention every posted/updated public comment with URL.
 - GH comments with backticks, `$`, or shell snippets: use heredoc/body file, not inline double-quoted `--body`.
 - PR create: real body required. Use the current template: `What Problem This Solves`, `Why This Change Was Made`, `User Impact`, and `Evidence`; include visible refs, behavior, and validation.
-- PR create races GitHub's merge-ref computation: the pull_request-open CI run can drop entirely or die as `startup_failure`/`BuildFailed` (`(Unknown event)`, not rerunnable). After opening, verify the CI workflow attached to the head SHA; if missing, close/reopen the PR to re-fire the event.
+- PR create races GitHub's merge-ref computation: the pull_request-open CI run can drop entirely or die as `startup_failure`/`BuildFailed` (`(Unknown event)`, not rerunnable). Prevention: `gh pr create --draft`, poll `mergeable` non-null, then `gh pr ready`. After opening, verify the CI workflow attached to the head SHA; if missing, the hourly `pr-ci-sweeper` re-fires it, or close/reopen manually.
 - PR create/refresh: keep PR branches takeover-ready. Use a branch maintainers can push to, or for fork PRs ensure `maintainer_can_modify` / GitHub's `Allow edits by maintainers` is enabled unless explicitly told otherwise or GitHub's Actions/secrets warning makes that unsafe.
 - GitHub issue/PR create: read `$agent-transcript`; ask about sanitized transcript logs when available.
 - Contributor PRs: parsed context requires authored `What Problem This Solves` and `Evidence` sections. Do not require field-level proof forms; reviewers inspect code, tests, and CI for correctness.


### PR DESCRIPTION
## What Problem This Solves

The AGENTS.md note from #110812 documents the dropped PR-open CI race and its manual remedy, but not the validated prevention or the now-landed automated repair (#110889/#110945).

## Why This Change Was Made

Draft-then-ready was validated twice this week: creating the PR as a draft, polling `mergeable` until non-null, then marking ready makes CI attach first try (`ready_for_review` is in ci.yml's trigger types and the draft preflight skips cheaply). The sweeper reference tells agents the self-heal path exists before they reach for manual close/reopen.

## User Impact

Agent-workflow guidance only; no runtime changes.

## Evidence

Docs-only: `git diff --check` clean. This PR is itself created non-draft immediately after push, deliberately racing the merge ref as a live test of the sweeper's repair path.