### PR TITLE
fix: prevent LINE channel reloads from hanging on stalled deliveries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **LINE webhook restart shutdown:** bound active-delivery drain during channel restart so a stalled handler cannot block reload indefinitely, while preserving at-least-once recovery after the grace window.
 - **Bounded input and provider responses:** cap pasted auth/config input and enforce wall-clock deadlines across generated-media downloads, polling JSON, and failed response details so oversized or slow-drip streams cannot exceed resource budgets (thanks @Pick-cat).
 - **Cloud worker derived workspace caches:** exclude Python caches, dependency trees, and macOS metadata symmetrically from outbound sync and inbound reconciliation so local cache rewrites cannot fence later cloud results or worker reclaim.
 - **Codex model status diagnostics:** report a configured Codex route as unavailable when its harness plugin is disabled, missing, or quarantined, while preserving the separate credential result and making `models status --check` fail instead of silently treating fallback execution as healthy. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **LINE webhook restart shutdown:** bound active-delivery drain during channel restart so a stalled handler cannot block reload indefinitely, while preserving at-least-once recovery after the grace window.
 - **Bounded input and provider responses:** cap pasted auth/config input and enforce wall-clock deadlines across generated-media downloads, polling JSON, and failed response details so oversized or slow-drip streams cannot exceed resource budgets (thanks @Pick-cat).
 - **Cloud worker derived workspace caches:** exclude Python caches, dependency trees, and macOS metadata symmetrically from outbound sync and inbound reconciliation so local cache rewrites cannot fence later cloud results or worker reclaim.
 - **Codex model status diagnostics:** report a configured Codex route as unavailable when its harness plugin is disabled, missing, or quarantined, while preserving the separate credential result and making `models status --check` fail instead of silently treating fallback execution as healthy. Thanks @shakkernerd.

--- a/docs/channels/msteams.md
+++ b/docs/channels/msteams.md
@@ -647,12 +647,13 @@ This applies to channels and group chats only. It adds one Graph message lookup 
 
 ### Webhook timeouts
 
-Teams delivers messages via HTTP webhook. OpenClaw applies fixed HTTP server timeouts to that webhook listener: 30s inactivity, 30s total request, 15s to receive headers. Optional inbound media and context enrichment has a shared 10-second budget, but the Teams SDK still waits for the agent turn before returning the webhook response. If the full turn exceeds Teams' retry window, you may see:
-
-- Teams retrying the message (causing duplicates).
-- Dropped replies.
-
-Replies are sent proactively once the agent responds, but slow agent runs can still surface retries or duplicates on the Teams side.
+Teams delivers messages via HTTP webhook. OpenClaw applies fixed HTTP server
+timeouts to that webhook listener: 30s inactivity, 30s total request, and 15s
+to receive headers. Optional inbound media and context enrichment has a shared
+10-second budget. The SDK returns after the raw activity is durably appended;
+the agent turn drains independently and replies proactively. If request
+handling or durable admission misses the transport window, Teams may retry the
+activity, and the ingress tombstone rejects a repeated event ID.
 
 ### Teams cloud and service URL support
 

--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -130,14 +130,16 @@ For ACP-specific behavior, see [ACP Agents](/tools/acp-agents).
 
 Session tools are scoped to limit what the agent can see:
 
-| Level   | Scope                                    |
-| ------- | ---------------------------------------- |
-| `self`  | Only the current session                 |
-| `tree`  | Current session + spawned sub-agents     |
-| `agent` | All sessions for this agent              |
-| `all`   | All sessions (cross-agent if configured) |
+| Level   | Scope                                                      |
+| ------- | ---------------------------------------------------------- |
+| `self`  | Only the current session                                   |
+| `tree`  | Current + spawned; reads include watched same-agent groups |
+| `agent` | All sessions for this agent                                |
+| `all`   | All sessions (cross-agent if configured)                   |
 
 Default is `tree`. Sandboxed sessions are clamped to `tree` regardless of config.
+With the default `session.dmScope: "main"`, group activity makes watched
+same-agent group sessions readable from the main session.
 
 ## Further reading
 

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -7389,6 +7389,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Message adapter
   - H3: Inbound ingress (experimental)
   - H3: Durable ingress and replay dedupe
+  - H4: Transport classes and retention
   - H4: At-least-once side effects
   - H4: Account-scoped restart contract
   - H3: Typing indicators

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -430,6 +430,7 @@ Common patterns: personal agent (full access, no sandbox), family/work agent (sa
         tools: {
           // Session tools can reveal transcript data. Default scope is current + spawned;
           // reads also include same-agent groups watched through ambient group awareness.
+          // Use visibility: "self" to exclude those watched sessions.
           sessions: { visibility: "tree" }, // self | tree | agent | all
           allow: [
             "sessions_list",

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -428,8 +428,8 @@ Common patterns: personal agent (full access, no sandbox), family/work agent (sa
         workspace: "~/.openclaw/workspace-public",
         sandbox: { mode: "all", scope: "agent", workspaceAccess: "none" },
         tools: {
-          // Session tools can reveal transcript data. Default scope is current session +
-          // spawned subagent sessions; clamp further with tools.sessions.visibility if needed.
+          // Session tools can reveal transcript data. Default scope is current + spawned;
+          // reads also include same-agent groups watched through ambient group awareness.
           sessions: { visibility: "tree" }, // self | tree | agent | all
           allow: [
             "sessions_list",

--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -116,6 +116,34 @@ guard when adopting the drain and size `completedTtlMs`/`completedMaxEntries`
 to cover the old guard window instead. Non-dedupe protections (age fences,
 outbound echo caches) are unrelated to this rule and stay.
 
+#### Transport classes and retention
+
+Classify a transport by the recovery guarantee at its receive boundary:
+
+- **Ack-gated webhook or event delivery:** acknowledge or return success only
+  after the durable append. An append failure must leave the delivery eligible
+  for retry or fail the receive boundary. This class includes Slack, SMS, Zalo,
+  Microsoft Teams, Google Chat, LINE, and Synology Chat.
+- **Awaited polling or stream delivery:** advance the remote cursor or send the
+  transport ack only after the append. When no explicit cursor exists, keep the
+  receive callback serialized and awaited so an append failure cannot let the
+  receive loop run ahead. Telegram polling, Signal, and Tlon use this class;
+  Telegram webhook delivery follows the ack-gated rule above.
+- **Non-replay sockets:** IRC, Mattermost, Twitch, and Zalo Personal cannot ask
+  the platform to redeliver an accepted event. Their durable queue protects the
+  process crash window and supports local restart recovery; completion
+  tombstones are near-inert against platform replay.
+
+Use 30 days as the fleet tombstone-TTL convention, not as an SDK default. A
+high-volume redelivery window normally uses a 20,000-entry completed cap;
+lower-volume awaited and non-replay transports normally use 1,000-2,000.
+Current exceptions include LINE's 4,096-entry caps, SMS's 24-hour completed
+TTL, and Tlon's cap-only completed retention. Failed-row caps may also be lower
+than completed caps. TTL and cap both prune rows, so effective retention ends
+when the first bound is reached. Deviate only for a documented platform retry
+horizon, preserved shipped replay-guard window, expected volume or disk budget,
+or non-replay transport, and cover the retention contract with tests.
+
 #### At-least-once side effects
 
 Drain dispatch runs command side effects before the ingress row reaches its

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -539,10 +539,10 @@ Session indexing is opt-in and runs asynchronously. Results can be slightly stal
 
 Ordinary model-invoked session transcript search obeys
 [`tools.sessions.visibility`](/gateway/config-tools#toolssessions). The default
-`tree` visibility only exposes the current session and sessions it spawned. To
-let ordinary `memory_search` calls inspect unrelated sessions, intentionally
-widen visibility to `agent` (or `all` only when cross-agent recall is also
-required and agent-to-agent policy allows it).
+`tree` visibility exposes the current session, sessions it spawned, and
+same-agent group sessions watched through ambient group awareness. Other
+unrelated sessions require `agent` visibility (or `all` only when cross-agent
+recall is also required and agent-to-agent policy allows it).
 
 `rememberAcrossConversations` does not widen that setting. It supplies a
 separate runtime-only authorization limited to same-agent private

--- a/extensions/line/src/webhook-spool.test.ts
+++ b/extensions/line/src/webhook-spool.test.ts
@@ -278,6 +278,66 @@ describe("LINE webhook spool", () => {
     });
   });
 
+  it("disposes after the active-delivery stop grace expires", async () => {
+    await withQueue(async (queue) => {
+      let releaseDelivery = () => {};
+      const deliveryGate = new Promise<void>((resolve) => {
+        releaseDelivery = resolve;
+      });
+      const firstDeliver = vi.fn(async () => {
+        await deliveryGate;
+      });
+      const firstRuntime = runtime();
+      const first = createLineWebhookSpool({
+        accountId: "default",
+        runtime: firstRuntime,
+        queue,
+        deliver: firstDeliver,
+      });
+      const event = createEvent({ webhookEventId: "event-stop-timeout" });
+
+      first.start();
+      await first.accept(callback(event));
+      await vi.waitFor(() => expect(firstDeliver).toHaveBeenCalledTimes(1));
+
+      vi.useFakeTimers();
+      const stopping = first.stop();
+      let stopSettled = false;
+      void stopping.then(() => {
+        stopSettled = true;
+      });
+      try {
+        await vi.advanceTimersByTimeAsync(4_999);
+        expect(stopSettled).toBe(false);
+        await vi.advanceTimersByTimeAsync(1);
+        await stopping;
+        expect(firstRuntime.log).toHaveBeenCalledWith(
+          expect.stringContaining("timed out after 5000ms"),
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+
+      const restartedDeliver = vi.fn(async (_event, _destination, control) => {
+        await control.turnAdoptionLifecycle.onAdopted();
+      });
+      const restarted = createLineWebhookSpool({
+        accountId: "default",
+        runtime: runtime(),
+        queue,
+        deliver: restartedDeliver,
+      });
+      restarted.start();
+      try {
+        await waitForVerdict(queue, "message:message-event-stop-timeout", "completed");
+        expect(restartedDeliver).toHaveBeenCalledTimes(1);
+      } finally {
+        releaseDelivery();
+        await restarted.stop();
+      }
+    });
+  });
+
   it("waits for deferred claim settlement before disposing on stop", async () => {
     await withQueue(async (queue) => {
       let deferredLifecycle: LineWebhookTurnAdoptionLifecycle | undefined;

--- a/extensions/line/src/webhook-spool.test.ts
+++ b/extensions/line/src/webhook-spool.test.ts
@@ -284,9 +284,17 @@ describe("LINE webhook spool", () => {
       const deliveryGate = new Promise<void>((resolve) => {
         releaseDelivery = resolve;
       });
-      const firstDeliver = vi.fn(async () => {
-        await deliveryGate;
-      });
+      let lateLifecycle: LineWebhookTurnAdoptionLifecycle | undefined;
+      const firstDeliver = vi.fn(
+        async (
+          _event: webhook.Event,
+          _destination: string,
+          control: { turnAdoptionLifecycle: LineWebhookTurnAdoptionLifecycle },
+        ) => {
+          lateLifecycle = control.turnAdoptionLifecycle;
+          await deliveryGate;
+        },
+      );
       const firstRuntime = runtime();
       const first = createLineWebhookSpool({
         accountId: "default",
@@ -314,6 +322,11 @@ describe("LINE webhook spool", () => {
         expect(firstRuntime.log).toHaveBeenCalledWith(
           expect.stringContaining("timed out after 5000ms"),
         );
+        if (!lateLifecycle) {
+          throw new Error("LINE delivery did not expose its adoption lifecycle");
+        }
+        lateLifecycle.onDeferred();
+        await vi.waitFor(async () => expect(await queue.listClaims()).toEqual([]));
       } finally {
         vi.useRealTimers();
       }
@@ -334,6 +347,77 @@ describe("LINE webhook spool", () => {
       } finally {
         releaseDelivery();
         await restarted.stop();
+      }
+    });
+  });
+
+  it("waits for claims deferred after an active-delivery stop timeout", async () => {
+    await withQueue(async (queue) => {
+      let releaseDelivery = () => {};
+      const deliveryGate = new Promise<void>((resolve) => {
+        releaseDelivery = resolve;
+      });
+      let deferredLifecycle: LineWebhookTurnAdoptionLifecycle | undefined;
+      let activeLifecycle: LineWebhookTurnAdoptionLifecycle | undefined;
+      const spoolRuntime = runtime();
+      const deliver = vi.fn(
+        async (
+          event: webhook.Event,
+          _destination: string,
+          control: { turnAdoptionLifecycle: LineWebhookTurnAdoptionLifecycle },
+        ) => {
+          if ((event as webhook.MessageEvent).message.id === "message-event-stop-deferred") {
+            deferredLifecycle = control.turnAdoptionLifecycle;
+            control.turnAdoptionLifecycle.onDeferred();
+            return;
+          }
+          activeLifecycle = control.turnAdoptionLifecycle;
+          await deliveryGate;
+        },
+      );
+      const spool = createLineWebhookSpool({
+        accountId: "default",
+        runtime: spoolRuntime,
+        queue,
+        deliver,
+      });
+
+      spool.start();
+      await spool.accept(callback(createEvent({ webhookEventId: "event-stop-active" })));
+      await spool.accept(
+        callback(createEvent({ webhookEventId: "event-stop-deferred", userId: "user-2" })),
+      );
+      await vi.waitFor(() => expect(deliver).toHaveBeenCalledTimes(2));
+
+      vi.useFakeTimers();
+      const stopping = spool.stop();
+      let stopSettled = false;
+      void stopping.then(() => {
+        stopSettled = true;
+      });
+      try {
+        await vi.advanceTimersByTimeAsync(5_000);
+        expect(spoolRuntime.log).toHaveBeenCalledWith(
+          expect.stringContaining("timed out after 5000ms"),
+        );
+        expect(stopSettled).toBe(false);
+
+        if (!deferredLifecycle || !activeLifecycle) {
+          throw new Error("LINE deliveries did not expose their adoption lifecycles");
+        }
+        activeLifecycle.onDeferred();
+        await deferredLifecycle.onAbandoned();
+        await vi.advanceTimersByTimeAsync(0);
+        expect(stopSettled).toBe(false);
+
+        await activeLifecycle.onAbandoned();
+        releaseDelivery();
+        await stopping;
+        expect(stopSettled).toBe(true);
+        expect(await queue.listClaims()).toEqual([]);
+      } finally {
+        releaseDelivery();
+        vi.useRealTimers();
       }
     });
   });

--- a/extensions/line/src/webhook-spool.ts
+++ b/extensions/line/src/webhook-spool.ts
@@ -7,7 +7,7 @@ import {
   DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
   type ChannelIngressQueue,
 } from "openclaw/plugin-sdk/channel-outbound";
-import { danger, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { danger, type RuntimeEnv, warn } from "openclaw/plugin-sdk/runtime-env";
 import { runDetachedWebhookWork } from "openclaw/plugin-sdk/webhook-request-guards";
 import { getLineRuntime } from "./runtime.js";
 
@@ -15,6 +15,7 @@ const LINE_WEBHOOK_SPOOL_VERSION = 1;
 const LINE_WEBHOOK_DRAIN_INTERVAL_MS = 500;
 const LINE_WEBHOOK_MAX_CONCURRENT_DELIVERIES = 8;
 const LINE_WEBHOOK_DRAIN_SCAN_LIMIT = 100;
+const LINE_WEBHOOK_ACTIVE_DELIVERY_STOP_GRACE_MS = 5_000;
 const LINE_WEBHOOK_TOMBSTONE_TTL_MS = 30 * 24 * 60 * 60_000;
 const LINE_WEBHOOK_TOMBSTONE_MAX_ENTRIES = 4096;
 
@@ -145,6 +146,25 @@ function isLineAuthenticationFailure(error: unknown): boolean {
   // @line/bot-sdk HTTPFetchError exposes the response code as `status`.
   const status = (error as { status?: unknown }).status;
   return status === 401 || status === 403;
+}
+
+async function waitForActiveDeliveriesBeforeDispose(
+  activeDeliveries: ReadonlySet<Promise<void>>,
+): Promise<boolean> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      Promise.allSettled(activeDeliveries).then(() => true),
+      new Promise<boolean>((resolve) => {
+        timeout = setTimeout(() => resolve(false), LINE_WEBHOOK_ACTIVE_DELIVERY_STOP_GRACE_MS);
+        timeout.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
 }
 
 export function createLineWebhookSpool(options: LineWebhookSpoolOptions): LineWebhookSpool {
@@ -322,15 +342,26 @@ export function createLineWebhookSpool(options: LineWebhookSpoolOptions): LineWe
       }
       shutdown.abort();
       await drainTask;
-      // Keep the claim owner live until every real delivery and core handler exits;
-      // disposing earlier lets a replacement drain recover work still producing replies.
-      await Promise.allSettled(activeDeliveries);
-      // Accepted shutdown tradeoff: deferred claims may wait for the full agent run.
-      // A deadline would allow duplicate side effects after replacement recovery;
-      // remove this wait only when core can cancel or abandon the run before release.
-      await Promise.allSettled(deferredClaims.values());
-      await drain.waitForIdle();
-      drain.dispose();
+      try {
+        // Bound restart even though a delivery may finish after its row is recovered;
+        // that duplicate-side-effect window is the accepted at-least-once tradeoff.
+        const deliveriesSettled = await waitForActiveDeliveriesBeforeDispose(activeDeliveries);
+        if (!deliveriesSettled) {
+          options.runtime.log(
+            warn(
+              `line: timed out after ${LINE_WEBHOOK_ACTIVE_DELIVERY_STOP_GRACE_MS}ms waiting for active webhook deliveries; releasing drain ownership`,
+            ),
+          );
+          return;
+        }
+        // Accepted shutdown tradeoff: deferred claims may wait for the full agent run.
+        // A deadline would allow duplicate side effects after replacement recovery;
+        // remove this wait only when core can cancel or abandon the run before release.
+        await Promise.allSettled(deferredClaims.values());
+        await drain.waitForIdle();
+      } finally {
+        drain.dispose();
+      }
     },
   };
 }

--- a/extensions/line/src/webhook-spool.ts
+++ b/extensions/line/src/webhook-spool.ts
@@ -177,6 +177,7 @@ export function createLineWebhookSpool(options: LineWebhookSpoolOptions): LineWe
   // Match the predecessor worker's per-spool cap across repeated drain pumps.
   const activeDeliveries = new Set<Promise<void>>();
   const deferredClaims = new Map<string, Promise<void>>();
+  let acceptsDeferredClaims = true;
   const drain = createChannelIngressDrain<LineWebhookSpoolPayload>({
     queue,
     abortSignal: shutdown.signal,
@@ -233,6 +234,11 @@ export function createLineWebhookSpool(options: LineWebhookSpoolOptions): LineWe
             }
           },
           onDeferred: () => {
+            if (!acceptsDeferredClaims) {
+              settleDeferredClaim();
+              void boundLifecycle.onAbandoned();
+              return;
+            }
             if (!deferredClaimSettled) {
               deferredClaims.set(claimed.id, deferredClaim);
             }
@@ -352,13 +358,19 @@ export function createLineWebhookSpool(options: LineWebhookSpoolOptions): LineWe
               `line: timed out after ${LINE_WEBHOOK_ACTIVE_DELIVERY_STOP_GRACE_MS}ms waiting for active webhook deliveries; releasing drain ownership`,
             ),
           );
-          return;
         }
         // Accepted shutdown tradeoff: deferred claims may wait for the full agent run.
         // A deadline would allow duplicate side effects after replacement recovery;
         // remove this wait only when core can cancel or abandon the run before release.
-        await Promise.allSettled(deferredClaims.values());
-        await drain.waitForIdle();
+        while (deferredClaims.size > 0) {
+          await Promise.allSettled(deferredClaims.values());
+        }
+        // Close registration only after the live map drains. Later deferrals
+        // are rejected through onAbandoned so disposal cannot orphan a run.
+        acceptsDeferredClaims = false;
+        if (deliveriesSettled) {
+          await drain.waitForIdle();
+        }
       } finally {
         drain.dispose();
       }

--- a/extensions/line/src/webhook-spool.ts
+++ b/extensions/line/src/webhook-spool.ts
@@ -236,7 +236,13 @@ export function createLineWebhookSpool(options: LineWebhookSpoolOptions): LineWe
           onDeferred: () => {
             if (!acceptsDeferredClaims) {
               settleDeferredClaim();
-              void boundLifecycle.onAbandoned();
+              void Promise.resolve()
+                .then(() => boundLifecycle.onAbandoned())
+                .catch((error: unknown) => {
+                  options.runtime.error?.(
+                    danger(`line: failed to abandon a late webhook delivery: ${errorText(error)}`),
+                  );
+                });
               return;
             }
             if (!deferredClaimSettled) {

--- a/src/agents/harness/user-input-bridge.ts
+++ b/src/agents/harness/user-input-bridge.ts
@@ -199,6 +199,8 @@ export function buildAgentHarnessUserInputAnswers(
   }
 
   const keyed = parseKeyedAnswers(inputText);
+  // Unkeyed multi-question replies are positional. Preserve blank lines so a
+  // skipped answer cannot shift every later response onto the wrong question.
   const fallbackLines = inputText.split(/\r?\n/).map((line) => line.trim());
   questions.forEach((question, index) => {
     const key =
@@ -219,6 +221,8 @@ export function normalizeAgentHarnessUserInputAnswer(
 ): string | undefined {
   const trimmed = answer.trim();
   const options = question.options ?? [];
+  // Numeric replies use the one-based option numbers emitted in the prompt.
+  // Convert to zero-based only at the options-array boundary.
   const optionIndex = /^\d+$/.test(trimmed) ? Number(trimmed) - 1 : -1;
   const indexed = optionIndex >= 0 ? options[optionIndex] : undefined;
   if (indexed) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where restarting or reloading a LINE channel could wait forever when an accepted webhook delivery never settled. It also resolves scattered or stale documentation about durable-ingress replay classes, tombstone retention, main-session group visibility, and Microsoft Teams webhook acknowledgement.

## Why This Change Was Made

LINE now gives active deliveries a five-second graceful shutdown window and always disposes the drain afterward, allowing a replacement worker to recover unfinished rows instead of blocking restart indefinitely. Existing deferred turns remain owned until adoption or abandonment; the shutdown barrier drains live deferrals, atomically closes registration, and abandons any later deferral with handled error logging. The remaining recovery race deliberately retains the fleet's accepted at-least-once shutdown semantics for the stuck delivery only.

The SDK guide now classifies transports by their actual receive/recovery boundary and records the 30-day fleet convention, the usual 20,000 versus 1,000-2,000 sizing profiles, and current source-backed exceptions. Related visibility and Teams docs were aligned with shipped behavior, and the shared ask-user parser now records its positional-index contracts at the code site.

Already-fixed review follow-ups were dropped after verification: Signal's async `onAbandoned` type and the queue lifecycle contract comment both landed in #110413. The canonical group-visibility docs were fixed there too; this PR updates the three secondary references that still carried the old shorthand.

## User Impact

Operators can restart a LINE channel without a permanently stalled delivery wedging shutdown, while unrelated deferred turns retain their durable ownership. Plugin authors get an explicit, source-accurate ingress retention contract, and operators configuring session visibility or Teams webhooks no longer receive misleading lifecycle guidance.

## Evidence

- Final focused Vitest shards: 32 tests passed (`extensions/line/src/webhook-spool.test.ts`, `src/plugin-sdk/agent-harness-runtime.test.ts`); an earlier Blacksmith Testbox run passed the pre-follow-up 31-test bundle.
- Documentation gates: formatting, Markdown lint, MDX parsing, generated docs-map verification, and internal-link audit all passed; 6,088 internal links checked with zero broken links.
- Dead-code gates: production/full-tree/script unused exports all zero; production/full-tree unused files all zero.
- `oxfmt` ran on every touched file; `git diff --check origin/main...HEAD` passed.
- Final diff: +258/-28, net +230. Production TypeScript is +63/-10, net +53; the growth is the bounded timer, live deferred-claim barrier, late-deferral abandonment fence with handled cleanup errors, and four requested parser-contract comment lines. The remaining growth is focused regression coverage and documentation.
- Mandatory uncommitted and branch autoreview passes are clean after fixing the deferred-ownership and detached-rejection findings.
- Exact pushed head: `63493602668d110c0f4f36565b3f4a336ec7d8ed`.
