### PR TITLE
fix(codex): mid-turn usage-limit errors hang the turn until an outer timeout

### DIFF
--- a/extensions/codex/src/app-server/attempt-notification-state.ts
+++ b/extensions/codex/src/app-server/attempt-notification-state.ts
@@ -16,6 +16,7 @@ import {
   isReasoningProgressNotification,
   isReasoningItemCompletionNotification,
   isRetryableErrorNotification,
+  isUsageLimitErrorNotification,
   readCodexNotificationItem,
   readNotificationItemId,
   shouldDisarmAssistantCompletionIdleWatch,
@@ -199,9 +200,16 @@ export function applyCodexTurnNotificationState(params: {
   };
 
   if (isCurrentTurnNotification && notification.method === "error") {
-    if (isRetryableErrorNotification(notification.params)) {
+    if (
+      isRetryableErrorNotification(notification.params) &&
+      !isUsageLimitErrorNotification(notification.params)
+    ) {
       turnWatches.disarmCompletionIdleWatch();
     } else {
+      // Usage-limit errors are flagged willRetry, but the app-server's silent
+      // retry can wait until the limit resets (potentially hours). Keep the
+      // completion watch pinned so the silence stays bounded; resumed retry
+      // activity still touches the watch and lets the turn continue.
       turnWatches.armCompletionIdleWatch({ pinnedByTerminalError: true });
     }
     turnWatches.disarmAssistantCompletionIdleWatch();

--- a/extensions/codex/src/app-server/attempt-notifications.ts
+++ b/extensions/codex/src/app-server/attempt-notifications.ts
@@ -9,6 +9,7 @@ import {
   type JsonObject,
   type JsonValue,
 } from "./protocol.js";
+import { isCodexUsageLimitError } from "./rate-limits.js";
 
 const CODEX_TURN_ABORT_MARKER_START = "<turn_aborted>";
 const CODEX_TURN_ABORT_MARKER_END = "</turn_aborted>";
@@ -318,6 +319,14 @@ function readRawAssistantTextPreview(item: JsonObject): string | undefined {
 /** Returns true for app-server error notifications that will retry. */
 export function isRetryableErrorNotification(value: JsonValue | undefined): boolean {
   return isJsonObject(value) && value.willRetry === true;
+}
+
+/** Returns true for app-server error notifications caused by a Codex usage limit. */
+export function isUsageLimitErrorNotification(value: JsonValue | undefined): boolean {
+  if (!isJsonObject(value) || !isJsonObject(value.error)) {
+    return false;
+  }
+  return isCodexUsageLimitError(value.error.codexErrorInfo);
 }
 
 /** Returns true for terminal app-server thread status strings. */

--- a/extensions/codex/src/app-server/rate-limits.ts
+++ b/extensions/codex/src/app-server/rate-limits.ts
@@ -225,7 +225,8 @@ export function buildCodexAppServerUsageSnapshot(value: unknown): ProviderUsageS
   };
 }
 
-function isCodexUsageLimitError(codexErrorInfo: JsonValue | null | undefined): boolean {
+/** Returns true when Codex error info marks a usage-limit failure. */
+export function isCodexUsageLimitError(codexErrorInfo: JsonValue | null | undefined): boolean {
   if (codexErrorInfo === "usageLimitExceeded") {
     return true;
   }

--- a/extensions/codex/src/app-server/run-attempt-finalize.ts
+++ b/extensions/codex/src/app-server/run-attempt-finalize.ts
@@ -40,6 +40,7 @@ import { normalizeCodexTrajectoryError, recordCodexTrajectoryCompletion } from "
 import { codexTranscriptMirrorRuntime } from "./transcript-mirror.js";
 import {
   createCodexUsageLimitPromptError,
+  formatCodexTurnStartUsageLimitError,
   isCodexUsageLimitPromptError,
   markCodexAuthProfileBlockedFromRateLimits,
   refreshCodexUsageLimitPromptError,
@@ -200,12 +201,29 @@ export async function finalizeCodexAttempt(
       threadId: resourceState.thread.threadId,
     });
   }
-  const refreshedUsageLimitPromptError = await refreshCodexUsageLimitPromptError({
-    client: resourceState.client,
-    message: finalPromptErrorMessage,
-    timeoutMs: appServer.requestTimeoutMs,
-    signal: runAbortController.signal,
-  });
+  // A mid-turn usage-limit error followed only by silence means the app-server
+  // stalled waiting for the limit to reset; surface the structured usage-limit
+  // failure instead of the generic idle-timeout message so blocking and
+  // failover classification engage.
+  const midTurnUsageLimitErrorNotification =
+    effectiveTurnCompletionIdleTimedOut && !clientClosedPromptErrorForFinal
+      ? state.latestUsageLimitErrorNotification
+      : undefined;
+  const refreshedUsageLimitPromptError = midTurnUsageLimitErrorNotification
+    ? await formatCodexTurnStartUsageLimitError({
+        client: resourceState.client,
+        error: undefined,
+        errorNotification: midTurnUsageLimitErrorNotification,
+        rateLimitsRevisionBeforeTurnStart: state.rateLimitsRevisionBeforeLastTurnStart,
+        timeoutMs: appServer.requestTimeoutMs,
+        signal: runAbortController.signal,
+      })
+    : await refreshCodexUsageLimitPromptError({
+        client: resourceState.client,
+        message: finalPromptErrorMessage,
+        timeoutMs: appServer.requestTimeoutMs,
+        signal: runAbortController.signal,
+      });
   if (refreshedUsageLimitPromptError) {
     await markCodexAuthProfileBlockedFromRateLimits({
       params,
@@ -234,9 +252,15 @@ export async function finalizeCodexAttempt(
   const replayBlockedReason = codexAppServerFailureKind
     ? resolveCodexAppServerReplayBlockedReason(result)
     : undefined;
+  const midTurnUsageLimitPromptErrorProduced = Boolean(
+    midTurnUsageLimitErrorNotification && refreshedUsageLimitPromptError,
+  );
   const promptTimeoutOutcome = buildCodexAppServerPromptTimeoutOutcome({
     result,
-    turnCompletionIdleTimedOut: effectiveTurnCompletionIdleTimedOut,
+    // The usage-limit prompt error is the user-facing explanation; the generic
+    // "stopped before confirming the turn" notice would be misleading here.
+    turnCompletionIdleTimedOut:
+      effectiveTurnCompletionIdleTimedOut && !midTurnUsageLimitPromptErrorProduced,
     turnWatchTimeoutKind: state.turnWatchTimeoutKind,
   });
   const failureDiagnostics =

--- a/extensions/codex/src/app-server/run-attempt-notification-controller.ts
+++ b/extensions/codex/src/app-server/run-attempt-notification-controller.ts
@@ -7,6 +7,7 @@ import {
   describeNotificationActivity,
   isAssistantCompletionReleaseNotification,
   isRawFunctionToolOutputCompletionNotification,
+  isUsageLimitErrorNotification,
   readCodexNotificationItem,
   readRawResponseToolCallId,
 } from "./attempt-notifications.js";
@@ -87,6 +88,25 @@ export function createCodexAttemptNotificationController(
       onReportExecutionNotification: reportExecutionNotification,
     });
     state.turnCrossedToolHandoff = notificationState.turnCrossedToolHandoff;
+    if (notificationState.isCurrentTurnNotification) {
+      if (notification.method === "error") {
+        // A later non-usage-limit error makes the stall cause ambiguous, so
+        // fall back to the generic timeout attribution.
+        state.latestUsageLimitErrorNotification = isUsageLimitErrorNotification(notification.params)
+          ? notification
+          : undefined;
+      } else if (state.latestUsageLimitErrorNotification !== undefined) {
+        // Any later current-turn activity means the retry recovered; a
+        // subsequent stall is no longer attributable to the usage limit, and
+        // the usage-limit pin should not keep a completion bound on the
+        // recovered turn. Terminal-error pins never reach here: their capture
+        // field is unset, so this only unwinds the usage-limit pin.
+        state.latestUsageLimitErrorNotification = undefined;
+        if (turnWatches.isCompletionIdleWatchPinnedByTerminalError()) {
+          turnWatches.armCompletionIdleWatch();
+        }
+      }
+    }
     if (notificationState.isCurrentTurnNotification && notification.method === "item/completed") {
       const item = readCodexNotificationItem(notification.params);
       if (item?.type === "userMessage" && typeof item.clientId === "string") {

--- a/extensions/codex/src/app-server/run-attempt-test-harness.ts
+++ b/extensions/codex/src/app-server/run-attempt-test-harness.ts
@@ -283,6 +283,7 @@ export function mockClientRuntimeMethods() {
   return {
     getRuntimeIdentity: getMockRuntimeIdentity,
     getServerVersion: getMockServerVersion,
+    getInstanceId: () => "codex-test-client-instance",
   };
 }
 

--- a/extensions/codex/src/app-server/run-attempt-turn-state.ts
+++ b/extensions/codex/src/app-server/run-attempt-turn-state.ts
@@ -42,6 +42,9 @@ export function createCodexAttemptTurnState(resources: CodexAttemptResources) {
   const { params, options, appServer, runAbortController } = connection;
   const state = {
     latestStartupErrorNotification: undefined as CodexServerNotification | undefined,
+    // Latest mid-turn usage-limit error with no later turn activity; finalize
+    // surfaces it as the structured usage-limit failure when the turn times out.
+    latestUsageLimitErrorNotification: undefined as CodexServerNotification | undefined,
     rateLimitsRevisionBeforeLastTurnStart: undefined as number | undefined,
     completed: false,
     terminalTurnNotificationQueued: false,

--- a/extensions/codex/src/app-server/run-attempt.usage-limits.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.usage-limits.test.ts
@@ -397,4 +397,254 @@ describe("runCodexAppServerAttempt usage limits", () => {
       false,
     );
   });
+
+  it("fails fast with a usage-limit error when a mid-turn retryable usage-limit error stalls the turn", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const harness = createStartedThreadHarness();
+    const params = createParams(sessionFile, workspaceDir);
+
+    const run = runCodexAppServerAttempt(params, {
+      pluginConfig: { appServer: { turnCompletionIdleTimeoutMs: 40 } },
+      turnAssistantCompletionIdleTimeoutMs: 5_000,
+      turnTerminalIdleTimeoutMs: 60_000,
+    });
+    await harness.waitForMethod("turn/start");
+    await harness.notify({
+      method: "error",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        willRetry: true,
+        error: {
+          message: "You've reached your usage limit.",
+          codexErrorInfo: "usageLimitExceeded",
+        },
+      },
+    });
+
+    const result = await run;
+
+    expect(result.timedOut).toBe(true);
+    const promptError = expectUsageLimitPromptError(result.promptError);
+    expect(promptError.message).toContain("You've reached your Codex subscription usage limit.");
+    expect(result.promptTimeoutOutcome).toBeUndefined();
+  });
+
+  it("blocks the auth profile when a mid-turn usage-limit stall has trusted in-turn limits", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const resetsAt = Math.ceil(Date.now() / 1000) + 120;
+    const authProfileId = "openai:work";
+    const harness = createStartedThreadHarness();
+    const params = createParams(sessionFile, workspaceDir);
+    params.agentDir = path.join(tempDir, "mid-turn-usage-limit-agent");
+    params.authProfileId = authProfileId;
+    params.authProfileStore = {
+      version: 1,
+      profiles: {
+        [authProfileId]: {
+          type: "oauth",
+          provider: "openai",
+          access: "placeholder",
+          refresh: "placeholder",
+          expires: Date.now() + 60_000,
+        },
+      },
+    };
+    saveAuthProfileStore(params.authProfileStore, params.agentDir);
+
+    const run = runCodexAppServerAttempt(params, {
+      pluginConfig: { appServer: { turnCompletionIdleTimeoutMs: 40 } },
+      turnAssistantCompletionIdleTimeoutMs: 5_000,
+      turnTerminalIdleTimeoutMs: 60_000,
+    });
+    await harness.waitForMethod("turn/start");
+    await harness.notify(rateLimitsUpdated(resetsAt));
+    await harness.notify({
+      method: "error",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        willRetry: true,
+        error: {
+          message: "You've reached your usage limit.",
+          codexErrorInfo: "usageLimitExceeded",
+        },
+      },
+    });
+
+    const result = await run;
+
+    const promptError = expectUsageLimitPromptError(result.promptError);
+    expect(promptError.message).toContain("Next reset in");
+    expect(params.authProfileStore.usageStats?.[authProfileId]?.blockedUntil).toBe(resetsAt * 1000);
+  });
+
+  it("keeps waiting through mid-turn retryable errors that are not usage limits", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const harness = createStartedThreadHarness();
+    const params = createParams(sessionFile, workspaceDir);
+    params.timeoutMs = 250;
+
+    const run = runCodexAppServerAttempt(params, {
+      pluginConfig: { appServer: { turnCompletionIdleTimeoutMs: 150 } },
+      turnAssistantCompletionIdleTimeoutMs: 5_000,
+      turnTerminalIdleTimeoutMs: 60_000,
+    });
+    await harness.waitForMethod("turn/start");
+    await harness.notify({
+      method: "error",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        willRetry: true,
+        error: { message: "stream disconnected; retrying" },
+      },
+    });
+
+    const result = await run;
+
+    // The completion idle watch stays disarmed for plain retryable errors, so
+    // the attempt runs to its overall progress cap instead of failing at the
+    // smaller completion-idle window a pinned watch would enforce.
+    expect(result.timedOut).toBe(true);
+    expect(result.codexAppServerFailure?.turnWatchTimeoutKind).toBe("progress");
+    expect((result.promptError as Error & { status?: number })?.status).toBeUndefined();
+  });
+
+  it("completes normally when the app-server retry recovers after a usage-limit error", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const harness = createStartedThreadHarness();
+    const params = createParams(sessionFile, workspaceDir);
+
+    const run = runCodexAppServerAttempt(params, {
+      pluginConfig: { appServer: { turnCompletionIdleTimeoutMs: 1_000 } },
+      turnAssistantCompletionIdleTimeoutMs: 5_000,
+      turnTerminalIdleTimeoutMs: 60_000,
+    });
+    await harness.waitForMethod("turn/start");
+    await harness.notify({
+      method: "error",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        willRetry: true,
+        error: {
+          message: "You've reached your usage limit.",
+          codexErrorInfo: "usageLimitExceeded",
+        },
+      },
+    });
+    await harness.notify({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        turn: { id: "turn-1", status: "completed" },
+      },
+    });
+
+    const result = await run;
+
+    expect(result.timedOut).toBe(false);
+    expect(result.promptError ?? undefined).toBeUndefined();
+  });
+
+  it("does not blame the usage limit for a stall after the retry recovered", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const harness = createStartedThreadHarness();
+    const params = createParams(sessionFile, workspaceDir);
+    params.timeoutMs = 500;
+
+    const run = runCodexAppServerAttempt(params, {
+      pluginConfig: { appServer: { turnCompletionIdleTimeoutMs: 40 } },
+      postToolRawAssistantCompletionIdleTimeoutMs: 50,
+      turnAssistantCompletionIdleTimeoutMs: 5_000,
+      turnTerminalIdleTimeoutMs: 60_000,
+    });
+    await harness.waitForMethod("turn/start");
+    await harness.notify({
+      method: "error",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        willRetry: true,
+        error: {
+          message: "You've reached your usage limit.",
+          codexErrorInfo: "usageLimitExceeded",
+        },
+      },
+    });
+    await harness.notify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          id: "cmd-1",
+          type: "commandExecution",
+          command: "touch done.txt",
+          status: "completed",
+        },
+      },
+    });
+
+    const result = await run;
+
+    expect(result.timedOut).toBe(true);
+    expect(result.promptError).toBe(
+      "codex app-server turn idle timed out waiting for turn/completed",
+    );
+  });
+
+  it("releases the usage-limit pin once retry activity resumes", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const harness = createStartedThreadHarness();
+    const params = createParams(sessionFile, workspaceDir);
+    params.timeoutMs = 400;
+
+    const run = runCodexAppServerAttempt(params, {
+      pluginConfig: { appServer: { turnCompletionIdleTimeoutMs: 40 } },
+      turnAssistantCompletionIdleTimeoutMs: 5_000,
+      turnTerminalIdleTimeoutMs: 60_000,
+    });
+    await harness.waitForMethod("turn/start");
+    await harness.notify({
+      method: "error",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        willRetry: true,
+        error: {
+          message: "You've reached your usage limit.",
+          codexErrorInfo: "usageLimitExceeded",
+        },
+      },
+    });
+    for (const delta of ["Recovered", " and writing"]) {
+      await harness.notify({
+        method: "item/agentMessage/delta",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "msg-recovered-1",
+          delta,
+        },
+      });
+    }
+
+    const result = await run;
+
+    // The first recovery notification releases the usage-limit pin, so the
+    // next delta disarms the completion watch as on a normal streaming turn
+    // and the stall falls to the overall progress cap, not the pinned window.
+    expect(result.timedOut).toBe(true);
+    expect(result.codexAppServerFailure?.turnWatchTimeoutKind).toBe("progress");
+    expect((result.promptError as Error & { status?: number })?.status).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Closes #110974

## What Problem This Solves

Fixes an issue where embedded Codex turns on a ChatGPT-subscription route would hang silently when the usage limit tripped **mid-turn**: Codex reports the limit as a retryable error (`willRetry: true`, `codexErrorInfo: "usageLimitExceeded"`) and then waits for the limit reset, and OpenClaw disarms its completion idle watch for every retryable error — so the turn stalls with no usage-limit message, no auth-profile block, and no 429/failover classification until an outer watchdog or the caller kills it as a generic timeout. Headless `openclaw agent` callers with their own kill timers see only opaque timeouts and re-dispatch into the exhausted credential (live incident evidence in the issue: 159 rate-limit failover log entries during one such window).

## Why This Change Was Made

A mid-turn usage-limit "retry" is a silent wait that can last until the limit reset (potentially hours), unlike the transient stream errors the disarm was designed for. The fix keeps the completion idle watch pinned when the retryable error is structurally a usage-limit error (bounding the silence at the existing `turnCompletionIdleTimeoutMs`), captures the notification, and lets finalize surface the same structured usage-limit failure that turn-start failures already produce — reusing the existing refresh, auth-profile blocking, and 429 classification paths rather than adding a parallel mechanism. Retry activity that resumes in time releases the pin and completes the turn normally; a later stall after recovery is deliberately *not* attributed to the usage limit. Non-usage-limit retryable errors keep today's behavior exactly.

One deliberate trade-off: between a usage-limit error and the first recovery notification, the turn carries the completion-idle bound; a limit whose silent retry succeeds only after that window now fails fast with the usage-limit error instead of eventually completing. Given the window default (60s) versus real reset horizons (minutes to hours), fail-fast is the better default for this specific error class.

## User Impact

Mid-turn usage-limit hits now fail within the completion-idle window with the standard "You've reached your Codex subscription usage limit." message (reset time included when Codex exposes it), the auth profile is blocked until the advertised reset when trusted rate limits are available, and the 429 classification lets model fallback/failover engage. Interactive sessions stop hanging silently; automation callers get an actionable, structured failure instead of a generic timeout.

## Evidence

- New focused tests in `run-attempt.usage-limits.test.ts` (6 added, file 14/14 green): mid-turn fail-fast with the 429 usage-limit prompt error; auth-profile `blockedUntil` from trusted in-turn limits; plain retryable errors unchanged (progress-cap timeout, no 429); recovery completes normally; a stall after recovery is not blamed on the usage limit; the usage-limit pin is released once retry activity resumes.
- Targeted suites around the touched surface: `run-attempt.test.ts`, `run-attempt.turn-watches.test.ts`, `event-projector.test.ts`, `turn-router.test.ts`, `attempt-turn-watches.test.ts`, `attempt-timeouts.test.ts`, `attempt-results.test.ts` — all pass except one failure that is unrelated and pre-existing (`counts pending user input requests as turn attempt progress` fails identically on clean `main`).
- `tsgo` extensions typecheck clean; `oxlint`/`oxfmt` clean on touched files.
- Note for reviewers: this PR includes a one-line repair to `run-attempt-test-harness.ts` (`getInstanceId` on the mock client runtime methods), required to run the run-attempt suites at all — `run-attempt-start.ts` began calling `client.getInstanceId()` in f14947d256 (#110587) without updating the test fakes. On current clean `main`, `run-attempt.usage-limits.test.ts`, `run-attempt.context-engine.test.ts`, `auth-profile-runtime-contract.test.ts`, and `run-attempt-thread-cleanup.test.ts` hang or fail on `state.client.getInstanceId is not a function`. This PR repairs only the shared harness it needs; the other files carry their own local fakes with the same gap and are left to the tracked main cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
