### PR TITLE
fix(cron): keep startup catch-up job changes

### DIFF
--- a/src/cron/service.restart-catchup.test.ts
+++ b/src/cron/service.restart-catchup.test.ts
@@ -5,7 +5,7 @@ import { setupCronServiceSuite } from "./service.test-harness.js";
 import type { CronEvent } from "./service/state.js";
 import { createCronServiceState } from "./service/state.js";
 import { runMissedJobs } from "./service/timer.js";
-import { saveCronStore } from "./store.js";
+import { loadCronStore, saveCronStore } from "./store.js";
 import type { CronJob } from "./types.js";
 
 const { logger: noopLogger, makeStorePath } = setupCronServiceSuite({
@@ -56,6 +56,14 @@ describe("CronService restart catch-up", () => {
       wakeMode: "next-heartbeat",
       payload: { kind: "systemEvent", text: `tick-${id}` },
       state: { nextRunAtMs },
+    };
+  }
+
+  function createOverdueIsolatedEveryJob(id: string, nextRunAtMs: number): CronJob {
+    return {
+      ...createOverdueEveryJob(id, nextRunAtMs),
+      sessionTarget: "isolated",
+      payload: { kind: "agentTurn", message: `run-${id}` },
     };
   }
 
@@ -184,6 +192,90 @@ describe("CronService restart catch-up", () => {
         expect(updated?.state.nextRunAtMs).toBeGreaterThan(Date.parse("2025-12-13T17:00:00.000Z"));
       },
     );
+  });
+
+  it("preserves delivery target writeback from a startup catch-up run", async () => {
+    const store = await makeStorePath();
+    const startNow = Date.parse("2025-12-13T17:00:00.000Z");
+    const originalTarget = "https://t.me/obviyus";
+    const rewrittenTarget = "-10012345/6789";
+    const job: CronJob = {
+      ...createOverdueIsolatedEveryJob("restart-writeback", startNow - 60_000),
+      delivery: { mode: "announce", channel: "telegram", to: originalTarget },
+    };
+    await writeStoreJobs(store.storePath, [job]);
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => startNow,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async (params: { job: { id: string } }) => {
+        const persisted = await loadCronStore(store.storePath);
+        const targetJob = persisted.jobs.find((entry) => entry.id === params.job.id);
+        if (targetJob?.delivery?.channel === "telegram") {
+          targetJob.delivery.to = rewrittenTarget;
+        }
+        await saveCronStore(store.storePath, persisted);
+        return { status: "ok" as const, summary: "done", delivered: true };
+      }),
+    });
+
+    try {
+      await runMissedJobs(state);
+
+      const persisted = await loadCronStore(store.storePath);
+      const updated = persisted.jobs.find((entry) => entry.id === job.id);
+      expect(updated?.delivery?.to).toBe(rewrittenTarget);
+      expect(updated?.state.lastRunStatus).toBe("ok");
+      expect(updated?.state.lastDelivered).toBe(true);
+    } finally {
+      await store.cleanup();
+    }
+  });
+
+  it("does not resurrect a job removed during startup catch-up", async () => {
+    const store = await makeStorePath();
+    const startNow = Date.parse("2025-12-13T17:00:00.000Z");
+    const job = createOverdueIsolatedEveryJob("restart-self-removal", startNow - 60_000);
+    await writeStoreJobs(store.storePath, [job]);
+
+    const events: CronEvent[] = [];
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => startNow,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      onEvent: (event) => {
+        events.push(event);
+      },
+      runIsolatedAgentJob: vi.fn(async (params: { job: { id: string } }) => {
+        const persisted = await loadCronStore(store.storePath);
+        await saveCronStore(store.storePath, {
+          ...persisted,
+          jobs: persisted.jobs.filter((entry) => entry.id !== params.job.id),
+        });
+        return { status: "ok" as const, summary: "removed", delivered: false };
+      }),
+    });
+
+    try {
+      await runMissedJobs(state);
+
+      expect((await loadCronStore(store.storePath)).jobs).toStrictEqual([]);
+      expect(state.store?.jobs).toStrictEqual([]);
+      expect(
+        events.some(
+          (event) => event.jobId === job.id && event.action === "finished" && event.status === "ok",
+        ),
+      ).toBe(true);
+    } finally {
+      await store.cleanup();
+    }
   });
 
   it("does not replay completed one-shot jobs restored with lastRunStatus only", async () => {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -2324,8 +2324,10 @@ async function applyStartupCatchupOutcomes(
     const currentOutcomes = filterCurrentCronRunOutcomes(outcomes);
     let finalizedOutcomes: TimedCronRunOutcome[] = [];
     await locked(state, async () => {
+      // Catch-up runners can rewrite delivery targets or remove their own jobs.
+      // Reload before merging outcomes so the startup snapshot cannot overwrite them.
       await ensureLoaded(state, {
-        forceReload: state.stopped,
+        forceReload: true,
         skipRecompute: true,
       });
       if (!state.store) {


### PR DESCRIPTION
Closes #110965

## What Problem This Solves

Fixes an issue where overdue isolated cron jobs running during gateway startup could lose their own durable job changes when catch-up finalization completed. Delivery-target normalization was reverted, and a job that removed itself could be recreated and run again later.

## Why This Change Was Made

Startup catch-up now reloads the canonical cron store before merging execution outcomes, matching the existing normal-timer and manual-run finalization boundaries. This preserves runner-side durable changes while still applying the completed run state.

Two regressions cover Telegram target writeback and self-removal during startup catch-up.

## User Impact

Cron jobs that catch up after a gateway restart keep their latest persisted configuration. Self-removed jobs stay removed, and normalized delivery targets are not silently reverted.

## Evidence

- Before fix: both new regressions fail deterministically; the old Telegram target returns and the removed job is recreated.
- After fix: `node scripts/run-vitest.mjs src/cron/service.restart-catchup.test.ts` — 22/22 passed.
- Blacksmith Testbox: full restart/catch-up suite plus 100 repeated iterations of both new regressions — passed.
- Blacksmith Testbox stress: 179-test cron baseline plus 100 repeated interleaving iterations across hook FIFO, flat model cron arguments, scheduler admission, restart/catch-up, triggers, heartbeat routing, and unattended prompts — passed.
- Blacksmith Testbox changed gate — passed (format, boundaries, core/test/extension typechecks, core/extension lint, SQLite/state/import-cycle and gateway guards).
- Live OpenAI QA on isolated custom-port gateways: model-authored one-shot and recurring jobs, natural firing, recurring post-restart firing, condition watcher quiet/fire/once behavior, and natural/forced deduplication — 4/4 scenarios passed.
- Autoreview: clean, no accepted/actionable findings (0.94 confidence).

AI-assisted: yes. I reviewed the implementation and the validation evidence.
