### PR TITLE
fix(provider-usage): parse MiniMax remaining-percent usage payload

### DIFF
--- a/src/infra/provider-usage.fetch.minimax.test.ts
+++ b/src/infra/provider-usage.fetch.minimax.test.ts
@@ -220,6 +220,32 @@ describe("fetchMinimaxUsage", () => {
       },
     },
     {
+      name: "treats current interval remaining percent as a 0-100 percentage",
+      payload: {
+        data: {
+          current_interval_remaining_percent: 1,
+          plan_name: "Coding Plan",
+        },
+      },
+      expected: {
+        plan: "Coding Plan",
+        windows: [{ label: "5h", usedPercent: 99, resetAt: undefined }],
+      },
+    },
+    {
+      name: "falls back to weekly remaining percent on the same 0-100 scale",
+      payload: {
+        data: {
+          current_weekly_remaining_percent: 1,
+          plan_name: "Coding Plan",
+        },
+      },
+      expected: {
+        plan: "Coding Plan",
+        windows: [{ label: "5h", usedPercent: 99, resetAt: undefined }],
+      },
+    },
+    {
       name: "falls back to payload-level reset and plan when nested usage records omit them",
       payload: {
         data: {

--- a/src/infra/provider-usage.fetch.minimax.test.ts
+++ b/src/infra/provider-usage.fetch.minimax.test.ts
@@ -307,6 +307,53 @@ describe("fetchMinimaxUsage", () => {
         windows: [{ label: "4h", usedPercent: 25, resetAt: 1_774_195_200_000 }],
       },
     },
+    {
+      name: "accepts live model_remains general entry with remaining-percent fields and zero totals",
+      payload: {
+        model_remains: [
+          {
+            start_time: 1_784_386_800_000,
+            end_time: 1_784_404_800_000,
+            remains_time: 4_878_202,
+            current_interval_total_count: 0,
+            current_interval_usage_count: 0,
+            model_name: "general",
+            current_weekly_total_count: 0,
+            current_weekly_usage_count: 0,
+            weekly_start_time: 1_783_900_800_000,
+            weekly_end_time: 1_784_505_600_000,
+            weekly_remains_time: 105_678_202,
+            current_interval_status: 1,
+            current_interval_remaining_percent: 97,
+            current_weekly_status: 1,
+            current_weekly_remaining_percent: 77,
+          },
+          {
+            start_time: 1_784_332_800_000,
+            end_time: 1_784_419_200_000,
+            remains_time: 19_278_202,
+            current_interval_total_count: 0,
+            current_interval_usage_count: 0,
+            model_name: "video",
+            current_weekly_total_count: 0,
+            current_weekly_usage_count: 0,
+            weekly_start_time: 1_783_900_800_000,
+            weekly_end_time: 1_784_505_600_000,
+            weekly_remains_time: 105_678_202,
+            current_interval_status: 3,
+            current_interval_remaining_percent: 100,
+            current_weekly_status: 3,
+            current_weekly_remaining_percent: 100,
+          },
+        ],
+        base_resp: { status_code: 0, status_msg: "success" },
+      },
+      expected: {
+        plan: "Coding Plan · general",
+        // 100 - 97 interval remaining percent; window from start_time/end_time (5h)
+        windows: [{ label: "5h", usedPercent: 3, resetAt: 1_784_404_800_000 }],
+      },
+    },
   ])("$name", async ({ payload, expected }) => {
     await expectMinimaxUsageResult({ payload, expected });
   });

--- a/src/infra/provider-usage.fetch.minimax.ts
+++ b/src/infra/provider-usage.fetch.minimax.ts
@@ -66,6 +66,25 @@ const PERCENT_KEYS = [
 // and invert to get usedPercent. Count-based fromCounts always takes priority.
 const REMAINING_PERCENT_KEYS = ["usage_percent", "usagePercent"] as const;
 
+// Live coding-plan payloads report remaining quota under interval/weekly keys
+// (e.g. current_interval_remaining_percent) instead of usage_percent.
+// Prefer interval remaining percent when both are present.
+const INTERVAL_REMAINING_PERCENT_KEYS = [
+  "current_interval_remaining_percent",
+  "currentIntervalRemainingPercent",
+] as const;
+
+const WEEKLY_REMAINING_PERCENT_KEYS = [
+  "current_weekly_remaining_percent",
+  "currentWeeklyRemainingPercent",
+] as const;
+
+const ALL_REMAINING_PERCENT_KEYS = [
+  ...REMAINING_PERCENT_KEYS,
+  ...INTERVAL_REMAINING_PERCENT_KEYS,
+  ...WEEKLY_REMAINING_PERCENT_KEYS,
+] as const;
+
 const USED_KEYS = [
   "used",
   "usage",
@@ -207,7 +226,7 @@ function hasAny(record: Record<string, unknown>, keys: readonly string[]): boole
 
 function scoreUsageRecord(record: Record<string, unknown>): number {
   let score = 0;
-  if (hasAny(record, PERCENT_KEYS)) {
+  if (hasAny(record, PERCENT_KEYS) || hasAny(record, ALL_REMAINING_PERCENT_KEYS)) {
     score += 4;
   }
   if (hasAny(record, TOTAL_KEYS)) {
@@ -326,9 +345,13 @@ function deriveUsedPercent(payload: Record<string, unknown>): number | null {
     return clampPercent(percentRaw <= 1 ? percentRaw * 100 : percentRaw);
   }
 
-  // usage_percent / usagePercent in MiniMax's API represents remaining quota,
-  // not consumed quota. Invert to get usedPercent.
-  const remainingPercentRaw = pickNumber(payload, REMAINING_PERCENT_KEYS);
+  // Remaining-percent fields (legacy usage_percent and live interval/weekly keys)
+  // report remaining quota, not consumed quota. Invert to get usedPercent.
+  // Prefer interval remaining percent, then weekly, then legacy usage_percent.
+  const remainingPercentRaw =
+    pickNumber(payload, INTERVAL_REMAINING_PERCENT_KEYS) ??
+    pickNumber(payload, WEEKLY_REMAINING_PERCENT_KEYS) ??
+    pickNumber(payload, REMAINING_PERCENT_KEYS);
   if (remainingPercentRaw !== undefined) {
     const remainingNormalized = clampPercent(
       remainingPercentRaw <= 1 ? remainingPercentRaw * 100 : remainingPercentRaw,
@@ -339,9 +362,15 @@ function deriveUsedPercent(payload: Record<string, unknown>): number | null {
   return null;
 }
 
+function hasRecognizedRemainingPercent(record: Record<string, unknown>): boolean {
+  return pickNumber(record, ALL_REMAINING_PERCENT_KEYS) !== undefined;
+}
+
 // Prefer the entry whose model_name matches a chat/text model (e.g. "MiniMax-M*")
 // and that has a non-zero current_interval_total_count.  Models with total_count === 0
 // (speech, video, image) are not relevant to the coding-plan budget.
+// Live payloads often use model_name "general" with zero totals and remaining-percent
+// fields instead of MiniMax-M* names and positive counts.
 function pickChatModelRemains(modelRemains: unknown[]): Record<string, unknown> | undefined {
   const records = modelRemains.filter(isRecord);
   if (records.length === 0) {
@@ -362,10 +391,29 @@ function pickChatModelRemains(modelRemains: unknown[]): Record<string, unknown> 
     return chatRecord;
   }
 
-  return records.find((r) => {
+  // Current live API: model_name "general" (or MiniMax-M* without totals) plus
+  // current_*_remaining_percent. Prefer chat/general over video/speech/image.
+  const generalWithRemainingPercent = records.find((r) => {
+    const name = typeof r.model_name === "string" ? r.model_name : "";
+    const normalized = normalizeLowercaseStringOrEmpty(name);
+    const isChatLike =
+      normalized === "general" || normalized === "" || normalized.startsWith("minimax-m");
+    return isChatLike && hasRecognizedRemainingPercent(r);
+  });
+  if (generalWithRemainingPercent) {
+    return generalWithRemainingPercent;
+  }
+
+  const nonzeroTotal = records.find((r) => {
     const total = parseFiniteNumber(r.current_interval_total_count);
     return total !== undefined && total > 0;
   });
+  if (nonzeroTotal) {
+    return nonzeroTotal;
+  }
+
+  // Last resort: any record that carries a recognized remaining-percent field.
+  return records.find((r) => hasRecognizedRemainingPercent(r));
 }
 
 function resolveMinimaxUsageUrl(baseUrl?: string): string {

--- a/src/infra/provider-usage.fetch.minimax.ts
+++ b/src/infra/provider-usage.fetch.minimax.ts
@@ -358,9 +358,7 @@ function deriveUsedPercent(payload: Record<string, unknown>): number | null {
   const legacyRemainingPercentRaw = pickNumber(payload, REMAINING_PERCENT_KEYS);
   if (legacyRemainingPercentRaw !== undefined) {
     const remainingNormalized = clampPercent(
-      legacyRemainingPercentRaw <= 1
-        ? legacyRemainingPercentRaw * 100
-        : legacyRemainingPercentRaw,
+      legacyRemainingPercentRaw <= 1 ? legacyRemainingPercentRaw * 100 : legacyRemainingPercentRaw,
     );
     return clampPercent(100 - remainingNormalized);
   }

--- a/src/infra/provider-usage.fetch.minimax.ts
+++ b/src/infra/provider-usage.fetch.minimax.ts
@@ -345,16 +345,22 @@ function deriveUsedPercent(payload: Record<string, unknown>): number | null {
     return clampPercent(percentRaw <= 1 ? percentRaw * 100 : percentRaw);
   }
 
-  // Remaining-percent fields (legacy usage_percent and live interval/weekly keys)
-  // report remaining quota, not consumed quota. Invert to get usedPercent.
-  // Prefer interval remaining percent, then weekly, then legacy usage_percent.
-  const remainingPercentRaw =
+  // Current interval/weekly fields are percentages on a 0-100 scale. Keep
+  // their contract separate from legacy usage_percent, which also appeared
+  // as a 0-1 ratio in older payloads.
+  const currentRemainingPercentRaw =
     pickNumber(payload, INTERVAL_REMAINING_PERCENT_KEYS) ??
-    pickNumber(payload, WEEKLY_REMAINING_PERCENT_KEYS) ??
-    pickNumber(payload, REMAINING_PERCENT_KEYS);
-  if (remainingPercentRaw !== undefined) {
+    pickNumber(payload, WEEKLY_REMAINING_PERCENT_KEYS);
+  if (currentRemainingPercentRaw !== undefined) {
+    return clampPercent(100 - clampPercent(currentRemainingPercentRaw));
+  }
+
+  const legacyRemainingPercentRaw = pickNumber(payload, REMAINING_PERCENT_KEYS);
+  if (legacyRemainingPercentRaw !== undefined) {
     const remainingNormalized = clampPercent(
-      remainingPercentRaw <= 1 ? remainingPercentRaw * 100 : remainingPercentRaw,
+      legacyRemainingPercentRaw <= 1
+        ? legacyRemainingPercentRaw * 100
+        : legacyRemainingPercentRaw,
     );
     return clampPercent(100 - remainingNormalized);
   }


### PR DESCRIPTION
Closes #110887

## What Problem This Solves

Fixes an issue where users running `openclaw status` (or the Usage dashboard) with a MiniMax coding-plan / portal key would see **MiniMax: Unsupported response shape** even though the live `/v1/token_plan/remains` call succeeds and returns billing data.

Affected surface: provider usage summary for MiniMax (`minimax` / `minimax-portal` status and usage views).

## Why This Change Was Made

MiniMax’s current coding-plan payload uses top-level `model_remains` entries named `general` / `video` with zero interval totals and remaining quota expressed as `current_interval_remaining_percent` / `current_weekly_remaining_percent`. The shared MiniMax usage fetcher only selected `MiniMax-M*` records with positive totals and only inverted legacy `usage_percent` fields, so every candidate failed and status reported an unsupported shape.

This change keeps the shared fetcher additive: prefer chat/general records that carry recognized remaining-percent fields, derive used percent from interval then weekly remaining percent (legacy `usage_percent` still works), and add a regression fixture for the reported live payload. No new config knobs; configured `baseUrl` origin handling is unchanged.

**Fix quality:** compatibility — additive field recognition only, existing count-based fixtures preserved; performance — same request path, small extra key scans; usability — status shows real usage percent instead of a false error; security — no auth/secret handling changes.

## User Impact

Operators with MiniMax portal/coding-plan credentials see a normal MiniMax usage window (percent used, window label, reset time) on status/usage surfaces instead of a permanent “Unsupported response shape” error for the current API shape.

## Evidence

Verification host: local macOS (Crabbox bypass).

Focused tests:

```text
node scripts/run-vitest.mjs src/infra/provider-usage.fetch.minimax.test.ts src/infra/provider-usage.test.ts
✓ |unit-fast| src/infra/provider-usage.fetch.minimax.test.ts (21 tests)
✓ |unit-fast| src/infra/provider-usage.test.ts (6 tests)
Test Files  2 passed (2)
Tests  27 passed (27)
```

Static substitutes after `pnpm check:changed` expanded into plugin-sdk dts regen (heavy expansion):

```text
git diff --check  # clean
oxfmt --check src/infra/provider-usage.fetch.minimax.ts src/infra/provider-usage.fetch.minimax.test.ts  # correct format
oxlint … on the two touched files  # 0 warnings / 0 errors
```

`pnpm check:changed` progressed through docs/guards and core typecheck before lint spawned plugin-sdk declaration rebuild; quality floor covered via path-scoped static + focused Vitest above.

## Real behavior proof

- Behavior addressed: MiniMax usage fetcher must accept the live coding-plan `model_remains` payload (`general` + remaining-percent fields, zero totals) and return a used-percent window instead of `Unsupported response shape`.
- Environment: local macOS openclaw checkout at this PR head; mocked HTTP response via production `fetchMinimaxUsage` (no live MiniMax credentials required).
- Current-main contrast: On main, feeding the issue’s reported top-level `model_remains` payload (general @ 97% interval remaining, video @ 100%) yields `{ error: "Unsupported response shape", windows: [] }` because `pickChatModelRemains` drops zero-total records and `deriveUsedPercent` ignores `current_interval_remaining_percent`.
- Exact steps or command run after this patch:
  1. Fixture case `accepts live model_remains general entry with remaining-percent fields and zero totals` in `src/infra/provider-usage.fetch.minimax.test.ts` (payload copied from the issue’s live JSON, including `base_resp.status_code === 0`).
  2. `node scripts/run-vitest.mjs src/infra/provider-usage.fetch.minimax.test.ts`
- Evidence after fix: that case expects `plan: "Coding Plan · general"` and `windows: [{ label: "5h", usedPercent: 3, resetAt: <end_time> }]` (100 − 97 interval remaining), and the full suite of 21 MiniMax usage tests pass.
- Control check: Legacy fixtures still pass (MiniMax-M* with positive counts; first non-zero fallback; unsupported shape when no usage fields). Only the chat/general remaining-percent path is newly accepted; video-only zero-total entries without preferred general selection remain deprioritized when a general record exists.
- Observed result after fix: live-shaped payload no longer errors; used percent is 3% for the reported 97% remaining interval window.
- What was not tested: live credentialed call to `api.minimax.io` / `api.minimaxi.com` (CS accepted source-repro without live MiniMax auth); Control UI Usage dashboard rendering beyond the fetcher snapshot contract.

## AI disclosure

This PR was authored with AI assistance (Grok).
