### PR TITLE
fix(channels): prevent prepared turn lifecycle leaks

### DIFF
--- a/src/channels/turn/execution.ts
+++ b/src/channels/turn/execution.ts
@@ -151,6 +151,7 @@ async function runPreparedChannelTurnCoreInTrace<
   const botLoopDrop = resolveBotLoopProtectionDrop(params);
   if (botLoopDrop) {
     clearPendingHistoryAfterTurn(params.history);
+    await params.runDispatchLifecycle?.onDispatchSkipped("botLoopProtection");
     return botLoopDrop;
   }
   emit({
@@ -219,6 +220,8 @@ async function runPreparedChannelTurnCoreInTrace<
   try {
     if (admission.kind === "observeOnly" && !options.suppressObserveOnlyDispatch) {
       await params.runDispatch();
+    } else if (admission.kind === "observeOnly") {
+      await params.runDispatchLifecycle?.onDispatchSkipped("observeOnly");
     }
     dispatchResult =
       admission.kind === "observeOnly"

--- a/src/channels/turn/kernel.test.ts
+++ b/src/channels/turn/kernel.test.ts
@@ -29,7 +29,7 @@ import {
   runPreparedInboundReply,
   runChannelInboundEvent,
 } from "./kernel.js";
-import type { PreparedChannelTurn } from "./types.js";
+import type { ChannelTurnResolved, PreparedChannelTurn } from "./types.js";
 
 const deliverOutboundPayloads = vi.hoisted(() => vi.fn());
 const resolveOutboundDurableFinalDeliverySupport = vi.hoisted(() => vi.fn());
@@ -934,6 +934,7 @@ describe("channel turn kernel", () => {
         counts: { tool: 0, block: 0, final: 1 },
       };
     });
+    const onDispatchSkipped = vi.fn();
     const botLoopProtection = {
       scopeId: "prepared-loop-test",
       conversationId: "room",
@@ -950,6 +951,10 @@ describe("channel turn kernel", () => {
       ctxPayload: createCtx(),
       recordInboundSession,
       runDispatch,
+      runDispatchLifecycle: {
+        turnAdoptionLifecycle: undefined,
+        onDispatchSkipped,
+      },
       botLoopProtection: { ...botLoopProtection, nowMs: 1_000 },
     });
     const second = await runPreparedInboundReply({
@@ -959,6 +964,10 @@ describe("channel turn kernel", () => {
       ctxPayload: createCtx(),
       recordInboundSession,
       runDispatch,
+      runDispatchLifecycle: {
+        turnAdoptionLifecycle: undefined,
+        onDispatchSkipped,
+      },
       log,
       messageId: "msg-loop",
       botLoopProtection: { ...botLoopProtection, nowMs: 1_001 },
@@ -979,6 +988,7 @@ describe("channel turn kernel", () => {
     expect(events).toEqual(["record", "dispatch"]);
     expect(recordInboundSession).toHaveBeenCalledTimes(1);
     expect(runDispatch).toHaveBeenCalledTimes(1);
+    expect(onDispatchSkipped).toHaveBeenCalledWith("botLoopProtection");
     expect(historyMap.get("room")).toStrictEqual([]);
     expect(loggedEvents(log)).toEqual([
       { stage: "authorize", event: "drop", messageId: "msg-loop" },
@@ -999,6 +1009,7 @@ describe("channel turn kernel", () => {
       queuedFinal: false,
       counts: { tool: 0, block: 0, final: 0 },
     };
+    const onDispatchSkipped = vi.fn();
 
     const result = await runPreparedInboundReply({
       channel: "test",
@@ -1007,12 +1018,17 @@ describe("channel turn kernel", () => {
       ctxPayload: createCtx({ SessionKey: "agent:observer:test:peer" }),
       recordInboundSession,
       runDispatch,
+      runDispatchLifecycle: {
+        turnAdoptionLifecycle: undefined,
+        onDispatchSkipped,
+      },
       observeOnlyDispatchResult,
       admission: { kind: "observeOnly", reason: "broadcast-observer" },
     });
 
     expect(events).toEqual(["record"]);
     expect(runDispatch).not.toHaveBeenCalled();
+    expect(onDispatchSkipped).toHaveBeenCalledWith("observeOnly");
     expect(result.admission).toEqual({ kind: "observeOnly", reason: "broadcast-observer" });
     expect(result.dispatched).toBe(true);
     expect(result.dispatchResult).toBe(observeOnlyDispatchResult);
@@ -1475,6 +1491,10 @@ describe("channel turn kernel", () => {
               counts: { tool: 0, block: 0, final: 1 },
             };
           },
+          runDispatchLifecycle: {
+            turnAdoptionLifecycle: undefined,
+            onDispatchSkipped: vi.fn(),
+          },
         }),
       },
     });
@@ -1487,7 +1507,39 @@ describe("channel turn kernel", () => {
     expect(result.dispatchResult.queuedFinal).toBe(true);
   });
 
-  it("rejects top-level adoption lifecycles for prepared turns", async () => {
+  it("rejects prepared turns that omit dispatch lifecycle ownership", async () => {
+    const recordInboundSession = createRecordInboundSession();
+    const runDispatch = vi.fn(async () => ({ visibleReplySent: true }));
+    const onFinalize = vi.fn();
+
+    await expect(
+      runChannelInboundEvent({
+        channel: "test",
+        raw: { id: "msg-1", text: "hello" },
+        adapter: {
+          ingest: () => ({ id: "msg-1", rawText: "hello" }),
+          resolveTurn: () =>
+            ({
+              channel: "test",
+              routeSessionKey: "agent:main:test:peer",
+              storePath: "/tmp/sessions.json",
+              ctxPayload: createCtx(),
+              recordInboundSession,
+              runDispatch,
+            }) as unknown as ChannelTurnResolved,
+          onFinalize,
+        },
+      }),
+    ).rejects.toThrow("runChannelInboundEvent prepared turns must declare runDispatchLifecycle");
+
+    expect(recordInboundSession).not.toHaveBeenCalled();
+    expect(runDispatch).not.toHaveBeenCalled();
+    expect(onFinalize).toHaveBeenCalledWith(
+      expect.objectContaining({ admission: { kind: "dispatch" }, dispatched: false }),
+    );
+  });
+
+  it("rejects a prepared dispatch lifecycle that does not own the top-level adoption", async () => {
     const recordInboundSession = createRecordInboundSession();
     const runDispatch = vi.fn(async () => ({ visibleReplySent: true }));
     const onFinalize = vi.fn();
@@ -1506,12 +1558,16 @@ describe("channel turn kernel", () => {
             ctxPayload: createCtx(),
             recordInboundSession,
             runDispatch,
+            runDispatchLifecycle: {
+              turnAdoptionLifecycle: undefined,
+              onDispatchSkipped: vi.fn(),
+            },
           }),
           onFinalize,
         },
       }),
     ).rejects.toThrow(
-      "runChannelInboundEvent cannot apply turnAdoptionLifecycle to a prepared turn",
+      "runChannelInboundEvent prepared turn runDispatchLifecycle must own the top-level turnAdoptionLifecycle",
     );
 
     expect(recordInboundSession).not.toHaveBeenCalled();
@@ -1521,51 +1577,99 @@ describe("channel turn kernel", () => {
     );
   });
 
-  it("suppresses prepared dispatch for observe-only full turns", async () => {
-    const events: string[] = [];
-    const onFinalize = vi.fn();
+  it("runs a prepared turn whose dispatch lifecycle owns the top-level adoption", async () => {
+    const onAdopted = vi.fn(async () => undefined);
+    const turnAdoptionLifecycle = { onAdopted };
     const runDispatch = vi.fn(async () => {
-      events.push("custom-dispatch");
-      return {
-        queuedFinal: true,
-        counts: { tool: 0, block: 0, final: 1 },
-      };
+      await turnAdoptionLifecycle.onAdopted();
+      return { visibleReplySent: true };
     });
+
     const result = await runChannelInboundEvent({
       channel: "test",
       raw: { id: "msg-1", text: "hello" },
+      turnAdoptionLifecycle,
       adapter: {
         ingest: () => ({ id: "msg-1", rawText: "hello" }),
-        preflight: () => ({ kind: "observeOnly", reason: "broadcast-observer" }),
         resolveTurn: () => ({
           channel: "test",
-          routeSessionKey: "agent:observer:test:peer",
+          routeSessionKey: "agent:main:test:peer",
           storePath: "/tmp/sessions.json",
-          ctxPayload: createCtx({ SessionKey: "agent:observer:test:peer" }),
-          recordInboundSession: createRecordInboundSession(events),
+          ctxPayload: createCtx(),
+          recordInboundSession: createRecordInboundSession(),
           runDispatch,
+          runDispatchLifecycle: {
+            turnAdoptionLifecycle,
+            onDispatchSkipped: vi.fn(),
+          },
         }),
-        onFinalize,
       },
     });
 
-    expect(result.admission).toEqual({ kind: "observeOnly", reason: "broadcast-observer" });
     expect(result.dispatched).toBe(true);
-    expect(events).toEqual(["record"]);
-    expect(runDispatch).not.toHaveBeenCalled();
-    if (!result.dispatched) {
-      throw new Error("expected dispatch");
-    }
-    expect(hasFinalChannelTurnDispatch(result.dispatchResult)).toBe(false);
-    expect(onFinalize).toHaveBeenCalledTimes(1);
-    const [finalized] = requireFirstMockCall(onFinalize, "finalize");
-    const finalizedResult = finalizeResult(finalized);
-    expect(finalizedResult.admission).toEqual({
-      kind: "observeOnly",
-      reason: "broadcast-observer",
-    });
-    expect(finalizedResult.dispatched).toBe(true);
+    expect(runDispatch).toHaveBeenCalledOnce();
+    expect(onAdopted).toHaveBeenCalledOnce();
   });
+
+  it.each(["draft lane", "typing indicator", "delivery correlation"])(
+    "settles a prepared %s when observe-only suppresses dispatch",
+    async () => {
+      const events: string[] = [];
+      const onFinalize = vi.fn();
+      let resourceOpen = true;
+      const onDispatchSkipped = vi.fn(async () => {
+        resourceOpen = false;
+        events.push("cleanup");
+      });
+      const runDispatch = vi.fn(async () => {
+        events.push("custom-dispatch");
+        return {
+          queuedFinal: true,
+          counts: { tool: 0, block: 0, final: 1 },
+        };
+      });
+      const result = await runChannelInboundEvent({
+        channel: "test",
+        raw: { id: "msg-1", text: "hello" },
+        adapter: {
+          ingest: () => ({ id: "msg-1", rawText: "hello" }),
+          preflight: () => ({ kind: "observeOnly", reason: "broadcast-observer" }),
+          resolveTurn: () => ({
+            channel: "test",
+            routeSessionKey: "agent:observer:test:peer",
+            storePath: "/tmp/sessions.json",
+            ctxPayload: createCtx({ SessionKey: "agent:observer:test:peer" }),
+            recordInboundSession: createRecordInboundSession(events),
+            runDispatch,
+            runDispatchLifecycle: {
+              turnAdoptionLifecycle: undefined,
+              onDispatchSkipped,
+            },
+          }),
+          onFinalize,
+        },
+      });
+
+      expect(result.admission).toEqual({ kind: "observeOnly", reason: "broadcast-observer" });
+      expect(result.dispatched).toBe(true);
+      expect(events).toEqual(["record", "cleanup"]);
+      expect(runDispatch).not.toHaveBeenCalled();
+      expect(onDispatchSkipped).toHaveBeenCalledWith("observeOnly");
+      expect(resourceOpen).toBe(false);
+      if (!result.dispatched) {
+        throw new Error("expected dispatch");
+      }
+      expect(hasFinalChannelTurnDispatch(result.dispatchResult)).toBe(false);
+      expect(onFinalize).toHaveBeenCalledTimes(1);
+      const [finalized] = requireFirstMockCall(onFinalize, "finalize");
+      const finalizedResult = finalizeResult(finalized);
+      expect(finalizedResult.admission).toEqual({
+        kind: "observeOnly",
+        reason: "broadcast-observer",
+      });
+      expect(finalizedResult.dispatched).toBe(true);
+    },
+  );
 
   it("finalizes failed dispatches before rethrowing", async () => {
     const onFinalize = vi.fn();

--- a/src/channels/turn/kernel.ts
+++ b/src/channels/turn/kernel.ts
@@ -29,6 +29,7 @@ import type {
   DispatchedChannelTurnResult,
   NormalizedTurnInput,
   PreflightFacts,
+  PreparedChannelTurn,
   RunChannelTurnParams,
 } from "./types.js";
 
@@ -107,6 +108,23 @@ function normalizePreflight(
     return { admission: value };
   }
   return value;
+}
+
+function assertPreparedDispatchLifecycle<TDispatchResult>(
+  turn: PreparedChannelTurn<TDispatchResult>,
+  turnAdoptionLifecycle: RunChannelTurnParams<unknown>["turnAdoptionLifecycle"],
+): void {
+  const lifecycle = turn.runDispatchLifecycle;
+  if (!lifecycle) {
+    throw new Error(
+      "runChannelInboundEvent prepared turns must declare runDispatchLifecycle when creating runDispatch",
+    );
+  }
+  if (turnAdoptionLifecycle && lifecycle.turnAdoptionLifecycle !== turnAdoptionLifecycle) {
+    throw new Error(
+      "runChannelInboundEvent prepared turn runDispatchLifecycle must own the top-level turnAdoptionLifecycle",
+    );
+  }
 }
 
 function emit(params: {
@@ -278,12 +296,8 @@ async function runChannelTurn<
   const admission = resolved.admission ?? preflightAdmission ?? ({ kind: "dispatch" } as const);
   let result: ChannelTurnResult<TDispatchResult>;
   try {
-    if ("runDispatch" in resolved && params.turnAdoptionLifecycle) {
-      // Prepared dispatchers already own their reply options. Accepting a top-level lifecycle
-      // here would silently orphan durable-ingress adoption.
-      throw new Error(
-        "runChannelInboundEvent cannot apply turnAdoptionLifecycle to a prepared turn; attach the lifecycle when creating runDispatch",
-      );
+    if ("runDispatch" in resolved) {
+      assertPreparedDispatchLifecycle(resolved, params.turnAdoptionLifecycle);
     }
     const dispatchResult = (
       "runDispatch" in resolved

--- a/src/channels/turn/types.ts
+++ b/src/channels/turn/types.ts
@@ -288,6 +288,16 @@ export type AssembledChannelTurn = {
   turnAdoptionLifecycle?: TurnAdoptionLifecycle;
 };
 
+type PreparedChannelTurnDispatchSkipReason = "botLoopProtection" | "observeOnly";
+
+/** Lifecycle ownership declared alongside an already-prepared dispatch runner. */
+type PreparedChannelTurnDispatchLifecycle = {
+  /** Exact adoption lifecycle captured by runDispatch, or undefined for non-durable turns. */
+  turnAdoptionLifecycle: TurnAdoptionLifecycle | undefined;
+  /** Releases resources that runDispatch would otherwise settle when dispatch is skipped. */
+  onDispatchSkipped: (reason: PreparedChannelTurnDispatchSkipReason) => void | Promise<void>;
+};
+
 /** Channel turn with dispatch runner already prepared. */
 export type PreparedChannelTurn<TDispatchResult = DispatchFromConfigResult> = {
   channel: string;
@@ -301,6 +311,8 @@ export type PreparedChannelTurn<TDispatchResult = DispatchFromConfigResult> = {
   history?: ChannelTurnHistoryFinalizeOptions;
   onPreDispatchFailure?: (err: unknown) => void | Promise<void>;
   runDispatch: () => Promise<TDispatchResult>;
+  /** Optional for the legacy direct prepared runner; inbound adapters use the stricter type. */
+  runDispatchLifecycle?: PreparedChannelTurnDispatchLifecycle;
   observeOnlyDispatchResult?: TDispatchResult;
   admission?: Extract<ChannelTurnAdmission, { kind: "dispatch" | "observeOnly" }>;
   botLoopProtection?: ChannelBotLoopProtectionFacts;
@@ -318,12 +330,17 @@ type RoutedChannelTurn<T> = Omit<T, "routeSessionKey" | "storePath" | "recordInb
   route: ChannelTurnRoute;
 };
 
+type InboundPreparedChannelTurn<TDispatchResult = DispatchFromConfigResult> =
+  PreparedChannelTurn<TDispatchResult> & {
+    runDispatchLifecycle: PreparedChannelTurnDispatchLifecycle;
+  };
+
 export type ChannelTurnPlan = RoutedChannelTurn<
   Omit<AssembledChannelTurn, "agentId" | "dispatchReplyWithBufferedBlockDispatcher">
 >;
 
 type PreparedChannelTurnPlan<TDispatchResult = DispatchFromConfigResult> = RoutedChannelTurn<
-  PreparedChannelTurn<TDispatchResult>
+  InboundPreparedChannelTurn<TDispatchResult>
 > & {
   cfg: OpenClawConfig;
 };
@@ -335,7 +352,7 @@ export type ChannelTurnResolved<TDispatchResult = DispatchFromConfigResult> =
   | (AssembledChannelTurn & {
       admission?: Extract<ChannelTurnAdmission, { kind: "dispatch" | "observeOnly" }>;
     })
-  | (PreparedChannelTurn<TDispatchResult> & {
+  | (InboundPreparedChannelTurn<TDispatchResult> & {
       admission?: Extract<ChannelTurnAdmission, { kind: "dispatch" | "observeOnly" }>;
     });
 

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.test.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.test.ts
@@ -198,7 +198,7 @@ describe("createPluginRuntimeMock", () => {
     );
   });
 
-  it("rejects top-level adoption lifecycles for prepared turns", async () => {
+  it("rejects prepared turns whose dispatch does not own top-level adoption", async () => {
     const recordInboundSession = vi.fn(async () => undefined);
     const runDispatch = vi.fn(async () => ({ visibleReplySent: true }));
     const runtime = createPluginRuntimeMock({
@@ -225,11 +225,15 @@ describe("createPluginRuntimeMock", () => {
             },
             recordInboundSession,
             runDispatch,
+            runDispatchLifecycle: {
+              turnAdoptionLifecycle: undefined,
+              onDispatchSkipped: vi.fn(),
+            },
           })),
         },
       }),
     ).rejects.toThrow(
-      "runChannelInboundEvent cannot apply turnAdoptionLifecycle to a prepared turn",
+      "runChannelInboundEvent prepared turn runDispatchLifecycle must own the top-level turnAdoptionLifecycle",
     );
 
     expect(recordInboundSession).not.toHaveBeenCalled();
@@ -312,6 +316,10 @@ describe("createPluginRuntimeMock", () => {
             SessionKey: "agent:main:test:direct:u1",
           },
           runDispatch,
+          runDispatchLifecycle: {
+            turnAdoptionLifecycle: undefined,
+            onDispatchSkipped: vi.fn(),
+          },
         })),
       },
     });

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
@@ -271,13 +271,16 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
         throw err;
       }
       const admission = params.admission ?? { kind: "dispatch" as const };
-      const dispatchResult =
-        admission.kind === "observeOnly"
-          ? (params.observeOnlyDispatchResult ?? {
-              queuedFinal: false,
-              counts: { tool: 0, block: 0, final: 0 },
-            })
-          : await params.runDispatch();
+      let dispatchResult;
+      if (admission.kind === "observeOnly") {
+        await params.runDispatchLifecycle?.onDispatchSkipped("observeOnly");
+        dispatchResult = params.observeOnlyDispatchResult ?? {
+          queuedFinal: false,
+          counts: { tool: 0, block: 0, final: 0 },
+        };
+      } else {
+        dispatchResult = await params.runDispatch();
+      }
       return {
         admission,
         dispatched: true,
@@ -344,9 +347,18 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
         resolved.admission ?? preflight.admission ?? ({ kind: "dispatch" } as const);
       let dispatchResult;
       if ("runDispatch" in resolved) {
-        if (params.turnAdoptionLifecycle) {
+        const lifecycle = resolved.runDispatchLifecycle;
+        if (!lifecycle) {
           throw new Error(
-            "runChannelInboundEvent cannot apply turnAdoptionLifecycle to a prepared turn; attach the lifecycle when creating runDispatch",
+            "runChannelInboundEvent prepared turns must declare runDispatchLifecycle when creating runDispatch",
+          );
+        }
+        if (
+          params.turnAdoptionLifecycle &&
+          lifecycle.turnAdoptionLifecycle !== params.turnAdoptionLifecycle
+        ) {
+          throw new Error(
+            "runChannelInboundEvent prepared turn runDispatchLifecycle must own the top-level turnAdoptionLifecycle",
           );
         }
         const prepared =


### PR DESCRIPTION
AI-assisted change. Maintainer-requested turn-kernel hardening; no linked issue.

## What Problem This Solves

Fixes an issue where durable inbound messages handled through a prepared turn could leave their ingress claim unadopted when the prepared dispatcher did not carry the turn adoption lifecycle. The same prepared path could leave draft lanes, typing indicators, or delivery correlations open when observe-only admission intentionally suppressed dispatch.

## Why This Change Was Made

Prepared inbound turns now declare the adoption lifecycle and skip cleanup owned by their dispatch runner. The inbound type requires that declaration, the kernel rejects missing or mismatched ownership before recording, and execution invokes lifecycle cleanup whenever a prepared dispatch is suppressed by observe-only admission or bot-loop protection. The legacy direct prepared-reply API keeps the field optional for compatibility.

Current-main verification also found that wave 4 already fixed assembled observe-only turns by running their full dispatch lifecycle against a no-op delivery adapter. This PR keeps that path unchanged and closes only the remaining prepared-turn seam.

## User Impact

Durable ingress claims can no longer silently stall because a prepared turn dropped its adoption lifecycle. Prepared observe-only turns now release delivery resources without sending a visible reply. Plugin developers returning a prepared turn from the raw inbound kernel get a compile-time requirement plus a runtime guard for untyped callers.

## Evidence

- `node scripts/run-vitest.mjs src/channels/turn/kernel.test.ts src/plugin-sdk/test-helpers/plugin-runtime-mock.test.ts` — 41 channel-kernel tests and 9 SDK-mock contract tests passed.
- Fresh exact-head Blacksmith Testbox `tbx_01kxvk2d10h6pzytf1bg8s271s`: `pnpm check:changed && pnpm deadcode:dependencies && pnpm deadcode:unused-files && pnpm deadcode:exports` passed on core, core-test, extension, and extension-test lanes: https://github.com/openclaw/openclaw/actions/runs/29662193768
- `oxfmt --check` on all six touched files and `git diff --check` passed.
- Mandatory autoreview found one actionable type-contract gap; the inbound prepared variant was made statically strict while the direct legacy runner remains compatible. The final committed branch review reported no accepted/actionable findings.
- Net diff: +158 lines overall. Production turn-kernel growth is +34 net lines, justified by the explicit lifecycle descriptor, static inbound contract, runtime identity guard, and two lifecycle-owned skip settlements; the remaining growth is behavior coverage and SDK test-helper parity.
