### PR TITLE
fix(plugins): allow intentional uninstall size drops

### DIFF
--- a/src/cli/plugins-cli.uninstall.test.ts
+++ b/src/cli/plugins-cli.uninstall.test.ts
@@ -185,6 +185,19 @@ describe("plugins cli uninstall", () => {
         entries: {},
       },
     });
+    expect(replaceConfigFile).toHaveBeenCalledWith({
+      baseHash: "mock",
+      nextConfig: {
+        plugins: {
+          entries: {},
+        },
+      },
+      writeOptions: {
+        allowConfigSizeDrop: true,
+        afterWrite: { mode: "restart", reason: "plugin source changed" },
+        unsetPaths: [["plugins", "installs"]],
+      },
+    });
     expect(refreshPluginRegistry).toHaveBeenCalledWith({
       config: {
         plugins: {

--- a/src/cli/plugins-uninstall-command.ts
+++ b/src/cli/plugins-uninstall-command.ts
@@ -184,6 +184,7 @@ export async function runPluginUninstallCommand(
         nextConfig,
         ...(snapshot.hash !== undefined ? { baseHash: snapshot.hash } : {}),
         writeOptions: {
+          allowConfigSizeDrop: true,
           afterWrite: { mode: "restart", reason: "plugin source changed" },
         },
       }),


### PR DESCRIPTION
## Summary

- allow the intentional config size reduction performed by `plugins uninstall`
- retain the independent gateway-mode removal guard
- assert the exact guarded write options in the uninstall regression test

## Proof

- `pnpm exec vitest run src/cli/plugins-cli.uninstall.test.ts`
- `pnpm test:docker:kitchen-sink-plugin` (7 scenarios; controlled pnpm-pack candidate because host npm 12 omits `npm-shrinkwrap.json`)
- `.agents/skills/autoreview/scripts/autoreview --mode local`
