### PR TITLE
fix(opencode): public models work without configured credentials

### DIFF
--- a/extensions/opencode/index.test.ts
+++ b/extensions/opencode/index.test.ts
@@ -12,7 +12,11 @@ import { expectPassthroughReplayPolicy } from "openclaw/plugin-sdk/provider-test
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import plugin from "./index.js";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
-import { buildOpencodeZenLiveProviderConfig } from "./provider-catalog.js";
+import {
+  buildOpencodeZenLiveProviderConfig,
+  buildStaticOpencodeZenProviderConfig,
+} from "./provider-catalog.js";
+import { resolveSyntheticAuth as resolvePolicySyntheticAuth } from "./provider-policy-api.js";
 
 function requireRecord(value: unknown, label: string): Record<string, unknown> {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
@@ -91,6 +95,110 @@ describe("opencode provider plugin", () => {
       providerId: "opencode",
       modelId: "claude-opus-4.6",
     });
+  });
+
+  it("uses OpenCode's public key only for zero-input-cost Zen models", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    const publicAuth = provider.resolveSyntheticAuth?.({
+      provider: "opencode",
+      modelId: "deepseek-v4-flash-free",
+    } as never);
+    const paidAuth = provider.resolveSyntheticAuth?.({
+      provider: "opencode",
+      modelId: "gpt-5.5",
+    } as never);
+
+    expect(publicAuth).toEqual({
+      apiKey: "public",
+      source: "OpenCode Zen public key",
+      mode: "api-key",
+      allowPreparedDirect: true,
+    });
+    expect(paidAuth).toBeUndefined();
+
+    for (const model of buildStaticOpencodeZenProviderConfig().models ?? []) {
+      const hasPaidInputTier = model.cost.tieredPricing?.some((tier) => tier.input > 0) ?? false;
+      const expectedAuth = model.cost.input > 0 || hasPaidInputTier ? undefined : publicAuth;
+      expect(
+        provider.resolveSyntheticAuth?.({ provider: "opencode", modelId: model.id } as never),
+      ).toEqual(expectedAuth);
+    }
+
+    const { default: discovery } = await import("./provider-discovery.js");
+    expect(
+      discovery.resolveSyntheticAuth?.({
+        provider: "opencode",
+        modelId: "deepseek-v4-flash-free",
+      } as never),
+    ).toEqual(publicAuth);
+    expect(
+      discovery.resolveSyntheticAuth?.({ provider: "opencode", modelId: "gpt-5.5" } as never),
+    ).toBeUndefined();
+    expect(
+      resolvePolicySyntheticAuth({
+        provider: "opencode",
+        modelId: "deepseek-v4-flash-free",
+      }),
+    ).toEqual(publicAuth);
+  });
+
+  it("keeps public auth scoped to the Zen endpoint and configured input cost", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    const context = {
+      provider: "opencode",
+      modelId: "deepseek-v4-flash-free",
+    };
+
+    expect(
+      provider.resolveSyntheticAuth?.({
+        ...context,
+        providerConfig: {
+          baseUrl: "http://127.0.0.1:43119/v1",
+          models: [],
+        },
+      } as never),
+    ).toBeUndefined();
+    expect(
+      provider.resolveSyntheticAuth?.({
+        ...context,
+        providerConfig: {
+          models: [
+            {
+              id: context.modelId,
+              cost: { input: 1, output: 0, cacheRead: 0, cacheWrite: 0 },
+            },
+          ],
+        },
+      } as never),
+    ).toBeUndefined();
+    expect(
+      provider.resolveSyntheticAuth?.({
+        provider: "opencode",
+        modelId: "unknown-free-model",
+        providerConfig: {
+          models: [
+            {
+              id: "unknown-free-model",
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            },
+          ],
+        },
+      } as never),
+    ).toBeUndefined();
+    expect(
+      provider.resolveSyntheticAuth?.({
+        provider: "opencode",
+        modelId: "gpt-5.5",
+        providerConfig: {
+          models: [
+            {
+              id: "gpt-5.5",
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            },
+          ],
+        },
+      } as never),
+    ).toBeUndefined();
   });
 
   it("keeps OpenCode Zen catalog coverage aligned with the curated seed", async () => {

--- a/extensions/opencode/index.ts
+++ b/extensions/opencode/index.ts
@@ -13,6 +13,7 @@ import {
   buildStaticOpencodeZenProviderConfig,
   listOpencodeZenModelCatalogEntries,
   normalizeOpencodeZenBaseUrl,
+  resolveOpencodeZenSyntheticAuth,
   resolveOpencodeZenModel,
 } from "./provider-catalog.js";
 import { resolveThinkingProfile as resolveOpencodeThinkingProfile } from "./provider-policy-api.js";
@@ -124,6 +125,7 @@ export default defineSingleProviderPluginEntry({
       staticRun: async () => ({ provider: buildStaticOpencodeZenProviderConfig() }),
     },
     augmentModelCatalog: () => listOpencodeZenModelCatalogEntries(),
+    resolveSyntheticAuth: (ctx) => resolveOpencodeZenSyntheticAuth(ctx),
     ...buildProviderReplayFamilyHooks({ family: "passthrough-gemini" }),
     isModernModelRef: ({ modelId }) => isModernOpencodeModel(modelId),
     resolveThinkingProfile: resolveOpencodeThinkingProfile,

--- a/extensions/opencode/openclaw.plugin.json
+++ b/extensions/opencode/openclaw.plugin.json
@@ -1,6 +1,7 @@
 {
   "id": "opencode",
   "icon": "https://cdn.simpleicons.org/opencode",
+  "syntheticAuthRefs": ["opencode"],
   "activation": {
     "onStartup": true
   },

--- a/extensions/opencode/provider-catalog.ts
+++ b/extensions/opencode/provider-catalog.ts
@@ -19,6 +19,7 @@ const OPENCODE_ZEN_ANTHROPIC_BASE_URL = "https://opencode.ai/zen";
 const OPENCODE_ZEN_MODELS_ENDPOINT = "https://opencode.ai/zen/v1/models";
 const OPENCODE_ZEN_MODELS_TIMEOUT_MS = 5_000;
 const OPENCODE_ZEN_MODELS_CACHE_TTL_MS = 60_000;
+const OPENCODE_ZEN_PUBLIC_API_KEY = "public";
 
 const FREE_COST: ModelDefinitionConfig["cost"] = {
   input: 0,
@@ -191,6 +192,54 @@ const MODEL_COSTS: Record<string, ModelDefinitionConfig["cost"]> = {
   "qwen3.5-plus": { input: 0.2, output: 1.2, cacheRead: 0.02, cacheWrite: 0.25 },
   "qwen3.6-plus": { input: 0.5, output: 3, cacheRead: 0.05, cacheWrite: 0.625 },
 };
+
+function normalizeOpencodeModelId(modelId: string | undefined): string | undefined {
+  const normalized = modelId?.trim().toLowerCase();
+  return normalized?.startsWith(`${PROVIDER_ID}/`)
+    ? normalized.slice(PROVIDER_ID.length + 1)
+    : normalized;
+}
+
+function hasZeroInputCost(cost: ModelDefinitionConfig["cost"] | undefined): boolean {
+  return Boolean(
+    cost && cost.input === 0 && (cost.tieredPricing?.every((tier) => tier.input === 0) ?? true),
+  );
+}
+
+export function resolveOpencodeZenSyntheticAuth(params: {
+  modelId?: string;
+  providerConfig?: ModelProviderConfig;
+}) {
+  const normalizedModelId = normalizeOpencodeModelId(params.modelId);
+  const configuredModel = params.providerConfig?.models?.find(
+    (model) => normalizeOpencodeModelId(model.id) === normalizedModelId,
+  );
+  const configuredBaseUrl = configuredModel?.baseUrl ?? params.providerConfig?.baseUrl;
+  if (
+    configuredBaseUrl &&
+    !normalizeOpencodeZenBaseUrl({
+      api: configuredModel?.api ?? params.providerConfig?.api,
+      baseUrl: configuredBaseUrl,
+    })
+  ) {
+    return undefined;
+  }
+  const catalogCost = normalizedModelId ? MODEL_COSTS[normalizedModelId] : undefined;
+  if (!hasZeroInputCost(catalogCost)) {
+    return undefined;
+  }
+  if (configuredModel?.cost && !hasZeroInputCost(configuredModel.cost)) {
+    return undefined;
+  }
+  // OpenCode's official client sends this public key and disables models with
+  // paid input tiers when the user has no account credential configured.
+  return {
+    apiKey: OPENCODE_ZEN_PUBLIC_API_KEY,
+    source: "OpenCode Zen public key",
+    mode: "api-key" as const,
+    allowPreparedDirect: true as const,
+  };
+}
 
 const MODEL_NAMES: Record<string, string> = {
   "big-pickle": "Big Pickle",

--- a/extensions/opencode/provider-discovery.ts
+++ b/extensions/opencode/provider-discovery.ts
@@ -1,12 +1,16 @@
 // Opencode Zen provider module exposes offline catalog metadata to core discovery.
 import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
-import { buildStaticOpencodeZenProviderConfig } from "./provider-catalog.js";
+import {
+  buildStaticOpencodeZenProviderConfig,
+  resolveOpencodeZenSyntheticAuth,
+} from "./provider-catalog.js";
 
 const opencodeProviderDiscovery: ProviderPlugin = {
   id: "opencode",
   label: "OpenCode Zen",
   docsPath: "/providers/models",
   auth: [],
+  resolveSyntheticAuth: (ctx) => resolveOpencodeZenSyntheticAuth(ctx),
   staticCatalog: {
     order: "simple",
     run: async () => ({

--- a/extensions/opencode/provider-policy-api.ts
+++ b/extensions/opencode/provider-policy-api.ts
@@ -3,7 +3,15 @@ import type {
   ProviderDefaultThinkingPolicyContext,
   ProviderThinkingProfile,
 } from "openclaw/plugin-sdk/plugin-entry";
-import { resolveClaudeThinkingProfile } from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  resolveClaudeThinkingProfile,
+  type ProviderPlugin,
+} from "openclaw/plugin-sdk/provider-model-shared";
+import { resolveOpencodeZenSyntheticAuth } from "./provider-catalog.js";
+
+type ResolveSyntheticAuthContext = Parameters<
+  NonNullable<ProviderPlugin["resolveSyntheticAuth"]>
+>[0];
 
 const GPT_56_THINKING_PROFILE = {
   levels: [
@@ -26,4 +34,8 @@ export function resolveThinkingProfile(params: ProviderDefaultThinkingPolicyCont
     return GPT_56_THINKING_PROFILE;
   }
   return resolveClaudeThinkingProfile(params.modelId);
+}
+
+export function resolveSyntheticAuth(params: ResolveSyntheticAuthContext) {
+  return resolveOpencodeZenSyntheticAuth(params);
 }

--- a/src/agents/model-auth-availability.test.ts
+++ b/src/agents/model-auth-availability.test.ts
@@ -661,6 +661,48 @@ describe("createModelAuthAvailabilityResolver", () => {
     expect(result).not.toHaveProperty("selectedRoute");
   });
 
+  it("resolves model-specific synthetic auth for catalog entries", () => {
+    const resolveProviderSyntheticAuth = vi.fn((params: { provider: string; modelId?: string }) =>
+      params.provider === "opencode" && params.modelId === "deepseek-v4-flash-free"
+        ? {
+            apiKey: "public",
+            source: "OpenCode Zen public key",
+            mode: "api-key" as const,
+            allowPreparedDirect: true as const,
+          }
+        : undefined,
+    );
+    const resolver = createModelAuthAvailabilityResolver({
+      cfg: {},
+      authStore: authStore(),
+      env: {},
+      syntheticAuthProviderRefs: ["opencode"],
+      resolveProviderSyntheticAuth,
+    });
+
+    expect(
+      resolver.evaluateModelAuth("opencode", {
+        modelId: "deepseek-v4-flash-free",
+        api: "openai-completions",
+      }),
+    ).toMatchObject({ availability: true, evidence: "synthetic" });
+    expect(
+      resolver.evaluateModelAuth("opencode", {
+        modelId: "gpt-5.5",
+        api: "openai-responses",
+      }),
+    ).toMatchObject({ availability: undefined });
+
+    resolveProviderSyntheticAuth.mockClear();
+    expect(
+      resolver.evaluateModelAuth("unrelated-provider", {
+        modelId: "free-looking-model",
+        api: "openai-completions",
+      }),
+    ).toMatchObject({ availability: undefined });
+    expect(resolveProviderSyntheticAuth).not.toHaveBeenCalled();
+  });
+
   it("does not let invalid automatic profile evidence block synthetic Codex ownership", () => {
     expect(
       evaluate({

--- a/src/agents/model-auth-availability.ts
+++ b/src/agents/model-auth-availability.ts
@@ -15,6 +15,11 @@ import type {
   ProviderModelRouteSource,
 } from "../plugin-sdk/provider-model-types.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
+import type {
+  ProviderResolveSyntheticAuthContext,
+  ProviderSyntheticAuthResult,
+} from "../plugins/provider-external-auth.types.js";
+import { resolveProviderPolicySurface } from "../plugins/provider-public-artifacts.js";
 import { isValidSecretRef } from "../secrets/ref-contract.js";
 import { hasUsableOAuthCredential } from "./auth-profiles/credential-state.js";
 import { resolveExternalCliAuthProfiles } from "./auth-profiles/external-cli-sync.js";
@@ -118,6 +123,9 @@ type CreateModelAuthAvailabilityResolverParams = {
   externalCliProviderIds?: readonly string[];
   routeResolverFactory?: typeof createOpenAIModelRoutesResolver;
   allowPreparedRuntimeAuth?: boolean;
+  resolveProviderSyntheticAuth?: (
+    params: ProviderResolveSyntheticAuthContext,
+  ) => ProviderSyntheticAuthResult | null | undefined;
 };
 
 type AuthTarget = ModelAuthAvailabilityRef & {
@@ -281,6 +289,12 @@ export function createModelAuthAvailabilityResolver(
   };
   const providerConfig = (provider: string) =>
     resolveMergedModelProviderConfig(params.cfg, provider);
+  const resolveProviderSyntheticAuth =
+    params.resolveProviderSyntheticAuth ??
+    ((context: ProviderResolveSyntheticAuthContext) =>
+      resolveProviderPolicySurface(context.provider, {
+        manifestRegistry: params.metadataSnapshot?.manifestRegistry,
+      })?.resolveSyntheticAuth?.(context));
   const prepareAuthTarget = (provider: string, ref: ModelAuthAvailabilityRef): AuthTarget => {
     const configured = providerConfig(provider);
     const configuredModelId = ref.modelId
@@ -612,6 +626,23 @@ export function createModelAuthAvailabilityResolver(
         selectedAuthMode: mode,
         evidence: "environment",
       };
+    }
+    const modelId = target.modelId
+      ? normalizeModelIdForProvider(provider, target.modelId)
+      : undefined;
+    if (
+      provider !== OPENAI_PROVIDER_ID &&
+      provider !== "codex" &&
+      modelId &&
+      synthetic.has(normalizeProvider(provider)) &&
+      resolveProviderSyntheticAuth({
+        config: params.cfg,
+        provider,
+        modelId,
+        providerConfig: configured,
+      })
+    ) {
+      return { availability: true, evidence: "synthetic" };
     }
     const hasCompatibleCodexSyntheticAuth =
       provider === OPENAI_PROVIDER_ID &&

--- a/src/agents/model-auth-availability.ts
+++ b/src/agents/model-auth-availability.ts
@@ -289,12 +289,25 @@ export function createModelAuthAvailabilityResolver(
   };
   const providerConfig = (provider: string) =>
     resolveMergedModelProviderConfig(params.cfg, provider);
+  const providerPolicySurfaceCache = new Map<
+    string,
+    ReturnType<typeof resolveProviderPolicySurface>
+  >();
+  const providerPolicySurface = (provider: string) => {
+    if (!providerPolicySurfaceCache.has(provider)) {
+      providerPolicySurfaceCache.set(
+        provider,
+        resolveProviderPolicySurface(provider, {
+          manifestRegistry: params.metadataSnapshot?.manifestRegistry,
+        }),
+      );
+    }
+    return providerPolicySurfaceCache.get(provider) ?? null;
+  };
   const resolveProviderSyntheticAuth =
     params.resolveProviderSyntheticAuth ??
     ((context: ProviderResolveSyntheticAuthContext) =>
-      resolveProviderPolicySurface(context.provider, {
-        manifestRegistry: params.metadataSnapshot?.manifestRegistry,
-      })?.resolveSyntheticAuth?.(context));
+      providerPolicySurface(context.provider)?.resolveSyntheticAuth?.(context));
   const prepareAuthTarget = (provider: string, ref: ModelAuthAvailabilityRef): AuthTarget => {
     const configured = providerConfig(provider);
     const configuredModelId = ref.modelId
@@ -630,19 +643,28 @@ export function createModelAuthAvailabilityResolver(
     const modelId = target.modelId
       ? normalizeModelIdForProvider(provider, target.modelId)
       : undefined;
-    if (
+    const syntheticAuth =
       provider !== OPENAI_PROVIDER_ID &&
       provider !== "codex" &&
       modelId &&
-      synthetic.has(normalizeProvider(provider)) &&
-      resolveProviderSyntheticAuth({
-        config: params.cfg,
-        provider,
-        modelId,
-        providerConfig: configured,
-      })
-    ) {
+      synthetic.has(normalizeProvider(provider))
+        ? resolveProviderSyntheticAuth({
+            config: params.cfg,
+            provider,
+            modelId,
+            providerConfig: configured,
+          })
+        : undefined;
+    if (syntheticAuth) {
       return { availability: true, evidence: "synthetic" };
+    }
+    if (
+      params.resolveProviderSyntheticAuth === undefined &&
+      modelId &&
+      synthetic.has(normalizeProvider(provider)) &&
+      typeof providerPolicySurface(provider)?.resolveSyntheticAuth === "function"
+    ) {
+      return { availability: false, evidence: "synthetic" };
     }
     const hasCompatibleCodexSyntheticAuth =
       provider === OPENAI_PROVIDER_ID &&

--- a/src/agents/model-auth-model.ts
+++ b/src/agents/model-auth-model.ts
@@ -165,7 +165,12 @@ export async function hasAvailableAuthForProvider(params: {
   ) {
     return true;
   }
-  const syntheticLocalAuth = resolveSyntheticLocalProviderAuth({ cfg, provider });
+  const syntheticLocalAuth = resolveSyntheticLocalProviderAuth({
+    cfg,
+    provider,
+    modelId: params.modelId,
+    modelApi: params.modelApi,
+  });
   if (
     syntheticLocalAuth &&
     (!authConfig.isConfigBackedInlineProviderApiKey({

--- a/src/agents/model-auth-provider.ts
+++ b/src/agents/model-auth-provider.ts
@@ -566,6 +566,7 @@ export async function resolveApiKeyForProvider(params: {
   const syntheticLocalAuth = resolveSyntheticLocalProviderAuth({
     cfg,
     provider,
+    modelId: params.modelId,
     modelApi: params.modelApi,
     secretSentinels: params.secretSentinels,
     allowPluginSyntheticAuth: params.allowAuthProfileFallback !== false,

--- a/src/agents/model-auth-runtime.ts
+++ b/src/agents/model-auth-runtime.ts
@@ -5,11 +5,13 @@ import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeUniqueStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { getRuntimeConfigSnapshot } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import type { ProviderSyntheticAuthResult } from "../plugins/provider-external-auth.types.js";
 import { resolveProviderSyntheticAuthWithPlugin } from "../plugins/provider-runtime.js";
 import {
   hasRuntimeSyntheticAuthCandidateRef,
   resolveRuntimeSyntheticAuthProviderRefState,
+  resolveValidatedSyntheticAuthProviderRefState,
 } from "../plugins/synthetic-auth.runtime.js";
 import { mintSecretSentinel } from "../secrets/sentinel.js";
 import type { AuthProfileStore } from "./auth-profiles.js";
@@ -38,17 +40,21 @@ export function createRuntimeProviderAuthLookup(params: {
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
   includePluginSyntheticAuth?: boolean;
+  metadataSnapshot?: PluginMetadataSnapshot;
 }): RuntimeProviderAuthLookup {
   const env = params.env ?? process.env;
   const lookupParams = {
     config: params.cfg,
     workspaceDir: params.workspaceDir,
     env,
+    ...(params.metadataSnapshot ? { metadataSnapshot: params.metadataSnapshot } : {}),
   };
   const syntheticAuthProviderRefs =
     params.includePluginSyntheticAuth === false
       ? undefined
-      : resolveRuntimeSyntheticAuthProviderRefState(lookupParams);
+      : params.metadataSnapshot
+        ? resolveValidatedSyntheticAuthProviderRefState(params.metadataSnapshot)
+        : resolveRuntimeSyntheticAuthProviderRefState(lookupParams);
   const authLookupMaps = resolveProviderEnvAuthLookupMaps(lookupParams);
   return {
     envApiKey: {

--- a/src/agents/model-auth-runtime.ts
+++ b/src/agents/model-auth-runtime.ts
@@ -5,8 +5,12 @@ import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeUniqueStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { getRuntimeConfigSnapshot } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { ProviderSyntheticAuthResult } from "../plugins/provider-external-auth.types.js";
 import { resolveProviderSyntheticAuthWithPlugin } from "../plugins/provider-runtime.js";
-import { resolveRuntimeSyntheticAuthProviderRefState } from "../plugins/synthetic-auth.runtime.js";
+import {
+  hasRuntimeSyntheticAuthCandidateRef,
+  resolveRuntimeSyntheticAuthProviderRefState,
+} from "../plugins/synthetic-auth.runtime.js";
 import { mintSecretSentinel } from "../secrets/sentinel.js";
 import type { AuthProfileStore } from "./auth-profiles.js";
 import { resolveProviderEnvAuthLookupMaps } from "./model-auth-env-vars.js";
@@ -132,6 +136,21 @@ function shouldResolvePluginSyntheticAuth(params: {
   return listProviderSyntheticAuthRefs(params).some((ref) => eligibleRefs.has(ref));
 }
 
+function shouldResolvePreparedPluginSyntheticAuth(params: {
+  cfg: OpenClawConfig | undefined;
+  provider: string;
+  modelApi?: string;
+}): boolean {
+  const provider = normalizeProviderId(params.provider);
+  if (provider === "openai" || provider === "codex") {
+    return false;
+  }
+  return hasRuntimeSyntheticAuthCandidateRef({
+    config: params.cfg,
+    providerRefs: listProviderSyntheticAuthRefs(params),
+  });
+}
+
 /** Fast auth-availability check for runtime provider/model selection. */
 export function hasRuntimeAvailableProviderAuth(params: {
   provider: string;
@@ -140,6 +159,7 @@ export function hasRuntimeAvailableProviderAuth(params: {
   env?: NodeJS.ProcessEnv;
   allowPluginSyntheticAuth?: boolean;
   runtimeLookup?: RuntimeProviderAuthLookup;
+  modelId?: string;
   modelApi?: string;
   store?: AuthProfileStore;
 }): boolean {
@@ -223,7 +243,11 @@ export function hasRuntimeAvailableProviderAuth(params: {
       provider,
       runtimeLookup: params.runtimeLookup,
     }) &&
-    resolveSyntheticLocalProviderAuth({ cfg: params.cfg, provider })
+    resolveSyntheticLocalProviderAuth({
+      cfg: params.cfg,
+      provider,
+      modelId: params.modelId,
+    })
   ) {
     return true;
   }
@@ -233,11 +257,13 @@ export function hasRuntimeAvailableProviderAuth(params: {
 type SyntheticProviderAuthResolution = {
   auth?: ResolvedProviderAuth;
   blockedOnManagedSecretRef?: boolean;
+  allowPreparedDirect?: boolean;
 };
 
 function resolveProviderSyntheticRuntimeAuth(params: {
   cfg: OpenClawConfig | undefined;
   provider: string;
+  modelId?: string;
   modelApi?: string;
   secretSentinels?: boolean;
 }): SyntheticProviderAuthResolution {
@@ -251,7 +277,7 @@ function resolveProviderSyntheticRuntimeAuth(params: {
 
   const resolveFromConfig = (
     config: OpenClawConfig | undefined,
-  ): ResolvedProviderAuth | undefined => {
+  ): ProviderSyntheticAuthResult | undefined => {
     const providerConfig = authConfig.resolveProviderConfig(config, params.provider);
     return (
       resolveProviderSyntheticAuthWithPlugin({
@@ -260,6 +286,7 @@ function resolveProviderSyntheticRuntimeAuth(params: {
         context: {
           config,
           provider: params.provider,
+          modelId: params.modelId,
           providerConfig,
         },
         modelApi: params.modelApi,
@@ -272,7 +299,7 @@ function resolveProviderSyntheticRuntimeAuth(params: {
     return {};
   }
   if (!authConfig.isManagedSecretRefApiKeyMarker(directAuth.apiKey)) {
-    return { auth: directAuth };
+    return { auth: directAuth, allowPreparedDirect: directAuth.allowPreparedDirect === true };
   }
 
   const runtimeConfig = getRuntimeConfigSnapshot();
@@ -300,18 +327,33 @@ function resolveProviderSyntheticRuntimeAuth(params: {
 export function resolveSyntheticLocalProviderAuth(params: {
   cfg: OpenClawConfig | undefined;
   provider: string;
+  modelId?: string;
   modelApi?: string;
   secretSentinels?: boolean;
   allowPluginSyntheticAuth?: boolean;
 }): ResolvedProviderAuth | null {
-  // Prepared direct attempts may use local no-auth config, but must not widen
-  // back into an unprepared plugin-owned credential source.
-  const syntheticProviderAuth =
-    params.allowPluginSyntheticAuth === false ? {} : resolveProviderSyntheticRuntimeAuth(params);
-  if (syntheticProviderAuth.auth) {
-    return syntheticProviderAuth.auth;
+  // Prepared direct attempts may use only credentials explicitly approved by
+  // the provider hook; they must not widen into other unprepared auth sources.
+  const mayResolvePluginSyntheticAuth =
+    params.allowPluginSyntheticAuth !== false || shouldResolvePreparedPluginSyntheticAuth(params);
+  const syntheticProviderAuth = mayResolvePluginSyntheticAuth
+    ? resolveProviderSyntheticRuntimeAuth(params)
+    : {};
+  const syntheticAuth = syntheticProviderAuth.auth;
+  const syntheticApiKey = syntheticAuth?.apiKey;
+  if (
+    syntheticAuth &&
+    syntheticApiKey &&
+    (params.allowPluginSyntheticAuth !== false ||
+      syntheticProviderAuth.allowPreparedDirect === true ||
+      isNonSecretApiKeyMarker(syntheticApiKey))
+  ) {
+    return syntheticAuth;
   }
-  if (syntheticProviderAuth.blockedOnManagedSecretRef) {
+  if (
+    params.allowPluginSyntheticAuth !== false &&
+    syntheticProviderAuth.blockedOnManagedSecretRef
+  ) {
     return null;
   }
 

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -10,6 +10,7 @@ import type { AuthProfileStore } from "./auth-profiles.js";
 import {
   CUSTOM_LOCAL_AUTH_MARKER,
   GCP_VERTEX_CREDENTIALS_MARKER,
+  isNonSecretApiKeyMarker,
   NON_ENV_SECRETREF_MARKER,
 } from "./model-auth-markers.js";
 import {
@@ -59,6 +60,15 @@ vi.mock("../plugins/plugin-registry.js", () => ({
   }),
 }));
 
+vi.mock("../plugins/synthetic-auth.runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../plugins/synthetic-auth.runtime.js")>();
+  return {
+    ...actual,
+    hasRuntimeSyntheticAuthCandidateRef: (params: { providerRefs: readonly string[] }) =>
+      params.providerRefs.some((ref) => ref === "opencode" || ref === "secret-synthetic"),
+  };
+});
+
 vi.mock("../plugins/manifest-metadata-scan.js", () => ({
   listOpenClawPluginManifestMetadata: () => [
     {
@@ -67,6 +77,13 @@ vi.mock("../plugins/manifest-metadata-scan.js", () => ({
       manifest: {
         id: "anthropic-vertex",
         nonSecretAuthMarkers: ["gcp-vertex-credentials"],
+      },
+    },
+    {
+      pluginDir: "/external/opencode",
+      origin: "external",
+      manifest: {
+        id: "opencode",
       },
     },
   ],
@@ -118,7 +135,10 @@ vi.mock("../plugins/provider-runtime.js", () => {
         };
       };
       modelApi?: string;
-      context: { providerConfig?: { api?: string; baseUrl?: string; models?: unknown[] } };
+      context: {
+        modelId?: string;
+        providerConfig?: { api?: string; baseUrl?: string; models?: unknown[] };
+      };
     }) => {
       if (params.provider === "plugin-web") {
         if (
@@ -150,6 +170,21 @@ vi.mock("../plugins/provider-runtime.js", () => {
           apiKey: "native-cli-access-token",
           source: "Native CLI auth",
           mode: "oauth" as const,
+        };
+      }
+      if (params.provider === "opencode" && params.context.modelId === "deepseek-v4-flash-free") {
+        return {
+          apiKey: "public",
+          source: "OpenCode Zen public key",
+          mode: "api-key" as const,
+          allowPreparedDirect: true as const,
+        };
+      }
+      if (params.provider === "secret-synthetic") {
+        return {
+          apiKey: "runtime-secret", // pragma: allowlist secret
+          source: "Synthetic secret fixture",
+          mode: "api-key" as const,
         };
       }
       const effectiveApi = params.modelApi ?? params.context.providerConfig?.api;
@@ -1802,6 +1837,61 @@ describe("resolveApiKeyForProvider", () => {
 });
 
 describe("resolveApiKeyForProvider – synthetic local auth for custom providers", () => {
+  it("passes the selected model id to provider-owned synthetic auth", async () => {
+    const auth = await resolveApiKeyForProvider({
+      provider: "opencode",
+      modelId: "deepseek-v4-flash-free",
+      modelApi: "openai-completions",
+      store: { version: 1, profiles: {} },
+    });
+
+    expectAuthFields(auth, {
+      apiKey: "public",
+      source: "OpenCode Zen public key",
+      mode: "api-key",
+    });
+  });
+
+  it("keeps provider-declared non-secret auth in prepared direct attempts", async () => {
+    expect(isNonSecretApiKeyMarker("public")).toBe(false);
+    const auth = await resolveApiKeyForProvider({
+      provider: "opencode",
+      modelId: "deepseek-v4-flash-free",
+      modelApi: "openai-completions",
+      store: { version: 1, profiles: {} },
+      allowAuthProfileFallback: false,
+    });
+
+    expectAuthFields(auth, {
+      apiKey: "public",
+      source: "OpenCode Zen public key",
+      mode: "api-key",
+    });
+  });
+
+  it("does not widen prepared direct attempts into synthetic secret auth", async () => {
+    await expect(
+      resolveApiKeyForProvider({
+        provider: "secret-synthetic",
+        modelId: "model-a",
+        store: { version: 1, profiles: {} },
+        allowAuthProfileFallback: false,
+      }),
+    ).rejects.toThrow('No API key found for provider "secret-synthetic"');
+
+    await expect(
+      resolveApiKeyForProvider({
+        provider: "secret-synthetic",
+        modelId: "model-a",
+        store: { version: 1, profiles: {} },
+      }),
+    ).resolves.toMatchObject({
+      apiKey: "runtime-secret",
+      source: "Synthetic secret fixture",
+      mode: "api-key",
+    });
+  });
+
   it("recognizes local baseUrl variants for synthetic auth config", () => {
     const localBaseUrls = [
       "http://127.0.0.1:8080/v1",

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -284,6 +284,27 @@ describe("createRuntimeProviderAuthLookup", () => {
       }).syntheticAuthProviderRefs,
     ).toBeUndefined();
   });
+
+  it("derives authoritative synthetic auth refs from lifecycle metadata", () => {
+    const lookup = createRuntimeProviderAuthLookup({
+      env: {},
+      metadataSnapshot: {
+        registrySource: "provided",
+        registryDiagnostics: [],
+        index: {
+          plugins: [
+            { enabled: true, syntheticAuthRefs: ["opencode"] },
+            { enabled: false, syntheticAuthRefs: ["disabled-provider"] },
+          ],
+        },
+        manifestRegistry: { plugins: [] },
+        plugins: [],
+      } as never,
+    });
+
+    expect(lookup.syntheticAuthProviderRefs).toEqual(["opencode"]);
+    expect(lookup.syntheticAuthProviderRefsComplete).toBe(true);
+  });
 });
 
 async function withoutEnv<T>(key: string, fn: () => Promise<T>): Promise<T> {

--- a/src/agents/model-provider-auth.test.ts
+++ b/src/agents/model-provider-auth.test.ts
@@ -25,7 +25,7 @@ const modelAuthMocks = vi.hoisted(() => ({
       candidateMap: {},
       authEvidenceMap: {},
     },
-    syntheticAuthProviderRefs: [],
+    syntheticAuthProviderRefs: [] as string[],
     syntheticAuthProviderRefsComplete: true,
   })),
   hasAvailableAuthForProvider: vi.fn(() => true),

--- a/src/agents/model-provider-auth.test.ts
+++ b/src/agents/model-provider-auth.test.ts
@@ -397,6 +397,51 @@ describe("prepared provider auth state", () => {
     expect(modelAuthMocks.hasRuntimeAvailableProviderAuth).not.toHaveBeenCalled();
   });
 
+  it("passes lifecycle plugin metadata and explicit synthetic refs to model availability", async () => {
+    const cfg = {} as OpenClawConfig;
+    const metadataSnapshot = { manifestRegistry: { plugins: [] } } as never;
+    const hasAuth = createProviderAuthChecker({
+      cfg,
+      metadataSnapshot,
+      syntheticAuthProviderRefs: ["opencode"],
+    });
+
+    await hasAuth("opencode", { modelId: "deepseek-v4-flash-free" });
+
+    expect(modelAuthAvailabilityMocks.createModelAuthAvailabilityResolver).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfg,
+        metadataSnapshot,
+        syntheticAuthProviderRefs: ["opencode"],
+      }),
+    );
+    expect(modelAuthMocks.createRuntimeProviderAuthLookup).toHaveBeenCalledWith(
+      expect.objectContaining({ cfg, metadataSnapshot }),
+    );
+  });
+
+  it("keeps explicit empty synthetic refs authoritative over runtime discovery", async () => {
+    modelAuthMocks.createRuntimeProviderAuthLookup.mockReturnValueOnce({
+      envApiKey: {
+        aliasMap: {},
+        candidateMap: {},
+        authEvidenceMap: {},
+      },
+      syntheticAuthProviderRefs: ["opencode"],
+      syntheticAuthProviderRefsComplete: true,
+    });
+    const hasAuth = createProviderAuthChecker({
+      cfg: {} as OpenClawConfig,
+      syntheticAuthProviderRefs: [],
+    });
+
+    await hasAuth("opencode", { modelId: "deepseek-v4-flash-free" });
+
+    expect(modelAuthAvailabilityMocks.createModelAuthAvailabilityResolver).toHaveBeenCalledWith(
+      expect.objectContaining({ syntheticAuthProviderRefs: [] }),
+    );
+  });
+
   it("caches OpenAI auth by the complete route tuple", async () => {
     const hasAuth = createProviderAuthChecker({ cfg: {} as OpenClawConfig });
     const platformRef = {

--- a/src/agents/model-provider-auth.ts
+++ b/src/agents/model-provider-auth.ts
@@ -9,6 +9,7 @@ import { Worker } from "node:worker_threads";
 import { hashRuntimeConfigValue } from "../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { toErrorObject } from "../infra/errors.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import {
   listAgentIds,
   resolveAgentDir,
@@ -245,6 +246,8 @@ export function createProviderAuthChecker(params: {
   allowPluginSyntheticAuth?: boolean;
   discoverExternalCliAuth?: boolean;
   allowPreparedRuntimeAuth?: boolean;
+  metadataSnapshot?: PluginMetadataSnapshot;
+  syntheticAuthProviderRefs?: readonly string[];
 }): ProviderModelAuthChecker {
   const authCache = new Map<string, Promise<ModelAuthAvailabilityEvaluation>>();
   let runtimeAuthLookup: RuntimeProviderAuthLookup | undefined;
@@ -266,6 +269,7 @@ export function createProviderAuthChecker(params: {
       workspaceDir: params.workspaceDir,
       env: params.env,
       includePluginSyntheticAuth: params.allowPluginSyntheticAuth !== false,
+      ...(params.metadataSnapshot ? { metadataSnapshot: params.metadataSnapshot } : {}),
     });
     modelAuthResolver = createModelAuthAvailabilityResolver({
       cfg: params.cfg ?? {},
@@ -277,7 +281,9 @@ export function createProviderAuthChecker(params: {
       allowPreparedRuntimeAuth:
         params.allowPreparedRuntimeAuth === true ||
         (params.discoverExternalCliAuth !== false && params.allowPluginSyntheticAuth !== false),
-      syntheticAuthProviderRefs: runtimeAuthLookup.syntheticAuthProviderRefs,
+      ...(params.metadataSnapshot ? { metadataSnapshot: params.metadataSnapshot } : {}),
+      syntheticAuthProviderRefs:
+        params.syntheticAuthProviderRefs ?? runtimeAuthLookup.syntheticAuthProviderRefs,
       ...(params.discoverExternalCliAuth === false ? {} : { externalCliProviderIds: ["openai"] }),
     });
     return modelAuthResolver;
@@ -317,6 +323,7 @@ export function createProviderAuthChecker(params: {
             workspaceDir: params.workspaceDir,
             env: params.env,
             includePluginSyntheticAuth: params.allowPluginSyntheticAuth !== false,
+            ...(params.metadataSnapshot ? { metadataSnapshot: params.metadataSnapshot } : {}),
           })),
       });
     const evaluation = Promise.resolve().then(

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -70,6 +70,13 @@ const modelProviderAuthMocks = vi.hoisted(() => {
 });
 const normalizeProviderModelIdWithRuntimeMock = vi.hoisted(() => vi.fn());
 const pluginMetadataMocks = vi.hoisted(() => ({
+  lifecycleSnapshot: {
+    registrySource: "provided" as const,
+    registryDiagnostics: [],
+    index: { plugins: [] },
+    manifestRegistry: { plugins: [] },
+    plugins: [],
+  },
   snapshot: undefined as
     | {
         plugins: unknown[];
@@ -138,6 +145,10 @@ vi.mock("../../agents/provider-model-normalization.runtime.js", () => ({
 
 vi.mock("../../plugins/current-plugin-metadata-snapshot.js", () => ({
   getCurrentPluginMetadataSnapshot: () => pluginMetadataMocks.snapshot,
+}));
+
+vi.mock("../../plugins/manifest-contract-eligibility.js", () => ({
+  loadManifestMetadataSnapshot: () => pluginMetadataMocks.lifecycleSnapshot,
 }));
 
 const telegramModelsTestPlugin: ChannelPlugin = {
@@ -331,6 +342,8 @@ describe("handleModelsCommand", () => {
     expect(result?.reply?.text).not.toContain("Add: /models add");
     const authCheckerParams = preparedAuthCheckerParams();
     expect(authCheckerParams?.workspaceDir).toBe("/tmp");
+    expect(authCheckerParams?.metadataSnapshot).toBe(pluginMetadataMocks.lifecycleSnapshot);
+    expect(authCheckerParams?.syntheticAuthProviderRefs).toEqual([]);
   });
 
   it("uses read-only catalog loading and static auth checks for default browse", async () => {

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -36,14 +36,12 @@ const modelProviderAuthMocks = vi.hoisted(() => {
       baseUrl?: unknown;
       observedRoutes?: readonly { api?: string | null; baseUrl?: unknown }[];
     };
-    const hasConflictingRoute = (ref?: AuthRef) => {
-      const routes = ref?.observedRoutes ?? [];
-      return [ref, ...routes].some(
+    const hasConflictingRoute = (ref?: AuthRef) =>
+      [ref, ...(ref?.observedRoutes ?? [])].some(
         (route) =>
           route?.api === "openai-chatgpt-responses" &&
           route.baseUrl === "https://api.openai.com/v1",
       );
-    };
     const checker = vi.fn((provider: string, ref?: AuthRef) => {
       return state.authenticatedProviders.has(provider) && !hasConflictingRoute(ref);
     });
@@ -70,13 +68,11 @@ const modelProviderAuthMocks = vi.hoisted(() => {
 });
 const normalizeProviderModelIdWithRuntimeMock = vi.hoisted(() => vi.fn());
 const pluginMetadataMocks = vi.hoisted(() => ({
-  lifecycleSnapshot: {
+  loadManifestMetadataSnapshot: vi.fn(() => ({
     registrySource: "provided" as const,
     registryDiagnostics: [],
     index: { plugins: [] },
-    manifestRegistry: { plugins: [] },
-    plugins: [],
-  },
+  })),
   snapshot: undefined as
     | {
         plugins: unknown[];
@@ -147,9 +143,7 @@ vi.mock("../../plugins/current-plugin-metadata-snapshot.js", () => ({
   getCurrentPluginMetadataSnapshot: () => pluginMetadataMocks.snapshot,
 }));
 
-vi.mock("../../plugins/manifest-contract-eligibility.js", () => ({
-  loadManifestMetadataSnapshot: () => pluginMetadataMocks.lifecycleSnapshot,
-}));
+vi.mock("../../plugins/manifest-contract-eligibility.js", () => pluginMetadataMocks);
 
 const telegramModelsTestPlugin: ChannelPlugin = {
   ...createChannelTestPluginBase({
@@ -226,7 +220,6 @@ beforeEach(() => {
     { provider: "google", id: "gemini-2.0-flash", name: "Gemini Flash" },
   ]);
   modelAuthLabelMocks.resolveModelAuthLabel.mockReset();
-  modelAuthLabelMocks.resolveModelAuthLabel.mockReturnValue(undefined);
   normalizeProviderModelIdWithRuntimeMock.mockReset();
   pluginMetadataMocks.snapshot = undefined;
   modelProviderAuthMocks.authenticatedProviders = new Set(["anthropic", "google", "openai"]);
@@ -342,8 +335,7 @@ describe("handleModelsCommand", () => {
     expect(result?.reply?.text).not.toContain("Add: /models add");
     const authCheckerParams = preparedAuthCheckerParams();
     expect(authCheckerParams?.workspaceDir).toBe("/tmp");
-    expect(authCheckerParams?.metadataSnapshot).toBe(pluginMetadataMocks.lifecycleSnapshot);
-    expect(authCheckerParams?.syntheticAuthProviderRefs).toEqual([]);
+    expect(authCheckerParams?.metadataSnapshot).toBeDefined();
   });
 
   it("uses read-only catalog loading and static auth checks for default browse", async () => {

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -39,6 +39,8 @@ import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import { getChannelPlugin } from "../../channels/plugins/index.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { loadManifestMetadataSnapshot } from "../../plugins/manifest-contract-eligibility.js";
+import { resolveValidatedSyntheticAuthProviderRefState } from "../../plugins/synthetic-auth.runtime.js";
 import { resolveAgentRuntimeLabel } from "../../status/agent-runtime-label.js";
 import type { ReplyPayload } from "../types.js";
 import { rejectUnauthorizedCommand } from "./command-gates.js";
@@ -167,6 +169,11 @@ export async function buildModelsProviderData(
   const cliRuntimeProviders = new Set(
     listCliRuntimeModelBackendBindings().map((binding) => normalizeProviderId(binding.runtime)),
   );
+  const metadataSnapshot = loadManifestMetadataSnapshot({
+    config: cfg,
+    workspaceDir,
+    env: process.env,
+  });
 
   const snapshot = await loadPreparedModelCatalogSnapshotForBrowse({
     cfg,
@@ -196,6 +203,8 @@ export async function buildModelsProviderData(
     allowPluginSyntheticAuth: false,
     discoverExternalCliAuth: false,
     allowPreparedRuntimeAuth: true,
+    metadataSnapshot,
+    syntheticAuthProviderRefs: resolveValidatedSyntheticAuthProviderRefState(metadataSnapshot).refs,
   });
   const logicalModelKey = (entry: { provider: string; id: string }) =>
     openAIModelCatalogRoutePolicy.resolveIdentity(entry)?.key ?? modelCatalogLogicalKey(entry);

--- a/src/commands/auth-choice.model-check.test.ts
+++ b/src/commands/auth-choice.model-check.test.ts
@@ -18,7 +18,23 @@ const pluginMetadataSnapshot = vi.hoisted(() => ({
   index: {
     plugins: [{ enabled: true, pluginId: "opencode", syntheticAuthRefs: ["opencode"] }],
   },
-  manifestRegistry: { plugins: [] },
+  manifestRegistry: {
+    plugins: [
+      {
+        id: "openai",
+        origin: "bundled" as const,
+        providerAuthChoices: [
+          {
+            provider: "openai",
+            method: "oauth",
+            choiceId: "openai",
+            choiceLabel: "OpenAI",
+          },
+        ],
+      },
+    ],
+  },
+  plugins: [],
 }));
 vi.mock("../agents/prepared-model-runtime.js", () => ({
   publishPreparedModelRuntimeSnapshot: async (...args: unknown[]) => {

--- a/src/commands/auth-choice.model-check.test.ts
+++ b/src/commands/auth-choice.model-check.test.ts
@@ -12,13 +12,48 @@ const loadModelCatalog = vi.hoisted(() => vi.fn());
 const modelCatalogMocks = vi.hoisted(() => ({
   routeVariants: undefined as unknown[] | undefined,
 }));
+const pluginMetadataSnapshot = vi.hoisted(() => ({
+  registrySource: "provided" as const,
+  registryDiagnostics: [],
+  index: {
+    plugins: [{ enabled: true, pluginId: "opencode", syntheticAuthRefs: ["opencode"] }],
+  },
+  manifestRegistry: { plugins: [] },
+}));
 vi.mock("../agents/prepared-model-runtime.js", () => ({
   publishPreparedModelRuntimeSnapshot: async (...args: unknown[]) => {
     const entries = await loadModelCatalog(...args);
     return {
       modelCatalog: { entries, routeVariants: modelCatalogMocks.routeVariants ?? entries },
+      metadataSnapshot: pluginMetadataSnapshot,
     };
   },
+}));
+
+const loadManifestMetadataSnapshot = vi.hoisted(() => vi.fn(() => pluginMetadataSnapshot));
+vi.mock("../plugins/manifest-contract-eligibility.js", () => ({
+  loadManifestMetadataSnapshot,
+}));
+
+const resolveProviderPolicySurface = vi.hoisted(() =>
+  vi.fn((_provider: string, options?: { manifestRegistry?: unknown }) =>
+    options?.manifestRegistry === pluginMetadataSnapshot.manifestRegistry
+      ? {
+          resolveSyntheticAuth: ({ modelId }: { modelId?: string }) =>
+            modelId === "deepseek-v4-flash-free"
+              ? {
+                  apiKey: "public",
+                  source: "OpenCode Zen public key",
+                  mode: "api-key" as const,
+                  allowPreparedDirect: true as const,
+                }
+              : undefined,
+        }
+      : null,
+  ),
+);
+vi.mock("../plugins/provider-public-artifacts.js", () => ({
+  resolveProviderPolicySurface,
 }));
 
 const openAIRouteMocks = vi.hoisted(() => ({
@@ -95,6 +130,54 @@ describe("warnIfModelConfigLooksOff", () => {
       status: "missing",
       hasAuth: false,
     });
+  });
+
+  it("keeps credentialless public defaults ready while paid and unknown models stay gated", async () => {
+    const publicConfig = {
+      agents: { defaults: { model: "opencode/deepseek-v4-flash-free" } },
+    } as OpenClawConfig;
+    const note = vi.fn(async () => {});
+
+    await warnIfModelConfigLooksOff(publicConfig, makePrompter({ note }), {
+      validateCatalog: false,
+      env: {},
+    });
+
+    expect(note).not.toHaveBeenCalled();
+    expect(loadManifestMetadataSnapshot).toHaveBeenCalledWith({
+      config: publicConfig,
+      workspaceDir: expect.any(String),
+      env: {},
+    });
+    expect(
+      resolveDefaultModelAuthStatus(
+        { agents: { defaults: { model: "opencode/gpt-5.5" } } } as OpenClawConfig,
+        { env: {}, metadataSnapshot: pluginMetadataSnapshot as never },
+      ),
+    ).toMatchObject({ status: "missing", hasAuth: false });
+    resolveProviderPolicySurface.mockClear();
+    expect(
+      resolveDefaultModelAuthStatus(
+        { agents: { defaults: { model: "unknown/free-looking" } } } as OpenClawConfig,
+        { env: {}, metadataSnapshot: pluginMetadataSnapshot as never },
+      ),
+    ).toMatchObject({ status: "missing", hasAuth: false });
+    expect(resolveProviderPolicySurface).not.toHaveBeenCalled();
+  });
+
+  it("keeps explicit empty synthetic refs authoritative over lifecycle metadata", () => {
+    expect(
+      resolveDefaultModelAuthStatus(
+        {
+          agents: { defaults: { model: "opencode/deepseek-v4-flash-free" } },
+        } as OpenClawConfig,
+        {
+          env: {},
+          metadataSnapshot: pluginMetadataSnapshot as never,
+          syntheticAuthProviderRefs: [],
+        },
+      ),
+    ).toMatchObject({ status: "missing", hasAuth: false });
   });
 
   it("accepts Codex OAuth profiles for canonical OpenAI models using the Codex runtime", async () => {

--- a/src/commands/auth-choice.model-check.ts
+++ b/src/commands/auth-choice.model-check.ts
@@ -16,6 +16,9 @@ import { canonicalizeProviderModelId } from "../agents/provider-model-route.js";
 import type { ModelApi } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ProviderModelRouteAuthRequirement } from "../plugin-sdk/provider-model-types.js";
+import { loadManifestMetadataSnapshot } from "../plugins/manifest-contract-eligibility.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
+import { resolveValidatedSyntheticAuthProviderRefState } from "../plugins/synthetic-auth.runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 
 type ModelRouteObservation = {
@@ -49,7 +52,9 @@ export function resolveDefaultModelAuthStatus(
     agentId?: string;
     agentDir?: string;
     env?: NodeJS.ProcessEnv;
+    metadataSnapshot?: PluginMetadataSnapshot;
     observedRoutes?: readonly ModelRouteObservation[];
+    syntheticAuthProviderRefs?: readonly string[];
   },
 ): DefaultModelAuthStatus {
   const ref = resolveDefaultModelForAgent({
@@ -67,6 +72,16 @@ export function resolveDefaultModelAuthStatus(
     authStore: store,
     ...(options?.agentDir ? { agentDir: options.agentDir } : {}),
     ...(options?.env ? { env: options.env } : {}),
+    ...(options?.metadataSnapshot ? { metadataSnapshot: options.metadataSnapshot } : {}),
+    ...(options?.syntheticAuthProviderRefs !== undefined
+      ? { syntheticAuthProviderRefs: options.syntheticAuthProviderRefs }
+      : options?.metadataSnapshot
+        ? {
+            syntheticAuthProviderRefs: resolveValidatedSyntheticAuthProviderRefState(
+              options.metadataSnapshot,
+            ).refs,
+          }
+        : {}),
   }).evaluateModelAuth(ref.provider, {
     modelId: ref.model,
     ...(options?.observedRoutes?.length ? { observedRoutes: options.observedRoutes } : {}),
@@ -165,25 +180,32 @@ export async function warnIfModelConfigLooksOff(
   });
   const warnings: string[] = [];
   const validationAgentId = options?.agentId ?? resolveDefaultAgentId(config);
-  const snapshot =
+  const validationWorkspaceDir = resolveAgentWorkspaceDir(config, validationAgentId);
+  const preparedSnapshot =
     options?.validateCatalog === false
-      ? { entries: [], routeVariants: [] }
-      : (
-          await publishPreparedModelRuntimeSnapshot(
-            {
-              config,
-              agentId: validationAgentId,
-              agentDir:
-                options?.agentDir ??
-                (options?.agentId
-                  ? resolveAgentDir(config, options.agentId)
-                  : resolveDefaultAgentDir(config)),
-              inheritedAuthDir: resolveDefaultAgentDir(config),
-              workspaceDir: resolveAgentWorkspaceDir(config, validationAgentId),
-            },
-            { force: true, provenance: "explicit" },
-          )
-        ).modelCatalog;
+      ? undefined
+      : await publishPreparedModelRuntimeSnapshot(
+          {
+            config,
+            agentId: validationAgentId,
+            agentDir:
+              options?.agentDir ??
+              (options?.agentId
+                ? resolveAgentDir(config, options.agentId)
+                : resolveDefaultAgentDir(config)),
+            inheritedAuthDir: resolveDefaultAgentDir(config),
+            workspaceDir: validationWorkspaceDir,
+          },
+          { force: true, provenance: "explicit" },
+        );
+  const snapshot = preparedSnapshot?.modelCatalog ?? { entries: [], routeVariants: [] };
+  const metadataSnapshot =
+    preparedSnapshot?.metadataSnapshot ??
+    loadManifestMetadataSnapshot({
+      config,
+      workspaceDir: validationWorkspaceDir,
+      env: options?.env ?? process.env,
+    });
   const catalog = snapshot.entries;
   const catalogFacts = resolveDefaultModelCatalogFacts(config, catalog, {
     ...(options?.agentId ? { agentId: options.agentId } : {}),
@@ -204,6 +226,7 @@ export async function warnIfModelConfigLooksOff(
     ...(options?.agentId ? { agentId: options.agentId } : {}),
     ...(options?.agentDir ? { agentDir: options.agentDir } : {}),
     ...(options?.env ? { env: options.env } : {}),
+    metadataSnapshot,
     ...(observedRoutes ? { observedRoutes } : {}),
   });
   if (authStatus.status === "missing") {

--- a/src/commands/model-picker.test.ts
+++ b/src/commands/model-picker.test.ts
@@ -19,10 +19,25 @@ const loadModelCatalog = vi.hoisted(() => vi.fn());
 const modelCatalogRouteVariants = vi.hoisted(() => ({
   value: undefined as readonly ModelCatalogEntry[] | undefined,
 }));
+const pickerMetadataSnapshot = vi.hoisted(() => ({
+  registrySource: "provided" as const,
+  registryDiagnostics: [],
+  index: {
+    plugins: [{ enabled: true, pluginId: "opencode", syntheticAuthRefs: ["opencode"] }],
+  },
+  manifestRegistry: { plugins: [] },
+}));
+const loadManifestMetadataSnapshot = vi.hoisted(() => vi.fn(() => pickerMetadataSnapshot));
+vi.mock("../plugins/manifest-contract-eligibility.js", () => ({
+  loadManifestMetadataSnapshot,
+}));
 vi.mock("../agents/prepared-model-catalog.js", () => ({
-  loadPreparedModelCatalogSnapshot: async (...args: unknown[]) => {
+  loadPreparedModelCatalogOwnerSnapshot: async (...args: unknown[]) => {
     const entries = await loadModelCatalog(...args);
-    return { entries, routeVariants: modelCatalogRouteVariants.value ?? entries };
+    return {
+      modelCatalog: { entries, routeVariants: modelCatalogRouteVariants.value ?? entries },
+      metadataSnapshot: pickerMetadataSnapshot,
+    };
   },
 }));
 
@@ -38,11 +53,12 @@ const loadPreferredProviderPickerCatalog = vi.hoisted(() =>
     (_params: {
       cfg: OpenClawConfig;
       preferredProvider: string;
+      agentId?: string;
       agentDir?: string;
       workspaceDir?: string;
       env?: NodeJS.ProcessEnv;
-    }) => Promise<ModelCatalogEntry[]>
-  >(async () => []),
+    }) => Promise<{ entries: ModelCatalogEntry[]; metadataSnapshot: unknown }>
+  >(async () => ({ entries: [], metadataSnapshot: pickerMetadataSnapshot })),
 );
 vi.mock("../flows/model-picker.provider-catalog.js", () => ({
   loadPreferredProviderPickerCatalog,
@@ -151,43 +167,62 @@ const providerAuthEvaluations = vi.hoisted(
     >(),
 );
 const createProviderAuthChecker = vi.hoisted(() =>
-  vi.fn((params: { cfg?: OpenClawConfig; workspaceDir?: string; env?: NodeJS.ProcessEnv }) => {
-    const checker = vi.fn(
-      async (provider: string, ref?: { api?: string | null; baseUrl?: unknown }) => {
-        const prepared = providerAuthEvaluations.get(provider);
-        if (prepared) {
-          return prepared.availability === true;
-        }
-        return (
-          hasRuntimeAvailableProviderAuth({
-            provider,
-            cfg: params.cfg,
-            workspaceDir: params.workspaceDir,
-            env: params.env,
-          }) &&
-          !(ref?.api === "openai-chatgpt-responses" && ref.baseUrl === "https://api.openai.com/v1")
-        );
-      },
-    );
-    const evaluateModelAuth = vi.fn(
-      async (provider: string, ref?: { api?: string | null; baseUrl?: unknown }) => {
-        const prepared = providerAuthEvaluations.get(provider);
-        if (prepared) {
-          return prepared;
-        }
-        const availability = await checker(provider, ref);
-        const selectedRoute = providerAuthRoute.value;
-        return {
-          availability,
-          routeResolution: selectedRoute
-            ? { kind: "routes" as const, routes: [selectedRoute] as const }
-            : null,
-          ...(selectedRoute ? { selectedRoute } : {}),
-        };
-      },
-    );
-    return Object.assign(checker, { evaluateModelAuth });
-  }),
+  vi.fn(
+    (params: {
+      cfg?: OpenClawConfig;
+      workspaceDir?: string;
+      env?: NodeJS.ProcessEnv;
+      metadataSnapshot?: unknown;
+    }) => {
+      const checker = vi.fn(
+        async (
+          provider: string,
+          ref?: { modelId?: string; api?: string | null; baseUrl?: unknown },
+        ) => {
+          if (provider === "opencode") {
+            return (
+              params.metadataSnapshot === pickerMetadataSnapshot &&
+              ref?.modelId === "deepseek-v4-flash-free"
+            );
+          }
+          const prepared = providerAuthEvaluations.get(provider);
+          if (prepared) {
+            return prepared.availability === true;
+          }
+          return (
+            hasRuntimeAvailableProviderAuth({
+              provider,
+              cfg: params.cfg,
+              workspaceDir: params.workspaceDir,
+              env: params.env,
+            }) &&
+            !(
+              ref?.api === "openai-chatgpt-responses" &&
+              ref.baseUrl === "https://api.openai.com/v1"
+            )
+          );
+        },
+      );
+      const evaluateModelAuth = vi.fn(
+        async (provider: string, ref?: { api?: string | null; baseUrl?: unknown }) => {
+          const prepared = providerAuthEvaluations.get(provider);
+          if (prepared) {
+            return prepared;
+          }
+          const availability = await checker(provider, ref);
+          const selectedRoute = providerAuthRoute.value;
+          return {
+            availability,
+            routeResolution: selectedRoute
+              ? { kind: "routes" as const, routes: [selectedRoute] as const }
+              : null,
+            ...(selectedRoute ? { selectedRoute } : {}),
+          };
+        },
+      );
+      return Object.assign(checker, { evaluateModelAuth });
+    },
+  ),
 );
 vi.mock("../agents/model-provider-auth.js", () => ({
   createProviderAuthChecker,
@@ -259,6 +294,14 @@ function promptDefaultPicker(params: Parameters<typeof promptDefaultModel>[0]) {
 
 function catalogModel(provider: string, id: string, name: string): ModelCatalogEntry {
   return { provider, id, name };
+}
+
+function pickerCatalog(entries: ModelCatalogEntry[]) {
+  return { entries, metadataSnapshot: pickerMetadataSnapshot };
+}
+
+function mockPreferredProviderCatalog(entries: ModelCatalogEntry[]) {
+  loadPreferredProviderPickerCatalog.mockResolvedValue(pickerCatalog(entries));
 }
 
 function configuredTextModel(id: string, name: string) {
@@ -394,7 +437,7 @@ beforeEach(() => {
     }),
   });
   loadStaticManifestCatalogRowsForList.mockReturnValue([]);
-  loadPreferredProviderPickerCatalog.mockResolvedValue([]);
+  mockPreferredProviderCatalog([]);
   listProfilesForProvider.mockReturnValue([]);
   resolveEnvApiKey.mockImplementation((_provider: string) => ({
     apiKey: "test-key",
@@ -614,6 +657,27 @@ describe("promptDefaultModel", () => {
     expect(values).toEqual(["amazon-bedrock/us.anthropic.claude-sonnet-4-5"]);
   });
 
+  it("keeps only lifecycle-approved public OpenCode models visible without credentials", async () => {
+    loadModelCatalog.mockResolvedValue([
+      { provider: "opencode", id: "deepseek-v4-flash-free", name: "DeepSeek Free" },
+      { provider: "opencode", id: "gpt-5.5", name: "GPT-5.5" },
+      { provider: "opencode", id: "unknown-free", name: "Unknown Free" },
+    ]);
+    const select = vi.fn(async (params) => params.initialValue as never);
+
+    await promptDefaultPicker({
+      config: { agents: { defaults: {} } } as OpenClawConfig,
+      prompter: makePrompter({ select }),
+    });
+
+    expect(createProviderAuthChecker).toHaveBeenCalledWith(
+      expect.objectContaining({ metadataSnapshot: pickerMetadataSnapshot }),
+    );
+    expect(optionValues(pickerOptions(select as MockCallSource))).toEqual([
+      "opencode/deepseek-v4-flash-free",
+    ]);
+  });
+
   it("shows AWS SDK models but hides unresolved non-OpenAI SecretRefs", async () => {
     providerAuthEvaluations.set("amazon-bedrock", {
       availability: true,
@@ -742,9 +806,15 @@ describe("promptDefaultModel", () => {
     const result = await promptDefaultPicker({
       config,
       prompter,
+      workspaceDir: "/tmp/minimax-workspace",
     });
 
     expect(loadModelCatalog).not.toHaveBeenCalled();
+    expect(loadManifestMetadataSnapshot).toHaveBeenCalledWith({
+      config,
+      workspaceDir: "/tmp/minimax-workspace",
+      env: process.env,
+    });
     const minimaxOption = requireOption(
       pickerOptions(select as MockCallSource),
       "minimax/MiniMax-M2.7-highspeed",
@@ -998,7 +1068,7 @@ describe("promptDefaultModel", () => {
   });
 
   it("loads the preferred provider catalog when the user chooses to browse", async () => {
-    loadPreferredProviderPickerCatalog.mockResolvedValue([
+    mockPreferredProviderCatalog([
       catalogModel("openai", "gpt-5.5", "GPT-5.5"),
       catalogModel("openai", "gpt-5.5-pro", "GPT-5.5 Pro"),
     ]);
@@ -1034,6 +1104,7 @@ describe("promptDefaultModel", () => {
       cfg: config,
       preferredProvider: "openai",
       agentDir: expect.stringContaining("agents/main/agent"),
+      workspaceDir: expect.any(String),
     });
     expect(loadModelCatalog).not.toHaveBeenCalled();
     expect(select).toHaveBeenCalledTimes(2);
@@ -1041,7 +1112,7 @@ describe("promptDefaultModel", () => {
   });
 
   it("scopes on-demand preferred-provider loads before the first model prompt", async () => {
-    loadPreferredProviderPickerCatalog.mockResolvedValue([
+    mockPreferredProviderCatalog([
       catalogModel("nvidia", "nvidia/nemotron-3-super-120b-a12b", "NVIDIA Nemotron 3 Super 120B"),
       catalogModel("nvidia", "moonshotai/kimi-k2.5", "Kimi K2.5"),
     ]);
@@ -1067,6 +1138,7 @@ describe("promptDefaultModel", () => {
       cfg: config,
       preferredProvider: "nvidia",
       agentDir: expect.stringContaining("agents/main/agent"),
+      workspaceDir: expect.any(String),
     });
     expect(loadModelCatalog).not.toHaveBeenCalled();
     expect(optionValues(pickerOptions(select as MockCallSource))).toEqual([
@@ -1076,7 +1148,7 @@ describe("promptDefaultModel", () => {
   });
 
   it("preselects the first live provider row when keep-current is disabled", async () => {
-    loadPreferredProviderPickerCatalog.mockResolvedValue([
+    mockPreferredProviderCatalog([
       catalogModel("nvidia", "z-ai/glm-5.1", "GLM 5.1"),
       catalogModel("nvidia", "nvidia/nemotron-3-super-120b-a12b", "NVIDIA Nemotron 3 Super 120B"),
     ]);
@@ -1111,7 +1183,7 @@ describe("promptDefaultModel", () => {
   });
 
   it("keeps on-demand NVIDIA vendor labels single-prefixed after browsing", async () => {
-    loadPreferredProviderPickerCatalog.mockResolvedValue([
+    mockPreferredProviderCatalog([
       catalogModel("nvidia", "nvidia/nemotron-3-super-120b-a12b", "NVIDIA Nemotron 3 Super 120B"),
       catalogModel("nvidia", "minimaxai/minimax-m2.7", "MiniMax M2.7"),
       catalogModel("nvidia", "z-ai/glm-5.1", "GLM 5.1"),
@@ -1154,7 +1226,7 @@ describe("promptDefaultModel", () => {
   });
 
   it("omits local NVIDIA static fallback rows when browsing live provider rows", async () => {
-    loadPreferredProviderPickerCatalog.mockResolvedValue([
+    mockPreferredProviderCatalog([
       catalogModel("nvidia", "nvidia/nemotron-3-super-120b-a12b", "NVIDIA Nemotron 3 Super 120B"),
       catalogModel("nvidia", "minimaxai/minimax-m2.7", "MiniMax M2.7"),
       catalogModel("nvidia", "z-ai/glm-5.1", "GLM 5.1"),
@@ -1200,7 +1272,7 @@ describe("promptDefaultModel", () => {
   });
 
   it("uses the configured default agent dir for provider-scoped catalog auth", async () => {
-    loadPreferredProviderPickerCatalog.mockResolvedValue([
+    mockPreferredProviderCatalog([
       catalogModel("nvidia", "z-ai/glm-5.1", "GLM 5.1"),
     ]);
     const select = vi.fn(async (params) => params.options[0]?.value as never);
@@ -1223,13 +1295,16 @@ describe("promptDefaultModel", () => {
       prompter,
       preferredProvider: "nvidia",
       browseCatalogOnDemand: true,
+      agentId: "worker",
       env,
     });
 
     expect(loadPreferredProviderPickerCatalog).toHaveBeenCalledWith({
       cfg: config,
       preferredProvider: "nvidia",
+      agentId: "worker",
       agentDir: "/tmp/openclaw-picker-state/agents/worker/agent",
+      workspaceDir: expect.any(String),
       env,
     });
   });
@@ -1479,6 +1554,7 @@ describe("promptModelAllowlist", () => {
     expect(loadStaticManifestCatalogRowsForList).toHaveBeenCalledWith({
       cfg: config,
       providerFilter: "github-copilot",
+      metadataSnapshot: pickerMetadataSnapshot,
     });
     expect(loadModelCatalog).not.toHaveBeenCalled();
     expect(optionValues(pickerOptions(multiselect as MockCallSource))).toEqual([
@@ -1593,6 +1669,30 @@ describe("promptModelAllowlist", () => {
       "zhipu/glm-4.5-air",
     ]);
     expect(result.models).toEqual(["minimax/MiniMax-M2.7-highspeed", "zhipu/glm-4.5-air"]);
+  });
+
+  it("keeps only lifecycle-approved public OpenCode models in the allowlist picker", async () => {
+    loadModelCatalog.mockResolvedValue([
+      catalogModel("opencode", "deepseek-v4-flash-free", "DeepSeek Free"),
+      catalogModel("opencode", "gpt-5.5", "GPT-5.5"),
+    ]);
+    const multiselect = createSelectAllMultiselect();
+
+    await promptModelAllowlist({
+      config: { agents: { defaults: {} } } as OpenClawConfig,
+      prompter: makePrompter({ multiselect }),
+      workspaceDir: "/tmp/opencode-workspace",
+    });
+
+    expect(createProviderAuthChecker).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceDir: "/tmp/opencode-workspace",
+        metadataSnapshot: pickerMetadataSnapshot,
+      }),
+    );
+    expect(optionValues(pickerOptions(multiselect as MockCallSource))).toEqual([
+      "opencode/deepseek-v4-flash-free",
+    ]);
   });
 
   it("scopes the initial allowlist picker to the preferred provider", async () => {
@@ -1712,7 +1812,7 @@ describe("promptModelAllowlist", () => {
   });
 
   it("keeps live preferred-provider rows before configured fallback supplements", async () => {
-    loadPreferredProviderPickerCatalog.mockResolvedValue([
+    mockPreferredProviderCatalog([
       catalogModel("nvidia", "minimaxai/minimax-m2.7", "MiniMax M2.7"),
       catalogModel("nvidia", "nvidia/nemotron-3-super-120b-a12b", "Nemotron 3 Super"),
     ]);
@@ -1755,7 +1855,7 @@ describe("promptModelAllowlist", () => {
   });
 
   it("keeps provider-scoped live rows authoritative over configured provider supplements", async () => {
-    loadPreferredProviderPickerCatalog.mockResolvedValue([
+    mockPreferredProviderCatalog([
       catalogModel("nvidia", "nvidia/nemotron-3-super-120b-a12b", "Nemotron 3 Super"),
       catalogModel("nvidia", "z-ai/glm-5.1", "GLM 5.1"),
       catalogModel("nvidia", "minimaxai/minimax-m2.7", "MiniMax M2.7"),
@@ -1814,7 +1914,7 @@ describe("promptModelAllowlist", () => {
   });
 
   it("keeps custom configured rows after provider-scoped live rows", async () => {
-    loadPreferredProviderPickerCatalog.mockResolvedValue([
+    mockPreferredProviderCatalog([
       catalogModel("nvidia", "nvidia/nemotron-3-super-120b-a12b", "Nemotron 3 Super"),
       catalogModel("nvidia", "z-ai/glm-5.1", "GLM 5.1"),
     ]);
@@ -1861,7 +1961,7 @@ describe("promptModelAllowlist", () => {
   });
 
   it("does not re-add configured static rows after filtering deprecated live rows", async () => {
-    loadPreferredProviderPickerCatalog.mockResolvedValue([
+    mockPreferredProviderCatalog([
       catalogModel("nvidia", "minimaxai/minimax-m2.5", "MiniMax M2.5"),
       catalogModel("nvidia", "z-ai/glm5", "GLM5"),
     ]);
@@ -2156,9 +2256,15 @@ describe("promptModelAllowlist", () => {
       prompter,
       allowedKeys: ["openai/gpt-5.5", "openai/gpt-5.4"],
       preferredProvider: "openai",
+      workspaceDir: "/tmp/allowed-model-workspace",
     });
 
     expect(loadModelCatalog).not.toHaveBeenCalled();
+    expect(loadManifestMetadataSnapshot).toHaveBeenCalledWith({
+      config,
+      workspaceDir: "/tmp/allowed-model-workspace",
+      env: process.env,
+    });
     expect(optionValues(pickerOptions(multiselect as MockCallSource))).toEqual([
       "openai/gpt-5.5",
       "openai/gpt-5.4",

--- a/src/commands/model-picker.test.ts
+++ b/src/commands/model-picker.test.ts
@@ -197,8 +197,7 @@ const createProviderAuthChecker = vi.hoisted(() =>
               env: params.env,
             }) &&
             !(
-              ref?.api === "openai-chatgpt-responses" &&
-              ref.baseUrl === "https://api.openai.com/v1"
+              ref?.api === "openai-chatgpt-responses" && ref.baseUrl === "https://api.openai.com/v1"
             )
           );
         },
@@ -1272,9 +1271,7 @@ describe("promptDefaultModel", () => {
   });
 
   it("uses the configured default agent dir for provider-scoped catalog auth", async () => {
-    mockPreferredProviderCatalog([
-      catalogModel("nvidia", "z-ai/glm-5.1", "GLM 5.1"),
-    ]);
+    mockPreferredProviderCatalog([catalogModel("nvidia", "z-ai/glm-5.1", "GLM 5.1")]);
     const select = vi.fn(async (params) => params.options[0]?.value as never);
     const prompter = makePrompter({ select });
     const env = {
@@ -1679,7 +1676,9 @@ describe("promptModelAllowlist", () => {
     const multiselect = createSelectAllMultiselect();
 
     await promptModelAllowlist({
-      config: { agents: { defaults: {} } } as OpenClawConfig,
+      config: {
+        agents: { defaults: { model: "opencode/deepseek-v4-flash-free" } },
+      } as OpenClawConfig,
       prompter: makePrompter({ multiselect }),
       workspaceDir: "/tmp/opencode-workspace",
     });

--- a/src/commands/models/list.auth-index.test.ts
+++ b/src/commands/models/list.auth-index.test.ts
@@ -302,6 +302,28 @@ describe("createModelListAuthIndex", () => {
     expect(index.evaluateModelAuth("openai").evidence).toBe("synthetic");
   });
 
+  it("keeps explicit empty synthetic refs authoritative over metadata", () => {
+    const metadataSnapshot = {
+      registrySource: "provided",
+      registryDiagnostics: [],
+      index: {
+        plugins: [{ enabled: true, syntheticAuthRefs: ["codex"] }],
+      },
+      manifestRegistry: { plugins: [] },
+      plugins: [],
+    } as unknown as PluginMetadataSnapshot;
+    const index = createTestModelListAuthIndex({
+      cfg: {},
+      authStore: emptyStore,
+      env: {},
+      metadataSnapshot,
+      syntheticAuthProviderRefs: [],
+      routeResolverFactory: dualRouteResolverFactory,
+    });
+
+    expect(index.evaluateModelAuth("openai").evidence).not.toBe("synthetic");
+  });
+
   it("fails closed before loading refs from a diagnostic-bearing metadata snapshot", () => {
     const metadataSnapshot = {
       index: { plugins: [] },

--- a/src/commands/models/list.auth-index.ts
+++ b/src/commands/models/list.auth-index.ts
@@ -8,6 +8,7 @@ import {
 import type { createOpenAIModelRoutesResolver } from "../../agents/openai-model-routes.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
+import { resolveValidatedSyntheticAuthProviderRefState } from "../../plugins/synthetic-auth.runtime.js";
 
 export type ModelListAuthRef = ModelAuthAvailabilityRef;
 export type ModelListAuthEvaluation = ModelAuthAvailabilityEvaluation;
@@ -29,21 +30,6 @@ type CreateModelListAuthIndexParams = {
   routeResolverFactory?: typeof createOpenAIModelRoutesResolver;
 };
 
-function listValidatedSyntheticAuthProviderRefs(params: {
-  metadataSnapshot: PluginMetadataSnapshot;
-}): readonly string[] {
-  if (
-    params.metadataSnapshot.registryDiagnostics.length > 0 ||
-    (params.metadataSnapshot.registrySource !== "persisted" &&
-      params.metadataSnapshot.registrySource !== "provided")
-  ) {
-    return [];
-  }
-  return params.metadataSnapshot.index.plugins
-    .filter((plugin) => plugin.enabled)
-    .flatMap((plugin) => plugin.syntheticAuthRefs ?? []);
-}
-
 /** Builds one snapshot-scoped command adapter around the shared evaluator. */
 export function createModelListAuthIndex(
   params: CreateModelListAuthIndexParams,
@@ -60,9 +46,7 @@ export function createModelListAuthIndex(
     routeResolverFactory: params.routeResolverFactory,
     syntheticAuthProviderRefs:
       params.syntheticAuthProviderRefs ??
-      listValidatedSyntheticAuthProviderRefs({
-        metadataSnapshot: params.metadataSnapshot,
-      }),
+      resolveValidatedSyntheticAuthProviderRefState(params.metadataSnapshot).refs,
   });
   return {
     providerDiscoveryProviderIds: resolver.providerDiscoveryProviderIds,

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -82,7 +82,7 @@ import { loadManifestMetadataSnapshot } from "../../plugins/manifest-contract-el
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
 import type { ProviderSyntheticAuthResult } from "../../plugins/provider-external-auth.types.js";
 import { resolveProviderSyntheticAuthWithPlugin } from "../../plugins/provider-runtime.js";
-import { resolveRuntimeSyntheticAuthProviderRefs } from "../../plugins/synthetic-auth.runtime.js";
+import { resolveValidatedSyntheticAuthProviderRefState } from "../../plugins/synthetic-auth.runtime.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { resolveUserPath, shortenHomePath } from "../../utils.js";
@@ -611,10 +611,9 @@ export async function modelsStatusCommand(
       }
     }
     const syntheticAuthProviderRefs = new Set(
-      resolveRuntimeSyntheticAuthProviderRefs({
-        index: metadataSnapshot.index,
-        registryDiagnostics: metadataSnapshot.registryDiagnostics,
-      }).map((provider) => normalizeProviderId(provider)),
+      resolveValidatedSyntheticAuthProviderRefState(metadataSnapshot).refs.map((provider) =>
+        normalizeProviderId(provider),
+      ),
     );
     const createStatusAuthResolver = (
       authStore: Parameters<typeof createModelAuthAvailabilityResolver>[0]["authStore"],

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -288,6 +288,10 @@ vi.mock("../../infra/provider-usage.js", () => ({
 }));
 vi.mock("../../plugins/synthetic-auth.runtime.js", () => ({
   resolveRuntimeSyntheticAuthProviderRefs: mocks.resolveRuntimeSyntheticAuthProviderRefs,
+  resolveValidatedSyntheticAuthProviderRefState: () => ({
+    refs: mocks.resolveRuntimeSyntheticAuthProviderRefs(),
+    complete: true,
+  }),
 }));
 vi.mock("../../plugins/provider-runtime.js", () => ({
   resolveProviderSyntheticAuthWithPlugin: mocks.resolveProviderSyntheticAuthWithPlugin,

--- a/src/flows/model-picker.provider-catalog.test.ts
+++ b/src/flows/model-picker.provider-catalog.test.ts
@@ -14,8 +14,9 @@ describe("loadPreferredProviderPickerCatalog", () => {
   });
 
   it("filters one committed generation by preferred provider", async () => {
+    const metadataSnapshot = { manifestRegistry: { plugins: [] } };
     mocks.loadPreparedModelCatalogOwnerSnapshot.mockResolvedValue({
-      metadataSnapshot: { manifestRegistry: { plugins: [] } },
+      metadataSnapshot,
       modelCatalog: {
         entries: [
           { provider: "nvidia", id: "nvidia/nemotron", name: "Nemotron" },
@@ -28,13 +29,18 @@ describe("loadPreferredProviderPickerCatalog", () => {
       loadPreferredProviderPickerCatalog({
         cfg: {},
         preferredProvider: "NVIDIA",
+        agentId: "worker",
         agentDir: "/tmp/agent",
         workspaceDir: "/tmp/workspace",
         env: { NVIDIA_API_KEY: "test-nvidia-api-key" },
       }),
-    ).resolves.toEqual([{ provider: "nvidia", id: "nvidia/nemotron", name: "Nemotron" }]);
+    ).resolves.toEqual({
+      entries: [{ provider: "nvidia", id: "nvidia/nemotron", name: "Nemotron" }],
+      metadataSnapshot,
+    });
     expect(mocks.loadPreparedModelCatalogOwnerSnapshot).toHaveBeenCalledWith({
       config: {},
+      agentId: "worker",
       agentDir: "/tmp/agent",
       workspaceDir: "/tmp/workspace",
       env: { NVIDIA_API_KEY: "test-nvidia-api-key" },
@@ -42,17 +48,18 @@ describe("loadPreferredProviderPickerCatalog", () => {
   });
 
   it("matches preferred provider aliases from the prepared metadata generation", async () => {
-    mocks.loadPreparedModelCatalogOwnerSnapshot.mockResolvedValue({
-      metadataSnapshot: {
-        manifestRegistry: {
-          plugins: [
-            {
-              id: "moonshot",
-              modelCatalog: { aliases: { kimi: { provider: "moonshot" } } },
-            },
-          ],
-        },
+    const metadataSnapshot = {
+      manifestRegistry: {
+        plugins: [
+          {
+            id: "moonshot",
+            modelCatalog: { aliases: { kimi: { provider: "moonshot" } } },
+          },
+        ],
       },
+    };
+    mocks.loadPreparedModelCatalogOwnerSnapshot.mockResolvedValue({
+      metadataSnapshot,
       modelCatalog: {
         entries: [{ provider: "moonshot", id: "kimi-k2.6", name: "Kimi K2.6" }],
       },
@@ -64,6 +71,9 @@ describe("loadPreferredProviderPickerCatalog", () => {
         preferredProvider: "kimi",
         agentDir: "/tmp/agent",
       }),
-    ).resolves.toEqual([{ provider: "moonshot", id: "kimi-k2.6", name: "Kimi K2.6" }]);
+    ).resolves.toEqual({
+      entries: [{ provider: "moonshot", id: "kimi-k2.6", name: "Kimi K2.6" }],
+      metadataSnapshot,
+    });
   });
 });

--- a/src/flows/model-picker.provider-catalog.ts
+++ b/src/flows/model-picker.provider-catalog.ts
@@ -1,28 +1,43 @@
 // Model picker provider choices projected from the lifecycle-owned catalog.
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
-import { resolveDefaultAgentDir } from "../agents/agent-scope.js";
+import { resolveAgentDir, resolveDefaultAgentDir } from "../agents/agent-scope.js";
 import {
   canonicalizePreparedModelCatalogProvider,
   type ModelCatalogEntry,
 } from "../agents/model-catalog.js";
 import { loadPreparedModelCatalogOwnerSnapshot } from "../agents/prepared-model-catalog.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 
 /** Loads committed catalog models for the user's preferred provider. */
 export async function loadPreferredProviderPickerCatalog(params: {
   cfg: OpenClawConfig;
   preferredProvider: string;
+  agentId?: string;
   agentDir?: string;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
-}): Promise<ModelCatalogEntry[]> {
+}): Promise<{ entries: ModelCatalogEntry[]; metadataSnapshot: PluginMetadataSnapshot }> {
   const requestedProvider = normalizeProviderId(params.preferredProvider);
+  const agentDir =
+    params.agentDir ??
+    (params.agentId
+      ? resolveAgentDir(params.cfg, params.agentId, params.env)
+      : resolveDefaultAgentDir(params.cfg, params.env));
   if (!requestedProvider) {
-    return [];
+    const owner = await loadPreparedModelCatalogOwnerSnapshot({
+      config: params.cfg,
+      ...(params.agentId ? { agentId: params.agentId } : {}),
+      agentDir,
+      ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+      ...(params.env ? { env: params.env } : {}),
+    });
+    return { entries: [], metadataSnapshot: owner.metadataSnapshot };
   }
   const owner = await loadPreparedModelCatalogOwnerSnapshot({
     config: params.cfg,
-    agentDir: params.agentDir ?? resolveDefaultAgentDir(params.cfg, params.env),
+    ...(params.agentId ? { agentId: params.agentId } : {}),
+    agentDir,
     ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
     ...(params.env ? { env: params.env } : {}),
   });
@@ -30,7 +45,10 @@ export async function loadPreferredProviderPickerCatalog(params: {
     requestedProvider,
     owner.metadataSnapshot,
   );
-  return owner.modelCatalog.entries.filter(
-    (entry) => normalizeProviderId(entry.provider) === providerFilter,
-  );
+  return {
+    entries: owner.modelCatalog.entries.filter(
+      (entry) => normalizeProviderId(entry.provider) === providerFilter,
+    ),
+    metadataSnapshot: owner.metadataSnapshot,
+  };
 }

--- a/src/flows/model-picker.ts
+++ b/src/flows/model-picker.ts
@@ -1,7 +1,13 @@
 // Model picker flow lets users select provider models for config defaults.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { sortUniqueStrings } from "@openclaw/normalization-core/string-normalization";
-import { resolveAgentConfig, resolveDefaultAgentDir } from "../agents/agent-scope.js";
+import {
+  resolveAgentConfig,
+  resolveAgentDir,
+  resolveAgentWorkspaceDir,
+  resolveDefaultAgentDir,
+  resolveDefaultAgentId,
+} from "../agents/agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { resolveAgentHarnessPolicy } from "../agents/harness/policy.js";
 import {
@@ -28,7 +34,7 @@ import {
   resolveModelRefFromString,
 } from "../agents/model-selection.js";
 import { openAIModelCatalogRoutePolicy } from "../agents/openai-model-routes.js";
-import { loadPreparedModelCatalogSnapshot } from "../agents/prepared-model-catalog.js";
+import { loadPreparedModelCatalogOwnerSnapshot } from "../agents/prepared-model-catalog.js";
 import { loadStaticManifestCatalogRowsForList } from "../commands/models/list.manifest-catalog.js";
 import { formatTokenK } from "../commands/models/shared.js";
 import {
@@ -39,6 +45,8 @@ import {
 } from "../config/model-input.js";
 import { computeModelPolicyAllowlist } from "../config/model-policy-allowlist-migration.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { loadManifestMetadataSnapshot } from "../plugins/manifest-contract-eligibility.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import { resolveOwningPluginIdsForProviderRef } from "../plugins/providers.js";
 import type { ProviderPlugin } from "../plugins/types.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -91,10 +99,32 @@ function formatModelRefLabel(params: {
 
 function resolvePickerAgentDir(params: {
   cfg: OpenClawConfig;
+  agentId?: string;
   agentDir?: string;
   env?: NodeJS.ProcessEnv;
 }): string {
-  return params.agentDir ?? resolveDefaultAgentDir(params.cfg, params.env ?? process.env);
+  return (
+    params.agentDir ??
+    (params.agentId
+      ? resolveAgentDir(params.cfg, params.agentId, params.env ?? process.env)
+      : resolveDefaultAgentDir(params.cfg, params.env ?? process.env))
+  );
+}
+
+function resolvePickerWorkspaceDir(params: {
+  cfg: OpenClawConfig;
+  agentId?: string;
+  workspaceDir?: string;
+  env?: NodeJS.ProcessEnv;
+}): string {
+  return (
+    params.workspaceDir ??
+    resolveAgentWorkspaceDir(
+      params.cfg,
+      params.agentId ?? resolveDefaultAgentId(params.cfg),
+      params.env ?? process.env,
+    )
+  );
 }
 
 type PromptDefaultModelParams = {
@@ -173,7 +203,12 @@ function toPickerCatalogEntry(
   };
 }
 
-function loadPickerModelCatalog(
+type PickerModelCatalogContext = {
+  modelCatalog: ModelCatalogSnapshot;
+  metadataSnapshot: PluginMetadataSnapshot;
+};
+
+async function loadPickerModelCatalog(
   cfg: OpenClawConfig,
   opts: {
     preferredProvider?: string;
@@ -181,61 +216,80 @@ function loadPickerModelCatalog(
     providerScoped?: boolean;
     allowStaticFallbackCatalog?: boolean;
     agentDir?: string;
+    agentId?: string;
     workspaceDir?: string;
     env?: NodeJS.ProcessEnv;
   } = {},
-): Promise<ModelCatalogSnapshot> {
-  const snapshot = (entries: ModelCatalogEntry[]): ModelCatalogSnapshot => ({
-    entries,
-    routeVariants: entries,
+): Promise<PickerModelCatalogContext> {
+  const context = (
+    entries: ModelCatalogEntry[],
+    metadataSnapshot: PluginMetadataSnapshot,
+  ): PickerModelCatalogContext => ({
+    modelCatalog: { entries, routeVariants: entries },
+    metadataSnapshot,
   });
+  const loadManifestSnapshot = () =>
+    loadManifestMetadataSnapshot({
+      config: cfg,
+      ...(opts.workspaceDir !== undefined ? { workspaceDir: opts.workspaceDir } : {}),
+      env: opts.env ?? process.env,
+    });
+  const loadPreparedContext = async (): Promise<PickerModelCatalogContext> => {
+    const owner = await loadPreparedModelCatalogOwnerSnapshot({
+      config: cfg,
+      ...(opts.agentId !== undefined ? { agentId: opts.agentId } : {}),
+      ...(opts.agentDir !== undefined ? { agentDir: opts.agentDir } : {}),
+      ...(opts.workspaceDir !== undefined ? { workspaceDir: opts.workspaceDir } : {}),
+      ...(opts.env !== undefined ? { env: opts.env } : {}),
+    });
+    return { modelCatalog: owner.modelCatalog, metadataSnapshot: owner.metadataSnapshot };
+  };
   if (cfg.models?.mode === "replace") {
-    return Promise.resolve(snapshot(buildConfiguredModelCatalog({ cfg })));
+    return context(buildConfiguredModelCatalog({ cfg }), loadManifestSnapshot());
   }
   if (opts.preferredProvider) {
     if (opts.preferLiveProviderCatalog) {
-      return loadPreferredProviderPickerCatalog({
+      const providerCatalog = await loadPreferredProviderPickerCatalog({
         cfg,
         preferredProvider: opts.preferredProvider,
+        ...(opts.agentId !== undefined ? { agentId: opts.agentId } : {}),
         ...(opts.agentDir !== undefined ? { agentDir: opts.agentDir } : {}),
         ...(opts.workspaceDir !== undefined ? { workspaceDir: opts.workspaceDir } : {}),
         ...(opts.env !== undefined ? { env: opts.env } : {}),
-      }).then((providerCatalog) => {
-        if (providerCatalog.length > 0) {
-          return snapshot(providerCatalog);
-        }
-        if (opts.allowStaticFallbackCatalog !== false) {
-          const manifestRows = loadStaticManifestCatalogRowsForList({
-            cfg,
-            providerFilter: opts.preferredProvider,
-            ...(opts.env !== undefined ? { env: opts.env } : {}),
-          });
-          if (manifestRows.length > 0) {
-            return snapshot(manifestRows.map(toPickerCatalogEntry));
-          }
-        }
-        return opts.providerScoped
-          ? snapshot([])
-          : loadPreparedModelCatalogSnapshot({
-              config: cfg,
-            });
       });
+      if (providerCatalog.entries.length > 0) {
+        return context(providerCatalog.entries, providerCatalog.metadataSnapshot);
+      }
+      if (opts.allowStaticFallbackCatalog !== false) {
+        const manifestRows = loadStaticManifestCatalogRowsForList({
+          cfg,
+          providerFilter: opts.preferredProvider,
+          metadataSnapshot: providerCatalog.metadataSnapshot,
+          ...(opts.env !== undefined ? { env: opts.env } : {}),
+        });
+        if (manifestRows.length > 0) {
+          return context(manifestRows.map(toPickerCatalogEntry), providerCatalog.metadataSnapshot);
+        }
+      }
+      return opts.providerScoped
+        ? context([], providerCatalog.metadataSnapshot)
+        : await loadPreparedContext();
     }
+    const metadataSnapshot = loadManifestSnapshot();
     const manifestRows = loadStaticManifestCatalogRowsForList({
       cfg,
       providerFilter: opts.preferredProvider,
+      metadataSnapshot,
       ...(opts.env !== undefined ? { env: opts.env } : {}),
     });
     if (manifestRows.length > 0) {
-      return Promise.resolve(snapshot(manifestRows.map(toPickerCatalogEntry)));
+      return context(manifestRows.map(toPickerCatalogEntry), metadataSnapshot);
     }
     if (opts.providerScoped) {
-      return Promise.resolve(snapshot([]));
+      return context([], metadataSnapshot);
     }
   }
-  return loadPreparedModelCatalogSnapshot({
-    config: cfg,
-  });
+  return await loadPreparedContext();
 }
 
 async function resolvePickerLogicalCatalog(params: {
@@ -807,7 +861,14 @@ export async function promptDefaultModel(
   const pickerConfig = resolveModelPickerConfig(cfg, params.agentId);
   const pickerAgentDir = resolvePickerAgentDir({
     cfg,
+    ...(params.agentId !== undefined ? { agentId: params.agentId } : {}),
     ...(params.agentDir !== undefined ? { agentDir: params.agentDir } : {}),
+    ...(params.env !== undefined ? { env: params.env } : {}),
+  });
+  const pickerWorkspaceDir = resolvePickerWorkspaceDir({
+    cfg,
+    ...(params.agentId !== undefined ? { agentId: params.agentId } : {}),
+    ...(params.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
     ...(params.env !== undefined ? { env: params.env } : {}),
   });
   const allowKeep = params.allowKeep ?? true;
@@ -835,7 +896,7 @@ export async function promptDefaultModel(
     if (!literalPrefixProvidersCache) {
       literalPrefixProvidersCache = await resolveLiteralPrefixProviderIds({
         cfg,
-        workspaceDir: params.workspaceDir,
+        workspaceDir: pickerWorkspaceDir,
         env: params.env,
       });
     }
@@ -952,20 +1013,22 @@ export async function promptDefaultModel(
   }
 
   const catalogProgress = params.prompter.progress(t("wizard.model.loadingModels"));
-  let catalogSnapshot: ModelCatalogSnapshot;
+  let catalogContext: PickerModelCatalogContext;
   try {
     const providerScopedCatalog = browseCatalogOnDemand && preferredProvider;
-    catalogSnapshot = await loadPickerModelCatalog(cfg, {
+    catalogContext = await loadPickerModelCatalog(cfg, {
       preferredProvider: providerScopedCatalog ? preferredProvider : undefined,
       preferLiveProviderCatalog: Boolean(providerScopedCatalog),
       providerScoped: Boolean(providerScopedCatalog),
+      ...(params.agentId !== undefined ? { agentId: params.agentId } : {}),
       agentDir: pickerAgentDir,
-      ...(params.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
+      workspaceDir: pickerWorkspaceDir,
       ...(params.env !== undefined ? { env: params.env } : {}),
     });
   } finally {
     catalogProgress.stop();
   }
+  const catalogSnapshot = catalogContext.modelCatalog;
   const catalog = catalogSnapshot.entries;
   if (catalog.length === 0) {
     return promptManualModel({
@@ -981,9 +1044,11 @@ export async function promptDefaultModel(
   });
   const hasAuth = createProviderAuthChecker({
     cfg,
-    workspaceDir: params.workspaceDir,
+    workspaceDir: pickerWorkspaceDir,
     agentDir: pickerAgentDir,
+    ...(params.agentId !== undefined ? { agentId: params.agentId } : {}),
     env: params.env,
+    metadataSnapshot: catalogContext.metadataSnapshot,
   });
   const resolveModelRouteRuntime = createModelRouteRuntimeResolver({
     config: cfg,
@@ -995,7 +1060,7 @@ export async function promptDefaultModel(
     routeVariants: catalogSnapshot.routeVariants,
     defaultProvider: DEFAULT_PROVIDER,
     defaultModel: resolved.model,
-    ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+    workspaceDir: pickerWorkspaceDir,
     ...(ignoreAllowlist ? { view: "all" as const } : {}),
     hasAuth,
   });
@@ -1032,7 +1097,7 @@ export async function promptDefaultModel(
     ? createPreferredProviderMatcher({
         preferredProvider,
         cfg,
-        workspaceDir: params.workspaceDir,
+        workspaceDir: pickerWorkspaceDir,
         env: params.env,
       })
     : undefined;
@@ -1174,6 +1239,11 @@ export async function promptModelAllowlist(params: {
     ...(params.agentDir !== undefined ? { agentDir: params.agentDir } : {}),
     ...(params.env !== undefined ? { env: params.env } : {}),
   });
+  const pickerWorkspaceDir = resolvePickerWorkspaceDir({
+    cfg,
+    ...(params.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
+    ...(params.env !== undefined ? { env: params.env } : {}),
+  });
   const existingKeys = resolveConfiguredModelKeys(cfg);
   const configuredRaw = resolveConfiguredModelRaw(cfg);
   const allowedKeys = normalizeModelKeys(params.allowedKeys ?? []);
@@ -1216,12 +1286,15 @@ export async function promptModelAllowlist(params: {
     fallbackKeys.length > 0 ||
     (params.initialSelections?.length ?? 0) > 0 ||
     configuredRaw.length > 0;
-  const hasAuth = createProviderAuthChecker({
-    cfg,
-    workspaceDir: params.workspaceDir,
-    agentDir: pickerAgentDir,
-    env: params.env,
-  });
+  let hasAuth: ProviderModelAuthChecker | undefined;
+  const resolveAuthChecker = (metadataSnapshot: PluginMetadataSnapshot) =>
+    (hasAuth ??= createProviderAuthChecker({
+      cfg,
+      workspaceDir: pickerWorkspaceDir,
+      agentDir: pickerAgentDir,
+      env: params.env,
+      metadataSnapshot,
+    }));
   const resolveModelRouteRuntime = createModelRouteRuntimeResolver({
     config: cfg,
     env: params.env,
@@ -1230,7 +1303,7 @@ export async function promptModelAllowlist(params: {
     ? createPreferredProviderMatcher({
         preferredProvider,
         cfg,
-        workspaceDir: params.workspaceDir,
+        workspaceDir: pickerWorkspaceDir,
         env: params.env,
       })
     : undefined;
@@ -1246,6 +1319,13 @@ export async function promptModelAllowlist(params: {
           })
         : [];
   if (scopedFastKeys.length > 0) {
+    const scopedAuthChecker = resolveAuthChecker(
+      loadManifestMetadataSnapshot({
+        config: cfg,
+        workspaceDir: pickerWorkspaceDir,
+        env: params.env ?? process.env,
+      }),
+    );
     const isVisibleProvider = createModelPickerVisibleProviderPredicate({
       config: cfg,
       env: params.env,
@@ -1262,7 +1342,7 @@ export async function promptModelAllowlist(params: {
         options,
         seen,
         aliasIndex,
-        hasAuth,
+        hasAuth: scopedAuthChecker,
         isVisibleProvider,
         resolveModelRouteRuntime,
         fallbackHint:
@@ -1297,20 +1377,22 @@ export async function promptModelAllowlist(params: {
   }
 
   const allowlistProgress = params.prompter.progress(t("wizard.model.loadingModels"));
-  let catalogSnapshot: ModelCatalogSnapshot;
+  let catalogContext: PickerModelCatalogContext;
   try {
-    catalogSnapshot = await loadPickerModelCatalog(cfg, {
+    catalogContext = await loadPickerModelCatalog(cfg, {
       preferredProvider,
       preferLiveProviderCatalog: Boolean(preferredProvider),
       providerScoped: Boolean(preferredProvider && params.providerScopedCatalog),
       allowStaticFallbackCatalog: !params.providerScopedCatalog,
       agentDir: pickerAgentDir,
-      ...(params.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
+      workspaceDir: pickerWorkspaceDir,
       ...(params.env !== undefined ? { env: params.env } : {}),
     });
   } finally {
     allowlistProgress.stop();
   }
+  const catalogSnapshot = catalogContext.modelCatalog;
+  const catalogAuthChecker = resolveAuthChecker(catalogContext.metadataSnapshot);
   let catalog = catalogSnapshot.entries;
   let providerStaticCatalogRows:
     | ReturnType<typeof loadStaticManifestCatalogRowsForList>
@@ -1320,6 +1402,7 @@ export async function promptModelAllowlist(params: {
       ? loadStaticManifestCatalogRowsForList({
           cfg,
           providerFilter: preferredProvider,
+          metadataSnapshot: catalogContext.metadataSnapshot,
           ...(params.env !== undefined ? { env: params.env } : {}),
         })
       : []);
@@ -1368,9 +1451,9 @@ export async function promptModelAllowlist(params: {
     routeVariants: catalogSnapshot.routeVariants,
     defaultProvider: DEFAULT_PROVIDER,
     defaultModel: resolved.model,
-    ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+    workspaceDir: pickerWorkspaceDir,
     view: "all",
-    hasAuth,
+    hasAuth: catalogAuthChecker,
   });
   if (catalog.length === 0 && allowedKeys.length === 0) {
     const noCatalogInitialKeys =
@@ -1392,7 +1475,7 @@ export async function promptModelAllowlist(params: {
 
   const literalPrefixProviders = await resolveLiteralPrefixProviderIds({
     cfg,
-    workspaceDir: params.workspaceDir,
+    workspaceDir: pickerWorkspaceDir,
     env: params.env,
   });
   const isVisibleProvider = createModelPickerVisibleProviderPredicate({
@@ -1450,7 +1533,7 @@ export async function promptModelAllowlist(params: {
       options,
       seen,
       aliasIndex,
-      hasAuth,
+      hasAuth: catalogAuthChecker,
       literalPrefixProviders,
       isVisibleProvider,
       resolveModelRouteRuntime,

--- a/src/gateway/server-methods/models-list-result.plugin-runtime.test.ts
+++ b/src/gateway/server-methods/models-list-result.plugin-runtime.test.ts
@@ -28,6 +28,8 @@ function catalogEntry(id: string): ModelCatalogEntry {
 
 function preparedMetadataSnapshot() {
   return {
+    registrySource: "provided",
+    registryDiagnostics: [],
     index: {
       plugins: [
         {

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -32,8 +32,7 @@ import {
   resolveLogicalModelCatalogEntryState,
   resolveLogicalVisibleModelCatalog,
 } from "../../agents/model-catalog-visibility.js";
-import type { ModelCatalogSnapshot } from "../../agents/model-catalog.types.js";
-import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
+import type { ModelCatalogEntry, ModelCatalogSnapshot } from "../../agents/model-catalog.types.js";
 import { resolveCliRuntimeExecutionProvider } from "../../agents/model-runtime-aliases.js";
 import {
   createModelVisibilityPolicy,
@@ -52,6 +51,7 @@ import { getCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-m
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
 import { loadPluginRegistrySnapshotWithMetadata } from "../../plugins/plugin-registry.js";
 import { resolveManifestProviderAuthChoices } from "../../plugins/provider-auth-choices.js";
+import { resolveValidatedSyntheticAuthProviderRefState } from "../../plugins/synthetic-auth.runtime.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import type { GatewayAgentRuntime } from "../../shared/session-types.js";
 import type { GatewayRequestContext } from "./types.js";
@@ -130,9 +130,7 @@ function listEnabledSyntheticAuthProviderRefs(params: {
   workspaceDir: string;
 }): readonly string[] {
   if (params.metadataSnapshot) {
-    return params.metadataSnapshot.index.plugins
-      .filter((plugin) => plugin.enabled)
-      .flatMap((plugin) => plugin.syntheticAuthRefs ?? []);
+    return resolveValidatedSyntheticAuthProviderRefState(params.metadataSnapshot).refs;
   }
   const result = loadPluginRegistrySnapshotWithMetadata({
     config: params.cfg,

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -571,6 +571,7 @@ async function resolveProviderExecutionAuth(params: {
       preferredProfile: params.entry.preferredProfile,
       agentDir: params.agentDir,
       workspaceDir: params.workspaceDir,
+      modelId: params.entry.model,
       modelApi,
     });
     const apiKey = requireApiKey(auth, params.providerId);

--- a/src/media-understanding/runner.local-no-auth.test.ts
+++ b/src/media-understanding/runner.local-no-auth.test.ts
@@ -23,6 +23,9 @@ vi.mock("../plugins/capability-provider-runtime.js", async () => {
 
 const modelAuthTestControl = vi.hoisted(() => ({
   forceMissingProvider: false,
+  lastParams: undefined as
+    | Parameters<typeof import("../agents/model-auth.js").resolveApiKeyForProvider>[0]
+    | undefined,
   store: undefined as AuthProfileStore | undefined,
 }));
 
@@ -33,6 +36,7 @@ vi.mock("../agents/model-auth.js", async (importOriginal) => {
     resolveApiKeyForProvider: async (
       ...args: Parameters<typeof actual.resolveApiKeyForProvider>
     ) => {
+      modelAuthTestControl.lastParams = args[0];
       if (modelAuthTestControl.forceMissingProvider) {
         throw new actual.ProviderAuthError(
           "missing-provider-auth",
@@ -63,6 +67,7 @@ const AUTH_ENV = {
 
 beforeEach(() => {
   modelAuthTestControl.forceMissingProvider = false;
+  modelAuthTestControl.lastParams = undefined;
   modelAuthTestControl.store = undefined;
 });
 
@@ -191,6 +196,7 @@ describe("runCapability local no-auth audio providers", () => {
           expect(result.outputs[0]?.text).toBe(`ok:${CUSTOM_LOCAL_AUTH_MARKER}`);
           expect(transcribeAudio).toHaveBeenCalledTimes(1);
           expect(transcribeAudio.mock.calls[0]?.[0].apiKey).toBe(CUSTOM_LOCAL_AUTH_MARKER);
+          expect(modelAuthTestControl.lastParams?.modelId).toBe("whisper-local");
         });
       });
     });

--- a/src/plugins/provider-external-auth.types.ts
+++ b/src/plugins/provider-external-auth.types.ts
@@ -15,6 +15,7 @@ export type ProviderAuthOptionBag = {
 export type ProviderResolveSyntheticAuthContext = {
   config?: OpenClawConfig;
   provider: string;
+  modelId?: string;
   providerConfig?: ModelProviderConfig;
 };
 
@@ -23,6 +24,8 @@ export type ProviderSyntheticAuthResult = {
   apiKey: string;
   source: string;
   mode: Exclude<ModelProviderAuthMode, "aws-sdk">;
+  /** Allows this provider-owned credential in a prepared attempt that disables profile fallback. */
+  allowPreparedDirect?: true;
   expiresAt?: number;
 };
 

--- a/src/plugins/provider-plugin.types.ts
+++ b/src/plugins/provider-plugin.types.ts
@@ -613,6 +613,9 @@ export type ProviderPlugin = {
    * Use this when the provider can operate without a real secret for certain
    * configured local/self-hosted cases and wants auth resolution to treat that
    * config as available.
+   *
+   * Set `allowPreparedDirect` only when this exact returned credential may be
+   * reused after the planner disables profile fallback for a direct attempt.
    */
   resolveSyntheticAuth?: (
     ctx: ProviderResolveSyntheticAuthContext,

--- a/src/plugins/provider-policy-surface.ts
+++ b/src/plugins/provider-policy-surface.ts
@@ -12,6 +12,10 @@ import type {
   ProviderNormalizeConfigContext,
   ProviderResolveConfigApiKeyContext,
 } from "./provider-config-context.types.js";
+import type {
+  ProviderResolveSyntheticAuthContext,
+  ProviderSyntheticAuthResult,
+} from "./provider-external-auth.types.js";
 import type { ProviderRuntimeModel } from "./provider-runtime-model.types.js";
 import type {
   ProviderDefaultThinkingPolicyContext,
@@ -40,6 +44,9 @@ export type ProviderPolicySurface = {
     ctx: ProviderApplyConfigDefaultsContext,
   ) => OpenClawConfig | null | undefined;
   resolveConfigApiKey?: (ctx: ProviderResolveConfigApiKeyContext) => string | null | undefined;
+  resolveSyntheticAuth?: (
+    ctx: ProviderResolveSyntheticAuthContext,
+  ) => ProviderSyntheticAuthResult | null | undefined;
   resolveThinkingProfile?: (
     ctx: ProviderDefaultThinkingPolicyContext,
   ) => ProviderThinkingProfile | null | undefined;
@@ -68,6 +75,7 @@ const PROVIDER_POLICY_HOOK_KEYS = [
   "normalizeConfig",
   "applyConfigDefaults",
   "resolveConfigApiKey",
+  "resolveSyntheticAuth",
   "resolveThinkingProfile",
   "resolveModelRoutes",
   "normalizeModelCatalogId",

--- a/src/plugins/provider-public-artifacts.test.ts
+++ b/src/plugins/provider-public-artifacts.test.ts
@@ -21,6 +21,11 @@ function writeExternalPolicyFixture(): string {
       '    ? { levels: [{ id: "off" }, { id: "high" }, { id: "max" }], defaultLevel: "off" }',
       '    : { levels: [{ id: "off" }, { id: "low", label: "on" }], defaultLevel: "off" };',
       "}",
+      "export function resolveSyntheticAuth({ modelId }) {",
+      '  return modelId === "free"',
+      '    ? { apiKey: "public", source: "fixture public auth", mode: "api-key", allowPreparedDirect: true }',
+      "    : undefined;",
+      "}",
       "export function projectConfiguredModelRow() { return null; }",
       "",
     ].join("\n"),
@@ -224,6 +229,17 @@ describe("provider public artifacts", () => {
           ?.resolveThinkingProfile?.({ provider: "fixture-provider", modelId: "legacy" })
           ?.levels.map((level) => level.label),
       ).toEqual([undefined, "on"]);
+      expect(
+        surface?.resolveSyntheticAuth?.({
+          provider: "fixture-provider",
+          modelId: "free",
+        }),
+      ).toEqual({
+        apiKey: "public",
+        source: "fixture public auth",
+        mode: "api-key",
+        allowPreparedDirect: true,
+      });
       expect(surface).not.toHaveProperty("projectConfiguredModelRow");
     } finally {
       restoreBundledPluginEnv();

--- a/src/plugins/synthetic-auth.runtime.test.ts
+++ b/src/plugins/synthetic-auth.runtime.test.ts
@@ -46,6 +46,7 @@ vi.mock("./manifest-registry-installed.js", () => ({
 }));
 
 import {
+  hasRuntimeSyntheticAuthCandidateRef,
   resolveRuntimeSyntheticAuthProviderRefState,
   resolveRuntimeSyntheticAuthProviderRefs,
 } from "./synthetic-auth.runtime.js";
@@ -131,6 +132,8 @@ describe("synthetic auth runtime refs", () => {
       refs: [],
       complete: false,
     });
+    expect(hasRuntimeSyntheticAuthCandidateRef({ providerRefs: ["remote-provider"] })).toBe(true);
+    expect(hasRuntimeSyntheticAuthCandidateRef({ providerRefs: ["unknown"] })).toBe(false);
   });
 
   it("does not treat a provided index with registry diagnostics as validated synthetic auth", () => {

--- a/src/plugins/synthetic-auth.runtime.test.ts
+++ b/src/plugins/synthetic-auth.runtime.test.ts
@@ -47,6 +47,7 @@ vi.mock("./manifest-registry-installed.js", () => ({
 
 import {
   hasRuntimeSyntheticAuthCandidateRef,
+  resolveValidatedSyntheticAuthProviderRefState,
   resolveRuntimeSyntheticAuthProviderRefState,
   resolveRuntimeSyntheticAuthProviderRefs,
 } from "./synthetic-auth.runtime.js";
@@ -64,6 +65,34 @@ describe("synthetic auth runtime refs", () => {
       diagnostics: [],
     } satisfies ExternalAuthManifestRegistryResult);
   });
+
+  it.each([
+    { source: "persisted", diagnostics: [], expected: ["enabled-provider"], complete: true },
+    { source: "provided", diagnostics: [], expected: ["enabled-provider"], complete: true },
+    { source: "derived", diagnostics: [], expected: [], complete: false },
+    {
+      source: "persisted",
+      diagnostics: [{ code: "persisted-registry-missing" }],
+      expected: [],
+      complete: false,
+    },
+  ] as const)(
+    "validates $source snapshot refs before use",
+    ({ source, diagnostics, expected, complete }) => {
+      expect(
+        resolveValidatedSyntheticAuthProviderRefState({
+          registrySource: source,
+          registryDiagnostics: diagnostics,
+          index: {
+            plugins: [
+              { enabled: true, syntheticAuthRefs: ["enabled-provider"] },
+              { enabled: false, syntheticAuthRefs: ["disabled-provider"] },
+            ],
+          },
+        } as never),
+      ).toEqual({ refs: expected, complete });
+    },
+  );
 
   it("uses persisted registry synthetic auth refs before the runtime registry exists", () => {
     pluginRegistryMocks.loadPluginRegistrySnapshotWithMetadata.mockReturnValue({

--- a/src/plugins/synthetic-auth.runtime.ts
+++ b/src/plugins/synthetic-auth.runtime.ts
@@ -1,5 +1,6 @@
 /** Resolves synthetic and external auth provider refs from active runtime state or persisted manifests. */
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.types.js";
 import { loadPluginRegistrySnapshotWithMetadata } from "./plugin-registry.js";
 import type { LoadPluginRegistryParams, PluginRegistrySnapshot } from "./plugin-registry.js";
 import { getPluginRegistryState } from "./runtime-state.js";
@@ -17,6 +18,26 @@ function uniqueProviderRefs(values: readonly string[]): string[] {
     next.push(trimmed);
   }
   return next;
+}
+
+/** Returns synthetic-auth refs only when the metadata registry is authoritative. */
+export function resolveValidatedSyntheticAuthProviderRefState(
+  snapshot: Pick<PluginMetadataSnapshot, "index" | "registryDiagnostics" | "registrySource">,
+): { refs: string[]; complete: boolean } {
+  const complete =
+    snapshot.registryDiagnostics.length === 0 &&
+    (snapshot.registrySource === "persisted" || snapshot.registrySource === "provided");
+  if (!complete) {
+    return { refs: [], complete: false };
+  }
+  return {
+    refs: uniqueProviderRefs(
+      snapshot.index.plugins
+        .filter((plugin) => plugin.enabled)
+        .flatMap((plugin) => plugin.syntheticAuthRefs ?? []),
+    ),
+    complete: true,
+  };
 }
 
 function resolveManifestSyntheticAuthProviderRefState(

--- a/src/plugins/synthetic-auth.runtime.ts
+++ b/src/plugins/synthetic-auth.runtime.ts
@@ -37,6 +37,32 @@ function resolveManifestSyntheticAuthProviderRefState(
   };
 }
 
+/** Lists positive synthetic-auth candidates without treating derived absence as authoritative. */
+function resolveRuntimeSyntheticAuthCandidateRefs(
+  params: SyntheticAuthProviderRefParams = {},
+): string[] {
+  const registry = getPluginRegistryState()?.activeRegistry;
+  const runtimeRefs = registry ? resolveRuntimeSyntheticAuthProviderRefState(params).refs : [];
+  if (params.index && (params.registryDiagnostics?.length ?? 0) > 0) {
+    return runtimeRefs;
+  }
+  const result = loadPluginRegistrySnapshotWithMetadata(params);
+  return uniqueProviderRefs([
+    ...runtimeRefs,
+    ...result.snapshot.plugins.flatMap((plugin) => plugin.syntheticAuthRefs ?? []),
+  ]);
+}
+
+/** Returns whether runtime or manifest metadata names one requested synthetic-auth ref. */
+export function hasRuntimeSyntheticAuthCandidateRef(
+  params: SyntheticAuthProviderRefParams & { providerRefs: readonly string[] },
+): boolean {
+  const candidates = new Set(
+    resolveRuntimeSyntheticAuthCandidateRefs(params).map((ref) => normalizeProviderId(ref)),
+  );
+  return params.providerRefs.some((ref) => candidates.has(normalizeProviderId(ref)));
+}
+
 type SyntheticAuthProviderRefParams = LoadPluginRegistryParams & {
   index?: PluginRegistrySnapshot;
   registryDiagnostics?: readonly unknown[];

--- a/src/wizard/setup.finalize.test.ts
+++ b/src/wizard/setup.finalize.test.ts
@@ -65,6 +65,7 @@ const resolveDefaultModelCatalogFacts = vi.hoisted(() =>
 const loadModelCatalog = vi.hoisted(() =>
   vi.fn<(_params?: unknown) => Promise<unknown[]>>(async () => []),
 );
+const preparedMetadataSnapshot = vi.hoisted(() => ({ manifestRegistry: { plugins: [] } }));
 const buildGatewayInstallPlan = vi.hoisted(() =>
   vi.fn(async (_params?: { warn?: (message: string, title?: string) => void }) => ({
     programArguments: [],
@@ -264,9 +265,12 @@ vi.mock("../commands/auth-choice.js", () => ({
 }));
 
 vi.mock("../agents/prepared-model-catalog.js", () => ({
-  loadPreparedModelCatalogSnapshot: async (...args: unknown[]) => {
+  loadPreparedModelCatalogOwnerSnapshot: async (...args: unknown[]) => {
     const entries = await loadModelCatalog(...args);
-    return { entries, routeVariants: entries };
+    return {
+      modelCatalog: { entries, routeVariants: entries },
+      metadataSnapshot: preparedMetadataSnapshot,
+    };
   },
 }));
 
@@ -898,6 +902,7 @@ describe("finalizeSetupWizard", () => {
     });
     expect(resolveDefaultModelAuthStatus).toHaveBeenCalledWith(nextConfig, {
       agentDir: "/tmp/custom-agent",
+      metadataSnapshot: preparedMetadataSnapshot,
       observedRoutes,
     });
   });

--- a/src/wizard/setup.finalize.test.ts
+++ b/src/wizard/setup.finalize.test.ts
@@ -937,7 +937,10 @@ describe("finalizeSetupWizard", () => {
           list: [{ id: "main", agentDir: "/tmp/custom-agent" }],
         },
       }),
-      { agentDir: "/tmp/custom-agent" },
+      {
+        agentDir: "/tmp/custom-agent",
+        metadataSnapshot: preparedMetadataSnapshot,
+      },
     );
     expectNoteContains(
       prompter,

--- a/src/wizard/setup.finalize.ts
+++ b/src/wizard/setup.finalize.ts
@@ -684,20 +684,22 @@ export async function finalizeSetupWizard(
     // route facts must not turn the onboarding greeting into a guaranteed failure.
     const [
       { resolveDefaultModelAuthStatus, resolveDefaultModelCatalogFacts },
-      { loadPreparedModelCatalogSnapshot },
+      { loadPreparedModelCatalogOwnerSnapshot },
     ] = await Promise.all([
       import("../commands/auth-choice.js"),
       import("../agents/prepared-model-catalog.js"),
     ]);
-    const modelCatalog = await loadPreparedModelCatalogSnapshot({
+    const preparedModelCatalogOwner = await loadPreparedModelCatalogOwnerSnapshot({
       config: nextConfig,
       readOnly: true,
     });
+    const modelCatalog = preparedModelCatalogOwner.modelCatalog;
     const modelCatalogFacts = resolveDefaultModelCatalogFacts(nextConfig, modelCatalog.entries, {
       routeVariants: modelCatalog.routeVariants,
     });
     const modelAuthStatus = resolveDefaultModelAuthStatus(nextConfig, {
       agentDir,
+      metadataSnapshot: preparedModelCatalogOwner.metadataSnapshot,
       ...(modelCatalogFacts.observedRoutes
         ? { observedRoutes: modelCatalogFacts.observedRoutes }
         : {}),


### PR DESCRIPTION
## What Problem This Solves

OpenCode Zen's released client supports a credentialless path for public models: when no account credential is configured, it sends the non-secret API key `public` and disables models with any positive input-cost tier. OpenClaw instead rejected those eligible models during auth preflight with `No API key found for provider "opencode"`.

Authoritative upstream contract:

- OpenCode source at commit [`b8142c7`](https://github.com/anomalyco/opencode/blob/b8142c7aa8f88222873fb79d636e312e28037c2d/packages/core/src/plugin/provider/opencode.ts#L165-L176) assigns `apiKey = "public"` without credentials and disables models when any input-cost tier is positive.
- OpenCode's tests cover [paid-model rejection](https://github.com/anomalyco/opencode/blob/b8142c7aa8f88222873fb79d636e312e28037c2d/packages/core/test/plugin/provider-opencode.test.ts#L200-L224), [free-model eligibility](https://github.com/anomalyco/opencode/blob/b8142c7aa8f88222873fb79d636e312e28037c2d/packages/core/test/plugin/provider-opencode.test.ts#L226-L250), and output-only-cost eligibility.

## Why This Change Was Made

The installed official OpenCode plugin owns the Zen-specific eligibility policy and returns `public` only for known models whose base and tiered input costs are all zero. Core receives only generic, optional model-aware synthetic-auth seams. Model listing uses the trusted official plugin's lightweight policy artifact, while execution uses the provider runtime hook; both reuse the same OpenCode eligibility helper.

The availability repair now carries the lifecycle-owned plugin metadata snapshot and its validated synthetic-auth refs through every affected consumer: onboarding/default-model checks, setup finalize, default and allowlist pickers, chat `/models` browse, CLI models list/status, and Gateway model listing. Catalog rows, provider policy artifacts, and auth evaluation therefore use the same workspace/agent generation instead of rediscovering or inferring provider-level auth.

The refresh preserves current `main` architecture: the split model-auth modules, snapshot-first model-list flow, external official plugin trust boundary, cold/static browse paths, and lazy provider loading remain intact. Paid or unknown models, configured paid overrides, custom/non-Zen endpoints, derived/diagnostic metadata, and explicit empty synthetic-ref sets remain credential-gated. No persisted schema, serialized data, config migration, or default setting changes are introduced.

## User Impact

Users with the official `@openclaw/opencode-provider` plugin installed can run and select OpenCode Zen models that the OpenCode client classifies as public without configuring a personal key. The same models no longer appear missing or unavailable during onboarding, setup finalize, picker, or model browse checks. Paid, unknown, and non-Zen models still require normal credentials.

Provider-owner decision still required: OpenCode's public documentation continues to direct users to obtain an API key, so maintainers must explicitly decide whether OpenClaw supports this released-but-not-publicly-documented credentialless Zen boundary.

## Evidence

- Current rebase and final-tree review:
  - Local head is `68f9def872`, rebased without conflicts onto OpenClaw `main` at `a8bcbf658143b50690289e8226dad468cb329fe0`.
  - The branch is three linear commits: the original product fix, a test-first availability-consumer regression commit, and the lifecycle metadata propagation fix.
  - Relative to that `main`: 38 files, `+1180/-205`; production `+487/-127`, tests `+693/-78`.
  - `git diff --check` passed, no conflict markers remain, the worktree is clean, and the canonical PR template matches the bundled workflow snapshot.
  - The optional Codex review transport returned HTTP 403 before producing a verdict, so it is not counted as review evidence.
- Current-head execution boundary:
  - This is contributor/fork source, so repository policy prohibits running its scripts, tests, checks, wrappers, config, package hooks, or dependency commands locally.
  - Exact-head PR CI run [`30910999588`](https://github.com/openclaw/openclaw/actions/runs/30910999588) reached a terminal failure with all changed-scope build, lint, type, contract, security, QA-smoke, and Node shards otherwise green.
  - The two failed jobs are unrelated baseline/flaky timeouts in untouched TUI/Doctor tests: `checks-node-compact-large-3` timed out in `src/commands/doctor/shared/open-policy-allowfrom.test.ts` (593 passed, 1 failed, 1 skipped), and `build-artifacts` timed out in `src/tui/tui-pty-local.e2e.test.ts` (73 passed, 1 failed). Gateway-watch passed.
  - The repository API refused rerunning those jobs with the available fork permissions (`403 Must have admin rights to Repository`), so no code change or empty commit was used to mask the unrelated failures.
  - The preceding `c34ed0dddc` CI exposed one stale onboarding assertion that omitted the newly authoritative `metadataSnapshot`; the assertion now covers the lifecycle-owned snapshot without changing product logic.
  - The subsequent `80ec20929a` CI made that shard green and exposed only max-lines lint limits in two touched files; the new mock fixture is leaner and duplicate imports are consolidated without adding suppressions or changing behavior.
  - The `f977dab0de` CI cleared all static lint rules and exposed canonical formatting drift after `main` advanced; the branch is now rebased again and the formatter-owned import/specifier layout is aligned.
  - The `7b85d1f905` CI narrowed the remaining format failure to `src/commands/model-picker.test.ts`; the final head applies the exact `oxfmt 0.60.0` output for that file.
- Resolved exact-head ClawSweeper P1 from `863ae948a03f`:
  - lifecycle metadata and validated refs are now passed to the shared availability resolver;
  - prepared catalog owners retain the matching workspace and agent identity;
  - explicit `syntheticAuthProviderRefs: []` remains authoritative and cannot be replaced by runtime discovery;
  - regression coverage includes public/paid/unknown default checks, default and allowlist pickers, finalize, chat `/models`, authoritative/derived/diagnostic metadata, and explicit empty-ref controls.
  - Current exact-head ClawSweeper review of `68f9def872` found no code-level actionable defect; it records the remaining provider-owner contract decision and exact-head third-party live-proof boundary.
- Historical exact-head CI on `863ae948a03fae3a4a16ff4ee2497841d476ec48` passed all required checks: 81 passed, 36 skipped, 0 failed, including `openclaw/ci-gate` and Real behavior proof: https://github.com/openclaw/openclaw/actions/runs/30896529893
- Earlier focused proof on product head `009585134c83015ffb7e818770f4dcd13acc7ed5`:
  - focused core, command, Gateway, and plugin tests passed;
  - `pnpm test:extension opencode` passed;
  - plugin contracts passed;
  - formatter, focused lint, conflict-marker check, and `git diff --check` passed.
- Earlier third-party live proof on product commit `089d9cc14864fde49df2fe10988040aa79db8360`, using Node 24.15.0, isolated state, and both OpenCode key variables unset:
  - a real request to `https://opencode.ai/zen/v1/chat/completions` returned HTTP 200 with visible output, one OpenCode attempt, no fallback, and exit 0;
  - the paid `opencode/gpt-5.5` control failed before transport with `ProviderAuthError`, as expected.
- OpenCode eligibility controls remain provider-owned and catalog-gated:
  - known zero-input-cost base/tier models may use `public` only on the Zen endpoint;
  - paid, unknown, configured paid override, and custom endpoint controls remain rejected without credentials;
  - unrelated providers do not trigger broad external policy loading.
