### PR TITLE
fix(test): stop Knip SIGTERM cleanup check from flaking

### DIFF
--- a/test/scripts/check-deadcode-unused-files.test.ts
+++ b/test/scripts/check-deadcode-unused-files.test.ts
@@ -55,6 +55,22 @@ async function waitForFile(filePath: string, timeoutMs: number): Promise<void> {
   throw new Error(`timeout waiting for ${filePath}`);
 }
 
+// Pid files are written with plain writeFileSync, so an existence poll can
+// observe the open-truncate 0-byte window and parse NaN. Wait for a real pid.
+async function waitForPidFile(filePath: string, timeoutMs: number): Promise<number> {
+  const deadlineAt = Date.now() + timeoutMs;
+  while (Date.now() < deadlineAt) {
+    if (existsSync(filePath)) {
+      const pid = Number.parseInt(readFileSync(filePath, "utf8"), 10);
+      if (Number.isInteger(pid) && pid > 0) {
+        return pid;
+      }
+    }
+    await sleep(5);
+  }
+  throw new Error(`timeout waiting for pid in ${filePath}`);
+}
+
 async function waitForDead(pid: number, timeoutMs: number): Promise<void> {
   const deadlineAt = Date.now() + timeoutMs;
   while (Date.now() < deadlineAt) {
@@ -353,8 +369,7 @@ Delete the files or model their real entrypoints in Knip.`,
           writeStatus: () => {},
         });
 
-        await waitForFile(childPidPath, 2_000);
-        childPid = Number.parseInt(readFileSync(childPidPath, "utf8"), 10);
+        childPid = await waitForPidFile(childPidPath, 2_000);
         expect(isProcessAlive(childPid)).toBe(true);
 
         await expect(resultPromise).resolves.toMatchObject({
@@ -412,8 +427,7 @@ Delete the files or model their real entrypoints in Knip.`,
         });
 
         await waitForFile(readyPath, 2_000);
-        await waitForFile(childPidPath, 2_000);
-        childPid = Number.parseInt(readFileSync(childPidPath, "utf8"), 10);
+        childPid = await waitForPidFile(childPidPath, 2_000);
         expect(isProcessAlive(childPid)).toBe(true);
 
         runner.kill("SIGTERM");


### PR DESCRIPTION
## What Problem This Solves

Resolves an intermittent tooling failure where the Knip SIGTERM cleanup test could report its descendant as dead before the test sent any signal. The failure appeared in CI run 29662058666 on PR #110969, whose change was limited to the channel setup wizard.

## Why This Change Was Made

The test previously treated PID-file existence as readiness. A synchronous PID write can expose the opened, still-empty file to a concurrent reader; parsing that empty content yields an invalid PID and makes the pre-signal liveness check fail. Both PID-file consumers now wait for a positive parsed PID, while the assertions that the descendant starts alive and dies after cleanup remain unchanged.

This matches the established fix used by sibling process-cleanup tests for the same PID publication race class.

## User Impact

No user-visible product change. Unrelated pull requests should no longer be failed by this low-probability tooling race.

## Evidence

- Failure: https://github.com/openclaw/openclaw/actions/runs/29662058666/job/88126390568
- Before the patch, a bounded Testbox loop ran the exact focused command 100 times without reproducing the low-probability race.
- After the patch, the same bounded loop passed 100/100 iterations: `node scripts/run-vitest.mjs test/scripts/check-deadcode-unused-files.test.ts`.
- Focused file: 16/16 tests passed on Blacksmith Testbox `tbx_01kxvmymjv4cdrmq03459dqse8`.
- Targeted Oxfmt check passed.
- Structured autoreview: clean, no accepted/actionable findings.
- `git diff --check`: passed.
- The broader changed gate was attempted on `tbx_01kxvnq9hh53pr0tqrw7r9t27n`, but Testbox sync timed out before any check executed; hosted PR CI provides the merge-tree gate.

AI-assisted: yes. I reviewed the exact CI log, traced the process tree and sibling fixes, and understand the change.
