### PR TITLE
fix(ui): openknot/dash dark theme AA contrast for text-bearing fills

### DIFF
--- a/ui/src/styles/approval.css
+++ b/ui/src/styles/approval.css
@@ -281,6 +281,10 @@
   background: var(--primary-hover);
 }
 
+:root[data-theme="openknot"] .approval-page__action--allow-once:hover:not(:disabled) {
+  background: var(--primary-hover);
+}
+
 .approval-page__action--deny {
   border-color: color-mix(in srgb, var(--danger) 52%, var(--border));
   color: var(--danger);

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -259,7 +259,10 @@
    * WCAG 2.1 AA audit (bg = #080808, relative luminance ≈ 0.003):
    *   --accent #e5243b  L ≈ 0.118  contrast ≈ 5.8:1  AA text ✓
    *   --accent-hover #f03e52  L ≈ 0.163  contrast ≈ 7.2:1  ✓
-   *   --primary-foreground #fafafa on #e5243b button: 4.6:1 AA ✓
+   *   --primary-foreground #fafafa on #d92a3f button: 4.62:1 AA ✓
+   *   --primary-foreground #fafafa on #c22537 hover: 5.57:1 AA ✓
+   *   --destructive-foreground #fafafa on #d32f2f button: 4.77:1 AA ✓
+   *   --destructive-foreground #fafafa on #bc2a2a hover: 5.74:1 AA ✓
    *   focus-ring at 70% opacity: ≈ 3.4:1 against bg ✓ (non-text 3:1 required)
    */
   --ring: #e5243b;
@@ -268,8 +271,13 @@
   --accent-muted: #e5243b;
   --accent-subtle: rgba(229, 36, 59, 0.12);
   --accent-glow: rgba(229, 36, 59, 0.24);
-  --primary: #e5243b;
+  --primary: #d92a3f;
+  --primary-hover: #c22537;
   --primary-foreground: #fafafa;
+
+  /* Deepen only the text-bearing destructive fill; keep danger accents vivid. */
+  --destructive: #d32f2f;
+  --destructive-hover: #bc2a2a;
 
   /* Focus — crimson ring */
   --focus: rgba(229, 36, 59, 0.2);
@@ -396,6 +404,9 @@
    *   --accent #b47840  L ≈ 0.235  contrast ≈ 5.0:1  AA text ✓  (floor: #a8703c → 4.4:1, fails)
    *   --accent-hover #c8885a  L ≈ 0.306  contrast ≈ 6.3:1  ✓
    *   --primary-foreground #1a1210 on #b47840 button: 5.0:1 AA ✓
+   *   --primary-foreground #1a1210 on #c8885a hover: 6.26:1 AA ✓
+   *   --destructive-foreground #fafafa on #d32f2f button: 4.77:1 AA ✓
+   *   --destructive-foreground #fafafa on #bc2a2a hover: 5.74:1 AA ✓
    *   focus-ring at 80% opacity: ≈ 3.5:1 against bg ✓ (non-text 3:1 required)
    */
   --ring: #b47840;
@@ -406,6 +417,10 @@
   --accent-glow: rgba(180, 120, 64, 0.24);
   --primary: #b47840;
   --primary-foreground: #1a1210;
+
+  /* Deepen only the text-bearing destructive fill; keep danger accents vivid. */
+  --destructive: #d32f2f;
+  --destructive-hover: #bc2a2a;
 
   /* Focus — match chocolate accent, slightly higher ring opacity for dark bg visibility */
   --focus: rgba(180, 120, 64, 0.2);

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -718,11 +718,22 @@ details.msg-meta:not([open]) .msg-meta__details {
   color: var(--destructive-foreground);
 }
 
+:root[data-theme="openknot"] .chat-delete-confirm__yes,
+:root[data-theme="dash"] .chat-delete-confirm__yes {
+  background: var(--destructive);
+  color: var(--destructive-foreground);
+}
+
 .chat-delete-confirm__yes:hover {
   background: #dc2626;
 }
 
 :root[data-theme="dark"] .chat-delete-confirm__yes:hover {
+  background: var(--destructive-hover);
+}
+
+:root[data-theme="openknot"] .chat-delete-confirm__yes:hover,
+:root[data-theme="dash"] .chat-delete-confirm__yes:hover {
   background: var(--destructive-hover);
 }
 

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -2255,6 +2255,10 @@ openclaw-chat-page {
   background: var(--primary-hover);
 }
 
+:root[data-theme="openknot"] .chat-send-btn:hover:not(:disabled) {
+  background: var(--primary-hover);
+}
+
 /* Outline (not box-shadow) so the hover rules' higher-specificity box-shadow
    overrides can never swallow the keyboard focus indicator. */
 .chat-send-btn:focus-visible {

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -728,6 +728,10 @@
   background: var(--primary-hover);
 }
 
+:root[data-theme="openknot"] .btn.primary:hover {
+  background: var(--primary-hover);
+}
+
 /* Keyboard shortcut badge (shadcn style) */
 .btn-kbd {
   display: inline-flex;

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -44,7 +44,7 @@
 
 .config-mode-toggle__btn.active {
   background: var(--primary);
-  color: white;
+  color: var(--primary-foreground);
   box-shadow: 0 1px 3px var(--accent-subtle);
 }
 

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -416,7 +416,7 @@ wa-popover.new-session-page__select--folder::part(body) {
   border: 1px solid transparent;
   border-radius: var(--radius-md);
   background: var(--primary);
-  color: var(--accent-contrast, #fff);
+  color: var(--primary-foreground);
   font-size: 13px;
   font-weight: 600;
   cursor: pointer;

--- a/ui/src/styles/skill-workshop.css
+++ b/ui/src/styles/skill-workshop.css
@@ -805,7 +805,7 @@
 
 .sw-btn--primary {
   background: var(--primary);
-  color: white;
+  color: var(--primary-foreground);
   border-color: var(--accent);
 }
 
@@ -818,6 +818,10 @@
 }
 
 :root[data-theme="dark"] .sw-btn--primary:hover:not(:disabled) {
+  background: var(--primary-hover);
+}
+
+:root[data-theme="openknot"] .sw-btn--primary:hover:not(:disabled) {
   background: var(--primary-hover);
 }
 
@@ -1503,7 +1507,7 @@
 .sw-today__big--primary {
   background: var(--primary);
   border-color: var(--accent);
-  color: white;
+  color: var(--primary-foreground);
 }
 
 .sw-today__big--primary:hover:not([disabled]) {
@@ -1511,6 +1515,11 @@
 }
 
 :root[data-theme="dark"] .sw-today__big--primary:hover:not([disabled]) {
+  background: var(--primary-hover);
+  filter: none;
+}
+
+:root[data-theme="openknot"] .sw-today__big--primary:hover:not([disabled]) {
   background: var(--primary-hover);
   filter: none;
 }


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #110957, which fixed the claw dark family and recorded audit-only failures for the other dark families: openknot primary `#e5243b`/`#fafafa` at 4.33:1 (hover 3.65:1), openknot/dash inherited destructive `#ef4444`/`#fafafa` at 3.61:1, and dash controls that bypass the configured dark foreground with literal white at 3.68:1.

## Why This Change Was Made

Same computed-minimal-darkening recipe as #110957, scoped to the openknot and dash dark blocks:

| Pair | Before | After |
|---|---|---|
| Openknot primary | `#e5243b` (4.33:1) | `#d92a3f` (4.62:1), hue 352.9°→352.8° |
| Openknot primary hover | `#f03e52` (3.65:1) | `#c22537` (5.57:1, darker like the light-theme pattern) |
| Openknot/dash destructive | `#ef4444` (3.61:1) | `#d32f2f` / hover `#bc2a2a` (4.77 / 5.74:1, matching claw) |
| Dash primary | unchanged `#b47840` | controls bypassing the configured foreground now use `--primary-foreground` (5.01:1) |

Accent/ring/glow rgba derivatives untouched (decorative, not text-bearing). Claw, light themes, and widget baked palettes untouched. Per-family AA audit comments added mirroring claw's.

## User Impact

Openknot and dash dark primary/destructive buttons reach WCAG AA; each family keeps its identity hue.

## Evidence

- WCAG contrast script before/after table above (relative-luminance computed, 1% lightness steps).
- `git diff --check` clean; no Vitest surface exists for these token/selector changes.
- Autoreview (Codex `gpt-5.6-sol`) clean, no actionable findings.

Release-note context: `fix: openknot and dash dark themes reach WCAG AA on primary and destructive buttons`.
