### PR TITLE
fix(auth-profiles): bound auth-profile JSON reads with size cap

### DIFF
--- a/src/agents/auth-profiles/source-check.test.ts
+++ b/src/agents/auth-profiles/source-check.test.ts
@@ -1,4 +1,5 @@
-import fs from "node:fs/promises";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -10,13 +11,13 @@ describe("hasAuthProfileStoreSourceForProvider", () => {
   });
 
   async function withAgentStore(profiles: Record<string, unknown>) {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-source-"));
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-source-"));
     const stateDir = path.join(root, "state");
     const agentDir = path.join(root, "agent");
-    await fs.mkdir(agentDir, { recursive: true });
-    await fs.mkdir(stateDir, { recursive: true });
+    await fsp.mkdir(agentDir, { recursive: true });
+    await fsp.mkdir(stateDir, { recursive: true });
     vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
-    await fs.writeFile(
+    await fsp.writeFile(
       path.join(agentDir, "auth-profiles.json"),
       JSON.stringify({ version: 1, profiles }),
     );
@@ -24,13 +25,13 @@ describe("hasAuthProfileStoreSourceForProvider", () => {
   }
 
   async function withLegacyAuthStore(profiles: Record<string, unknown>) {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-source-"));
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-source-"));
     const stateDir = path.join(root, "state");
     const agentDir = path.join(root, "agent");
-    await fs.mkdir(agentDir, { recursive: true });
-    await fs.mkdir(stateDir, { recursive: true });
+    await fsp.mkdir(agentDir, { recursive: true });
+    await fsp.mkdir(stateDir, { recursive: true });
     vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
-    await fs.writeFile(path.join(agentDir, "auth.json"), JSON.stringify(profiles));
+    await fsp.writeFile(path.join(agentDir, "auth.json"), JSON.stringify(profiles));
     return { agentDir };
   }
 
@@ -119,6 +120,44 @@ describe("hasAuthProfileStoreSourceForProvider", () => {
         expires: Date.now() - 1000,
       },
     });
+
+    expect(hasAuthProfileStoreSourceForProvider("openai", agentDir)).toBe(false);
+  });
+
+  it("treats oversized auth-profiles.json as having no credentials", async () => {
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-source-"));
+    const stateDir = path.join(root, "state");
+    const agentDir = path.join(root, "agent");
+    await fsp.mkdir(agentDir, { recursive: true });
+    await fsp.mkdir(stateDir, { recursive: true });
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+
+    // Write an auth-profiles.json exceeding the 10 MiB internal limit.
+    const largeContent = Buffer.alloc(11 * 1024 * 1024);
+    // Inject valid JSON at the start so the file is at least parseable if read.
+    const header = JSON.stringify({
+      version: 1,
+      profiles: { "openai:default": { type: "api_key", provider: "openai", key: "sk-test" } },
+    });
+    largeContent.set(Buffer.from(header, "utf8"), 0);
+    await fsp.writeFile(path.join(agentDir, "auth-profiles.json"), largeContent);
+
+    // The oversized file is silently skipped — no credentials detected.
+    expect(hasAuthProfileStoreSourceForProvider("openai", agentDir)).toBe(false);
+  });
+
+  it("treats oversized legacy auth.json as having no credentials", async () => {
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-source-"));
+    const stateDir = path.join(root, "state");
+    const agentDir = path.join(root, "agent");
+    await fsp.mkdir(agentDir, { recursive: true });
+    await fsp.mkdir(stateDir, { recursive: true });
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+
+    const largeContent = Buffer.alloc(11 * 1024 * 1024);
+    const header = JSON.stringify({ openai: { mode: "apiKey", apiKey: "sk-test" } });
+    largeContent.set(Buffer.from(header, "utf8"), 0);
+    await fsp.writeFile(path.join(agentDir, "auth.json"), largeContent);
 
     expect(hasAuthProfileStoreSourceForProvider("openai", agentDir)).toBe(false);
   });

--- a/src/agents/auth-profiles/source-check.test.ts
+++ b/src/agents/auth-profiles/source-check.test.ts
@@ -1,4 +1,3 @@
-import fs from "node:fs";
 import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -10,28 +9,44 @@ describe("hasAuthProfileStoreSourceForProvider", () => {
     vi.unstubAllEnvs();
   });
 
-  async function withAgentStore(profiles: Record<string, unknown>) {
+  async function writeStoreFile(storePath: string, content: string, symlink?: boolean) {
+    if (!symlink) {
+      await fsp.writeFile(storePath, content);
+      return;
+    }
+    // Dotfile-manager style installs link the store to a target outside the
+    // agent dir; credential discovery must keep following those links.
+    const target = path.join(path.dirname(storePath), "..", `linked-${path.basename(storePath)}`);
+    await fsp.writeFile(target, content);
+    await fsp.symlink(target, storePath);
+  }
+
+  async function withAgentStore(profiles: Record<string, unknown>, opts?: { symlink?: boolean }) {
     const root = await fsp.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-source-"));
     const stateDir = path.join(root, "state");
     const agentDir = path.join(root, "agent");
     await fsp.mkdir(agentDir, { recursive: true });
     await fsp.mkdir(stateDir, { recursive: true });
     vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
-    await fsp.writeFile(
+    await writeStoreFile(
       path.join(agentDir, "auth-profiles.json"),
       JSON.stringify({ version: 1, profiles }),
+      opts?.symlink,
     );
     return { agentDir };
   }
 
-  async function withLegacyAuthStore(profiles: Record<string, unknown>) {
+  async function withLegacyAuthStore(
+    profiles: Record<string, unknown>,
+    opts?: { symlink?: boolean },
+  ) {
     const root = await fsp.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-source-"));
     const stateDir = path.join(root, "state");
     const agentDir = path.join(root, "agent");
     await fsp.mkdir(agentDir, { recursive: true });
     await fsp.mkdir(stateDir, { recursive: true });
     vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
-    await fsp.writeFile(path.join(agentDir, "auth.json"), JSON.stringify(profiles));
+    await writeStoreFile(path.join(agentDir, "auth.json"), JSON.stringify(profiles), opts?.symlink);
     return { agentDir };
   }
 
@@ -47,6 +62,24 @@ describe("hasAuthProfileStoreSourceForProvider", () => {
     const { agentDir } = await withLegacyAuthStore({
       openai: { mode: "apiKey", apiKey: "sk-test" },
     });
+
+    expect(hasAuthProfileStoreSourceForProvider("openai", agentDir)).toBe(true);
+  });
+
+  it("follows symlinked auth-profiles.json stores", async () => {
+    const { agentDir } = await withAgentStore(
+      { "openai:default": { type: "api_key", provider: "openai", key: "sk-test" } },
+      { symlink: true },
+    );
+
+    expect(hasAuthProfileStoreSourceForProvider("openai", agentDir)).toBe(true);
+  });
+
+  it("follows symlinked legacy auth.json stores", async () => {
+    const { agentDir } = await withLegacyAuthStore(
+      { openai: { mode: "apiKey", apiKey: "sk-test" } },
+      { symlink: true },
+    );
 
     expect(hasAuthProfileStoreSourceForProvider("openai", agentDir)).toBe(true);
   });

--- a/src/agents/auth-profiles/source-check.ts
+++ b/src/agents/auth-profiles/source-check.ts
@@ -3,6 +3,7 @@
  * These checks intentionally avoid loading secret-bearing credential payloads.
  */
 import fs from "node:fs";
+import { readRegularFileSync } from "@openclaw/fs-safe/advanced";
 import { evaluateStoredCredentialEligibility } from "./credential-state.js";
 import {
   resolveAuthStatePath,
@@ -28,18 +29,16 @@ function hasStoredAuthProfileFiles(agentDir?: string): boolean {
 }
 
 // Cap auth-profile JSON reads at 10 MiB — credential stores are compact config files.
+// Uses descriptor-level bounded reads to prevent OOM and TOCTOU races.
 const MAX_AUTH_PROFILE_JSON_BYTES = 10 * 1024 * 1024;
 
 function readJsonFile(pathname: string): unknown {
   try {
-    const stats = fs.statSync(pathname);
-    if (!stats.isFile()) {
-      return null;
-    }
-    if (stats.size > MAX_AUTH_PROFILE_JSON_BYTES) {
-      return null;
-    }
-    return JSON.parse(fs.readFileSync(pathname, "utf8")) as unknown;
+    const { buffer } = readRegularFileSync({
+      filePath: pathname,
+      maxBytes: MAX_AUTH_PROFILE_JSON_BYTES,
+    });
+    return JSON.parse(buffer.toString("utf8")) as unknown;
   } catch {
     return null;
   }

--- a/src/agents/auth-profiles/source-check.ts
+++ b/src/agents/auth-profiles/source-check.ts
@@ -27,8 +27,18 @@ function hasStoredAuthProfileFiles(agentDir?: string): boolean {
   );
 }
 
+// Cap auth-profile JSON reads at 10 MiB — credential stores are compact config files.
+const MAX_AUTH_PROFILE_JSON_BYTES = 10 * 1024 * 1024;
+
 function readJsonFile(pathname: string): unknown {
   try {
+    const stats = fs.statSync(pathname);
+    if (!stats.isFile()) {
+      return null;
+    }
+    if (stats.size > MAX_AUTH_PROFILE_JSON_BYTES) {
+      return null;
+    }
     return JSON.parse(fs.readFileSync(pathname, "utf8")) as unknown;
   } catch {
     return null;

--- a/src/agents/auth-profiles/source-check.ts
+++ b/src/agents/auth-profiles/source-check.ts
@@ -3,7 +3,7 @@
  * These checks intentionally avoid loading secret-bearing credential payloads.
  */
 import fs from "node:fs";
-import { readRegularFileSync } from "@openclaw/fs-safe/advanced";
+import { readRegularFileSync } from "../../infra/regular-file.js";
 import { evaluateStoredCredentialEligibility } from "./credential-state.js";
 import {
   resolveAuthStatePath,
@@ -34,8 +34,11 @@ const MAX_AUTH_PROFILE_JSON_BYTES = 10 * 1024 * 1024;
 
 function readJsonFile(pathname: string): unknown {
   try {
+    // Auth stores may be symlinks to regular files (dotfile managers); the
+    // previous readFileSync followed them. Resolve first so the bounded read
+    // keeps that contract while still rejecting non-regular targets.
     const { buffer } = readRegularFileSync({
-      filePath: pathname,
+      filePath: fs.realpathSync(pathname),
       maxBytes: MAX_AUTH_PROFILE_JSON_BYTES,
     });
     return JSON.parse(buffer.toString("utf8")) as unknown;


### PR DESCRIPTION
## What Problem This Solves

The internal `readJsonFile` function in `source-check.ts` reads auth-profile JSON files with no size bound. A corrupted or hostile auth-profiles.json could exhaust memory when the runtime checks for available credentials.

## Why This Change Was Made

`readJsonFile` previously used raw `fs.readFileSync(pathname, "utf8")` with no size check. The fix reads through `readRegularFileSync` (imported via the `src/infra/regular-file.ts` policy wrapper, per the fs-safe import boundary) with a descriptor-level 10 MiB cap:

1. The path is first resolved with `fs.realpathSync`, so symlinked auth stores (dotfile-manager setups) keep working exactly as they did under `readFileSync` — the established file contract is preserved, while non-regular resolved targets are still rejected.
2. The resolved target is opened once and inspected via its descriptor, binding the size check to the file actually being read (no stat-then-read TOCTOU race).
3. Files exceeding 10 MiB are rejected and return null, same as other read failures — silent skip with no credentials detected, and the caller surfaces its normal "no credential source" guidance.

## User Impact

- Prevents OOM crashes from oversized auth-profile stores
- All existing behavior preserved for normal-sized files, including stores reached through symlinks (current `auth-profiles.json` and legacy `auth.json`)
- Oversized stores are safely skipped before read; the process keeps running and the CLI reports its standard "no credentials found" guidance
- No user-visible change in credential detection results

## Evidence

**`node scripts/run-vitest.mjs src/agents/auth-profiles/source-check.test.ts`** — all 12 tests pass (8 existing + 4 new):

```
 ✓ |agents| src/agents/auth-profiles/source-check.test.ts (12 tests)
 Test Files  1 passed (1)
      Tests  12 passed (12)
```

New tests:

- "treats oversized auth-profiles.json as having no credentials" — 11 MiB file skipped
- "treats oversized legacy auth.json as having no credentials" — 11 MiB legacy file skipped
- "follows symlinked auth-profiles.json stores" — linked current store still discovered
- "follows symlinked legacy auth.json stores" — linked legacy store still discovered

**`node scripts/run-vitest.mjs src/infra/fs-safe-import-boundary.test.ts`** — 2/2 pass (direct `@openclaw/fs-safe` imports stay behind OpenClaw policy wrappers).

Lint/format/typecheck on touched files: `run-oxlint.mjs` 0 warnings/0 errors, `oxfmt` clean, `tsgo:core` + `tsgo:test:src` lanes pass.

## Real Behavior Proof

Real runtime run of the exact credential-discovery probe used by `openclaw doctor` memory-search auth checks (`hasAuthProfileStoreSourceForProvider` in `src/agents/auth-profiles/source-check.ts`), executed via tsx against an isolated `OPENCLAW_STATE_DIR` with the production layout `<state>/agents/main/agent/`. No mocks; every token is a fake placeholder; user name redacted.

Scenarios: normal store, exactly-at-cap store (10 MiB), oversized store (11 MiB), symlinked current store, symlinked legacy store, and an oversized target behind a symlink.

```
== environment ==
v24.15.0
state dir (isolated): /tmp/openclaw-proof-111004/state
agent dir: /tmp/openclaw-proof-111004/state/agents/main/agent

== scenario 1: normal auth-profiles.json ==
总用量 4
-rw-rw-r-- 1 <user> <user> 149 7月  19 08:40 auth-profiles.json
[1-normal] hasAuthProfileStoreSourceForProvider("openai") => true
[1-normal] probe returned normally; process healthy (rss=154 MiB)

== scenario 2: boundary auth-profiles.json (exactly 10 MiB, valid JSON) ==
wrote exactly 10485760 bytes (10 MiB cap = 10485760)
总用量 10240
-rw-rw-r-- 1 <user> <user> 10485760 7月  19 08:40 auth-profiles.json
[2-boundary-10MiB] hasAuthProfileStoreSourceForProvider("openai") => true
[2-boundary-10MiB] probe returned normally; process healthy (rss=191 MiB)

== scenario 3: oversized auth-profiles.json (11 MiB) ==
wrote 11534336 bytes (over the 10 MiB cap)
总用量 11264
-rw-rw-r-- 1 <user> <user> 11534336 7月  19 08:40 auth-profiles.json
[3-oversized-11MiB] hasAuthProfileStoreSourceForProvider("openai") => false
[3-oversized-11MiB] no usable openai credential source detected -> CLI guides user to configure credentials
[3-oversized-11MiB] probe returned normally; process healthy (rss=153 MiB)

== scenario 4: symlinked auth-profiles.json (dotfile-manager style) ==
总用量 0
lrwxrwxrwx 1 <user> <user> 52 7月  19 08:40 auth-profiles.json -> /tmp/openclaw-proof-111004/linked/auth-profiles.json
/tmp/openclaw-proof-111004/linked/auth-profiles.json
[4-symlinked-current] hasAuthProfileStoreSourceForProvider("openai") => true
[4-symlinked-current] probe returned normally; process healthy (rss=151 MiB)

== scenario 5: symlinked legacy auth.json ==
总用量 0
lrwxrwxrwx 1 <user> <user> 43 7月  19 08:40 auth.json -> /tmp/openclaw-proof-111004/linked/auth.json
/tmp/openclaw-proof-111004/linked/auth.json
[5-symlinked-legacy] hasAuthProfileStoreSourceForProvider("openai") => true
[5-symlinked-legacy] probe returned normally; process healthy (rss=150 MiB)

== scenario 6: oversized target behind symlink (cap enforced on resolved target) ==
wrote 11534336 bytes to the symlink target
总用量 0
lrwxrwxrwx 1 <user> <user> 52 7月  19 08:40 auth-profiles.json -> /tmp/openclaw-proof-111004/linked/auth-profiles.json
[6-oversized-via-symlink] hasAuthProfileStoreSourceForProvider("openai") => false
[6-oversized-via-symlink] no usable openai credential source detected -> CLI guides user to configure credentials
[6-oversized-via-symlink] probe returned normally; process healthy (rss=152 MiB)

== all scenarios completed; runner exiting normally ==
```

Observed contract:

- Normal and exactly-10 MiB stores: credentials discovered (`true`), process healthy.
- 11 MiB store: safely rejected (`false`); the probe returns normally and the process continues with stable RSS — the CLI shows its standard "configure credentials" guidance in this state.
- Symlinked current and legacy stores: still discovered (`true`) — the pre-change `readFileSync` symlink-following behavior is preserved.
- Oversized file behind a symlink: the 10 MiB cap is enforced on the resolved target (`false`).