### PR TITLE
fix(extensions): bound extension source read with size cap

### DIFF
--- a/src/agents/sessions/extensions/loader.native-js.test.ts
+++ b/src/agents/sessions/extensions/loader.native-js.test.ts
@@ -333,15 +333,17 @@ export default async function extension(api) {
     tempDirs.push(dir);
     const extensionPath = join(dir, "extension.js");
 
-    // Write a compiled .js file exceeding the 10 MiB source-scan cap.
+    // Write a valid oversize JavaScript file exceeding the 10 MiB source-scan cap.
     // The file contains no alias imports — normally it would bypass jiti.
     // When oversized, the source scan is skipped and jiti is used as a fallback.
-    const largeSource = Buffer.alloc(11 * 1024 * 1024);
-    Buffer.from(
-      'export default async function extension(api){api.registerCommand("cmd",{description:"p",handler(){}});}',
-      "utf8",
-    ).copy(largeSource, 0);
-    await writeFile(extensionPath, largeSource);
+    // Padding uses line comments so the file is syntactically valid JS.
+    const exportCode =
+      'export default async function extension(api){api.registerCommand("cmd",{description:"p",handler(){}});}';
+    const paddingLine = "// padding line for oversized extension test\n";
+    const paddingNeeded = 11 * 1024 * 1024 - Buffer.byteLength(exportCode, "utf8");
+    const repeats = Math.ceil(paddingNeeded / Buffer.byteLength(paddingLine, "utf8"));
+    const source = exportCode + paddingLine.repeat(repeats);
+    await writeFile(extensionPath, source, "utf8");
 
     const result = await loadExtensions([extensionPath], dir);
 

--- a/src/agents/sessions/extensions/loader.native-js.test.ts
+++ b/src/agents/sessions/extensions/loader.native-js.test.ts
@@ -322,4 +322,32 @@ export default async function extension(api) {
     expect(jitiCalls.options).toHaveLength(1);
     expect(jitiCalls.imports).toEqual([extensionPath]);
   });
+
+  it("falls back to jiti for oversized extension source files", async () => {
+    // This test verifies the contract: when extensionSourceNeedsJitiAliasResolution
+    // encounters a file exceeding MAX_EXTENSION_SOURCE_BYTES (10 MiB), it returns true
+    // (jiti needed) instead of trying to read the source. The function already returns
+    // true on any error, so the stat pre-check integrates naturally.
+    const { loadExtensions } = await import("./loader.js");
+    const dir = await mkdtemp(join(tmpdir(), "openclaw-extension-js-"));
+    tempDirs.push(dir);
+    const extensionPath = join(dir, "extension.js");
+
+    // Write a compiled .js file exceeding the 10 MiB source-scan cap.
+    // The file contains no alias imports — normally it would bypass jiti.
+    // When oversized, the source scan is skipped and jiti is used as a fallback.
+    const largeSource = Buffer.alloc(11 * 1024 * 1024);
+    Buffer.from(
+      'export default async function extension(api){api.registerCommand("cmd",{description:"p",handler(){}});}',
+      "utf8",
+    ).copy(largeSource, 0);
+    await writeFile(extensionPath, largeSource);
+
+    const result = await loadExtensions([extensionPath], dir);
+
+    expect(result.errors).toEqual([]);
+    expect(result.extensions).toHaveLength(1);
+    // jiti should have been used since the oversized file can't be scanned.
+    expect(jitiCalls.imports).toEqual([extensionPath]);
+  });
 });

--- a/src/agents/sessions/extensions/loader.native-js.test.ts
+++ b/src/agents/sessions/extensions/loader.native-js.test.ts
@@ -328,7 +328,7 @@ export default async function extension(api) {
     // encounters a file exceeding MAX_EXTENSION_SOURCE_BYTES (10 MiB), it returns true
     // (jiti needed) instead of trying to read the source. The function already returns
     // true on any error, so the stat pre-check integrates naturally.
-    const { loadExtensions } = await import("./loader.js");
+    const { loadExtensionsCached: loadExtensions } = await import("./loader.js");
     const dir = await mkdtemp(join(tmpdir(), "openclaw-extension-js-"));
     tempDirs.push(dir);
     const extensionPath = join(dir, "extension.js");

--- a/src/agents/sessions/extensions/loader.ts
+++ b/src/agents/sessions/extensions/loader.ts
@@ -8,6 +8,7 @@ import { createRequire } from "node:module";
 import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { readRegularFileSync } from "@openclaw/fs-safe/advanced";
 import type { createJiti } from "jiti/static";
 import * as bundledLlm from "openclaw/plugin-sdk/llm";
 // Static imports of packages that extensions may use.
@@ -487,15 +488,11 @@ const MAX_EXTENSION_SOURCE_BYTES = 10 * 1024 * 1024;
 
 function extensionSourceNeedsJitiAliasResolution(extensionPath: string): boolean {
   try {
-    const stats = fs.statSync(extensionPath);
-    if (!stats.isFile()) {
-      return true;
-    }
-    if (stats.size > MAX_EXTENSION_SOURCE_BYTES) {
-      // File is too large to read safely — assume jiti alias resolution is needed.
-      return true;
-    }
-    const source = fs.readFileSync(extensionPath, "utf8");
+    const { buffer } = readRegularFileSync({
+      filePath: extensionPath,
+      maxBytes: MAX_EXTENSION_SOURCE_BYTES,
+    });
+    const source = buffer.toString("utf8");
     return (
       EXTENSION_LOADER_ALIAS_IMPORT_PATTERN.test(source) ||
       RELATIVE_EXTENSION_IMPORT_PATTERN.test(source) ||

--- a/src/agents/sessions/extensions/loader.ts
+++ b/src/agents/sessions/extensions/loader.ts
@@ -481,8 +481,20 @@ function isJavaScriptExtensionPath(extensionPath: string): boolean {
   }
 }
 
+// Cap extension source reads at 10 MiB — extension source files scanned for
+// import patterns should not exhaust memory from a large bundled file.
+const MAX_EXTENSION_SOURCE_BYTES = 10 * 1024 * 1024;
+
 function extensionSourceNeedsJitiAliasResolution(extensionPath: string): boolean {
   try {
+    const stats = fs.statSync(extensionPath);
+    if (!stats.isFile()) {
+      return true;
+    }
+    if (stats.size > MAX_EXTENSION_SOURCE_BYTES) {
+      // File is too large to read safely — assume jiti alias resolution is needed.
+      return true;
+    }
     const source = fs.readFileSync(extensionPath, "utf8");
     return (
       EXTENSION_LOADER_ALIAS_IMPORT_PATTERN.test(source) ||

--- a/src/agents/sessions/extensions/loader.ts
+++ b/src/agents/sessions/extensions/loader.ts
@@ -8,7 +8,6 @@ import { createRequire } from "node:module";
 import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { readRegularFileSync } from "@openclaw/fs-safe/advanced";
 import type { createJiti } from "jiti/static";
 import * as bundledLlm from "openclaw/plugin-sdk/llm";
 // Static imports of packages that extensions may use.
@@ -18,6 +17,7 @@ import * as bundledTypebox from "typebox";
 import * as bundledTypeboxCompile from "typebox/compile";
 import * as bundledTypeboxFormat from "typebox/format";
 import * as bundledTypeboxValue from "typebox/value";
+import { readRegularFileSync } from "../../../infra/regular-file.js";
 import { installOpenClawInternalCorePackageNativeResolver } from "../../../plugins/plugin-sdk-native-resolver.js";
 import {
   buildPluginLoaderAliasMap,


### PR DESCRIPTION
## What Problem This Solves

The `extensionSourceNeedsJitiAliasResolution` function reads entire extension source files into memory with no size bound. Extension source files can be large (compiled bundles, bundled dependencies), risking OOM.

## Why This Change Was Made

The function used raw `fs.readFileSync(extensionPath, "utf8")` with no size bound, risking OOM on large files. The fix uses the internal `readRegularFileSync` wrapper (via `infra/regular-file.ts`) with a 10 MiB cap:

1. Rejects symlinks and non-regular files (returns `true`, sending to jiti)
2. Caps reads at 10 MiB — larger files return `true` for jiti fallback
3. Returns the bounded content for source inspection

## User Impact

- Prevents OOM crashes when scanning large extension source files
- Oversized extensions are still loaded (via jiti) — no functionality lost

## Evidence

**`pnpm test src/agents/sessions/extensions/loader.native-js.test.ts`** — all 11 tests pass, including the new oversized extension fallback test:
```
 ✓ |agents| src/agents/sessions/extensions/loader.native-js.test.ts (11 tests)
     ✓ falls back to jiti for oversized extension source files  458ms
     ...
 Test Files  1 passed (1)
      Tests  11 passed (11)
```