### PR TITLE
fix(release): declare validateTrustedToolingPin in the checklist contract

### DIFF
--- a/scripts/release-candidate-checklist.d.mts
+++ b/scripts/release-candidate-checklist.d.mts
@@ -199,6 +199,17 @@ export function validateNpmPreflightRunSource({
   headSha: string;
   workflowRef: string;
 };
+export function validateTrustedToolingPin({
+  toolingSha,
+  pinnedToolingSha,
+  latestTrustedToolingSha,
+  isAncestor,
+}: {
+  toolingSha: string;
+  pinnedToolingSha: string;
+  latestTrustedToolingSha: string;
+  isAncestor?: ((ancestor: string, target: string) => boolean) | undefined;
+}): string;
 export function candidateParallelsArgs(
   tarballPath: unknown,
   dependencyTarballPaths?: unknown[],


### PR DESCRIPTION
## What Problem This Solves

`main` currently fails `check-guards` and `check-test-types` on every PR: commit 26e7575780b added the `validateTrustedToolingPin` export to `scripts/release-candidate-checklist.mjs` plus its test, but the adjacent `.d.mts` declaration contract was not updated. `check-script-declarations` reports value-export contract drift, and `test/scripts/release-candidate-checklist.test.ts` fails typecheck with TS2305.

## Why This Change Was Made

Adds the missing declaration to `scripts/release-candidate-checklist.d.mts`, typed to match the implementation and test usage (string shas, optional `isAncestor`, string return).

## User Impact

Unblocks CI for all open PRs (observed blocking #110886).

## Evidence

- `node scripts/check-script-declarations.mjs` — 235 declaration contracts match.
- `node scripts/run-vitest.mjs test/scripts/release-candidate-checklist.test.ts` — green.
