### PR TITLE
fix(scripts): declare validateTrustedToolingPin in the release-candidate contract

### DIFF
--- a/scripts/release-candidate-checklist.d.mts
+++ b/scripts/release-candidate-checklist.d.mts
@@ -186,6 +186,17 @@ export function requireRunIdFromDispatchOutput(output: unknown, workflowFile: un
 export function buildPublishCommand(options: unknown): string;
 export function validatePreflightManifest(manifest: unknown, params: unknown): void;
 export function validateFullManifest(manifest: unknown, params: unknown): void;
+export function validateTrustedToolingPin({
+  toolingSha,
+  pinnedToolingSha,
+  latestTrustedToolingSha,
+  isAncestor,
+}: {
+  toolingSha: string;
+  pinnedToolingSha: string;
+  latestTrustedToolingSha: string;
+  isAncestor?: ((ancestor: string, target: string) => boolean) | undefined;
+}): string;
 export function validateNpmPreflightRunSource({
   workflowRun,
   workflowRef,


### PR DESCRIPTION
## What Problem This Solves

The `script-declarations` CI gate is red on `main`, blocking every PR from merging. `26e7575780b` (fix(release): pin trusted candidate tooling across main advances) added `export function validateTrustedToolingPin` to `scripts/release-candidate-checklist.mjs` but did not add the matching declaration to the adjacent `scripts/release-candidate-checklist.d.mts` contract, so `check-script-declarations.mjs` fails with `value-export contract drift; missing validateTrustedToolingPin` for all changed-file sets.

## Why This Change Was Made

Adds the missing `.d.mts` declaration for `validateTrustedToolingPin`, matching its `.mjs` signature (object param `{ toolingSha, pinnedToolingSha, latestTrustedToolingSha, isAncestor? }` returning the validated pin string) and the surrounding declaration style.

## User Impact

None (build tooling only). Unblocks PR merges.

## Evidence

`node scripts/check-script-declarations.mjs` → `[script-declarations] 235 declaration contracts match` (was failing on `main`). Declaration-only change; no runtime behavior.
