### PR TITLE
fix: prevent duplicate A2A replies after message delivery

### DIFF
--- a/src/agents/embedded-agent-message-tool-source-reply.test.ts
+++ b/src/agents/embedded-agent-message-tool-source-reply.test.ts
@@ -319,6 +319,24 @@ describe("isDeliveredMessagingToolResult", () => {
       }),
     ).toBe(true);
   });
+
+  it("accepts a nested provider message id as delivery evidence", () => {
+    expect(
+      isDeliveredMessagingToolResult({
+        toolName: "message",
+        args: {
+          action: "send",
+          channel: "qa-channel",
+          target: "qa-a2a-requester",
+          message: "reply",
+        },
+        result: {
+          content: [{ type: "text", text: '{"message":{"id":"qa-message-242"}}' }],
+          details: { message: { id: "qa-message-242" } },
+        },
+      }),
+    ).toBe(true);
+  });
 });
 
 describe("isDeliveredMessageToolOnlySourceReplyResult", () => {

--- a/src/agents/embedded-agent-message-tool-source-reply.ts
+++ b/src/agents/embedded-agent-message-tool-source-reply.ts
@@ -84,7 +84,12 @@ function recordHasDeliveredMessageId(record: Record<string, unknown>): boolean {
     const normalized = normalizeStatus(value);
     return Boolean(normalized && !NON_DELIVERY_MESSAGE_IDS.has(normalized));
   };
-  if (hasDeliveredId(record.messageId) || hasDeliveredId(record.pollId)) {
+  const message = asRecord(record.message);
+  if (
+    hasDeliveredId(record.messageId) ||
+    hasDeliveredId(record.pollId) ||
+    hasDeliveredId(message.id)
+  ) {
     return true;
   }
   const receipt = record.receipt;

--- a/src/agents/embedded-agent-runner/run/message-tool-terminal.test.ts
+++ b/src/agents/embedded-agent-runner/run/message-tool-terminal.test.ts
@@ -55,6 +55,18 @@ describe("message-tool-only source replies", () => {
       expected: true,
     },
     {
+      label: "gateway plugin send result",
+      context: createAfterToolCallContext({
+        toolName: "message",
+        args: { action: "send", message: "visible reply" },
+        result: {
+          content: [{ type: "text", text: '{"message":{"id":"qa-message-1"}}' }],
+          details: { message: { id: "qa-message-1" } },
+        },
+      }),
+      expected: true,
+    },
+    {
       label: "hook result delivery evidence",
       context: createAfterToolCallContext({
         toolName: "message",


### PR DESCRIPTION
Closes #110996

## What Problem This Solves

Fixes an issue where an agent-to-agent reply delivered through the message tool could appear twice when a gateway plugin returned its provider message ID inside a nested `message` object. The first send succeeded, but empty-response recovery treated it as invisible and asked the agent to send again.

## Why This Change Was Made

Recognize a non-empty nested provider `message.id` as the same delivery evidence as existing top-level message, poll, and receipt IDs. Existing dry-run, suppressed, no-op, and error guards still run before the result can complete a message-tool-only source reply.

## User Impact

Agent-to-agent visible replies through gateway-backed channel plugins are delivered once instead of being repeated by empty-response recovery.

## Evidence

- Before fix: full mock QA suite reported 109 passed and 2 failed; isolated `a2a-message-tool-mirror-dedupe` showed one `sessions_send`, two successful `message` sends, and two requester-visible markers.
- After fix: `a2a-message-tool-mirror-dedupe` passed through a real QA Gateway child, qa-channel bus, and mock OpenAI provider with the eight-second duplicate window: https://github.com/openclaw/openclaw/actions/runs/29663908097
- Focused tests: 41/41 passed across the delivery classifier and terminal message-tool hook.
- Changed-surface gate passed core/core-test typechecks, changed-file lint, format, import-cycle, dependency, boundary, and database-first checks: https://github.com/openclaw/openclaw/actions/runs/29663748325
- Behavior validation: 4/4 contract clauses passed; zero failed, blocked, or skipped.
- Autoreview: no findings; patch correct at 0.94 confidence.
