### PR TITLE
fix(scripts): remove duplicate release checklist declarations

### DIFF
--- a/scripts/release-candidate-checklist.d.mts
+++ b/scripts/release-candidate-checklist.d.mts
@@ -120,17 +120,6 @@ export function validateCandidateCheckout({
   toolingSha: unknown;
   workflowRef: unknown;
 };
-export function validateTrustedToolingPin({
-  toolingSha,
-  pinnedToolingSha,
-  latestTrustedToolingSha,
-  isAncestor,
-}: {
-  toolingSha: string;
-  pinnedToolingSha: string;
-  latestTrustedToolingSha: string;
-  isAncestor?: (ancestor: string, target: string) => boolean;
-}): string;
 export function candidateCumulativeShippedPullRequests(
   changelog: string,
   label: string,
@@ -221,17 +210,6 @@ export function validateNpmPreflightRunSource({
   headSha: string;
   workflowRef: string;
 };
-export function validateTrustedToolingPin({
-  toolingSha,
-  pinnedToolingSha,
-  latestTrustedToolingSha,
-  isAncestor,
-}: {
-  toolingSha: string;
-  pinnedToolingSha: string;
-  latestTrustedToolingSha: string;
-  isAncestor?: ((ancestor: string, target: string) => boolean) | undefined;
-}): string;
 export function candidateParallelsArgs(
   tarballPath: unknown,
   dependencyTarballPaths?: unknown[],


### PR DESCRIPTION
Related: #110750, #111009, #111011

## What Problem This Solves

Resolves a release-tooling declaration cleanup where three concurrent fixes left three identical `validateTrustedToolingPin` declarations on `main`.

## Why This Change Was Made

Keeps the single declaration beside `validateNpmPreflightRunSource`, matching the runtime export order and full optional callback type, and removes the two redundant copies. Runtime behavior and the declared API are unchanged.

## User Impact

No user-visible impact. The release checklist declaration contract is restored to one canonical entry.

## Evidence

- `node scripts/check-script-declarations.mjs` — 235 declaration contracts match.
- `node scripts/run-vitest.mjs test/scripts/release-candidate-checklist.test.ts` — 55 tests passed.
- `git diff --check` — clean.
- Exactly one `validateTrustedToolingPin` declaration remains.
