### PR TITLE
fix(scripts): dedupe validateTrustedToolingPin declaration

### DIFF
--- a/scripts/release-candidate-checklist.d.mts
+++ b/scripts/release-candidate-checklist.d.mts
@@ -197,17 +197,6 @@ export function requireRunIdFromDispatchOutput(output: unknown, workflowFile: un
 export function buildPublishCommand(options: unknown): string;
 export function validatePreflightManifest(manifest: unknown, params: unknown): void;
 export function validateFullManifest(manifest: unknown, params: unknown): void;
-export function validateTrustedToolingPin({
-  toolingSha,
-  pinnedToolingSha,
-  latestTrustedToolingSha,
-  isAncestor,
-}: {
-  toolingSha: string;
-  pinnedToolingSha: string;
-  latestTrustedToolingSha: string;
-  isAncestor?: ((ancestor: string, target: string) => boolean) | undefined;
-}): string;
 export function validateNpmPreflightRunSource({
   workflowRun,
   workflowRef,
@@ -221,17 +210,6 @@ export function validateNpmPreflightRunSource({
   headSha: string;
   workflowRef: string;
 };
-export function validateTrustedToolingPin({
-  toolingSha,
-  pinnedToolingSha,
-  latestTrustedToolingSha,
-  isAncestor,
-}: {
-  toolingSha: string;
-  pinnedToolingSha: string;
-  latestTrustedToolingSha: string;
-  isAncestor?: ((ancestor: string, target: string) => boolean) | undefined;
-}): string;
 export function candidateParallelsArgs(
   tarballPath: unknown,
   dependencyTarballPaths?: unknown[],


### PR DESCRIPTION
## What Problem This Solves

`main` is red on the `check-lint` gate (`adjacent-overload-signatures`), blocking all PR merges. Parallel fixes for the earlier "missing validateTrustedToolingPin declaration" gate (#111009 and #111011) each added the declaration to `scripts/release-candidate-checklist.d.mts`, leaving three non-adjacent copies (lines 123, 200, 224) — which the TypeScript lint rejects.

## Why This Change Was Made

Removes the two later duplicate `validateTrustedToolingPin` declarations, keeping a single canonical one (the first, at the original insertion site). This is the same class of cleanup as `22563878857` (fix(ci): clear duplicate declaration).

## User Impact

None (build tooling only). Unblocks PR merges.

## Evidence

- `node scripts/check-script-declarations.mjs` → `235 declaration contracts match`.
- `node scripts/run-oxlint.mjs scripts/release-candidate-checklist.d.mts` → clean (the `adjacent-overload-signatures` error is gone).

Declaration-only change; no runtime behavior.
