### PR TITLE
fix: prevent unknown channel bindings from silently falling back

### DIFF
--- a/src/config/validation.channel-metadata.test.ts
+++ b/src/config/validation.channel-metadata.test.ts
@@ -844,3 +844,99 @@ describe("validateConfigObjectWithPlugins bundled allowlist compatibility", () =
     expect(mockLoadPluginManifestRegistry).not.toHaveBeenCalled();
   });
 });
+
+describe("validateConfigObjectRawWithPlugins binding channels", () => {
+  const emptyRegistry: PluginManifestRegistry = { diagnostics: [], plugins: [] };
+
+  it("accepts a bundled channel id", () => {
+    const result = validateConfigObjectRawWithPlugins(
+      {
+        bindings: [{ agentId: "main", match: { channel: "telegram" } }],
+      },
+      { pluginMetadataSnapshot: { manifestRegistry: emptyRegistry } },
+    );
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts a registered external plugin channel id", () => {
+    const externalRegistry: PluginManifestRegistry = {
+      diagnostics: [],
+      plugins: [
+        createPluginManifestRecord({
+          id: "external-chat-plugin",
+          origin: "global",
+          channels: ["external-chat"],
+        }),
+      ],
+    };
+    const result = validateConfigObjectRawWithPlugins(
+      {
+        bindings: [{ agentId: "main", match: { channel: "external-chat" } }],
+      },
+      { pluginMetadataSnapshot: { manifestRegistry: externalRegistry } },
+    );
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects a bundled alias that inbound routing does not canonicalize", () => {
+    const result = validateConfigObjectRawWithPlugins(
+      {
+        bindings: [{ agentId: "main", match: { channel: "imsg" } }],
+      },
+      { pluginMetadataSnapshot: { manifestRegistry: emptyRegistry } },
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      issues: [
+        {
+          path: "bindings.0.match.channel",
+          message: 'binding references unknown channel id: "imsg"; use "imessage" instead',
+        },
+      ],
+      warnings: [],
+    });
+  });
+
+  it("rejects an unknown channel id with the binding path", () => {
+    const result = validateConfigObjectRawWithPlugins(
+      {
+        bindings: [{ agentId: "main", match: { channel: "retired-chat" } }],
+      },
+      { pluginMetadataSnapshot: { manifestRegistry: emptyRegistry } },
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      issues: [
+        {
+          path: "bindings.0.match.channel",
+          message: 'binding references unknown channel id: "retired-chat"',
+        },
+      ],
+      warnings: [],
+    });
+  });
+
+  it("suggests imessage for the retired bluebubbles channel id", () => {
+    const result = validateConfigObjectRawWithPlugins(
+      {
+        bindings: [{ agentId: "private", match: { channel: "bluebubbles" } }],
+      },
+      { pluginMetadataSnapshot: { manifestRegistry: emptyRegistry } },
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      issues: [
+        {
+          path: "bindings.0.match.channel",
+          message: 'binding references unknown channel id: "bluebubbles"; use "imessage" instead',
+        },
+      ],
+      warnings: [],
+    });
+  });
+});

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -69,6 +69,9 @@ const LEGACY_REMOVED_PLUGIN_IDS = new Set([
   "skill-workshop",
 ]);
 const BLOCKED_PLUGIN_CANDIDATE_PREFIX = "blocked plugin candidate:";
+// BlueBubbles was removed in favor of the imsg-backed iMessage channel. Keep the
+// documented migration actionable when a retired binding id blocks config load.
+const RETIRED_BINDING_CHANNEL_RENAMES = new Map([["bluebubbles", "imessage"]]);
 
 function formatRemovedPluginConfigWarning(pluginId: string): string {
   if (pluginId === "skill-workshop") {
@@ -1714,6 +1717,45 @@ function validateConfigObjectWithPluginsBase(
   };
 
   const allowedChannels = new Set<string>(["defaults", "modelByChannel", ...bundledChannelIds]);
+
+  if (Array.isArray(config.bindings)) {
+    let registryChannelsLoaded = false;
+    const bindingChannelIds = new Set(bundledChannelIds);
+    const loadRegistryChannels = () => {
+      if (registryChannelsLoaded) {
+        return;
+      }
+      registryChannelsLoaded = true;
+      const { registry } = ensureRegistry();
+      for (const record of registry.plugins) {
+        for (const channelId of record.channels) {
+          const normalized = normalizeLowercaseStringOrEmpty(channelId);
+          if (normalized) {
+            bindingChannelIds.add(normalized);
+          }
+        }
+      }
+    };
+
+    for (const [index, binding] of config.bindings.entries()) {
+      const rawChannelId = binding.match.channel;
+      const channelId = normalizeLowercaseStringOrEmpty(rawChannelId);
+      if (!bindingChannelIds.has(channelId)) {
+        loadRegistryChannels();
+      }
+      if (bindingChannelIds.has(channelId)) {
+        continue;
+      }
+      const canonicalChannelId =
+        bundledChannelAliases.get(channelId) ?? RETIRED_BINDING_CHANNEL_RENAMES.get(channelId);
+      issues.push({
+        path: `bindings.${index}.match.channel`,
+        message:
+          `binding references unknown channel id: ${JSON.stringify(sanitizeForLog(rawChannelId))}` +
+          (canonicalChannelId ? `; use ${JSON.stringify(canonicalChannelId)} instead` : ""),
+      });
+    }
+  }
 
   if (config.channels && isRecord(config.channels)) {
     for (const key of Object.keys(config.channels)) {

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -116,6 +116,27 @@ describe("resolveAgentRoute", () => {
     });
   });
 
+  test.each([
+    { alias: "lark", canonical: "feishu" },
+    { alias: "imsg", canonical: "imessage" },
+  ])("does not canonicalize the $alias binding alias to $canonical", ({ alias, canonical }) => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "main", default: true }, { id: "alias-agent" }],
+      },
+      bindings: [{ agentId: "alias-agent", match: { channel: alias } }],
+    };
+
+    expectResolvedRoute(resolveRoute({ cfg, channel: canonical }), {
+      agentId: "main",
+      matchedBy: "default",
+    });
+    expectResolvedRoute(resolveRoute({ cfg, channel: alias }), {
+      agentId: "alias-agent",
+      matchedBy: "binding.account",
+    });
+  });
+
   test("uses the configured main session key for shared direct routes", () => {
     const route = resolveRoute({
       cfg: { session: { dmScope: "main", mainKey: "work" } },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users with routing bindings that reference a retired or unknown channel id would see those bindings listed as configured even though they could never match. Inbound messages then silently fell through to the default agent.

A production install retained `bluebubbles` bindings after the channel moved to `imessage`, causing all inbound traffic to use the default agent for about ten weeks with no validation or startup warning.

## Why This Change Was Made

Plugin-aware config validation now requires every binding channel to be a canonical bundled or registered plugin channel id. Invalid bindings identify the exact array entry, and known aliases or the retired `bluebubbles` id suggest the canonical replacement.

This remains structural validation only. It does not infer agent privilege, peer intent, or fallback policy. It intentionally does not warn about channels with allowlists but no bindings because that is valid for single-agent installs.

This PR was developed with Codex assistance. I reviewed the implementation and understand the behavior it changes.

## User Impact

`openclaw config validate` and Gateway startup now fail clearly when a binding can never match because its channel id is unknown or noncanonical. Operators get an actionable `bluebubbles` to `imessage` fix instead of silent fallback to the default agent.

## Evidence

- Added validation coverage for bundled channels, registered external plugin channels, unknown ids, unsupported aliases, and `bluebubbles` migration guidance.
- Added direct routing coverage proving `lark` does not match canonical `feishu` inbound traffic and `imsg` does not match canonical `imessage` inbound traffic.
- 85 focused assertions passed on Blacksmith Testbox.
- Scoped `core`, `coreTests`, formatting, typecheck, lint, plugin-boundary, import-cycle, and security/storage guards passed.
- Fresh autoreview reported no accepted or actionable findings.
