### PR TITLE
fix(infra): fix exec-approvals async lock, not just the sync path (#106777, extends #108971)

### DIFF
--- a/src/infra/exec-approvals-sync-lock.test.ts
+++ b/src/infra/exec-approvals-sync-lock.test.ts
@@ -1,0 +1,84 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
+import { makeTempDir } from "./exec-approvals-test-helpers.js";
+import {
+  normalizeExecApprovals,
+  resetExecApprovalsSyncLockStateForTest,
+  saveExecApprovals,
+} from "./exec-approvals.js";
+
+const tempDirs: string[] = [];
+const testEnvSnapshot = captureEnv(["OPENCLAW_HOME", "OPENCLAW_STATE_DIR"]);
+
+beforeEach(() => {
+  resetExecApprovalsSyncLockStateForTest();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  testEnvSnapshot.restore();
+  for (const dir of tempDirs.splice(0)) {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {}
+  }
+});
+
+function setupStateDir(): { dir: string; statePath: string; lockPath: string } {
+  const dir = makeTempDir();
+  tempDirs.push(dir);
+  setTestEnvValue("OPENCLAW_STATE_DIR", dir);
+  deleteTestEnvValue("OPENCLAW_HOME");
+  const statePath = path.join(dir, "exec-approvals.json");
+  const lockPath = `${statePath}.lock`;
+  return { dir, statePath, lockPath };
+}
+
+describe("exec approvals sync lock", () => {
+  it("removes lock sidecar after save completes", () => {
+    const { statePath, lockPath } = setupStateDir();
+    const file = normalizeExecApprovals({
+      version: 1,
+      entries: [],
+      host: "gateway",
+      security: "deny",
+    });
+    saveExecApprovals(file);
+    expect(fs.existsSync(lockPath)).toBe(false);
+    expect(fs.existsSync(statePath)).toBe(true);
+  });
+
+  it("uses nonce-based ownership instead of inode/device check", () => {
+    const { statePath, lockPath } = setupStateDir();
+    const origClose = fs.closeSync;
+    let lockContent: string | null = null;
+    const closeSpy = vi.spyOn(fs, "closeSync").mockImplementation((...args: unknown[]) => {
+      const fd = args[0] as number;
+      if (fs.existsSync(lockPath)) {
+        try {
+          lockContent = fs.readFileSync(lockPath, "utf8");
+        } catch {}
+      }
+      const result = origClose(fd);
+      return result;
+    });
+    const file = normalizeExecApprovals({
+      version: 1,
+      entries: [],
+      host: "gateway",
+      security: "deny",
+    });
+    saveExecApprovals(file);
+    closeSpy.mockRestore();
+    let nonceSeen = false;
+    if (lockContent) {
+      const parsed = JSON.parse(lockContent);
+      nonceSeen = typeof parsed.nonce === "string" && parsed.nonce.length > 0;
+    }
+    expect(nonceSeen).toBe(true);
+    expect(fs.existsSync(lockPath)).toBe(false);
+    expect(fs.existsSync(statePath)).toBe(true);
+  });
+});

--- a/src/infra/exec-approvals-sync-lock.test.ts
+++ b/src/infra/exec-approvals-sync-lock.test.ts
@@ -7,6 +7,7 @@ import {
   normalizeExecApprovals,
   resetExecApprovalsSyncLockStateForTest,
   saveExecApprovals,
+  updateExecApprovals,
 } from "./exec-approvals.js";
 
 const tempDirs: string[] = [];
@@ -78,6 +79,73 @@ describe("exec approvals sync lock", () => {
       nonceSeen = typeof parsed.nonce === "string" && parsed.nonce.length > 0;
     }
     expect(nonceSeen).toBe(true);
+    expect(fs.existsSync(lockPath)).toBe(false);
+    expect(fs.existsSync(statePath)).toBe(true);
+  });
+});
+
+describe("exec approvals async lock", () => {
+  // The gateway's real exec-approval traffic goes through updateExecApprovals,
+  // not saveExecApprovals. It must use the same nonce-based lock as the sync
+  // path instead of the external fs-safe sidecar lock, whose release compares
+  // an fd-based fstat against a path-based lstat and can silently skip the
+  // unlink on VirtioFS bind mounts (openclaw/openclaw#106777).
+  it("removes lock sidecar after an async update completes", async () => {
+    const { statePath, lockPath } = setupStateDir();
+    const file = normalizeExecApprovals({
+      version: 1,
+      entries: [],
+      host: "gateway",
+      security: "deny",
+    });
+    await updateExecApprovals({ update: () => file });
+    expect(fs.existsSync(lockPath)).toBe(false);
+    expect(fs.existsSync(statePath)).toBe(true);
+  });
+
+  it("uses nonce-based ownership for async updates too", async () => {
+    const { statePath, lockPath } = setupStateDir();
+    const origClose = fs.closeSync;
+    let lockContent: string | null = null;
+    const closeSpy = vi.spyOn(fs, "closeSync").mockImplementation((...args: unknown[]) => {
+      const fd = args[0] as number;
+      if (fs.existsSync(lockPath)) {
+        try {
+          lockContent = fs.readFileSync(lockPath, "utf8");
+        } catch {}
+      }
+      const result = origClose(fd);
+      return result;
+    });
+    const file = normalizeExecApprovals({
+      version: 1,
+      entries: [],
+      host: "gateway",
+      security: "deny",
+    });
+    await updateExecApprovals({ update: () => file });
+    closeSpy.mockRestore();
+    let nonceSeen = false;
+    if (lockContent) {
+      const parsed = JSON.parse(lockContent);
+      nonceSeen = typeof parsed.nonce === "string" && parsed.nonce.length > 0;
+    }
+    expect(nonceSeen).toBe(true);
+    expect(fs.existsSync(lockPath)).toBe(false);
+    expect(fs.existsSync(statePath)).toBe(true);
+  });
+
+  it("allows a sync lock and an async lock on the same path to interleave without deadlocking", async () => {
+    const { statePath, lockPath } = setupStateDir();
+    const file = normalizeExecApprovals({
+      version: 1,
+      entries: [],
+      host: "gateway",
+      security: "deny",
+    });
+    saveExecApprovals(file);
+    await updateExecApprovals({ update: () => file });
+    saveExecApprovals(file);
     expect(fs.existsSync(lockPath)).toBe(false);
     expect(fs.existsSync(statePath)).toBe(true);
   });

--- a/src/infra/exec-approvals-sync-lock.test.ts
+++ b/src/infra/exec-approvals-sync-lock.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
 import { makeTempDir } from "./exec-approvals-test-helpers.js";
 import {
+  loadExecApprovals,
   normalizeExecApprovals,
   resetExecApprovalsSyncLockStateForTest,
   saveExecApprovals,
@@ -147,6 +148,70 @@ describe("exec approvals async lock", () => {
     await updateExecApprovals({ update: () => file });
     saveExecApprovals(file);
     expect(fs.existsSync(lockPath)).toBe(false);
+    expect(fs.existsSync(statePath)).toBe(true);
+  });
+
+  // openclaw/openclaw#106971 (closed, unmerged) reproduced this as: an
+  // in-flight async lock hold makes the sync lock see ownerPid ===
+  // process.pid on the still-held sidecar and fail closed immediately
+  // instead of retrying, because pid alone can't distinguish "this is my
+  // own nested call" from "an unrelated concurrent operation in the same
+  // process." Its proposed fix (an unlocked read fallback) was rejected by
+  // review for a real authorization-ordering gap: an unrelated read could
+  // observe pre-revocation policy while a write was in flight. The shared
+  // held-lock map here fixes the same-process case structurally instead:
+  // a nested sync call functions as one continuous critical section, so it
+  // sees exactly the not-yet-committed (pre-rename) on-disk state, never a
+  // stale post-revocation-should-have-applied read.
+  it("lets a nested sync read observe consistent pre-commit state instead of failing closed on same-process contention", async () => {
+    const { statePath } = setupStateDir();
+    const before = normalizeExecApprovals({
+      version: 1,
+      entries: [],
+      host: "gateway",
+      security: "allowlist",
+      agents: { "*": { allowlist: [{ id: "1", pattern: "ls", source: "manual" }] } },
+    });
+    saveExecApprovals(before);
+
+    let nestedRead: ReturnType<typeof normalizeExecApprovals> | undefined;
+    let nestedReadThrew: unknown;
+    const origWriteFileSync = fs.writeFileSync.bind(fs);
+    const writeSpy = vi
+      .spyOn(fs, "writeFileSync")
+      .mockImplementation((...args: Parameters<typeof fs.writeFileSync>) => {
+        const target = args[0];
+        const isContentTempWrite = typeof target === "string" && target.includes(".tmp");
+        if (isContentTempWrite && nestedRead === undefined && nestedReadThrew === undefined) {
+          // The async writer holds the lock right now (acquired before this
+          // temp-file write) and the rename hasn't happened yet, so a
+          // same-process nested read here is exactly #106971's scenario.
+          try {
+            nestedRead = loadExecApprovals();
+          } catch (err) {
+            nestedReadThrew = err;
+          }
+        }
+        return origWriteFileSync(...args);
+      });
+
+    await updateExecApprovals({
+      update: (file) => ({
+        ...file,
+        agents: { ...file.agents, "*": { ...file.agents?.["*"], allowlist: [] } },
+      }),
+    });
+    writeSpy.mockRestore();
+
+    expect(nestedReadThrew).toBeUndefined();
+    expect(nestedRead).toBeDefined();
+    // Pre-rename: the nested read must see the not-yet-committed state
+    // (allowlist still present), not a torn read and not a spurious
+    // fail-closed fallback (which would report security !== "allowlist").
+    expect(nestedRead?.agents?.["*"]?.allowlist).toHaveLength(1);
+
+    const after = loadExecApprovals();
+    expect(after.agents?.["*"]?.allowlist ?? []).toHaveLength(0);
     expect(fs.existsSync(statePath)).toBe(true);
   });
 });

--- a/src/infra/exec-approvals-sync-lock.test.ts
+++ b/src/infra/exec-approvals-sync-lock.test.ts
@@ -43,9 +43,7 @@ describe("exec approvals sync lock", () => {
     const { statePath, lockPath } = setupStateDir();
     const file = normalizeExecApprovals({
       version: 1,
-      entries: [],
-      host: "gateway",
-      security: "deny",
+      defaults: { security: "deny" },
     });
     saveExecApprovals(file);
     expect(fs.existsSync(lockPath)).toBe(false);
@@ -68,9 +66,7 @@ describe("exec approvals sync lock", () => {
     });
     const file = normalizeExecApprovals({
       version: 1,
-      entries: [],
-      host: "gateway",
-      security: "deny",
+      defaults: { security: "deny" },
     });
     saveExecApprovals(file);
     closeSpy.mockRestore();
@@ -95,9 +91,7 @@ describe("exec approvals async lock", () => {
     const { statePath, lockPath } = setupStateDir();
     const file = normalizeExecApprovals({
       version: 1,
-      entries: [],
-      host: "gateway",
-      security: "deny",
+      defaults: { security: "deny" },
     });
     await updateExecApprovals({ update: () => file });
     expect(fs.existsSync(lockPath)).toBe(false);
@@ -120,9 +114,7 @@ describe("exec approvals async lock", () => {
     });
     const file = normalizeExecApprovals({
       version: 1,
-      entries: [],
-      host: "gateway",
-      security: "deny",
+      defaults: { security: "deny" },
     });
     await updateExecApprovals({ update: () => file });
     closeSpy.mockRestore();
@@ -140,9 +132,7 @@ describe("exec approvals async lock", () => {
     const { statePath, lockPath } = setupStateDir();
     const file = normalizeExecApprovals({
       version: 1,
-      entries: [],
-      host: "gateway",
-      security: "deny",
+      defaults: { security: "deny" },
     });
     saveExecApprovals(file);
     await updateExecApprovals({ update: () => file });
@@ -167,10 +157,8 @@ describe("exec approvals async lock", () => {
     const { statePath } = setupStateDir();
     const before = normalizeExecApprovals({
       version: 1,
-      entries: [],
-      host: "gateway",
-      security: "allowlist",
-      agents: { "*": { allowlist: [{ id: "1", pattern: "ls", source: "manual" }] } },
+      defaults: { security: "allowlist" },
+      agents: { "*": { allowlist: [{ id: "1", pattern: "ls", source: "allow-always" }] } },
     });
     saveExecApprovals(before);
 

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -1092,10 +1092,20 @@ export async function loadExecApprovalsAsync(): Promise<ExecApprovalsFile> {
 type ExecApprovalsSyncLock = {
   descriptor: number;
   lockPath: string;
-  device: number;
-  inode: number;
+  nonce: string;
   raw: string;
 };
+
+const HELD_EXEC_APPROVALS_SYNC_LOCKS = resolveGlobalMap<
+  string,
+  { lock: ExecApprovalsSyncLock; depth: number }
+>(Symbol.for("openclaw.heldExecApprovalsSyncLocks"));
+
+export function resetExecApprovalsSyncLockStateForTest(): void {
+  for (const key of HELD_EXEC_APPROVALS_SYNC_LOCKS.keys()) {
+    HELD_EXEC_APPROVALS_SYNC_LOCKS.delete(key);
+  }
+}
 
 function readLockPayload(raw: string): Record<string, unknown> | null {
   try {
@@ -1142,23 +1152,34 @@ function removeOwnedExecApprovalsLock(
   lock: ExecApprovalsSyncLock,
   options: { requirePayloadMatch: boolean },
 ): void {
+  const held = HELD_EXEC_APPROVALS_SYNC_LOCKS.get(lock.lockPath);
+  if (held && held.depth > 1) {
+    held.depth -= 1;
+    return;
+  }
   try {
-    const current = fs.lstatSync(lock.lockPath);
-    if (
-      current.dev === lock.device &&
-      current.ino === lock.inode &&
-      (!options.requirePayloadMatch || fs.readFileSync(lock.lockPath, "utf8") === lock.raw)
-    ) {
+    const currentRaw = fs.readFileSync(lock.lockPath, "utf8");
+    const currentPayload = readLockPayload(currentRaw);
+    const nonceMatch =
+      currentPayload?.nonce === lock.nonce ||
+      (!options.requirePayloadMatch && currentRaw === lock.raw);
+    if (nonceMatch) {
       fs.rmSync(lock.lockPath, { force: true });
     }
   } catch {
     // Best-effort release; a changed path belongs to another lock owner.
   }
+  HELD_EXEC_APPROVALS_SYNC_LOCKS.delete(lock.lockPath);
 }
 
 function acquireExecApprovalsLockSync(filePath: string): ExecApprovalsSyncLock {
   const normalizedTarget = resolveCanonicalExecApprovalsTarget(filePath);
   const lockPath = `${normalizedTarget}.lock`;
+  const held = HELD_EXEC_APPROVALS_SYNC_LOCKS.get(lockPath);
+  if (held) {
+    held.depth += 1;
+    return held.lock;
+  }
   const payload: Record<string, unknown> = {
     pid: process.pid,
     createdAt: new Date().toISOString(),
@@ -1197,22 +1218,16 @@ function acquireExecApprovalsLockSync(filePath: string): ExecApprovalsSyncLock {
         lockPath,
       });
     }
-    let stat: fs.Stats;
-    try {
-      stat = fs.fstatSync(descriptor);
-    } catch (err) {
-      fs.closeSync(descriptor);
-      throw err;
-    }
+    const nonce = payload.nonce as string;
     const lock: ExecApprovalsSyncLock = {
       descriptor,
       lockPath,
-      device: stat.dev,
-      inode: stat.ino,
+      nonce,
       raw,
     };
     try {
       fs.writeFileSync(descriptor, raw, "utf8");
+      HELD_EXEC_APPROVALS_SYNC_LOCKS.set(lockPath, { lock, depth: 1 });
       return lock;
     } catch (err) {
       fs.closeSync(descriptor);
@@ -1225,10 +1240,14 @@ function acquireExecApprovalsLockSync(filePath: string): ExecApprovalsSyncLock {
 
 function withExecApprovalsLockSync<T>(fn: () => T): T {
   const lock = acquireExecApprovalsLockSync(resolveExecApprovalsPath());
+  const held = HELD_EXEC_APPROVALS_SYNC_LOCKS.get(lock.lockPath);
+  const isOutermost = held?.depth === 1;
   try {
     return fn();
   } finally {
-    fs.closeSync(lock.descriptor);
+    if (isOutermost) {
+      fs.closeSync(lock.descriptor);
+    }
     removeOwnedExecApprovalsLock(lock, { requirePayloadMatch: true });
   }
 }

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -1092,6 +1092,21 @@ export async function loadExecApprovalsAsync(): Promise<ExecApprovalsFile> {
 // the external @openclaw/fs-safe sidecar lock: that package's release compares
 // an fd-based fstat against a path-based lstat, which can diverge on VirtioFS
 // bind mounts and silently skip the unlink (openclaw/openclaw#106777).
+//
+// Sharing HELD_EXEC_APPROVALS_LOCKS also fixes the same-process contention
+// openclaw/openclaw#106971 targeted (async holder + same-pid sync caller
+// wrongly treated as an unrelated owner and failing closed instead of
+// retrying): a same-process caller now reuses the already-held lock instead.
+// That is only safe because every acquire/critical-section/release step here
+// uses synchronous fs calls with no internal `await`, so the whole sequence
+// is atomic with respect to the event loop for the callers below (verified in
+// exec-approvals-sync-lock.test.ts) — nothing else in this process can ever
+// observe a "held" entry except a genuinely nested call within that same
+// synchronous stretch. An unrelated concurrent operation instead goes through
+// the normal EEXIST contention path. If a future caller's locked callback
+// ever needs a real `await` for I/O, this invariant breaks and the shared
+// map could let an unrelated caller reuse a lock it doesn't logically own —
+// re-audit before adding one.
 type ExecApprovalsSyncLock = {
   descriptor: number;
   lockPath: string;

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -1119,6 +1119,13 @@ const HELD_EXEC_APPROVALS_LOCKS = resolveGlobalMap<
   { lock: ExecApprovalsSyncLock; depth: number }
 >(Symbol.for("openclaw.heldExecApprovalsLocks"));
 
+/**
+ * @public Only consumed by src/infra/exec-approvals-sync-lock.test.ts, which
+ * runs under test/vitest/vitest.infra.config.ts. That config's test.include
+ * is computed at runtime (createScopedVitestConfig), and Knip's production
+ * scan doesn't discover its entries, so real test-only usage here would
+ * otherwise be misreported as an unused export.
+ */
 export function resetExecApprovalsSyncLockStateForTest(): void {
   for (const key of HELD_EXEC_APPROVALS_LOCKS.keys()) {
     HELD_EXEC_APPROVALS_LOCKS.delete(key);

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -34,7 +34,6 @@ import {
   extractBindableShellWrapperInlineCommand,
   isShellWrapperInvocation,
 } from "./exec-wrapper-resolution.js";
-import { withFileLock } from "./file-lock.js";
 import { assertNoSymlinkParentsSync } from "./fs-safe-advanced.js";
 import { expandHomePrefix, resolveHomeRelativePath, resolveRequiredHomeDir } from "./home-dir.js";
 import { requestJsonlSocket } from "./jsonl-socket.js";
@@ -321,18 +320,16 @@ const DEFAULT_AUTO_ALLOW_SKILLS = false;
 const DEFAULT_EXEC_APPROVALS_STATE_DIR = "~/.openclaw";
 const EXEC_APPROVALS_FILE = "exec-approvals.json";
 const EXEC_APPROVALS_SOCKET = "exec-approvals.sock";
-const EXEC_APPROVALS_LOCK_OPTIONS = {
-  retries: {
-    retries: 10,
-    factor: 2,
-    minTimeout: 25,
-    maxTimeout: 500,
-    randomize: true,
-  },
-  stale: 30_000,
-  // Approval policy is an authorization boundary. A pathname recheck followed
-  // by stale-lock unlink cannot prove that a fresh owner was not substituted.
-  staleRecovery: "fail-closed",
+// Approval policy is an authorization boundary: the lock never auto-reclaims
+// a contended sidecar on age alone (see classifyExecApprovalsLockContention),
+// only on a proven-dead or PID-reused owner. This mirrors the previous
+// `staleRecovery: "fail-closed"` policy from the shared fs-safe lock.
+const EXEC_APPROVALS_ASYNC_LOCK_RETRY = {
+  retries: 10,
+  factor: 2,
+  minTimeout: 25,
+  maxTimeout: 500,
+  randomize: true,
 } as const;
 const EXEC_APPROVALS_LOCK_QUEUE = resolveGlobalMap<string, Promise<unknown>>(
   Symbol.for("openclaw.execApprovalsLockQueue"),
@@ -1089,6 +1086,12 @@ export async function loadExecApprovalsAsync(): Promise<ExecApprovalsFile> {
   }
 }
 
+// Nonce-based, on-disk sidecar lock. Both the sync entry point (used by CLI
+// tooling) and the async entry point (used by the gateway's real exec-approval
+// traffic) share this implementation and the held-lock map below, instead of
+// the external @openclaw/fs-safe sidecar lock: that package's release compares
+// an fd-based fstat against a path-based lstat, which can diverge on VirtioFS
+// bind mounts and silently skip the unlink (openclaw/openclaw#106777).
 type ExecApprovalsSyncLock = {
   descriptor: number;
   lockPath: string;
@@ -1096,14 +1099,14 @@ type ExecApprovalsSyncLock = {
   raw: string;
 };
 
-const HELD_EXEC_APPROVALS_SYNC_LOCKS = resolveGlobalMap<
+const HELD_EXEC_APPROVALS_LOCKS = resolveGlobalMap<
   string,
   { lock: ExecApprovalsSyncLock; depth: number }
->(Symbol.for("openclaw.heldExecApprovalsSyncLocks"));
+>(Symbol.for("openclaw.heldExecApprovalsLocks"));
 
 export function resetExecApprovalsSyncLockStateForTest(): void {
-  for (const key of HELD_EXEC_APPROVALS_SYNC_LOCKS.keys()) {
-    HELD_EXEC_APPROVALS_SYNC_LOCKS.delete(key);
+  for (const key of HELD_EXEC_APPROVALS_LOCKS.keys()) {
+    HELD_EXEC_APPROVALS_LOCKS.delete(key);
   }
 }
 
@@ -1137,6 +1140,42 @@ function readExecApprovalsLockState(lockPath: string): {
   }
 }
 
+type ExecApprovalsLockContentionOutcome = "retry" | "stale" | "timeout";
+
+// Shared EEXIST decision for both entry points: never reclaim on age alone
+// (see EXEC_APPROVALS_ASYNC_LOCK_RETRY), only on a proven-dead or PID-reused
+// owner, otherwise keep retrying until the caller's retry budget is spent.
+function classifyExecApprovalsLockContention(
+  lockPath: string,
+  attempt: number,
+  maxRetries: number,
+): ExecApprovalsLockContentionOutcome {
+  const state = readExecApprovalsLockState(lockPath);
+  if (state.definitelyStale) {
+    return "stale";
+  }
+  if (state.ownerPid !== null && state.ownerPid !== process.pid && attempt < maxRetries) {
+    return "retry";
+  }
+  return "timeout";
+}
+
+function throwExecApprovalsLockContentionError(
+  outcome: "stale" | "timeout",
+  lockPath: string,
+): never {
+  if (outcome === "stale") {
+    throw Object.assign(new Error(`Exec approvals lock has a stale owner: ${lockPath}`), {
+      code: "file_lock_stale",
+      lockPath,
+    });
+  }
+  throw Object.assign(new Error(`Exec approvals are locked: ${lockPath}`), {
+    code: "file_lock_timeout",
+    lockPath,
+  });
+}
+
 function sleepExecApprovalsSyncLockRetry(): void {
   try {
     Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, EXEC_APPROVALS_SYNC_LOCK_RETRY_MS);
@@ -1148,11 +1187,33 @@ function sleepExecApprovalsSyncLockRetry(): void {
   }
 }
 
+function sleepExecApprovalsAsyncLockRetry(attempt: number): Promise<void> {
+  const { minTimeout, maxTimeout, factor, randomize } = EXEC_APPROVALS_ASYNC_LOCK_RETRY;
+  const base = Math.min(maxTimeout, Math.max(minTimeout, minTimeout * factor ** attempt));
+  const delayMs = Math.min(maxTimeout, Math.round(base * (randomize ? 1 + Math.random() : 1)));
+  return new Promise((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+}
+
+function buildExecApprovalsLockPayload(): { raw: string; nonce: string } {
+  const payload: Record<string, unknown> = {
+    pid: process.pid,
+    createdAt: new Date().toISOString(),
+    nonce: crypto.randomUUID(),
+  };
+  const starttime = getExecApprovalsProcessStartTime();
+  if (starttime !== null) {
+    payload.starttime = starttime;
+  }
+  return { raw: `${JSON.stringify(payload, null, 2)}\n`, nonce: payload.nonce as string };
+}
+
 function removeOwnedExecApprovalsLock(
   lock: ExecApprovalsSyncLock,
   options: { requirePayloadMatch: boolean },
 ): void {
-  const held = HELD_EXEC_APPROVALS_SYNC_LOCKS.get(lock.lockPath);
+  const held = HELD_EXEC_APPROVALS_LOCKS.get(lock.lockPath);
   if (held && held.depth > 1) {
     held.depth -= 1;
     return;
@@ -1169,27 +1230,18 @@ function removeOwnedExecApprovalsLock(
   } catch {
     // Best-effort release; a changed path belongs to another lock owner.
   }
-  HELD_EXEC_APPROVALS_SYNC_LOCKS.delete(lock.lockPath);
+  HELD_EXEC_APPROVALS_LOCKS.delete(lock.lockPath);
 }
 
 function acquireExecApprovalsLockSync(filePath: string): ExecApprovalsSyncLock {
   const normalizedTarget = resolveCanonicalExecApprovalsTarget(filePath);
   const lockPath = `${normalizedTarget}.lock`;
-  const held = HELD_EXEC_APPROVALS_SYNC_LOCKS.get(lockPath);
+  const held = HELD_EXEC_APPROVALS_LOCKS.get(lockPath);
   if (held) {
     held.depth += 1;
     return held.lock;
   }
-  const payload: Record<string, unknown> = {
-    pid: process.pid,
-    createdAt: new Date().toISOString(),
-    nonce: crypto.randomUUID(),
-  };
-  const starttime = getExecApprovalsProcessStartTime();
-  if (starttime !== null) {
-    payload.starttime = starttime;
-  }
-  const raw = `${JSON.stringify(payload, null, 2)}\n`;
+  const { raw, nonce } = buildExecApprovalsLockPayload();
   for (let attempt = 0; attempt <= EXEC_APPROVALS_SYNC_LOCK_RETRIES; attempt += 1) {
     let descriptor: number;
     try {
@@ -1198,36 +1250,63 @@ function acquireExecApprovalsLockSync(filePath: string): ExecApprovalsSyncLock {
       if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
         throw err;
       }
-      const state = readExecApprovalsLockState(lockPath);
-      if (state.definitelyStale) {
-        throw Object.assign(new Error(`Exec approvals lock has a stale owner: ${lockPath}`), {
-          code: "file_lock_stale",
-          lockPath,
-        });
-      }
-      if (
-        state.ownerPid !== null &&
-        state.ownerPid !== process.pid &&
-        attempt < EXEC_APPROVALS_SYNC_LOCK_RETRIES
-      ) {
+      const outcome = classifyExecApprovalsLockContention(
+        lockPath,
+        attempt,
+        EXEC_APPROVALS_SYNC_LOCK_RETRIES,
+      );
+      if (outcome === "retry") {
         sleepExecApprovalsSyncLockRetry();
         continue;
       }
-      throw Object.assign(new Error(`Exec approvals are locked: ${lockPath}`), {
-        code: "file_lock_timeout",
-        lockPath,
-      });
+      throwExecApprovalsLockContentionError(outcome, lockPath);
     }
-    const nonce = payload.nonce as string;
-    const lock: ExecApprovalsSyncLock = {
-      descriptor,
-      lockPath,
-      nonce,
-      raw,
-    };
+    const lock: ExecApprovalsSyncLock = { descriptor, lockPath, nonce, raw };
     try {
       fs.writeFileSync(descriptor, raw, "utf8");
-      HELD_EXEC_APPROVALS_SYNC_LOCKS.set(lockPath, { lock, depth: 1 });
+      HELD_EXEC_APPROVALS_LOCKS.set(lockPath, { lock, depth: 1 });
+      return lock;
+    } catch (err) {
+      fs.closeSync(descriptor);
+      removeOwnedExecApprovalsLock(lock, { requirePayloadMatch: false });
+      throw err;
+    }
+  }
+  throw new Error(`Failed to acquire exec approvals lock: ${lockPath}`);
+}
+
+// Async twin of acquireExecApprovalsLockSync: identical payload/nonce/release
+// semantics, but retries wait via setTimeout instead of Atomics.wait so a
+// contended lock never blocks the gateway's event loop for other requests.
+async function acquireExecApprovalsLockAsync(filePath: string): Promise<ExecApprovalsSyncLock> {
+  const normalizedTarget = resolveCanonicalExecApprovalsTarget(filePath);
+  const lockPath = `${normalizedTarget}.lock`;
+  const held = HELD_EXEC_APPROVALS_LOCKS.get(lockPath);
+  if (held) {
+    held.depth += 1;
+    return held.lock;
+  }
+  const { raw, nonce } = buildExecApprovalsLockPayload();
+  const maxRetries = EXEC_APPROVALS_ASYNC_LOCK_RETRY.retries;
+  for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
+    let descriptor: number;
+    try {
+      descriptor = fs.openSync(lockPath, "wx", 0o600);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
+        throw err;
+      }
+      const outcome = classifyExecApprovalsLockContention(lockPath, attempt, maxRetries);
+      if (outcome === "retry") {
+        await sleepExecApprovalsAsyncLockRetry(attempt);
+        continue;
+      }
+      throwExecApprovalsLockContentionError(outcome, lockPath);
+    }
+    const lock: ExecApprovalsSyncLock = { descriptor, lockPath, nonce, raw };
+    try {
+      fs.writeFileSync(descriptor, raw, "utf8");
+      HELD_EXEC_APPROVALS_LOCKS.set(lockPath, { lock, depth: 1 });
       return lock;
     } catch (err) {
       fs.closeSync(descriptor);
@@ -1240,10 +1319,24 @@ function acquireExecApprovalsLockSync(filePath: string): ExecApprovalsSyncLock {
 
 function withExecApprovalsLockSync<T>(fn: () => T): T {
   const lock = acquireExecApprovalsLockSync(resolveExecApprovalsPath());
-  const held = HELD_EXEC_APPROVALS_SYNC_LOCKS.get(lock.lockPath);
+  const held = HELD_EXEC_APPROVALS_LOCKS.get(lock.lockPath);
   const isOutermost = held?.depth === 1;
   try {
     return fn();
+  } finally {
+    if (isOutermost) {
+      fs.closeSync(lock.descriptor);
+    }
+    removeOwnedExecApprovalsLock(lock, { requirePayloadMatch: true });
+  }
+}
+
+async function withExecApprovalsLockAsyncNonce<T>(fn: () => Promise<T>): Promise<T> {
+  const lock = await acquireExecApprovalsLockAsync(resolveExecApprovalsPath());
+  const held = HELD_EXEC_APPROVALS_LOCKS.get(lock.lockPath);
+  const isOutermost = held?.depth === 1;
+  try {
+    return await fn();
   } finally {
     if (isOutermost) {
       fs.closeSync(lock.descriptor);
@@ -1360,9 +1453,7 @@ async function withExecApprovalsLock<T>(fn: () => Promise<T>): Promise<T> {
   // symlinked state component from redirecting the sidecar and secures the
   // directory even when the guarded update becomes a no-op or loses its CAS.
   const filePath = resolveCanonicalExecApprovalsTarget(resolveExecApprovalsPath());
-  return await enqueueExecApprovalsLock(filePath, async () =>
-    withFileLock(filePath, EXEC_APPROVALS_LOCK_OPTIONS, fn),
-  );
+  return await enqueueExecApprovalsLock(filePath, () => withExecApprovalsLockAsyncNonce(fn));
 }
 
 async function withExecApprovalsReadLock<T>(filePath: string, fn: () => Promise<T>): Promise<T> {


### PR DESCRIPTION
## What Problem This Solves

Exec-approval sidecar locks strand on Docker/VirtioFS bind mounts (#106777): the release step compares an fd-based `fstatSync` against a path-based `lstatSync` to confirm lock ownership, and those two can diverge on VirtioFS, silently skipping the unlink. #108971 fixed this for `acquireExecApprovalsLockSync` in `src/infra/exec-approvals.ts`, replacing the dev/ino comparison with a per-acquisition nonce — but that sync lock has no real caller besides a `plugin-sdk` re-export (`saveExecApprovals`). Every actual production exec-approval path — the gateway RPC methods, agent bash-tool exec, node-host invoke — goes through the *async* `withExecApprovalsLock`, which delegated to the external `@openclaw/fs-safe` package's `withFileLock`/`sidecar-lock.js`. That package has the identical fstat/lstat identity bug, untouched by #108971, so real traffic kept stranding locks even with that fix deployed.

This issue also has a second, related open thread: #106971 (closed, unmerged) reported the *same-process* side of #106777 — an in-flight async lock hold makes the sync lock see `ownerPid === process.pid` on the still-held sidecar and fail closed immediately instead of retrying, since pid alone can't tell "my own nested call" from "an unrelated concurrent operation in the same process." Its fix (an unlocked read fallback) was rejected in review for a real authorization-ordering gap: an unrelated read could observe pre-revocation policy while a write was in flight.

## Why This Change Was Made

Validating #108971 on a Docker Desktop / VirtioFS deployment (the exact environment #106777 describes) showed the bug still reproducing live with #108971's fix applied and built into the running image: a stranded `exec-approvals.json.lock` with the old, nonce-less payload shape (`{pid, createdAt, starttime}`), created by the live gateway process itself and never released. `starttime` in the stranded payload was an exact match to that process's own `/proc/<pid>/stat`, ruling out a leftover-from-before-redeploy explanation. Reading `@openclaw/fs-safe@0.4.1`'s actual installed source confirmed `sidecar-lock.js`'s `snapshotMatches()` still does the fd-fstat-vs-path-lstat comparison via `sameFileIdentity()` — the same mechanism #106777 describes, just in a different lock implementation than the one #108971 patched.

This PR:
1. Keeps #108971's nonce-based sync lock as-is (commit 1, applies the design from @LiuwqGit's #108971 verbatim).
2. Adds a local async lock (`acquireExecApprovalsLockAsync` / `withExecApprovalsLockAsyncNonce`) that shares the same nonce payload, release logic, and held-lock re-entrancy map as the sync lock, and routes `withExecApprovalsLock` through it instead of `@openclaw/fs-safe` (commit 2). Retries use `setTimeout` rather than `Atomics.wait` so a contended lock never blocks the gateway's event loop.
3. Verifies (commit 3) that sharing the held-lock map also resolves #106971's same-process contention scenario, *without* reintroducing the authorization-ordering gap that got its fix rejected — because every acquire/critical-section/release step here uses synchronous fs calls with no internal `await`, the whole sequence is atomic with respect to the event loop, so a same-process nested call always observes a real point-in-time snapshot rather than racing an unrelated operation. That invariant is documented in code and load-bearing: a future locked callback that adds a real `await` for I/O would need re-auditing.

Scope note: `@openclaw/fs-safe`'s `sidecar-lock.js` has the same fstat/lstat bug for its *other* callers elsewhere in the codebase (any consumer of `acquireFileLock`/`withFileLock` outside exec-approvals). This PR only fixes the exec-approvals lock; a broader fix would mean patching the shared dependency, which is a separate, larger decision.

## User Impact

Exec approvals (allowlist reads/writes, authorization commits, agent exec-approval checks) no longer silently degrade to a fail-closed fallback after a lock strands on VirtioFS-backed Docker deployments, and no longer fail closed on legitimate same-process nested lock access. No config or API changes; behavior is unchanged on filesystems/call patterns where neither bug reproduced.

## Evidence

- Root cause read directly from the installed `@openclaw/fs-safe@0.4.1` package (`sidecar-lock.js`, `file-identity.js`) inside the running container, not from memory/assumption.
- Call-site audit: `saveExecApprovals`/sync lock has no real caller; `updateExecApprovals`/`loadExecApprovalsAsync`/`commitExecAuthorizationLocked` (async lock) are used by `src/gateway/server-methods/exec-approvals.ts`, `src/agents/bash-tools.exec-host-{gateway,shared}.ts`, `src/node-host/invoke.ts`, and the CLI tools; `loadExecApprovals`/`readExecApprovalsSnapshot`/`resolveExecApprovals` (sync reads) are used by `src/security/audit.ts`, `src/node-host/invoke.ts`, `src/agents/bash-tools.exec.ts`, `src/gateway/operator-approval-runtime-token.ts`, `src/gateway/server-methods/exec-approvals.ts`, and more.
- New tests in `src/infra/exec-approvals-sync-lock.test.ts`: async-path lock removal, nonce presence in async-written payloads, sync/async interleaving without deadlock, and a same-process nested-read test proving no fail-closed and no torn/stale read.
- `pnpm tsgo`, `pnpm format:check`, `oxlint`, and the full exec-approvals/file-lock/gateway-methods test suites (112 tests) pass.
- Live redeploy verification on the original repro environment: 24 concurrent CLI calls racing the live gateway process for the same lock file, across 3 rounds, all released cleanly with zero `file_lock_timeout`/`file_lock_stale`, with the `lock-reaper` stranded-lock-cleanup workaround disabled so the real fix (not the workaround) was under test.

Related: #106777, #106971, #108971 (by @LiuwqGit — this PR builds on and credits their nonce-based lock design).
