### PR TITLE
fix(channels): recover dead-lettered inbound events

### DIFF
--- a/docs/cli/channels.md
+++ b/docs/cli/channels.md
@@ -1,8 +1,9 @@
 ---
-summary: "CLI reference for `openclaw channels` (accounts, status, capabilities, resolve, logs, login/logout)"
+summary: "CLI reference for `openclaw channels` (accounts, status, dead letters, capabilities, resolve, logs, login/logout)"
 read_when:
   - You want to add or remove channel accounts (Discord, Google Chat, iMessage, Matrix, Signal, Slack, Telegram, WhatsApp, and more)
   - You want to check channel status or tail channel logs
+  - You need to inspect or resubmit a failed inbound channel event
 title: "Channels"
 ---
 
@@ -25,6 +26,7 @@ openclaw channels capabilities
 openclaw channels capabilities --channel discord --target channel:123
 openclaw channels resolve --channel slack "#general" "@jane"
 openclaw channels logs --channel all
+openclaw channels dead-letters list --channel telegram --account default
 ```
 
 `channels list` shows chat channels only: configured accounts by default, with `installed`, `configured`, and `enabled` status tags per account (`--json` for machine output). Pass `--all` to also surface bundled channels that have no configured account yet and installable catalog channels that are not yet on disk. Provider auth and model usage live elsewhere: `openclaw models auth list` for provider auth profiles, `openclaw status` or `openclaw models list` for usage/quota.
@@ -41,6 +43,27 @@ openclaw channels logs --channel all
 state plus probe results such as `works`, `probe failed`, `audit ok`, or `audit failed`.
 If the gateway is unreachable, `channels status` falls back to config-only summaries
 instead of live probe output.
+
+## Inbound dead letters
+
+Inbound events that exhaust their retry policy remain in the shared state database for the queue's existing failed-entry retention period. Inspect one channel account with:
+
+```bash
+openclaw channels dead-letters list --channel telegram --account default
+openclaw channels dead-letters list --channel telegram --account default --json
+```
+
+The text view shows event ids, failure reasons, attempt counts, and failure ages. JSON output also includes the retained payload, metadata, lane, and attempt timestamps for diagnostics.
+
+After correcting the underlying problem, re-enqueue one event with its original event id:
+
+```bash
+openclaw channels dead-letters resubmit <event-id> --channel telegram --account default
+```
+
+Run these commands on the Gateway host so they access the same shared state database as the channel runtime. Resubmission preserves the payload, metadata, and lane, but resets the attempt counter and queue age. It atomically replaces that event's failed marker, so repeating the command while the event is pending or claimed refuses instead of creating a second dispatch. The running channel picks it up on its next ingress drain. Completed events remain terminal and cannot be resubmitted. Failed rows created before payload retention was added can still appear in the list, but resubmission refuses them because their payload is unavailable.
+
+`openclaw health` reports dead-letter counts and oldest failure age per channel account. `openclaw doctor` names affected accounts and points back to the inspection command.
 
 Do not use `openclaw sessions`, Gateway `sessions.list`, or the agent
 `sessions_list` tool as a channel socket-health signal. Those surfaces report

--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -12,6 +12,8 @@ Health checks and quick fixes for the gateway, channels, plugins, skills, model 
 
 When Gateway status reports degraded SecretRef owners, doctor prints a **Secret runtime degradation** warning with every cold or stale owner, affected config path, redacted reason, and the `openclaw secrets reload` retry command.
 
+When channel ingress events are dead-lettered, doctor names each affected channel account and points to [`openclaw channels dead-letters list`](/cli/channels#inbound-dead-letters) for inspection and recovery.
+
 Related:
 
 - Troubleshooting: [Troubleshooting](/gateway/troubleshooting)

--- a/docs/cli/health.md
+++ b/docs/cli/health.md
@@ -32,7 +32,8 @@ openclaw health --debug
 
 - Without `--verbose`, the Gateway can return a cached snapshot (fresh for up to 60 seconds and unchanged from live channel runtime state) and refresh it in the background for the next caller.
 - `--verbose` forces a live probe (per-channel account probes), prints Gateway connection details, and expands human-readable output across all configured accounts and agents instead of just the default agent.
-- `--json` always returns the full snapshot: channels, per-account probes, plugin load state, context-engine quarantine state, model-pricing cache state, event-loop health, and per-agent session stores.
+- `--json` always returns the full snapshot: channels, per-account probes, plugin load state, context-engine quarantine state, model-pricing cache state, event-loop health, delivery-queue dead letters, and per-agent session stores.
+- When outbound deliveries or inbound channel events are dead-lettered, text output reports their counts and oldest failure age. Inbound counts are grouped by channel account; inspect or recover individual events with [`openclaw channels dead-letters`](/cli/channels#inbound-dead-letters).
 
 ## Related
 

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -1336,6 +1336,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H1: openclaw channels
   - H2: Common commands
   - H2: Status / capabilities / resolve / logs
+  - H2: Inbound dead letters
   - H2: Add / remove accounts
   - H2: Login and logout (interactive)
   - H2: Troubleshooting

--- a/src/channels/message/ingress-drain.test.ts
+++ b/src/channels/message/ingress-drain.test.ts
@@ -82,6 +82,47 @@ describe("channel ingress drain", () => {
     });
   });
 
+  it("dispatches a resubmitted dead letter exactly once", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createChannelIngressQueue<Payload>({
+        channelId: "test",
+        accountId: "a",
+        stateDir,
+      });
+      await queue.enqueue("evt-replay", { text: "recover" }, { laneKey: "lane-a" });
+      const originalClaim = await queue.claim("evt-replay", { ownerId: "worker" });
+      if (!originalClaim) {
+        throw new Error("Expected a claimed ingress event");
+      }
+      await queue.fail(originalClaim, { reason: "handler-error", failedAt: 20 });
+      if (!queue.resubmit) {
+        throw new Error("Expected queue.resubmit");
+      }
+      await expect(queue.resubmit("evt-replay", { resubmittedAt: 30 })).resolves.toMatchObject({
+        kind: "resubmitted",
+        record: { attempts: 0, receivedAt: 30 },
+      });
+
+      const dispatch = vi.fn(
+        async (_event: unknown, lifecycle: ChannelIngressDispatchLifecycle) => {
+          await lifecycle.onAdopted();
+        },
+      );
+      const drain = createChannelIngressDrain<Payload>({ queue, dispatchClaimedEvent: dispatch });
+
+      expect(await drain.drainOnce()).toEqual({ started: 1 });
+      await drain.waitForIdle();
+      expect(await drain.drainOnce()).toEqual({ started: 0 });
+      expect(dispatch).toHaveBeenCalledTimes(1);
+      expect(dispatch.mock.calls[0]?.[0]).toMatchObject({
+        id: "evt-replay",
+        payload: { text: "recover" },
+        attempts: 0,
+      });
+      drain.dispose();
+    });
+  });
+
   it("complete-at-adoption: adoption tombstones; settle is not required", async () => {
     await withTempState(async (stateDir) => {
       const queue = createChannelIngressQueue<Payload>({

--- a/src/channels/message/ingress-queue.dead-letters.test.ts
+++ b/src/channels/message/ingress-queue.dead-letters.test.ts
@@ -1,0 +1,187 @@
+// Dead-letter queue tests cover retained diagnostics, replay, and health counts.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import {
+  countFailedChannelIngressQueueEntries,
+  createChannelIngressQueue,
+} from "./ingress-queue.js";
+
+async function withTempState<T>(run: (stateDir: string) => Promise<T>): Promise<T> {
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ingress-dead-letters-"));
+  try {
+    return await run(stateDir);
+  } finally {
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  }
+}
+
+describe("channel ingress dead letters", () => {
+  afterEach(() => closeOpenClawStateDatabaseForTest());
+
+  it("retains failed payload, metadata, and attempt history", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createChannelIngressQueue<{ text: string }, { source: string }>({
+        channelId: "telegram",
+        accountId: "ops",
+        stateDir,
+      });
+
+      await queue.enqueue(
+        "event-1",
+        { text: "recover me" },
+        { metadata: { source: "webhook" }, receivedAt: 5, laneKey: "chat-1" },
+      );
+      const firstClaim = await queue.claim("event-1", { ownerId: "worker" });
+      if (!firstClaim) {
+        throw new Error("Expected a claimed ingress event");
+      }
+      await queue.release(firstClaim, { lastError: "retryable", releasedAt: 20 });
+      const finalClaim = await queue.claim("event-1", { ownerId: "worker" });
+      if (!finalClaim) {
+        throw new Error("Expected a reclaimed ingress event");
+      }
+      await queue.fail(finalClaim, { reason: "handler-error", message: "fatal", failedAt: 30 });
+
+      expect(await queue.listFailed?.({ limit: "all" })).toEqual([
+        {
+          id: "event-1",
+          channelId: "telegram",
+          accountId: "ops",
+          queueName: JSON.stringify(["telegram", "ops"]),
+          payload: { text: "recover me" },
+          metadata: { source: "webhook" },
+          receivedAt: 5,
+          updatedAt: 30,
+          laneKey: "chat-1",
+          attempts: 1,
+          lastAttemptAt: 20,
+          failedAt: 30,
+          reason: "handler-error",
+          message: "fatal",
+        },
+      ]);
+    });
+  });
+
+  it("resubmits a failed event exactly once and refuses its completed tombstone", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createChannelIngressQueue<{ text: string }, { source: string }>({
+        channelId: "line",
+        accountId: "default",
+        stateDir,
+      });
+      if (!queue.resubmit) {
+        throw new Error("Expected queue.resubmit");
+      }
+
+      await queue.enqueue(
+        "event-1",
+        { text: "once" },
+        { metadata: { source: "webhook" }, receivedAt: 10, laneKey: "chat-1" },
+      );
+      const originalClaim = await queue.claim("event-1", { ownerId: "worker" });
+      if (!originalClaim) {
+        throw new Error("Expected a claimed ingress event");
+      }
+      await queue.fail(originalClaim, { reason: "handler-error", failedAt: 20 });
+
+      await expect(queue.resubmit("event-1", { resubmittedAt: 30 })).resolves.toMatchObject({
+        kind: "resubmitted",
+        record: {
+          id: "event-1",
+          payload: { text: "once" },
+          metadata: { source: "webhook" },
+          receivedAt: 30,
+          laneKey: "chat-1",
+          attempts: 0,
+        },
+        previous: { attempts: 0, failedAt: 20, reason: "handler-error" },
+      });
+      await expect(queue.resubmit("event-1", { resubmittedAt: 31 })).resolves.toEqual({
+        kind: "active",
+        status: "pending",
+      });
+
+      const replay = await queue.claimNext({ ownerId: "replay-worker" });
+      expect(replay).toMatchObject({ id: "event-1", payload: { text: "once" } });
+      await expect(queue.claimNext({ ownerId: "other-worker" })).resolves.toBeNull();
+      if (!replay) {
+        throw new Error("Expected the resubmitted event to be claimable");
+      }
+      expect(await queue.complete(replay, { completedAt: 40 })).toBe(true);
+      await expect(queue.resubmit("event-1", { resubmittedAt: 50 })).resolves.toMatchObject({
+        kind: "completed",
+        record: { id: "event-1", completedAt: 40 },
+      });
+      await expect(queue.claimNext()).resolves.toBeNull();
+    });
+  });
+
+  it("retains and resubmits a valid null payload", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createChannelIngressQueue<null>({
+        channelId: "telegram",
+        accountId: "null-payload",
+        stateDir,
+      });
+      if (!queue.resubmit) {
+        throw new Error("Expected queue.resubmit");
+      }
+
+      await queue.enqueue("event-null", null);
+      const claim = await queue.claim("event-null", { ownerId: "worker" });
+      if (!claim) {
+        throw new Error("Expected a claimed ingress event");
+      }
+      await queue.fail(claim, { reason: "handler-error", failedAt: 20 });
+
+      await expect(queue.listFailed?.()).resolves.toEqual([
+        expect.objectContaining({ id: "event-null", payload: null }),
+      ]);
+      await expect(queue.resubmit("event-null", { resubmittedAt: 30 })).resolves.toMatchObject({
+        kind: "resubmitted",
+        record: { id: "event-null", payload: null, attempts: 0 },
+      });
+      await expect(queue.claimNext({ ownerId: "replay-worker" })).resolves.toMatchObject({
+        id: "event-null",
+        payload: null,
+      });
+    });
+  });
+
+  it("counts dead letters by channel account with their oldest failure", async () => {
+    await withTempState(async (stateDir) => {
+      const telegram = createChannelIngressQueue<{ text: string }>({
+        channelId: "telegram",
+        accountId: "ops",
+        stateDir,
+      });
+      const line = createChannelIngressQueue<{ text: string }>({
+        channelId: "line",
+        accountId: "default",
+        stateDir,
+      });
+      for (const [queue, id, failedAt] of [
+        [telegram, "tg-1", 20],
+        [telegram, "tg-2", 30],
+        [line, "line-1", 40],
+      ] as const) {
+        await queue.enqueue(id, { text: id });
+        const claim = await queue.claim(id, { ownerId: "worker" });
+        if (!claim) {
+          throw new Error(`Expected ${id} to be claimed`);
+        }
+        await queue.fail(claim, { reason: "handler-error", failedAt });
+      }
+
+      expect(countFailedChannelIngressQueueEntries(stateDir)).toEqual([
+        { channelId: "line", accountId: "default", count: 1, oldestFailedAt: 40 },
+        { channelId: "telegram", accountId: "ops", count: 2, oldestFailedAt: 20 },
+      ]);
+    });
+  });
+});

--- a/src/channels/message/ingress-queue.test.ts
+++ b/src/channels/message/ingress-queue.test.ts
@@ -519,7 +519,7 @@ describe("channel ingress queue", () => {
           last_attempt_at: null,
           last_error: "bad",
           metadata_json: null,
-          payload_json: "null",
+          payload_json: JSON.stringify({ text: "keep" }),
         },
         {
           event_id: "old",

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -81,15 +81,52 @@ type ChannelIngressQueueCompletedRecord<TCompletedMetadata = unknown> = {
   metadata?: TCompletedMetadata;
 };
 
-/** Failed ingress event tombstone retained for duplicate detection and diagnostics. */
-type ChannelIngressQueueFailedRecord = {
+/** Failed ingress event retained for diagnostics and operator recovery. */
+type ChannelIngressQueueFailedRecord<TPayload = unknown, TMetadata = unknown> = {
   id: string;
   channelId: string;
   accountId: string;
   queueName: string;
+  payload?: TPayload;
+  metadata?: TMetadata;
+  receivedAt: number;
+  updatedAt: number;
+  laneKey?: string;
+  attempts: number;
+  lastAttemptAt?: number;
   failedAt: number;
   reason: string;
   message?: string;
+};
+
+/** Outcome of asking a channel/account queue to re-enqueue one failed event. */
+type ChannelIngressQueueResubmitResult<
+  TPayload,
+  TMetadata = unknown,
+  TCompletedMetadata = unknown,
+> =
+  | {
+      kind: "resubmitted";
+      record: ChannelIngressQueueRecord<TPayload, TMetadata>;
+      previous: ChannelIngressQueueFailedRecord<TPayload, TMetadata>;
+    }
+  | { kind: "not-found" }
+  | {
+      kind: "completed";
+      record: ChannelIngressQueueCompletedRecord<TCompletedMetadata>;
+    }
+  | { kind: "active"; status: "pending" | "claimed" }
+  | {
+      kind: "unrecoverable";
+      record: ChannelIngressQueueFailedRecord<TPayload, TMetadata>;
+    };
+
+/** Per-channel/account dead-letter count used by health and doctor. */
+type ChannelIngressQueueFailedCount = {
+  channelId: string;
+  accountId: string;
+  count: number;
+  oldestFailedAt: number | null;
 };
 
 /** Retention options for pending, completed, and failed ingress queue rows. */
@@ -129,7 +166,7 @@ type ChannelIngressQueueEnqueueResult<TPayload, TMetadata, TCompletedMetadata> =
   | {
       kind: "failed";
       duplicate: true;
-      record: ChannelIngressQueueFailedRecord;
+      record: ChannelIngressQueueFailedRecord<TPayload, TMetadata>;
     };
 
 /** Durable FIFO-ish ingress queue with claims, duplicate detection, and retention pruning. */
@@ -148,6 +185,10 @@ export type ChannelIngressQueue<TPayload, TMetadata = unknown, TCompletedMetadat
     orderBy?: "received" | "id";
   }): Promise<Array<ChannelIngressQueueRecord<TPayload, TMetadata>>>;
   listClaims(): Promise<Array<ChannelIngressQueueClaim<TPayload, TMetadata>>>;
+  /** Additive SDK seam; optional so existing external queue test doubles remain compatible. */
+  listFailed?(options?: {
+    limit?: number | "all";
+  }): Promise<Array<ChannelIngressQueueFailedRecord<TPayload, TMetadata>>>;
   claimNext(options?: {
     ownerId?: string;
     blockedLaneKeys?: Iterable<string>;
@@ -177,6 +218,11 @@ export type ChannelIngressQueue<TPayload, TMetadata = unknown, TCompletedMetadat
     idOrClaim: string | ChannelIngressQueueClaimRef,
     options: { reason: string; message?: string; failedAt?: number },
   ): Promise<boolean>;
+  /** Additive SDK seam; actual runtime queues support operator resubmission. */
+  resubmit?(
+    id: string,
+    options?: { resubmittedAt?: number },
+  ): Promise<ChannelIngressQueueResubmitResult<TPayload, TMetadata, TCompletedMetadata>>;
   delete(
     idOrClaim:
       | string
@@ -204,6 +250,10 @@ export type CreateChannelIngressQueueOptions = {
 
 type ChannelIngressDatabase = Pick<OpenClawStateKyselyDatabase, "channel_ingress_events">;
 type ChannelIngressRow = Selectable<ChannelIngressEvents>;
+
+// Failed rows need to distinguish a retained JSON null payload from the "null"
+// scrub marker written by older versions. Invalid JSON cannot collide with enqueue output.
+const FAILED_NULL_PAYLOAD_SENTINEL = "OPENCLAW_CHANNEL_INGRESS_FAILED_NULL_V1";
 
 function normalizePart(value: string | undefined, fallback: string): string {
   const normalized = value?.trim();
@@ -242,6 +292,10 @@ function parseJson(value: string): ParseJsonResult {
   } catch {
     return { ok: false };
   }
+}
+
+function parseFailedPayload(value: string): ParseJsonResult {
+  return value === FAILED_NULL_PAYLOAD_SENTINEL ? { ok: true, value: null } : parseJson(value);
 }
 
 function baseRecord<TPayload, TMetadata>(
@@ -319,12 +373,25 @@ function completedRecord<TCompletedMetadata>(
   };
 }
 
-function failedRecord(row: ChannelIngressRow): ChannelIngressQueueFailedRecord {
+function failedRecord<TPayload, TMetadata>(
+  row: ChannelIngressRow,
+): ChannelIngressQueueFailedRecord<TPayload, TMetadata> {
+  const payloadResult = parseFailedPayload(row.payload_json);
+  const metadataResult = row.metadata_json === null ? null : parseJson(row.metadata_json);
   return {
     id: row.event_id,
     channelId: row.channel_id,
     accountId: row.account_id,
     queueName: row.queue_name,
+    ...(payloadResult.ok && row.payload_json !== "null"
+      ? { payload: payloadResult.value as TPayload }
+      : {}),
+    ...(metadataResult?.ok ? { metadata: metadataResult.value as TMetadata } : {}),
+    receivedAt: row.received_at,
+    updatedAt: row.updated_at,
+    ...(row.lane_key === null ? {} : { laneKey: row.lane_key }),
+    attempts: row.attempts,
+    ...(row.last_attempt_at === null ? {} : { lastAttemptAt: row.last_attempt_at }),
     failedAt: row.failed_at ?? row.updated_at,
     reason: row.failed_reason ?? "failed",
     ...(row.last_error === null ? {} : { message: row.last_error }),
@@ -403,7 +470,11 @@ function rowToEnqueueResult<TPayload, TMetadata, TCompletedMetadata>(
     return { kind: "completed", duplicate: true, record: completedRecord(row) };
   }
   if (row.status === "failed") {
-    return { kind: "failed", duplicate: true, record: failedRecord(row) };
+    return {
+      kind: "failed",
+      duplicate: true,
+      record: failedRecord<TPayload, TMetadata>(row),
+    };
   }
   if (row.status === "claimed") {
     const rec = claimedRecord<TPayload, TMetadata>(row);
@@ -443,6 +514,40 @@ function normalizedCandidateIds(ids: Iterable<string> | undefined): string[] | u
 function queueNameForParts(channelId: string, accountId: string): string {
   // JSON tuple encoding keeps channel/account scopes unambiguous even when ids contain separators.
   return JSON.stringify([channelId, accountId]);
+}
+
+/** Count failed channel ingress events per channel account for operator health surfaces. */
+export function countFailedChannelIngressQueueEntries(
+  stateDir?: string,
+): ChannelIngressQueueFailedCount[] {
+  const database = openStateDatabase(stateDir);
+  const queueDb = getChannelIngressKysely(database.db);
+  const rows = executeSqliteQuerySync(
+    database.db,
+    queueDb
+      .selectFrom("channel_ingress_events")
+      .select((eb) => [
+        "channel_id",
+        "account_id",
+        eb.fn.countAll().as("failed_count"),
+        eb.fn.min("failed_at").as("oldest_failed_at"),
+      ])
+      .where("status", "=", "failed")
+      .groupBy(["channel_id", "account_id"])
+      .orderBy("channel_id", "asc")
+      .orderBy("account_id", "asc"),
+  ).rows as Array<{
+    channel_id: string;
+    account_id: string;
+    failed_count: number | bigint;
+    oldest_failed_at: number | bigint | null;
+  }>;
+  return rows.map((row) => ({
+    channelId: row.channel_id,
+    accountId: row.account_id,
+    count: Number(row.failed_count),
+    oldestFailedAt: row.oldest_failed_at == null ? null : Number(row.oldest_failed_at),
+  }));
 }
 
 /** Creates a durable channel/account-scoped ingress queue backed by the OpenClaw state database. */
@@ -532,17 +637,14 @@ export function createChannelIngressQueue<
           ) {
             throw new Error(`Failed to tombstone corrupt ingress event ${queueName}/${eventId}`);
           }
+          const failedRow = selectRow(tx.db, queueName, eventId);
+          if (!failedRow) {
+            throw new Error(`Failed to read corrupt ingress tombstone ${queueName}/${eventId}`);
+          }
           return {
             kind: "failed",
             duplicate: true,
-            record: {
-              id: row.event_id,
-              channelId: row.channel_id,
-              accountId: row.account_id,
-              queueName: row.queue_name,
-              failedAt: updatedAt,
-              reason: "corrupt_payload",
-            },
+            record: failedRecord<TPayload, TMetadata>(failedRow),
           };
         }
         return dup;
@@ -625,6 +727,24 @@ export function createChannelIngressQueue<
     return rows
       .map((row) => claimedRecord<TPayload, TMetadata>(row))
       .filter((rec): rec is ChannelIngressQueueClaim<TPayload, TMetadata> => rec !== null);
+  };
+
+  const listFailed: NonNullable<
+    ChannelIngressQueue<TPayload, TMetadata, TCompletedMetadata>["listFailed"]
+  > = async (listOptions) => {
+    const { db } = openStateDatabase(options.stateDir);
+    const rows = executeSqliteQuerySync(
+      db,
+      getChannelIngressKysely(db)
+        .selectFrom("channel_ingress_events")
+        .selectAll()
+        .where("queue_name", "=", queueName)
+        .where("status", "=", "failed")
+        .orderBy("failed_at", "asc")
+        .orderBy("event_id", "asc")
+        .limit(normalizeLimit(listOptions?.limit)),
+    ).rows;
+    return rows.map((row) => failedRecord<TPayload, TMetadata>(row));
   };
 
   const claimNext: ChannelIngressQueue<
@@ -1072,18 +1192,22 @@ export function createChannelIngressQueue<
         const kysely = getChannelIngressKysely(tx.db);
         const baseUpdate = kysely
           .updateTable("channel_ingress_events")
-          .set({
+          .set((eb) => ({
             status: "failed",
             failed_at: failedAt,
             failed_reason: failOptions.reason,
             last_error: failOptions.message ?? null,
-            payload_json: "null",
-            metadata_json: null,
+            payload_json: eb
+              .case()
+              .when("payload_json", "=", "null")
+              .then(FAILED_NULL_PAYLOAD_SENTINEL)
+              .else(eb.ref("payload_json"))
+              .end(),
             claim_token: null,
             claim_owner: null,
             claimed_at: null,
             updated_at: failedAt,
-          })
+          }))
           .where("queue_name", "=", queueName)
           .where("event_id", "=", eventId);
         const update =
@@ -1091,6 +1215,74 @@ export function createChannelIngressQueue<
             ? baseUpdate.where("status", "=", "pending")
             : baseUpdate.where("status", "=", "claimed").where("claim_token", "=", token);
         return affectedRows(executeSqliteQuerySync(tx.db, update)) > 0;
+      },
+      { path: database.path },
+    );
+  };
+
+  const resubmit: NonNullable<
+    ChannelIngressQueue<TPayload, TMetadata, TCompletedMetadata>["resubmit"]
+  > = async (id, resubmitOptions) => {
+    const eventId = idFrom(id);
+    const resubmittedAt = resubmitOptions?.resubmittedAt ?? now();
+    const database = openStateDatabase(options.stateDir);
+    return runOpenClawStateWriteTransaction(
+      (tx) => {
+        const row = selectRow(tx.db, queueName, eventId);
+        if (!row) {
+          return { kind: "not-found" };
+        }
+        if (row.status === "completed") {
+          return { kind: "completed", record: completedRecord<TCompletedMetadata>(row) };
+        }
+        if (row.status !== "failed") {
+          return {
+            kind: "active",
+            status: row.status === "claimed" ? "claimed" : "pending",
+          };
+        }
+        const previous = failedRecord<TPayload, TMetadata>(row);
+        // Pre-retention tombstones and corrupt-payload failures stored JSON null.
+        // Refuse them rather than enqueueing an event with invented payload data.
+        if (row.payload_json === "null" || !parseFailedPayload(row.payload_json).ok) {
+          return { kind: "unrecoverable", record: previous };
+        }
+        const result = executeSqliteQuerySync(
+          tx.db,
+          getChannelIngressKysely(tx.db)
+            .updateTable("channel_ingress_events")
+            .set({
+              status: "pending",
+              payload_json:
+                row.payload_json === FAILED_NULL_PAYLOAD_SENTINEL ? "null" : row.payload_json,
+              received_at: resubmittedAt,
+              updated_at: resubmittedAt,
+              attempts: 0,
+              last_attempt_at: null,
+              last_error: null,
+              failed_at: null,
+              failed_reason: null,
+              claim_token: null,
+              claim_owner: null,
+              claimed_at: null,
+              completed_at: null,
+              completed_metadata_json: null,
+            })
+            .where("queue_name", "=", queueName)
+            .where("event_id", "=", eventId)
+            .where("status", "=", "failed"),
+        );
+        if (affectedRows(result) === 0) {
+          return { kind: "active", status: "pending" };
+        }
+        const updated = selectRow(tx.db, queueName, eventId);
+        const record = updated ? baseRecord<TPayload, TMetadata>(updated) : null;
+        if (!record) {
+          throw new Error(
+            `Failed to read resubmitted channel ingress event ${queueName}/${eventId}`,
+          );
+        }
+        return { kind: "resubmitted", record, previous };
       },
       { path: database.path },
     );
@@ -1232,12 +1424,14 @@ export function createChannelIngressQueue<
     enqueue,
     listPending,
     listClaims,
+    listFailed,
     claimNext,
     claim,
     refreshClaim,
     complete,
     release,
     fail,
+    resubmit,
     delete: deleteEntry,
     recoverStaleClaims,
     prune,

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -81,12 +81,22 @@ type ChannelIngressQueueCompletedRecord<TCompletedMetadata = unknown> = {
   metadata?: TCompletedMetadata;
 };
 
-/** Failed ingress event retained for diagnostics and operator recovery. */
-type ChannelIngressQueueFailedRecord<TPayload = unknown, TMetadata = unknown> = {
+/** Failed ingress event tombstone retained for duplicate detection. */
+type ChannelIngressQueueFailedRecord = {
   id: string;
   channelId: string;
   accountId: string;
   queueName: string;
+  failedAt: number;
+  reason: string;
+  message?: string;
+};
+
+/** Rich failed ingress event retained for diagnostics and operator recovery. */
+type ChannelIngressQueueDeadLetterRecord<
+  TPayload = unknown,
+  TMetadata = unknown,
+> = ChannelIngressQueueFailedRecord & {
   payload?: TPayload;
   metadata?: TMetadata;
   receivedAt: number;
@@ -94,9 +104,6 @@ type ChannelIngressQueueFailedRecord<TPayload = unknown, TMetadata = unknown> = 
   laneKey?: string;
   attempts: number;
   lastAttemptAt?: number;
-  failedAt: number;
-  reason: string;
-  message?: string;
 };
 
 /** Outcome of asking a channel/account queue to re-enqueue one failed event. */
@@ -108,7 +115,7 @@ type ChannelIngressQueueResubmitResult<
   | {
       kind: "resubmitted";
       record: ChannelIngressQueueRecord<TPayload, TMetadata>;
-      previous: ChannelIngressQueueFailedRecord<TPayload, TMetadata>;
+      previous: ChannelIngressQueueDeadLetterRecord<TPayload, TMetadata>;
     }
   | { kind: "not-found" }
   | {
@@ -118,7 +125,7 @@ type ChannelIngressQueueResubmitResult<
   | { kind: "active"; status: "pending" | "claimed" }
   | {
       kind: "unrecoverable";
-      record: ChannelIngressQueueFailedRecord<TPayload, TMetadata>;
+      record: ChannelIngressQueueDeadLetterRecord<TPayload, TMetadata>;
     };
 
 /** Per-channel/account dead-letter count used by health and doctor. */
@@ -166,7 +173,7 @@ type ChannelIngressQueueEnqueueResult<TPayload, TMetadata, TCompletedMetadata> =
   | {
       kind: "failed";
       duplicate: true;
-      record: ChannelIngressQueueFailedRecord<TPayload, TMetadata>;
+      record: ChannelIngressQueueFailedRecord;
     };
 
 /** Durable FIFO-ish ingress queue with claims, duplicate detection, and retention pruning. */
@@ -188,7 +195,7 @@ export type ChannelIngressQueue<TPayload, TMetadata = unknown, TCompletedMetadat
   /** Additive SDK seam; optional so existing external queue test doubles remain compatible. */
   listFailed?(options?: {
     limit?: number | "all";
-  }): Promise<Array<ChannelIngressQueueFailedRecord<TPayload, TMetadata>>>;
+  }): Promise<Array<ChannelIngressQueueDeadLetterRecord<TPayload, TMetadata>>>;
   claimNext(options?: {
     ownerId?: string;
     blockedLaneKeys?: Iterable<string>;
@@ -375,7 +382,7 @@ function completedRecord<TCompletedMetadata>(
 
 function failedRecord<TPayload, TMetadata>(
   row: ChannelIngressRow,
-): ChannelIngressQueueFailedRecord<TPayload, TMetadata> {
+): ChannelIngressQueueDeadLetterRecord<TPayload, TMetadata> {
   const payloadResult = parseFailedPayload(row.payload_json);
   const metadataResult = row.metadata_json === null ? null : parseJson(row.metadata_json);
   return {

--- a/src/cli/channels-cli.test.ts
+++ b/src/cli/channels-cli.test.ts
@@ -19,6 +19,12 @@ function getChannelAddOptionFlags(program: Command): string[] {
   return add?.options.map((option) => option.flags) ?? [];
 }
 
+function getChannelSubcommandNames(program: Command, parentName: string): string[] {
+  const channels = program.commands.find((command) => command.name() === "channels");
+  const parent = channels?.commands.find((command) => command.name() === parentName);
+  return parent?.commands.map((command) => command.name()) ?? [];
+}
+
 describe("registerChannelsCli", () => {
   const originalArgv = [...process.argv];
 
@@ -38,6 +44,14 @@ describe("registerChannelsCli", () => {
     await registerChannelsCli(new Command().name("openclaw"));
 
     expect(listBundledPackageChannelMetadataMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("registers dead-letter inspection and resubmission commands", async () => {
+    const program = new Command().name("openclaw");
+
+    await registerChannelsCli(program);
+
+    expect(getChannelSubcommandNames(program, "dead-letters")).toEqual(["list", "resubmit"]);
   });
 
   it("registers ClickClack setup options before an external channel plugin is installed", async () => {

--- a/src/cli/channels-cli.ts
+++ b/src/cli/channels-cli.ts
@@ -205,6 +205,42 @@ export async function registerChannelsCli(
       });
     });
 
+  const deadLetters = channels
+    .command("dead-letters")
+    .description("Inspect and resubmit failed inbound channel events");
+
+  deadLetters
+    .command("list")
+    .description("List failed inbound events for one channel account")
+    .requiredOption("--channel <name>", "Channel id")
+    .option("--account <id>", "Account id", "default")
+    .option("--limit <n>", "Maximum entries", "100")
+    .option("--json", "Output JSON", false)
+    .action(async (opts) => {
+      await runChannelsCommand(async () => {
+        const { channelsDeadLettersListCommand } =
+          await import("../commands/channels/dead-letters.js");
+        await channelsDeadLettersListCommand(opts, defaultRuntime);
+      });
+    });
+
+  deadLetters
+    .command("resubmit")
+    .description("Re-enqueue one failed inbound event")
+    .argument("<event-id>", "Ingress event id")
+    .requiredOption("--channel <name>", "Channel id")
+    .option("--account <id>", "Account id", "default")
+    .option("--json", "Output JSON", false)
+    .action(async (eventId, opts) => {
+      await runChannelsCommand(async () => {
+        const { channelsDeadLettersResubmitCommand } =
+          await import("../commands/channels/dead-letters.js");
+        await channelsDeadLettersResubmitCommand(eventId, opts, defaultRuntime);
+      });
+    });
+
+  applyParentDefaultHelpAction(deadLetters);
+
   const addCommand = channels
     .command("add")
     .description("Add or update a channel account")

--- a/src/commands/channels/dead-letters.test.ts
+++ b/src/commands/channels/dead-letters.test.ts
@@ -1,0 +1,101 @@
+// Channels dead-letter command tests exercise the operator-visible recovery path.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createChannelIngressQueue } from "../../channels/message/ingress-queue.js";
+import type { RuntimeEnv } from "../../runtime.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import {
+  channelsDeadLettersListCommand,
+  channelsDeadLettersResubmitCommand,
+} from "./dead-letters.js";
+
+const originalStateDir = process.env.OPENCLAW_STATE_DIR;
+
+async function withTempState(run: (stateDir: string) => Promise<void>): Promise<void> {
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-channel-dead-letters-"));
+  process.env.OPENCLAW_STATE_DIR = stateDir;
+  try {
+    await run(stateDir);
+  } finally {
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  }
+}
+
+function createRuntime() {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  } as unknown as RuntimeEnv;
+}
+
+describe("channel dead-letter commands", () => {
+  afterEach(() => {
+    closeOpenClawStateDatabaseForTest();
+    if (originalStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = originalStateDir;
+    }
+  });
+
+  it("lists retained failures as JSON", async () => {
+    await withTempState(async () => {
+      const queue = createChannelIngressQueue<{ text: string }>({
+        channelId: "telegram",
+        accountId: "ops",
+      });
+      await queue.enqueue("event-1", { text: "recover me" });
+      const claim = await queue.claim("event-1", { ownerId: "worker" });
+      if (!claim) {
+        throw new Error("Expected a claimed ingress event");
+      }
+      await queue.fail(claim, { reason: "handler-error", failedAt: 20 });
+      const runtime = createRuntime();
+
+      await channelsDeadLettersListCommand(
+        { channel: "telegram", account: "ops", json: true },
+        runtime,
+      );
+
+      const output = JSON.parse(String(vi.mocked(runtime.log).mock.calls[0]?.[0])) as {
+        deadLetters: Array<{ id: string; payload?: unknown; reason: string }>;
+      };
+      expect(output.deadLetters).toEqual([
+        expect.objectContaining({
+          id: "event-1",
+          payload: { text: "recover me" },
+          reason: "handler-error",
+        }),
+      ]);
+    });
+  });
+
+  it("resubmits through the queue API and reports completed events as terminal", async () => {
+    await withTempState(async () => {
+      const queue = createChannelIngressQueue<{ text: string }>({ channelId: "line" });
+      await queue.enqueue("event-1", { text: "once" });
+      const claim = await queue.claim("event-1", { ownerId: "worker" });
+      if (!claim) {
+        throw new Error("Expected a claimed ingress event");
+      }
+      await queue.fail(claim, { reason: "handler-error", failedAt: 20 });
+      const runtime = createRuntime();
+
+      await channelsDeadLettersResubmitCommand("event-1", { channel: "line" }, runtime);
+      const replay = await queue.claimNext({ ownerId: "replay-worker" });
+      expect(replay).toMatchObject({ id: "event-1", payload: { text: "once" } });
+      if (!replay) {
+        throw new Error("Expected a resubmitted ingress event");
+      }
+      await queue.complete(replay, { completedAt: 40 });
+
+      await expect(
+        channelsDeadLettersResubmitCommand("event-1", { channel: "line" }, runtime),
+      ).rejects.toThrow("is completed and cannot be resubmitted");
+    });
+  });
+});

--- a/src/commands/channels/dead-letters.ts
+++ b/src/commands/channels/dead-letters.ts
@@ -1,0 +1,93 @@
+// Operator commands for inspecting and resubmitting failed channel ingress events.
+import { sanitizeTerminalText } from "../../../packages/terminal-core/src/safe-text.js";
+import { theme } from "../../../packages/terminal-core/src/theme.js";
+import { createChannelIngressQueue } from "../../channels/message/ingress-queue.js";
+import { formatDurationHuman } from "../../infra/format-time/format-duration.js";
+import { parseStrictPositiveInteger } from "../../infra/parse-finite-number.js";
+import { defaultRuntime, type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
+
+type ChannelsDeadLettersOptions = {
+  channel?: string;
+  account?: string;
+  limit?: string | number;
+  json?: boolean;
+};
+
+function resolveScope(options: ChannelsDeadLettersOptions) {
+  const channelId = options.channel?.trim();
+  if (!channelId) {
+    throw new Error("--channel is required.");
+  }
+  return { channelId, accountId: options.account?.trim() || "default" };
+}
+
+function parseLimit(value: unknown): number {
+  const parsed = parseStrictPositiveInteger(value ?? "100");
+  if (parsed === undefined) {
+    throw new Error("--limit must be a positive integer.");
+  }
+  return parsed;
+}
+
+/** List retained ingress failures for one channel account. */
+export async function channelsDeadLettersListCommand(
+  options: ChannelsDeadLettersOptions,
+  runtime: RuntimeEnv = defaultRuntime,
+): Promise<void> {
+  const { channelId, accountId } = resolveScope(options);
+  const queue = createChannelIngressQueue({ channelId, accountId });
+  if (!queue.listFailed) {
+    throw new Error("This runtime does not support channel ingress dead-letter inspection.");
+  }
+  const deadLetters = await queue.listFailed({ limit: parseLimit(options.limit) });
+  if (options.json) {
+    writeRuntimeJson(runtime, { channelId, accountId, deadLetters });
+    return;
+  }
+  runtime.log(theme.heading(`Channel ingress dead letters (${channelId}/${accountId})`));
+  if (deadLetters.length === 0) {
+    runtime.log(theme.muted("No dead-lettered ingress events."));
+    return;
+  }
+  const now = Date.now();
+  for (const entry of deadLetters) {
+    const age = formatDurationHuman(Math.max(0, now - entry.failedAt));
+    runtime.log(
+      `- ${sanitizeTerminalText(entry.id)}: ${sanitizeTerminalText(entry.reason)}; attempts=${entry.attempts}; failed ${age} ago`,
+    );
+  }
+}
+
+/** Atomically return one retained ingress failure to its channel/account queue. */
+export async function channelsDeadLettersResubmitCommand(
+  eventId: string,
+  options: ChannelsDeadLettersOptions,
+  runtime: RuntimeEnv = defaultRuntime,
+): Promise<void> {
+  const { channelId, accountId } = resolveScope(options);
+  const queue = createChannelIngressQueue({ channelId, accountId });
+  if (!queue.resubmit) {
+    throw new Error("This runtime does not support channel ingress dead-letter resubmission.");
+  }
+  const result = await queue.resubmit(eventId);
+  if (result.kind === "resubmitted") {
+    if (options.json) {
+      writeRuntimeJson(runtime, { channelId, accountId, eventId, result });
+    } else {
+      runtime.log(
+        `${theme.success("Resubmitted")} channel ingress event ${sanitizeTerminalText(eventId)} (${channelId}/${accountId}).`,
+      );
+    }
+    return;
+  }
+  if (result.kind === "completed") {
+    throw new Error(`Ingress event ${eventId} is completed and cannot be resubmitted.`);
+  }
+  if (result.kind === "active") {
+    throw new Error(`Ingress event ${eventId} is already ${result.status}.`);
+  }
+  if (result.kind === "unrecoverable") {
+    throw new Error(`Ingress event ${eventId} has no retained payload and cannot be resubmitted.`);
+  }
+  throw new Error(`Ingress event ${eventId} was not found for ${channelId}/${accountId}.`);
+}

--- a/src/commands/doctor-channel-ingress.test.ts
+++ b/src/commands/doctor-channel-ingress.test.ts
@@ -1,0 +1,41 @@
+// Doctor channel ingress tests cover dead-letter visibility and recovery guidance.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { createChannelIngressQueue } from "../channels/message/ingress-queue.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { noteChannelIngressDeadLetters } from "./doctor-channel-ingress.js";
+
+describe("noteChannelIngressDeadLetters", () => {
+  it("mentions affected channel accounts and the inspection command", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-doctor-ingress-"));
+    try {
+      const queue = createChannelIngressQueue<{ text: string }>({
+        channelId: "telegram",
+        accountId: "ops",
+        stateDir,
+      });
+      await queue.enqueue("event-1", { text: "recover me" });
+      const claim = await queue.claim("event-1", { ownerId: "worker" });
+      if (!claim) {
+        throw new Error("Expected a claimed ingress event");
+      }
+      await queue.fail(claim, { reason: "handler-error", failedAt: 20 });
+      const noteFn = vi.fn();
+
+      noteChannelIngressDeadLetters({ stateDir, noteFn });
+
+      expect(noteFn).toHaveBeenCalledWith(
+        expect.stringContaining("telegram/ops: 1 dead-lettered ingress event"),
+        "Channel ingress",
+      );
+      expect(noteFn.mock.calls[0]?.[0]).toContain(
+        "openclaw channels dead-letters list --channel telegram --account ops",
+      );
+    } finally {
+      closeOpenClawStateDatabaseForTest();
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/commands/doctor-channel-ingress.ts
+++ b/src/commands/doctor-channel-ingress.ts
@@ -1,0 +1,44 @@
+// Doctor visibility for channel ingress events retained after terminal failure.
+import { note } from "../../packages/terminal-core/src/note.js";
+import { countFailedChannelIngressQueueEntries } from "../channels/message/ingress-queue.js";
+import { formatCliCommand } from "../cli/command-format.js";
+import { quoteCliArg } from "../cli/quote-cli-arg.js";
+
+type NoteChannelIngressDeadLettersOptions = {
+  stateDir?: string;
+  noteFn?: typeof note;
+};
+
+/** Mention channel accounts with retained ingress failures and their recovery command. */
+export function noteChannelIngressDeadLetters(
+  options: NoteChannelIngressDeadLettersOptions = {},
+): void {
+  const failed = countFailedChannelIngressQueueEntries(options.stateDir);
+  if (failed.length === 0) {
+    return;
+  }
+  const lines = failed.map(
+    (entry) =>
+      `- ${entry.channelId}/${entry.accountId}: ${entry.count} dead-lettered ingress event${entry.count === 1 ? "" : "s"}.`,
+  );
+  const first = failed[0];
+  if (first) {
+    lines.push(
+      `- Inspect with ${formatCliCommand(
+        [
+          "openclaw",
+          "channels",
+          "dead-letters",
+          "list",
+          "--channel",
+          first.channelId,
+          "--account",
+          first.accountId,
+        ]
+          .map(quoteCliArg)
+          .join(" "),
+      )}.`,
+    );
+  }
+  (options.noteFn ?? note)(lines.join("\n"), "Channel ingress");
+}

--- a/src/commands/health.delivery-queue.test.ts
+++ b/src/commands/health.delivery-queue.test.ts
@@ -1,0 +1,55 @@
+// Delivery queue health tests cover independent inbound and outbound diagnostic reads.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const countOutbound = vi.fn();
+const countIngress = vi.fn();
+
+vi.mock("../infra/delivery-queue-sqlite.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../infra/delivery-queue-sqlite.js")>();
+  return {
+    ...actual,
+    countFailedDeliveryQueueEntries: () => countOutbound(),
+  };
+});
+
+vi.mock("../channels/message/ingress-queue.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../channels/message/ingress-queue.js")>();
+  return {
+    ...actual,
+    countFailedChannelIngressQueueEntries: () => countIngress(),
+  };
+});
+
+const { buildDeliveryQueueHealthSummary } = await import("./health.js");
+
+describe("buildDeliveryQueueHealthSummary", () => {
+  beforeEach(() => {
+    countOutbound.mockReset().mockReturnValue([]);
+    countIngress.mockReset().mockReturnValue([]);
+  });
+
+  it("preserves outbound failures when the ingress health read fails", () => {
+    countOutbound.mockReturnValue([{ queueName: "outbound", count: 2, oldestFailedAt: 1_000 }]);
+    countIngress.mockImplementation(() => {
+      throw new Error("ingress database unavailable");
+    });
+
+    expect(buildDeliveryQueueHealthSummary()).toEqual({
+      failed: [{ queueName: "outbound", count: 2, oldestFailedAt: 1_000 }],
+    });
+  });
+
+  it("preserves ingress failures when the outbound health read fails", () => {
+    countOutbound.mockImplementation(() => {
+      throw new Error("outbound database unavailable");
+    });
+    countIngress.mockReturnValue([
+      { channelId: "telegram", accountId: "ops", count: 1, oldestFailedAt: 2_000 },
+    ]);
+
+    expect(buildDeliveryQueueHealthSummary()).toEqual({
+      failed: [],
+      ingressFailed: [{ channelId: "telegram", accountId: "ops", count: 1, oldestFailedAt: 2_000 }],
+    });
+  });
+});

--- a/src/commands/health.snapshot.test.ts
+++ b/src/commands/health.snapshot.test.ts
@@ -557,7 +557,7 @@ describe("getHealthSnapshot", () => {
     ]);
   });
 
-  it("includes dead-lettered delivery queue entries in the health snapshot", async () => {
+  it("includes outbound and ingress dead letters in the health snapshot", async () => {
     testConfig = { session: { store: "/tmp/x" } };
     testStore = {};
     setActivePluginRegistry(createTestRegistry([]));
@@ -575,12 +575,28 @@ describe("getHealthSnapshot", () => {
         entry: { id: "dead-1", enqueuedAt: 1_000, retryCount: 5 },
       });
       moveDeliveryQueueEntryToFailed("outbound", "dead-1");
+      const { createChannelIngressQueue } = await import("../channels/message/ingress-queue.js");
+      const ingressQueue = createChannelIngressQueue<{ text: string }>({
+        channelId: "telegram",
+        accountId: "ops",
+      });
+      await ingressQueue.enqueue("dead-2", { text: "recover me" });
+      const claim = await ingressQueue.claim("dead-2", { ownerId: "worker" });
+      if (!claim) {
+        throw new Error("Expected a claimed ingress event");
+      }
+      await ingressQueue.fail(claim, { reason: "handler-error", failedAt: 50_000 });
 
       const snap = await getHealthSnapshot({ timeoutMs: 10, probe: false });
-      expect(snap.deliveryQueues?.failed).toEqual([
-        { queueName: "outbound", count: 1, oldestFailedAt: expect.any(Number) },
-      ]);
+      expect(snap.deliveryQueues).toEqual({
+        failed: [{ queueName: "outbound", count: 1, oldestFailedAt: expect.any(Number) }],
+        ingressFailed: [
+          { channelId: "telegram", accountId: "ops", count: 1, oldestFailedAt: 50_000 },
+        ],
+      });
     } finally {
+      const { closeOpenClawStateDatabaseForTest } = await import("../state/openclaw-state-db.js");
+      closeOpenClawStateDatabaseForTest();
       if (previousStateDir === undefined) {
         delete process.env.OPENCLAW_STATE_DIR;
       } else {

--- a/src/commands/health.test.ts
+++ b/src/commands/health.test.ts
@@ -572,6 +572,25 @@ describe("formatDeliveryQueueHealthLine", () => {
     );
   });
 
+  it("summarizes dead-lettered ingress entries per channel account", () => {
+    const summary = createHealthSummary({
+      channels: {},
+      channelOrder: [],
+      channelLabels: {},
+    });
+    summary.deliveryQueues = {
+      failed: [],
+      ingressFailed: [
+        { channelId: "line", accountId: "default", count: 1, oldestFailedAt: 90_000 },
+        { channelId: "telegram", accountId: "ops", count: 2 },
+      ],
+    };
+
+    expect(formatDeliveryQueueHealthLine(summary, 7_290_000)).toBe(
+      "Delivery queue: warning (dead-lettered entries — inbound line/default: 1, inbound telegram/ops: 2; oldest 2h ago)",
+    );
+  });
+
   it("returns null when no dead-lettered entries are reported", () => {
     const summary = createHealthSummary({
       channels: {},

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -11,6 +11,7 @@ import {
   resolveChannelAccountConfigured,
   resolveChannelAccountEnabled,
 } from "../channels/account-summary.js";
+import { countFailedChannelIngressQueueEntries } from "../channels/message/ingress-queue.js";
 import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
 import { listReadOnlyChannelPluginsForConfig } from "../channels/plugins/read-only.js";
 import { buildChannelAccountSnapshotFromAccount } from "../channels/plugins/status.js";
@@ -253,10 +254,10 @@ export function formatContextEngineHealthLine(summary: HealthSummary): string | 
   return `Context engine: warning (${quarantined.length} quarantined; downgraded to legacy: ${engines})`;
 }
 
-/** Builds dead-lettered delivery queue health; shared with cached gateway responses. */
+/** Builds dead-lettered inbound and outbound queue health for cached gateway responses. */
 export function buildDeliveryQueueHealthSummary(): DeliveryQueueHealthSummary | undefined {
-  // Dead-lettered deliveries are retained in SQLite for diagnostics but had no
-  // health surface; a storage read failure must not take health down with it.
+  // Queue health reads are diagnostic; a storage failure must not take the
+  // gateway health endpoint down with it.
   try {
     const failed = countFailedDeliveryQueueEntries().map((queue) => {
       const entry: DeliveryQueueHealthSummary["failed"][number] = {
@@ -268,7 +269,24 @@ export function buildDeliveryQueueHealthSummary(): DeliveryQueueHealthSummary | 
       }
       return entry;
     });
-    return failed.length > 0 ? { failed } : undefined;
+    const ingressFailed = countFailedChannelIngressQueueEntries().map((queue) => {
+      const entry: NonNullable<DeliveryQueueHealthSummary["ingressFailed"]>[number] = {
+        channelId: queue.channelId,
+        accountId: queue.accountId,
+        count: queue.count,
+      };
+      if (queue.oldestFailedAt != null) {
+        entry.oldestFailedAt = queue.oldestFailedAt;
+      }
+      return entry;
+    });
+    if (failed.length === 0 && ingressFailed.length === 0) {
+      return undefined;
+    }
+    return {
+      failed,
+      ...(ingressFailed.length > 0 ? { ingressFailed } : {}),
+    };
   } catch (error) {
     debugHealth(undefined, "delivery queue health read failed", error);
     return undefined;
@@ -281,11 +299,17 @@ export function formatDeliveryQueueHealthLine(
   now = Date.now(),
 ): string | null {
   const failed = summary.deliveryQueues?.failed ?? [];
-  if (failed.length === 0) {
+  const ingressFailed = summary.deliveryQueues?.ingressFailed ?? [];
+  if (failed.length === 0 && ingressFailed.length === 0) {
     return null;
   }
-  const counts = failed.map((queue) => `${queue.queueName}: ${queue.count}`).join(", ");
-  const oldest = failed
+  const counts = [
+    ...failed.map((queue) => `${queue.queueName}: ${queue.count}`),
+    ...ingressFailed.map(
+      (queue) => `inbound ${queue.channelId}/${queue.accountId}: ${queue.count}`,
+    ),
+  ].join(", ");
+  const oldest = [...failed, ...ingressFailed]
     .map((queue) => queue.oldestFailedAt)
     .filter((value): value is number => typeof value === "number");
   const oldestNote =

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -258,8 +258,9 @@ export function formatContextEngineHealthLine(summary: HealthSummary): string | 
 export function buildDeliveryQueueHealthSummary(): DeliveryQueueHealthSummary | undefined {
   // Queue health reads are diagnostic; a storage failure must not take the
   // gateway health endpoint down with it.
+  let failed: DeliveryQueueHealthSummary["failed"] = [];
   try {
-    const failed = countFailedDeliveryQueueEntries().map((queue) => {
+    failed = countFailedDeliveryQueueEntries().map((queue) => {
       const entry: DeliveryQueueHealthSummary["failed"][number] = {
         queueName: queue.queueName,
         count: queue.count,
@@ -269,7 +270,12 @@ export function buildDeliveryQueueHealthSummary(): DeliveryQueueHealthSummary | 
       }
       return entry;
     });
-    const ingressFailed = countFailedChannelIngressQueueEntries().map((queue) => {
+  } catch (error) {
+    debugHealth(undefined, "outbound delivery queue health read failed", error);
+  }
+  let ingressFailed: NonNullable<DeliveryQueueHealthSummary["ingressFailed"]> = [];
+  try {
+    ingressFailed = countFailedChannelIngressQueueEntries().map((queue) => {
       const entry: NonNullable<DeliveryQueueHealthSummary["ingressFailed"]>[number] = {
         channelId: queue.channelId,
         accountId: queue.accountId,
@@ -280,17 +286,16 @@ export function buildDeliveryQueueHealthSummary(): DeliveryQueueHealthSummary | 
       }
       return entry;
     });
-    if (failed.length === 0 && ingressFailed.length === 0) {
-      return undefined;
-    }
-    return {
-      failed,
-      ...(ingressFailed.length > 0 ? { ingressFailed } : {}),
-    };
   } catch (error) {
-    debugHealth(undefined, "delivery queue health read failed", error);
+    debugHealth(undefined, "channel ingress queue health read failed", error);
+  }
+  if (failed.length === 0 && ingressFailed.length === 0) {
     return undefined;
   }
+  return {
+    failed,
+    ...(ingressFailed.length > 0 ? { ingressFailed } : {}),
+  };
 }
 
 /** Formats dead-lettered delivery queue entries for text health output. */

--- a/src/commands/health.types.ts
+++ b/src/commands/health.types.ts
@@ -72,6 +72,12 @@ export type DeliveryQueueHealthSummary = {
     count: number;
     oldestFailedAt?: number;
   }>;
+  ingressFailed?: Array<{
+    channelId: string;
+    accountId: string;
+    count: number;
+    oldestFailedAt?: number;
+  }>;
 };
 
 /** Optional model pricing cache health reported by the gateway. */

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -642,6 +642,11 @@ async function runDatabaseBloatHealth(ctx: DoctorHealthFlowContext): Promise<voi
   noteSqliteDatabaseBloat(ctx.cfg);
 }
 
+async function runChannelIngressDeadLettersHealth(): Promise<void> {
+  const { noteChannelIngressDeadLetters } = await import("../commands/doctor-channel-ingress.js");
+  noteChannelIngressDeadLetters();
+}
+
 async function runStateIntegrityHealth(ctx: DoctorHealthFlowContext): Promise<void> {
   const { noteStateIntegrity } = await loadDoctorStateIntegrityModule();
   await noteStateIntegrity(ctx.cfg, ctx.prompter, ctx.configPath);
@@ -1778,6 +1783,11 @@ function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
       id: "doctor:db-bloat",
       label: "SQLite database size",
       run: runDatabaseBloatHealth,
+    }),
+    createDoctorHealthContribution({
+      id: "doctor:channel-ingress-dead-letters",
+      label: "Channel ingress dead letters",
+      run: runChannelIngressDeadLettersHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:state-integrity",


### PR DESCRIPTION
Closes #109911

## What Problem This Solves

Fixes an issue where operators could not inspect or recover inbound channel events after retry exhaustion. Failed ingress rows erased their payloads, duplicate submissions were absorbed by the failed tombstone, and the existing health and doctor surfaces did not report the failures.

## Why This Change Was Made

Retains payload, metadata, failure reason, and attempt history within the existing failed-row TTL and cap, then adds an atomic failed-to-pending resubmit transition that preserves the event ID while resetting retry state. The queue API, `openclaw channels dead-letters` CLI, health summary, and doctor note mirror the existing outbound dead-letter operator model. Valid JSON null payloads use a durable sentinel while failed and are restored on resubmit so they remain distinct from older scrubbed tombstones.

This adds no schema version, schema surface, config key, gateway protocol, or plugin policy.

## User Impact

Operators can list retained inbound dead letters per channel account, see their counts and oldest age in health output, receive a doctor warning for affected accounts, and resubmit a recoverable event exactly once. Completed events remain terminal, active events refuse duplicate resubmission, and pre-retention scrubbed rows are reported as unrecoverable rather than replayed with invented data.

## Evidence

- 111 focused tests passed across ingress queue/drain, CLI registration and commands, health, and doctor suites.
- Final changed-surface gate passed: core and test typechecks, full core lint, formatting, storage policy, plugin boundaries, import cycles, and runtime guards.
- Both dead-code gates passed with zero unused files and zero unused exports.
- Packaged build passed, including CLI bootstrap imports, plugin SDK declaration checks, runtime post-build checks, and Control UI performance limits.
- Docs validation passed for 739 files; 6,091 internal links checked with zero broken links, and the generated docs map is current.
- Built-CLI behavior validation passed for list, resubmit, empty-after-resubmit, duplicate-active refusal, and required-channel validation.
- Mandatory branch autoreview completed clean with no accepted/actionable findings.
- `oxfmt` ran on every touched file; `git diff --check` passed.
- Diff size: 951 additions, 31 deletions (479 test lines, 29 docs lines, net +419 production lines). Production growth covers the queue transition/diagnostics, CLI, health, and doctor parity surfaces.

Proof deviation: the final Blacksmith Testbox could not sync the sparse worktree (targeted sync timeout followed by the five-minute full-sync guard), so the trusted-source fallback ran the final changed-surface gate, dead-code gates, and build locally under supported Node 24.15.0. Earlier Testbox runs completed the focused suites, changed-surface gate, dead-code gates, docs validation, packaged build, and built-CLI behavior proof successfully.
