### PR TITLE
fix(heartbeat): keep replacement wake lifecycles isolated

### DIFF
--- a/src/infra/heartbeat-wake.test.ts
+++ b/src/infra/heartbeat-wake.test.ts
@@ -664,38 +664,195 @@ describe("heartbeat-wake", () => {
     expect(handler).toHaveBeenCalledWith(wake("exec-event"));
   });
 
-  it("resets running/scheduled flags when new handler is registered", async () => {
+  it("does not let a stale run release a replacement handler's execution slot", async () => {
     vi.useFakeTimers();
 
-    // Simulate a handler that's mid-execution when SIGUSR1 fires.
-    // We do this by having the handler hang forever (never resolve).
-    let resolveHang: () => void;
-    const hangPromise = new Promise<void>((r) => {
-      resolveHang = r;
+    let resolveA!: () => void;
+    let resolveB!: () => void;
+    const pendingA = new Promise<void>((resolve) => {
+      resolveA = resolve;
+    });
+    const pendingB = new Promise<void>((resolve) => {
+      resolveB = resolve;
     });
     const handlerA = vi
       .fn()
-      .mockReturnValue(hangPromise.then(() => ({ status: "ran" as const, durationMs: 1 })));
+      .mockReturnValue(pendingA.then(() => ({ status: "ran" as const, durationMs: 1 })));
+    const handlerB = vi
+      .fn()
+      .mockReturnValue(pendingB.then(() => ({ status: "ran" as const, durationMs: 1 })));
     setHeartbeatWakeHandler(handlerA);
 
-    // Trigger the handler — it starts running but never finishes
     requestHeartbeat(wake("interval", { coalesceMs: 0 }));
     await vi.advanceTimersByTimeAsync(1);
     expect(handlerA).toHaveBeenCalledTimes(1);
 
-    // Now simulate SIGUSR1: register a new handler while handlerA is still running.
-    // Without the fix, `running` would stay true and handlerB would never fire.
-    const handlerB = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
     setHeartbeatWakeHandler(handlerB);
-
-    // handlerB should be able to fire (running was reset)
-    requestHeartbeat(wake("interval", { coalesceMs: 0 }));
+    requestHeartbeat(wake("manual", { coalesceMs: 0 }));
     await vi.advanceTimersByTimeAsync(1);
     expect(handlerB).toHaveBeenCalledTimes(1);
 
-    // Clean up the hanging promise
-    resolveHang!();
-    await Promise.resolve();
+    resolveA();
+    await vi.advanceTimersByTimeAsync(0);
+
+    requestHeartbeat(wake("hook:after-restart", { coalesceMs: 100 }));
+    await vi.advanceTimersByTimeAsync(100);
+    expect(handlerB).toHaveBeenCalledTimes(1);
+
+    resolveB();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(handlerB).toHaveBeenCalledTimes(2);
+    expectWakeCall(handlerB, 1, wake("hook:after-restart"));
+  });
+
+  it("does not let a stale run preempt a replacement handler timer", async () => {
+    vi.useFakeTimers();
+
+    let resolveA!: () => void;
+    const pendingA = new Promise<void>((resolve) => {
+      resolveA = resolve;
+    });
+    const handlerA = vi
+      .fn()
+      .mockReturnValue(pendingA.then(() => ({ status: "ran" as const, durationMs: 1 })));
+    const handlerB = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    setHeartbeatWakeHandler(handlerA);
+
+    requestHeartbeat(wake("interval", { coalesceMs: 0 }));
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handlerA).toHaveBeenCalledTimes(1);
+
+    setHeartbeatWakeHandler(handlerB);
+    requestHeartbeat(wake("manual", { coalesceMs: 1_000 }));
+
+    resolveA();
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(999);
+    expect(handlerB).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handlerB).toHaveBeenCalledOnce();
+    expect(handlerB).toHaveBeenCalledWith(wake("manual"));
+  });
+
+  it("does not let a stale busy result queue a retry on a replacement handler", async () => {
+    vi.useFakeTimers();
+
+    let resolveA!: (result: { status: "skipped"; reason: string }) => void;
+    const pendingA = new Promise<{ status: "skipped"; reason: string }>((resolve) => {
+      resolveA = resolve;
+    });
+    const handlerA = vi.fn().mockReturnValue(pendingA);
+    const handlerB = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    setHeartbeatWakeHandler(handlerA);
+
+    requestHeartbeat(wake("interval", { coalesceMs: 0, agentId: "old" }));
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handlerA).toHaveBeenCalledOnce();
+
+    setHeartbeatWakeHandler(handlerB);
+    requestHeartbeat(wake("manual", { coalesceMs: 2_000, agentId: "new" }));
+    resolveA({ status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT });
+    await vi.advanceTimersByTimeAsync(1_999);
+    expect(handlerB).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handlerB).toHaveBeenCalledOnce();
+    expect(handlerB).toHaveBeenCalledWith(wake("manual", { agentId: "new" }));
+  });
+
+  it("does not let a stale rejection queue a retry on a replacement handler", async () => {
+    vi.useFakeTimers();
+
+    let rejectA!: (error: Error) => void;
+    const pendingA = new Promise<never>((_resolve, reject) => {
+      rejectA = reject;
+    });
+    const handlerA = vi.fn().mockReturnValue(pendingA);
+    const handlerB = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    setHeartbeatWakeHandler(handlerA);
+
+    requestHeartbeat(wake("interval", { coalesceMs: 0, agentId: "old" }));
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handlerA).toHaveBeenCalledOnce();
+
+    setHeartbeatWakeHandler(handlerB);
+    requestHeartbeat(wake("manual", { coalesceMs: 2_000, agentId: "new" }));
+    rejectA(new Error("stale run failed"));
+    await vi.advanceTimersByTimeAsync(1_999);
+    expect(handlerB).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handlerB).toHaveBeenCalledOnce();
+    expect(handlerB).toHaveBeenCalledWith(wake("manual", { agentId: "new" }));
+  });
+
+  it("hands unattempted stale batch entries to the replacement handler", async () => {
+    vi.useFakeTimers();
+
+    let resolveA!: () => void;
+    const pendingA = new Promise<void>((resolve) => {
+      resolveA = resolve;
+    });
+    const handlerA = vi
+      .fn()
+      .mockReturnValue(pendingA.then(() => ({ status: "ran" as const, durationMs: 1 })));
+    const handlerB = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    setHeartbeatWakeHandler(handlerA);
+
+    requestHeartbeat(wake("cron:first", { coalesceMs: 0, agentId: "first" }));
+    requestHeartbeat(wake("cron:second", { coalesceMs: 0, agentId: "second" }));
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handlerA).toHaveBeenCalledOnce();
+    expect(handlerA).toHaveBeenCalledWith(wake("cron:first", { agentId: "first" }));
+
+    setHeartbeatWakeHandler(handlerB);
+    requestHeartbeat(wake("manual", { coalesceMs: 2_000, agentId: "second" }));
+    resolveA();
+    await vi.advanceTimersByTimeAsync(249);
+    expect(handlerB).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handlerA).toHaveBeenCalledOnce();
+    expect(handlerB).toHaveBeenCalledOnce();
+    expect(handlerB).toHaveBeenCalledWith(wake("manual", { agentId: "second" }));
+
+    await vi.advanceTimersByTimeAsync(1_750);
+    expect(handlerB).toHaveBeenCalledOnce();
+  });
+
+  it("preserves scheduled task fields when handing off an unattempted wake", async () => {
+    vi.useFakeTimers();
+
+    let resolveA!: () => void;
+    const pendingA = new Promise<void>((resolve) => {
+      resolveA = resolve;
+    });
+    const handlerA = vi
+      .fn()
+      .mockReturnValue(pendingA.then(() => ({ status: "ran" as const, durationMs: 1 })));
+    const handlerB = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    setHeartbeatWakeHandler(handlerA);
+
+    requestHeartbeat(wake("cron:first", { coalesceMs: 0, agentId: "first" }));
+    const taskWake = wake("heartbeat-task:mail", {
+      source: "interval",
+      intent: "task",
+      agentId: "second",
+      scheduledEveryMs: 60_000,
+      scheduledAnchorMs: 1_000,
+      tasks: [{ jobId: "mail", name: "mail", prompt: "Check mail" }],
+    });
+    requestHeartbeat({ ...taskWake, coalesceMs: 0 });
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handlerA).toHaveBeenCalledOnce();
+
+    setHeartbeatWakeHandler(handlerB);
+    resolveA();
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(handlerB).toHaveBeenCalledOnce();
+    expect(handlerB).toHaveBeenCalledWith(taskWake);
   });
 
   it("does not let a stale disposer clear a newer handler", async () => {

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -113,7 +113,7 @@ let handlerGeneration = 0;
 // One bounded group per target owns every pending/retry class for that agent/session.
 const pendingWakes = new Map<string, PendingWakeGroup>();
 let scheduled = false;
-let running = false;
+let runningGeneration: number | null = null;
 let timer: NodeJS.Timeout | null = null;
 let timerDueAt: number | null = null;
 
@@ -357,20 +357,54 @@ function schedule(coalesceMs: number) {
       timer = null;
       timerDueAt = null;
       scheduled = false;
+      const runGeneration = handlerGeneration;
       const active = handler;
       if (!active) {
         return;
       }
-      if (running) {
+      if (runningGeneration === runGeneration) {
         scheduled = true;
         schedule(delay);
         return;
       }
 
       const pendingBatch = takePendingWakeBatch();
-      running = true;
+      runningGeneration = runGeneration;
+      const ownsCurrentRun = () =>
+        handlerGeneration === runGeneration && runningGeneration === runGeneration;
+      const handOffPendingBatch = (startIndex: number) => {
+        const remaining = pendingBatch.slice(startIndex);
+        for (const pendingWake of remaining) {
+          queuePendingWakeReason({
+            source: pendingWake.source,
+            intent: pendingWake.intent,
+            reason: pendingWake.reason,
+            requestedAt: pendingWake.requestedAt,
+            agentId: pendingWake.agentId,
+            sessionKey: pendingWake.sessionKey,
+            heartbeat: pendingWake.heartbeat,
+            scheduledEveryMs: pendingWake.scheduledEveryMs,
+            scheduledAnchorMs: pendingWake.scheduledAnchorMs,
+            tasks: pendingWake.tasks,
+            notBeforeMs: pendingWake.notBeforeMs,
+            guardRetry: pendingWake.guardRetry,
+          });
+        }
+        if (handler && remaining.length > 0) {
+          schedulePendingWakes(DEFAULT_COALESCE_MS);
+        }
+      };
+      let pendingIndex = 0;
       try {
-        for (const pendingWake of pendingBatch) {
+        for (pendingIndex = 0; pendingIndex < pendingBatch.length; pendingIndex += 1) {
+          if (!ownsCurrentRun()) {
+            handOffPendingBatch(pendingIndex);
+            return;
+          }
+          const pendingWake = pendingBatch[pendingIndex];
+          if (!pendingWake) {
+            continue;
+          }
           const wakeOpts = {
             source: pendingWake.source,
             intent: pendingWake.intent,
@@ -392,6 +426,12 @@ function schedule(coalesceMs: number) {
           const res = await runWithGatewayIndependentRootWorkAdmission(async () =>
             active(wakeOpts),
           );
+          if (!ownsCurrentRun()) {
+            // The current wake already ran on the retired handler. Only wakes
+            // that were never attempted transfer to the replacement lifecycle.
+            handOffPendingBatch(pendingIndex + 1);
+            return;
+          }
           if (res.status === "skipped" && isRetryableHeartbeatBusySkipReason(res.reason)) {
             // The target runtime is busy; retry this wake target soon.
             queuePendingWakeReason({
@@ -438,27 +478,35 @@ function schedule(coalesceMs: number) {
           }
         }
       } catch {
-        // Error is already logged by the heartbeat runner; schedule a retry.
-        for (const pendingWake of pendingBatch) {
-          queuePendingWakeReason({
-            source: pendingWake.source,
-            intent: pendingWake.intent,
-            reason: pendingWake.reason ?? "retry",
-            agentId: pendingWake.agentId,
-            sessionKey: pendingWake.sessionKey,
-            heartbeat: pendingWake.heartbeat,
-            scheduledEveryMs: pendingWake.scheduledEveryMs,
-            scheduledAnchorMs: pendingWake.scheduledAnchorMs,
-            tasks: pendingWake.tasks,
-            requestedAt: pendingWake.requestedAt,
-            blockTargetUntilMs: Date.now() + DEFAULT_RETRY_MS,
-          });
+        if (ownsCurrentRun()) {
+          // Error is already logged by the heartbeat runner; schedule a retry.
+          for (const pendingWake of pendingBatch) {
+            queuePendingWakeReason({
+              source: pendingWake.source,
+              intent: pendingWake.intent,
+              reason: pendingWake.reason ?? "retry",
+              agentId: pendingWake.agentId,
+              sessionKey: pendingWake.sessionKey,
+              heartbeat: pendingWake.heartbeat,
+              scheduledEveryMs: pendingWake.scheduledEveryMs,
+              scheduledAnchorMs: pendingWake.scheduledAnchorMs,
+              tasks: pendingWake.tasks,
+              requestedAt: pendingWake.requestedAt,
+              blockTargetUntilMs: Date.now() + DEFAULT_RETRY_MS,
+            });
+          }
+          schedule(DEFAULT_RETRY_MS);
+        } else {
+          handOffPendingBatch(pendingIndex + 1);
         }
-        schedule(DEFAULT_RETRY_MS);
       } finally {
-        running = false;
-        if (pendingWakes.size > 0 || scheduled) {
-          schedulePendingWakes(delay);
+        // Handler replacement retires this generation while its async work may
+        // still settle. A stale completion must not release or rearm the new one.
+        if (ownsCurrentRun()) {
+          runningGeneration = null;
+          if (pendingWakes.size > 0 || scheduled) {
+            schedulePendingWakes(delay);
+          }
         }
       }
     })();
@@ -525,11 +573,8 @@ export function setHeartbeatWakeHandler(next: HeartbeatWakeHandler | null): () =
     }
     timer = null;
     timerDueAt = null;
-    // Reset module-level execution state that may be stale from interrupted
-    // runs in the previous lifecycle. Without this, `running === true` from
-    // an interrupted heartbeat blocks all future schedule() attempts, and
-    // `scheduled === true` can cause spurious immediate re-runs.
-    running = false;
+    // Retire the previous lifecycle's scheduling marker. In-flight work keeps
+    // its generation token, so its finally path cannot release this lifecycle.
     scheduled = false;
     clearPendingWakeRetryState();
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes a heartbeat lifecycle race where replacing a wake handler while an older
heartbeat is still awaiting can let the older completion clear the replacement
handler's running state or preempt its timer. A subsequent wake may then run
concurrently with the replacement heartbeat, risking duplicate session work or
lost wake delivery during an in-process restart/config lifecycle transition.

## Why This Change Was Made

Tracks the wake handler lifecycle with a generation-owned execution marker. All
post-await retry, scheduling, and cleanup mutations require the run to still
own the current generation. If replacement occurs mid-batch, the wake already
attempted on the retired handler is not replayed; only unattempted remainder
entries are handed back through the existing coalescing/dedupe path, preserving
target identity and original request ordering metadata.

## User Impact

Heartbeat wakes remain serialized within the active handler lifecycle across
restarts and replacement. In-flight work is not duplicated, replacement timers
are not shortened by stale completions, and unattempted targeted wakes are not
silently dropped.

## Evidence

- P2 reliability fix; exact head: `c4640ce77a4525c021a2fecc03ad1e479e30860c`
- Base: `0483001ef65c93aeadc3acce72980f38361a38de`
- Frozen binary diff hash: `8b493da64a1f5228a9a0335a2249b54122d9cb9f85c60626f997f50a77f8e9f0`
- Focused deterministic coverage added in `src/infra/heartbeat-wake.test.ts`:
  - stale completion cannot release a replacement handler's execution slot;
  - stale completion cannot preempt a replacement timer;
  - stale busy and rejection results cannot schedule replacement retries;
  - only unattempted batch remainder transfers to the replacement handler;
  - same-target replacement wakes retain canonical priority/dedupe behavior.
- Static proof: targeted `oxfmt --check` passed; `git diff --check` passed.

### Secretless production-entry trace

Fork-only workflow run: https://github.com/Alix-007/openclaw/actions/runs/29666006643
(job: https://github.com/Alix-007/openclaw/actions/runs/29666006643/job/88136426349)

The workflow has `permissions: {}`, uses no secrets or credentials, fetches only
public immutable refs, and exists only on the fork proof branch (it is not part
of this PR diff). It invokes the production `setHeartbeatWakeHandler` and
`requestHeartbeat` entry points with real timers and gateway work admission.

- Before: upstream `main` at `d411559dfbb3af4cb8549ab1dca2dd575a777a37`
- After: PR head `c4640ce77a4525c021a2fecc03ad1e479e30860c`
- `d411559` retained the boolean-running implementation. Its two target files
  were byte-identical to PR base `0483001`, so the before trace had no target
  behavior drift.
- Execution slot: before, stale A completion allowed C to enter while B was
  pending (`replacementCallsWhileFirstReplacementPending=2`, concurrent C=1);
  after, B retained its slot (`=1`, concurrent C=0), then C ran exactly once.
- Timer ownership: before, stale A completion fired B's 180 ms timer early
  (`replacementCallsBeforeDue=1`); after, the deadline remained intact (`=0`).
- Batch remainder: before, retired A consumed the second target wake (A=1,
  B=0); after, A stopped and B received that remainder exactly once (A=0,
  B=1, duplicates=0).

### CI status

Exact-head upstream CI run https://github.com/openclaw/openclaw/actions/runs/29665291020
completed with two unrelated Node shard failures:
`src/process/child-process.test.ts` (TICK6 timing) and
`src/system-agent/setup-inference-detection.test.ts` (recommended installs
fixture). Neither file is touched here. A failed-only rerun was attempted, but
GitHub rejected it because contributor accounts do not have repository admin
permission.

The repository `autoreview` helper was attempted once with Codex but failed
before producing a verdict (Codex auth/runtime setup failure). A separate
read-only Codex adversarial review of the frozen exact head/base passed with
no actionable findings; this is reported as contingency review, not as a
clean helper result.

AI-assisted contribution; the author reviewed the generation, timer, retry,
pending-wake ownership, and gateway admission paths.

### Exact-head runtime proof (2026-07-20)

Re-ran the production setHeartbeatWakeHandler / requestHeartbeat lifecycle trace against exact PR head 4ab74d57911ecf2380b289dc112c59bf8ef46c22 (base bc76bb893379c21fd86134e5ca5521833a69daa7) in a permissions-empty fork workflow:

- Run: https://github.com/Alix-007/openclaw/actions/runs/29718986235
- Job: https://github.com/Alix-007/openclaw/actions/runs/29718986235/job/88277742778
- Before (base): replacement calls while first replacement was pending 2, concurrent follow-up calls 1, early timer calls 1, original remainder 1, replacement remainder 0.
- After (PR head): replacement calls while first replacement was pending 1, concurrent follow-up calls 0, early timer calls 0, original remainder 0, replacement remainder 1, duplicate remainder count 0, final follow-up calls 1.

The run checked out immutable public refs, used no credentials or private endpoints, and exercised the production entry points. The before/after trace confirms stale completions no longer release the replacement slot, preempt its timer, or consume the unattempted remainder.

### Exact-current-head runtime proof (2026-07-27)

A fresh permissions-empty fork workflow exercised the production `setHeartbeatWakeHandler` and `requestHeartbeat` entry points against immutable refs:

- Current PR head: `41713f0393ade521761cd99b209a1da099eb42d6`.
- Current rebase parent / before ref: `0951d0dd307d5008276714679c62459293d3b619`.
- Workflow run: https://github.com/Alix-007/openclaw/actions/runs/30269411154
- Proof job: https://github.com/Alix-007/openclaw/actions/runs/30269411154/job/89987962777
- Before: replacement calls while the first replacement remained pending = 2; concurrent follow-up calls = 1; replacement timer calls before due = 1; old-handler remainder calls = 1; replacement remainder calls = 0.
- After: replacement calls while the first replacement remained pending = 1; concurrent follow-up calls = 0; final follow-up calls = 1; replacement timer calls before due = 0; old-handler remainder calls = 0; replacement remainder calls = 1; duplicate remainder count = 0.
- The workflow uses `permissions: {}`, no secrets, credentials, private endpoints, or persisted user state. It checks out and asserts both full SHAs before running real timers and the production entry points.
- Current-head repository checks are complete with zero failures and zero pending checks.

`PROOF_RESULT=PASS`: stale completion no longer releases the replacement slot, fires its timer early, or consumes the unattempted remainder on the exact submitted head.