### PR TITLE
fix(macos): PortGuardian opens current shared state databases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2923,6 +2923,17 @@ jobs:
           xcodebuild -version
           swift --version
 
+      - name: Native state schema version contract
+        run: |
+          if [[ -f scripts/check-native-state-schema-version.mjs ]]; then
+            node scripts/check-native-state-schema-version.mjs
+          elif [[ "$HISTORICAL_TARGET" == "true" ]]; then
+            echo "[skip] native state schema version guard is not present in this historical target"
+          else
+            echo "Current CI targets must provide scripts/check-native-state-schema-version.mjs." >&2
+            exit 1
+          fi
+
       - name: Swift lint
         run: |
           if [[ -x ./scripts/lint-swift.sh && -x ./scripts/format-swift.sh ]]; then

--- a/apps/macos/Tests/OpenClawIPCTests/PortGuardianRecordStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/PortGuardianRecordStoreTests.swift
@@ -528,7 +528,33 @@ struct PortGuardianRecordStoreTests {
     }
 
     @Test
-    func `foreign newer and incompatible databases fail closed`() throws {
+    func `supported and newer Node schema versions open or fail closed`() throws {
+        let fixture = try Self.fixture()
+        defer { fixture.cleanup() }
+
+        for version in [4, 5] {
+            let databaseURL = fixture.root.appendingPathComponent("supported-v\(version).sqlite")
+            try Self.seedVersionedPortGuardianDatabase(databaseURL, schemaVersion: version)
+            let store = try PortGuardianRecordStore(databaseURL: databaseURL)
+            let record = Self.record(
+                pid: Int32(4200 + version),
+                port: 18780 + version,
+                timestamp: Double(version))
+            try store.upsert(record)
+            #expect(try store.records() == [record])
+        }
+
+        for version in [6, 99] {
+            let databaseURL = fixture.root.appendingPathComponent("newer-v\(version).sqlite")
+            try Self.seedVersionedPortGuardianDatabase(databaseURL, schemaVersion: version)
+            #expect(throws: PortGuardianStoreError.self) {
+                try PortGuardianRecordStore(databaseURL: databaseURL)
+            }
+        }
+    }
+
+    @Test
+    func `foreign and incompatible databases fail closed`() throws {
         let fixture = try Self.fixture()
         defer { fixture.cleanup() }
 
@@ -536,12 +562,6 @@ struct PortGuardianRecordStoreTests {
         try Self.execute(foreignURL, "CREATE TABLE unrelated (id INTEGER PRIMARY KEY) STRICT")
         #expect(throws: PortGuardianStoreError.self) {
             try PortGuardianRecordStore(databaseURL: foreignURL)
-        }
-
-        let newerURL = fixture.root.appendingPathComponent("newer.sqlite")
-        try Self.execute(newerURL, "PRAGMA user_version = 5")
-        #expect(throws: PortGuardianStoreError.self) {
-            try PortGuardianRecordStore(databaseURL: newerURL)
         }
 
         let uniqueIndexURL = fixture.root.appendingPathComponent("unique-index.sqlite")
@@ -572,7 +592,7 @@ struct PortGuardianRecordStoreTests {
         try store.upsert(existing)
         try JSONEncoder().encode([existing]).write(to: fixture.legacyURL, options: [.atomic])
 
-        try Self.execute(fixture.databaseURL, "PRAGMA user_version = 5")
+        try Self.execute(fixture.databaseURL, "PRAGMA user_version = 6")
 
         #expect(throws: PortGuardianStoreError.self) {
             try store.upsert(Self.record(pid: 4243, port: 18790, timestamp: 43))
@@ -647,6 +667,36 @@ struct PortGuardianRecordStoreTests {
         guard sqlite3_exec(database, sql, nil, nil, nil) == SQLITE_OK else {
             throw PortGuardianStoreError(String(cString: sqlite3_errmsg(database)))
         }
+    }
+
+    private static func seedVersionedPortGuardianDatabase(
+        _ databaseURL: URL,
+        schemaVersion: Int) throws
+    {
+        try self.execute(databaseURL, """
+        CREATE TABLE schema_meta (
+          meta_key TEXT NOT NULL PRIMARY KEY,
+          role TEXT NOT NULL,
+          schema_version INTEGER NOT NULL,
+          agent_id TEXT,
+          app_version TEXT,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL
+        ) STRICT;
+        INSERT INTO schema_meta (
+          meta_key, role, schema_version, agent_id, app_version, created_at, updated_at
+        ) VALUES ('primary', 'global', \(schemaVersion), NULL, NULL, 1, 1);
+        CREATE TABLE macos_port_guardian_records (
+          pid INTEGER NOT NULL PRIMARY KEY,
+          port INTEGER NOT NULL,
+          command TEXT NOT NULL,
+          mode TEXT NOT NULL,
+          timestamp REAL NOT NULL
+        ) STRICT;
+        CREATE INDEX idx_macos_port_guardian_records_port
+          ON macos_port_guardian_records(port, timestamp DESC);
+        PRAGMA user_version = \(schemaVersion);
+        """)
     }
 
     private static func scalarInt(_ databaseURL: URL, _ sql: String) throws -> Int64 {

--- a/apps/shared/OpenClawKit/Sources/OpenClawNativeState/OpenClawNativeStateSQLite.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawNativeState/OpenClawNativeStateSQLite.swift
@@ -35,7 +35,7 @@ public enum OpenClawNativeStateSQLiteValueType: Equatable, Sendable {
 /// One recursive connection lock serializes transactions and statement access.
 public final class OpenClawNativeStateSQLite: @unchecked Sendable {
     // Keep aligned with OPENCLAW_STATE_SCHEMA_VERSION. Native clients never upgrade this database.
-    private static let maximumSupportedSchemaVersion: Int64 = 4
+    private static let maximumSupportedSchemaVersion: Int64 = 5
     private static let defaultBusyTimeoutMilliseconds: Int32 = 5000
 
     private struct SchemaObject: Hashable {

--- a/scripts/check-changed.mjs
+++ b/scripts/check-changed.mjs
@@ -634,6 +634,14 @@ export function createChangedCheckPlan(result, options = {}) {
   if (hasMacosAppCiPath(result.paths)) {
     add("macOS app CI tests", ["test:macos:ci"], baseEnv);
   }
+  if (lanes.apps || lanes.core) {
+    addCommand(
+      "native state schema version guard",
+      "node",
+      ["scripts/check-native-state-schema-version.mjs"],
+      baseEnv,
+    );
+  }
 
   if (lanes.core || lanes.extensions) {
     add("database-first legacy-store guard", ["check:database-first-legacy-stores"]);

--- a/scripts/check-native-state-schema-version.d.mts
+++ b/scripts/check-native-state-schema-version.d.mts
@@ -1,0 +1,9 @@
+export interface NativeStateSchemaSources {
+  swiftSource: string;
+  typescriptSource: string;
+}
+
+export function compareNativeStateSchemaVersions(sources: NativeStateSchemaSources): number;
+export function checkNativeStateSchemaVersion(
+  readFileSync?: typeof import("node:fs").readFileSync,
+): number;

--- a/scripts/check-native-state-schema-version.mjs
+++ b/scripts/check-native-state-schema-version.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import { isDirectRunUrl } from "./lib/direct-run.mjs";
+
+const SWIFT_CONTRACT_PATH =
+  "apps/shared/OpenClawKit/Sources/OpenClawNativeState/OpenClawNativeStateSQLite.swift";
+const TYPESCRIPT_CONTRACT_PATH = "src/state/openclaw-state-db-contract.ts";
+
+function extractSingleVersion(source, pattern, label) {
+  const matches = [...source.matchAll(pattern)];
+  if (matches.length !== 1) {
+    throw new Error(`Expected exactly one ${label} declaration; found ${matches.length}`);
+  }
+  return Number(matches[0][1]);
+}
+
+export function compareNativeStateSchemaVersions({ swiftSource, typescriptSource }) {
+  const swiftVersion = extractSingleVersion(
+    swiftSource,
+    /^\s*private static let maximumSupportedSchemaVersion: Int64 = (\d+)\s*$/gmu,
+    "Swift maximumSupportedSchemaVersion",
+  );
+  const typescriptVersion = extractSingleVersion(
+    typescriptSource,
+    /^export const OPENCLAW_STATE_SCHEMA_VERSION = (\d+);\s*$/gmu,
+    "TypeScript OPENCLAW_STATE_SCHEMA_VERSION",
+  );
+  if (swiftVersion !== typescriptVersion) {
+    throw new Error(
+      `Native state schema version drift: Swift supports ${swiftVersion}, TypeScript owns ${typescriptVersion}`,
+    );
+  }
+  return swiftVersion;
+}
+
+export function checkNativeStateSchemaVersion(readFileSync = fs.readFileSync) {
+  return compareNativeStateSchemaVersions({
+    swiftSource: readFileSync(SWIFT_CONTRACT_PATH, "utf8"),
+    typescriptSource: readFileSync(TYPESCRIPT_CONTRACT_PATH, "utf8"),
+  });
+}
+
+if (isDirectRunUrl(process.argv[1], import.meta.url)) {
+  try {
+    const version = checkNativeStateSchemaVersion();
+    console.log(`native state schema version guard passed (v${version})`);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/run-additional-boundary-checks.mjs
+++ b/scripts/run-additional-boundary-checks.mjs
@@ -76,6 +76,7 @@ export const BOUNDARY_CHECKS = [
     ["run", "lint:extensions:telegram-grammy-types"],
   ],
   ["lint:ui:no-raw-window-open", "pnpm", ["lint:ui:no-raw-window-open"]],
+  ["native-state-schema-version", "node", ["scripts/check-native-state-schema-version.mjs"]],
 ].map(([label, command, args]) => ({ label, command, args }));
 
 /**

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -770,6 +770,10 @@ const TOOLING_SOURCE_TEST_TARGETS = new Map([
   ["scripts/check.mjs", ["test/scripts/check.test.ts"]],
   ["scripts/check-changed.mjs", ["test/scripts/changed-lanes.test.ts"]],
   ["scripts/check-max-lines-ratchet.mjs", ["test/scripts/check-max-lines-ratchet.test.ts"]],
+  [
+    "scripts/check-native-state-schema-version.mjs",
+    ["test/scripts/check-native-state-schema-version.test.ts"],
+  ],
   ["config/max-lines-baseline.txt", ["test/scripts/check-max-lines-ratchet.test.ts"]],
   [".oxlintrc.json", ["test/scripts/oxlint-config.test.ts"]],
   [
@@ -2175,6 +2179,10 @@ for (const sourcePath of CROSS_OS_RELEASE_CHECK_SOURCE_PATHS) {
 const TOOLING_DECLARATION_SOURCE_MIRRORS = [
   ["scripts/build-stamp.d.mts", "scripts/build-stamp.mjs"],
   ["scripts/ci-changed-scope.d.mts", "scripts/ci-changed-scope.mjs"],
+  [
+    "scripts/check-native-state-schema-version.d.mts",
+    "scripts/check-native-state-schema-version.mjs",
+  ],
   ["scripts/copy-bundled-plugin-metadata.d.mts", "scripts/copy-bundled-plugin-metadata.mjs"],
   ["scripts/docs-link-audit.d.mts", "scripts/docs-link-audit.mjs"],
   ["scripts/openclaw-npm-resume-run.d.mts", "scripts/openclaw-npm-resume-run.mjs"],

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -2092,6 +2092,27 @@ describe("scripts/changed-lanes", () => {
     }
   });
 
+  it("runs the native state schema guard for either contract owner", () => {
+    for (const changedPath of [
+      "apps/shared/OpenClawKit/Sources/OpenClawNativeState/OpenClawNativeStateSQLite.swift",
+      "src/state/openclaw-state-db-contract.ts",
+    ]) {
+      const plan = createChangedCheckPlan(detectChangedLanes([changedPath]), {
+        env: { PATH: "/usr/bin" },
+        platform: "linux",
+        swiftlintAvailable: false,
+      });
+
+      expect(plan.commands).toContainEqual(
+        expect.objectContaining({
+          name: "native state schema version guard",
+          bin: "node",
+          args: ["scripts/check-native-state-schema-version.mjs"],
+        }),
+      );
+    }
+  });
+
   it("runs macOS app CI tests for macOS packaging scripts and owner tests", () => {
     for (const changedPath of [
       "scripts/codesign-mac-app.sh",

--- a/test/scripts/check-native-state-schema-version.test.ts
+++ b/test/scripts/check-native-state-schema-version.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import {
+  checkNativeStateSchemaVersion,
+  compareNativeStateSchemaVersions,
+} from "../../scripts/check-native-state-schema-version.mjs";
+
+describe("native state schema version guard", () => {
+  it("keeps the checked-in Swift and TypeScript contracts aligned", () => {
+    expect(checkNativeStateSchemaVersion()).toBe(5);
+  });
+
+  it("fails when a deliberate Swift fixture drifts behind TypeScript", () => {
+    expect(() =>
+      compareNativeStateSchemaVersions({
+        swiftSource: "private static let maximumSupportedSchemaVersion: Int64 = 4\n",
+        typescriptSource: "export const OPENCLAW_STATE_SCHEMA_VERSION = 5;\n",
+      }),
+    ).toThrow("Native state schema version drift: Swift supports 4, TypeScript owns 5");
+  });
+});

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -3170,6 +3170,16 @@ describe("ci workflow guards", () => {
     }
   });
 
+  it("checks native and Node state schema versions in the macOS lane", () => {
+    const workflow = readCiWorkflow();
+    const schemaVersionStep = workflow.jobs["macos-swift"].steps.find(
+      (step: WorkflowStep) => step.name === "Native state schema version contract",
+    );
+
+    expect(schemaVersionStep.run).toContain("node scripts/check-native-state-schema-version.mjs");
+    expect(schemaVersionStep.run).toContain('elif [[ "$HISTORICAL_TARGET" == "true" ]]');
+  });
+
   it("resets SwiftPM state between macOS release build retries", () => {
     const workflow = readCiWorkflow();
     const macosInstallStep = workflow.jobs["macos-swift"].steps.find(

--- a/test/scripts/run-additional-boundary-checks.test.ts
+++ b/test/scripts/run-additional-boundary-checks.test.ts
@@ -246,6 +246,14 @@ describe("run-additional-boundary-checks", () => {
     });
   });
 
+  it("keeps native and Node state schema versions aligned in CI", () => {
+    expect(BOUNDARY_CHECKS).toContainEqual({
+      label: "native-state-schema-version",
+      command: "node",
+      args: ["scripts/check-native-state-schema-version.mjs"],
+    });
+  });
+
   it("buffers grouped output and reports aggregate failures", async () => {
     const buffer = createOutputBuffer();
     const failures = await runChecks(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the macOS PortGuardian could refuse to start after the Node runtime upgraded the shared host-global state database to schema version 5.

## Why This Change Was Made

The native SQLite reader now accepts the canonical Node-owned schema through version 5 while continuing to fail closed on version 6 and newer. A dependency-free guard compares the Swift and TypeScript constants in both relevant CI/check lanes so a future one-sided schema bump cannot silently recur. Node remains the database and WAL-mode owner; the native reader does not migrate the database or change its journal mode.

## User Impact

macOS users can keep PortGuardian running against state databases upgraded by the current Node runtime. Databases from a genuinely newer OpenClaw schema still fail closed instead of being opened unsafely.

## Evidence

- Mixed-version PortGuardian fixture matrix covers schema versions 4 and 5 opening successfully and versions 6 and 99 failing closed.
- `node scripts/check-native-state-schema-version.mjs` — passed at schema v5.
- Deliberately drifted Swift v4 / TypeScript v5 fixture — rejected with the expected mismatch.
- `pnpm test test/scripts/check-native-state-schema-version.test.ts test/scripts/changed-lanes.test.ts test/scripts/ci-workflow-guards.test.ts test/scripts/run-additional-boundary-checks.test.ts test/scripts/test-projects.test.ts` on [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/29664878425) — 428 tests passed.
- `pnpm test src/state/openclaw-database-preflight.test.ts src/state/openclaw-state-db.test.ts` on [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/29664878425) — 94 tests passed.
- `pnpm check:changed` on the [rebased Blacksmith Testbox head](https://github.com/openclaw/openclaw/actions/runs/29665102113) — guard, formatting, declaration contracts, typechecks, lint, macOS packaging-adjacent tests, and the v5 guard passed. SwiftLint was deferred to exact-head macOS CI as designed. The first pre-rebase run exposed an unrelated main-branch declaration lint defect, fixed upstream by #111024 before this branch was rebased.
- Autoreview: clean, no accepted/actionable findings.

AI-assisted maintainer fix; the implementation and ownership boundaries were reviewed against the complete native and Node state database paths.
