### PR TITLE
fix(android): stabilize Wear realtime Talk audio and tool calls

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -13299,7 +13299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 602,
+      "line": 579,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Speech recognizer unavailable",
       "surface": "android",
@@ -13307,7 +13307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 800,
+      "line": 777,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Ready",
       "surface": "android",
@@ -13315,7 +13315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1018,
+      "line": 1019,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Start failed: $message",
       "surface": "android",
@@ -13323,7 +13323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1114,
+      "line": 1115,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -13331,7 +13331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1183,
+      "line": 1190,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Off",
       "surface": "android",
@@ -13339,7 +13339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1186,
+      "line": 1193,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Talk failed: Realtime provider closed unexpectedly.",
       "surface": "android",
@@ -13347,7 +13347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1191,
+      "line": 1198,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Talk failed: Realtime provider closed: $reason",
       "surface": "android",
@@ -13355,7 +13355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2546,
+      "line": 2323,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Thinking…",
       "surface": "android",
@@ -13363,7 +13363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2563,
+      "line": 2340,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Gateway not connected",
       "surface": "android",
@@ -13371,7 +13371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2576,
+      "line": 2353,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Aborted",
       "surface": "android",
@@ -13379,7 +13379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2576,
+      "line": 2353,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Chat error",
       "surface": "android",
@@ -13387,7 +13387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2593,
+      "line": 2370,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "No reply",
       "surface": "android",
@@ -13395,7 +13395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2609,
+      "line": 2386,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Talk failed: $message",
       "surface": "android",
@@ -13403,7 +13403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2902,
+      "line": 2679,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Generating voice…",
       "surface": "android",
@@ -13411,7 +13411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2930,
+      "line": 2707,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Speak failed: $message",
       "surface": "android",
@@ -13419,7 +13419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3079,
+      "line": 2856,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Speaking…",
       "surface": "android",
@@ -13427,7 +13427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3430,
+      "line": 3202,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Listening (PTT)",
       "surface": "android",
@@ -13435,7 +13435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3441,
+      "line": 3213,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Microphone permission required",
       "surface": "android",
@@ -13443,7 +13443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3447,
+      "line": 3219,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Audio error",
       "surface": "android",
@@ -13451,7 +13451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3448,
+      "line": 3220,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Client error",
       "surface": "android",
@@ -13459,7 +13459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3449,
+      "line": 3221,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Network error",
       "surface": "android",
@@ -13467,7 +13467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3450,
+      "line": 3222,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Network timeout",
       "surface": "android",
@@ -13475,7 +13475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3452,
+      "line": 3224,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Recognizer busy",
       "surface": "android",
@@ -13483,7 +13483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3453,
+      "line": 3225,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Server error",
       "surface": "android",
@@ -13491,7 +13491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3454,
+      "line": 3226,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Listening",
       "surface": "android",
@@ -13499,7 +13499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3455,
+      "line": 3227,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Speech error ($error)",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/RealtimeAgentCoordinator.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/RealtimeAgentCoordinator.kt
@@ -58,6 +58,7 @@ private data class RealtimeAgentPendingFinish(
 
 private data class RealtimeAgentRunRegistration(
   val completion: RealtimeAgentCompletion?,
+  val errorMessage: String?,
   val unhandled: List<RealtimeAgentUnhandledCompletion>,
 )
 
@@ -153,7 +154,7 @@ internal class RealtimeAgentCoordinator(
         val accepted =
           synchronized(lock) {
             activeSession == session &&
-              pendingCalls.size < maxCachedCompletions &&
+              pendingCalls.size + runs.size < maxCachedCompletions &&
               pendingCalls.add(pendingCall)
           }
         if (accepted) {
@@ -272,9 +273,14 @@ internal class RealtimeAgentCoordinator(
           }
           val cached = earlyCompletions.remove(runId)
           pendingCalls.remove(pendingCall)
+          var errorMessage: String? = null
           if (activeSession == session) {
             if (cached == null) {
-              runs[runId] = RealtimeAgentRun(callId = callId, session = session)
+              if (runId in retiredRunIds || runId in runs) {
+                errorMessage = "tool call returned a duplicate run id"
+              } else {
+                runs[runId] = RealtimeAgentRun(callId = callId, session = session)
+              }
             } else {
               retireRunLocked(runId)
             }
@@ -283,11 +289,14 @@ internal class RealtimeAgentCoordinator(
           }
           RealtimeAgentRunRegistration(
             completion = cached.takeIf { activeSession == session },
+            errorMessage = errorMessage,
             unhandled = drainEarlyCompletionsIfIdleLocked(),
           )
         }
       registration.unhandled.forEach(onUnhandledCompletion)
-      if (registration.completion != null) {
+      if (registration.errorMessage != null) {
+        submitError(session, callId, registration.errorMessage)
+      } else if (registration.completion != null) {
         dispatchCompletion(RealtimeAgentRun(callId = callId, session = session), registration.completion)
       }
     } catch (err: TimeoutCancellationException) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/RealtimeAgentCoordinator.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/RealtimeAgentCoordinator.kt
@@ -41,6 +41,24 @@ internal data class RealtimeAgentUnhandledCompletion(
 private class RealtimeAgentPendingCall(
   val callId: String,
   val session: RealtimeAgentSession,
+) {
+  var job: Job? = null
+  var failed = false
+}
+
+private data class RealtimeAgentCacheOverflow(
+  val unhandled: List<RealtimeAgentUnhandledCompletion>,
+  val failedCalls: List<RealtimeAgentPendingCall>,
+)
+
+private data class RealtimeAgentPendingFinish(
+  val canSubmitError: Boolean,
+  val unhandled: List<RealtimeAgentUnhandledCompletion>,
+)
+
+private data class RealtimeAgentRunRegistration(
+  val completion: RealtimeAgentCompletion?,
+  val unhandled: List<RealtimeAgentUnhandledCompletion>,
 )
 
 /**
@@ -62,8 +80,7 @@ internal class RealtimeAgentCoordinator(
   private val lock = Any()
   private val parentContext = parentScope.coroutineContext
   private val parentJob = parentContext[Job]
-  private val correlationScope = CoroutineScope(parentContext)
-  private val correlationJobs = LinkedHashSet<Job>()
+  private var correlationScope = newCorrelationScope()
   private var activeSession: RealtimeAgentSession? = null
   private var sessionScope: CoroutineScope? = null
   private val runs = LinkedHashMap<String, RealtimeAgentRun>()
@@ -79,31 +96,40 @@ internal class RealtimeAgentCoordinator(
   }
 
   fun beginSession(session: RealtimeAgentSession) {
-    synchronized(lock) {
-      if (activeSession == session) return
-      clearLocked()
-      activeSession = session
-      sessionScope = CoroutineScope(parentContext + SupervisorJob(parentJob))
-    }
+    val unhandled =
+      synchronized(lock) {
+        if (activeSession == session) return
+        clearSessionLocked().also {
+          activeSession = session
+          sessionScope = CoroutineScope(parentContext + SupervisorJob(parentJob))
+        }
+      }
+    unhandled.forEach(onUnhandledCompletion)
   }
 
   fun endSession(expectedRelaySessionId: String? = null) {
-    synchronized(lock) {
-      if (expectedRelaySessionId != null && activeSession?.relaySessionId != expectedRelaySessionId) return
-      clearLocked()
-    }
+    val unhandled =
+      synchronized(lock) {
+        if (expectedRelaySessionId != null && activeSession?.relaySessionId != expectedRelaySessionId) return
+        clearSessionLocked()
+      }
+    unhandled.forEach(onUnhandledCompletion)
   }
 
   /** Cancels requests that must not survive a Gateway or account replacement. */
   fun resetTransport() {
-    val jobs =
+    // Lazy correlation jobs can complete synchronously during cancellation. Drop
+    // account-bound state first so their handlers cannot release stale output.
+    val staleScope =
       synchronized(lock) {
-        clearLocked()
-        pendingCalls.clear()
-        earlyCompletions.clear()
-        correlationJobs.toList().also { correlationJobs.clear() }
+        clearSessionLocked()
+        correlationScope.also {
+          correlationScope = newCorrelationScope()
+          pendingCalls.clear()
+          earlyCompletions.clear()
+        }
       }
-    jobs.forEach { it.cancel() }
+    staleScope.cancel()
   }
 
   fun handleToolCall(
@@ -112,33 +138,43 @@ internal class RealtimeAgentCoordinator(
     args: JsonElement?,
     forced: Boolean,
   ): Boolean {
-    val sessionAndScope =
+    val sessionAndScopes =
       synchronized(lock) {
         val session = activeSession ?: return false
-        val scope = sessionScope ?: return false
-        session to scope
+        val resultScope = sessionScope ?: return false
+        Triple(session, resultScope, correlationScope)
       }
-    val (session, scope) = sessionAndScope
+    val (session, resultScope, requestScope) = sessionAndScopes
     when (name) {
       AGENT_CONSULT_TOOL -> {
-        // Keep the bounded Gateway request alive across replacement so its run ID
-        // can still be quarantined if the old agent finishes late.
-        val job =
-          correlationScope.launch(start = CoroutineStart.LAZY) {
-            runConsult(session, callId, args, forced)
+        val pendingCall = RealtimeAgentPendingCall(callId = callId, session = session)
+        val accepted =
+          synchronized(lock) {
+            activeSession == session &&
+              pendingCalls.size < maxCachedCompletions &&
+              pendingCalls.add(pendingCall)
           }
-        job.invokeOnCompletion { synchronized(lock) { correlationJobs.remove(job) } }
-        synchronized(lock) {
-          if (activeSession == session) {
-            correlationJobs += job
-            job.start()
-          } else {
-            job.cancel()
+        if (accepted) {
+          val job = requestScope.launch(start = CoroutineStart.LAZY) { runConsult(pendingCall, args, forced) }
+          job.invokeOnCompletion {
+            finishPending(pendingCall).unhandled.forEach(onUnhandledCompletion)
           }
+          val shouldStart =
+            synchronized(lock) {
+              if (activeSession == session && isPendingLocked(pendingCall)) {
+                pendingCall.job = job
+                true
+              } else {
+                false
+              }
+            }
+          if (shouldStart) job.start() else job.cancel()
+        } else {
+          resultScope.launch { submitError(session, callId, "too many concurrent realtime Talk tool calls") }
         }
       }
-      AGENT_CONTROL_TOOL -> scope.launch { runControl(session, callId, args) }
-      else -> scope.launch { submitError(session, callId, "unsupported realtime Talk tool: $name") }
+      AGENT_CONTROL_TOOL -> resultScope.launch { runControl(session, callId, args) }
+      else -> resultScope.launch { submitError(session, callId, "unsupported realtime Talk tool: $name") }
     }
     return true
   }
@@ -152,52 +188,42 @@ internal class RealtimeAgentCoordinator(
     if (state !in TERMINAL_STATES) return false
     val completion = RealtimeAgentCompletion(sessionKey = sessionKey, state = state, message = message)
     var dispatch: Pair<RealtimeAgentRun, RealtimeAgentCompletion>? = null
-    var unhandled: RealtimeAgentUnhandledCompletion? = null
+    var overflow: RealtimeAgentCacheOverflow? = null
     val handled =
       synchronized(lock) {
         if (runId in retiredRunIds) return@synchronized true
-        val session = activeSession
-        if (session == null) {
-          if (!hasPendingCallForSessionLocked(sessionKey)) {
-            false
-          } else {
-            unhandled = cacheEarlyCompletionLocked(runId, completion)
-            true
+        val run = runs[runId]
+        if (run != null && (sessionKey == null || sessionKey == run.session.sessionKey)) {
+          runs.remove(runId)
+          retireRunLocked(runId)
+          if (run.session == activeSession) {
+            dispatch = run to completion
           }
-        } else if (sessionKey != null && sessionKey != session.sessionKey) {
+          true
+        } else if (run != null) {
           false
+        } else if (hasPendingCallForSessionLocked(sessionKey)) {
+          overflow = cacheEarlyCompletionLocked(runId, completion)
+          true
         } else {
-          val run = runs.remove(runId)
-          if (run != null) {
-            retireRunLocked(runId)
-            if (run.session == session) {
-              dispatch = run to completion
-            }
-            true
-          } else if (!hasPendingCallForSessionLocked(sessionKey)) {
-            false
-          } else {
-            unhandled = cacheEarlyCompletionLocked(runId, completion)
-            true
-          }
+          false
         }
       }
     dispatch?.let { dispatchCompletion(it.first, it.second) }
-    unhandled?.let(onUnhandledCompletion)
+    overflow?.let { result ->
+      result.unhandled.forEach(onUnhandledCompletion)
+      failOverflowedCalls(result.failedCalls)
+    }
     return handled
   }
 
   private suspend fun runConsult(
-    session: RealtimeAgentSession,
-    callId: String,
+    pendingCall: RealtimeAgentPendingCall,
     args: JsonElement?,
     forced: Boolean,
   ) {
-    val pendingCall = RealtimeAgentPendingCall(callId = callId, session = session)
-    synchronized(lock) {
-      if (activeSession != session) return
-      pendingCalls += pendingCall
-    }
+    val session = pendingCall.session
+    val callId = pendingCall.callId
     try {
       if (forced) submitWorking(session, callId)
       if (!isActive(session)) return
@@ -212,60 +238,59 @@ internal class RealtimeAgentCoordinator(
       val response = requestGateway("talk.client.toolCall", params.toString(), TOOL_CALL_TIMEOUT_MILLIS)
       val runId = parseRunId(response)
       if (runId.isNullOrBlank()) {
-        submitError(session, callId, "tool call returned no run id")
+        val finish = finishPending(pendingCall)
+        finish.unhandled.forEach(onUnhandledCompletion)
+        if (finish.canSubmitError) submitError(session, callId, "tool call returned no run id")
         return
       }
-      val stillActive = synchronized(lock) { activeSession == session }
-      if (!stillActive) {
-        synchronized(lock) {
-          earlyCompletions.remove(runId)
-          retireRunLocked(runId)
-        }
+      if (!isPending(pendingCall)) {
+        synchronized(lock) { retireRunLocked(runId) }
         return
       }
       // Surface callbacks may take their own lifecycle locks, so never invoke one
       // while holding the coordinator lock. A final racing this callback is cached
       // against the pending call and consumed immediately after registration.
-      onWorking(session)
-      val completion =
+      if (isActive(session)) onWorking(session)
+      val registration =
         synchronized(lock) {
-          if (activeSession != session) {
-            earlyCompletions.remove(runId)
+          if (!isPendingLocked(pendingCall)) {
             retireRunLocked(runId)
             return
           }
-          earlyCompletions.remove(runId).also { cached ->
+          val cached = earlyCompletions.remove(runId)
+          pendingCalls.remove(pendingCall)
+          if (activeSession == session) {
             if (cached == null) {
               runs[runId] = RealtimeAgentRun(callId = callId, session = session)
             } else {
               retireRunLocked(runId)
             }
+          } else {
+            retireRunLocked(runId)
           }
+          RealtimeAgentRunRegistration(
+            completion = cached.takeIf { activeSession == session },
+            unhandled = drainEarlyCompletionsIfIdleLocked(),
+          )
         }
-      if (completion != null) {
-        dispatchCompletion(RealtimeAgentRun(callId = callId, session = session), completion)
+      registration.unhandled.forEach(onUnhandledCompletion)
+      if (registration.completion != null) {
+        dispatchCompletion(RealtimeAgentRun(callId = callId, session = session), registration.completion)
       }
     } catch (err: TimeoutCancellationException) {
-      submitError(session, callId, "tool call timed out")
+      val finish = finishPending(pendingCall)
+      finish.unhandled.forEach(onUnhandledCompletion)
+      if (finish.canSubmitError) submitError(session, callId, "tool call timed out")
     } catch (err: CancellationException) {
       throw err
     } catch (err: Throwable) {
       val message = err.message ?: "tool call failed"
-      onError(session, "realtime toolCall failed: $message")
-      submitError(session, callId, message)
-    } finally {
-      val unhandled =
-        synchronized(lock) {
-          val removed = pendingCalls.remove(pendingCall)
-          if (removed && pendingCalls.isEmpty()) {
-            earlyCompletions
-              .map { (runId, completion) -> completion.toUnhandled(runId) }
-              .also { earlyCompletions.clear() }
-          } else {
-            emptyList()
-          }
-        }
-      unhandled.forEach(onUnhandledCompletion)
+      val finish = finishPending(pendingCall)
+      finish.unhandled.forEach(onUnhandledCompletion)
+      if (finish.canSubmitError) {
+        onError(session, "realtime toolCall failed: $message")
+        submitError(session, callId, message)
+      }
     }
   }
 
@@ -330,6 +355,14 @@ internal class RealtimeAgentCoordinator(
         }
         "aborted", "error" -> submitError(run.session, run.callId, completion.state)
       }
+    }
+  }
+
+  private fun failOverflowedCalls(calls: List<RealtimeAgentPendingCall>) {
+    calls.forEach { it.job?.cancel() }
+    calls.forEach { call ->
+      val scope = synchronized(lock) { sessionScope.takeIf { activeSession == call.session } } ?: return@forEach
+      scope.launch { submitError(call.session, call.callId, "tool completion correlation buffer overflow") }
     }
   }
 
@@ -401,30 +434,52 @@ internal class RealtimeAgentCoordinator(
 
   private fun isActive(session: RealtimeAgentSession): Boolean = synchronized(lock) { activeSession == session }
 
-  private fun clearLocked() {
+  private fun isPending(call: RealtimeAgentPendingCall): Boolean = synchronized(lock) { isPendingLocked(call) }
+
+  private fun isPendingLocked(call: RealtimeAgentPendingCall): Boolean = call in pendingCalls && !call.failed
+
+  private fun clearSessionLocked(): List<RealtimeAgentUnhandledCompletion> {
     runs.keys.forEach(::retireRunLocked)
     activeSession = null
     sessionScope?.cancel()
     sessionScope = null
     runs.clear()
-    if (pendingCalls.isEmpty()) {
-      earlyCompletions.clear()
-    }
+    return drainEarlyCompletionsIfIdleLocked()
   }
+
+  private fun finishPending(call: RealtimeAgentPendingCall): RealtimeAgentPendingFinish =
+    synchronized(lock) {
+      val removed = pendingCalls.remove(call)
+      RealtimeAgentPendingFinish(
+        canSubmitError = removed && !call.failed && activeSession == call.session,
+        unhandled = if (removed) drainEarlyCompletionsIfIdleLocked() else emptyList(),
+      )
+    }
+
+  private fun drainEarlyCompletionsIfIdleLocked(): List<RealtimeAgentUnhandledCompletion> {
+    if (pendingCalls.isNotEmpty()) return emptyList()
+    return earlyCompletions
+      .map { (runId, completion) -> completion.toUnhandled(runId) }
+      .also { earlyCompletions.clear() }
+  }
+
+  private fun newCorrelationScope(): CoroutineScope = CoroutineScope(parentContext + SupervisorJob(parentJob))
 
   private fun hasPendingCallForSessionLocked(
     sessionKey: String?,
-  ): Boolean = pendingCalls.any { sessionKey == null || it.session.sessionKey == sessionKey }
+  ): Boolean = pendingCalls.any { !it.failed && (sessionKey == null || it.session.sessionKey == sessionKey) }
 
   private fun cacheEarlyCompletionLocked(
     runId: String,
     completion: RealtimeAgentCompletion,
-  ): RealtimeAgentUnhandledCompletion? {
+  ): RealtimeAgentCacheOverflow? {
     earlyCompletions[runId] = completion
     if (earlyCompletions.size <= maxCachedCompletions) return null
-    val evictedRunId = earlyCompletions.keys.first()
-    val evicted = earlyCompletions.remove(evictedRunId) ?: return null
-    return evicted.toUnhandled(evictedRunId)
+    val unhandled = earlyCompletions.map { (cachedRunId, cached) -> cached.toUnhandled(cachedRunId) }
+    val failedCalls = pendingCalls.filterNot { it.failed }
+    failedCalls.forEach { it.failed = true }
+    earlyCompletions.clear()
+    return RealtimeAgentCacheOverflow(unhandled = unhandled, failedCalls = failedCalls)
   }
 
   private fun retireRunLocked(runId: String) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/RealtimeAgentCoordinator.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/RealtimeAgentCoordinator.kt
@@ -1,0 +1,455 @@
+package ai.openclaw.app.voice
+
+import android.util.Log
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+
+internal data class RealtimeAgentSession(
+  val relaySessionId: String,
+  val sessionKey: String,
+)
+
+private data class RealtimeAgentRun(
+  val callId: String,
+  val session: RealtimeAgentSession,
+)
+
+private data class RealtimeAgentCompletion(
+  val sessionKey: String?,
+  val state: String,
+  val message: JsonElement?,
+)
+
+internal data class RealtimeAgentUnhandledCompletion(
+  val sessionKey: String?,
+  val runId: String,
+  val state: String,
+  val message: JsonElement?,
+)
+
+private class RealtimeAgentPendingCall(
+  val callId: String,
+  val session: RealtimeAgentSession,
+)
+
+/**
+ * Owns Android's provider-tool-call lifecycle for every realtime Talk surface.
+ * Replacing the session cancels session-owned work while retaining bounded
+ * correlation for late Gateway responses; transport replacement cancels both.
+ */
+internal class RealtimeAgentCoordinator(
+  parentScope: CoroutineScope,
+  private val requestGateway: suspend (method: String, paramsJson: String?, timeoutMs: Long) -> String,
+  private val onWorking: (RealtimeAgentSession) -> Unit = {},
+  private val onError: (RealtimeAgentSession, String) -> Unit = { _, message ->
+    Log.w(TAG, message)
+  },
+  private val onUnhandledCompletion: (RealtimeAgentUnhandledCompletion) -> Unit = {},
+  private val maxCachedCompletions: Int = MAX_CACHED_COMPLETIONS,
+) {
+  private val json = Json { ignoreUnknownKeys = true }
+  private val lock = Any()
+  private val parentContext = parentScope.coroutineContext
+  private val parentJob = parentContext[Job]
+  private val correlationScope = CoroutineScope(parentContext)
+  private val correlationJobs = LinkedHashSet<Job>()
+  private var activeSession: RealtimeAgentSession? = null
+  private var sessionScope: CoroutineScope? = null
+  private val runs = LinkedHashMap<String, RealtimeAgentRun>()
+  private val pendingCalls = LinkedHashSet<RealtimeAgentPendingCall>()
+  private val earlyCompletions = LinkedHashMap<String, RealtimeAgentCompletion>()
+
+  // A replacement can reuse the same chat session key, so keep known old run IDs
+  // long enough to consume delayed finals instead of leaking them into normal Talk TTS.
+  private val retiredRunIds = LinkedHashSet<String>()
+
+  init {
+    require(maxCachedCompletions > 0)
+  }
+
+  fun beginSession(session: RealtimeAgentSession) {
+    synchronized(lock) {
+      if (activeSession == session) return
+      clearLocked()
+      activeSession = session
+      sessionScope = CoroutineScope(parentContext + SupervisorJob(parentJob))
+    }
+  }
+
+  fun endSession(expectedRelaySessionId: String? = null) {
+    synchronized(lock) {
+      if (expectedRelaySessionId != null && activeSession?.relaySessionId != expectedRelaySessionId) return
+      clearLocked()
+    }
+  }
+
+  /** Cancels requests that must not survive a Gateway or account replacement. */
+  fun resetTransport() {
+    val jobs =
+      synchronized(lock) {
+        clearLocked()
+        pendingCalls.clear()
+        earlyCompletions.clear()
+        correlationJobs.toList().also { correlationJobs.clear() }
+      }
+    jobs.forEach { it.cancel() }
+  }
+
+  fun handleToolCall(
+    callId: String,
+    name: String,
+    args: JsonElement?,
+    forced: Boolean,
+  ): Boolean {
+    val sessionAndScope =
+      synchronized(lock) {
+        val session = activeSession ?: return false
+        val scope = sessionScope ?: return false
+        session to scope
+      }
+    val (session, scope) = sessionAndScope
+    when (name) {
+      AGENT_CONSULT_TOOL -> {
+        // Keep the bounded Gateway request alive across replacement so its run ID
+        // can still be quarantined if the old agent finishes late.
+        val job =
+          correlationScope.launch(start = CoroutineStart.LAZY) {
+            runConsult(session, callId, args, forced)
+          }
+        job.invokeOnCompletion { synchronized(lock) { correlationJobs.remove(job) } }
+        synchronized(lock) {
+          if (activeSession == session) {
+            correlationJobs += job
+            job.start()
+          } else {
+            job.cancel()
+          }
+        }
+      }
+      AGENT_CONTROL_TOOL -> scope.launch { runControl(session, callId, args) }
+      else -> scope.launch { submitError(session, callId, "unsupported realtime Talk tool: $name") }
+    }
+    return true
+  }
+
+  fun handleChatEvent(
+    sessionKey: String?,
+    runId: String,
+    state: String,
+    message: JsonElement?,
+  ): Boolean {
+    if (state !in TERMINAL_STATES) return false
+    val completion = RealtimeAgentCompletion(sessionKey = sessionKey, state = state, message = message)
+    var dispatch: Pair<RealtimeAgentRun, RealtimeAgentCompletion>? = null
+    var unhandled: RealtimeAgentUnhandledCompletion? = null
+    val handled =
+      synchronized(lock) {
+        if (runId in retiredRunIds) return@synchronized true
+        val session = activeSession
+        if (session == null) {
+          if (!hasPendingCallForSessionLocked(sessionKey)) {
+            false
+          } else {
+            unhandled = cacheEarlyCompletionLocked(runId, completion)
+            true
+          }
+        } else if (sessionKey != null && sessionKey != session.sessionKey) {
+          false
+        } else {
+          val run = runs.remove(runId)
+          if (run != null) {
+            retireRunLocked(runId)
+            if (run.session == session) {
+              dispatch = run to completion
+            }
+            true
+          } else if (!hasPendingCallForSessionLocked(sessionKey)) {
+            false
+          } else {
+            unhandled = cacheEarlyCompletionLocked(runId, completion)
+            true
+          }
+        }
+      }
+    dispatch?.let { dispatchCompletion(it.first, it.second) }
+    unhandled?.let(onUnhandledCompletion)
+    return handled
+  }
+
+  private suspend fun runConsult(
+    session: RealtimeAgentSession,
+    callId: String,
+    args: JsonElement?,
+    forced: Boolean,
+  ) {
+    val pendingCall = RealtimeAgentPendingCall(callId = callId, session = session)
+    synchronized(lock) {
+      if (activeSession != session) return
+      pendingCalls += pendingCall
+    }
+    try {
+      if (forced) submitWorking(session, callId)
+      if (!isActive(session)) return
+      val params =
+        buildJsonObject {
+          put("sessionKey", JsonPrimitive(session.sessionKey))
+          put("callId", JsonPrimitive(callId))
+          put("name", JsonPrimitive(AGENT_CONSULT_TOOL))
+          put("relaySessionId", JsonPrimitive(session.relaySessionId))
+          if (args != null) put("args", args)
+        }
+      val response = requestGateway("talk.client.toolCall", params.toString(), TOOL_CALL_TIMEOUT_MILLIS)
+      val runId = parseRunId(response)
+      if (runId.isNullOrBlank()) {
+        submitError(session, callId, "tool call returned no run id")
+        return
+      }
+      val stillActive = synchronized(lock) { activeSession == session }
+      if (!stillActive) {
+        synchronized(lock) {
+          earlyCompletions.remove(runId)
+          retireRunLocked(runId)
+        }
+        return
+      }
+      // Surface callbacks may take their own lifecycle locks, so never invoke one
+      // while holding the coordinator lock. A final racing this callback is cached
+      // against the pending call and consumed immediately after registration.
+      onWorking(session)
+      val completion =
+        synchronized(lock) {
+          if (activeSession != session) {
+            earlyCompletions.remove(runId)
+            retireRunLocked(runId)
+            return
+          }
+          earlyCompletions.remove(runId).also { cached ->
+            if (cached == null) {
+              runs[runId] = RealtimeAgentRun(callId = callId, session = session)
+            } else {
+              retireRunLocked(runId)
+            }
+          }
+        }
+      if (completion != null) {
+        dispatchCompletion(RealtimeAgentRun(callId = callId, session = session), completion)
+      }
+    } catch (err: TimeoutCancellationException) {
+      submitError(session, callId, "tool call timed out")
+    } catch (err: CancellationException) {
+      throw err
+    } catch (err: Throwable) {
+      val message = err.message ?: "tool call failed"
+      onError(session, "realtime toolCall failed: $message")
+      submitError(session, callId, message)
+    } finally {
+      val unhandled =
+        synchronized(lock) {
+          val removed = pendingCalls.remove(pendingCall)
+          if (removed && pendingCalls.isEmpty()) {
+            earlyCompletions
+              .map { (runId, completion) -> completion.toUnhandled(runId) }
+              .also { earlyCompletions.clear() }
+          } else {
+            emptyList()
+          }
+        }
+      unhandled.forEach(onUnhandledCompletion)
+    }
+  }
+
+  private suspend fun runControl(
+    session: RealtimeAgentSession,
+    callId: String,
+    args: JsonElement?,
+  ) {
+    try {
+      val argsObject = args as? JsonObject
+      val text =
+        argsObject
+          ?.get("text")
+          .asStringOrNull()
+          ?.trim()
+          .orEmpty()
+      val mode =
+        argsObject
+          ?.get("mode")
+          .asStringOrNull()
+          ?.trim()
+          ?.takeIf(String::isNotEmpty)
+      val params =
+        buildJsonObject {
+          put("sessionId", JsonPrimitive(session.relaySessionId))
+          put("sessionKey", JsonPrimitive(session.sessionKey))
+          put("text", JsonPrimitive(text.ifEmpty { "status" }))
+          if (mode != null) put("mode", JsonPrimitive(mode))
+        }
+      val response = requestGateway("talk.session.steer", params.toString(), TOOL_CALL_TIMEOUT_MILLIS)
+      val result = runCatching { json.parseToJsonElement(response) as? JsonObject }.getOrNull()
+      if (result == null) {
+        submitError(session, callId, "control call returned no result")
+      } else {
+        submitResult(session, callId, result)
+      }
+    } catch (err: TimeoutCancellationException) {
+      submitError(session, callId, "control call timed out")
+    } catch (err: CancellationException) {
+      throw err
+    } catch (err: Throwable) {
+      val message = err.message ?: "control call failed"
+      onError(session, "realtime control failed: $message")
+      submitError(session, callId, message)
+    }
+  }
+
+  private fun dispatchCompletion(
+    run: RealtimeAgentRun,
+    completion: RealtimeAgentCompletion,
+  ) {
+    val scope = synchronized(lock) { sessionScope.takeIf { activeSession == run.session } } ?: return
+    scope.launch {
+      when (completion.state) {
+        "final" -> {
+          val text = ChatEventText.assistantTextFromMessage(completion.message).orEmpty()
+          submitResult(
+            run.session,
+            run.callId,
+            buildJsonObject { put("text", JsonPrimitive(text)) },
+          )
+        }
+        "aborted", "error" -> submitError(run.session, run.callId, completion.state)
+      }
+    }
+  }
+
+  private suspend fun submitWorking(
+    session: RealtimeAgentSession,
+    callId: String,
+  ) {
+    submitResult(
+      session = session,
+      callId = callId,
+      result =
+        buildJsonObject {
+          put("status", JsonPrimitive("working"))
+          put("tool", JsonPrimitive(AGENT_CONSULT_TOOL))
+          put(
+            "message",
+            JsonPrimitive(
+              "Tell the person briefly that you are checking, then wait for the final OpenClaw result before answering with the actual result.",
+            ),
+          )
+        },
+      options = buildJsonObject { put("willContinue", JsonPrimitive(true)) },
+    )
+  }
+
+  private suspend fun submitError(
+    session: RealtimeAgentSession,
+    callId: String,
+    message: String,
+  ) {
+    submitResult(
+      session = session,
+      callId = callId,
+      result = buildJsonObject { put("error", JsonPrimitive(message)) },
+    )
+  }
+
+  private suspend fun submitResult(
+    session: RealtimeAgentSession,
+    callId: String,
+    result: JsonObject,
+    options: JsonObject? = null,
+  ) {
+    if (!isActive(session)) return
+    val params =
+      buildJsonObject {
+        put("sessionId", JsonPrimitive(session.relaySessionId))
+        put("callId", JsonPrimitive(callId))
+        put("result", result)
+        if (options != null) put("options", options)
+      }
+    try {
+      requestGateway("talk.session.submitToolResult", params.toString(), TOOL_CALL_TIMEOUT_MILLIS)
+    } catch (err: TimeoutCancellationException) {
+      onError(session, "realtime submitToolResult timed out")
+    } catch (err: CancellationException) {
+      throw err
+    } catch (err: Throwable) {
+      onError(session, "realtime submitToolResult failed: ${err.message ?: err::class.simpleName}")
+    }
+  }
+
+  private fun parseRunId(payloadJson: String): String? =
+    runCatching {
+      (json.parseToJsonElement(payloadJson) as? JsonObject)
+        ?.get("runId")
+        .asStringOrNull()
+    }.getOrNull()
+
+  private fun isActive(session: RealtimeAgentSession): Boolean = synchronized(lock) { activeSession == session }
+
+  private fun clearLocked() {
+    runs.keys.forEach(::retireRunLocked)
+    activeSession = null
+    sessionScope?.cancel()
+    sessionScope = null
+    runs.clear()
+    if (pendingCalls.isEmpty()) {
+      earlyCompletions.clear()
+    }
+  }
+
+  private fun hasPendingCallForSessionLocked(
+    sessionKey: String?,
+  ): Boolean = pendingCalls.any { sessionKey == null || it.session.sessionKey == sessionKey }
+
+  private fun cacheEarlyCompletionLocked(
+    runId: String,
+    completion: RealtimeAgentCompletion,
+  ): RealtimeAgentUnhandledCompletion? {
+    earlyCompletions[runId] = completion
+    if (earlyCompletions.size <= maxCachedCompletions) return null
+    val evictedRunId = earlyCompletions.keys.first()
+    val evicted = earlyCompletions.remove(evictedRunId) ?: return null
+    return evicted.toUnhandled(evictedRunId)
+  }
+
+  private fun retireRunLocked(runId: String) {
+    retiredRunIds += runId
+    while (retiredRunIds.size > maxCachedCompletions) {
+      retiredRunIds.remove(retiredRunIds.first())
+    }
+  }
+
+  private companion object {
+    const val TAG = "RealtimeAgent"
+    const val AGENT_CONSULT_TOOL = "openclaw_agent_consult"
+    const val AGENT_CONTROL_TOOL = "openclaw_agent_control"
+    const val TOOL_CALL_TIMEOUT_MILLIS = 15_000L
+    const val MAX_CACHED_COMPLETIONS = 128
+    val TERMINAL_STATES = setOf("final", "aborted", "error")
+  }
+}
+
+private fun RealtimeAgentCompletion.toUnhandled(runId: String) =
+  RealtimeAgentUnhandledCompletion(
+    sessionKey = sessionKey,
+    runId = runId,
+    state = state,
+    message = message,
+  )
+
+private fun JsonElement?.asStringOrNull(): String? = (this as? JsonPrimitive)?.takeIf { it.isString }?.content

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/RealtimeAgentCoordinator.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/RealtimeAgentCoordinator.kt
@@ -80,9 +80,10 @@ internal class RealtimeAgentCoordinator(
   private val lock = Any()
   private val parentContext = parentScope.coroutineContext
   private val parentJob = parentContext[Job]
-  private var correlationScope = newCorrelationScope()
+  private var transportGeneration = Any()
   private var activeSession: RealtimeAgentSession? = null
   private var sessionScope: CoroutineScope? = null
+  private val correlationJobs = LinkedHashSet<Job>()
   private val runs = LinkedHashMap<String, RealtimeAgentRun>()
   private val pendingCalls = LinkedHashSet<RealtimeAgentPendingCall>()
   private val earlyCompletions = LinkedHashMap<String, RealtimeAgentCompletion>()
@@ -120,16 +121,17 @@ internal class RealtimeAgentCoordinator(
   fun resetTransport() {
     // Lazy correlation jobs can complete synchronously during cancellation. Drop
     // account-bound state first so their handlers cannot release stale output.
-    val staleScope =
+    val staleJobs =
       synchronized(lock) {
         clearSessionLocked()
-        correlationScope.also {
-          correlationScope = newCorrelationScope()
-          pendingCalls.clear()
-          earlyCompletions.clear()
-        }
+        transportGeneration = Any()
+        val jobs = correlationJobs.toList()
+        correlationJobs.clear()
+        pendingCalls.clear()
+        earlyCompletions.clear()
+        jobs
       }
-    staleScope.cancel()
+    staleJobs.forEach(Job::cancel)
   }
 
   fun handleToolCall(
@@ -142,9 +144,9 @@ internal class RealtimeAgentCoordinator(
       synchronized(lock) {
         val session = activeSession ?: return false
         val resultScope = sessionScope ?: return false
-        Triple(session, resultScope, correlationScope)
+        Triple(session, resultScope, transportGeneration)
       }
-    val (session, resultScope, requestScope) = sessionAndScopes
+    val (session, resultScope, generation) = sessionAndScopes
     when (name) {
       AGENT_CONSULT_TOOL -> {
         val pendingCall = RealtimeAgentPendingCall(callId = callId, session = session)
@@ -155,14 +157,25 @@ internal class RealtimeAgentCoordinator(
               pendingCalls.add(pendingCall)
           }
         if (accepted) {
-          val job = requestScope.launch(start = CoroutineStart.LAZY) { runConsult(pendingCall, args, forced) }
+          val supervisor = SupervisorJob(parentJob)
+          val job =
+            CoroutineScope(parentContext + supervisor).launch(start = CoroutineStart.LAZY) {
+              runConsult(pendingCall, args, forced)
+            }
           job.invokeOnCompletion {
+            supervisor.cancel()
+            synchronized(lock) { correlationJobs.remove(job) }
             finishPending(pendingCall).unhandled.forEach(onUnhandledCompletion)
           }
           val shouldStart =
             synchronized(lock) {
-              if (activeSession == session && isPendingLocked(pendingCall)) {
+              if (
+                activeSession == session &&
+                transportGeneration === generation &&
+                isPendingLocked(pendingCall)
+              ) {
                 pendingCall.job = job
+                correlationJobs += job
                 true
               } else {
                 false
@@ -462,8 +475,6 @@ internal class RealtimeAgentCoordinator(
       .map { (runId, completion) -> completion.toUnhandled(runId) }
       .also { earlyCompletions.clear() }
   }
-
-  private fun newCorrelationScope(): CoroutineScope = CoroutineScope(parentContext + SupervisorJob(parentJob))
 
   private fun hasPendingCallForSessionLocked(
     sessionKey: String?,

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -112,14 +112,6 @@ internal sealed interface TalkPttOnceStart {
   ) : TalkPttOnceStart
 }
 
-internal data class RealtimeToolRun(
-  val callId: String,
-  val relaySessionId: String,
-)
-
-private const val REALTIME_AGENT_CONSULT_TOOL = "openclaw_agent_consult"
-private const val REALTIME_AGENT_CONTROL_TOOL = "openclaw_agent_control"
-
 internal suspend fun requestPhoneRealtimeSessionWithLanguageFallback(
   language: String?,
   request: suspend (language: String?) -> String,
@@ -132,37 +124,6 @@ internal suspend fun requestPhoneRealtimeSessionWithLanguageFallback(
     }
     request(null)
   }
-
-private data class RealtimeToolCompletion(
-  val state: String,
-  val messageEl: JsonElement?,
-)
-
-private data class RealtimeToolCompletionDispatch(
-  val toolRun: RealtimeToolRun,
-  val state: String,
-  val messageEl: JsonElement?,
-)
-
-private sealed interface RealtimeToolRegistration {
-  data object SessionEnded : RealtimeToolRegistration
-
-  data object AwaitingCompletion : RealtimeToolRegistration
-
-  data class Completed(
-    val dispatch: RealtimeToolCompletionDispatch,
-  ) : RealtimeToolRegistration
-}
-
-private sealed interface RealtimeToolCompletionDecision {
-  data object NotHandled : RealtimeToolCompletionDecision
-
-  data object Consumed : RealtimeToolCompletionDecision
-
-  data class Dispatch(
-    val completion: RealtimeToolCompletionDispatch,
-  ) : RealtimeToolCompletionDecision
-}
 
 private enum class TalkStatusState {
   Off,
@@ -391,11 +352,25 @@ class TalkModeManager internal constructor(
 
   @Volatile private var finishingPttJob: Job? = null
 
-  // Realtime tool calls can complete before their chat final arrives; cache by call/run id until both sides meet.
-  private val realtimeToolLock = Any()
-  private val realtimeToolRuns = LinkedHashMap<String, RealtimeToolRun>()
-  private val pendingRealtimeToolCalls = LinkedHashSet<String>()
-  private val pendingRealtimeToolCompletions = LinkedHashMap<String, RealtimeToolCompletion>()
+  private val realtimeAgentCoordinator =
+    RealtimeAgentCoordinator(
+      parentScope = scope,
+      requestGateway = ::requestGateway,
+      onWorking = { session ->
+        if (realtimeSessionId == session.relaySessionId) {
+          setStatus(nativeText("Thinking…"), awaitingAgent = true)
+        }
+      },
+      onError = { _, message -> Log.w(tag, message) },
+      onUnhandledCompletion = { completion ->
+        handleNonRealtimeAgentChatEvent(
+          sessionKey = completion.sessionKey,
+          runId = completion.runId,
+          state = completion.state,
+          message = completion.message,
+        )
+      },
+    )
   private var realtimeUserEntryId: String? = null
   private var realtimeUserEntryAwaitingFinal = false
   private var realtimeUserEntryAwaitingFinalStartedAtMs: Long? = null
@@ -476,6 +451,8 @@ class TalkModeManager internal constructor(
 
   /** Cancels work carrying voice/session data before a replacement gateway can connect. */
   fun onGatewayScopeChanging() {
+    stopRealtimeRelay(closeSession = false)
+    realtimeAgentCoordinator.resetTransport()
     gatewayGeneration.incrementAndGet()
     gatewayWorkJob.cancel()
     gatewayWorkJob = SupervisorJob()
@@ -909,9 +886,33 @@ class TalkModeManager internal constructor(
     val activeSession = mainSessionKey.ifBlank { "main" }
     if (eventSession != null && eventSession != activeSession) return
 
-    if (handleRealtimeToolCompletion(runId = runId, state = state, messageEl = obj["message"])) {
+    if (
+      realtimeAgentCoordinator.handleChatEvent(
+        sessionKey = eventSession,
+        runId = runId,
+        state = state,
+        message = obj["message"],
+      )
+    ) {
       return
     }
+
+    handleNonRealtimeAgentChatEvent(
+      sessionKey = eventSession,
+      runId = runId,
+      state = state,
+      message = obj["message"],
+    )
+  }
+
+  private fun handleNonRealtimeAgentChatEvent(
+    sessionKey: String?,
+    runId: String,
+    state: String,
+    message: JsonElement?,
+  ) {
+    val activeSession = mainSessionKey.ifBlank { "main" }
+    if (sessionKey != null && sessionKey != activeSession) return
 
     // If this is a response we initiated, handle normally below.
     // Otherwise, if ttsOnAllResponses, finish streaming TTS on terminal events.
@@ -919,7 +920,7 @@ class TalkModeManager internal constructor(
     val knownRun = pending == runId || hasRunCompletion(runId)
     if (!knownRun) {
       if (ttsOnAllResponses && state == "final") {
-        val text = extractTextFromChatEventMessage(obj["message"])
+        val text = extractTextFromChatEventMessage(message)
         if (!text.isNullOrBlank()) {
           playTtsForText(text)
         }
@@ -935,7 +936,7 @@ class TalkModeManager internal constructor(
       } ?: return
     // Cache text from final event so we never need to poll chat.history
     if (terminal) {
-      val text = extractTextFromChatEventMessage(obj["message"])
+      val text = extractTextFromChatEventMessage(message)
       if (!text.isNullOrBlank()) {
         synchronized(completedRunsLock) {
           completedRunTexts[runId] = text
@@ -1140,6 +1141,12 @@ class TalkModeManager internal constructor(
       synchronized(realtimeCapturePauseLock) {
         // Session publication and capture installation are one transition. PTT
         // therefore either blocks startup or detaches every installed capture job.
+        realtimeAgentCoordinator.beginSession(
+          RealtimeAgentSession(
+            relaySessionId = sessionId,
+            sessionKey = mainSessionKey.ifBlank { "main" },
+          ),
+        )
         realtimeSessionId = sessionId
         val pause = realtimeCapturePause
         if (pause != null) {
@@ -1355,7 +1362,7 @@ class TalkModeManager internal constructor(
       "toolCall" -> {
         val callId = obj["callId"].asStringOrNull() ?: return
         val name = obj["name"].asStringOrNull() ?: return
-        handleRealtimeToolCall(
+        realtimeAgentCoordinator.handleToolCall(
           callId = callId,
           name = name,
           args = obj["args"],
@@ -1657,11 +1664,7 @@ class TalkModeManager internal constructor(
     if (cancelAppend) {
       captureJobs.second?.cancel()
     }
-    synchronized(realtimeToolLock) {
-      realtimeToolRuns.clear()
-      pendingRealtimeToolCalls.clear()
-      pendingRealtimeToolCompletions.clear()
-    }
+    realtimeAgentCoordinator.endSession(sessionId)
     realtimeUserEntryId = null
     realtimeUserEntryAwaitingFinal = false
     realtimeUserEntryAwaitingFinalStartedAtMs = null
@@ -1766,232 +1769,6 @@ class TalkModeManager internal constructor(
       if (err !is CancellationException) {
         Log.d(tag, "realtime close ignored: ${err.message ?: err::class.simpleName}")
       }
-    }
-  }
-
-  private fun handleRealtimeToolCall(
-    callId: String,
-    name: String,
-    args: JsonElement?,
-    forced: Boolean = false,
-  ) {
-    val relaySessionId = realtimeSessionId ?: return
-    synchronized(realtimeToolLock) {
-      pendingRealtimeToolCalls.add(callId)
-    }
-    gatewayWorkScope.launch {
-      try {
-        if (name == REALTIME_AGENT_CONTROL_TOOL) {
-          submitRealtimeAgentControl(callId = callId, relaySessionId = relaySessionId, args = args)
-          return@launch
-        }
-        if (forced) {
-          submitRealtimeToolWorking(callId, relaySessionId)
-        }
-        val params =
-          buildJsonObject {
-            put("sessionKey", JsonPrimitive(mainSessionKey.ifBlank { "main" }))
-            put("callId", JsonPrimitive(callId))
-            put("name", JsonPrimitive(name))
-            put("relaySessionId", JsonPrimitive(relaySessionId))
-            if (args != null) put("args", args)
-          }
-        val response =
-          requestGateway("talk.client.toolCall", params.toString(), timeoutMs = 15_000)
-        val runId = parseRunId(response)
-        if (!runId.isNullOrBlank()) {
-          when (val registration = registerRealtimeToolRun(runId, callId, relaySessionId)) {
-            RealtimeToolRegistration.SessionEnded -> return@launch
-            RealtimeToolRegistration.AwaitingCompletion -> setStatus(nativeText("Thinking…"), awaitingAgent = true)
-            is RealtimeToolRegistration.Completed ->
-              dispatchRealtimeToolCompletion(registration.dispatch)
-          }
-        } else {
-          submitRealtimeToolError(callId, "tool call returned no run id", relaySessionId)
-        }
-      } catch (err: Throwable) {
-        if (err is CancellationException) throw err
-        Log.w(tag, "realtime toolCall failed: ${err.message ?: err::class.simpleName}")
-        submitRealtimeToolError(callId, err.message ?: "tool call failed", relaySessionId)
-      } finally {
-        synchronized(realtimeToolLock) {
-          pendingRealtimeToolCalls.remove(callId)
-        }
-      }
-    }
-  }
-
-  private fun registerRealtimeToolRun(
-    runId: String,
-    callId: String,
-    relaySessionId: String,
-  ): RealtimeToolRegistration =
-    synchronized(realtimeToolLock) {
-      if (realtimeSessionId != relaySessionId) {
-        return@synchronized RealtimeToolRegistration.SessionEnded
-      }
-      val toolRun = RealtimeToolRun(callId = callId, relaySessionId = relaySessionId)
-      val completion = pendingRealtimeToolCompletions.remove(runId)
-      if (completion == null) {
-        realtimeToolRuns[runId] = toolRun
-        RealtimeToolRegistration.AwaitingCompletion
-      } else {
-        RealtimeToolRegistration.Completed(
-          RealtimeToolCompletionDispatch(
-            toolRun = toolRun,
-            state = completion.state,
-            messageEl = completion.messageEl,
-          ),
-        )
-      }
-    }
-
-  private fun handleRealtimeToolCompletion(
-    runId: String,
-    state: String,
-    messageEl: JsonElement?,
-  ): Boolean {
-    if (state != "final" && state != "aborted" && state != "error") return false
-    val decision =
-      synchronized(realtimeToolLock) {
-        val toolRun = realtimeToolRuns.remove(runId)
-        if (toolRun != null) {
-          if (toolRun.relaySessionId != realtimeSessionId) {
-            return@synchronized RealtimeToolCompletionDecision.Consumed
-          }
-          return@synchronized RealtimeToolCompletionDecision.Dispatch(
-            RealtimeToolCompletionDispatch(toolRun = toolRun, state = state, messageEl = messageEl),
-          )
-        }
-        if (realtimeSessionId == null || pendingRealtimeToolCalls.isEmpty()) {
-          return@synchronized RealtimeToolCompletionDecision.NotHandled
-        }
-        pendingRealtimeToolCompletions[runId] =
-          RealtimeToolCompletion(state = state, messageEl = messageEl)
-        while (pendingRealtimeToolCompletions.size > maxCachedRunCompletions) {
-          pendingRealtimeToolCompletions.remove(pendingRealtimeToolCompletions.keys.first())
-        }
-        RealtimeToolCompletionDecision.Consumed
-      }
-    return when (decision) {
-      RealtimeToolCompletionDecision.NotHandled -> false
-      RealtimeToolCompletionDecision.Consumed -> true
-      is RealtimeToolCompletionDecision.Dispatch -> {
-        dispatchRealtimeToolCompletion(decision.completion)
-        true
-      }
-    }
-  }
-
-  private fun dispatchRealtimeToolCompletion(dispatch: RealtimeToolCompletionDispatch) {
-    when (dispatch.state) {
-      "final" -> {
-        val text = extractTextFromChatEventMessage(dispatch.messageEl).orEmpty()
-        val toolRun = dispatch.toolRun
-        gatewayWorkScope.launch {
-          submitRealtimeToolResult(
-            callId = toolRun.callId,
-            result = buildJsonObject { put("text", JsonPrimitive(text)) },
-            sessionId = toolRun.relaySessionId,
-          )
-        }
-      }
-      "aborted", "error" -> {
-        val toolRun = dispatch.toolRun
-        val state = dispatch.state
-        gatewayWorkScope.launch {
-          submitRealtimeToolError(toolRun.callId, state, toolRun.relaySessionId)
-        }
-      }
-    }
-  }
-
-  private suspend fun submitRealtimeToolError(
-    callId: String,
-    message: String,
-    sessionId: String? = realtimeSessionId,
-  ) {
-    submitRealtimeToolResult(
-      callId = callId,
-      result = buildJsonObject { put("error", JsonPrimitive(message)) },
-      sessionId = sessionId,
-    )
-  }
-
-  private suspend fun submitRealtimeToolResult(
-    callId: String,
-    result: JsonObject,
-    sessionId: String? = realtimeSessionId,
-    options: JsonObject? = null,
-  ) {
-    val activeSessionId = sessionId ?: return
-    val params =
-      buildJsonObject {
-        put("sessionId", JsonPrimitive(activeSessionId))
-        put("callId", JsonPrimitive(callId))
-        put("result", result)
-        if (options != null) put("options", options)
-      }
-    try {
-      requestGateway("talk.session.submitToolResult", params.toString(), timeoutMs = 15_000)
-    } catch (err: Throwable) {
-      if (err is CancellationException) throw err
-      Log.w(tag, "realtime submitToolResult failed: ${err.message ?: err::class.simpleName}")
-    }
-  }
-
-  private suspend fun submitRealtimeToolWorking(
-    callId: String,
-    sessionId: String,
-  ) {
-    submitRealtimeToolResult(
-      callId = callId,
-      sessionId = sessionId,
-      result =
-        buildJsonObject {
-          put("status", JsonPrimitive("working"))
-          put("tool", JsonPrimitive(REALTIME_AGENT_CONSULT_TOOL))
-          put(
-            "message",
-            JsonPrimitive(
-              "Tell the person briefly that you are checking, then wait for the final OpenClaw result before answering with the actual result.",
-            ),
-          )
-        },
-      options = buildJsonObject { put("willContinue", JsonPrimitive(true)) },
-    )
-  }
-
-  private suspend fun submitRealtimeAgentControl(
-    callId: String,
-    relaySessionId: String,
-    args: JsonElement?,
-  ) {
-    val argsObject = args.asObjectOrNull()
-    val text =
-      argsObject
-        ?.get("text")
-        .asStringOrNull()
-        ?.trim()
-        .orEmpty()
-    val mode =
-      argsObject
-        ?.get("mode")
-        .asStringOrNull()
-        ?.trim()
-    val params =
-      buildJsonObject {
-        put("sessionId", JsonPrimitive(relaySessionId))
-        put("sessionKey", JsonPrimitive(mainSessionKey.ifBlank { "main" }))
-        put("text", JsonPrimitive(text.ifEmpty { "status" }))
-        if (!mode.isNullOrEmpty()) put("mode", JsonPrimitive(mode))
-      }
-    val response = requestGateway("talk.session.steer", params.toString(), timeoutMs = 15_000)
-    val result = json.parseToJsonElement(response).asObjectOrNull()
-    if (result != null) {
-      submitRealtimeToolResult(callId = callId, result = result, sessionId = relaySessionId)
-    } else {
-      submitRealtimeToolError(callId, "control call returned no result", relaySessionId)
     }
   }
 
@@ -3300,11 +3077,6 @@ class TalkModeManager internal constructor(
   }
 
   private fun resolvedSpeechLocaleTag(): String = speechLocale ?: Locale.getDefault().toLanguageTag()
-
-  private fun parseRunId(jsonString: String): String? {
-    val obj = json.parseToJsonElement(jsonString).asObjectOrNull() ?: return null
-    return obj["runId"].asStringOrNull()
-  }
 
   private object TalkModeRuntime {
     fun resolveSpeed(

--- a/apps/android/app/src/main/java/ai/openclaw/app/wear/WearRealtimeTalkController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/wear/WearRealtimeTalkController.kt
@@ -19,9 +19,11 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -464,15 +466,28 @@ internal class WearRealtimeTalkController(
     outputJob =
       scope.launch {
         for (message in messages) {
+          var delivered = false
           try {
             if (sessionId != activeSessionId) continue
             val nodeId = ownerNodeId ?: continue
             when (message.type) {
-              WearRealtimeAudioFrameType.OUTPUT_PCM ->
-                chunkWearRealtimeOutput(message.payload).forEach { chunk ->
+              WearRealtimeAudioFrameType.OUTPUT_PCM -> {
+                delivered = true
+                for (chunk in chunkWearRealtimeOutput(message.payload)) {
+                  if (!isCurrentOutput(activeSessionId, nodeId)) {
+                    delivered = false
+                    break
+                  }
                   sendWatchFrame(nodeId, message.type, chunk)
                 }
-              WearRealtimeAudioFrameType.CLEAR_OUTPUT -> sendWatchFrame(nodeId, message.type, message.payload)
+                if (!isCurrentOutput(activeSessionId, nodeId)) {
+                  delivered = false
+                }
+              }
+              WearRealtimeAudioFrameType.CLEAR_OUTPUT -> {
+                sendWatchFrame(nodeId, message.type, message.payload)
+                delivered = isCurrentOutput(activeSessionId, nodeId)
+              }
               WearRealtimeAudioFrameType.INPUT_PCM -> error("Phone cannot emit Watch input audio")
             }
           } catch (err: Throwable) {
@@ -490,6 +505,7 @@ internal class WearRealtimeTalkController(
               }
             }
           }
+          if (!delivered) continue
           when (message.type) {
             WearRealtimeAudioFrameType.OUTPUT_PCM -> {
               val sampleCount = message.payload.size / PCM_16_BYTES
@@ -519,6 +535,14 @@ internal class WearRealtimeTalkController(
         }
       }
   }
+
+  private suspend fun isCurrentOutput(
+    activeSessionId: String,
+    nodeId: String,
+  ): Boolean =
+    currentCoroutineContext().isActive &&
+      sessionId == activeSessionId &&
+      ownerNodeId == nodeId
 
   private fun enqueueOutput(
     type: WearRealtimeAudioFrameType,

--- a/apps/android/app/src/main/java/ai/openclaw/app/wear/WearRealtimeTalkController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/wear/WearRealtimeTalkController.kt
@@ -4,7 +4,8 @@ import ai.openclaw.app.gateway.GatewayRequestRejected
 import ai.openclaw.app.gateway.GatewaySession
 import ai.openclaw.app.node.asObjectOrNull
 import ai.openclaw.app.node.asStringOrNull
-import ai.openclaw.app.voice.ChatEventText
+import ai.openclaw.app.voice.RealtimeAgentCoordinator
+import ai.openclaw.app.voice.RealtimeAgentSession
 import ai.openclaw.wear.shared.WearProtocol
 import ai.openclaw.wear.shared.WearRealtimeAudioFrameType
 import ai.openclaw.wear.shared.WearRealtimeTalkEntry
@@ -44,41 +45,6 @@ private data class WearRealtimeAttemptKey(
   val nodeId: String,
   val attemptId: String,
 )
-
-private data class WearRealtimeToolRun(
-  val callId: String,
-  val relaySessionId: String,
-)
-
-private data class WearRealtimeToolCompletion(
-  val state: String,
-  val message: JsonElement?,
-)
-
-private data class WearRealtimeToolCompletionDispatch(
-  val toolRun: WearRealtimeToolRun,
-  val completion: WearRealtimeToolCompletion,
-)
-
-private sealed interface WearRealtimeToolRegistration {
-  data object SessionEnded : WearRealtimeToolRegistration
-
-  data object AwaitingCompletion : WearRealtimeToolRegistration
-
-  data class Completed(
-    val dispatch: WearRealtimeToolCompletionDispatch,
-  ) : WearRealtimeToolRegistration
-}
-
-private sealed interface WearRealtimeToolCompletionDecision {
-  data object NotHandled : WearRealtimeToolCompletionDecision
-
-  data object Consumed : WearRealtimeToolCompletionDecision
-
-  data class Dispatch(
-    val dispatch: WearRealtimeToolCompletionDispatch,
-  ) : WearRealtimeToolCompletionDecision
-}
 
 internal fun chunkWearRealtimeOutput(
   payload: ByteArray,
@@ -136,10 +102,25 @@ internal class WearRealtimeTalkController(
   private var playbackEndsAtMillis = 0L
   private var userEntryId: String? = null
   private var assistantEntryId: String? = null
-  private val realtimeToolLock = Any()
-  private val realtimeToolRuns = LinkedHashMap<String, WearRealtimeToolRun>()
-  private val pendingRealtimeToolCalls = LinkedHashSet<String>()
-  private val pendingRealtimeToolCompletions = LinkedHashMap<String, WearRealtimeToolCompletion>()
+  private val realtimeAgentCoordinator =
+    RealtimeAgentCoordinator(
+      parentScope = scope,
+      requestGateway = requestGateway,
+      onWorking = { activeSession ->
+        synchronized(lifecycleStateLock) {
+          if (sessionId == activeSession.relaySessionId) {
+            updateState(
+              active = true,
+              listening = false,
+              speaking = false,
+              status = WearRealtimeTalkStatus.THINKING,
+              statusText = "Agent working",
+            )
+          }
+        }
+      },
+      onError = { _, message -> Log.w(TAG, message) },
+    )
 
   suspend fun start(
     nodeId: String,
@@ -210,6 +191,12 @@ internal class WearRealtimeTalkController(
             fail("Real-Time Talk returned no session")
             false
           } else {
+            realtimeAgentCoordinator.beginSession(
+              RealtimeAgentSession(
+                relaySessionId = createdSessionId,
+                sessionKey = sessionKey,
+              ),
+            )
             sessionId = createdSessionId
             startOutputLoop(createdSessionId)
             startAppendLoop(createdSessionId)
@@ -429,7 +416,7 @@ internal class WearRealtimeTalkController(
       "toolCall" -> {
         val callId = obj["callId"].asStringOrNull() ?: return
         val name = obj["name"].asStringOrNull() ?: return
-        handleRealtimeToolCall(
+        realtimeAgentCoordinator.handleToolCall(
           callId = callId,
           name = name,
           args = obj["args"],
@@ -445,268 +432,13 @@ internal class WearRealtimeTalkController(
   private fun handleChatEvent(obj: JsonObject) {
     val runId = obj["runId"].asStringOrNull() ?: return
     val state = obj["state"].asStringOrNull() ?: return
-    val activeSessionKey = ownerSessionKey ?: return
     val eventSessionKey = obj["sessionKey"].asStringOrNull()
-    if (eventSessionKey != null && eventSessionKey != activeSessionKey) return
-    handleRealtimeToolCompletion(runId = runId, state = state, message = obj["message"])
-  }
-
-  private fun handleRealtimeToolCall(
-    callId: String,
-    name: String,
-    args: JsonElement?,
-    forced: Boolean,
-  ) {
-    val activeSessionId = sessionId ?: return
-    val activeSessionKey = ownerSessionKey ?: return
-    synchronized(realtimeToolLock) {
-      pendingRealtimeToolCalls += callId
-    }
-    scope.launch {
-      try {
-        if (sessionId != activeSessionId || ownerSessionKey != activeSessionKey) return@launch
-        if (name == REALTIME_AGENT_CONTROL_TOOL) {
-          submitRealtimeAgentControl(
-            callId = callId,
-            relaySessionId = activeSessionId,
-            sessionKey = activeSessionKey,
-            args = args,
-          )
-          return@launch
-        }
-        if (forced) {
-          submitRealtimeToolWorking(callId = callId, sessionId = activeSessionId)
-        }
-        val params =
-          buildJsonObject {
-            put("sessionKey", JsonPrimitive(activeSessionKey))
-            put("callId", JsonPrimitive(callId))
-            put("name", JsonPrimitive(name))
-            put("relaySessionId", JsonPrimitive(activeSessionId))
-            if (args != null) put("args", args)
-          }
-        val response = requestGateway("talk.client.toolCall", params.toString(), TOOL_CALL_TIMEOUT_MILLIS)
-        val runId = parseRunId(response)
-        if (runId.isNullOrBlank()) {
-          submitRealtimeToolError(callId, "tool call returned no run id", activeSessionId)
-          return@launch
-        }
-        when (val registration = registerRealtimeToolRun(runId, callId, activeSessionId)) {
-          WearRealtimeToolRegistration.SessionEnded -> Unit
-          WearRealtimeToolRegistration.AwaitingCompletion ->
-            synchronized(lifecycleStateLock) {
-              if (sessionId == activeSessionId) {
-                updateState(
-                  active = true,
-                  listening = false,
-                  speaking = false,
-                  status = WearRealtimeTalkStatus.THINKING,
-                  statusText = "Agent working",
-                )
-              }
-            }
-          is WearRealtimeToolRegistration.Completed -> dispatchRealtimeToolCompletion(registration.dispatch)
-        }
-      } catch (err: Throwable) {
-        if (err is CancellationException) throw err
-        Log.w(TAG, "realtime toolCall failed: ${err.message ?: err::class.simpleName}")
-        submitRealtimeToolError(callId, err.message ?: "tool call failed", activeSessionId)
-      } finally {
-        synchronized(realtimeToolLock) {
-          pendingRealtimeToolCalls -= callId
-        }
-      }
-    }
-  }
-
-  private fun registerRealtimeToolRun(
-    runId: String,
-    callId: String,
-    relaySessionId: String,
-  ): WearRealtimeToolRegistration =
-    synchronized(realtimeToolLock) {
-      if (sessionId != relaySessionId) {
-        return@synchronized WearRealtimeToolRegistration.SessionEnded
-      }
-      val toolRun = WearRealtimeToolRun(callId = callId, relaySessionId = relaySessionId)
-      val completion = pendingRealtimeToolCompletions.remove(runId)
-      if (completion == null) {
-        realtimeToolRuns[runId] = toolRun
-        WearRealtimeToolRegistration.AwaitingCompletion
-      } else {
-        WearRealtimeToolRegistration.Completed(
-          WearRealtimeToolCompletionDispatch(toolRun = toolRun, completion = completion),
-        )
-      }
-    }
-
-  private fun handleRealtimeToolCompletion(
-    runId: String,
-    state: String,
-    message: JsonElement?,
-  ): Boolean {
-    if (state != "final" && state != "aborted" && state != "error") return false
-    val decision =
-      synchronized(realtimeToolLock) {
-        val toolRun = realtimeToolRuns.remove(runId)
-        if (toolRun != null) {
-          if (toolRun.relaySessionId != sessionId) {
-            return@synchronized WearRealtimeToolCompletionDecision.Consumed
-          }
-          return@synchronized WearRealtimeToolCompletionDecision.Dispatch(
-            WearRealtimeToolCompletionDispatch(
-              toolRun = toolRun,
-              completion = WearRealtimeToolCompletion(state = state, message = message),
-            ),
-          )
-        }
-        if (sessionId == null || pendingRealtimeToolCalls.isEmpty()) {
-          return@synchronized WearRealtimeToolCompletionDecision.NotHandled
-        }
-        pendingRealtimeToolCompletions[runId] =
-          WearRealtimeToolCompletion(state = state, message = message)
-        while (pendingRealtimeToolCompletions.size > MAX_CACHED_TOOL_COMPLETIONS) {
-          pendingRealtimeToolCompletions.remove(pendingRealtimeToolCompletions.keys.first())
-        }
-        WearRealtimeToolCompletionDecision.Consumed
-      }
-    return when (decision) {
-      WearRealtimeToolCompletionDecision.NotHandled -> false
-      WearRealtimeToolCompletionDecision.Consumed -> true
-      is WearRealtimeToolCompletionDecision.Dispatch -> {
-        dispatchRealtimeToolCompletion(decision.dispatch)
-        true
-      }
-    }
-  }
-
-  private fun dispatchRealtimeToolCompletion(dispatch: WearRealtimeToolCompletionDispatch) {
-    val toolRun = dispatch.toolRun
-    scope.launch {
-      when (dispatch.completion.state) {
-        "final" -> {
-          val text = ChatEventText.assistantTextFromMessage(dispatch.completion.message).orEmpty()
-          submitRealtimeToolResult(
-            callId = toolRun.callId,
-            result = buildJsonObject { put("text", JsonPrimitive(text)) },
-            sessionId = toolRun.relaySessionId,
-          )
-        }
-        "aborted", "error" ->
-          submitRealtimeToolError(
-            callId = toolRun.callId,
-            message = dispatch.completion.state,
-            sessionId = toolRun.relaySessionId,
-          )
-      }
-    }
-  }
-
-  private suspend fun submitRealtimeToolWorking(
-    callId: String,
-    sessionId: String,
-  ) {
-    submitRealtimeToolResult(
-      callId = callId,
-      sessionId = sessionId,
-      result =
-        buildJsonObject {
-          put("status", JsonPrimitive("working"))
-          put("tool", JsonPrimitive(REALTIME_AGENT_CONSULT_TOOL))
-          put(
-            "message",
-            JsonPrimitive(
-              "Tell the person briefly that you are checking, then wait for the final OpenClaw result before answering with the actual result.",
-            ),
-          )
-        },
-      options = buildJsonObject { put("willContinue", JsonPrimitive(true)) },
+    realtimeAgentCoordinator.handleChatEvent(
+      sessionKey = eventSessionKey,
+      runId = runId,
+      state = state,
+      message = obj["message"],
     )
-  }
-
-  private suspend fun submitRealtimeAgentControl(
-    callId: String,
-    relaySessionId: String,
-    sessionKey: String,
-    args: JsonElement?,
-  ) {
-    val argsObject = args.asObjectOrNull()
-    val text =
-      argsObject
-        ?.get("text")
-        .asStringOrNull()
-        ?.trim()
-        .orEmpty()
-    val mode =
-      argsObject
-        ?.get("mode")
-        .asStringOrNull()
-        ?.trim()
-        ?.takeIf(String::isNotEmpty)
-    val params =
-      buildJsonObject {
-        put("sessionId", JsonPrimitive(relaySessionId))
-        put("sessionKey", JsonPrimitive(sessionKey))
-        put("text", JsonPrimitive(text.ifEmpty { "status" }))
-        if (mode != null) put("mode", JsonPrimitive(mode))
-      }
-    val response = requestGateway("talk.session.steer", params.toString(), TOOL_CALL_TIMEOUT_MILLIS)
-    val result = runCatching { json.parseToJsonElement(response).asObjectOrNull() }.getOrNull()
-    if (result == null) {
-      submitRealtimeToolError(callId, "control call returned no result", relaySessionId)
-    } else {
-      submitRealtimeToolResult(callId = callId, result = result, sessionId = relaySessionId)
-    }
-  }
-
-  private suspend fun submitRealtimeToolError(
-    callId: String,
-    message: String,
-    sessionId: String,
-  ) {
-    submitRealtimeToolResult(
-      callId = callId,
-      result = buildJsonObject { put("error", JsonPrimitive(message)) },
-      sessionId = sessionId,
-    )
-  }
-
-  private suspend fun submitRealtimeToolResult(
-    callId: String,
-    result: JsonObject,
-    sessionId: String,
-    options: JsonObject? = null,
-  ) {
-    val params =
-      buildJsonObject {
-        put("sessionId", JsonPrimitive(sessionId))
-        put("callId", JsonPrimitive(callId))
-        put("result", result)
-        if (options != null) put("options", options)
-      }
-    try {
-      requestGateway("talk.session.submitToolResult", params.toString(), TOOL_CALL_TIMEOUT_MILLIS)
-    } catch (err: Throwable) {
-      if (err is CancellationException) throw err
-      Log.w(TAG, "realtime submitToolResult failed: ${err.message ?: err::class.simpleName}")
-    }
-  }
-
-  private fun parseRunId(payloadJson: String): String? =
-    runCatching {
-      json
-        .parseToJsonElement(payloadJson)
-        .asObjectOrNull()
-        ?.get("runId")
-        .asStringOrNull()
-    }.getOrNull()
-
-  private fun clearRealtimeToolState() {
-    synchronized(realtimeToolLock) {
-      realtimeToolRuns.clear()
-      pendingRealtimeToolCalls.clear()
-      pendingRealtimeToolCompletions.clear()
-    }
   }
 
   private fun startOutputLoop(activeSessionId: String) {
@@ -898,6 +630,7 @@ internal class WearRealtimeTalkController(
         Log.w(TAG, message)
         val currentSession = sessionId
         val currentNodeId = ownerNodeId
+        realtimeAgentCoordinator.endSession(currentSession)
         setSnapshot(
           _snapshot.value.copy(
             active = false,
@@ -922,7 +655,6 @@ internal class WearRealtimeTalkController(
         playbackIdleJob?.cancel()
         playbackIdleJob = null
         playbackEndsAtMillis = 0L
-        clearRealtimeToolState()
         currentSession to currentNodeId
       }
     if (!closingSession.isNullOrBlank()) {
@@ -938,6 +670,7 @@ internal class WearRealtimeTalkController(
 
   private fun resetLocked() {
     val closingAttemptId = ownerAttemptId
+    realtimeAgentCoordinator.endSession(sessionId)
     sessionId = null
     ownerNodeId = null
     ownerSessionKey = null
@@ -953,7 +686,6 @@ internal class WearRealtimeTalkController(
     playbackIdleJob?.cancel()
     playbackIdleJob = null
     playbackEndsAtMillis = 0L
-    clearRealtimeToolState()
     userEntryId = null
     assistantEntryId = null
     setSnapshot(WearRealtimeTalkSnapshot(attemptId = closingAttemptId))
@@ -968,13 +700,9 @@ internal class WearRealtimeTalkController(
     const val TAG = "WearRealtimeTalk"
     const val MAX_CONVERSATION_ENTRIES = 20
     const val MAX_CANCELED_ATTEMPTS = 32
-    const val MAX_CACHED_TOOL_COMPLETIONS = 32
     const val MAX_TRANSCRIPT_LENGTH = 1_500
     const val MAX_STATUS_LENGTH = 160
     const val SESSION_CREATE_TIMEOUT_MILLIS = 15_000L
-    const val TOOL_CALL_TIMEOUT_MILLIS = 15_000L
-    const val REALTIME_AGENT_CONSULT_TOOL = "openclaw_agent_consult"
-    const val REALTIME_AGENT_CONTROL_TOOL = "openclaw_agent_control"
   }
 }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/wear/WearRealtimeTalkController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/wear/WearRealtimeTalkController.kt
@@ -17,7 +17,6 @@ import android.util.Log
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -377,20 +376,11 @@ internal class WearRealtimeTalkController(
             .getOrNull()
             ?.takeIf(ByteArray::isNotEmpty)
             ?: return
-        val chunks =
-          runCatching { chunkWearRealtimeOutput(bytes) }
-            .getOrElse {
-              fail("Invalid Watch audio frame")
-              return
-            }
-        if (
-          chunks.any { chunk ->
-            !enqueueOutput(
-              type = WearRealtimeAudioFrameType.OUTPUT_PCM,
-              payload = chunk,
-            )
-          }
-        ) {
+        if (bytes.size % PCM_16_BYTES != 0) {
+          fail("Invalid Watch audio frame")
+          return
+        }
+        if (!enqueueOutput(WearRealtimeAudioFrameType.OUTPUT_PCM, bytes)) {
           return
         }
         updateState(
@@ -722,7 +712,7 @@ internal class WearRealtimeTalkController(
   private fun startOutputLoop(activeSessionId: String) {
     outputMessages?.close()
     outputJob?.cancel()
-    val messages = Channel<WearRealtimeOutputMessage>(capacity = OUTPUT_QUEUE_CAPACITY)
+    val messages = Channel<WearRealtimeOutputMessage>(capacity = Channel.UNLIMITED)
     outputMessages = messages
     outputJob =
       scope.launch {
@@ -730,7 +720,36 @@ internal class WearRealtimeTalkController(
           if (sessionId != activeSessionId) continue
           val nodeId = ownerNodeId ?: continue
           try {
-            sendWatchFrame(nodeId, message.type, message.payload)
+            when (message.type) {
+              WearRealtimeAudioFrameType.OUTPUT_PCM -> {
+                chunkWearRealtimeOutput(message.payload).forEach { chunk ->
+                  sendWatchFrame(nodeId, message.type, chunk)
+                }
+                val sampleCount = message.payload.size / PCM_16_BYTES
+                val durationMillis =
+                  (
+                    sampleCount *
+                      1_000L /
+                      WearProtocol.REALTIME_AUDIO_SAMPLE_RATE_HZ
+                  ).coerceAtLeast(1L)
+                playbackEndsAtMillis =
+                  maxOf(SystemClock.elapsedRealtime(), playbackEndsAtMillis) + durationMillis
+                schedulePlaybackIdle()
+              }
+              WearRealtimeAudioFrameType.CLEAR_OUTPUT -> {
+                sendWatchFrame(nodeId, message.type, message.payload)
+                playbackEndsAtMillis = 0L
+                playbackIdleJob?.cancel()
+                updateState(
+                  active = true,
+                  listening = true,
+                  speaking = false,
+                  status = WearRealtimeTalkStatus.LISTENING,
+                  statusText = "Listening",
+                )
+              }
+              WearRealtimeAudioFrameType.INPUT_PCM -> error("Phone cannot emit Watch input audio")
+            }
           } catch (err: Throwable) {
             if (err is CancellationException) throw err
             fail(
@@ -738,32 +757,6 @@ internal class WearRealtimeTalkController(
               expectedSessionId = activeSessionId,
             )
             break
-          }
-          when (message.type) {
-            WearRealtimeAudioFrameType.OUTPUT_PCM -> {
-              val sampleCount = message.payload.size / PCM_16_BYTES
-              val durationMillis =
-                (
-                  sampleCount *
-                    1_000L /
-                    WearProtocol.REALTIME_AUDIO_SAMPLE_RATE_HZ
-                ).coerceAtLeast(1L)
-              playbackEndsAtMillis =
-                maxOf(SystemClock.elapsedRealtime(), playbackEndsAtMillis) + durationMillis
-              schedulePlaybackIdle()
-            }
-            WearRealtimeAudioFrameType.CLEAR_OUTPUT -> {
-              playbackEndsAtMillis = 0L
-              playbackIdleJob?.cancel()
-              updateState(
-                active = true,
-                listening = true,
-                speaking = false,
-                status = WearRealtimeTalkStatus.LISTENING,
-                statusText = "Listening",
-              )
-            }
-            WearRealtimeAudioFrameType.INPUT_PCM -> error("Phone cannot emit Watch input audio")
           }
         }
       }
@@ -787,11 +780,7 @@ internal class WearRealtimeTalkController(
   private fun startAppendLoop(activeSessionId: String) {
     audioFrames?.close()
     appendJob?.cancel()
-    val frames =
-      Channel<ByteArray>(
-        capacity = 4,
-        onBufferOverflow = BufferOverflow.DROP_OLDEST,
-      )
+    val frames = Channel<ByteArray>(capacity = Channel.UNLIMITED)
     audioFrames = frames
     appendJob =
       scope.launch {
@@ -982,7 +971,6 @@ internal class WearRealtimeTalkController(
     const val MAX_CACHED_TOOL_COMPLETIONS = 32
     const val MAX_TRANSCRIPT_LENGTH = 1_500
     const val MAX_STATUS_LENGTH = 160
-    const val OUTPUT_QUEUE_CAPACITY = 64
     const val SESSION_CREATE_TIMEOUT_MILLIS = 15_000L
     const val TOOL_CALL_TIMEOUT_MILLIS = 15_000L
     const val REALTIME_AGENT_CONSULT_TOOL = "openclaw_agent_consult"

--- a/apps/android/app/src/main/java/ai/openclaw/app/wear/WearRealtimeTalkController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/wear/WearRealtimeTalkController.kt
@@ -41,6 +41,11 @@ private data class WearRealtimeOutputMessage(
   val payload: ByteArray,
 )
 
+private class WearRealtimeOutputQueue(
+  val messages: Channel<WearRealtimeOutputMessage>,
+  var retainedAudioBytes: Int = 0,
+)
+
 private data class WearRealtimeAttemptKey(
   val nodeId: String,
   val attemptId: String,
@@ -96,7 +101,8 @@ internal class WearRealtimeTalkController(
 
   private var audioFrames: Channel<ByteArray>? = null
   private var appendJob: Job? = null
-  private var outputMessages: Channel<WearRealtimeOutputMessage>? = null
+  private val outputQueueLock = Any()
+  private var outputQueue: WearRealtimeOutputQueue? = null
   private var outputJob: Job? = null
   private var playbackIdleJob: Job? = null
   private var playbackEndsAtMillis = 0L
@@ -361,6 +367,10 @@ internal class WearRealtimeTalkController(
         )
       "audio" -> {
         val encoded = obj["audioBase64"].asStringOrNull() ?: return
+        if (encoded.length > OUTPUT_QUEUE_BASE64_CHAR_CAPACITY) {
+          fail("Watch audio output exceeds the relay buffer")
+          return
+        }
         val bytes =
           runCatching { Base64.decode(encoded, Base64.DEFAULT) }
             .getOrNull()
@@ -445,16 +455,18 @@ internal class WearRealtimeTalkController(
   }
 
   private fun startOutputLoop(activeSessionId: String) {
-    outputMessages?.close()
-    outputJob?.cancel()
     val messages = Channel<WearRealtimeOutputMessage>(capacity = OUTPUT_QUEUE_CAPACITY)
-    outputMessages = messages
+    val queue = WearRealtimeOutputQueue(messages)
+    synchronized(outputQueueLock) { outputQueue.also { outputQueue = queue } }
+      ?.messages
+      ?.close()
+    outputJob?.cancel()
     outputJob =
       scope.launch {
         for (message in messages) {
-          if (sessionId != activeSessionId) continue
-          val nodeId = ownerNodeId ?: continue
           try {
+            if (sessionId != activeSessionId) continue
+            val nodeId = ownerNodeId ?: continue
             when (message.type) {
               WearRealtimeAudioFrameType.OUTPUT_PCM ->
                 chunkWearRealtimeOutput(message.payload).forEach { chunk ->
@@ -470,6 +482,13 @@ internal class WearRealtimeTalkController(
               expectedSessionId = activeSessionId,
             )
             break
+          } finally {
+            if (message.type == WearRealtimeAudioFrameType.OUTPUT_PCM) {
+              synchronized(outputQueueLock) {
+                queue.retainedAudioBytes =
+                  (queue.retainedAudioBytes - message.payload.size).coerceAtLeast(0)
+              }
+            }
           }
           when (message.type) {
             WearRealtimeAudioFrameType.OUTPUT_PCM -> {
@@ -505,11 +524,19 @@ internal class WearRealtimeTalkController(
     type: WearRealtimeAudioFrameType,
     payload: ByteArray,
   ): Boolean {
-    val messages = outputMessages
-    if (
-      messages == null ||
-      !messages.trySend(WearRealtimeOutputMessage(type, payload)).isSuccess
-    ) {
+    val accepted =
+      synchronized(outputQueueLock) {
+        val queue = outputQueue ?: return@synchronized false
+        val audioBytes = payload.size.takeIf { type == WearRealtimeAudioFrameType.OUTPUT_PCM } ?: 0
+        if (audioBytes > OUTPUT_QUEUE_BYTE_CAPACITY - queue.retainedAudioBytes) {
+          return@synchronized false
+        }
+        queue.retainedAudioBytes += audioBytes
+        queue.messages.trySend(WearRealtimeOutputMessage(type, payload)).isSuccess.also { sent ->
+          if (!sent) queue.retainedAudioBytes -= audioBytes
+        }
+      }
+    if (!accepted) {
       fail("Watch audio link is unavailable")
       return false
     }
@@ -655,8 +682,9 @@ internal class WearRealtimeTalkController(
         audioFrames = null
         appendJob?.cancel()
         appendJob = null
-        outputMessages?.close()
-        outputMessages = null
+        synchronized(outputQueueLock) { outputQueue.also { outputQueue = null } }
+          ?.messages
+          ?.close()
         outputJob?.cancel()
         outputJob = null
         playbackIdleJob?.cancel()
@@ -686,8 +714,9 @@ internal class WearRealtimeTalkController(
     audioFrames = null
     appendJob?.cancel()
     appendJob = null
-    outputMessages?.close()
-    outputMessages = null
+    synchronized(outputQueueLock) { outputQueue.also { outputQueue = null } }
+      ?.messages
+      ?.close()
     outputJob?.cancel()
     outputJob = null
     playbackIdleJob?.cancel()
@@ -711,6 +740,8 @@ internal class WearRealtimeTalkController(
     const val MAX_STATUS_LENGTH = 160
     const val INPUT_QUEUE_CAPACITY = 64
     const val OUTPUT_QUEUE_CAPACITY = 64
+    const val OUTPUT_QUEUE_BYTE_CAPACITY = WearProtocol.MAX_REALTIME_AUDIO_FRAME_BYTES * 128
+    const val OUTPUT_QUEUE_BASE64_CHAR_CAPACITY = (OUTPUT_QUEUE_BYTE_CAPACITY + 2) / 3 * 4
     const val SESSION_CREATE_TIMEOUT_MILLIS = 15_000L
   }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/wear/WearRealtimeTalkController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/wear/WearRealtimeTalkController.kt
@@ -4,6 +4,7 @@ import ai.openclaw.app.gateway.GatewayRequestRejected
 import ai.openclaw.app.gateway.GatewaySession
 import ai.openclaw.app.node.asObjectOrNull
 import ai.openclaw.app.node.asStringOrNull
+import ai.openclaw.app.voice.ChatEventText
 import ai.openclaw.wear.shared.WearProtocol
 import ai.openclaw.wear.shared.WearRealtimeAudioFrameType
 import ai.openclaw.wear.shared.WearRealtimeTalkEntry
@@ -26,6 +27,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.buildJsonObject
@@ -43,6 +45,41 @@ private data class WearRealtimeAttemptKey(
   val nodeId: String,
   val attemptId: String,
 )
+
+private data class WearRealtimeToolRun(
+  val callId: String,
+  val relaySessionId: String,
+)
+
+private data class WearRealtimeToolCompletion(
+  val state: String,
+  val message: JsonElement?,
+)
+
+private data class WearRealtimeToolCompletionDispatch(
+  val toolRun: WearRealtimeToolRun,
+  val completion: WearRealtimeToolCompletion,
+)
+
+private sealed interface WearRealtimeToolRegistration {
+  data object SessionEnded : WearRealtimeToolRegistration
+
+  data object AwaitingCompletion : WearRealtimeToolRegistration
+
+  data class Completed(
+    val dispatch: WearRealtimeToolCompletionDispatch,
+  ) : WearRealtimeToolRegistration
+}
+
+private sealed interface WearRealtimeToolCompletionDecision {
+  data object NotHandled : WearRealtimeToolCompletionDecision
+
+  data object Consumed : WearRealtimeToolCompletionDecision
+
+  data class Dispatch(
+    val dispatch: WearRealtimeToolCompletionDispatch,
+  ) : WearRealtimeToolCompletionDecision
+}
 
 internal fun chunkWearRealtimeOutput(
   payload: ByteArray,
@@ -100,6 +137,10 @@ internal class WearRealtimeTalkController(
   private var playbackEndsAtMillis = 0L
   private var userEntryId: String? = null
   private var assistantEntryId: String? = null
+  private val realtimeToolLock = Any()
+  private val realtimeToolRuns = LinkedHashMap<String, WearRealtimeToolRun>()
+  private val pendingRealtimeToolCalls = LinkedHashSet<String>()
+  private val pendingRealtimeToolCompletions = LinkedHashMap<String, WearRealtimeToolCompletion>()
 
   suspend fun start(
     nodeId: String,
@@ -304,11 +345,16 @@ internal class WearRealtimeTalkController(
     event: String,
     payloadJson: String?,
   ) {
-    if (event != "talk.event" || payloadJson.isNullOrBlank()) return
+    if (payloadJson.isNullOrBlank()) return
     val obj =
       runCatching { json.parseToJsonElement(payloadJson).asObjectOrNull() }
         .getOrNull()
         ?: return
+    if (event == "chat") {
+      handleChatEvent(obj)
+      return
+    }
+    if (event != "talk.event") return
     val eventSessionId =
       obj["relaySessionId"].asStringOrNull()
         ?: obj["sessionId"].asStringOrNull()
@@ -390,8 +436,286 @@ internal class WearRealtimeTalkController(
           "assistant" -> upsertConversation(WearRealtimeTalkRole.ASSISTANT, text, final)
         }
       }
+      "toolCall" -> {
+        val callId = obj["callId"].asStringOrNull() ?: return
+        val name = obj["name"].asStringOrNull() ?: return
+        handleRealtimeToolCall(
+          callId = callId,
+          name = name,
+          args = obj["args"],
+          forced = obj["forced"].asBooleanOrNull() == true,
+        )
+      }
+      "toolResult" -> Unit
       "error" -> fail(obj["message"].asStringOrNull() ?: "Real-Time Talk failed")
       "close" -> abort()
+    }
+  }
+
+  private fun handleChatEvent(obj: JsonObject) {
+    val runId = obj["runId"].asStringOrNull() ?: return
+    val state = obj["state"].asStringOrNull() ?: return
+    val activeSessionKey = ownerSessionKey ?: return
+    val eventSessionKey = obj["sessionKey"].asStringOrNull()
+    if (eventSessionKey != null && eventSessionKey != activeSessionKey) return
+    handleRealtimeToolCompletion(runId = runId, state = state, message = obj["message"])
+  }
+
+  private fun handleRealtimeToolCall(
+    callId: String,
+    name: String,
+    args: JsonElement?,
+    forced: Boolean,
+  ) {
+    val activeSessionId = sessionId ?: return
+    val activeSessionKey = ownerSessionKey ?: return
+    synchronized(realtimeToolLock) {
+      pendingRealtimeToolCalls += callId
+    }
+    scope.launch {
+      try {
+        if (sessionId != activeSessionId || ownerSessionKey != activeSessionKey) return@launch
+        if (name == REALTIME_AGENT_CONTROL_TOOL) {
+          submitRealtimeAgentControl(
+            callId = callId,
+            relaySessionId = activeSessionId,
+            sessionKey = activeSessionKey,
+            args = args,
+          )
+          return@launch
+        }
+        if (forced) {
+          submitRealtimeToolWorking(callId = callId, sessionId = activeSessionId)
+        }
+        val params =
+          buildJsonObject {
+            put("sessionKey", JsonPrimitive(activeSessionKey))
+            put("callId", JsonPrimitive(callId))
+            put("name", JsonPrimitive(name))
+            put("relaySessionId", JsonPrimitive(activeSessionId))
+            if (args != null) put("args", args)
+          }
+        val response = requestGateway("talk.client.toolCall", params.toString(), TOOL_CALL_TIMEOUT_MILLIS)
+        val runId = parseRunId(response)
+        if (runId.isNullOrBlank()) {
+          submitRealtimeToolError(callId, "tool call returned no run id", activeSessionId)
+          return@launch
+        }
+        when (val registration = registerRealtimeToolRun(runId, callId, activeSessionId)) {
+          WearRealtimeToolRegistration.SessionEnded -> Unit
+          WearRealtimeToolRegistration.AwaitingCompletion ->
+            synchronized(lifecycleStateLock) {
+              if (sessionId == activeSessionId) {
+                updateState(
+                  active = true,
+                  listening = false,
+                  speaking = false,
+                  status = WearRealtimeTalkStatus.THINKING,
+                  statusText = "Agent working",
+                )
+              }
+            }
+          is WearRealtimeToolRegistration.Completed -> dispatchRealtimeToolCompletion(registration.dispatch)
+        }
+      } catch (err: Throwable) {
+        if (err is CancellationException) throw err
+        Log.w(TAG, "realtime toolCall failed: ${err.message ?: err::class.simpleName}")
+        submitRealtimeToolError(callId, err.message ?: "tool call failed", activeSessionId)
+      } finally {
+        synchronized(realtimeToolLock) {
+          pendingRealtimeToolCalls -= callId
+        }
+      }
+    }
+  }
+
+  private fun registerRealtimeToolRun(
+    runId: String,
+    callId: String,
+    relaySessionId: String,
+  ): WearRealtimeToolRegistration =
+    synchronized(realtimeToolLock) {
+      if (sessionId != relaySessionId) {
+        return@synchronized WearRealtimeToolRegistration.SessionEnded
+      }
+      val toolRun = WearRealtimeToolRun(callId = callId, relaySessionId = relaySessionId)
+      val completion = pendingRealtimeToolCompletions.remove(runId)
+      if (completion == null) {
+        realtimeToolRuns[runId] = toolRun
+        WearRealtimeToolRegistration.AwaitingCompletion
+      } else {
+        WearRealtimeToolRegistration.Completed(
+          WearRealtimeToolCompletionDispatch(toolRun = toolRun, completion = completion),
+        )
+      }
+    }
+
+  private fun handleRealtimeToolCompletion(
+    runId: String,
+    state: String,
+    message: JsonElement?,
+  ): Boolean {
+    if (state != "final" && state != "aborted" && state != "error") return false
+    val decision =
+      synchronized(realtimeToolLock) {
+        val toolRun = realtimeToolRuns.remove(runId)
+        if (toolRun != null) {
+          if (toolRun.relaySessionId != sessionId) {
+            return@synchronized WearRealtimeToolCompletionDecision.Consumed
+          }
+          return@synchronized WearRealtimeToolCompletionDecision.Dispatch(
+            WearRealtimeToolCompletionDispatch(
+              toolRun = toolRun,
+              completion = WearRealtimeToolCompletion(state = state, message = message),
+            ),
+          )
+        }
+        if (sessionId == null || pendingRealtimeToolCalls.isEmpty()) {
+          return@synchronized WearRealtimeToolCompletionDecision.NotHandled
+        }
+        pendingRealtimeToolCompletions[runId] =
+          WearRealtimeToolCompletion(state = state, message = message)
+        while (pendingRealtimeToolCompletions.size > MAX_CACHED_TOOL_COMPLETIONS) {
+          pendingRealtimeToolCompletions.remove(pendingRealtimeToolCompletions.keys.first())
+        }
+        WearRealtimeToolCompletionDecision.Consumed
+      }
+    return when (decision) {
+      WearRealtimeToolCompletionDecision.NotHandled -> false
+      WearRealtimeToolCompletionDecision.Consumed -> true
+      is WearRealtimeToolCompletionDecision.Dispatch -> {
+        dispatchRealtimeToolCompletion(decision.dispatch)
+        true
+      }
+    }
+  }
+
+  private fun dispatchRealtimeToolCompletion(dispatch: WearRealtimeToolCompletionDispatch) {
+    val toolRun = dispatch.toolRun
+    scope.launch {
+      when (dispatch.completion.state) {
+        "final" -> {
+          val text = ChatEventText.assistantTextFromMessage(dispatch.completion.message).orEmpty()
+          submitRealtimeToolResult(
+            callId = toolRun.callId,
+            result = buildJsonObject { put("text", JsonPrimitive(text)) },
+            sessionId = toolRun.relaySessionId,
+          )
+        }
+        "aborted", "error" ->
+          submitRealtimeToolError(
+            callId = toolRun.callId,
+            message = dispatch.completion.state,
+            sessionId = toolRun.relaySessionId,
+          )
+      }
+    }
+  }
+
+  private suspend fun submitRealtimeToolWorking(
+    callId: String,
+    sessionId: String,
+  ) {
+    submitRealtimeToolResult(
+      callId = callId,
+      sessionId = sessionId,
+      result =
+        buildJsonObject {
+          put("status", JsonPrimitive("working"))
+          put("tool", JsonPrimitive(REALTIME_AGENT_CONSULT_TOOL))
+          put(
+            "message",
+            JsonPrimitive(
+              "Tell the person briefly that you are checking, then wait for the final OpenClaw result before answering with the actual result.",
+            ),
+          )
+        },
+      options = buildJsonObject { put("willContinue", JsonPrimitive(true)) },
+    )
+  }
+
+  private suspend fun submitRealtimeAgentControl(
+    callId: String,
+    relaySessionId: String,
+    sessionKey: String,
+    args: JsonElement?,
+  ) {
+    val argsObject = args.asObjectOrNull()
+    val text =
+      argsObject
+        ?.get("text")
+        .asStringOrNull()
+        ?.trim()
+        .orEmpty()
+    val mode =
+      argsObject
+        ?.get("mode")
+        .asStringOrNull()
+        ?.trim()
+        ?.takeIf(String::isNotEmpty)
+    val params =
+      buildJsonObject {
+        put("sessionId", JsonPrimitive(relaySessionId))
+        put("sessionKey", JsonPrimitive(sessionKey))
+        put("text", JsonPrimitive(text.ifEmpty { "status" }))
+        if (mode != null) put("mode", JsonPrimitive(mode))
+      }
+    val response = requestGateway("talk.session.steer", params.toString(), TOOL_CALL_TIMEOUT_MILLIS)
+    val result = runCatching { json.parseToJsonElement(response).asObjectOrNull() }.getOrNull()
+    if (result == null) {
+      submitRealtimeToolError(callId, "control call returned no result", relaySessionId)
+    } else {
+      submitRealtimeToolResult(callId = callId, result = result, sessionId = relaySessionId)
+    }
+  }
+
+  private suspend fun submitRealtimeToolError(
+    callId: String,
+    message: String,
+    sessionId: String,
+  ) {
+    submitRealtimeToolResult(
+      callId = callId,
+      result = buildJsonObject { put("error", JsonPrimitive(message)) },
+      sessionId = sessionId,
+    )
+  }
+
+  private suspend fun submitRealtimeToolResult(
+    callId: String,
+    result: JsonObject,
+    sessionId: String,
+    options: JsonObject? = null,
+  ) {
+    val params =
+      buildJsonObject {
+        put("sessionId", JsonPrimitive(sessionId))
+        put("callId", JsonPrimitive(callId))
+        put("result", result)
+        if (options != null) put("options", options)
+      }
+    try {
+      requestGateway("talk.session.submitToolResult", params.toString(), TOOL_CALL_TIMEOUT_MILLIS)
+    } catch (err: Throwable) {
+      if (err is CancellationException) throw err
+      Log.w(TAG, "realtime submitToolResult failed: ${err.message ?: err::class.simpleName}")
+    }
+  }
+
+  private fun parseRunId(payloadJson: String): String? =
+    runCatching {
+      json
+        .parseToJsonElement(payloadJson)
+        .asObjectOrNull()
+        ?.get("runId")
+        .asStringOrNull()
+    }.getOrNull()
+
+  private fun clearRealtimeToolState() {
+    synchronized(realtimeToolLock) {
+      realtimeToolRuns.clear()
+      pendingRealtimeToolCalls.clear()
+      pendingRealtimeToolCompletions.clear()
     }
   }
 
@@ -609,6 +933,7 @@ internal class WearRealtimeTalkController(
         playbackIdleJob?.cancel()
         playbackIdleJob = null
         playbackEndsAtMillis = 0L
+        clearRealtimeToolState()
         currentSession to currentNodeId
       }
     if (!closingSession.isNullOrBlank()) {
@@ -639,6 +964,7 @@ internal class WearRealtimeTalkController(
     playbackIdleJob?.cancel()
     playbackIdleJob = null
     playbackEndsAtMillis = 0L
+    clearRealtimeToolState()
     userEntryId = null
     assistantEntryId = null
     setSnapshot(WearRealtimeTalkSnapshot(attemptId = closingAttemptId))
@@ -653,10 +979,14 @@ internal class WearRealtimeTalkController(
     const val TAG = "WearRealtimeTalk"
     const val MAX_CONVERSATION_ENTRIES = 20
     const val MAX_CANCELED_ATTEMPTS = 32
+    const val MAX_CACHED_TOOL_COMPLETIONS = 32
     const val MAX_TRANSCRIPT_LENGTH = 1_500
     const val MAX_STATUS_LENGTH = 160
     const val OUTPUT_QUEUE_CAPACITY = 64
     const val SESSION_CREATE_TIMEOUT_MILLIS = 15_000L
+    const val TOOL_CALL_TIMEOUT_MILLIS = 15_000L
+    const val REALTIME_AGENT_CONSULT_TOOL = "openclaw_agent_consult"
+    const val REALTIME_AGENT_CONTROL_TOOL = "openclaw_agent_control"
   }
 }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/wear/WearRealtimeTalkController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/wear/WearRealtimeTalkController.kt
@@ -70,6 +70,22 @@ internal fun chunkWearRealtimeOutput(
   }
 }
 
+internal fun advanceWearRealtimePlaybackDeadline(
+  currentEndsAtMillis: Long,
+  deliveredAtMillis: Long,
+  audioByteCount: Int,
+): Long {
+  require(audioByteCount >= 0 && audioByteCount % PCM_16_BYTES == 0)
+  val sampleCount = audioByteCount / PCM_16_BYTES
+  val durationMillis =
+    (
+      sampleCount *
+        1_000L /
+        WearProtocol.REALTIME_AUDIO_SAMPLE_RATE_HZ
+    ).coerceAtLeast(1L)
+  return maxOf(deliveredAtMillis, currentEndsAtMillis) + durationMillis
+}
+
 internal class WearRealtimeTalkController(
   private val scope: CoroutineScope,
   private val isConnected: () -> Boolean,
@@ -479,6 +495,16 @@ internal class WearRealtimeTalkController(
                     break
                   }
                   sendWatchFrame(nodeId, message.type, chunk)
+                  if (!isCurrentOutput(activeSessionId, nodeId)) {
+                    delivered = false
+                    break
+                  }
+                  playbackEndsAtMillis =
+                    advanceWearRealtimePlaybackDeadline(
+                      currentEndsAtMillis = playbackEndsAtMillis,
+                      deliveredAtMillis = SystemClock.elapsedRealtime(),
+                      audioByteCount = chunk.size,
+                    )
                 }
                 if (!isCurrentOutput(activeSessionId, nodeId)) {
                   delivered = false
@@ -508,15 +534,6 @@ internal class WearRealtimeTalkController(
           if (!delivered) continue
           when (message.type) {
             WearRealtimeAudioFrameType.OUTPUT_PCM -> {
-              val sampleCount = message.payload.size / PCM_16_BYTES
-              val durationMillis =
-                (
-                  sampleCount *
-                    1_000L /
-                    WearProtocol.REALTIME_AUDIO_SAMPLE_RATE_HZ
-                ).coerceAtLeast(1L)
-              playbackEndsAtMillis =
-                maxOf(SystemClock.elapsedRealtime(), playbackEndsAtMillis) + durationMillis
               schedulePlaybackIdle()
             }
             WearRealtimeAudioFrameType.CLEAR_OUTPUT -> {

--- a/apps/android/app/src/main/java/ai/openclaw/app/wear/WearRealtimeTalkController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/wear/WearRealtimeTalkController.kt
@@ -324,7 +324,10 @@ internal class WearRealtimeTalkController(
     ) {
       return
     }
-    audioFrames?.trySend(payload.copyOf())
+    val activeSessionId = sessionId ?: return
+    if (audioFrames?.trySend(payload.copyOf())?.isSuccess != true) {
+      fail("Watch audio input is unavailable", expectedSessionId = activeSessionId)
+    }
   }
 
   fun handleGatewayEvent(
@@ -444,7 +447,7 @@ internal class WearRealtimeTalkController(
   private fun startOutputLoop(activeSessionId: String) {
     outputMessages?.close()
     outputJob?.cancel()
-    val messages = Channel<WearRealtimeOutputMessage>(capacity = Channel.UNLIMITED)
+    val messages = Channel<WearRealtimeOutputMessage>(capacity = OUTPUT_QUEUE_CAPACITY)
     outputMessages = messages
     outputJob =
       scope.launch {
@@ -453,33 +456,11 @@ internal class WearRealtimeTalkController(
           val nodeId = ownerNodeId ?: continue
           try {
             when (message.type) {
-              WearRealtimeAudioFrameType.OUTPUT_PCM -> {
+              WearRealtimeAudioFrameType.OUTPUT_PCM ->
                 chunkWearRealtimeOutput(message.payload).forEach { chunk ->
                   sendWatchFrame(nodeId, message.type, chunk)
                 }
-                val sampleCount = message.payload.size / PCM_16_BYTES
-                val durationMillis =
-                  (
-                    sampleCount *
-                      1_000L /
-                      WearProtocol.REALTIME_AUDIO_SAMPLE_RATE_HZ
-                  ).coerceAtLeast(1L)
-                playbackEndsAtMillis =
-                  maxOf(SystemClock.elapsedRealtime(), playbackEndsAtMillis) + durationMillis
-                schedulePlaybackIdle()
-              }
-              WearRealtimeAudioFrameType.CLEAR_OUTPUT -> {
-                sendWatchFrame(nodeId, message.type, message.payload)
-                playbackEndsAtMillis = 0L
-                playbackIdleJob?.cancel()
-                updateState(
-                  active = true,
-                  listening = true,
-                  speaking = false,
-                  status = WearRealtimeTalkStatus.LISTENING,
-                  statusText = "Listening",
-                )
-              }
+              WearRealtimeAudioFrameType.CLEAR_OUTPUT -> sendWatchFrame(nodeId, message.type, message.payload)
               WearRealtimeAudioFrameType.INPUT_PCM -> error("Phone cannot emit Watch input audio")
             }
           } catch (err: Throwable) {
@@ -489,6 +470,32 @@ internal class WearRealtimeTalkController(
               expectedSessionId = activeSessionId,
             )
             break
+          }
+          when (message.type) {
+            WearRealtimeAudioFrameType.OUTPUT_PCM -> {
+              val sampleCount = message.payload.size / PCM_16_BYTES
+              val durationMillis =
+                (
+                  sampleCount *
+                    1_000L /
+                    WearProtocol.REALTIME_AUDIO_SAMPLE_RATE_HZ
+                ).coerceAtLeast(1L)
+              playbackEndsAtMillis =
+                maxOf(SystemClock.elapsedRealtime(), playbackEndsAtMillis) + durationMillis
+              schedulePlaybackIdle()
+            }
+            WearRealtimeAudioFrameType.CLEAR_OUTPUT -> {
+              playbackEndsAtMillis = 0L
+              playbackIdleJob?.cancel()
+              updateState(
+                active = true,
+                listening = true,
+                speaking = false,
+                status = WearRealtimeTalkStatus.LISTENING,
+                statusText = "Listening",
+              )
+            }
+            WearRealtimeAudioFrameType.INPUT_PCM -> error("Phone cannot emit Watch input audio")
           }
         }
       }
@@ -512,7 +519,7 @@ internal class WearRealtimeTalkController(
   private fun startAppendLoop(activeSessionId: String) {
     audioFrames?.close()
     appendJob?.cancel()
-    val frames = Channel<ByteArray>(capacity = Channel.UNLIMITED)
+    val frames = Channel<ByteArray>(capacity = INPUT_QUEUE_CAPACITY)
     audioFrames = frames
     appendJob =
       scope.launch {
@@ -702,6 +709,8 @@ internal class WearRealtimeTalkController(
     const val MAX_CANCELED_ATTEMPTS = 32
     const val MAX_TRANSCRIPT_LENGTH = 1_500
     const val MAX_STATUS_LENGTH = 160
+    const val INPUT_QUEUE_CAPACITY = 64
+    const val OUTPUT_QUEUE_CAPACITY = 64
     const val SESSION_CREATE_TIMEOUT_MILLIS = 15_000L
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/RealtimeAgentCoordinatorTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/RealtimeAgentCoordinatorTest.kt
@@ -232,15 +232,25 @@ class RealtimeAgentCoordinatorTest {
     runTest {
       val calls = mutableListOf<GatewayCall>()
       val oldResponse = CompletableDeferred<String>()
+      val unhandled = mutableListOf<RealtimeAgentUnhandledCompletion>()
       val coordinator =
         coordinator(
           calls = calls,
           responses = { method -> if (method == "talk.client.toolCall") oldResponse.await() else "{}" },
+          onUnhandledCompletion = unhandled::add,
         )
       coordinator.beginSession(RealtimeAgentSession("relay-old", "session-main"))
       coordinator.handleToolCall("call-old", "openclaw_agent_consult", null, forced = false)
       coordinator.handleToolCall("call-old-2", "openclaw_agent_consult", null, forced = false)
       runCurrent()
+      assertTrue(
+        coordinator.handleChatEvent(
+          sessionKey = "session-main",
+          runId = "cached-old-run",
+          state = "final",
+          message = Json.parseToJsonElement("""{"role":"assistant","content":"stale cached"}"""),
+        ),
+      )
 
       coordinator.resetTransport()
       coordinator.beginSession(RealtimeAgentSession("relay-new", "session-main"))
@@ -248,6 +258,7 @@ class RealtimeAgentCoordinatorTest {
       runCurrent()
 
       assertTrue(calls.none { it.method == "talk.session.submitToolResult" })
+      assertTrue(unhandled.isEmpty())
       assertFalse(
         coordinator.handleChatEvent(
           sessionKey = "session-main",
@@ -316,16 +327,14 @@ class RealtimeAgentCoordinatorTest {
     }
 
   @Test
-  fun `session end quarantines a final that beats the old run response`() =
+  fun `session end retains unresolved correlation and quarantines its final`() =
     runTest {
       val calls = mutableListOf<GatewayCall>()
-      val unhandled = mutableListOf<RealtimeAgentUnhandledCompletion>()
       val response = CompletableDeferred<String>()
       val coordinator =
         coordinator(
           calls = calls,
           responses = { method -> if (method == "talk.client.toolCall") response.await() else "{}" },
-          onUnhandledCompletion = unhandled::add,
         )
       coordinator.beginSession(RealtimeAgentSession("relay-old", "session-main"))
       coordinator.handleToolCall("call-old", "openclaw_agent_consult", null, forced = false)
@@ -340,34 +349,74 @@ class RealtimeAgentCoordinatorTest {
           message = Json.parseToJsonElement("""{"role":"assistant","content":"stale"}"""),
         ),
       )
-      assertTrue(
-        coordinator.handleChatEvent(
-          sessionKey = "session-main",
-          runId = "ordinary-run",
-          state = "final",
-          message = Json.parseToJsonElement("""{"role":"assistant","content":"ordinary"}"""),
-        ),
-      )
       response.complete("""{"runId":"run-old"}""")
       runCurrent()
 
       assertTrue(calls.none { it.method == "talk.session.submitToolResult" })
-      assertEquals(listOf("ordinary-run"), unhandled.map { it.runId })
-      assertEquals("session-main", unhandled.single().sessionKey)
-      assertTrue(
-        coordinator.handleChatEvent(
-          sessionKey = "session-main",
-          runId = "run-old",
-          state = "final",
-          message = Json.parseToJsonElement("""{"role":"assistant","content":"duplicate"}"""),
-        ),
-      )
     }
 
   @Test
-  fun `early completion cache stays bounded`() =
+  fun `session end suppresses a late gateway failure`() =
     runTest {
       val calls = mutableListOf<GatewayCall>()
+      val response = CompletableDeferred<String>()
+      val errors = mutableListOf<String>()
+      val coordinator =
+        coordinator(
+          calls = calls,
+          responses = { method -> if (method == "talk.client.toolCall") response.await() else "{}" },
+          onError = errors::add,
+        )
+      coordinator.beginSession(RealtimeAgentSession("relay-old", "session-main"))
+      coordinator.handleToolCall("call-old", "openclaw_agent_consult", null, forced = false)
+      runCurrent()
+
+      coordinator.endSession("relay-old")
+      response.completeExceptionally(IllegalStateException("late failure"))
+      runCurrent()
+
+      assertTrue(errors.isEmpty())
+      assertTrue(calls.none { it.method == "talk.session.submitToolResult" })
+    }
+
+  @Test
+  fun `session cleanup releases uncertain early completions`() =
+    runTest {
+      val calls = mutableListOf<GatewayCall>()
+      val response = CompletableDeferred<String>()
+      val unhandled = mutableListOf<RealtimeAgentUnhandledCompletion>()
+      val coordinator =
+        coordinator(
+          calls = calls,
+          responses = { method -> if (method == "talk.client.toolCall") response.await() else "{}" },
+          onUnhandledCompletion = unhandled::add,
+        )
+      coordinator.beginSession(RealtimeAgentSession("relay-old", "session-main"))
+      coordinator.handleToolCall("call-old", "openclaw_agent_consult", null, forced = false)
+      runCurrent()
+      assertTrue(
+        coordinator.handleChatEvent(
+          sessionKey = "session-main",
+          runId = "uncertain-run",
+          state = "final",
+          message = Json.parseToJsonElement("""{"role":"assistant","content":"ordinary"}"""),
+        ),
+      )
+
+      coordinator.beginSession(RealtimeAgentSession("relay-new", "session-main"))
+      response.complete("""{"runId":"old-tool-run"}""")
+      runCurrent()
+
+      assertEquals(listOf("uncertain-run"), unhandled.map { it.runId })
+      assertEquals("final", unhandled.single().state)
+      assertTrue(calls.none { it.method == "talk.session.submitToolResult" })
+    }
+
+  @Test
+  fun `early completion overflow fails pending calls instead of stranding them`() =
+    runTest {
+      val calls = mutableListOf<GatewayCall>()
+      val unhandled = mutableListOf<RealtimeAgentUnhandledCompletion>()
       val responses = List(3) { CompletableDeferred<String>() }
       var responseIndex = 0
       val coordinator =
@@ -376,6 +425,7 @@ class RealtimeAgentCoordinatorTest {
           responses = { method ->
             if (method == "talk.client.toolCall") responses[responseIndex++].await() else "{}"
           },
+          onUnhandledCompletion = unhandled::add,
           maxCachedCompletions = 2,
         )
       coordinator.beginSession(RealtimeAgentSession("relay-1", "session-1"))
@@ -391,16 +441,22 @@ class RealtimeAgentCoordinatorTest {
           message = Json.parseToJsonElement("""{"role":"assistant","content":"result-${index + 1}"}"""),
         )
       }
-      responses.forEachIndexed { index, response -> response.complete("""{"runId":"run-${index + 1}"}""") }
+      runCurrent()
+      responses.take(2).forEachIndexed { index, response -> response.complete("""{"runId":"run-${index + 1}"}""") }
       runCurrent()
 
-      val submittedCallIds =
+      val submittedResults =
         calls
           .filter { it.method == "talk.session.submitToolResult" }
-          .map { call ->
-            (Json.parseToJsonElement(call.params) as JsonObject).getValue("callId").jsonPrimitive.content
+          .associate { call ->
+            val params = Json.parseToJsonElement(call.params) as JsonObject
+            params.getValue("callId").jsonPrimitive.content to call.params
           }
-      assertEquals(listOf("call-2", "call-3"), submittedCallIds)
+      assertTrue(submittedResults.getValue("call-1").contains("correlation buffer overflow"))
+      assertTrue(submittedResults.getValue("call-2").contains("correlation buffer overflow"))
+      assertTrue(submittedResults.getValue("call-3").contains("too many concurrent"))
+      assertEquals(listOf("run-1", "run-2", "run-3"), unhandled.map { it.runId })
+      assertEquals(2, calls.count { it.method == "talk.client.toolCall" })
     }
 
   private fun kotlinx.coroutines.test.TestScope.coordinator(

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/RealtimeAgentCoordinatorTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/RealtimeAgentCoordinatorTest.kt
@@ -270,6 +270,40 @@ class RealtimeAgentCoordinatorTest {
     }
 
   @Test
+  fun `transport reset rejects a reused retired run id without stranding the call`() =
+    runTest {
+      val calls = mutableListOf<GatewayCall>()
+      val coordinator =
+        coordinator(
+          calls = calls,
+          responses = { method -> if (method == "talk.client.toolCall") """{"runId":"shared-run"}""" else "{}" },
+        )
+      coordinator.beginSession(RealtimeAgentSession("relay-old", "session-main"))
+      coordinator.handleToolCall("call-old", "openclaw_agent_consult", null, forced = false)
+      runCurrent()
+
+      coordinator.resetTransport()
+      coordinator.beginSession(RealtimeAgentSession("relay-new", "session-main"))
+      coordinator.handleToolCall("call-new", "openclaw_agent_consult", null, forced = false)
+      runCurrent()
+
+      assertTrue(
+        coordinator.handleChatEvent(
+          sessionKey = "session-main",
+          runId = "shared-run",
+          state = "final",
+          message = Json.parseToJsonElement("""{"role":"assistant","content":"late"}"""),
+        ),
+      )
+      runCurrent()
+
+      val result = calls.single { it.method == "talk.session.submitToolResult" }
+      assertTrue(result.params.contains("\"sessionId\":\"relay-new\""))
+      assertTrue(result.params.contains("\"callId\":\"call-new\""))
+      assertTrue(result.params.contains("tool call returned a duplicate run id"))
+    }
+
+  @Test
   fun `old session request does not buffer a new session completion`() =
     runTest {
       val calls = mutableListOf<GatewayCall>()
@@ -457,6 +491,32 @@ class RealtimeAgentCoordinatorTest {
       assertTrue(submittedResults.getValue("call-3").contains("too many concurrent"))
       assertEquals(listOf("run-1", "run-2", "run-3"), unhandled.map { it.runId })
       assertEquals(2, calls.count { it.method == "talk.client.toolCall" })
+    }
+
+  @Test
+  fun `registered runs count against the concurrent call limit`() =
+    runTest {
+      val calls = mutableListOf<GatewayCall>()
+      var runIndex = 0
+      val coordinator =
+        coordinator(
+          calls = calls,
+          responses = { method ->
+            if (method == "talk.client.toolCall") """{"runId":"run-${++runIndex}"}""" else "{}"
+          },
+          maxCachedCompletions = 2,
+        )
+      coordinator.beginSession(RealtimeAgentSession("relay-1", "session-1"))
+
+      repeat(3) { index ->
+        coordinator.handleToolCall("call-${index + 1}", "openclaw_agent_consult", null, forced = false)
+        runCurrent()
+      }
+
+      assertEquals(2, calls.count { it.method == "talk.client.toolCall" })
+      val rejection = calls.single { it.method == "talk.session.submitToolResult" }
+      assertTrue(rejection.params.contains("\"callId\":\"call-3\""))
+      assertTrue(rejection.params.contains("too many concurrent realtime Talk tool calls"))
     }
 
   private fun kotlinx.coroutines.test.TestScope.coordinator(

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/RealtimeAgentCoordinatorTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/RealtimeAgentCoordinatorTest.kt
@@ -1,0 +1,430 @@
+package ai.openclaw.app.voice
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class RealtimeAgentCoordinatorTest {
+  @Test
+  fun `consult correlates the active run and submits its final text`() =
+    runTest {
+      val calls = mutableListOf<GatewayCall>()
+      val working = mutableListOf<RealtimeAgentSession>()
+      val coordinator =
+        coordinator(
+          calls = calls,
+          responses = { method -> if (method == "talk.client.toolCall") """{"runId":"run-1"}""" else "{}" },
+          onWorking = working::add,
+        )
+      val session = RealtimeAgentSession("relay-1", "session-1")
+      coordinator.beginSession(session)
+
+      assertTrue(
+        coordinator.handleToolCall(
+          callId = "call-1",
+          name = "openclaw_agent_consult",
+          args = null,
+          forced = false,
+        ),
+      )
+      runCurrent()
+
+      assertEquals(listOf(session), working)
+      assertFalse(
+        coordinator.handleChatEvent(
+          sessionKey = "other-session",
+          runId = "run-1",
+          state = "final",
+          message = Json.parseToJsonElement("""{"role":"assistant","content":"wrong"}"""),
+        ),
+      )
+      assertTrue(
+        coordinator.handleChatEvent(
+          sessionKey = "session-1",
+          runId = "run-1",
+          state = "final",
+          message = Json.parseToJsonElement("""{"role":"assistant","content":"done"}"""),
+        ),
+      )
+      runCurrent()
+
+      val consult = calls.single { it.method == "talk.client.toolCall" }
+      assertEquals(15_000L, consult.timeoutMs)
+      assertTrue(consult.params.contains("\"name\":\"openclaw_agent_consult\""))
+      val result = calls.single { it.method == "talk.session.submitToolResult" }
+      assertTrue(result.params.contains("\"sessionId\":\"relay-1\""))
+      assertTrue(result.params.contains("\"callId\":\"call-1\""))
+      assertTrue(result.params.contains("\"text\":\"done\""))
+    }
+
+  @Test
+  fun `early completion waits for run metadata`() =
+    runTest {
+      val calls = mutableListOf<GatewayCall>()
+      val response = CompletableDeferred<String>()
+      val coordinator =
+        coordinator(
+          calls = calls,
+          responses = { method -> if (method == "talk.client.toolCall") response.await() else "{}" },
+        )
+      coordinator.beginSession(RealtimeAgentSession("relay-1", "session-1"))
+      coordinator.handleToolCall("call-1", "openclaw_agent_consult", null, forced = false)
+      runCurrent()
+
+      assertTrue(
+        coordinator.handleChatEvent(
+          sessionKey = "session-1",
+          runId = "run-early",
+          state = "final",
+          message = Json.parseToJsonElement("""{"role":"assistant","content":"early"}"""),
+        ),
+      )
+      response.complete("""{"runId":"run-early"}""")
+      runCurrent()
+
+      assertTrue(
+        calls
+          .single { it.method == "talk.session.submitToolResult" }
+          .params
+          .contains("\"text\":\"early\""),
+      )
+    }
+
+  @Test
+  fun `validates tool names and dispatches control without a consult`() =
+    runTest {
+      val calls = mutableListOf<GatewayCall>()
+      val coordinator =
+        coordinator(
+          calls = calls,
+          responses = { method ->
+            when (method) {
+              "talk.session.steer" -> """{"status":"steered"}"""
+              else -> "{}"
+            }
+          },
+        )
+      coordinator.beginSession(RealtimeAgentSession("relay-1", "session-1"))
+
+      coordinator.handleToolCall(
+        callId = "control-1",
+        name = "openclaw_agent_control",
+        args = Json.parseToJsonElement("""{"text":"stop","mode":"cancel"}"""),
+        forced = false,
+      )
+      coordinator.handleToolCall(
+        callId = "unknown-1",
+        name = "other_tool",
+        args = null,
+        forced = false,
+      )
+      runCurrent()
+
+      assertTrue(calls.none { it.method == "talk.client.toolCall" })
+      val steer = calls.single { it.method == "talk.session.steer" }
+      assertTrue(steer.params.contains("\"mode\":\"cancel\""))
+      val results = calls.filter { it.method == "talk.session.submitToolResult" }
+      assertTrue(results.any { it.params.contains("\"status\":\"steered\"") })
+      assertTrue(results.any { it.params.contains("unsupported realtime Talk tool: other_tool") })
+    }
+
+  @Test
+  fun `forced consult reports working then returns gateway errors`() =
+    runTest {
+      val calls = mutableListOf<GatewayCall>()
+      val errors = mutableListOf<String>()
+      val coordinator =
+        coordinator(
+          calls = calls,
+          responses = { method ->
+            if (method == "talk.client.toolCall") error("gateway offline") else "{}"
+          },
+          onError = errors::add,
+        )
+      coordinator.beginSession(RealtimeAgentSession("relay-1", "session-1"))
+
+      coordinator.handleToolCall(
+        callId = "call-1",
+        name = "openclaw_agent_consult",
+        args = null,
+        forced = true,
+      )
+      runCurrent()
+
+      val results = calls.filter { it.method == "talk.session.submitToolResult" }
+      assertEquals(2, results.size)
+      assertTrue(results[0].params.contains("\"status\":\"working\""))
+      assertTrue(results[0].params.contains("\"willContinue\":true"))
+      assertTrue(results[1].params.contains("\"error\":\"gateway offline\""))
+      assertEquals(listOf("realtime toolCall failed: gateway offline"), errors)
+    }
+
+  @Test
+  fun `session replacement quarantines the old run while a call id is reused`() =
+    runTest {
+      val calls = mutableListOf<GatewayCall>()
+      val oldResponse = CompletableDeferred<String>()
+      val newResponse = CompletableDeferred<String>()
+      var requestCount = 0
+      val coordinator =
+        coordinator(
+          calls = calls,
+          responses = { method ->
+            if (method != "talk.client.toolCall") {
+              "{}"
+            } else if (requestCount++ == 0) {
+              oldResponse.await()
+            } else {
+              newResponse.await()
+            }
+          },
+        )
+      coordinator.beginSession(RealtimeAgentSession("relay-old", "session-main"))
+      coordinator.handleToolCall("call-shared", "openclaw_agent_consult", null, forced = false)
+      runCurrent()
+
+      coordinator.beginSession(RealtimeAgentSession("relay-new", "session-main"))
+      coordinator.handleToolCall("call-shared", "openclaw_agent_consult", null, forced = false)
+      runCurrent()
+
+      assertTrue(
+        coordinator.handleChatEvent(
+          sessionKey = "session-main",
+          runId = "run-new",
+          state = "final",
+          message = Json.parseToJsonElement("""{"role":"assistant","content":"fresh"}"""),
+        ),
+      )
+      newResponse.complete("""{"runId":"run-new"}""")
+      runCurrent()
+
+      val result = calls.single { it.method == "talk.session.submitToolResult" }
+      assertTrue(result.params.contains("\"sessionId\":\"relay-new\""))
+      assertTrue(result.params.contains("\"text\":\"fresh\""))
+
+      oldResponse.complete("""{"runId":"run-old"}""")
+      runCurrent()
+      assertTrue(
+        coordinator.handleChatEvent(
+          sessionKey = "session-main",
+          runId = "run-old",
+          state = "final",
+          message = Json.parseToJsonElement("""{"role":"assistant","content":"stale"}"""),
+        ),
+      )
+      assertEquals(1, calls.count { it.method == "talk.session.submitToolResult" })
+    }
+
+  @Test
+  fun `transport reset cancels an old consult before a new gateway session`() =
+    runTest {
+      val calls = mutableListOf<GatewayCall>()
+      val oldResponse = CompletableDeferred<String>()
+      val coordinator =
+        coordinator(
+          calls = calls,
+          responses = { method -> if (method == "talk.client.toolCall") oldResponse.await() else "{}" },
+        )
+      coordinator.beginSession(RealtimeAgentSession("relay-old", "session-main"))
+      coordinator.handleToolCall("call-old", "openclaw_agent_consult", null, forced = false)
+      coordinator.handleToolCall("call-old-2", "openclaw_agent_consult", null, forced = false)
+      runCurrent()
+
+      coordinator.resetTransport()
+      coordinator.beginSession(RealtimeAgentSession("relay-new", "session-main"))
+      oldResponse.complete("""{"runId":"run-old"}""")
+      runCurrent()
+
+      assertTrue(calls.none { it.method == "talk.session.submitToolResult" })
+      assertFalse(
+        coordinator.handleChatEvent(
+          sessionKey = "session-main",
+          runId = "run-old",
+          state = "final",
+          message = Json.parseToJsonElement("""{"role":"assistant","content":"stale"}"""),
+        ),
+      )
+    }
+
+  @Test
+  fun `old session request does not buffer a new session completion`() =
+    runTest {
+      val calls = mutableListOf<GatewayCall>()
+      val oldResponse = CompletableDeferred<String>()
+      val coordinator =
+        coordinator(
+          calls = calls,
+          responses = { method -> if (method == "talk.client.toolCall") oldResponse.await() else "{}" },
+        )
+      coordinator.beginSession(RealtimeAgentSession("relay-old", "session-old"))
+      coordinator.handleToolCall("call-old", "openclaw_agent_consult", null, forced = false)
+      runCurrent()
+
+      coordinator.beginSession(RealtimeAgentSession("relay-new", "session-new"))
+
+      assertFalse(
+        coordinator.handleChatEvent(
+          sessionKey = "session-new",
+          runId = "ordinary-run",
+          state = "final",
+          message = Json.parseToJsonElement("""{"role":"assistant","content":"ordinary"}"""),
+        ),
+      )
+      oldResponse.complete("""{"runId":"run-old"}""")
+      runCurrent()
+      assertTrue(calls.none { it.method == "talk.session.submitToolResult" })
+    }
+
+  @Test
+  fun `session replacement consumes a known old run with the same session key`() =
+    runTest {
+      val calls = mutableListOf<GatewayCall>()
+      val coordinator =
+        coordinator(
+          calls = calls,
+          responses = { method -> if (method == "talk.client.toolCall") """{"runId":"run-old"}""" else "{}" },
+        )
+      coordinator.beginSession(RealtimeAgentSession("relay-old", "session-main"))
+      coordinator.handleToolCall("call-old", "openclaw_agent_consult", null, forced = false)
+      runCurrent()
+
+      coordinator.beginSession(RealtimeAgentSession("relay-new", "session-main"))
+
+      assertTrue(
+        coordinator.handleChatEvent(
+          sessionKey = "session-main",
+          runId = "run-old",
+          state = "final",
+          message = Json.parseToJsonElement("""{"role":"assistant","content":"stale"}"""),
+        ),
+      )
+      runCurrent()
+
+      assertTrue(calls.none { it.method == "talk.session.submitToolResult" })
+    }
+
+  @Test
+  fun `session end quarantines a final that beats the old run response`() =
+    runTest {
+      val calls = mutableListOf<GatewayCall>()
+      val unhandled = mutableListOf<RealtimeAgentUnhandledCompletion>()
+      val response = CompletableDeferred<String>()
+      val coordinator =
+        coordinator(
+          calls = calls,
+          responses = { method -> if (method == "talk.client.toolCall") response.await() else "{}" },
+          onUnhandledCompletion = unhandled::add,
+        )
+      coordinator.beginSession(RealtimeAgentSession("relay-old", "session-main"))
+      coordinator.handleToolCall("call-old", "openclaw_agent_consult", null, forced = false)
+      runCurrent()
+
+      coordinator.endSession("relay-old")
+      assertTrue(
+        coordinator.handleChatEvent(
+          sessionKey = "session-main",
+          runId = "run-old",
+          state = "final",
+          message = Json.parseToJsonElement("""{"role":"assistant","content":"stale"}"""),
+        ),
+      )
+      assertTrue(
+        coordinator.handleChatEvent(
+          sessionKey = "session-main",
+          runId = "ordinary-run",
+          state = "final",
+          message = Json.parseToJsonElement("""{"role":"assistant","content":"ordinary"}"""),
+        ),
+      )
+      response.complete("""{"runId":"run-old"}""")
+      runCurrent()
+
+      assertTrue(calls.none { it.method == "talk.session.submitToolResult" })
+      assertEquals(listOf("ordinary-run"), unhandled.map { it.runId })
+      assertEquals("session-main", unhandled.single().sessionKey)
+      assertTrue(
+        coordinator.handleChatEvent(
+          sessionKey = "session-main",
+          runId = "run-old",
+          state = "final",
+          message = Json.parseToJsonElement("""{"role":"assistant","content":"duplicate"}"""),
+        ),
+      )
+    }
+
+  @Test
+  fun `early completion cache stays bounded`() =
+    runTest {
+      val calls = mutableListOf<GatewayCall>()
+      val responses = List(3) { CompletableDeferred<String>() }
+      var responseIndex = 0
+      val coordinator =
+        coordinator(
+          calls = calls,
+          responses = { method ->
+            if (method == "talk.client.toolCall") responses[responseIndex++].await() else "{}"
+          },
+          maxCachedCompletions = 2,
+        )
+      coordinator.beginSession(RealtimeAgentSession("relay-1", "session-1"))
+      repeat(3) { index ->
+        coordinator.handleToolCall("call-${index + 1}", "openclaw_agent_consult", null, forced = false)
+      }
+      runCurrent()
+      repeat(3) { index ->
+        coordinator.handleChatEvent(
+          sessionKey = "session-1",
+          runId = "run-${index + 1}",
+          state = "final",
+          message = Json.parseToJsonElement("""{"role":"assistant","content":"result-${index + 1}"}"""),
+        )
+      }
+      responses.forEachIndexed { index, response -> response.complete("""{"runId":"run-${index + 1}"}""") }
+      runCurrent()
+
+      val submittedCallIds =
+        calls
+          .filter { it.method == "talk.session.submitToolResult" }
+          .map { call ->
+            (Json.parseToJsonElement(call.params) as JsonObject).getValue("callId").jsonPrimitive.content
+          }
+      assertEquals(listOf("call-2", "call-3"), submittedCallIds)
+    }
+
+  private fun kotlinx.coroutines.test.TestScope.coordinator(
+    calls: MutableList<GatewayCall>,
+    responses: suspend (String) -> String,
+    onWorking: (RealtimeAgentSession) -> Unit = {},
+    onError: (String) -> Unit = {},
+    onUnhandledCompletion: (RealtimeAgentUnhandledCompletion) -> Unit = {},
+    maxCachedCompletions: Int = 128,
+  ) = RealtimeAgentCoordinator(
+    parentScope = backgroundScope,
+    requestGateway = { method, params, timeoutMs ->
+      calls += GatewayCall(method, params.orEmpty(), timeoutMs)
+      responses(method)
+    },
+    onWorking = onWorking,
+    onError = { _, message -> onError(message) },
+    onUnhandledCompletion = onUnhandledCompletion,
+    maxCachedCompletions = maxCachedCompletions,
+  )
+
+  private data class GatewayCall(
+    val method: String,
+    val params: String,
+    val timeoutMs: Long,
+  )
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -463,35 +463,6 @@ class TalkModeManagerTest {
   }
 
   @Test
-  fun realtimeToolFinalDoesNotUseAllResponseTts() {
-    val manager = createManager()
-
-    manager.ttsOnAllResponses = true
-    setPrivateField(manager, "realtimeSessionId", "relay-1")
-    realtimeToolRuns(manager)["run-tool"] =
-      RealtimeToolRun(callId = "call-1", relaySessionId = "relay-1")
-
-    manager.handleGatewayEvent("chat", chatFinalPayload(runId = "run-tool", text = "tool result"))
-
-    assertEquals(0L, playbackGeneration(manager).get())
-    assertTrue(realtimeToolRuns(manager).isEmpty())
-  }
-
-  @Test
-  fun realtimeToolFinalBeforeRunMetadataIsHeldForToolCompletion() {
-    val manager = createManager()
-
-    manager.ttsOnAllResponses = true
-    setPrivateField(manager, "realtimeSessionId", "relay-1")
-    pendingRealtimeToolCalls(manager).add("call-1")
-
-    manager.handleGatewayEvent("chat", chatFinalPayload(runId = "run-tool", text = "tool result"))
-
-    assertEquals(0L, playbackGeneration(manager).get())
-    assertTrue(pendingRealtimeToolCompletions(manager).containsKey("run-tool"))
-  }
-
-  @Test
   fun realtimeCloseErrorDisablesTalkButKeepsFailureStatus() {
     var stoppedByRelay = false
     val manager = createManager(onStoppedByRelay = { stoppedByRelay = true })
@@ -867,21 +838,6 @@ class TalkModeManagerTest {
     }
 
   @Test
-  fun staleRealtimeToolFinalDoesNotUseAllResponseTts() {
-    val manager = createManager()
-
-    manager.ttsOnAllResponses = true
-    setPrivateField(manager, "realtimeSessionId", "relay-2")
-    realtimeToolRuns(manager)["run-tool"] =
-      RealtimeToolRun(callId = "call-1", relaySessionId = "relay-1")
-
-    manager.handleGatewayEvent("chat", chatFinalPayload(runId = "run-tool", text = "stale result"))
-
-    assertEquals(0L, playbackGeneration(manager).get())
-    assertTrue(realtimeToolRuns(manager).isEmpty())
-  }
-
-  @Test
   fun textReadyDoesNotEnterSpeakingUntilAudioPlaybackStarts() =
     runTest {
       val talkSpeakClient = FakeTalkSpeechSynthesizer()
@@ -1210,15 +1166,6 @@ class TalkModeManagerTest {
 
   @Suppress("UNCHECKED_CAST")
   private fun playbackGeneration(manager: TalkModeManager) = readPrivateField(manager, "playbackGeneration") as AtomicLong
-
-  @Suppress("UNCHECKED_CAST")
-  private fun realtimeToolRuns(manager: TalkModeManager) = readPrivateField(manager, "realtimeToolRuns") as MutableMap<String, RealtimeToolRun>
-
-  @Suppress("UNCHECKED_CAST")
-  private fun pendingRealtimeToolCalls(manager: TalkModeManager) = readPrivateField(manager, "pendingRealtimeToolCalls") as MutableSet<String>
-
-  @Suppress("UNCHECKED_CAST")
-  private fun pendingRealtimeToolCompletions(manager: TalkModeManager) = readPrivateField(manager, "pendingRealtimeToolCompletions") as MutableMap<String, Any>
 
   private fun setPrivateField(
     target: Any,

--- a/apps/android/app/src/test/java/ai/openclaw/app/wear/WearRealtimeTalkControllerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/wear/WearRealtimeTalkControllerTest.kt
@@ -616,7 +616,7 @@ class WearRealtimeTalkControllerTest {
     }
 
   @Test
-  fun `relays provider output larger than the legacy queue capacity`() =
+  fun `relays provider output larger than the frame queue capacity`() =
     runTest {
       val output = mutableListOf<ByteArray>()
       val controller =
@@ -660,10 +660,9 @@ class WearRealtimeTalkControllerTest {
     }
 
   @Test
-  fun `relays every frame from a bursty Watch microphone`() =
+  fun `fails instead of dropping Watch audio when the input queue is full`() =
     runTest {
-      val releaseFirstFrame = CompletableDeferred<Unit>()
-      var appendCalls = 0
+      val forcedChannelCloses = mutableListOf<String>()
       val controller =
         WearRealtimeTalkController(
           scope = this,
@@ -675,25 +674,19 @@ class WearRealtimeTalkControllerTest {
               """{"ok":true}"""
             }
           },
-          sendGatewayFrame = { method, _, _, _ ->
-            if (method == "talk.session.appendAudio") {
-              appendCalls += 1
-              if (appendCalls == 1) releaseFirstFrame.await()
-            }
-          },
+          sendGatewayFrame = { _, _, _, _ -> },
           sendWatchFrame = { _, _, _ -> },
+          onForceCloseWatchChannel = forcedChannelCloses::add,
         )
       assertTrue(controller.start("watch-a", "session-a", "attempt-a", "de"))
 
-      repeat(12) { index ->
+      repeat(65) { index ->
         controller.appendAudio("watch-a", byteArrayOf(index.toByte(), 0))
       }
-      runCurrent()
-      releaseFirstFrame.complete(Unit)
-      runCurrent()
 
-      assertEquals(12, appendCalls)
-      assertTrue(controller.stop("watch-a"))
+      assertEquals(WearRealtimeTalkStatus.ERROR, controller.snapshot.value.status)
+      assertEquals(listOf("watch-a"), forcedChannelCloses)
+      runCurrent()
     }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/wear/WearRealtimeTalkControllerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/wear/WearRealtimeTalkControllerTest.kt
@@ -660,6 +660,45 @@ class WearRealtimeTalkControllerTest {
     }
 
   @Test
+  fun `stops chunking provider output when the session is aborted`() =
+    runTest {
+      val output = mutableListOf<ByteArray>()
+      lateinit var controller: WearRealtimeTalkController
+      controller =
+        WearRealtimeTalkController(
+          scope = this,
+          isConnected = { true },
+          requestGateway = { method, _, _ ->
+            if (method == "talk.session.create") """{"relaySessionId":"relay-1"}""" else """{"ok":true}"""
+          },
+          sendGatewayFrame = { _, _, _, _ -> },
+          sendWatchFrame = { _, type, payload ->
+            if (type == WearRealtimeAudioFrameType.OUTPUT_PCM) {
+              output += payload
+              if (output.size == 1) controller.abort()
+            }
+          },
+        )
+      assertTrue(controller.start("watch-a", "session-a", "attempt-a", "de"))
+      val audio = ByteArray(WearProtocol.MAX_REALTIME_AUDIO_FRAME_BYTES * 3)
+
+      controller.handleGatewayEvent(
+        "talk.event",
+        """
+        {
+          "relaySessionId":"relay-1",
+          "type":"audio",
+          "audioBase64":"${Base64.encodeToString(audio, Base64.NO_WRAP)}"
+        }
+        """.trimIndent(),
+      )
+      runCurrent()
+
+      assertEquals(1, output.size)
+      assertEquals(WearRealtimeTalkStatus.OFF, controller.snapshot.value.status)
+    }
+
+  @Test
   fun `fails when queued provider output exceeds the byte budget`() =
     runTest {
       val outputStarted = CompletableDeferred<Unit>()

--- a/apps/android/app/src/test/java/ai/openclaw/app/wear/WearRealtimeTalkControllerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/wear/WearRealtimeTalkControllerTest.kt
@@ -351,6 +351,204 @@ class WearRealtimeTalkControllerTest {
     }
 
   @Test
+  fun `does not force final transcripts and relays a provider-selected tool call`() =
+    runTest {
+      val gatewayCalls = mutableListOf<Pair<String, String?>>()
+      val controller =
+        WearRealtimeTalkController(
+          scope = this,
+          isConnected = { true },
+          requestGateway = { method, params, _ ->
+            gatewayCalls += method to params
+            when (method) {
+              "talk.session.create" -> """{"relaySessionId":"relay-1"}"""
+              "talk.client.toolCall" -> """{"runId":"run-1"}"""
+              else -> """{"ok":true}"""
+            }
+          },
+          sendGatewayFrame = { _, _, _, _ -> },
+          sendWatchFrame = { _, _, _ -> },
+        )
+      assertTrue(
+        controller.start(
+          nodeId = "watch-a",
+          sessionKey = "session-a",
+          attemptId = "attempt-a",
+          language = "de",
+        ),
+      )
+
+      controller.handleGatewayEvent(
+        "talk.event",
+        """{"relaySessionId":"relay-1","type":"transcript","role":"user","text":"Hello","final":true}""",
+      )
+      runCurrent()
+      assertTrue(gatewayCalls.none { it.first == "talk.client.toolCall" })
+
+      controller.handleGatewayEvent(
+        "talk.event",
+        """
+        {
+          "relaySessionId":"relay-1",
+          "type":"toolCall",
+          "callId":"call-1",
+          "name":"openclaw_agent_consult",
+          "args":{"question":"Check the repository"}
+        }
+        """.trimIndent(),
+      )
+      runCurrent()
+
+      val toolCall = gatewayCalls.single { it.first == "talk.client.toolCall" }.second.orEmpty()
+      assertTrue(toolCall.contains("\"sessionKey\":\"session-a\""))
+      assertTrue(toolCall.contains("\"relaySessionId\":\"relay-1\""))
+      assertTrue(toolCall.contains("\"callId\":\"call-1\""))
+      assertEquals(WearRealtimeTalkStatus.THINKING, controller.snapshot.value.status)
+
+      controller.handleGatewayEvent(
+        "chat",
+        """
+        {
+          "sessionKey":"other-session",
+          "runId":"run-1",
+          "state":"final",
+          "message":{"role":"assistant","content":[{"type":"text","text":"Wrong session"}]}
+        }
+        """.trimIndent(),
+      )
+      runCurrent()
+      assertTrue(gatewayCalls.none { it.first == "talk.session.submitToolResult" })
+
+      controller.handleGatewayEvent(
+        "chat",
+        """
+        {
+          "sessionKey":"session-a",
+          "runId":"run-1",
+          "state":"final",
+          "message":{"role":"assistant","content":[{"type":"text","text":"Repository checked"}]}
+        }
+        """.trimIndent(),
+      )
+      runCurrent()
+
+      val result = gatewayCalls.single { it.first == "talk.session.submitToolResult" }.second.orEmpty()
+      assertTrue(result.contains("\"sessionId\":\"relay-1\""))
+      assertTrue(result.contains("\"callId\":\"call-1\""))
+      assertTrue(result.contains("\"text\":\"Repository checked\""))
+      assertTrue(controller.stop("watch-a"))
+    }
+
+  @Test
+  fun `keeps an early chat completion until the tool call run id arrives`() =
+    runTest {
+      val toolCallResponse = CompletableDeferred<String>()
+      val submittedResults = mutableListOf<String>()
+      val controller =
+        WearRealtimeTalkController(
+          scope = this,
+          isConnected = { true },
+          requestGateway = { method, params, _ ->
+            when (method) {
+              "talk.session.create" -> """{"relaySessionId":"relay-1"}"""
+              "talk.client.toolCall" -> toolCallResponse.await()
+              "talk.session.submitToolResult" -> {
+                submittedResults += params.orEmpty()
+                """{"ok":true}"""
+              }
+              else -> """{"ok":true}"""
+            }
+          },
+          sendGatewayFrame = { _, _, _, _ -> },
+          sendWatchFrame = { _, _, _ -> },
+        )
+      assertTrue(
+        controller.start(
+          nodeId = "watch-a",
+          sessionKey = "session-a",
+          attemptId = "attempt-a",
+          language = null,
+        ),
+      )
+
+      controller.handleGatewayEvent(
+        "talk.event",
+        """{"relaySessionId":"relay-1","type":"toolCall","callId":"call-1","name":"openclaw_agent_consult"}""",
+      )
+      runCurrent()
+      controller.handleGatewayEvent(
+        "chat",
+        """
+        {
+          "sessionKey":"session-a",
+          "runId":"run-early",
+          "state":"final",
+          "message":{"role":"assistant","content":"Early result"}
+        }
+        """.trimIndent(),
+      )
+      toolCallResponse.complete("""{"runId":"run-early"}""")
+      runCurrent()
+
+      assertEquals(1, submittedResults.size)
+      assertTrue(submittedResults.single().contains("\"text\":\"Early result\""))
+      assertTrue(controller.stop("watch-a"))
+    }
+
+  @Test
+  fun `relays realtime agent control without starting another consult`() =
+    runTest {
+      val gatewayCalls = mutableListOf<Pair<String, String?>>()
+      val controller =
+        WearRealtimeTalkController(
+          scope = this,
+          isConnected = { true },
+          requestGateway = { method, params, _ ->
+            gatewayCalls += method to params
+            when (method) {
+              "talk.session.create" -> """{"relaySessionId":"relay-1"}"""
+              "talk.session.steer" -> """{"status":"steered","message":"Stopping"}"""
+              else -> """{"ok":true}"""
+            }
+          },
+          sendGatewayFrame = { _, _, _, _ -> },
+          sendWatchFrame = { _, _, _ -> },
+        )
+      assertTrue(
+        controller.start(
+          nodeId = "watch-a",
+          sessionKey = "session-a",
+          attemptId = "attempt-a",
+          language = null,
+        ),
+      )
+
+      controller.handleGatewayEvent(
+        "talk.event",
+        """
+        {
+          "relaySessionId":"relay-1",
+          "type":"toolCall",
+          "callId":"control-1",
+          "name":"openclaw_agent_control",
+          "args":{"text":"stop","mode":"cancel"}
+        }
+        """.trimIndent(),
+      )
+      runCurrent()
+
+      assertTrue(gatewayCalls.none { it.first == "talk.client.toolCall" })
+      val steer = gatewayCalls.single { it.first == "talk.session.steer" }.second.orEmpty()
+      assertTrue(steer.contains("\"sessionId\":\"relay-1\""))
+      assertTrue(steer.contains("\"sessionKey\":\"session-a\""))
+      assertTrue(steer.contains("\"mode\":\"cancel\""))
+      val result = gatewayCalls.single { it.first == "talk.session.submitToolResult" }.second.orEmpty()
+      assertTrue(result.contains("\"callId\":\"control-1\""))
+      assertTrue(result.contains("\"status\":\"steered\""))
+      assertTrue(controller.stop("watch-a"))
+    }
+
+  @Test
   fun `chunks provider audio and sends clear in order`() =
     runTest {
       val output = mutableListOf<Pair<WearRealtimeAudioFrameType, ByteArray>>()

--- a/apps/android/app/src/test/java/ai/openclaw/app/wear/WearRealtimeTalkControllerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/wear/WearRealtimeTalkControllerTest.kt
@@ -660,6 +660,49 @@ class WearRealtimeTalkControllerTest {
     }
 
   @Test
+  fun `fails when queued provider output exceeds the byte budget`() =
+    runTest {
+      val outputStarted = CompletableDeferred<Unit>()
+      val releaseOutput = CompletableDeferred<Unit>()
+      val forcedChannelCloses = mutableListOf<String>()
+      val controller =
+        WearRealtimeTalkController(
+          scope = this,
+          isConnected = { true },
+          requestGateway = { method, _, _ ->
+            if (method == "talk.session.create") """{"relaySessionId":"relay-1"}""" else """{"ok":true}"""
+          },
+          sendGatewayFrame = { _, _, _, _ -> },
+          sendWatchFrame = { _, type, _ ->
+            if (type == WearRealtimeAudioFrameType.OUTPUT_PCM) {
+              outputStarted.complete(Unit)
+              releaseOutput.await()
+            }
+          },
+          onForceCloseWatchChannel = { forcedChannelCloses += it },
+        )
+      assertTrue(controller.start("watch-a", "session-a", "attempt-a", "de"))
+      val audio = ByteArray(WearProtocol.MAX_REALTIME_AUDIO_FRAME_BYTES * 65)
+      val event =
+        """
+        {
+          "relaySessionId":"relay-1",
+          "type":"audio",
+          "audioBase64":"${Base64.encodeToString(audio, Base64.NO_WRAP)}"
+        }
+        """.trimIndent()
+
+      controller.handleGatewayEvent("talk.event", event)
+      outputStarted.await()
+      controller.handleGatewayEvent("talk.event", event)
+
+      assertEquals(WearRealtimeTalkStatus.ERROR, controller.snapshot.value.status)
+      assertEquals(listOf("watch-a"), forcedChannelCloses)
+      releaseOutput.complete(Unit)
+      runCurrent()
+    }
+
+  @Test
   fun `fails instead of dropping Watch audio when the input queue is full`() =
     runTest {
       val forcedChannelCloses = mutableListOf<String>()

--- a/apps/android/app/src/test/java/ai/openclaw/app/wear/WearRealtimeTalkControllerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/wear/WearRealtimeTalkControllerTest.kt
@@ -25,6 +25,17 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class WearRealtimeTalkControllerTest {
   @Test
+  fun `playback deadline counts only audio remaining after slow chunk delivery`() {
+    val chunkBytes = WearProtocol.REALTIME_AUDIO_SAMPLE_RATE_HZ / 10 * 2
+
+    val first = advanceWearRealtimePlaybackDeadline(0L, 0L, chunkBytes)
+    val second = advanceWearRealtimePlaybackDeadline(first, 100L, chunkBytes)
+    val third = advanceWearRealtimePlaybackDeadline(second, 200L, chunkBytes)
+
+    assertEquals(300L, third)
+  }
+
+  @Test
   fun `stop before a delayed start prevents relay resurrection`() =
     runTest {
       var gatewayCalls = 0

--- a/apps/android/app/src/test/java/ai/openclaw/app/wear/WearRealtimeTalkControllerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/wear/WearRealtimeTalkControllerTest.kt
@@ -616,6 +616,87 @@ class WearRealtimeTalkControllerTest {
     }
 
   @Test
+  fun `relays provider output larger than the legacy queue capacity`() =
+    runTest {
+      val output = mutableListOf<ByteArray>()
+      val controller =
+        WearRealtimeTalkController(
+          scope = this,
+          isConnected = { true },
+          requestGateway = { method, _, _ ->
+            if (method == "talk.session.create") {
+              """{"relaySessionId":"relay-1"}"""
+            } else {
+              """{"ok":true}"""
+            }
+          },
+          sendGatewayFrame = { _, _, _, _ -> },
+          sendWatchFrame = { _, type, payload ->
+            if (type == WearRealtimeAudioFrameType.OUTPUT_PCM) output += payload
+          },
+        )
+      assertTrue(controller.start("watch-a", "session-a", "attempt-a", "de"))
+      val audio =
+        ByteArray(WearProtocol.MAX_REALTIME_AUDIO_FRAME_BYTES * 65 + 8) { index ->
+          (index % 127).toByte()
+        }
+
+      controller.handleGatewayEvent(
+        "talk.event",
+        """
+        {
+          "relaySessionId":"relay-1",
+          "type":"audio",
+          "audioBase64":"${Base64.encodeToString(audio, Base64.NO_WRAP)}"
+        }
+        """.trimIndent(),
+      )
+      runCurrent()
+
+      val deliveredAudio = output.flatMap { it.asIterable() }.toByteArray()
+      assertArrayEquals(audio, deliveredAudio)
+      assertEquals(WearRealtimeTalkStatus.SPEAKING, controller.snapshot.value.status)
+      assertTrue(controller.stop("watch-a"))
+    }
+
+  @Test
+  fun `relays every frame from a bursty Watch microphone`() =
+    runTest {
+      val releaseFirstFrame = CompletableDeferred<Unit>()
+      var appendCalls = 0
+      val controller =
+        WearRealtimeTalkController(
+          scope = this,
+          isConnected = { true },
+          requestGateway = { method, _, _ ->
+            if (method == "talk.session.create") {
+              """{"relaySessionId":"relay-1"}"""
+            } else {
+              """{"ok":true}"""
+            }
+          },
+          sendGatewayFrame = { method, _, _, _ ->
+            if (method == "talk.session.appendAudio") {
+              appendCalls += 1
+              if (appendCalls == 1) releaseFirstFrame.await()
+            }
+          },
+          sendWatchFrame = { _, _, _ -> },
+        )
+      assertTrue(controller.start("watch-a", "session-a", "attempt-a", "de"))
+
+      repeat(12) { index ->
+        controller.appendAudio("watch-a", byteArrayOf(index.toByte(), 0))
+      }
+      runCurrent()
+      releaseFirstFrame.complete(Unit)
+      runCurrent()
+
+      assertEquals(12, appendCalls)
+      assertTrue(controller.stop("watch-a"))
+    }
+
+  @Test
   fun `reports an error and closes the relay when watch audio delivery fails`() =
     runTest {
       val gatewayMethods = mutableListOf<String>()

--- a/apps/android/wear/src/main/java/ai/openclaw/wear/WearRealtimeTalkClient.kt
+++ b/apps/android/wear/src/main/java/ai/openclaw/wear/WearRealtimeTalkClient.kt
@@ -21,14 +21,17 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.yield
 import java.io.InputStream
 import java.io.OutputStream
 import java.util.Locale
@@ -220,10 +223,20 @@ internal class WearRealtimeTalkClient(
       scope.launch {
         val buffer = ByteArray(frameBytes)
         try {
-          while (audioRecord === recorder && activeNodeId == nodeId) {
+          while (
+            currentCoroutineContext().isActive &&
+            _isCapturing.value &&
+            audioRecord === recorder &&
+            activeNodeId == nodeId
+          ) {
             val read = recorder.read(buffer, 0, buffer.size)
             val evenBytes = read - (read and 1)
-            if (evenBytes <= 0 || !_isCapturing.value || audioRecord !== recorder) continue
+            if (!_isCapturing.value || audioRecord !== recorder) break
+            check(read >= 0) { "Watch microphone read failed: $read" }
+            if (evenBytes == 0) {
+              yield()
+              continue
+            }
             sendInputFrame(buffer.copyOf(evenBytes))
           }
         } catch (err: CancellationException) {

--- a/apps/android/wear/src/main/java/ai/openclaw/wear/WearRealtimeTalkClient.kt
+++ b/apps/android/wear/src/main/java/ai/openclaw/wear/WearRealtimeTalkClient.kt
@@ -21,7 +21,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -63,7 +62,6 @@ internal class WearRealtimeTalkClient(
   private var channelOutput: OutputStream? = null
   private var captureJob: Job? = null
   private var readJob: Job? = null
-  private val playbackMessages = Channel<PlaybackMessage>(capacity = Channel.UNLIMITED)
   private var playbackIdleJob: Job? = null
   private var audioTrack: AudioTrack? = null
   private var playbackEndsAtMillis = 0L
@@ -73,25 +71,6 @@ internal class WearRealtimeTalkClient(
     val input: InputStream,
     val output: OutputStream,
   )
-
-  private data class PlaybackMessage(
-    val attemptId: String,
-    val type: WearRealtimeAudioFrameType,
-    val payload: ByteArray,
-  )
-
-  init {
-    scope.launch {
-      for (message in playbackMessages) {
-        if (activeAttemptId != message.attemptId) continue
-        when (message.type) {
-          WearRealtimeAudioFrameType.OUTPUT_PCM -> writeOutput(message.payload)
-          WearRealtimeAudioFrameType.CLEAR_OUTPUT -> clearOutput(resumeCapture = true)
-          WearRealtimeAudioFrameType.INPUT_PCM -> error("Watch cannot queue input audio for playback")
-        }
-      }
-    }
-  }
 
   suspend fun start(
     session: WearSession,
@@ -144,7 +123,6 @@ internal class WearRealtimeTalkClient(
 
   fun shutdown() {
     closeLocal()
-    playbackMessages.close()
     scope.cancel()
   }
 
@@ -185,17 +163,12 @@ internal class WearRealtimeTalkClient(
     readJob =
       scope.launch {
         try {
-          while (activeNodeId == nodeId) {
+          while (activeNodeId == nodeId && activeAttemptId == attemptId) {
             val frame = WearRealtimeAudioFraming.read(input) ?: break
+            if (activeNodeId != nodeId || activeAttemptId != attemptId) break
             when (frame.type) {
-              WearRealtimeAudioFrameType.OUTPUT_PCM,
-              WearRealtimeAudioFrameType.CLEAR_OUTPUT,
-              ->
-                check(
-                  playbackMessages
-                    .trySend(PlaybackMessage(attemptId, frame.type, frame.payload))
-                    .isSuccess,
-                ) { "Watch audio playback queue is unavailable" }
+              WearRealtimeAudioFrameType.OUTPUT_PCM -> writeOutput(frame.payload)
+              WearRealtimeAudioFrameType.CLEAR_OUTPUT -> clearOutput(resumeCapture = true)
               WearRealtimeAudioFrameType.INPUT_PCM -> error("Phone sent an invalid Watch audio frame")
             }
           }
@@ -215,15 +188,10 @@ internal class WearRealtimeTalkClient(
 
   @SuppressLint("MissingPermission")
   private fun startCaptureLocked(nodeId: String) {
-    if (_isPlaying.value || activeNodeId != nodeId) return
-    if (audioRecord != null) {
-      _isCapturing.value = true
-      return
-    }
-    if (_isCapturing.value) return
+    if (_isCapturing.value || _isPlaying.value || activeNodeId != nodeId) return
     val frameBytes =
       WearProtocol.REALTIME_AUDIO_SAMPLE_RATE_HZ * PCM_16_BYTES *
-        WearProtocol.REALTIME_AUDIO_FRAME_MILLIS * CAPTURE_FRAMES_PER_SEND / 1_000
+        WearProtocol.REALTIME_AUDIO_FRAME_MILLIS / 1_000
     val minimumBuffer =
       AudioRecord.getMinBufferSize(
         WearProtocol.REALTIME_AUDIO_SAMPLE_RATE_HZ,
@@ -255,7 +223,7 @@ internal class WearRealtimeTalkClient(
           while (audioRecord === recorder && activeNodeId == nodeId) {
             val read = recorder.read(buffer, 0, buffer.size)
             val evenBytes = read - (read and 1)
-            if (evenBytes <= 0 || !_isCapturing.value) continue
+            if (evenBytes <= 0 || !_isCapturing.value || audioRecord !== recorder) continue
             sendInputFrame(buffer.copyOf(evenBytes))
           }
         } catch (err: CancellationException) {
@@ -283,9 +251,7 @@ internal class WearRealtimeTalkClient(
     synchronized(audioLock) {
       if (activeNodeId == null) return
       if (!_isPlaying.value) {
-        // Keep AudioRecord alive across output so turn boundaries do not churn
-        // the Watch microphone or block the audio-channel reader during teardown.
-        _isCapturing.value = false
+        pauseCaptureLocked()
         check(audioFocus.request())
       }
       val track = audioTrack ?: createAudioTrack(bytes.size).also { audioTrack = it }
@@ -437,7 +403,6 @@ internal class WearRealtimeTalkClient(
     const val CHANNEL_RETRY_DELAY_MILLIS = 250L
     const val ISO_639_1_LANGUAGE_LENGTH = 2
     const val PCM_16_BYTES = 2
-    const val CAPTURE_FRAMES_PER_SEND = 4
     const val PLAYBACK_DRAIN_GRACE_MILLIS = 120L
   }
 }

--- a/apps/android/wear/src/main/java/ai/openclaw/wear/WearRealtimeTalkClient.kt
+++ b/apps/android/wear/src/main/java/ai/openclaw/wear/WearRealtimeTalkClient.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -62,6 +63,7 @@ internal class WearRealtimeTalkClient(
   private var channelOutput: OutputStream? = null
   private var captureJob: Job? = null
   private var readJob: Job? = null
+  private val playbackMessages = Channel<PlaybackMessage>(capacity = Channel.UNLIMITED)
   private var playbackIdleJob: Job? = null
   private var audioTrack: AudioTrack? = null
   private var playbackEndsAtMillis = 0L
@@ -71,6 +73,25 @@ internal class WearRealtimeTalkClient(
     val input: InputStream,
     val output: OutputStream,
   )
+
+  private data class PlaybackMessage(
+    val attemptId: String,
+    val type: WearRealtimeAudioFrameType,
+    val payload: ByteArray,
+  )
+
+  init {
+    scope.launch {
+      for (message in playbackMessages) {
+        if (activeAttemptId != message.attemptId) continue
+        when (message.type) {
+          WearRealtimeAudioFrameType.OUTPUT_PCM -> writeOutput(message.payload)
+          WearRealtimeAudioFrameType.CLEAR_OUTPUT -> clearOutput(resumeCapture = true)
+          WearRealtimeAudioFrameType.INPUT_PCM -> error("Watch cannot queue input audio for playback")
+        }
+      }
+    }
+  }
 
   suspend fun start(
     session: WearSession,
@@ -92,7 +113,7 @@ internal class WearRealtimeTalkClient(
         val snapshot = repository.startRealtimeTalk(session.key, attemptId, language, nodeId)
         activeNodeId = nodeId
         activeAttemptId = attemptId
-        startReader(nodeId)
+        startReader(nodeId, attemptId)
         startCapture(nodeId)
         snapshot
       } catch (err: Throwable) {
@@ -123,6 +144,7 @@ internal class WearRealtimeTalkClient(
 
   fun shutdown() {
     closeLocal()
+    playbackMessages.close()
     scope.cancel()
   }
 
@@ -154,7 +176,10 @@ internal class WearRealtimeTalkClient(
     throw WearProxyException("phone_unavailable", lastError?.message ?: "Unable to open Watch audio channel")
   }
 
-  private fun startReader(nodeId: String) {
+  private fun startReader(
+    nodeId: String,
+    attemptId: String,
+  ) {
     val input = checkNotNull(channelInput)
     readJob?.cancel()
     readJob =
@@ -163,8 +188,14 @@ internal class WearRealtimeTalkClient(
           while (activeNodeId == nodeId) {
             val frame = WearRealtimeAudioFraming.read(input) ?: break
             when (frame.type) {
-              WearRealtimeAudioFrameType.OUTPUT_PCM -> writeOutput(frame.payload)
-              WearRealtimeAudioFrameType.CLEAR_OUTPUT -> clearOutput(resumeCapture = true)
+              WearRealtimeAudioFrameType.OUTPUT_PCM,
+              WearRealtimeAudioFrameType.CLEAR_OUTPUT,
+              ->
+                check(
+                  playbackMessages
+                    .trySend(PlaybackMessage(attemptId, frame.type, frame.payload))
+                    .isSuccess,
+                ) { "Watch audio playback queue is unavailable" }
               WearRealtimeAudioFrameType.INPUT_PCM -> error("Phone sent an invalid Watch audio frame")
             }
           }
@@ -184,10 +215,15 @@ internal class WearRealtimeTalkClient(
 
   @SuppressLint("MissingPermission")
   private fun startCaptureLocked(nodeId: String) {
-    if (_isCapturing.value || _isPlaying.value || activeNodeId != nodeId) return
+    if (_isPlaying.value || activeNodeId != nodeId) return
+    if (audioRecord != null) {
+      _isCapturing.value = true
+      return
+    }
+    if (_isCapturing.value) return
     val frameBytes =
       WearProtocol.REALTIME_AUDIO_SAMPLE_RATE_HZ * PCM_16_BYTES *
-        WearProtocol.REALTIME_AUDIO_FRAME_MILLIS / 1_000
+        WearProtocol.REALTIME_AUDIO_FRAME_MILLIS * CAPTURE_FRAMES_PER_SEND / 1_000
     val minimumBuffer =
       AudioRecord.getMinBufferSize(
         WearProtocol.REALTIME_AUDIO_SAMPLE_RATE_HZ,
@@ -216,10 +252,10 @@ internal class WearRealtimeTalkClient(
       scope.launch {
         val buffer = ByteArray(frameBytes)
         try {
-          while (_isCapturing.value && activeNodeId == nodeId) {
+          while (audioRecord === recorder && activeNodeId == nodeId) {
             val read = recorder.read(buffer, 0, buffer.size)
             val evenBytes = read - (read and 1)
-            if (evenBytes <= 0) continue
+            if (evenBytes <= 0 || !_isCapturing.value) continue
             sendInputFrame(buffer.copyOf(evenBytes))
           }
         } catch (err: CancellationException) {
@@ -247,7 +283,9 @@ internal class WearRealtimeTalkClient(
     synchronized(audioLock) {
       if (activeNodeId == null) return
       if (!_isPlaying.value) {
-        pauseCaptureLocked()
+        // Keep AudioRecord alive across output so turn boundaries do not churn
+        // the Watch microphone or block the audio-channel reader during teardown.
+        _isCapturing.value = false
         check(audioFocus.request())
       }
       val track = audioTrack ?: createAudioTrack(bytes.size).also { audioTrack = it }
@@ -399,6 +437,7 @@ internal class WearRealtimeTalkClient(
     const val CHANNEL_RETRY_DELAY_MILLIS = 250L
     const val ISO_639_1_LANGUAGE_LENGTH = 2
     const val PCM_16_BYTES = 2
+    const val CAPTURE_FRAMES_PER_SEND = 4
     const val PLAYBACK_DRAIN_GRACE_MILLIS = 120L
   }
 }


### PR DESCRIPTION
[AI-assisted]

## What Problem This Solves

Wear OS Real-Time Talk could leave provider-selected agent tool calls unresolved, silently drop bursty Watch microphone audio before it reached the Gateway, or close the Watch audio link when a provider response exceeded the phone relay's fixed output queue. These failures could produce incorrect speech recognition, interrupted replies, or `Watch audio link is unavailable` during an otherwise valid session.

## Why This Change Was Made

Android now has one shared realtime-agent coordinator used by both phone `TalkModeManager` and `WearRealtimeTalkController`. It owns strict `openclaw_agent_control` versus `openclaw_agent_consult` dispatch, call/run correlation, bounded early-completion and retired-run state, timeouts, result submission through `talk.session.submitToolResult`, and session/transport cleanup. The phone and Wear surfaces retain only their relay/session identity, status behavior, and Gateway transport. No second Wear-specific correlation implementation remains.

The Wear relay also preserves every accepted Watch microphone frame, bounds provider output by aggregate bytes, performs 8 KiB Watch framing inside its serial output worker, stops stale chunks at session replacement, and accounts for playback as each chunk is delivered. On the Watch, microphone capture is sent in 80 ms packets, playback is processed outside the Data Layer reader, and `AudioRecord` remains open while assistant audio is playing.

The existing Gateway contracts are unchanged: `talk.client.toolCall` starts the correlated run and `talk.session.submitToolResult` returns the provider result. Credentials and authenticated Gateway access remain phone-side.

## User Impact

Wear OS users can hold stable realtime conversations and complete intentional agent-backed requests without losing the beginning of bursty microphone input or having longer replies tear down the audio channel. Normal final transcripts remain direct realtime conversation and do not automatically start an agent consult.

## Evidence

Validated at head `980a66d15f0468fd03f1b7f7e90838853a07aa9f` on base `c95a8e3df1e6e8d1ea4925b615707bc97f6f52b5`.

- [x] `./gradlew --no-daemon :app:testPlayDebugUnitTest :app:testThirdPartyDebugUnitTest --tests ai.openclaw.app.voice.TalkModeManagerTest --tests ai.openclaw.app.voice.RealtimeAgentCoordinatorTest --tests ai.openclaw.app.wear.WearRealtimeTalkControllerTest :wear:testDebugUnitTest :app:ktlintCheck :benchmark:ktlintCheck :wear:ktlintCheck :wear-shared:ktlintCheck :app:assemblePlayDebug :wear:assembleDebug` — PASS on Blacksmith Testbox; 184 tasks executed.
- [x] `node scripts/check-changed.mjs -- apps/android/app/src/main/java/ai/openclaw/app/voice/RealtimeAgentCoordinator.kt apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt apps/android/app/src/main/java/ai/openclaw/app/wear/WearRealtimeTalkController.kt apps/android/app/src/test/java/ai/openclaw/app/voice/RealtimeAgentCoordinatorTest.kt apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt apps/android/app/src/test/java/ai/openclaw/app/wear/WearRealtimeTalkControllerTest.kt apps/android/wear/src/main/java/ai/openclaw/wear/WearRealtimeTalkClient.kt` — PASS.
- [x] Regression coverage includes phone and Wear tool dispatch, early completion, missing/duplicate run IDs, concurrent limits, overflow, session replacement/end, Gateway transport reset, stale output cancellation, slow-link playback timing, aggregate provider-audio bounds, and Watch microphone queue failure.
- [x] `pnpm native:i18n:check` — PASS on Blacksmith Testbox after refreshing the generated native source line inventory (`changed=false`).
- [x] Fresh whole-branch autoreview against the exact base reported no accepted/actionable findings.

> [!WARNING]
> **Remaining hardware proof gap:** `adb devices -l` reported only `emulator-5554`; no physical Android phone or Wear OS watch was attached to this maintainer environment. The real Watch request → provider-selected consult → phone Gateway run → spoken result roundtrip and physical replaced-session rejection were therefore not rerun. Automated controller, coordinator, build, and CI proof is complete, but this exact device path still needs final hardware confirmation.

## Existing Physical Audio Proof

The previously supplied matched Phone/Watch capture demonstrates realtime German audio, playback completion, and return to microphone capture without an audio-link error. It does not close the provider-selected tool-call hardware gap called out above.

https://github.com/user-attachments/assets/88641770-38da-4611-bd83-b26cb2e3e393
