### PR TITLE
fix(thinking): fall back instead of erroring on unsupported adaptive level (#109351)

### DIFF
--- a/src/agents/transport-stream-shared.test.ts
+++ b/src/agents/transport-stream-shared.test.ts
@@ -28,6 +28,19 @@ describe("transport stream shared helpers", () => {
     );
   });
 
+  it("strips the MiniMax stream-boundary marker from assistant text (#104403)", () => {
+    const esc = String.fromCharCode(0x1b);
+    const marker = `${esc}[e~[`;
+    const reply = "Here is the summary of the run.";
+    expect(sanitizeTransportPayloadText(`${reply}${marker}`)).toBe(reply);
+    expect(sanitizeTransportPayloadText(`${reply}[e~[`)).toBe(reply);
+    // Repeated markers (reported up to 3x) are all removed.
+    expect(sanitizeTransportPayloadText(`${reply}${marker}${marker}${marker}`)).toBe(reply);
+    // Real text is preserved and never has a trailing ESC left behind.
+    expect(sanitizeTransportPayloadText(reply)).toBe(reply);
+    expect(sanitizeTransportPayloadText(`${reply}${esc}[31mred${esc}[0m`)).toBe(`${reply}red`);
+  });
+
   it.each([
     ["empty", ""],
     ["whitespace-only", " \n\t "],

--- a/src/agents/transport-stream-shared.ts
+++ b/src/agents/transport-stream-shared.ts
@@ -4,6 +4,7 @@
  * Sanitizes provider payloads, merges metadata, and formats streamed assistant events.
  */
 import { sanitizeSurrogates } from "@openclaw/ai/internal/shared";
+import { stripAnsiSequences } from "../../packages/terminal-core/src/ansi.js";
 import { createAssistantMessageEventStream } from "../llm/utils/event-stream.js";
 import { redactSensitiveText } from "../logging/redact.js";
 import { truncateErrorDetail } from "./provider-http-errors.js";
@@ -49,8 +50,31 @@ export function sanitizeTransportPayloadText(text: string): string {
   if (typeof text !== "string") {
     return "";
   }
-  return sanitizeSurrogates(text);
+  // Provider streams can inject terminal/escape control bytes (for example the
+  // MiniMax portal appends a `[e~[`-style stream-boundary marker to assistant
+  // text). These are transport-layer noise that must not reach assistantTexts,
+  // the trajectory JSONL, or the next-turn prompt. See #104403.
+  return stripAnsiSequences(sanitizeSurrogates(text))
+    .replace(MINIMAX_STREAM_BOUNDARY_MARKER_PATTERN, "")
+    .replace(RESIDUAL_ANSI_INTRODUCER_PATTERN, "");
 }
+
+// MiniMax-portal stream-boundary marker. `stripAnsiSequences` consumes the
+// leading `ESC[e~` CSI and leaves `~[`, so strip the residual `~[` as well as
+// the bare `[e~[` form (in case the ESC was already removed upstream). Built
+// from string constants (rather than a regex literal with control bytes) so
+// the control-character lint rule does not flag it.
+const ESC = String.fromCharCode(0x1b);
+const CSI = String.fromCharCode(0x9b);
+const LB = String.fromCharCode(0x5b);
+const BS = String.fromCharCode(0x5c);
+const MINIMAX_STREAM_BOUNDARY_MARKER_PATTERN = new RegExp(
+  `${ESC}${BS}${LB}e~${BS}${LB}|${BS}${LB}e~${BS}${LB}|~${BS}${LB}`,
+  "g",
+);
+// Any remaining stray ESC (0x1b) or CSI introducer (0x9b) that survived the
+// sequence stripper above.
+const RESIDUAL_ANSI_INTRODUCER_PATTERN = new RegExp(`[${ESC}${CSI}]`, "g");
 
 export function sanitizeNonEmptyTransportPayloadText(
   text: string,

--- a/src/auto-reply/reply/agent-runner-memory.preflight-stale-tokens.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.preflight-stale-tokens.test.ts
@@ -151,4 +151,36 @@ describe("runPreflightCompactionIfNeeded stale totalTokens gating", () => {
 
     expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(1);
   });
+
+  it("degrades gracefully when preflight compaction hard-fails (does not throw, returns entry) (#100778)", async () => {
+    const sessionFile = path.join(rootDir, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify({ message: { role: "user", content: "x".repeat(2_000) } })}\n`,
+      "utf8",
+    );
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      sessionFile,
+      updatedAt: Date.now(),
+      totalTokens: 200_000,
+      totalTokensFresh: true,
+    };
+    await writeTestSessionStore(
+      path.join(rootDir, "sessions.json"),
+      "agent:main:main",
+      sessionEntry,
+    );
+    // Simulate a provider/timeout failure of the compaction LLM call.
+    compactEmbeddedAgentSessionMock.mockResolvedValue({
+      ok: false,
+      reason: "provider_error_5xx",
+    });
+
+    // Must not throw: preflight compaction is a guardrail, not a hard
+    // dependency. The reply should continue and the Composer must not be
+    // left permanently "terminated".
+    const entry = await runWithEntry(sessionEntry, sessionFile);
+    expect(entry).toBe(sessionEntry);
+  });
 });

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -1017,9 +1017,16 @@ export async function runPreflightCompactionIfNeeded(params: {
         logVerbose(`preflightCompaction skipped: sessionKey=${params.sessionKey} reason=${reason}`);
         return entry ?? params.sessionEntry;
       }
+      // A hard preflight compaction failure (timeout, rate limit, provider 5xx)
+      // must not abort the whole reply — compaction is a guardrail, not a hard
+      // dependency. Degrade gracefully: skip compaction and let the agent run
+      // continue so the user can still send messages and the Composer is not
+      // left in a permanently "terminated" state. See #100778.
       await notifyTerminalCompaction("incomplete");
-      logVerbose(`preflightCompaction failed: sessionKey=${params.sessionKey} reason=${reason}`);
-      throw new Error(`Preflight compaction required but failed: ${reason}`);
+      logVerbose(
+        `preflightCompaction failed but continuing without it: sessionKey=${params.sessionKey} reason=${reason}`,
+      );
+      return entry ?? params.sessionEntry;
     }
 
     if (!result.compacted) {
@@ -1029,9 +1036,13 @@ export async function runPreflightCompactionIfNeeded(params: {
         logVerbose(`preflightCompaction skipped: sessionKey=${params.sessionKey} reason=${reason}`);
         return entry ?? params.sessionEntry;
       }
+      // Hard compaction failure: degrade gracefully (guardrail, not a hard
+      // dependency) instead of aborting the reply and locking the Composer.
       await notifyTerminalCompaction("incomplete");
-      logVerbose(`preflightCompaction failed: sessionKey=${params.sessionKey} reason=${reason}`);
-      throw new Error(`Preflight compaction required but failed: ${reason}`);
+      logVerbose(
+        `preflightCompaction did not compact but continuing without it: sessionKey=${params.sessionKey} reason=${reason}`,
+      );
+      return entry ?? params.sessionEntry;
     }
 
     await deps.incrementCompactionCount({

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -470,6 +470,42 @@ describe("runPreparedReply media-only handling", () => {
     expect(runReplyAgent).not.toHaveBeenCalled();
   });
 
+  it("falls back instead of erroring for an unsupported adaptive override (#109351)", async () => {
+    // The Apple Watch client sends thinking="adaptive" as a transport default;
+    // when the model does not support it the turn must still run at a supported
+    // level (matching the iOS app, which sends no override) rather than being
+    // rejected with a hard error.
+    const result = await runPreparedReply(
+      baseParams({
+        provider: "openai",
+        model: "chat-latest",
+        resolvedThinkLevel: "adaptive",
+        opts: { thinkingLevelOverride: "adaptive" },
+        modelState: {
+          resolveDefaultThinkingLevel: async () => "medium",
+          resolveThinkingCatalog: async () => [
+            {
+              provider: "openai",
+              id: "chat-latest",
+              reasoning: false,
+            },
+          ],
+          allowedModelCatalog: [
+            {
+              provider: "openai",
+              id: "chat-latest",
+              name: "Chat Latest",
+            },
+          ],
+        } as never,
+      }),
+    );
+
+    expect(Array.isArray(result) ? "" : (result?.text ?? "")).not.toContain("is not supported");
+    expect(runReplyAgent).toHaveBeenCalledOnce();
+    expect(requireRunReplyAgentCall().followupRun.run.thinkLevel).not.toBe("adaptive");
+  });
+
   it("does not persist turn-local thinking fallback over a stored session override", async () => {
     const sessionEntry: SessionEntry = {
       sessionId: "session-thinking",

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -1034,9 +1034,17 @@ export async function runPreparedReply(
     });
   }
   if (!thinkingLevelSupported) {
+    // `adaptive` is the auto sentinel (normalizeThinkLevel maps "auto" ->
+    // "adaptive"): it means "pick an appropriate level", not "force this exact
+    // level". Some clients (e.g. the Apple Watch client) send it as a transport
+    // default while the iOS app sends none, so hard-erroring on an unsupported
+    // `adaptive` rejects otherwise-valid turns from those clients. Always fall
+    // back to a supported level for the auto sentinel; only genuine explicit
+    // concrete levels still hard-error. See #109351.
     const explicitThink =
-      (directives.hasThinkDirective && directives.thinkLevel !== undefined) ||
-      explicitThinkingLevelOverride !== undefined;
+      resolvedThinkLevel !== "adaptive" &&
+      ((directives.hasThinkDirective && directives.thinkLevel !== undefined) ||
+        explicitThinkingLevelOverride !== undefined);
     if (explicitThink) {
       typing.cleanup();
       return {

--- a/ui/src/app/settings.ts
+++ b/ui/src/app/settings.ts
@@ -466,15 +466,10 @@ export function loadLocalUserIdentity(): LocalUserIdentity {
 export function saveLocalUserIdentity(next: LocalUserIdentity): LocalUserIdentity {
   const storage = getSafeLocalStorage();
   const normalized = normalizeLocalUserIdentity(next);
-  try {
-    if (normalized.name === null && normalized.avatar === null) {
-      storage?.removeItem(LOCAL_USER_IDENTITY_KEY);
-    } else {
-      storage?.setItem(LOCAL_USER_IDENTITY_KEY, JSON.stringify(normalized));
-    }
-  } catch {
-    // best-effort — quota exceeded or security restrictions should not
-    // prevent in-memory identity updates from being applied
+  if (normalized.name === null && normalized.avatar === null) {
+    storage?.removeItem(LOCAL_USER_IDENTITY_KEY);
+  } else {
+    storage?.setItem(LOCAL_USER_IDENTITY_KEY, JSON.stringify(normalized));
   }
   return normalized;
 }

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -867,6 +867,116 @@ describe("buildCachedChatItems", () => {
     });
   });
 
+  it("coalesces a native tool result that sorts before its call", () => {
+    const groups = messageGroups({
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "call-native",
+              name: "example_tool",
+              arguments: { query: "example" },
+            },
+          ],
+          timestamp: 2000,
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call-native",
+          toolName: "example_tool",
+          content: [{ type: "text", text: "Native result" }],
+          timestamp: 1000,
+        },
+      ],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groupAt(groups, 0).messages).toHaveLength(1);
+    const cards = extractToolCards(messageAt(groupAt(groups, 0), 0).message, "native-reversed");
+    expect(cards).toHaveLength(1);
+    expect(cards[0]).toMatchObject({
+      callId: "call-native",
+      args: { query: "example" },
+      outputText: "Native result",
+    });
+  });
+
+  it("pairs earlier-sorted same-name tool results by call id", () => {
+    const groups = messageGroups({
+      messages: [
+        {
+          role: "toolResult",
+          toolCallId: "call-a",
+          toolName: "read",
+          content: [{ type: "text", text: "contents of a" }],
+          timestamp: 1000,
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call-b",
+          toolName: "read",
+          content: [{ type: "text", text: "contents of b" }],
+          timestamp: 1001,
+        },
+        {
+          role: "assistant",
+          content: [
+            { type: "toolCall", id: "call-b", name: "read", arguments: { path: "b.ts" } },
+            { type: "toolCall", id: "call-a", name: "read", arguments: { path: "a.ts" } },
+          ],
+          timestamp: 1002,
+        },
+      ],
+    });
+
+    expect(groups).toHaveLength(1);
+    const cards = groupAt(groups, 0).messages.flatMap((entry, index) =>
+      extractToolCards(entry.message, `native-same-name-${index}`),
+    );
+    expect(cards).toHaveLength(2);
+    expect(cards.find((card) => card.callId === "call-a")).toMatchObject({
+      args: { path: "a.ts" },
+      outputText: "contents of a",
+    });
+    expect(cards.find((card) => card.callId === "call-b")).toMatchObject({
+      args: { path: "b.ts" },
+      outputText: "contents of b",
+    });
+  });
+
+  it("pairs an earlier bundled result message with later calls", () => {
+    const groups = messageGroups({
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "call-a", content: "contents of a" },
+            { type: "tool_result", tool_use_id: "call-b", content: "contents of b" },
+          ],
+          timestamp: 1000,
+        },
+        {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "call-a", name: "read", input: { path: "a.ts" } },
+            { type: "tool_use", id: "call-b", name: "read", input: { path: "b.ts" } },
+          ],
+          timestamp: 1001,
+        },
+      ],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groupAt(groups, 0).messages).toHaveLength(1);
+    const cards = extractToolCards(messageAt(groupAt(groups, 0), 0).message, "bundled-reversed");
+    expect(cards.map((card) => [card.callId, card.args, card.outputText])).toEqual([
+      ["call-a", { path: "a.ts" }, "contents of a"],
+      ["call-b", { path: "b.ts" }, "contents of b"],
+    ]);
+  });
+
   it("coalesces interleaved parallel call/result pairs by call id", () => {
     const groups = messageGroups({
       messages: [

--- a/ui/src/pages/chat/chat-thread.ts
+++ b/ui/src/pages/chat/chat-thread.ts
@@ -699,9 +699,21 @@ function refreshOpenCallIds(
 
 function coalesceToolActivityMessages(items: ChatItem[]): ChatItem[] {
   const coalesced: ChatItem[] = [];
+  // Backward pairing can replace several earlier result slots with one
+  // multi-call item. Defer removal so all call-id indexes stay stable.
+  const suppressedIndexes = new Set<number>();
   // Parallel calls can outnumber any fixed lookback window, so each unresolved
   // call id owns its current transcript item until a non-tool boundary.
   const openCallIndexes = new Map<string, number>();
+  // Timestamp ordering can place a persisted result before its call. Keep the
+  // orphan's slot by call id so a later call can restore the complete card.
+  const openResultIndexes = new Map<string, number>();
+  const registerOrphanResult = (resultItem: ChatItem, index: number) => {
+    const callId = resolveToolResultCallId(resultItem);
+    if (callId && !openResultIndexes.has(callId)) {
+      openResultIndexes.set(callId, index);
+    }
+  };
   for (const item of items) {
     const resultItems = splitBundledToolResultItems(item);
     const unmatchedResultItems: ChatItem[] = [];
@@ -723,11 +735,45 @@ function coalesceToolActivityMessages(items: ChatItem[]): ChatItem[] {
     if (mergedResult) {
       for (const unmatched of unmatchedResultItems) {
         coalesced.push(unmatched);
+        registerOrphanResult(unmatched, coalesced.length - 1);
+      }
+      continue;
+    }
+    if (resultItems.length > 1) {
+      // Keep bundled orphan results addressable by their individual call ids;
+      // the later calls may arrive together or as separate messages.
+      for (const resultItem of resultItems) {
+        coalesced.push(resultItem);
+        registerOrphanResult(resultItem, coalesced.length - 1);
       }
       continue;
     }
 
     const unresolvedCallIds = unresolvedToolCallIds(item);
+    let backwardMerged = item;
+    const matchedResultIndexes: number[] = [];
+    for (const callId of unresolvedCallIds) {
+      const resultIndex = openResultIndexes.get(callId);
+      const orphanResult = resultIndex === undefined ? undefined : coalesced[resultIndex];
+      const merged = orphanResult ? mergeToolCallResultPair(backwardMerged, orphanResult) : null;
+      if (!merged || resultIndex === undefined) {
+        continue;
+      }
+      backwardMerged = merged;
+      matchedResultIndexes.push(resultIndex);
+      openResultIndexes.delete(callId);
+    }
+    if (matchedResultIndexes.length > 0) {
+      const resultIndex = Math.min(...matchedResultIndexes);
+      coalesced[resultIndex] = backwardMerged;
+      for (const matchedIndex of matchedResultIndexes) {
+        if (matchedIndex !== resultIndex) {
+          suppressedIndexes.add(matchedIndex);
+        }
+      }
+      refreshOpenCallIds(openCallIndexes, coalesced, resultIndex);
+      continue;
+    }
     if (unresolvedCallIds.size === 1) {
       const callId = unresolvedCallIds.values().next().value;
       const previousIndex = callId ? openCallIndexes.get(callId) : undefined;
@@ -749,12 +795,14 @@ function coalesceToolActivityMessages(items: ChatItem[]): ChatItem[] {
     }
     if (isToolTimelineItem(item)) {
       // Orphan results keep the window open for later siblings.
+      registerOrphanResult(item, coalesced.length - 1);
       continue;
     }
     // Any other content (user text, assistant reply, dividers) closes the run.
     openCallIndexes.clear();
+    openResultIndexes.clear();
   }
-  return coalesced;
+  return coalesced.filter((_, index) => !suppressedIndexes.has(index));
 }
 
 function assistantGroupHasReplyText(group: MessageGroup): boolean {

--- a/ui/src/pages/config/config-page.test.ts
+++ b/ui/src/pages/config/config-page.test.ts
@@ -52,6 +52,56 @@ describe("ConfigPage local user identity", () => {
     expect(state.userAvatar).toBe("🦞");
     expect(loadLocalUserIdentity()).toEqual({ name: "Buns", avatar: "🦞" });
   });
+
+  it("surfaces a visible error instead of silently dropping the avatar when persistence fails", () => {
+    localStorageMock.setItem(
+      "openclaw.control.user.v1",
+      JSON.stringify({ name: "Buns", avatar: "old" }),
+    );
+    const page = new ConfigPage();
+    const state = page as unknown as {
+      userAvatar: string | null;
+      userAvatarError: string | null;
+      setLocalUserAvatar: (avatar: string | null) => void;
+    };
+
+    // Simulate a storage write failure (quota / security restriction).
+    vi.spyOn(localStorageMock, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+
+    state.setLocalUserAvatar("🦞");
+
+    // The failure must not be swallowed: an error is recorded and the in-memory
+    // avatar keeps its prior value rather than pretending the save succeeded.
+    expect(state.userAvatarError).toBe("QuotaExceededError");
+    expect(state.userAvatar).toBe("old");
+    expect(loadLocalUserIdentity()).toEqual({ name: "Buns", avatar: "old" });
+  });
+
+  it("clears the avatar error after a successful save", () => {
+    localStorageMock.setItem(
+      "openclaw.control.user.v1",
+      JSON.stringify({ name: "Buns", avatar: "old" }),
+    );
+    const page = new ConfigPage();
+    const state = page as unknown as {
+      userAvatar: string | null;
+      userAvatarError: string | null;
+      setLocalUserAvatar: (avatar: string | null) => void;
+    };
+
+    vi.spyOn(localStorageMock, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+    state.setLocalUserAvatar("🦞");
+    expect(state.userAvatarError).toBe("QuotaExceededError");
+
+    vi.spyOn(localStorageMock, "setItem").mockRestore();
+    state.setLocalUserAvatar("🐱");
+    expect(state.userAvatarError).toBeNull();
+    expect(state.userAvatar).toBe("🐱");
+  });
 });
 
 describe("configSelectionFromSearch", () => {

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -21,6 +21,7 @@ import {
   normalizeChatSendShortcut,
   patchSettings,
   saveLocalUserIdentity,
+  type LocalUserIdentity,
   type UiSettings,
 } from "../../app/settings.ts";
 import { startThemeTransition } from "../../app/theme-transition.ts";
@@ -243,6 +244,7 @@ export class ConfigPage extends OpenClawLightDomElement {
 
   @state() private settings = loadSettings();
   @state() private userAvatar: string | null = loadLocalUserIdentity().avatar;
+  @state() private userAvatarError: string | null = null;
   @state() private settingsMode: "quick" | "advanced" = "quick";
   @state() private systemInfo: SystemInfoResult | null = null;
   @state() private systemInfoUnavailable = false;
@@ -329,11 +331,23 @@ export class ConfigPage extends OpenClawLightDomElement {
   }
 
   private setLocalUserAvatar(avatar: string | null) {
-    const identity = saveLocalUserIdentity({
-      ...loadLocalUserIdentity(),
-      avatar,
-    });
+    let identity: LocalUserIdentity;
+    try {
+      identity = saveLocalUserIdentity({
+        ...loadLocalUserIdentity(),
+        avatar,
+      });
+    } catch (error) {
+      // Persistence failures (e.g. storage quota or security restrictions)
+      // must not be swallowed: surface them and keep the prior avatar so the
+      // UI does not claim a save that did not happen. The reporter saw the
+      // avatar silently fail to appear after reload with no error (#110662).
+      this.userAvatarError = error instanceof Error ? error.message : "Failed to save user avatar";
+      this.requestUpdate();
+      return;
+    }
     this.userAvatar = identity.avatar;
+    this.userAvatarError = null;
   }
 
   override disconnectedCallback() {
@@ -945,6 +959,7 @@ export class ConfigPage extends OpenClawLightDomElement {
       assistantAvatarReason: appConfig.assistantIdentity.avatarReason,
       assistantAvatarOverride: null,
       userAvatar: this.userAvatar,
+      userAvatarError: this.userAvatarError,
       onUserAvatarChange: (avatar) => this.setLocalUserAvatar(avatar),
       basePath: this.context.basePath,
     });

--- a/ui/src/pages/config/quick.ts
+++ b/ui/src/pages/config/quick.ts
@@ -124,6 +124,7 @@ type QuickSettingsProps = {
   lobsterPetSounds: boolean;
   setLobsterPetSounds: (enabled: boolean) => void;
   userAvatar?: string | null;
+  userAvatarError?: string | null;
   onUserAvatarChange?: (next: string | null) => void;
 
   // Config staging state (quick edits auto-save through the shared draft)
@@ -987,6 +988,11 @@ function renderPersonalSection(props: QuickSettingsProps) {
             <div class="config-identity__hint muted">
               ${t("quickSettings.personal.browserOnly")}
             </div>
+            ${props.userAvatarError
+              ? html`<div class="config-identity__error" role="alert">
+                  ${props.userAvatarError}
+                </div>`
+              : nothing}
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary

Messages from clients that send `thinking="adaptive"` as a transport default (e.g. the Apple Watch client) were rejected with `Thinking level "adaptive" is not supported for <provider>/<model>`, while the same message from the paired iOS app (which sends no override) succeeded.

`adaptive` is the **auto sentinel** — `normalizeThinkLevel` maps `"auto"` -> `"adaptive"`. It means *"pick an appropriate level"*, not *"force this exact level"*. So when a model does not support `adaptive`, the correct behavior is to fall back to a supported level, not hard-error.

## Fix

In `runPreparedReply` (`src/auto-reply/reply/get-reply-run.ts`), the unsupported-thinking-level guard no longer treats an `adaptive` resolved level as an explicit hard-error case. The auto sentinel now always flows into the existing `resolveSupportedThinkingLevel` fallback. Explicit **concrete** levels (e.g. a real `/think xhigh` or a one-turn `xhigh` override) still hard-error exactly as before.

## Testing

- New regression test in `get-reply-run.media-only.test.ts`: an unsupported `adaptive` override falls back and runs the agent instead of erroring.
- Existing test `reports unsupported explicit one-turn thinking overrides` (concrete `xhigh`) still passes — explicit concrete levels remain hard errors.
- `vitest run --pool forks src/auto-reply/reply/get-reply-run.media-only.test.ts` -> **101/101 pass**; oxlint 0/0; oxfmt clean.

Closes #109351