### PR TITLE
feat(chat-ui): inline diffs for edit and write tool rows

### DIFF
--- a/apps/.i18n/apple-translation-contradictions.json
+++ b/apps/.i18n/apple-translation-contradictions.json
@@ -1210,6 +1210,70 @@
       ]
     },
     {
+      "locale": "id",
+      "source": "Collapsed",
+      "translations": [
+        "Ciut",
+        "Diciutkan"
+      ]
+    },
+    {
+      "locale": "ja-JP",
+      "source": "Collapsed",
+      "translations": [
+        "折りたたみ",
+        "折りたたみ済み"
+      ]
+    },
+    {
+      "locale": "ko",
+      "source": "Collapsed",
+      "translations": [
+        "접힘",
+        "축소됨"
+      ]
+    },
+    {
+      "locale": "sv",
+      "source": "Collapsed",
+      "translations": [
+        "Ihopfälld",
+        "Komprimerad"
+      ]
+    },
+    {
+      "locale": "th",
+      "source": "Collapsed",
+      "translations": [
+        "ยุบอยู่",
+        "ยุบแล้ว"
+      ]
+    },
+    {
+      "locale": "tr",
+      "source": "Collapsed",
+      "translations": [
+        "Daraltıldı",
+        "Daraltılmış"
+      ]
+    },
+    {
+      "locale": "vi",
+      "source": "Collapsed",
+      "translations": [
+        "Thu gọn",
+        "Đã thu gọn"
+      ]
+    },
+    {
+      "locale": "zh-CN",
+      "source": "Collapsed",
+      "translations": [
+        "已折叠",
+        "已收起"
+      ]
+    },
+    {
       "locale": "zh-TW",
       "source": "Command",
       "translations": [

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -38362,30 +38362,6 @@
       "id": "native.apple.065f4da5ddaf14a1"
     },
     {
-      "kind": "ui-call",
-      "line": 221,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift",
-      "source": "+\\(stat.added)",
-      "surface": "apple",
-      "id": "native.apple.6a40eab4ba296b77"
-    },
-    {
-      "kind": "ui-call",
-      "line": 225,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift",
-      "source": "−\\(stat.removed)",
-      "surface": "apple",
-      "id": "native.apple.e1fea5bf84fcbe90"
-    },
-    {
-      "kind": "ui-call",
-      "line": 257,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift",
-      "source": "\\(lineNo)",
-      "surface": "apple",
-      "id": "native.apple.e37561f1fb3469c3"
-    },
-    {
       "kind": "conditional-branch",
       "line": 1347,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTranscriptCache.swift",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -38362,6 +38362,14 @@
       "id": "native.apple.065f4da5ddaf14a1"
     },
     {
+      "kind": "ui-call",
+      "line": 256,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift",
+      "source": "Collapsed",
+      "surface": "apple",
+      "id": "native.apple.f80bb83a659d23f4"
+    },
+    {
       "kind": "conditional-branch",
       "line": 1347,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTranscriptCache.swift",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -37187,7 +37187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 553,
+      "line": 554,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Voice note",
       "surface": "apple",
@@ -37195,7 +37195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 598,
+      "line": 599,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Writing",
       "surface": "apple",
@@ -37203,7 +37203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 624,
+      "line": 625,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Preparing audio…",
       "surface": "apple",
@@ -37211,7 +37211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 627,
+      "line": 628,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Speaking…",
       "surface": "apple",
@@ -37219,7 +37219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 635,
+      "line": 636,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Preparing audio, tap to cancel",
       "surface": "apple",
@@ -37227,7 +37227,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 636,
+      "line": 637,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Speaking, tap to stop",
       "surface": "apple",
@@ -38323,7 +38323,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 76,
+      "line": 80,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift",
       "source": "Running",
       "surface": "apple",
@@ -38331,7 +38331,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 109,
+      "line": 129,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift",
       "source": "Collapse tool result",
       "surface": "apple",
@@ -38339,7 +38339,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 109,
+      "line": 129,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift",
       "source": "Expand tool result",
       "surface": "apple",
@@ -38347,7 +38347,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 130,
+      "line": 165,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift",
       "source": "Show less",
       "surface": "apple",
@@ -38355,11 +38355,35 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 132,
+      "line": 167,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift",
       "source": "Show all %lld lines",
       "surface": "apple",
       "id": "native.apple.065f4da5ddaf14a1"
+    },
+    {
+      "kind": "ui-call",
+      "line": 221,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift",
+      "source": "+\\(stat.added)",
+      "surface": "apple",
+      "id": "native.apple.6a40eab4ba296b77"
+    },
+    {
+      "kind": "ui-call",
+      "line": 225,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift",
+      "source": "−\\(stat.removed)",
+      "surface": "apple",
+      "id": "native.apple.e1fea5bf84fcbe90"
+    },
+    {
+      "kind": "ui-call",
+      "line": 257,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift",
+      "source": "\\(lineNo)",
+      "surface": "apple",
+      "id": "native.apple.e37561f1fb3469c3"
     },
     {
       "kind": "conditional-branch",
@@ -38451,7 +38475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1080,
+      "line": 1083,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Copy Message",
       "surface": "apple",
@@ -38459,7 +38483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1103,
+      "line": 1106,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Open Full Message",
       "surface": "apple",
@@ -38467,7 +38491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1122,
+      "line": 1125,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Rewind to Here",
       "surface": "apple",
@@ -38475,7 +38499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1142,
+      "line": 1145,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Fork from Here",
       "surface": "apple",
@@ -38483,7 +38507,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1170,
+      "line": 1173,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Reply",
       "surface": "apple",
@@ -38491,7 +38515,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1180,
+      "line": 1183,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "You",
       "surface": "apple",
@@ -38499,7 +38523,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1182,
+      "line": 1185,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Assistant",
       "surface": "apple",
@@ -38507,7 +38531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1248,
+      "line": 1251,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Loading chat",
       "surface": "apple",
@@ -38515,7 +38539,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1328,
+      "line": 1331,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Dismiss",
       "surface": "apple",

--- a/apps/.i18n/native/ar.json
+++ b/apps/.i18n/native/ar.json
@@ -23979,6 +23979,11 @@
       "translated": "عرض جميع الأسطر البالغ عددها %lld"
     },
     {
+      "id": "native.apple.f80bb83a659d23f4",
+      "source": "Collapsed",
+      "translated": "مطوي"
+    },
+    {
       "id": "native.apple.c4e808a2ec8d49f5",
       "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
       "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"

--- a/apps/.i18n/native/de.json
+++ b/apps/.i18n/native/de.json
@@ -23979,6 +23979,11 @@
       "translated": "Alle %lld Zeilen anzeigen"
     },
     {
+      "id": "native.apple.f80bb83a659d23f4",
+      "source": "Collapsed",
+      "translated": "Eingeklappt"
+    },
+    {
       "id": "native.apple.c4e808a2ec8d49f5",
       "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
       "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"

--- a/apps/.i18n/native/es.json
+++ b/apps/.i18n/native/es.json
@@ -23979,6 +23979,11 @@
       "translated": "Mostrar las %lld líneas"
     },
     {
+      "id": "native.apple.f80bb83a659d23f4",
+      "source": "Collapsed",
+      "translated": "Contraído"
+    },
+    {
       "id": "native.apple.c4e808a2ec8d49f5",
       "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
       "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"

--- a/apps/.i18n/native/fa.json
+++ b/apps/.i18n/native/fa.json
@@ -23979,6 +23979,11 @@
       "translated": "نمایش همه %lld خط"
     },
     {
+      "id": "native.apple.f80bb83a659d23f4",
+      "source": "Collapsed",
+      "translated": "جمع‌شده"
+    },
+    {
       "id": "native.apple.c4e808a2ec8d49f5",
       "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
       "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"

--- a/apps/.i18n/native/fr.json
+++ b/apps/.i18n/native/fr.json
@@ -23979,6 +23979,11 @@
       "translated": "Afficher les %lld lignes"
     },
     {
+      "id": "native.apple.f80bb83a659d23f4",
+      "source": "Collapsed",
+      "translated": "Réduit"
+    },
+    {
       "id": "native.apple.c4e808a2ec8d49f5",
       "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
       "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"

--- a/apps/.i18n/native/hi.json
+++ b/apps/.i18n/native/hi.json
@@ -23979,6 +23979,11 @@
       "translated": "सभी %lld पंक्तियाँ दिखाएँ"
     },
     {
+      "id": "native.apple.f80bb83a659d23f4",
+      "source": "Collapsed",
+      "translated": "संक्षिप्त"
+    },
+    {
       "id": "native.apple.c4e808a2ec8d49f5",
       "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
       "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"

--- a/apps/.i18n/native/id.json
+++ b/apps/.i18n/native/id.json
@@ -23979,6 +23979,11 @@
       "translated": "Tampilkan semua %lld baris"
     },
     {
+      "id": "native.apple.f80bb83a659d23f4",
+      "source": "Collapsed",
+      "translated": "Diciutkan"
+    },
+    {
       "id": "native.apple.c4e808a2ec8d49f5",
       "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
       "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"

--- a/apps/.i18n/native/it.json
+++ b/apps/.i18n/native/it.json
@@ -23979,6 +23979,11 @@
       "translated": "Mostra tutte le %lld righe"
     },
     {
+      "id": "native.apple.f80bb83a659d23f4",
+      "source": "Collapsed",
+      "translated": "Compresso"
+    },
+    {
       "id": "native.apple.c4e808a2ec8d49f5",
       "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
       "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"

--- a/apps/.i18n/native/ja-JP.json
+++ b/apps/.i18n/native/ja-JP.json
@@ -23979,6 +23979,11 @@
       "translated": "%lld 行すべてを表示"
     },
     {
+      "id": "native.apple.f80bb83a659d23f4",
+      "source": "Collapsed",
+      "translated": "折りたたみ済み"
+    },
+    {
       "id": "native.apple.c4e808a2ec8d49f5",
       "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
       "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -23979,6 +23979,11 @@
       "translated": "%lld줄 모두 보기"
     },
     {
+      "id": "native.apple.f80bb83a659d23f4",
+      "source": "Collapsed",
+      "translated": "축소됨"
+    },
+    {
       "id": "native.apple.c4e808a2ec8d49f5",
       "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
       "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"

--- a/apps/.i18n/native/nl.json
+++ b/apps/.i18n/native/nl.json
@@ -23979,6 +23979,11 @@
       "translated": "Alle %lld regels weergeven"
     },
     {
+      "id": "native.apple.f80bb83a659d23f4",
+      "source": "Collapsed",
+      "translated": "Ingeklapt"
+    },
+    {
       "id": "native.apple.c4e808a2ec8d49f5",
       "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
       "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"

--- a/apps/.i18n/native/pl.json
+++ b/apps/.i18n/native/pl.json
@@ -23979,6 +23979,11 @@
       "translated": "Pokaż wszystkie wiersze (%lld)"
     },
     {
+      "id": "native.apple.f80bb83a659d23f4",
+      "source": "Collapsed",
+      "translated": "Zwinięte"
+    },
+    {
       "id": "native.apple.c4e808a2ec8d49f5",
       "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
       "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"

--- a/apps/.i18n/native/pt-BR.json
+++ b/apps/.i18n/native/pt-BR.json
@@ -23979,6 +23979,11 @@
       "translated": "Mostrar todas as %lld linhas"
     },
     {
+      "id": "native.apple.f80bb83a659d23f4",
+      "source": "Collapsed",
+      "translated": "Recolhido"
+    },
+    {
       "id": "native.apple.c4e808a2ec8d49f5",
       "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
       "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"

--- a/apps/.i18n/native/ru.json
+++ b/apps/.i18n/native/ru.json
@@ -23979,6 +23979,11 @@
       "translated": "Показать все %lld строк"
     },
     {
+      "id": "native.apple.f80bb83a659d23f4",
+      "source": "Collapsed",
+      "translated": "Свернуто"
+    },
+    {
       "id": "native.apple.c4e808a2ec8d49f5",
       "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
       "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"

--- a/apps/.i18n/native/sv.json
+++ b/apps/.i18n/native/sv.json
@@ -23979,6 +23979,11 @@
       "translated": "Visa alla %lld rader"
     },
     {
+      "id": "native.apple.f80bb83a659d23f4",
+      "source": "Collapsed",
+      "translated": "Komprimerad"
+    },
+    {
       "id": "native.apple.c4e808a2ec8d49f5",
       "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
       "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -23979,6 +23979,11 @@
       "translated": "แสดงทั้งหมด %lld บรรทัด"
     },
     {
+      "id": "native.apple.f80bb83a659d23f4",
+      "source": "Collapsed",
+      "translated": "ยุบแล้ว"
+    },
+    {
       "id": "native.apple.c4e808a2ec8d49f5",
       "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
       "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"

--- a/apps/.i18n/native/tr.json
+++ b/apps/.i18n/native/tr.json
@@ -23979,6 +23979,11 @@
       "translated": "%lld satırın tümünü göster"
     },
     {
+      "id": "native.apple.f80bb83a659d23f4",
+      "source": "Collapsed",
+      "translated": "Daraltıldı"
+    },
+    {
       "id": "native.apple.c4e808a2ec8d49f5",
       "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
       "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"

--- a/apps/.i18n/native/uk.json
+++ b/apps/.i18n/native/uk.json
@@ -23979,6 +23979,11 @@
       "translated": "Показати всі %lld рядків"
     },
     {
+      "id": "native.apple.f80bb83a659d23f4",
+      "source": "Collapsed",
+      "translated": "Згорнуто"
+    },
+    {
       "id": "native.apple.c4e808a2ec8d49f5",
       "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
       "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"

--- a/apps/.i18n/native/vi.json
+++ b/apps/.i18n/native/vi.json
@@ -23979,6 +23979,11 @@
       "translated": "Hiển thị tất cả %lld dòng"
     },
     {
+      "id": "native.apple.f80bb83a659d23f4",
+      "source": "Collapsed",
+      "translated": "Đã thu gọn"
+    },
+    {
       "id": "native.apple.c4e808a2ec8d49f5",
       "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
       "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"

--- a/apps/.i18n/native/zh-CN.json
+++ b/apps/.i18n/native/zh-CN.json
@@ -23979,6 +23979,11 @@
       "translated": "显示全部 %lld 行"
     },
     {
+      "id": "native.apple.f80bb83a659d23f4",
+      "source": "Collapsed",
+      "translated": "已折叠"
+    },
+    {
       "id": "native.apple.c4e808a2ec8d49f5",
       "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
       "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"

--- a/apps/.i18n/native/zh-TW.json
+++ b/apps/.i18n/native/zh-TW.json
@@ -23979,6 +23979,11 @@
       "translated": "顯示全部 %lld 行"
     },
     {
+      "id": "native.apple.f80bb83a659d23f4",
+      "source": "Collapsed",
+      "translated": "已收合"
+    },
+    {
       "id": "native.apple.c4e808a2ec8d49f5",
       "source": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3",
       "translated": "INSERT INTO cached_transcripts(gateway_id, session_key, agent_id, payload, updated_at)\nSELECT gateway_id, session_key, agent_id, payload, updated_at\nFROM cached_transcripts_pre_v3"

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
@@ -393,6 +393,7 @@ private struct ChatMessageBody: View {
                 id: self.message.content.first?.id ?? "result-0",
                 name: self.message.toolName,
                 arguments: nil,
+                details: self.message.details,
                 resultText: self.primaryText,
                 isPending: false)]
         }
@@ -810,6 +811,7 @@ struct ChatPendingToolsBubble: View {
                 id: call.id,
                 name: call.name,
                 arguments: call.args,
+                details: nil,
                 resultText: nil,
                 isPending: true)
         }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModels.swift
@@ -124,6 +124,7 @@ public struct OpenClawChatMessageContent: Codable, Hashable, Sendable {
     public let id: String?
     public let name: String?
     public let arguments: AnyCodable?
+    public let details: AnyCodable?
 
     public init(
         type: String?,
@@ -137,7 +138,8 @@ public struct OpenClawChatMessageContent: Codable, Hashable, Sendable {
         preview: OpenClawChatCanvasPreview? = nil,
         id: String? = nil,
         name: String? = nil,
-        arguments: AnyCodable? = nil)
+        arguments: AnyCodable? = nil,
+        details: AnyCodable? = nil)
     {
         self.type = type
         self.text = text
@@ -151,6 +153,7 @@ public struct OpenClawChatMessageContent: Codable, Hashable, Sendable {
         self.id = id
         self.name = name
         self.arguments = arguments
+        self.details = details
     }
 
     enum CodingKeys: String, CodingKey {
@@ -166,6 +169,7 @@ public struct OpenClawChatMessageContent: Codable, Hashable, Sendable {
         case id
         case name
         case arguments
+        case details
     }
 
     public init(from decoder: Decoder) throws {
@@ -180,6 +184,7 @@ public struct OpenClawChatMessageContent: Codable, Hashable, Sendable {
         self.id = try container.decodeIfPresent(String.self, forKey: .id)
         self.name = try container.decodeIfPresent(String.self, forKey: .name)
         self.arguments = try container.decodeIfPresent(AnyCodable.self, forKey: .arguments)
+        self.details = try container.decodeIfPresent(AnyCodable.self, forKey: .details)
         self.preview = try container.decodeIfPresent(OpenClawChatCanvasPreview.self, forKey: .preview)
 
         if let any = try container.decodeIfPresent(AnyCodable.self, forKey: .content) {
@@ -237,6 +242,7 @@ public struct OpenClawChatMessage: Codable, Hashable, Identifiable, Sendable {
     public let usage: OpenClawChatUsage?
     public let stopReason: String?
     public let errorMessage: String?
+    public let details: AnyCodable?
 
     enum CodingKeys: String, CodingKey {
         case role
@@ -251,6 +257,7 @@ public struct OpenClawChatMessage: Codable, Hashable, Identifiable, Sendable {
         case usage
         case stopReason
         case errorMessage
+        case details
         case mediaPath = "MediaPath"
         case mediaPaths = "MediaPaths"
         case mediaType = "MediaType"
@@ -269,7 +276,8 @@ public struct OpenClawChatMessage: Codable, Hashable, Identifiable, Sendable {
         toolName: String? = nil,
         usage: OpenClawChatUsage? = nil,
         stopReason: String? = nil,
-        errorMessage: String? = nil)
+        errorMessage: String? = nil,
+        details: AnyCodable? = nil)
     {
         self.id = id
         self.transcriptMessageID = transcriptMessageID
@@ -283,6 +291,7 @@ public struct OpenClawChatMessage: Codable, Hashable, Identifiable, Sendable {
         self.usage = usage
         self.stopReason = stopReason
         self.errorMessage = errorMessage
+        self.details = details
     }
 
     public init(from decoder: Decoder) throws {
@@ -301,6 +310,7 @@ public struct OpenClawChatMessage: Codable, Hashable, Identifiable, Sendable {
         let decodedUsage = try container.decodeIfPresent(OpenClawChatUsage.self, forKey: .usage)
         let decodedStopReason = try container.decodeIfPresent(String.self, forKey: .stopReason)
         let decodedErrorMessage = try container.decodeIfPresent(String.self, forKey: .errorMessage)
+        let decodedDetails = try container.decodeIfPresent(AnyCodable.self, forKey: .details)
 
         self.role = decodedRole
         self.transcriptMessageID = decodedOpenClaw?.id
@@ -311,6 +321,7 @@ public struct OpenClawChatMessage: Codable, Hashable, Identifiable, Sendable {
         self.usage = decodedUsage
         self.stopReason = decodedStopReason
         self.errorMessage = decodedErrorMessage
+        self.details = decodedDetails
 
         let decodedContent: [OpenClawChatMessageContent] = if let decoded = try? container.decode(
             [OpenClawChatMessageContent].self,
@@ -420,6 +431,7 @@ public struct OpenClawChatMessage: Codable, Hashable, Identifiable, Sendable {
         try container.encodeIfPresent(self.usage, forKey: .usage)
         try container.encodeIfPresent(self.stopReason, forKey: .stopReason)
         try container.encodeIfPresent(self.errorMessage, forKey: .errorMessage)
+        try container.encodeIfPresent(self.details, forKey: .details)
         try container.encode(self.content, forKey: .content)
     }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTheme.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTheme.swift
@@ -135,6 +135,14 @@ enum OpenClawChatTheme {
         #endif
     }
 
+    static var success: Color {
+        #if os(macOS)
+        Color(nsColor: .systemGreen)
+        #else
+        Color(uiColor: .systemGreen)
+        #endif
+    }
+
     static var assistantBubble: Color {
         #if os(macOS)
         Color(nsColor: self.assistantBubbleDynamicNSColor)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift
@@ -251,6 +251,9 @@ struct ChatToolActivityRow: View {
                 .foregroundStyle(.secondary.opacity(0.6))
                 .frame(maxWidth: .infinity, alignment: .center)
                 .padding(.vertical, 2)
+                // Reuses the existing localized "Collapsed" key so omitted
+                // preview rows stay announced to assistive tech.
+                .accessibilityLabel(Text("Collapsed"))
         } else {
             HStack(spacing: 6) {
                 if let lineNo = line.lineNo {
@@ -259,7 +262,9 @@ struct ChatToolActivityRow: View {
                         .foregroundStyle(.secondary.opacity(0.6))
                         .frame(minWidth: 34, alignment: .trailing)
                 }
-                Text(line.text)
+                // Bound per-line render work; generated/minified payloads can put
+                // megabytes on a single line.
+                Text(verbatim: String(line.text.unicodeScalars.prefix(2000)))
                     .font(OpenClawChatTypography.mono(size: 12, relativeTo: .footnote))
                     .foregroundStyle(self.diffTextColor(line.kind))
                     .lineLimit(1)
@@ -267,6 +272,21 @@ struct ChatToolActivityRow: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
             .background(self.diffBackground(line.kind))
+            // Color alone must not carry add/del semantics for assistive tech.
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(Text(verbatim: Self
+                    .accessibilityMarker(line.kind) + String(line.text.unicodeScalars.prefix(2000))))
+        }
+    }
+
+    private static func accessibilityMarker(_ kind: ChatToolDiffLineKind) -> String {
+        switch kind {
+        case .add:
+            "+ "
+        case .del:
+            "\u{2212} "
+        case .ctx, .skip:
+            ""
         }
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift
@@ -220,11 +220,11 @@ struct ChatToolActivityRow: View {
             if let stat = self.resolvedDiff?.stat {
                 Text(verbatim: "+\(stat.added)")
                     .font(OpenClawChatTypography.mono(size: 12, relativeTo: .footnote))
-                    .foregroundStyle(Color.green.opacity(0.9))
+                    .foregroundStyle(OpenClawChatTheme.success.opacity(0.9))
                     .lineLimit(1)
                 Text(verbatim: "−\(stat.removed)")
                     .font(OpenClawChatTypography.mono(size: 12, relativeTo: .footnote))
-                    .foregroundStyle(Color.red.opacity(0.9))
+                    .foregroundStyle(OpenClawChatTheme.danger.opacity(0.9))
                     .lineLimit(1)
             }
 
@@ -282,9 +282,9 @@ struct ChatToolActivityRow: View {
     private func diffBackground(_ kind: ChatToolDiffLineKind) -> Color {
         switch kind {
         case .add:
-            Color.green.opacity(0.14)
+            OpenClawChatTheme.success.opacity(0.14)
         case .del:
-            Color.red.opacity(0.12)
+            OpenClawChatTheme.danger.opacity(0.12)
         case .ctx, .skip:
             .clear
         }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift
@@ -218,11 +218,11 @@ struct ChatToolActivityRow: View {
             }
 
             if let stat = self.resolvedDiff?.stat {
-                Text("+\(stat.added)")
+                Text(verbatim: "+\(stat.added)")
                     .font(OpenClawChatTypography.mono(size: 12, relativeTo: .footnote))
                     .foregroundStyle(Color.green.opacity(0.9))
                     .lineLimit(1)
-                Text("−\(stat.removed)")
+                Text(verbatim: "−\(stat.removed)")
                     .font(OpenClawChatTypography.mono(size: 12, relativeTo: .footnote))
                     .foregroundStyle(Color.red.opacity(0.9))
                     .lineLimit(1)
@@ -254,7 +254,7 @@ struct ChatToolActivityRow: View {
         } else {
             HStack(spacing: 6) {
                 if let lineNo = line.lineNo {
-                    Text("\(lineNo)")
+                    Text(verbatim: "\(lineNo)")
                         .font(OpenClawChatTypography.mono(size: 10, relativeTo: .caption2))
                         .foregroundStyle(.secondary.opacity(0.6))
                         .frame(minWidth: 34, alignment: .trailing)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift
@@ -274,9 +274,13 @@ struct ChatToolActivityRow: View {
             .background(self.diffBackground(line.kind))
             // Color alone must not carry add/del semantics for assistive tech.
             .accessibilityElement(children: .ignore)
-            .accessibilityLabel(Text(verbatim: Self
-                    .accessibilityMarker(line.kind) + String(line.text.unicodeScalars.prefix(2000))))
+            .accessibilityLabel(Text(verbatim: Self.accessibilityText(for: line)))
         }
+    }
+
+    private static func accessibilityText(for line: ChatToolDiffLine) -> String {
+        let lineNo = line.lineNo.map { "\($0) " } ?? ""
+        return lineNo + self.accessibilityMarker(line.kind) + String(line.text.unicodeScalars.prefix(2000))
     }
 
     private static func accessibilityMarker(_ kind: ChatToolDiffLineKind) -> String {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift
@@ -9,6 +9,7 @@ struct ChatToolActivityItem: Identifiable, Equatable {
     let id: String
     let name: String?
     let arguments: AnyCodable?
+    let details: AnyCodable?
     let resultText: String?
     let isPending: Bool
 }
@@ -29,6 +30,7 @@ enum ChatToolActivity {
                 id: call.id ?? "call-\(index)",
                 name: call.name,
                 arguments: call.arguments,
+                details: result?.details,
                 resultText: result?.text,
                 isPending: false)
         }
@@ -38,6 +40,7 @@ enum ChatToolActivity {
                 id: result.id ?? "result-\(index)",
                 name: result.name,
                 arguments: nil,
+                details: result.details,
                 resultText: result.text,
                 isPending: false)
         })
@@ -47,6 +50,7 @@ enum ChatToolActivity {
 
 struct ChatToolActivityRow: View {
     let item: ChatToolActivityItem
+    private let resolvedDiff: (lines: [ChatToolDiffLine], stat: ChatToolDiffStat?)?
     @State private var expanded = false
     @State private var showsFullResult = false
 
@@ -68,7 +72,7 @@ struct ChatToolActivityRow: View {
     }
 
     private var expandable: Bool {
-        !self.formattedResult.isEmpty
+        self.resolvedDiff != nil || !self.formattedResult.isEmpty
     }
 
     private var accessibilityValue: String {
@@ -77,18 +81,34 @@ struct ChatToolActivityRow: View {
         return self.detailLine.map { "\(running), \($0)" } ?? running
     }
 
-    private var resultLineCount: Int {
-        self.formattedResult.components(separatedBy: .newlines).count
+    private var expandedLineCount: Int {
+        self.resolvedDiff?.lines.count ?? self.formattedResult.components(separatedBy: .newlines).count
     }
 
     private var isResultTruncated: Bool {
-        self.resultLineCount > Self.expandedLineLimit
+        self.expandedLineCount > Self.expandedLineLimit
     }
 
     private var expandedResult: String {
         guard self.isResultTruncated, !self.showsFullResult else { return self.formattedResult }
         let lines = self.formattedResult.components(separatedBy: .newlines)
         return lines.prefix(Self.expandedLineLimit - 1).joined(separator: "\n") + "\n…"
+    }
+
+    private var expandedDiffLines: [ChatToolDiffLine] {
+        guard let lines = self.resolvedDiff?.lines else { return [] }
+        guard self.isResultTruncated, !self.showsFullResult else { return lines }
+        return Array(lines.prefix(Self.expandedLineLimit - 1)) + [
+            ChatToolDiffLine(kind: .skip, text: ""),
+        ]
+    }
+
+    init(item: ChatToolActivityItem) {
+        self.item = item
+        self.resolvedDiff = ChatToolDiff.resolveDiff(
+            name: item.name,
+            arguments: item.arguments,
+            details: item.details)
     }
 
     var body: some View {
@@ -116,10 +136,25 @@ struct ChatToolActivityRow: View {
 
             if self.expanded, self.expandable {
                 VStack(alignment: .leading, spacing: 6) {
-                    Text(self.expandedResult)
-                        .font(OpenClawChatTypography.mono(size: 12, relativeTo: .footnote))
-                        .foregroundStyle(.secondary)
-                        .textSelection(.enabled)
+                    if self.resolvedDiff != nil {
+                        self.diffRows
+                        // The result text carries the outcome (success summary or the
+                        // error diagnostic); hiding it would misrepresent failed edits
+                        // as applied changes. Bounded so foreign harness output cannot
+                        // dwarf the diff.
+                        if !self.formattedResult.isEmpty {
+                            Text(self.formattedResult)
+                                .font(OpenClawChatTypography.mono(size: 12, relativeTo: .footnote))
+                                .foregroundStyle(.secondary)
+                                .textSelection(.enabled)
+                                .lineLimit(Self.expandedLineLimit)
+                        }
+                    } else {
+                        Text(self.expandedResult)
+                            .font(OpenClawChatTypography.mono(size: 12, relativeTo: .footnote))
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                    }
 
                     if self.isResultTruncated {
                         Button {
@@ -130,7 +165,7 @@ struct ChatToolActivityRow: View {
                                     ? String(localized: "Show less")
                                     : String(
                                         format: String(localized: "Show all %lld lines"),
-                                        Int64(self.resultLineCount)))
+                                        Int64(self.expandedLineCount)))
                                 .font(OpenClawChatTypography.caption)
                                 .foregroundStyle(.secondary)
                         }
@@ -182,9 +217,77 @@ struct ChatToolActivityRow: View {
                     .truncationMode(.tail)
             }
 
+            if let stat = self.resolvedDiff?.stat {
+                Text("+\(stat.added)")
+                    .font(OpenClawChatTypography.mono(size: 12, relativeTo: .footnote))
+                    .foregroundStyle(Color.green.opacity(0.9))
+                    .lineLimit(1)
+                Text("−\(stat.removed)")
+                    .font(OpenClawChatTypography.mono(size: 12, relativeTo: .footnote))
+                    .foregroundStyle(Color.red.opacity(0.9))
+                    .lineLimit(1)
+            }
+
             Spacer(minLength: 0)
         }
         .padding(.vertical, 3)
+    }
+
+    private var diffRows: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(self.expandedDiffLines.indices, id: \.self) { index in
+                self.diffRow(self.expandedDiffLines[index])
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .textSelection(.enabled)
+    }
+
+    @ViewBuilder
+    private func diffRow(_ line: ChatToolDiffLine) -> some View {
+        if line.kind == .skip {
+            Text("⋯")
+                .font(OpenClawChatTypography.mono(size: 12, relativeTo: .footnote))
+                .foregroundStyle(.secondary.opacity(0.6))
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.vertical, 2)
+        } else {
+            HStack(spacing: 6) {
+                if let lineNo = line.lineNo {
+                    Text("\(lineNo)")
+                        .font(OpenClawChatTypography.mono(size: 10, relativeTo: .caption2))
+                        .foregroundStyle(.secondary.opacity(0.6))
+                        .frame(minWidth: 34, alignment: .trailing)
+                }
+                Text(line.text)
+                    .font(OpenClawChatTypography.mono(size: 12, relativeTo: .footnote))
+                    .foregroundStyle(self.diffTextColor(line.kind))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .background(self.diffBackground(line.kind))
+        }
+    }
+
+    private func diffTextColor(_ kind: ChatToolDiffLineKind) -> Color {
+        switch kind {
+        case .add:
+            OpenClawChatTheme.assistantText
+        case .del, .ctx, .skip:
+            .secondary
+        }
+    }
+
+    private func diffBackground(_ kind: ChatToolDiffLineKind) -> Color {
+        switch kind {
+        case .add:
+            Color.green.opacity(0.14)
+        case .del:
+            Color.red.opacity(0.12)
+        case .ctx, .skip:
+            .clear
+        }
     }
 
     private static func symbol(forToolName name: String?) -> String {
@@ -197,7 +300,9 @@ struct ChatToolActivityRow: View {
             "clock": "clock",
             "command": "terminal",
             "cron": "clock",
+            "create_file": "square.and.pencil",
             "edit": "pencil.line",
+            "edit_file": "pencil.line",
             "exec": "terminal",
             "fetch": "globe",
             "find": "magnifyingglass",
@@ -209,7 +314,13 @@ struct ChatToolActivityRow: View {
             "ls": "magnifyingglass",
             "memory": "brain",
             "message": "bubble.left",
+            "multi_edit": "pencil.line",
+            "multiedit": "pencil.line",
+            "notebook_edit": "pencil.line",
+            "notebookedit": "pencil.line",
             "node": "server.rack",
+            "apply_patch": "pencil.line",
+            "applypatch": "pencil.line",
             "patch": "pencil.line",
             "photo": "photo",
             "read": "doc.text",
@@ -223,6 +334,9 @@ struct ChatToolActivityRow: View {
             "terminal": "terminal",
             "web": "globe",
             "write": "square.and.pencil",
+            "write_file": "square.and.pencil",
+            "str_replace_based_edit_tool": "pencil.line",
+            "str_replace_editor": "pencil.line",
         ]
         if let symbol = exact[normalized] { return symbol }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolDiff.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolDiff.swift
@@ -39,6 +39,7 @@ enum ChatToolDiff {
     private static let maxInputLines = 600
     private static let maxRenderLines = 400
     private static let maxLocalPairs = 8
+    private static let maxWritePreviewLines = 80
     private static let maxLocalInputCharacters = 120_000
 
     private static let editToolNames: Set<String> = [
@@ -54,6 +55,7 @@ enum ChatToolDiff {
         "str_replace_based_edit_tool",
     ]
     private static let writeToolNames: Set<String> = ["write", "write_file", "create_file"]
+    private static let patchToolNames: Set<String> = ["apply_patch", "applypatch", "patch"]
 
     private static func parseDetailsDiffResult(_ diff: String) -> ParsedDetailsDiff? {
         guard !diff.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
@@ -162,16 +164,19 @@ enum ChatToolDiff {
             }
         }
 
-        if let detailsDiff = self.resolveDetailsDiff(details) {
-            return detailsDiff
-        }
-
-        guard let argumentsRecord else { return nil }
+        // Plugin tools own their details schema; only edit-family tools may
+        // interpret details.diff as a filesystem diff (mirrors the web guard).
         if self.editToolNames.contains(normalizedName) {
-            return self.resolveEditDiff(argumentsRecord, details: nil)
+            return self.resolveEditDiff(argumentsRecord, details: details)
         }
         if self.writeToolNames.contains(normalizedName) {
+            if let detailsDiff = self.resolveDetailsDiff(details) {
+                return detailsDiff
+            }
             return self.resolveWriteDiff(argumentsRecord, keys: ["content", "text", "file_text"])
+        }
+        if self.patchToolNames.contains(normalizedName) {
+            return self.resolveDetailsDiff(details)
         }
         return nil
     }
@@ -289,9 +294,22 @@ enum ChatToolDiff {
         keys: [String]) -> (lines: [ChatToolDiffLine], stat: ChatToolDiffStat?)?
     {
         guard let content = self.string(in: arguments, keys: keys) else { return nil }
-        let lines = self.computeLineDiff(old: "", new: content)
-        guard !lines.isEmpty else { return nil }
-        return (lines, ChatToolDiffStat(added: self.splitLines(content).count, removed: 0))
+        let allLines = self.splitLines(content)
+        guard !allLines.isEmpty else { return nil }
+        // Written content is fully known, so number additions from line 1 and
+        // keep the exact stat even when the rendered preview is clipped.
+        var lines: [ChatToolDiffLine] = []
+        var remainingCharacters = self.maxLocalInputCharacters
+        for (index, text) in allLines.prefix(self.maxWritePreviewLines).enumerated() {
+            let lineCharacters = text.utf16.count
+            guard lineCharacters <= remainingCharacters else { break }
+            remainingCharacters -= lineCharacters
+            lines.append(ChatToolDiffLine(kind: .add, lineNo: index + 1, text: text))
+        }
+        if lines.count < allLines.count {
+            lines.append(ChatToolDiffLine(kind: .skip, text: ""))
+        }
+        return (lines, ChatToolDiffStat(added: allLines.count, removed: 0))
     }
 
     private static func resolveEditDiff(

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolDiff.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolDiff.swift
@@ -1,0 +1,431 @@
+import Foundation
+import OpenClawKit
+
+enum ChatToolDiffLineKind: Equatable, Sendable {
+    case add
+    case del
+    case ctx
+    case skip
+}
+
+struct ChatToolDiffLine: Equatable, Sendable {
+    let kind: ChatToolDiffLineKind
+    let lineNo: Int?
+    let text: String
+
+    init(kind: ChatToolDiffLineKind, lineNo: Int? = nil, text: String) {
+        self.kind = kind
+        self.lineNo = lineNo
+        self.text = text
+    }
+}
+
+struct ChatToolDiffStat: Equatable, Sendable {
+    let added: Int
+    let removed: Int
+}
+
+enum ChatToolDiff {
+    private struct EditPair {
+        let oldText: String
+        let newText: String
+    }
+
+    private struct ParsedDetailsDiff {
+        let lines: [ChatToolDiffLine]
+        let truncated: Bool
+    }
+
+    private static let maxInputLines = 600
+    private static let maxRenderLines = 400
+    private static let maxLocalPairs = 8
+    private static let maxLocalInputCharacters = 120_000
+
+    private static let editToolNames: Set<String> = [
+        "edit",
+        "edit_file",
+        "multiedit",
+        "multi_edit",
+        "notebookedit",
+        "notebook_edit",
+    ]
+    private static let textEditorToolNames: Set<String> = [
+        "str_replace_editor",
+        "str_replace_based_edit_tool",
+    ]
+    private static let writeToolNames: Set<String> = ["write", "write_file", "create_file"]
+
+    static func parseDetailsDiff(_ diff: String) -> [ChatToolDiffLine]? {
+        self.parseDetailsDiffResult(diff)?.lines
+    }
+
+    private static func parseDetailsDiffResult(_ diff: String) -> ParsedDetailsDiff? {
+        guard !diff.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+
+        var lines: [ChatToolDiffLine] = []
+        var truncated = diff.components(separatedBy: "\n").contains { raw in
+            raw.trimmingCharacters(in: .whitespacesAndNewlines) == "...(truncated)..."
+        }
+        for raw in diff.components(separatedBy: "\n") {
+            guard !raw.isEmpty else { continue }
+            let marker = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            let line: ChatToolDiffLine
+            if marker == "..." || marker == "...(truncated)..." {
+                line = ChatToolDiffLine(kind: .skip, text: "")
+            } else {
+                guard let numberedLine = self.parseNumberedLine(raw) else { return nil }
+                line = numberedLine
+            }
+            if lines.count >= self.maxRenderLines {
+                truncated = true
+                if lines.last?.kind != .skip {
+                    lines.append(ChatToolDiffLine(kind: .skip, text: ""))
+                }
+                break
+            }
+            lines.append(line)
+        }
+
+        guard lines.contains(where: { $0.kind == .add || $0.kind == .del }) else { return nil }
+        return ParsedDetailsDiff(lines: lines, truncated: truncated)
+    }
+
+    static func computeLineDiff(old: String, new: String) -> [ChatToolDiffLine] {
+        let allOldLines = self.splitLines(old)
+        let allNewLines = self.splitLines(new)
+        let inputTruncated = allOldLines.count > self.maxInputLines || allNewLines.count > self.maxInputLines
+        let oldLines = Array(allOldLines.prefix(self.maxInputLines))
+        let newLines = Array(allNewLines.prefix(self.maxInputLines))
+        let oldCount = oldLines.count
+        let newCount = newLines.count
+        let width = newCount + 1
+        var lcs = Array(repeating: 0, count: (oldCount + 1) * width)
+
+        if oldCount > 0, newCount > 0 {
+            for oldIndex in stride(from: oldCount - 1, through: 0, by: -1) {
+                for newIndex in stride(from: newCount - 1, through: 0, by: -1) {
+                    let index = oldIndex * width + newIndex
+                    if oldLines[oldIndex] == newLines[newIndex] {
+                        lcs[index] = lcs[(oldIndex + 1) * width + newIndex + 1] + 1
+                    } else {
+                        lcs[index] = max(
+                            lcs[(oldIndex + 1) * width + newIndex],
+                            lcs[oldIndex * width + newIndex + 1])
+                    }
+                }
+            }
+        }
+
+        var lines: [ChatToolDiffLine] = []
+        var oldIndex = 0
+        var newIndex = 0
+        while oldIndex < oldCount, newIndex < newCount {
+            if oldLines[oldIndex] == newLines[newIndex] {
+                lines.append(ChatToolDiffLine(kind: .ctx, text: oldLines[oldIndex]))
+                oldIndex += 1
+                newIndex += 1
+            } else if lcs[(oldIndex + 1) * width + newIndex] >= lcs[oldIndex * width + newIndex + 1] {
+                lines.append(ChatToolDiffLine(kind: .del, text: oldLines[oldIndex]))
+                oldIndex += 1
+            } else {
+                lines.append(ChatToolDiffLine(kind: .add, text: newLines[newIndex]))
+                newIndex += 1
+            }
+        }
+        while oldIndex < oldCount {
+            lines.append(ChatToolDiffLine(kind: .del, text: oldLines[oldIndex]))
+            oldIndex += 1
+        }
+        while newIndex < newCount {
+            lines.append(ChatToolDiffLine(kind: .add, text: newLines[newIndex]))
+            newIndex += 1
+        }
+        return self.compact(lines, inputTruncated: inputTruncated)
+    }
+
+    static func resolveDiff(
+        name: String?,
+        arguments: AnyCodable?,
+        details: AnyCodable?) -> (lines: [ChatToolDiffLine], stat: ChatToolDiffStat?)?
+    {
+        let normalizedName = name?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+        let argumentsRecord = arguments?.dictionaryValue
+        if self.textEditorToolNames.contains(normalizedName) {
+            switch self.string(in: argumentsRecord, keys: ["command"])?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased()
+            {
+            case "create":
+                return self.resolveWriteDiff(
+                    argumentsRecord,
+                    keys: ["file_text", "content"])
+            case "insert":
+                return self.resolveInsertionDiff(argumentsRecord, details: details)
+            default:
+                return self.resolveEditDiff(argumentsRecord, details: details)
+            }
+        }
+
+        if let detailsDiff = self.resolveDetailsDiff(details) {
+            return detailsDiff
+        }
+
+        guard let argumentsRecord else { return nil }
+        if self.editToolNames.contains(normalizedName) {
+            return self.resolveEditDiff(argumentsRecord, details: nil)
+        }
+        if self.writeToolNames.contains(normalizedName) {
+            return self.resolveWriteDiff(argumentsRecord, keys: ["content", "text", "file_text"])
+        }
+        return nil
+    }
+
+    private static func parseNumberedLine(_ raw: String) -> ChatToolDiffLine? {
+        guard let sign = raw.first, sign == "+" || sign == "-" || sign == " " else { return nil }
+        var remainder = raw.dropFirst()
+        while remainder.first?.isWhitespace == true {
+            remainder = remainder.dropFirst()
+        }
+        let digits = remainder.prefix { character in
+            character >= "0" && character <= "9"
+        }
+        guard !digits.isEmpty, let lineNo = Int(digits) else { return nil }
+        remainder = remainder.dropFirst(digits.count)
+        if remainder.first == " " {
+            remainder = remainder.dropFirst()
+        }
+        let kind: ChatToolDiffLineKind = switch sign {
+        case "+": .add
+        case "-": .del
+        default: .ctx
+        }
+        return ChatToolDiffLine(kind: kind, lineNo: lineNo, text: String(remainder))
+    }
+
+    private static func splitLines(_ text: String) -> [String] {
+        let normalized = text
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+        guard !normalized.isEmpty else { return [] }
+        var lines = normalized.components(separatedBy: "\n")
+        if lines.count > 1, lines.last?.isEmpty == true {
+            lines.removeLast()
+        }
+        return lines
+    }
+
+    private static func compact(
+        _ lines: [ChatToolDiffLine],
+        inputTruncated: Bool) -> [ChatToolDiffLine]
+    {
+        if lines.count <= self.maxRenderLines, !inputTruncated {
+            return lines
+        }
+        let hasChange = lines.contains { $0.kind == .add || $0.kind == .del }
+        guard hasChange else {
+            return inputTruncated
+                ? [ChatToolDiffLine(kind: .skip, text: "")]
+                : Array(lines.prefix(self.maxRenderLines)) + [ChatToolDiffLine(kind: .skip, text: "")]
+        }
+
+        var keep = Array(repeating: false, count: lines.count)
+        for index in lines.indices where lines[index].kind == .add || lines[index].kind == .del {
+            let start = max(0, index - 3)
+            let end = min(lines.count, index + 4)
+            for contextIndex in start..<end {
+                keep[contextIndex] = true
+            }
+        }
+
+        var preview: [ChatToolDiffLine] = []
+        var gap = false
+        var clipped = inputTruncated
+        for index in lines.indices {
+            guard keep[index] else {
+                gap = true
+                clipped = true
+                continue
+            }
+            if gap, preview.last?.kind != .skip {
+                preview.append(ChatToolDiffLine(kind: .skip, text: ""))
+            }
+            gap = false
+            if preview.count >= self.maxRenderLines {
+                clipped = true
+                break
+            }
+            preview.append(lines[index])
+        }
+        if clipped, preview.last?.kind != .skip {
+            preview.append(ChatToolDiffLine(kind: .skip, text: ""))
+        }
+        return preview
+    }
+
+    private static func resolveDetailsDiff(
+        _ details: AnyCodable?) -> (lines: [ChatToolDiffLine], stat: ChatToolDiffStat?)?
+    {
+        guard let diff = details?.dictionaryValue?["diff"]?.stringValue,
+              !diff.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              let parsed = self.parseDetailsDiffResult(diff)
+        else {
+            return nil
+        }
+        // Only explicit truncation or the render cap makes a persisted stat incomplete.
+        return (parsed.lines, parsed.truncated ? nil : self.stat(for: parsed.lines))
+    }
+
+    private static func resolveInsertionDiff(
+        _ arguments: [String: AnyCodable]?,
+        details: AnyCodable?) -> (lines: [ChatToolDiffLine], stat: ChatToolDiffStat?)?
+    {
+        if let detailsDiff = self.resolveDetailsDiff(details) {
+            return detailsDiff
+        }
+        guard let insertText = self.string(in: arguments, keys: ["insert_text"]) else { return nil }
+        let lines = self.computeLineDiff(old: "", new: insertText)
+        // The inserted text is known, but its final placement is not, so keep the stat absent.
+        return lines.isEmpty ? nil : (lines, nil)
+    }
+
+    private static func resolveWriteDiff(
+        _ arguments: [String: AnyCodable]?,
+        keys: [String]) -> (lines: [ChatToolDiffLine], stat: ChatToolDiffStat?)?
+    {
+        guard let content = self.string(in: arguments, keys: keys) else { return nil }
+        let lines = self.computeLineDiff(old: "", new: content)
+        guard !lines.isEmpty else { return nil }
+        return (lines, ChatToolDiffStat(added: self.splitLines(content).count, removed: 0))
+    }
+
+    private static func resolveEditDiff(
+        _ arguments: [String: AnyCodable]?,
+        details: AnyCodable?) -> (lines: [ChatToolDiffLine], stat: ChatToolDiffStat?)?
+    {
+        // Persisted details are authoritative; args are a local fallback for live/foreign harnesses.
+        if let detailsDiff = self.resolveDetailsDiff(details) {
+            return detailsDiff
+        }
+        guard let arguments else { return nil }
+        let resolved = self.readEditPairs(arguments)
+        guard !resolved.pairs.isEmpty else {
+            return resolved.truncated
+                ? ([ChatToolDiffLine(kind: .skip, text: "")], nil)
+                : nil
+        }
+
+        let sections = resolved.pairs.map { pair in
+            self.computeLineDiff(old: pair.oldText, new: pair.newText)
+        }
+        let sectionTruncated = sections.contains { section in
+            section.contains(where: { $0.kind == .skip })
+        }
+        let joined = self.join(sections, truncated: resolved.truncated)
+        guard !joined.lines.isEmpty else { return nil }
+        let truncated = resolved.truncated || sectionTruncated || joined.truncated
+        let stat = truncated ? nil : sections.reduce(ChatToolDiffStat(added: 0, removed: 0)) { sum, section in
+            let sectionStat = self.stat(for: section)
+            return ChatToolDiffStat(
+                added: sum.added + sectionStat.added,
+                removed: sum.removed + sectionStat.removed)
+        }
+        return (joined.lines, stat)
+    }
+
+    private static func readEditPairs(
+        _ arguments: [String: AnyCodable]) -> (pairs: [EditPair], truncated: Bool)
+    {
+        var pairs: [EditPair] = []
+        var inputCharacters = 0
+        var truncated = false
+
+        func appendPair(oldValue: AnyCodable?, newValue: AnyCodable?) {
+            guard let oldText = oldValue?.stringValue, let newText = newValue?.stringValue else { return }
+            let pairCharacters = oldText.utf16.count + newText.utf16.count
+            guard pairCharacters <= self.maxLocalInputCharacters - inputCharacters else {
+                truncated = true
+                return
+            }
+            inputCharacters += pairCharacters
+            pairs.append(EditPair(oldText: oldText, newText: newText))
+        }
+
+        if let edits = arguments["edits"]?.arrayValue {
+            for (index, edit) in edits.enumerated() {
+                guard index < self.maxLocalPairs else {
+                    truncated = true
+                    break
+                }
+                guard let record = edit.dictionaryValue else { continue }
+                appendPair(
+                    oldValue: self.firstValue(in: record, keys: ["oldText", "old_string", "oldString", "old_str"]),
+                    newValue: self.firstValue(in: record, keys: ["newText", "new_string", "newString", "new_str"]))
+                if truncated { break }
+            }
+        } else {
+            appendPair(
+                oldValue: self.firstValue(
+                    in: arguments,
+                    keys: ["oldText", "old_string", "oldString", "old_str"]),
+                newValue: self.firstValue(
+                    in: arguments,
+                    keys: ["newText", "new_string", "newString", "new_str"]))
+        }
+        return (pairs, truncated)
+    }
+
+    private static func join(
+        _ sections: [[ChatToolDiffLine]],
+        truncated initialTruncated: Bool) -> (lines: [ChatToolDiffLine], truncated: Bool)
+    {
+        var joined: [ChatToolDiffLine] = []
+        var truncated = initialTruncated
+        for section in sections where !section.isEmpty {
+            if !joined.isEmpty {
+                guard joined.count < self.maxRenderLines else {
+                    truncated = true
+                    break
+                }
+                joined.append(ChatToolDiffLine(kind: .skip, text: ""))
+            }
+            let remaining = self.maxRenderLines - joined.count
+            guard section.count <= remaining else {
+                joined.append(contentsOf: section.prefix(remaining))
+                truncated = true
+                break
+            }
+            joined.append(contentsOf: section)
+        }
+        if truncated, joined.last?.kind != .skip {
+            joined.append(ChatToolDiffLine(kind: .skip, text: ""))
+        }
+        return (joined, truncated)
+    }
+
+    private static func stat(for lines: [ChatToolDiffLine]) -> ChatToolDiffStat {
+        lines.reduce(ChatToolDiffStat(added: 0, removed: 0)) { stat, line in
+            switch line.kind {
+            case .add:
+                ChatToolDiffStat(added: stat.added + 1, removed: stat.removed)
+            case .del:
+                ChatToolDiffStat(added: stat.added, removed: stat.removed + 1)
+            case .ctx, .skip:
+                stat
+            }
+        }
+    }
+
+    private static func string(in record: [String: AnyCodable]?, keys: [String]) -> String? {
+        guard let record else { return nil }
+        return self.firstValue(in: record, keys: keys)?.stringValue
+    }
+
+    private static func firstValue(in record: [String: AnyCodable], keys: [String]) -> AnyCodable? {
+        for key in keys {
+            if let value = record[key] {
+                return value
+            }
+        }
+        return nil
+    }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolDiff.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolDiff.swift
@@ -55,10 +55,6 @@ enum ChatToolDiff {
     ]
     private static let writeToolNames: Set<String> = ["write", "write_file", "create_file"]
 
-    static func parseDetailsDiff(_ diff: String) -> [ChatToolDiffLine]? {
-        self.parseDetailsDiffResult(diff)?.lines
-    }
-
     private static func parseDetailsDiffResult(_ diff: String) -> ParsedDetailsDiff? {
         guard !diff.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
@@ -948,6 +948,7 @@ extension OpenClawChatView {
             }
 
             var content = last.content
+            // Tool-result diff metadata arrives on the message, but the UI renders the merged block.
             content.append(
                 OpenClawChatMessageContent(
                     type: "tool_result",
@@ -959,7 +960,8 @@ extension OpenClawChatView {
                     content: nil,
                     id: toolCallId,
                     name: message.toolName,
-                    arguments: nil))
+                    arguments: nil,
+                    details: message.details))
 
             let merged = OpenClawChatMessage(
                 id: last.id,
@@ -973,7 +975,8 @@ extension OpenClawChatView {
                 toolName: last.toolName,
                 usage: last.usage,
                 stopReason: last.stopReason,
-                errorMessage: last.errorMessage)
+                errorMessage: last.errorMessage,
+                details: last.details)
             result[result.count - 1] = merged
         }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+HistoryReconciliation.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+HistoryReconciliation.swift
@@ -143,7 +143,8 @@ extension OpenClawChatViewModel {
             toolName: incoming.toolName,
             usage: incoming.usage,
             stopReason: incoming.stopReason,
-            errorMessage: incoming.errorMessage)
+            errorMessage: incoming.errorMessage,
+            details: incoming.details)
     }
 
     private static func preservingLocalAudioDurations(

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TransportEvents.swift
@@ -282,7 +282,8 @@ extension OpenClawChatViewModel {
             toolName: message.toolName,
             usage: message.usage,
             stopReason: message.stopReason,
-            errorMessage: message.errorMessage)
+            errorMessage: message.errorMessage,
+            details: message.details)
     }
 
     private func handleAgentEvent(_ evt: OpenClawAgentEventPayload) {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMessageDetailsPreservationTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMessageDetailsPreservationTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import OpenClawKit
+import Testing
+@testable import OpenClawChatUI
+
+// Tool-result diff metadata rides on `OpenClawChatMessage.details`; every
+// field-enumerating message rebuild must carry it or inline diffs silently
+// disappear after cache-warm reconciliation.
+@Suite("ChatMessageDetailsPreservation")
+struct ChatMessageDetailsPreservationTests {
+    private func toolResultMessage(id: UUID = UUID()) -> OpenClawChatMessage {
+        OpenClawChatMessage(
+            id: id,
+            role: "toolResult",
+            content: [
+                OpenClawChatMessageContent(
+                    type: "text",
+                    text: "Successfully replaced 1 block(s).",
+                    mimeType: nil,
+                    fileName: nil,
+                    content: nil),
+            ],
+            timestamp: 1,
+            toolCallId: "call-1",
+            toolName: "edit",
+            details: AnyCodable(["diff": AnyCodable("+1 added\n-1 removed")]))
+    }
+
+    @MainActor @Test func `decode pipeline keeps message details`() throws {
+        let payloadData = try JSONEncoder().encode([self.toolResultMessage()])
+        let anyMessages = try JSONDecoder().decode([AnyCodable].self, from: payloadData)
+        let decoded = OpenClawChatViewModel.decodeMessages(anyMessages)
+
+        #expect(decoded.first?.details != nil)
+    }
+
+    @MainActor @Test func `canonical adoption keeps incoming details`() {
+        let incoming = self.toolResultMessage()
+        let existing = self.toolResultMessage()
+
+        let adopted = OpenClawChatViewModel.adoptingCanonicalMessage(incoming, over: existing)
+
+        #expect(adopted.id == existing.id)
+        #expect(adopted.details != nil)
+    }
+}

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatToolActivityTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatToolActivityTests.swift
@@ -1,3 +1,4 @@
+import OpenClawKit
 import Testing
 @testable import OpenClawChatUI
 
@@ -12,6 +13,7 @@ struct ChatToolActivityTests {
             id: "call-1",
             name: "exec",
             arguments: nil,
+            details: nil,
             resultText: "done",
             isPending: false)])
     }
@@ -25,6 +27,7 @@ struct ChatToolActivityTests {
             id: "result-0",
             name: "read",
             arguments: nil,
+            details: nil,
             resultText: "orphaned",
             isPending: false)])
     }
@@ -53,15 +56,31 @@ struct ChatToolActivityTests {
             id: "call-0",
             name: "search",
             arguments: nil,
+            details: nil,
             resultText: nil,
             isPending: false)])
+    }
+
+    @Test func `threads paired result details`() {
+        let details = AnyCodable(["diff": AnyCodable("+1 added")])
+        let items = ChatToolActivity.items(
+            calls: [self.content(type: "toolCall", id: "call-1", name: "edit")],
+            results: [self.content(
+                type: "toolResult",
+                text: "done",
+                id: "call-1",
+                name: "edit",
+                details: details)])
+
+        #expect(items.first?.details == details)
     }
 
     private func content(
         type: String,
         text: String? = nil,
         id: String? = nil,
-        name: String? = nil) -> OpenClawChatMessageContent
+        name: String? = nil,
+        details: AnyCodable? = nil) -> OpenClawChatMessageContent
     {
         OpenClawChatMessageContent(
             type: type,
@@ -70,6 +89,7 @@ struct ChatToolActivityTests {
             fileName: nil,
             content: nil,
             id: id,
-            name: name)
+            name: name,
+            details: details)
     }
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatToolDiffTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatToolDiffTests.swift
@@ -1,0 +1,220 @@
+import Foundation
+import OpenClawKit
+import Testing
+@testable import OpenClawChatUI
+
+@Suite("ChatToolDiff")
+struct ChatToolDiffTests {
+    @Test func `parses numbered details diffs`() {
+        let parsed = ChatToolDiff.parseDetailsDiff(" 455 before\n-456 old\n+456 new")
+
+        #expect(parsed == [
+            ChatToolDiffLine(kind: .ctx, lineNo: 455, text: "before"),
+            ChatToolDiffLine(kind: .del, lineNo: 456, text: "old"),
+            ChatToolDiffLine(kind: .add, lineNo: 456, text: "new"),
+        ])
+    }
+
+    @Test func `parses skip markers`() {
+        let cases = ["+1 kept\n...", "+1 kept\n...(truncated)..."]
+        for diff in cases {
+            #expect(ChatToolDiff.parseDetailsDiff(diff) == [
+                ChatToolDiffLine(kind: .add, lineNo: 1, text: "kept"),
+                ChatToolDiffLine(kind: .skip, text: ""),
+            ])
+        }
+    }
+
+    @Test func `rejects malformed or unchanged details`() {
+        for diff in ["raw line", " 1 context\n 2 context"] {
+            #expect(ChatToolDiff.parseDetailsDiff(diff) == nil)
+        }
+    }
+
+    @Test func `computes basic line diffs`() {
+        let cases: [(String, String, [ChatToolDiffLine])] = [
+            ("before", "after", [
+                ChatToolDiffLine(kind: .del, text: "before"),
+                ChatToolDiffLine(kind: .add, text: "after"),
+            ]),
+            ("same", "same\nadded", [
+                ChatToolDiffLine(kind: .ctx, text: "same"),
+                ChatToolDiffLine(kind: .add, text: "added"),
+            ]),
+            ("same\nremoved", "same", [
+                ChatToolDiffLine(kind: .ctx, text: "same"),
+                ChatToolDiffLine(kind: .del, text: "removed"),
+            ]),
+            ("", "written", [ChatToolDiffLine(kind: .add, text: "written")]),
+        ]
+        for (old, new, expected) in cases {
+            #expect(ChatToolDiff.computeLineDiff(old: old, new: new) == expected)
+        }
+    }
+
+    @Test func `trailing newline is not an extra line`() {
+        #expect(ChatToolDiff.computeLineDiff(old: "", new: "foo\n") == [
+            ChatToolDiffLine(kind: .add, text: "foo"),
+        ])
+    }
+
+    @Test func `oversized input degrades to a skip`() {
+        let text = (0...600).map { "line \($0)" }.joined(separator: "\n")
+        #expect(ChatToolDiff.computeLineDiff(old: text, new: text) == [
+            ChatToolDiffLine(kind: .skip, text: ""),
+        ])
+    }
+
+    @Test func `compaction keeps three context lines around a change`() {
+        let oldLines = (0..<500).map { "line \($0)" }
+        var newLines = oldLines
+        newLines[250] = "changed"
+        let expected = [
+            ChatToolDiffLine(kind: .skip, text: ""),
+            ChatToolDiffLine(kind: .ctx, text: "line 247"),
+            ChatToolDiffLine(kind: .ctx, text: "line 248"),
+            ChatToolDiffLine(kind: .ctx, text: "line 249"),
+            ChatToolDiffLine(kind: .del, text: "line 250"),
+            ChatToolDiffLine(kind: .add, text: "changed"),
+            ChatToolDiffLine(kind: .ctx, text: "line 251"),
+            ChatToolDiffLine(kind: .ctx, text: "line 252"),
+            ChatToolDiffLine(kind: .ctx, text: "line 253"),
+            ChatToolDiffLine(kind: .skip, text: ""),
+        ]
+
+        #expect(ChatToolDiff.computeLineDiff(
+            old: oldLines.joined(separator: "\n"),
+            new: newLines.joined(separator: "\n")) == expected)
+    }
+
+    @Test func `details diff wins over argument fallback`() throws {
+        let resolved = try #require(ChatToolDiff.resolveDiff(
+            name: "edit",
+            arguments: AnyCodable(["oldText": "arg old", "newText": "arg new"]),
+            details: AnyCodable(["diff": "-12 detail old\n+12 detail new"])))
+
+        #expect(resolved.lines == [
+            ChatToolDiffLine(kind: .del, lineNo: 12, text: "detail old"),
+            ChatToolDiffLine(kind: .add, lineNo: 12, text: "detail new"),
+        ])
+        #expect(resolved.stat == ChatToolDiffStat(added: 1, removed: 1))
+    }
+
+    @Test func `bare details skip keeps an exact stat`() throws {
+        let resolved = try #require(ChatToolDiff.resolveDiff(
+            name: "edit",
+            arguments: nil,
+            details: AnyCodable(["diff": "+1 added\n...\n-2 removed"])))
+
+        #expect(resolved.stat == ChatToolDiffStat(added: 1, removed: 1))
+    }
+
+    @Test func `reads multi edit pairs`() throws {
+        let resolved = try #require(ChatToolDiff.resolveDiff(
+            name: "multiedit",
+            arguments: AnyCodable(["edits": [
+                ["oldText": "one", "newText": "uno"],
+                ["old_string": "two", "new_string": "dos"],
+            ]]),
+            details: nil))
+
+        #expect(resolved.lines == [
+            ChatToolDiffLine(kind: .del, text: "one"),
+            ChatToolDiffLine(kind: .add, text: "uno"),
+            ChatToolDiffLine(kind: .skip, text: ""),
+            ChatToolDiffLine(kind: .del, text: "two"),
+            ChatToolDiffLine(kind: .add, text: "dos"),
+        ])
+        #expect(resolved.stat == ChatToolDiffStat(added: 2, removed: 2))
+    }
+
+    @Test func `renders write content as additions`() throws {
+        let resolved = try #require(ChatToolDiff.resolveDiff(
+            name: "write_file",
+            arguments: AnyCodable(["content": "one\ntwo\n"]),
+            details: nil))
+
+        #expect(resolved.lines == [
+            ChatToolDiffLine(kind: .add, text: "one"),
+            ChatToolDiffLine(kind: .add, text: "two"),
+        ])
+        #expect(resolved.stat == ChatToolDiffStat(added: 2, removed: 0))
+    }
+
+    @Test func `renders editor create and insert commands`() throws {
+        let create = try #require(ChatToolDiff.resolveDiff(
+            name: "str_replace_editor",
+            arguments: AnyCodable(["command": "create", "file_text": "one\ntwo"]),
+            details: nil))
+        #expect(create.lines == [
+            ChatToolDiffLine(kind: .add, text: "one"),
+            ChatToolDiffLine(kind: .add, text: "two"),
+        ])
+        #expect(create.stat == ChatToolDiffStat(added: 2, removed: 0))
+
+        let createFallback = try #require(ChatToolDiff.resolveDiff(
+            name: "str_replace_editor",
+            arguments: AnyCodable(["command": "create", "content": "fallback"]),
+            details: nil))
+        #expect(createFallback.lines == [ChatToolDiffLine(kind: .add, text: "fallback")])
+        #expect(createFallback.stat == ChatToolDiffStat(added: 1, removed: 0))
+
+        let insert = try #require(ChatToolDiff.resolveDiff(
+            name: "str_replace_based_edit_tool",
+            arguments: AnyCodable(["command": "insert", "insert_text": "three"]),
+            details: nil))
+        #expect(insert.lines == [ChatToolDiffLine(kind: .add, text: "three")])
+        #expect(insert.stat == nil)
+    }
+
+    @Test func `keeps a full write stat when the preview is clipped`() throws {
+        let content = (0...400).map { "line \($0)" }.joined(separator: "\n")
+        let resolved = try #require(ChatToolDiff.resolveDiff(
+            name: "write",
+            arguments: AnyCodable(["content": content]),
+            details: nil))
+
+        #expect(resolved.lines.count == 401)
+        #expect(resolved.lines.last == ChatToolDiffLine(kind: .skip, text: ""))
+        #expect(resolved.stat == ChatToolDiffStat(added: 401, removed: 0))
+    }
+
+    @Test func `unknown tools do not resolve local diffs`() {
+        #expect(ChatToolDiff.resolveDiff(
+            name: "custom_tool",
+            arguments: AnyCodable(["oldText": "old", "newText": "new"]),
+            details: nil) == nil)
+    }
+
+    @Test func `truncated details omit the stat`() throws {
+        let resolved = try #require(ChatToolDiff.resolveDiff(
+            name: "edit",
+            arguments: nil,
+            details: AnyCodable(["diff": "+1 kept\n...(truncated)..."])))
+
+        #expect(resolved.stat == nil)
+    }
+
+    @Test func `capped details omit the stat`() throws {
+        let diff = (1...401).map { "+\($0) line \($0)" }.joined(separator: "\n")
+        let resolved = try #require(ChatToolDiff.resolveDiff(
+            name: "edit",
+            arguments: nil,
+            details: AnyCodable(["diff": diff])))
+
+        #expect(resolved.lines.count == 401)
+        #expect(resolved.lines.last == ChatToolDiffLine(kind: .skip, text: ""))
+        #expect(resolved.stat == nil)
+    }
+
+    @Test func `message details survive coding roundtrip`() throws {
+        let data = Data(#"{"role":"toolResult","content":"done","details":{"diff":"+1 added"}}"#.utf8)
+        let decoded = try JSONDecoder().decode(OpenClawChatMessage.self, from: data)
+        let roundTripped = try JSONDecoder().decode(
+            OpenClawChatMessage.self,
+            from: JSONEncoder().encode(decoded))
+
+        #expect(decoded.details == AnyCodable(["diff": AnyCodable("+1 added")]))
+        #expect(roundTripped.details == decoded.details)
+    }
+}

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatToolDiffTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatToolDiffTests.swift
@@ -5,8 +5,15 @@ import Testing
 
 @Suite("ChatToolDiff")
 struct ChatToolDiffTests {
+    private func parsedLines(_ diff: String) -> [ChatToolDiffLine]? {
+        ChatToolDiff.resolveDiff(
+            name: "edit",
+            arguments: nil,
+            details: AnyCodable(["diff": AnyCodable(diff)]))?.lines
+    }
+
     @Test func `parses numbered details diffs`() {
-        let parsed = ChatToolDiff.parseDetailsDiff(" 455 before\n-456 old\n+456 new")
+        let parsed = self.parsedLines(" 455 before\n-456 old\n+456 new")
 
         #expect(parsed == [
             ChatToolDiffLine(kind: .ctx, lineNo: 455, text: "before"),
@@ -18,7 +25,7 @@ struct ChatToolDiffTests {
     @Test func `parses skip markers`() {
         let cases = ["+1 kept\n...", "+1 kept\n...(truncated)..."]
         for diff in cases {
-            #expect(ChatToolDiff.parseDetailsDiff(diff) == [
+            #expect(self.parsedLines(diff) == [
                 ChatToolDiffLine(kind: .add, lineNo: 1, text: "kept"),
                 ChatToolDiffLine(kind: .skip, text: ""),
             ])
@@ -27,7 +34,7 @@ struct ChatToolDiffTests {
 
     @Test func `rejects malformed or unchanged details`() {
         for diff in ["raw line", " 1 context\n 2 context"] {
-            #expect(ChatToolDiff.parseDetailsDiff(diff) == nil)
+            #expect(self.parsedLines(diff) == nil)
         }
     }
 

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatToolDiffTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatToolDiffTests.swift
@@ -142,8 +142,8 @@ struct ChatToolDiffTests {
             details: nil))
 
         #expect(resolved.lines == [
-            ChatToolDiffLine(kind: .add, text: "one"),
-            ChatToolDiffLine(kind: .add, text: "two"),
+            ChatToolDiffLine(kind: .add, lineNo: 1, text: "one"),
+            ChatToolDiffLine(kind: .add, lineNo: 2, text: "two"),
         ])
         #expect(resolved.stat == ChatToolDiffStat(added: 2, removed: 0))
     }
@@ -154,8 +154,8 @@ struct ChatToolDiffTests {
             arguments: AnyCodable(["command": "create", "file_text": "one\ntwo"]),
             details: nil))
         #expect(create.lines == [
-            ChatToolDiffLine(kind: .add, text: "one"),
-            ChatToolDiffLine(kind: .add, text: "two"),
+            ChatToolDiffLine(kind: .add, lineNo: 1, text: "one"),
+            ChatToolDiffLine(kind: .add, lineNo: 2, text: "two"),
         ])
         #expect(create.stat == ChatToolDiffStat(added: 2, removed: 0))
 
@@ -163,7 +163,7 @@ struct ChatToolDiffTests {
             name: "str_replace_editor",
             arguments: AnyCodable(["command": "create", "content": "fallback"]),
             details: nil))
-        #expect(createFallback.lines == [ChatToolDiffLine(kind: .add, text: "fallback")])
+        #expect(createFallback.lines == [ChatToolDiffLine(kind: .add, lineNo: 1, text: "fallback")])
         #expect(createFallback.stat == ChatToolDiffStat(added: 1, removed: 0))
 
         let insert = try #require(ChatToolDiff.resolveDiff(
@@ -181,7 +181,7 @@ struct ChatToolDiffTests {
             arguments: AnyCodable(["content": content]),
             details: nil))
 
-        #expect(resolved.lines.count == 401)
+        #expect(resolved.lines.count == 81)
         #expect(resolved.lines.last == ChatToolDiffLine(kind: .skip, text: ""))
         #expect(resolved.stat == ChatToolDiffStat(added: 401, removed: 0))
     }
@@ -191,6 +191,21 @@ struct ChatToolDiffTests {
             name: "custom_tool",
             arguments: AnyCodable(["oldText": "old", "newText": "new"]),
             details: nil) == nil)
+    }
+
+    @Test func `unknown tools never interpret details as a diff`() {
+        #expect(ChatToolDiff.resolveDiff(
+            name: "custom_tool",
+            arguments: nil,
+            details: AnyCodable(["diff": AnyCodable("+1 added\n-1 removed")])) == nil)
+    }
+
+    @Test func `patch tools resolve persisted details`() throws {
+        let resolved = try #require(ChatToolDiff.resolveDiff(
+            name: "apply_patch",
+            arguments: nil,
+            details: AnyCodable(["diff": AnyCodable("+1 added\n-1 removed")])))
+        #expect(resolved.stat == ChatToolDiffStat(added: 1, removed: 1))
     }
 
     @Test func `truncated details omit the stat`() throws {


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #110618: iOS/macOS tool rows showed edit and write results only as raw summary text ("Successfully replaced 1 block(s)…"), while the web Control UI renders proper inline diffs with a +N/−M diffstat. On mobile you couldn't see *what* an agent actually changed in a file.

## Why This Change Was Made

Port the web's kind-aware diff rendering (`ui/src/lib/chat/tool-call-diff.ts` semantics) to the shared SwiftUI chat:

- New `ChatToolDiff` pure model: parses the edit tool's persisted `details.diff` (numbered `+`/`−`/context lines with `…` skip markers), falls back to a local LCS line diff from edit args (`edits[]`/old-new pairs, capped at 600 input / 400 render lines with ±3-context compaction), renders write/`create` content as additions, and `insert` text without a stat (placement unknown). Exact +N/−M stats are kept for bare context ellipses and clipped write previews; only true truncation suppresses them.
- `ChatToolActivityRow`: collapsed rows append a green/red diffstat (theme `success`/`danger` tokens — new `success` token added); expanded rows render the colored diff with line numbers, and keep the result summary or error diagnostic beneath it so failed edits can't masquerade as applied changes.
- Data plumbing: `OpenClawChatMessage`/`OpenClawChatMessageContent` now decode the gateway's message-level `details` (already emitted by `projectToolResultDetails`), and `mergeToolResults` threads it onto the merged result block.
- Reconciliation fix (second commit): `adoptingCanonicalMessage`/`messageWithTimestampIfNeeded` rebuilt messages field-by-field and silently dropped `details`, so diffs vanished after cache-warm reconciliation on every app relaunch. Now preserved, with regression tests.

No new localized strings (reuses the existing expand/Show-all machinery), no core/gateway changes.

## User Impact

Edit/write tool activity in the iOS and macOS apps now shows exactly what changed: a `+2 −1` stat at a glance and a proper colored diff on tap — matching the web.

## Evidence

- `swift test --package-path apps/shared/OpenClawKit --parallel` → 1029 tests in 87 suites pass (17 new `ChatToolDiff` tests, details-propagation and preservation regressions).
- Autoreview (Codex gpt-5.6-sol, xhigh): four rounds; found and fixed text-editor `create`/`insert` handling, stat suppression rules, result-text visibility, and confirmed clean.
- Screenshots from the iPhone 17 simulator (seeded fixture, identical data both builds):

| Before | After (collapsed, diffstat) |
| --- | --- |
| ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/ios-tool-diffs/before-light.png) | ![after collapsed](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/ios-tool-diffs/after-collapsed-light.png) |

| After expanded (light) | After expanded (dark) |
| --- | --- |
| ![after expanded light](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/ios-tool-diffs/after-expanded-light.png) | ![after expanded dark](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/ios-tool-diffs/after-expanded-dark.png) |
