### PR TITLE
fix(process): preserve descendant output under event-loop stalls

### DIFF
--- a/src/process/child-process.test.ts
+++ b/src/process/child-process.test.ts
@@ -19,8 +19,7 @@ describe.skipIf(process.platform === "win32")("releaseChildProcessOutputAfterExi
   });
 
   it("drains active descendant output after the parent exits", async () => {
-    const command =
-      'printf "HEAD\\n"; ( for i in 1 2 3 4 5 6; do sleep 0.05; printf "TICK$i\\n"; done ) &';
+    const command = 'printf "HEAD\\n"; ( sleep 0.05; printf "TAIL\\n" ) &';
     child = execa("/bin/sh", ["-c", command], {
       buffer: false,
       detached: true,
@@ -33,9 +32,18 @@ describe.skipIf(process.platform === "win32")("releaseChildProcessOutputAfterExi
       output += chunk.toString();
     });
 
+    // Simulate a contended worker after the direct child exits. The descendant
+    // writes while JS is parked, so its pipe data and the idle timer are both
+    // ready when the event loop resumes.
+    await new Promise<void>((resolve) => {
+      child?.once("exit", () => {
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 250);
+        resolve();
+      });
+    });
     await child.finally(releaseOutput);
     expect(output).toContain("HEAD");
-    expect(output).toContain("TICK6");
+    expect(output).toContain("TAIL");
   });
 
   it("releases a quiet inherited pipe after the idle grace", async () => {

--- a/src/process/child-process.ts
+++ b/src/process/child-process.ts
@@ -14,12 +14,17 @@ const EXIT_STDIO_MAX_DRAIN_MS = 1_000;
 export function releaseChildProcessOutputAfterExit(child: ChildProcess): () => void {
   let exited = false;
   let idleTimer: NodeJS.Timeout | undefined;
+  let idleReleaseImmediate: NodeJS.Immediate | undefined;
   let deadlineTimer: NodeJS.Timeout | undefined;
 
   const clearTimers = () => {
     if (idleTimer) {
       clearTimeout(idleTimer);
       idleTimer = undefined;
+    }
+    if (idleReleaseImmediate) {
+      clearImmediate(idleReleaseImmediate);
+      idleReleaseImmediate = undefined;
     }
     if (deadlineTimer) {
       clearTimeout(deadlineTimer);
@@ -41,7 +46,20 @@ export function releaseChildProcessOutputAfterExit(child: ChildProcess): () => v
     if (idleTimer) {
       clearTimeout(idleTimer);
     }
-    idleTimer = setTimeout(release, EXIT_STDIO_GRACE_MS);
+    if (idleReleaseImmediate) {
+      clearImmediate(idleReleaseImmediate);
+      idleReleaseImmediate = undefined;
+    }
+    idleTimer = setTimeout(() => {
+      idleTimer = undefined;
+      // A loaded event loop can observe the idle timer before already-buffered
+      // pipe data. Give the poll phase one turn so that data can rearm the grace.
+      idleReleaseImmediate = setImmediate(() => {
+        idleReleaseImmediate = undefined;
+        release();
+      });
+      idleReleaseImmediate.unref();
+    }, EXIT_STDIO_GRACE_MS);
     idleTimer.unref();
   };
   const onData = () => {

--- a/src/process/exec.windows.test.ts
+++ b/src/process/exec.windows.test.ts
@@ -389,6 +389,8 @@ describe("Windows command execution", () => {
       expect(execaMock).toHaveBeenCalledTimes(1);
       expect(command.stdout.destroyed).toBe(false);
       await vi.advanceTimersByTimeAsync(19);
+      expect(command.stdout.destroyed).toBe(false);
+      await vi.advanceTimersToNextTimerAsync();
       expect(command.stdout.destroyed).toBe(true);
       expect(command.stderr.destroyed).toBe(true);
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where commands whose direct child exited before a descendant finished writing could lose the descendant's final output when the Node.js event loop was briefly starved. The failure was observed twice in unchanged CI runs as `HEAD` being captured while `TICK6` was lost.

## Why This Change Was Made

The output-drain idle timer now defers pipe destruction through one event-loop check phase. That gives already-buffered pipe data its poll-phase callback and a chance to rearm the idle grace, while the existing one-second maximum drain deadline remains authoritative. The regression test deliberately parks JavaScript after the direct child exits, reproducing the real timer-versus-I/O ordering instead of widening a sleep.

## User Impact

Buffered exec and agent shell callers retain short descendant output tails under host contention instead of occasionally returning incomplete command output. There is no config or API change.

## Evidence

- Before fix: the forced event-loop-stall regression fails deterministically with `expected 'HEAD\n' to contain 'TAIL'`, matching CI runs [29517575739](https://github.com/openclaw/openclaw/actions/runs/29517575739) and [29620886178](https://github.com/openclaw/openclaw/actions/runs/29620886178).
- After fix: `node scripts/run-vitest.mjs src/process/child-process.test.ts` passed 10/10 bounded repetitions (3 tests each).
- The first PR CI run exposed the sibling fake-timer phase expectation on Linux and Windows. After updating that assertion, `node scripts/run-vitest.mjs src/process/child-process.test.ts src/process/exec.windows.test.ts` passed 5/5 repetitions (25 tests each), and exact-head [CI run 29665951057](https://github.com/openclaw/openclaw/actions/runs/29665951057) passed.
- `node scripts/check-changed.mjs -- src/process/child-process.ts src/process/child-process.test.ts` passed on [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/29665480257), including core and core-test typechecks, format, lint, boundary, and static guards.
- `git diff --check` passed.
- Mandatory autoreview reported no accepted or actionable findings.

AI-assisted: yes. I reviewed the production callers, failure logs, event-loop ownership, and regression behavior.
