### PR TITLE
feat(ui): microphone picker on the composer talk button

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3890,6 +3890,7 @@ export const en: TranslationMap = {
       microphoneBusy: "Microphone inputs are busy or unavailable to the browser.",
       microphoneFallback: "Microphone {number}",
       microphoneInput: "Microphone input",
+      microphoneAppliesNextSession: "Changes apply when you start your next Talk session.",
       microphoneListUnsupported: "This browser cannot list microphone inputs.",
       noCameras: "No additional cameras found",
       noMicrophones: "No additional microphones found",

--- a/ui/src/pages/chat/chat-composer.test.ts
+++ b/ui/src/pages/chat/chat-composer.test.ts
@@ -3,8 +3,15 @@
 import { html, render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { QuestionPrompt } from "../../app/question-prompt.ts";
+import { loadSettings, patchSettings } from "../../app/settings.ts";
 import { i18n, t } from "../../i18n/index.ts";
 import { renderChatComposer, resetChatComposerState } from "./components/chat-composer.ts";
+
+const discoverRealtimeTalkInputsMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./realtime-talk-input.ts", () => ({
+  discoverRealtimeTalkInputs: discoverRealtimeTalkInputsMock,
+}));
 
 vi.mock("../../components/icons.ts", async () => {
   const { html: litHtml } = await import("lit");
@@ -13,6 +20,8 @@ vi.mock("../../components/icons.ts", async () => {
       camera: litHtml`<svg data-icon="camera"></svg>`,
       cameraOff: litHtml`<svg data-icon="camera-off"></svg>`,
       switchCamera: litHtml`<svg data-icon="switch-camera"></svg>`,
+      check: litHtml`<svg data-icon="check"></svg>`,
+      chevronDown: litHtml`<svg data-icon="chevron-down"></svg>`,
     },
   };
 });
@@ -85,6 +94,9 @@ function button(container: Element, label: string): HTMLButtonElement {
 
 afterEach(async () => {
   resetChatComposerState();
+  discoverRealtimeTalkInputsMock.mockReset();
+  localStorage.clear();
+  document.body.replaceChildren();
   await i18n.setLocale("en");
   vi.restoreAllMocks();
 });
@@ -146,6 +158,110 @@ describe("renderChatComposer controls", () => {
       onAbort,
     });
     expect(button(view.container, t("chat.runControls.sendMessage")).disabled).toBe(false);
+  });
+
+  it("opens the microphone picker, marks the selected input, and persists a selection", async () => {
+    discoverRealtimeTalkInputsMock.mockResolvedValue({
+      devices: [
+        { deviceId: "studio-mic", label: "Studio microphone" },
+        { deviceId: "headset", label: "USB headset" },
+      ],
+      warning: null,
+    });
+    patchSettings({ realtimeTalkInputDeviceId: "studio-mic" });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const composerProps = props({ onToggleRealtimeTalk: vi.fn() });
+    const draw = () => render(renderChatComposer(composerProps), container);
+    composerProps.onRequestUpdate = draw;
+    draw();
+
+    const dropdown = container.querySelector<
+      HTMLElement & { open: boolean; updateComplete: Promise<unknown> }
+    >("wa-dropdown.chat-talk-input-picker");
+    await dropdown?.updateComplete;
+    button(container, t("chat.composer.microphoneInput")).click();
+    await dropdown?.updateComplete;
+
+    expect(dropdown?.open).toBe(true);
+    await vi.waitFor(() => expect(discoverRealtimeTalkInputsMock).toHaveBeenCalledWith(true));
+    await vi.waitFor(() =>
+      expect(container.querySelectorAll(".chat-talk-input-picker__item")).toHaveLength(3),
+    );
+    const items = [
+      ...container.querySelectorAll<HTMLElement & { value: string }>(
+        ".chat-talk-input-picker__item",
+      ),
+    ];
+    expect(items.map((item) => item.textContent?.trim())).toEqual([
+      t("chat.composer.systemDefaultMicrophone"),
+      "Studio microphone",
+      "USB headset",
+    ]);
+    expect(items.map((item) => item.getAttribute("role"))).toEqual([
+      "menuitemradio",
+      "menuitemradio",
+      "menuitemradio",
+    ]);
+    expect(items.find((item) => item.value === "studio-mic")?.getAttribute("aria-checked")).toBe(
+      "true",
+    );
+    expect(
+      items.find((item) => item.value === "studio-mic")?.querySelector('[data-icon="check"]'),
+    ).not.toBeNull();
+
+    items.find((item) => item.value === "headset")?.click();
+    await dropdown?.updateComplete;
+    expect(loadSettings().realtimeTalkInputDeviceId).toBe("headset");
+    expect(dropdown?.open).toBe(false);
+
+    button(container, t("chat.composer.microphoneInput")).click();
+    await vi.waitFor(() => expect(discoverRealtimeTalkInputsMock).toHaveBeenCalledTimes(2));
+    expect(dropdown?.open).toBe(true);
+  });
+
+  it("shows discovery warnings and the next-session hint during active Talk", async () => {
+    discoverRealtimeTalkInputsMock.mockResolvedValue({
+      devices: [],
+      warning: "Microphone permission is blocked.",
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    const composerProps = props({
+      onToggleRealtimeTalk: vi.fn(),
+      realtimeTalkActive: true,
+      realtimeTalkStatus: "listening",
+    });
+    const draw = () => render(renderChatComposer(composerProps), container);
+    composerProps.onRequestUpdate = draw;
+    draw();
+
+    const dropdown = container.querySelector<
+      HTMLElement & { open: boolean; updateComplete: Promise<unknown> }
+    >("wa-dropdown.chat-talk-input-picker");
+    await dropdown?.updateComplete;
+    button(container, t("chat.composer.microphoneInput")).click();
+    await vi.waitFor(() =>
+      expect(container.querySelector(".chat-talk-input-picker__warning")?.textContent).toContain(
+        "Microphone permission is blocked.",
+      ),
+    );
+
+    expect(container.querySelector(".chat-talk-input-picker__warning")?.getAttribute("role")).toBe(
+      "alert",
+    );
+    expect(container.querySelector(".chat-talk-input-picker__note")?.textContent).toContain(
+      t("chat.composer.noMicrophones"),
+    );
+    expect(container.querySelector(".chat-talk-input-picker__hint")?.textContent).toContain(
+      t("chat.composer.microphoneAppliesNextSession"),
+    );
+
+    dropdown?.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }),
+    );
+    await dropdown?.updateComplete;
+    expect(dropdown?.open).toBe(false);
   });
 
   it("offers camera only inside a video-capable active talk session", () => {

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -1594,7 +1594,7 @@ describe("chat composer workbench", () => {
     expect(labels).not.toContain(t("chat.runControls.exportChat"));
   });
 
-  it("uses the primary action for voice without a separate voice settings button", () => {
+  it("uses the primary action for voice with only the compact device-picker caret", () => {
     const container = renderChatView({
       onToggleRealtimeTalk: () => undefined,
     });
@@ -1603,7 +1603,9 @@ describe("chat composer workbench", () => {
     expect(voiceButton).not.toBeNull();
     expect(voiceButton?.closest(".agent-chat__composer-input-row")).not.toBeNull();
     expect(container.querySelector('button[aria-label="Talk settings"]')).toBeNull();
-    expect(container.querySelector('button[aria-label="Microphone input"]')).toBeNull();
+    // The mic device picker is a caret on the voice button, not a separate settings button.
+    const picker = container.querySelector('button[aria-label="Microphone input"]');
+    expect(picker?.classList.contains("chat-talk-input-picker__trigger")).toBe(true);
   });
 });
 

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -1787,10 +1787,11 @@ type MicrophonePickerProps = {
 };
 
 function renderMicrophonePicker(props: MicrophonePickerProps) {
-  const options = [
-    { deviceId: "", label: t("chat.composer.systemDefaultMicrophone") },
-    ...props.devices,
-  ];
+  // System default renders even while discovery runs: the dropdown's one-time
+  // focus step needs at least one item or keyboard users never enter the menu.
+  const options = props.loading
+    ? [{ deviceId: "", label: t("chat.composer.systemDefaultMicrophone") }]
+    : [{ deviceId: "", label: t("chat.composer.systemDefaultMicrophone") }, ...props.devices];
   const label = t("chat.composer.microphoneInput");
   return html`
     <wa-dropdown
@@ -1814,33 +1815,30 @@ function renderMicrophonePicker(props: MicrophonePickerProps) {
         ${icons.chevronDown}
       </button>
       <div class="chat-talk-input-picker__heading">${label}</div>
+      ${options.map((option) => {
+        const selected = option.deviceId === props.selectedDeviceId;
+        return html`
+          <wa-dropdown-item
+            class="chat-talk-input-picker__item"
+            value=${option.deviceId}
+            type="checkbox"
+            role="menuitemradio"
+            aria-checked=${String(selected)}
+            ${ref((element) => syncDropdownItemRadio(element, selected))}
+          >
+            <span class="chat-talk-input-picker__label">${option.label}</span>
+            <span slot="details" class="chat-talk-input-picker__check" aria-hidden="true"
+              >${selected ? icons.check : nothing}</span
+            >
+          </wa-dropdown-item>
+        `;
+      })}
       ${props.loading
         ? html`<div class="chat-talk-input-picker__note" role="status">${t("common.loading")}</div>`
-        : html`
-            ${options.map((option) => {
-              const selected = option.deviceId === props.selectedDeviceId;
-              return html`
-                <wa-dropdown-item
-                  class="chat-talk-input-picker__item"
-                  value=${option.deviceId}
-                  type="checkbox"
-                  role="menuitemradio"
-                  aria-checked=${String(selected)}
-                  ${ref((element) => syncDropdownItemRadio(element, selected))}
-                >
-                  <span class="chat-talk-input-picker__label">${option.label}</span>
-                  <span slot="details" class="chat-talk-input-picker__check" aria-hidden="true"
-                    >${selected ? icons.check : nothing}</span
-                  >
-                </wa-dropdown-item>
-              `;
-            })}
-            ${props.devices.length === 0
-              ? html`<div class="chat-talk-input-picker__note">
-                  ${t("chat.composer.noMicrophones")}
-                </div>`
-              : nothing}
-          `}
+        : nothing}
+      ${!props.loading && props.devices.length === 0
+        ? html`<div class="chat-talk-input-picker__note">${t("chat.composer.noMicrophones")}</div>`
+        : nothing}
       ${props.warning
         ? html`<div class="chat-talk-input-picker__warning" role="alert">${props.warning}</div>`
         : nothing}

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -1824,7 +1824,6 @@ function renderMicrophonePicker(props: MicrophonePickerProps) {
                   class="chat-talk-input-picker__item"
                   value=${option.deviceId}
                   type="checkbox"
-                  .checked=${selected}
                   role="menuitemradio"
                   aria-checked=${String(selected)}
                   ${ref((element) => syncDropdownItemRadio(element, selected))}

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -6,10 +6,15 @@ import { ref } from "lit/directives/ref.js";
 import type { GatewaySessionRow, SessionGoal, SessionsListResult } from "../../../api/types.ts";
 import { normalizeBasePath } from "../../../app-route-paths.ts";
 import type { QuestionPrompt } from "../../../app/question-prompt.ts";
-import { normalizeChatSendShortcut, type ChatSendShortcut } from "../../../app/settings.ts";
+import {
+  loadSettings,
+  normalizeChatSendShortcut,
+  patchSettings,
+  type ChatSendShortcut,
+} from "../../../app/settings.ts";
 import { icons, type IconName } from "../../../components/icons.ts";
 import "../../../components/tooltip.ts";
-import "../../../components/web-awesome.ts";
+import { syncDropdownItemRadio } from "../../../components/web-awesome.ts";
 import { t } from "../../../i18n/index.ts";
 import type { ChatAttachment, ChatQueueItem } from "../../../lib/chat/chat-types.ts";
 import {
@@ -44,7 +49,11 @@ import { detectTextDirection } from "../../../lib/text-direction.ts";
 import { exportChatMarkdown } from "../export.ts";
 import type { ChatInputHistoryKeyInput, ChatInputHistoryKeyResult } from "../input-history.ts";
 import type { RealtimeTalkConversationEntry } from "../realtime-talk-conversation.ts";
-import type { RealtimeTalkCameraDevice } from "../realtime-talk-input.ts";
+import {
+  discoverRealtimeTalkInputs,
+  type RealtimeTalkCameraDevice,
+  type RealtimeTalkInputDevice,
+} from "../realtime-talk-input.ts";
 import type { RealtimeTalkLevelSignal } from "../realtime-talk-level.ts";
 import type { RealtimeTalkStatus } from "../realtime-talk.ts";
 import { CHAT_RUN_STATUS_TOAST_DURATION_MS, type ChatRunUiStatus } from "../run-lifecycle.ts";
@@ -179,6 +188,11 @@ type ChatComposerState = {
   questionTakeoverActive: boolean;
   restoreComposerFocus: boolean;
   composerTextarea: HTMLTextAreaElement | null;
+  microphonePickerOpen: boolean;
+  microphonePickerLoading: boolean;
+  microphoneDevices: RealtimeTalkInputDevice[];
+  microphoneWarning: string | null;
+  microphoneDiscoveryRequest: number;
   // Stable Lit ref: an inline arrow would change identity per render and force
   // a layout re-measure of the textarea on every chat render, not just attach.
   textareaRef: ((element?: Element) => void) | null;
@@ -204,6 +218,11 @@ function createChatComposerState(): ChatComposerState {
     questionTakeoverActive: false,
     restoreComposerFocus: false,
     composerTextarea: null,
+    microphonePickerOpen: false,
+    microphonePickerLoading: false,
+    microphoneDevices: [],
+    microphoneWarning: null,
+    microphoneDiscoveryRequest: 0,
     textareaRef: null,
   };
 }
@@ -1750,9 +1769,90 @@ type ChatRunControlsProps = {
   onStoreDraft: (draft: string) => void;
   onToggleVoice?: () => void;
   onToggleCamera?: () => void;
+  microphonePicker?: TemplateResult | typeof nothing;
   showPrimary?: boolean;
   showSecondary?: boolean;
 };
+
+type MicrophonePickerProps = {
+  devices: RealtimeTalkInputDevice[];
+  loading: boolean;
+  open: boolean;
+  selectedDeviceId: string;
+  voiceActive: boolean;
+  warning: string | null;
+  onOpen: () => void;
+  onClose: () => void;
+  onSelect: (deviceId: string) => void;
+};
+
+function renderMicrophonePicker(props: MicrophonePickerProps) {
+  const options = [
+    { deviceId: "", label: t("chat.composer.systemDefaultMicrophone") },
+    ...props.devices,
+  ];
+  const label = t("chat.composer.microphoneInput");
+  return html`
+    <wa-dropdown
+      class="chat-talk-input-picker"
+      placement="top-end"
+      aria-label=${label}
+      .open=${props.open}
+      @wa-show=${props.onOpen}
+      @wa-hide=${props.onClose}
+      @wa-select=${(event: CustomEvent<{ item: { value?: string } }>) =>
+        props.onSelect(event.detail.item.value ?? "")}
+    >
+      <button
+        slot="trigger"
+        type="button"
+        class="chat-talk-input-picker__trigger"
+        aria-label=${label}
+        aria-haspopup="menu"
+        aria-expanded=${String(props.open)}
+      >
+        ${icons.chevronDown}
+      </button>
+      <div class="chat-talk-input-picker__heading">${label}</div>
+      ${props.loading
+        ? html`<div class="chat-talk-input-picker__note" role="status">${t("common.loading")}</div>`
+        : html`
+            ${options.map((option) => {
+              const selected = option.deviceId === props.selectedDeviceId;
+              return html`
+                <wa-dropdown-item
+                  class="chat-talk-input-picker__item"
+                  value=${option.deviceId}
+                  type="checkbox"
+                  .checked=${selected}
+                  role="menuitemradio"
+                  aria-checked=${String(selected)}
+                  ${ref((element) => syncDropdownItemRadio(element, selected))}
+                >
+                  <span class="chat-talk-input-picker__label">${option.label}</span>
+                  <span slot="details" class="chat-talk-input-picker__check" aria-hidden="true"
+                    >${selected ? icons.check : nothing}</span
+                  >
+                </wa-dropdown-item>
+              `;
+            })}
+            ${props.devices.length === 0
+              ? html`<div class="chat-talk-input-picker__note">
+                  ${t("chat.composer.noMicrophones")}
+                </div>`
+              : nothing}
+          `}
+      ${props.warning
+        ? html`<div class="chat-talk-input-picker__warning" role="alert">${props.warning}</div>`
+        : nothing}
+      ${props.voiceActive
+        ? html`<div class="chat-talk-input-picker__hint">
+            ${t("chat.composer.microphoneAppliesNextSession")}
+          </div>`
+        : nothing}
+    </wa-dropdown>
+  `;
+}
 
 function renderChatPrimaryActions(props: ChatRunControlsProps) {
   const hasComposedContent = Boolean(props.draft.trim() || props.hasAttachments);
@@ -1803,23 +1903,26 @@ function renderChatPrimaryActions(props: ChatRunControlsProps) {
   return html`
     ${props.voiceActive && props.onToggleVoice
       ? html`
-          <openclaw-tooltip .content=${t("chat.composer.stopVoiceInput")}>
-            <button
-              class="chat-send-btn chat-send-btn--voice-live${voiceErrored
-                ? " chat-send-btn--voice-error"
-                : ""}"
-              @click=${props.onToggleVoice}
-              aria-label=${t("chat.composer.stopVoiceInput")}
-            >
-              ${voiceErrored
-                ? nothing
-                : renderMicrophoneActivity({
-                    status: props.voiceStatus,
-                    inputLevel: props.voiceInputLevel,
-                  })}
-              <span class="chat-send-btn__voice-stop-glyph">${icons.stop}</span>
-            </button>
-          </openclaw-tooltip>
+          <span class="chat-talk-control chat-talk-control--active">
+            <openclaw-tooltip .content=${t("chat.composer.stopVoiceInput")}>
+              <button
+                class="chat-send-btn chat-send-btn--voice-live${voiceErrored
+                  ? " chat-send-btn--voice-error"
+                  : ""}"
+                @click=${props.onToggleVoice}
+                aria-label=${t("chat.composer.stopVoiceInput")}
+              >
+                ${voiceErrored
+                  ? nothing
+                  : renderMicrophoneActivity({
+                      status: props.voiceStatus,
+                      inputLevel: props.voiceInputLevel,
+                    })}
+                <span class="chat-send-btn__voice-stop-glyph">${icons.stop}</span>
+              </button>
+            </openclaw-tooltip>
+            ${props.microphonePicker}
+          </span>
           ${voiceErrored
             ? nothing
             : html`
@@ -1912,19 +2015,22 @@ function renderChatPrimaryActions(props: ChatRunControlsProps) {
               </openclaw-tooltip>
             `
           : html`
-              <openclaw-tooltip .content=${t("chat.composer.startVoiceInput")}>
-                <button
-                  class="chat-send-btn chat-send-btn--voice"
-                  @click=${props.onToggleVoice}
-                  ?disabled=${!props.connected || props.sending || props.isBusy}
-                  aria-label=${t("chat.composer.startVoiceInput")}
-                >
-                  ${icons.mic}
-                  <span class="agent-chat__control-label"
-                    >${t("chat.composer.startVoiceInput")}</span
+              <span class="chat-talk-control">
+                <openclaw-tooltip .content=${t("chat.composer.startVoiceInput")}>
+                  <button
+                    class="chat-send-btn chat-send-btn--voice"
+                    @click=${props.onToggleVoice}
+                    ?disabled=${!props.connected || props.sending || props.isBusy}
+                    aria-label=${t("chat.composer.startVoiceInput")}
                   >
-                </button>
-              </openclaw-tooltip>
+                    ${icons.mic}
+                    <span class="agent-chat__control-label"
+                      >${t("chat.composer.startVoiceInput")}</span
+                    >
+                  </button>
+                </openclaw-tooltip>
+                ${props.microphonePicker}
+              </span>
             `}
   `;
 }
@@ -2320,6 +2426,65 @@ export function renderChatComposer(props: ChatComposerProps) {
     }
     props.onToggleRealtimeTalk?.();
   };
+  const openMicrophonePicker = () => {
+    if (state.microphonePickerOpen) {
+      return;
+    }
+    state.microphonePickerOpen = true;
+    state.microphonePickerLoading = true;
+    state.microphoneWarning = null;
+    const request = ++state.microphoneDiscoveryRequest;
+    requestUpdate();
+    void discoverRealtimeTalkInputs(true)
+      .then((result) => {
+        if (request !== state.microphoneDiscoveryRequest) {
+          return;
+        }
+        state.microphoneDevices = result.devices;
+        state.microphoneWarning = result.warning;
+      })
+      .catch((error: unknown) => {
+        if (request !== state.microphoneDiscoveryRequest) {
+          return;
+        }
+        state.microphoneDevices = [];
+        state.microphoneWarning =
+          error instanceof Error ? error.message : t("chat.composer.microphoneAccessFailed");
+      })
+      .finally(() => {
+        if (request !== state.microphoneDiscoveryRequest) {
+          return;
+        }
+        state.microphonePickerLoading = false;
+        requestUpdate();
+      });
+  };
+  const closeMicrophonePicker = () => {
+    if (!state.microphonePickerOpen) {
+      return;
+    }
+    state.microphonePickerOpen = false;
+    requestUpdate();
+  };
+  const selectMicrophone = (deviceId: string) => {
+    patchSettings({ realtimeTalkInputDeviceId: deviceId.trim() || undefined });
+    state.microphonePickerOpen = false;
+    requestUpdate();
+  };
+  const selectedMicrophoneId = loadSettings().realtimeTalkInputDeviceId?.trim() ?? "";
+  const microphonePicker = props.onToggleRealtimeTalk
+    ? renderMicrophonePicker({
+        devices: state.microphoneDevices,
+        loading: state.microphonePickerLoading,
+        open: state.microphonePickerOpen,
+        selectedDeviceId: selectedMicrophoneId,
+        voiceActive: Boolean(props.realtimeTalkActive),
+        warning: state.microphoneWarning,
+        onOpen: openMicrophonePicker,
+        onClose: closeMicrophonePicker,
+        onSelect: selectMicrophone,
+      })
+    : nothing;
   const runControlsProps: ChatRunControlsProps = {
     canAbort: showAbortableUi,
     canSend: canSubmitDraft(actionDraft),
@@ -2344,6 +2509,7 @@ export function renderChatComposer(props: ChatComposerProps) {
     onStoreDraft: () => {},
     onToggleVoice: props.onToggleRealtimeTalk ? handleVoicePrimaryAction : undefined,
     onToggleCamera: props.onToggleRealtimeCamera,
+    microphonePicker,
   };
   const cameraFacingMode = props.realtimeTalkVideoStream
     ?.getVideoTracks?.()[0]

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -2290,6 +2290,130 @@ openclaw-chat-page {
   box-shadow: none;
 }
 
+.chat-talk-control {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+}
+
+.chat-talk-control > openclaw-tooltip {
+  display: inline-flex;
+}
+
+.chat-talk-control .chat-send-btn {
+  border-radius: var(--radius-full) 0 0 var(--radius-full);
+}
+
+.chat-talk-input-picker {
+  display: inline-flex;
+}
+
+.chat-talk-input-picker__trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  min-width: 20px;
+  height: 36px;
+  padding: 0;
+  border: 0;
+  border-left: 1px solid color-mix(in srgb, var(--accent) 24%, transparent);
+  border-radius: 0 var(--radius-full) var(--radius-full) 0;
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  color: var(--accent);
+  transition: background var(--duration-fast) ease;
+}
+
+.chat-talk-control--active .chat-talk-input-picker__trigger {
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+}
+
+.chat-talk-input-picker__trigger:hover,
+.chat-talk-input-picker[open] .chat-talk-input-picker__trigger {
+  background: color-mix(in srgb, var(--accent) 20%, transparent);
+}
+
+.chat-talk-input-picker__trigger:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+.chat-talk-input-picker__trigger svg {
+  width: 12px;
+  height: 12px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2px;
+}
+
+.chat-talk-input-picker[open] .chat-talk-input-picker__trigger svg {
+  transform: rotate(180deg);
+}
+
+.chat-talk-input-picker::part(menu) {
+  width: min(300px, calc(100vw - 24px));
+  padding: 6px;
+  border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--bg-elevated) 96%, var(--card));
+  box-shadow: var(--shadow-md);
+}
+
+.chat-talk-input-picker__heading {
+  padding: 6px 9px 5px;
+  color: var(--text-strong);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.chat-talk-input-picker__item {
+  color: var(--text);
+  font-size: 13px;
+}
+
+.chat-talk-input-picker__label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-talk-input-picker__check {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  color: var(--accent);
+}
+
+.chat-talk-input-picker__check svg {
+  width: 14px;
+  height: 14px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2px;
+}
+
+.chat-talk-input-picker__note,
+.chat-talk-input-picker__warning,
+.chat-talk-input-picker__hint {
+  padding: 5px 9px;
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.chat-talk-input-picker__warning {
+  color: var(--warn);
+}
+
+.chat-talk-input-picker__hint {
+  margin-top: 3px;
+  border-top: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
+  padding-top: 8px;
+}
+
 .agent-chat__video-preview {
   position: relative;
   align-self: flex-end;


### PR DESCRIPTION
## What Problem This Solves

Microphone selection for realtime Talk exists only on the Settings page. Users in a chat have no way to see or change which mic Talk will use without leaving the conversation — a papercut every time a headset, interface, or virtual device grabs the default.

## Why This Change Was Made

The mic choice belongs where the mic button is. The composer talk button now carries a small device menu (split-button caret), reusing the existing discovery (`discoverRealtimeTalkInputs`) and the existing persisted setting (`realtimeTalkInputDeviceId`) — no new state model, no protocol changes.

## User Impact

- A caret next to the composer mic button opens a device menu: System default first, then each microphone, with a radio checkmark on the active choice.
- List refreshes on every open (permission-probes so labels populate), shows discovery warnings inline, and works during an active Talk session with a hint that changes apply to the next session.
- Keyboard/a11y: radio-menu semantics, Escape dismisses.
- Settings-page picker keeps working unchanged (same underlying setting).

## Evidence

- Composer Vitest: 22/22 passing (open/list/check/persist, refresh-on-reopen, warning, active-session hint, Escape) — independently re-verified.
- Remote typecheck, lint, formatting, guards, and i18n verification via the changed-check classifier: clean. i18n baseline: no drift (one new English string).
- Built on the existing `wa-dropdown` + `syncDropdownItemRadio` primitives; +438/-31 across 4 files.

## Screenshots

Composer, before (plain mic button) / after (caret + device menu open, fake Chromium devices):

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/talk-device-selectors/mic-before.png) | ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/talk-device-selectors/mic-popover-open.png) |
