### PR TITLE
feat(ios): Talk camera flip control and mic input selection

### DIFF
--- a/apps/.i18n/apple-translation-contradictions.json
+++ b/apps/.i18n/apple-translation-contradictions.json
@@ -1540,6 +1540,22 @@
       ]
     },
     {
+      "locale": "it",
+      "source": "Connecting...",
+      "translations": [
+        "Connessione in corso...",
+        "Connessione..."
+      ]
+    },
+    {
+      "locale": "nl",
+      "source": "Connecting...",
+      "translations": [
+        "Verbinden...",
+        "Verbinding maken..."
+      ]
+    },
+    {
       "locale": "zh-TW",
       "source": "Connecting...",
       "translations": [
@@ -3259,39 +3275,23 @@
       "source": "Gateway connected",
       "translations": [
         "Gateway متصل",
-        "تم اتصال Gateway"
+        "تم الاتصال بـ Gateway"
       ]
     },
     {
-      "locale": "fa",
+      "locale": "tr",
       "source": "Gateway connected",
       "translations": [
-        "Gateway متصل است",
-        "Gateway متصل شد"
+        "Gateway bağlandı",
+        "Gateway bağlı"
       ]
     },
     {
-      "locale": "ja-JP",
+      "locale": "vi",
       "source": "Gateway connected",
       "translations": [
-        "Gateway に接続しました",
-        "Gatewayに接続済み"
-      ]
-    },
-    {
-      "locale": "pl",
-      "source": "Gateway connected",
-      "translations": [
-        "Gateway połączony",
-        "Połączono z Gateway"
-      ]
-    },
-    {
-      "locale": "ru",
-      "source": "Gateway connected",
-      "translations": [
-        "Gateway подключен",
-        "Gateway подключён"
+        "Gateway đã kết nối",
+        "Đã kết nối Gateway"
       ]
     },
     {
@@ -8614,6 +8614,14 @@
       "translations": [
         "Стан",
         "Статус"
+      ]
+    },
+    {
+      "locale": "id",
+      "source": "Stop",
+      "translations": [
+        "Berhenti",
+        "Hentikan"
       ]
     },
     {

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -36675,7 +36675,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 83,
+      "line": 73,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift",
       "source": "Stop",
       "surface": "apple",
@@ -36683,7 +36683,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 83,
+      "line": 73,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift",
       "source": "Talk",
       "surface": "apple",
@@ -36691,7 +36691,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 128,
+      "line": 118,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift",
       "source": "Start realtime chat",
       "surface": "apple",
@@ -36699,7 +36699,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 128,
+      "line": 118,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift",
       "source": "Stop realtime chat",
       "surface": "apple",
@@ -36707,7 +36707,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 201,
+      "line": 203,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -36715,7 +36715,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 201,
+      "line": 203,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift",
       "source": "Gateway connected",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -13667,7 +13667,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 189,
+      "line": 193,
       "path": "apps/ios/Sources/Camera/CameraController.swift",
       "source": "Camera",
       "surface": "apple",
@@ -13675,7 +13675,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 189,
+      "line": 193,
       "path": "apps/ios/Sources/Camera/CameraController.swift",
       "source": "Microphone",
       "surface": "apple",
@@ -17011,7 +17011,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 173,
+      "line": 174,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Unable to Export Transcript",
       "surface": "apple",
@@ -17019,7 +17019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 177,
+      "line": 178,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "OK",
       "surface": "apple",
@@ -17027,7 +17027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 181,
+      "line": 182,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "OpenClaw could not prepare the Markdown file.",
       "surface": "apple",
@@ -17035,7 +17035,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 203,
+      "line": 204,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "What would you like to work on?",
       "surface": "apple",
@@ -17043,7 +17043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 223,
+      "line": 224,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "The thread attaches once the gateway is ready.",
       "surface": "apple",
@@ -17051,7 +17051,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 311,
+      "line": 312,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Collapsed",
       "surface": "apple",
@@ -17059,7 +17059,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 311,
+      "line": 312,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Expanded",
       "surface": "apple",
@@ -17067,7 +17067,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 381,
+      "line": 382,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Opens Settings / Gateway",
       "surface": "apple",
@@ -17075,7 +17075,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 384,
+      "line": 385,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Hides the gateway status label",
       "surface": "apple",
@@ -17083,7 +17083,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 385,
+      "line": 386,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Shows the full gateway status label",
       "surface": "apple",
@@ -17091,7 +17091,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 404,
+      "line": 405,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Voice off",
       "surface": "apple",
@@ -17099,7 +17099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 545,
+      "line": 568,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "New Chat",
       "surface": "apple",
@@ -17107,7 +17107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 558,
+      "line": 581,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "New Chat in Worktree",
       "surface": "apple",
@@ -17115,7 +17115,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 571,
+      "line": 594,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Threads…",
       "surface": "apple",
@@ -17123,7 +17123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 584,
+      "line": 607,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Background Tasks",
       "surface": "apple",
@@ -17131,7 +17131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 596,
+      "line": 619,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Export Transcript",
       "surface": "apple",
@@ -17139,7 +17139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 609,
+      "line": 632,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Gateway Settings",
       "surface": "apple",
@@ -17147,7 +17147,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 620,
+      "line": 643,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Show reasoning & tool activity",
       "surface": "apple",
@@ -17155,7 +17155,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 629,
+      "line": 652,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Chat actions",
       "surface": "apple",
@@ -17163,7 +17163,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 731,
+      "line": 754,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Connected",
       "surface": "apple",
@@ -17171,7 +17171,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 731,
+      "line": 754,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Unavailable",
       "surface": "apple",
@@ -17179,7 +17179,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 744,
+      "line": 767,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Message %@...",
       "surface": "apple",
@@ -17187,7 +17187,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 749,
+      "line": 772,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Message %@; sends when connected",
       "surface": "apple",
@@ -17195,7 +17195,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 752,
+      "line": 775,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Connect to a gateway",
       "surface": "apple",
@@ -17203,7 +17203,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 841,
+      "line": 864,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Check OpenClaw status",
       "surface": "apple",
@@ -17211,7 +17211,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 842,
+      "line": 865,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Summarize the current OpenClaw status and tell me what needs attention.",
       "surface": "apple",
@@ -17219,7 +17219,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 845,
+      "line": 868,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "What can I control here?",
       "surface": "apple",
@@ -17227,7 +17227,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 846,
+      "line": 869,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Show me which phone controls and device capabilities are available right now.",
       "surface": "apple",
@@ -17235,7 +17235,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 849,
+      "line": 872,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Help me start voice chat",
       "surface": "apple",
@@ -17243,7 +17243,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 850,
+      "line": 873,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Help me start a realtime voice session from this phone.",
       "surface": "apple",
@@ -23563,7 +23563,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4087,
+      "line": 4112,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval needed",
       "surface": "apple",
@@ -23571,7 +23571,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4088,
+      "line": 4113,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Action required",
       "surface": "apple",
@@ -23579,7 +23579,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4803,
+      "line": 4828,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -23587,7 +23587,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4804,
+      "line": 4829,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting...",
       "surface": "apple",
@@ -23595,7 +23595,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5156,
+      "line": 5181,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connected",
       "surface": "apple",
@@ -23603,7 +23603,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 5156,
+      "line": 5181,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Offline",
       "surface": "apple",
@@ -23611,7 +23611,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6326,
+      "line": 6351,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "No chat messages yet",
       "surface": "apple",
@@ -23619,7 +23619,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6525,
+      "line": 6550,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting…",
       "surface": "apple",
@@ -23627,7 +23627,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6525,
+      "line": 6550,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting…",
       "surface": "apple",
@@ -23635,7 +23635,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8934,
+      "line": 8959,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval",
       "surface": "apple",
@@ -23643,7 +23643,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8934,
+      "line": 8959,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "This approval was already",
       "surface": "apple",
@@ -23651,7 +23651,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8940,
+      "line": 8965,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "This approval was already set to Always Allow.",
       "surface": "apple",
@@ -23659,7 +23659,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 8941,
+      "line": 8966,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval set to Always Allow.",
       "surface": "apple",
@@ -23667,7 +23667,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 10278,
+      "line": 10303,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "\\(urlText.prefix(500))…",
       "surface": "apple",
@@ -25411,7 +25411,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 591,
+      "line": 608,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Gateway relay ready",
       "surface": "apple",
@@ -25419,7 +25419,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 593,
+      "line": 610,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Realtime Voice, Gateway relay ready",
       "surface": "apple",
@@ -25427,7 +25427,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 595,
+      "line": 612,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Listening starts from this phone",
       "surface": "apple",
@@ -25435,7 +25435,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 835,
+      "line": 852,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Off",
       "surface": "apple",
@@ -25443,7 +25443,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 838,
+      "line": 855,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Not active",
       "surface": "apple",
@@ -25451,7 +25451,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1024,
+      "line": 1041,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Requesting permissions…",
       "surface": "apple",
@@ -25459,7 +25459,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1053,
+      "line": 1070,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Start failed: %@",
       "surface": "apple",
@@ -25467,7 +25467,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1309,
+      "line": 1326,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Microphone permission denied",
       "surface": "apple",
@@ -25475,7 +25475,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1319,
+      "line": 1336,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Speech recognition",
       "surface": "apple",
@@ -25483,7 +25483,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1450,
+      "line": 1467,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Offline",
       "surface": "apple",
@@ -25491,7 +25491,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1649,
+      "line": 1666,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Speech error: %@",
       "surface": "apple",
@@ -25499,7 +25499,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1964,
+      "line": 1981,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Gateway not connected",
       "surface": "apple",
@@ -25507,7 +25507,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2008,
+      "line": 2025,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Aborted",
       "surface": "apple",
@@ -25515,7 +25515,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2008,
+      "line": 2025,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Chat error",
       "surface": "apple",
@@ -25523,7 +25523,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 2036,
+      "line": 2053,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Talk failed: %@",
       "surface": "apple",
@@ -25531,7 +25531,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 2140,
+      "line": 2157,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "No reply",
       "surface": "apple",
@@ -25539,7 +25539,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 2232,
+      "line": 2252,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Paused",
       "surface": "apple",
@@ -25547,7 +25547,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 2644,
+      "line": 2664,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Generating voice…",
       "surface": "apple",
@@ -25555,7 +25555,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 2782,
+      "line": 2802,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Speak failed: %@",
       "surface": "apple",
@@ -25563,7 +25563,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 2881,
+      "line": 2901,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Speaking (System)…",
       "surface": "apple",
@@ -25571,7 +25571,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3762,
+      "line": 3782,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "iOS System Voice",
       "surface": "apple",
@@ -25579,7 +25579,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3764,
+      "line": 3784,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Realtime Voice",
       "surface": "apple",
@@ -25587,7 +25587,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3768,
+      "line": 3788,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Gateway Default",
       "surface": "apple",
@@ -25595,7 +25595,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3827,
+      "line": 3847,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Listening (Realtime)",
       "surface": "apple",
@@ -25603,7 +25603,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3829,
+      "line": 3849,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Thinking",
       "surface": "apple",
@@ -25611,7 +25611,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3831,
+      "line": 3851,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Thinking…",
       "surface": "apple",
@@ -25619,7 +25619,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3833,
+      "line": 3853,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Asking OpenClaw",
       "surface": "apple",
@@ -25627,7 +25627,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3835,
+      "line": 3855,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Still asking OpenClaw",
       "surface": "apple",
@@ -25635,7 +25635,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3837,
+      "line": 3857,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Updating OpenClaw",
       "surface": "apple",
@@ -25643,7 +25643,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3839,
+      "line": 3859,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Speaking",
       "surface": "apple",
@@ -25651,7 +25651,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3841,
+      "line": 3861,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Speaking…",
       "surface": "apple",
@@ -25659,7 +25659,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3843,
+      "line": 3863,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Connecting",
       "surface": "apple",
@@ -25667,7 +25667,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3845,
+      "line": 3865,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Connecting realtime…",
       "surface": "apple",
@@ -25675,7 +25675,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3847,
+      "line": 3867,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Waiting for realtime…",
       "surface": "apple",
@@ -25683,7 +25683,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3849,
+      "line": 3869,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Ready",
       "surface": "apple",
@@ -25691,7 +25691,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3851,
+      "line": 3871,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Reconnecting",
       "surface": "apple",
@@ -25699,7 +25699,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3853,
+      "line": 3873,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Reconnecting…",
       "surface": "apple",
@@ -25707,7 +25707,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3855,
+      "line": 3875,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Realtime failed before connecting",
       "surface": "apple",
@@ -25715,7 +25715,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3857,
+      "line": 3877,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Realtime disconnected",
       "surface": "apple",
@@ -25723,7 +25723,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3859,
+      "line": 3879,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "OpenClaw unavailable",
       "surface": "apple",
@@ -25731,7 +25731,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3899,
+      "line": 3919,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "iOS Speech + TTS",
       "surface": "apple",
@@ -25739,7 +25739,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3901,
+      "line": 3921,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Listening",
       "surface": "apple",
@@ -25747,7 +25747,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 3905,
+      "line": 3925,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "iOS Speech fallback",
       "surface": "apple",
@@ -25755,7 +25755,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4166,
+      "line": 4186,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Gateway Relay",
       "surface": "apple",
@@ -25763,7 +25763,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4168,
+      "line": 4188,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Native WebRTC",
       "surface": "apple",
@@ -25771,7 +25771,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4169,
+      "line": 4189,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Native",
       "surface": "apple",
@@ -25779,7 +25779,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4230,
+      "line": 4250,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Gateway permission required",
       "surface": "apple",
@@ -25787,7 +25787,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4252,
+      "line": 4272,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Not loaded",
       "surface": "apple",
@@ -25795,7 +25795,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4270,
+      "line": 4290,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Approval requested",
       "surface": "apple",
@@ -25803,7 +25803,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4693,
+      "line": 4729,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Realtime unavailable",
       "surface": "apple",
@@ -25811,7 +25811,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 4715,
+      "line": 4751,
       "path": "apps/ios/Sources/Voice/TalkModeManager.swift",
       "source": "Listening (PTT)",
       "surface": "apple",
@@ -36651,6 +36651,78 @@
     },
     {
       "kind": "ui-localized-call",
+      "line": 36,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift",
+      "source": "Switch to back camera",
+      "surface": "apple",
+      "id": "native.apple.fc5931c1f0a6bbec"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 38,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift",
+      "source": "Switch to front camera",
+      "surface": "apple",
+      "id": "native.apple.cce3b539e31701c0"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 40,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift",
+      "source": "Flip camera",
+      "surface": "apple",
+      "id": "native.apple.f397daffdfd02ee0"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 83,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift",
+      "source": "Stop",
+      "surface": "apple",
+      "id": "native.apple.11f8de87ca3fcb11"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 83,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift",
+      "source": "Talk",
+      "surface": "apple",
+      "id": "native.apple.7c92bec1c8a83e43"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 128,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift",
+      "source": "Start realtime chat",
+      "surface": "apple",
+      "id": "native.apple.dae61543f9b416ca"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 128,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift",
+      "source": "Stop realtime chat",
+      "surface": "apple",
+      "id": "native.apple.d376b015a90792a9"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 201,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift",
+      "source": "Connecting...",
+      "surface": "apple",
+      "id": "native.apple.ac48dbe25ac4d40d"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 201,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift",
+      "source": "Gateway connected",
+      "surface": "apple",
+      "id": "native.apple.ccce98756eb1dacd"
+    },
+    {
+      "kind": "ui-localized-call",
       "line": 415,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Context %@%% used",
@@ -36803,31 +36875,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 813,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
-      "source": "Talk",
-      "surface": "apple",
-      "id": "native.apple.ee2c0d22f5861159"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 884,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
-      "source": "Start realtime chat",
-      "surface": "apple",
-      "id": "native.apple.5d5041aefe6dfddd"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 884,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
-      "source": "Stop realtime chat",
-      "surface": "apple",
-      "id": "native.apple.21a7d3a3386a2218"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 918,
+      "line": 821,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Start",
       "surface": "apple",
@@ -36835,7 +36883,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 918,
+      "line": 821,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop",
       "surface": "apple",
@@ -36843,7 +36891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1035,
+      "line": 919,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Loading commands",
       "surface": "apple",
@@ -36851,7 +36899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1044,
+      "line": 928,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Commands unavailable",
       "surface": "apple",
@@ -36859,7 +36907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1053,
+      "line": 937,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Retry",
       "surface": "apple",
@@ -36867,7 +36915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1062,
+      "line": 946,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "No matching commands",
       "surface": "apple",
@@ -36875,7 +36923,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1294,
+      "line": 1178,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop response",
       "surface": "apple",
@@ -36883,7 +36931,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1319,
+      "line": 1203,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Send message",
       "surface": "apple",
@@ -36891,7 +36939,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1333,
+      "line": 1217,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -36899,23 +36947,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1458,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
-      "source": "Connecting...",
-      "surface": "apple",
-      "id": "native.apple.6c984c0e3ed3a69e"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 1458,
-      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
-      "source": "Gateway connected",
-      "surface": "apple",
-      "id": "native.apple.898849eb2bcb0b53"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 1467,
+      "line": 1343,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Message…",
       "surface": "apple",

--- a/apps/.i18n/native/ar.json
+++ b/apps/.i18n/native/ar.json
@@ -22909,6 +22909,51 @@
       "translated": "<\\(tag)"
     },
     {
+      "id": "native.apple.fc5931c1f0a6bbec",
+      "source": "Switch to back camera",
+      "translated": "التبديل إلى الكاميرا الخلفية"
+    },
+    {
+      "id": "native.apple.cce3b539e31701c0",
+      "source": "Switch to front camera",
+      "translated": "التبديل إلى الكاميرا الأمامية"
+    },
+    {
+      "id": "native.apple.f397daffdfd02ee0",
+      "source": "Flip camera",
+      "translated": "عكس الكاميرا"
+    },
+    {
+      "id": "native.apple.11f8de87ca3fcb11",
+      "source": "Stop",
+      "translated": "إيقاف"
+    },
+    {
+      "id": "native.apple.7c92bec1c8a83e43",
+      "source": "Talk",
+      "translated": "تحدّث"
+    },
+    {
+      "id": "native.apple.dae61543f9b416ca",
+      "source": "Start realtime chat",
+      "translated": "بدء الدردشة الفورية"
+    },
+    {
+      "id": "native.apple.d376b015a90792a9",
+      "source": "Stop realtime chat",
+      "translated": "إيقاف الدردشة الفورية"
+    },
+    {
+      "id": "native.apple.ac48dbe25ac4d40d",
+      "source": "Connecting...",
+      "translated": "جارٍ الاتصال..."
+    },
+    {
+      "id": "native.apple.ccce98756eb1dacd",
+      "source": "Gateway connected",
+      "translated": "تم الاتصال بـ Gateway"
+    },
+    {
       "id": "native.apple.03aca5cfee32f12d",
       "source": "Context %@%% used",
       "translated": "تم استخدام %@%% من السياق"
@@ -23004,36 +23049,6 @@
       "translated": "المرفقات"
     },
     {
-      "id": "native.apple.ee2c0d22f5861159",
-      "source": "Talk",
-      "translated": "تحدث"
-    },
-    {
-      "id": "native.apple.5d5041aefe6dfddd",
-      "source": "Start realtime chat",
-      "translated": "بدء دردشة فورية"
-    },
-    {
-      "id": "native.apple.21a7d3a3386a2218",
-      "source": "Stop realtime chat",
-      "translated": "إيقاف الدردشة الفورية"
-    },
-    {
-      "id": "native.apple.e37904df667f350c",
-      "source": "Switch to back camera",
-      "translated": "التبديل إلى الكاميرا الخلفية"
-    },
-    {
-      "id": "native.apple.7849ca56b4b45e8f",
-      "source": "Switch to front camera",
-      "translated": "التبديل إلى الكاميرا الأمامية"
-    },
-    {
-      "id": "native.apple.8bf42d1dd3bb2d7a",
-      "source": "Flip camera",
-      "translated": "تبديل الكاميرا"
-    },
-    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "بدء"
@@ -23077,16 +23092,6 @@
       "id": "native.apple.f4473f79bb87b2fd",
       "source": "Refresh",
       "translated": "تحديث"
-    },
-    {
-      "id": "native.apple.6c984c0e3ed3a69e",
-      "source": "Connecting...",
-      "translated": "جارٍ الاتصال..."
-    },
-    {
-      "id": "native.apple.898849eb2bcb0b53",
-      "source": "Gateway connected",
-      "translated": "تم اتصال Gateway"
     },
     {
       "id": "native.apple.b6adfcd17a6e73d7",

--- a/apps/.i18n/native/ar.json
+++ b/apps/.i18n/native/ar.json
@@ -23019,6 +23019,21 @@
       "translated": "إيقاف الدردشة الفورية"
     },
     {
+      "id": "native.apple.e37904df667f350c",
+      "source": "Switch to back camera",
+      "translated": "التبديل إلى الكاميرا الخلفية"
+    },
+    {
+      "id": "native.apple.7849ca56b4b45e8f",
+      "source": "Switch to front camera",
+      "translated": "التبديل إلى الكاميرا الأمامية"
+    },
+    {
+      "id": "native.apple.8bf42d1dd3bb2d7a",
+      "source": "Flip camera",
+      "translated": "تبديل الكاميرا"
+    },
+    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "بدء"

--- a/apps/.i18n/native/de.json
+++ b/apps/.i18n/native/de.json
@@ -22909,6 +22909,51 @@
       "translated": "<\\(tag)"
     },
     {
+      "id": "native.apple.fc5931c1f0a6bbec",
+      "source": "Switch to back camera",
+      "translated": "Zur Rückkamera wechseln"
+    },
+    {
+      "id": "native.apple.cce3b539e31701c0",
+      "source": "Switch to front camera",
+      "translated": "Zur Frontkamera wechseln"
+    },
+    {
+      "id": "native.apple.f397daffdfd02ee0",
+      "source": "Flip camera",
+      "translated": "Kamera wechseln"
+    },
+    {
+      "id": "native.apple.11f8de87ca3fcb11",
+      "source": "Stop",
+      "translated": "Stopp"
+    },
+    {
+      "id": "native.apple.7c92bec1c8a83e43",
+      "source": "Talk",
+      "translated": "Sprechen"
+    },
+    {
+      "id": "native.apple.dae61543f9b416ca",
+      "source": "Start realtime chat",
+      "translated": "Echtzeit-Chat starten"
+    },
+    {
+      "id": "native.apple.d376b015a90792a9",
+      "source": "Stop realtime chat",
+      "translated": "Echtzeit-Chat beenden"
+    },
+    {
+      "id": "native.apple.ac48dbe25ac4d40d",
+      "source": "Connecting...",
+      "translated": "Verbindung wird hergestellt..."
+    },
+    {
+      "id": "native.apple.ccce98756eb1dacd",
+      "source": "Gateway connected",
+      "translated": "Gateway verbunden"
+    },
+    {
       "id": "native.apple.03aca5cfee32f12d",
       "source": "Context %@%% used",
       "translated": "%@%% des Kontexts verwendet"
@@ -23004,36 +23049,6 @@
       "translated": "Anhänge"
     },
     {
-      "id": "native.apple.ee2c0d22f5861159",
-      "source": "Talk",
-      "translated": "Sprechen"
-    },
-    {
-      "id": "native.apple.5d5041aefe6dfddd",
-      "source": "Start realtime chat",
-      "translated": "Echtzeit-Chat starten"
-    },
-    {
-      "id": "native.apple.21a7d3a3386a2218",
-      "source": "Stop realtime chat",
-      "translated": "Echtzeit-Chat beenden"
-    },
-    {
-      "id": "native.apple.e37904df667f350c",
-      "source": "Switch to back camera",
-      "translated": "Zur rückseitigen Kamera wechseln"
-    },
-    {
-      "id": "native.apple.7849ca56b4b45e8f",
-      "source": "Switch to front camera",
-      "translated": "Zur Frontkamera wechseln"
-    },
-    {
-      "id": "native.apple.8bf42d1dd3bb2d7a",
-      "source": "Flip camera",
-      "translated": "Kamera wechseln"
-    },
-    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "Starten"
@@ -23077,16 +23092,6 @@
       "id": "native.apple.f4473f79bb87b2fd",
       "source": "Refresh",
       "translated": "Aktualisieren"
-    },
-    {
-      "id": "native.apple.6c984c0e3ed3a69e",
-      "source": "Connecting...",
-      "translated": "Verbindung wird hergestellt..."
-    },
-    {
-      "id": "native.apple.898849eb2bcb0b53",
-      "source": "Gateway connected",
-      "translated": "Gateway verbunden"
     },
     {
       "id": "native.apple.b6adfcd17a6e73d7",

--- a/apps/.i18n/native/de.json
+++ b/apps/.i18n/native/de.json
@@ -23019,6 +23019,21 @@
       "translated": "Echtzeit-Chat beenden"
     },
     {
+      "id": "native.apple.e37904df667f350c",
+      "source": "Switch to back camera",
+      "translated": "Zur rückseitigen Kamera wechseln"
+    },
+    {
+      "id": "native.apple.7849ca56b4b45e8f",
+      "source": "Switch to front camera",
+      "translated": "Zur Frontkamera wechseln"
+    },
+    {
+      "id": "native.apple.8bf42d1dd3bb2d7a",
+      "source": "Flip camera",
+      "translated": "Kamera wechseln"
+    },
+    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "Starten"

--- a/apps/.i18n/native/es.json
+++ b/apps/.i18n/native/es.json
@@ -23019,6 +23019,21 @@
       "translated": "Detener chat en tiempo real"
     },
     {
+      "id": "native.apple.e37904df667f350c",
+      "source": "Switch to back camera",
+      "translated": "Cambiar a la cámara trasera"
+    },
+    {
+      "id": "native.apple.7849ca56b4b45e8f",
+      "source": "Switch to front camera",
+      "translated": "Cambiar a la cámara frontal"
+    },
+    {
+      "id": "native.apple.8bf42d1dd3bb2d7a",
+      "source": "Flip camera",
+      "translated": "Cambiar de cámara"
+    },
+    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "Iniciar"

--- a/apps/.i18n/native/es.json
+++ b/apps/.i18n/native/es.json
@@ -22909,6 +22909,51 @@
       "translated": "<\\(tag)"
     },
     {
+      "id": "native.apple.fc5931c1f0a6bbec",
+      "source": "Switch to back camera",
+      "translated": "Cambiar a la cámara trasera"
+    },
+    {
+      "id": "native.apple.cce3b539e31701c0",
+      "source": "Switch to front camera",
+      "translated": "Cambiar a la cámara frontal"
+    },
+    {
+      "id": "native.apple.f397daffdfd02ee0",
+      "source": "Flip camera",
+      "translated": "Voltear la cámara"
+    },
+    {
+      "id": "native.apple.11f8de87ca3fcb11",
+      "source": "Stop",
+      "translated": "Detener"
+    },
+    {
+      "id": "native.apple.7c92bec1c8a83e43",
+      "source": "Talk",
+      "translated": "Hablar"
+    },
+    {
+      "id": "native.apple.dae61543f9b416ca",
+      "source": "Start realtime chat",
+      "translated": "Iniciar chat en tiempo real"
+    },
+    {
+      "id": "native.apple.d376b015a90792a9",
+      "source": "Stop realtime chat",
+      "translated": "Detener chat en tiempo real"
+    },
+    {
+      "id": "native.apple.ac48dbe25ac4d40d",
+      "source": "Connecting...",
+      "translated": "Conectando..."
+    },
+    {
+      "id": "native.apple.ccce98756eb1dacd",
+      "source": "Gateway connected",
+      "translated": "Gateway conectado"
+    },
+    {
       "id": "native.apple.03aca5cfee32f12d",
       "source": "Context %@%% used",
       "translated": "%@%% del contexto usado"
@@ -23004,36 +23049,6 @@
       "translated": "Archivos adjuntos"
     },
     {
-      "id": "native.apple.ee2c0d22f5861159",
-      "source": "Talk",
-      "translated": "Hablar"
-    },
-    {
-      "id": "native.apple.5d5041aefe6dfddd",
-      "source": "Start realtime chat",
-      "translated": "Iniciar chat en tiempo real"
-    },
-    {
-      "id": "native.apple.21a7d3a3386a2218",
-      "source": "Stop realtime chat",
-      "translated": "Detener chat en tiempo real"
-    },
-    {
-      "id": "native.apple.e37904df667f350c",
-      "source": "Switch to back camera",
-      "translated": "Cambiar a la cámara trasera"
-    },
-    {
-      "id": "native.apple.7849ca56b4b45e8f",
-      "source": "Switch to front camera",
-      "translated": "Cambiar a la cámara frontal"
-    },
-    {
-      "id": "native.apple.8bf42d1dd3bb2d7a",
-      "source": "Flip camera",
-      "translated": "Cambiar de cámara"
-    },
-    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "Iniciar"
@@ -23077,16 +23092,6 @@
       "id": "native.apple.f4473f79bb87b2fd",
       "source": "Refresh",
       "translated": "Actualizar"
-    },
-    {
-      "id": "native.apple.6c984c0e3ed3a69e",
-      "source": "Connecting...",
-      "translated": "Conectando..."
-    },
-    {
-      "id": "native.apple.898849eb2bcb0b53",
-      "source": "Gateway connected",
-      "translated": "Gateway conectado"
     },
     {
       "id": "native.apple.b6adfcd17a6e73d7",

--- a/apps/.i18n/native/fa.json
+++ b/apps/.i18n/native/fa.json
@@ -23019,6 +23019,21 @@
       "translated": "توقف گفتگوی بلادرنگ"
     },
     {
+      "id": "native.apple.e37904df667f350c",
+      "source": "Switch to back camera",
+      "translated": "تغییر به دوربین پشتی"
+    },
+    {
+      "id": "native.apple.7849ca56b4b45e8f",
+      "source": "Switch to front camera",
+      "translated": "تغییر به دوربین جلو"
+    },
+    {
+      "id": "native.apple.8bf42d1dd3bb2d7a",
+      "source": "Flip camera",
+      "translated": "تعویض دوربین"
+    },
+    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "شروع"

--- a/apps/.i18n/native/fa.json
+++ b/apps/.i18n/native/fa.json
@@ -22909,6 +22909,51 @@
       "translated": "<\\(tag)"
     },
     {
+      "id": "native.apple.fc5931c1f0a6bbec",
+      "source": "Switch to back camera",
+      "translated": "تغییر به دوربین پشت"
+    },
+    {
+      "id": "native.apple.cce3b539e31701c0",
+      "source": "Switch to front camera",
+      "translated": "تغییر به دوربین جلو"
+    },
+    {
+      "id": "native.apple.f397daffdfd02ee0",
+      "source": "Flip camera",
+      "translated": "برگرداندن دوربین"
+    },
+    {
+      "id": "native.apple.11f8de87ca3fcb11",
+      "source": "Stop",
+      "translated": "توقف"
+    },
+    {
+      "id": "native.apple.7c92bec1c8a83e43",
+      "source": "Talk",
+      "translated": "صحبت"
+    },
+    {
+      "id": "native.apple.dae61543f9b416ca",
+      "source": "Start realtime chat",
+      "translated": "شروع گفت‌وگوی هم‌زمان"
+    },
+    {
+      "id": "native.apple.d376b015a90792a9",
+      "source": "Stop realtime chat",
+      "translated": "توقف گفت‌وگوی هم‌زمان"
+    },
+    {
+      "id": "native.apple.ac48dbe25ac4d40d",
+      "source": "Connecting...",
+      "translated": "در حال اتصال..."
+    },
+    {
+      "id": "native.apple.ccce98756eb1dacd",
+      "source": "Gateway connected",
+      "translated": "Gateway متصل است"
+    },
+    {
       "id": "native.apple.03aca5cfee32f12d",
       "source": "Context %@%% used",
       "translated": "%@%% از زمینه استفاده شده است"
@@ -23004,36 +23049,6 @@
       "translated": "پیوست‌ها"
     },
     {
-      "id": "native.apple.ee2c0d22f5861159",
-      "source": "Talk",
-      "translated": "گفتگو"
-    },
-    {
-      "id": "native.apple.5d5041aefe6dfddd",
-      "source": "Start realtime chat",
-      "translated": "شروع گفتگوی بلادرنگ"
-    },
-    {
-      "id": "native.apple.21a7d3a3386a2218",
-      "source": "Stop realtime chat",
-      "translated": "توقف گفتگوی بلادرنگ"
-    },
-    {
-      "id": "native.apple.e37904df667f350c",
-      "source": "Switch to back camera",
-      "translated": "تغییر به دوربین پشتی"
-    },
-    {
-      "id": "native.apple.7849ca56b4b45e8f",
-      "source": "Switch to front camera",
-      "translated": "تغییر به دوربین جلو"
-    },
-    {
-      "id": "native.apple.8bf42d1dd3bb2d7a",
-      "source": "Flip camera",
-      "translated": "تعویض دوربین"
-    },
-    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "شروع"
@@ -23077,16 +23092,6 @@
       "id": "native.apple.f4473f79bb87b2fd",
       "source": "Refresh",
       "translated": "تازه‌سازی"
-    },
-    {
-      "id": "native.apple.6c984c0e3ed3a69e",
-      "source": "Connecting...",
-      "translated": "در حال اتصال..."
-    },
-    {
-      "id": "native.apple.898849eb2bcb0b53",
-      "source": "Gateway connected",
-      "translated": "Gateway متصل شد"
     },
     {
       "id": "native.apple.b6adfcd17a6e73d7",

--- a/apps/.i18n/native/fr.json
+++ b/apps/.i18n/native/fr.json
@@ -22909,6 +22909,51 @@
       "translated": "<\\(tag)"
     },
     {
+      "id": "native.apple.fc5931c1f0a6bbec",
+      "source": "Switch to back camera",
+      "translated": "Passer à la caméra arrière"
+    },
+    {
+      "id": "native.apple.cce3b539e31701c0",
+      "source": "Switch to front camera",
+      "translated": "Passer à la caméra avant"
+    },
+    {
+      "id": "native.apple.f397daffdfd02ee0",
+      "source": "Flip camera",
+      "translated": "Retourner la caméra"
+    },
+    {
+      "id": "native.apple.11f8de87ca3fcb11",
+      "source": "Stop",
+      "translated": "Arrêter"
+    },
+    {
+      "id": "native.apple.7c92bec1c8a83e43",
+      "source": "Talk",
+      "translated": "Parler"
+    },
+    {
+      "id": "native.apple.dae61543f9b416ca",
+      "source": "Start realtime chat",
+      "translated": "Démarrer le chat en temps réel"
+    },
+    {
+      "id": "native.apple.d376b015a90792a9",
+      "source": "Stop realtime chat",
+      "translated": "Arrêter le chat en temps réel"
+    },
+    {
+      "id": "native.apple.ac48dbe25ac4d40d",
+      "source": "Connecting...",
+      "translated": "Connexion..."
+    },
+    {
+      "id": "native.apple.ccce98756eb1dacd",
+      "source": "Gateway connected",
+      "translated": "Gateway connecté"
+    },
+    {
       "id": "native.apple.03aca5cfee32f12d",
       "source": "Context %@%% used",
       "translated": "%@%% du contexte utilisé"
@@ -23004,36 +23049,6 @@
       "translated": "Pièces jointes"
     },
     {
-      "id": "native.apple.ee2c0d22f5861159",
-      "source": "Talk",
-      "translated": "Parler"
-    },
-    {
-      "id": "native.apple.5d5041aefe6dfddd",
-      "source": "Start realtime chat",
-      "translated": "Démarrer la discussion en temps réel"
-    },
-    {
-      "id": "native.apple.21a7d3a3386a2218",
-      "source": "Stop realtime chat",
-      "translated": "Arrêter la discussion en temps réel"
-    },
-    {
-      "id": "native.apple.e37904df667f350c",
-      "source": "Switch to back camera",
-      "translated": "Passer à la caméra arrière"
-    },
-    {
-      "id": "native.apple.7849ca56b4b45e8f",
-      "source": "Switch to front camera",
-      "translated": "Passer à la caméra avant"
-    },
-    {
-      "id": "native.apple.8bf42d1dd3bb2d7a",
-      "source": "Flip camera",
-      "translated": "Inverser la caméra"
-    },
-    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "Démarrer"
@@ -23077,16 +23092,6 @@
       "id": "native.apple.f4473f79bb87b2fd",
       "source": "Refresh",
       "translated": "Actualiser"
-    },
-    {
-      "id": "native.apple.6c984c0e3ed3a69e",
-      "source": "Connecting...",
-      "translated": "Connexion..."
-    },
-    {
-      "id": "native.apple.898849eb2bcb0b53",
-      "source": "Gateway connected",
-      "translated": "Gateway connecté"
     },
     {
       "id": "native.apple.b6adfcd17a6e73d7",

--- a/apps/.i18n/native/fr.json
+++ b/apps/.i18n/native/fr.json
@@ -23019,6 +23019,21 @@
       "translated": "Arrêter la discussion en temps réel"
     },
     {
+      "id": "native.apple.e37904df667f350c",
+      "source": "Switch to back camera",
+      "translated": "Passer à la caméra arrière"
+    },
+    {
+      "id": "native.apple.7849ca56b4b45e8f",
+      "source": "Switch to front camera",
+      "translated": "Passer à la caméra avant"
+    },
+    {
+      "id": "native.apple.8bf42d1dd3bb2d7a",
+      "source": "Flip camera",
+      "translated": "Inverser la caméra"
+    },
+    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "Démarrer"

--- a/apps/.i18n/native/hi.json
+++ b/apps/.i18n/native/hi.json
@@ -22909,6 +22909,51 @@
       "translated": "<\\(tag)"
     },
     {
+      "id": "native.apple.fc5931c1f0a6bbec",
+      "source": "Switch to back camera",
+      "translated": "पीछे वाले कैमरे पर स्विच करें"
+    },
+    {
+      "id": "native.apple.cce3b539e31701c0",
+      "source": "Switch to front camera",
+      "translated": "सामने वाले कैमरे पर स्विच करें"
+    },
+    {
+      "id": "native.apple.f397daffdfd02ee0",
+      "source": "Flip camera",
+      "translated": "कैमरा पलटें"
+    },
+    {
+      "id": "native.apple.11f8de87ca3fcb11",
+      "source": "Stop",
+      "translated": "रोकें"
+    },
+    {
+      "id": "native.apple.7c92bec1c8a83e43",
+      "source": "Talk",
+      "translated": "बात करें"
+    },
+    {
+      "id": "native.apple.dae61543f9b416ca",
+      "source": "Start realtime chat",
+      "translated": "रीयल-टाइम चैट शुरू करें"
+    },
+    {
+      "id": "native.apple.d376b015a90792a9",
+      "source": "Stop realtime chat",
+      "translated": "रीयल-टाइम चैट रोकें"
+    },
+    {
+      "id": "native.apple.ac48dbe25ac4d40d",
+      "source": "Connecting...",
+      "translated": "कनेक्ट हो रहा है..."
+    },
+    {
+      "id": "native.apple.ccce98756eb1dacd",
+      "source": "Gateway connected",
+      "translated": "Gateway कनेक्ट हो गया"
+    },
+    {
       "id": "native.apple.03aca5cfee32f12d",
       "source": "Context %@%% used",
       "translated": "संदर्भ का %@%% उपयोग हुआ"
@@ -23004,36 +23049,6 @@
       "translated": "अटैचमेंट"
     },
     {
-      "id": "native.apple.ee2c0d22f5861159",
-      "source": "Talk",
-      "translated": "बात करें"
-    },
-    {
-      "id": "native.apple.5d5041aefe6dfddd",
-      "source": "Start realtime chat",
-      "translated": "रीयल-टाइम चैट शुरू करें"
-    },
-    {
-      "id": "native.apple.21a7d3a3386a2218",
-      "source": "Stop realtime chat",
-      "translated": "रीयल-टाइम चैट बंद करें"
-    },
-    {
-      "id": "native.apple.e37904df667f350c",
-      "source": "Switch to back camera",
-      "translated": "पीछे वाले कैमरे पर स्विच करें"
-    },
-    {
-      "id": "native.apple.7849ca56b4b45e8f",
-      "source": "Switch to front camera",
-      "translated": "सामने वाले कैमरे पर स्विच करें"
-    },
-    {
-      "id": "native.apple.8bf42d1dd3bb2d7a",
-      "source": "Flip camera",
-      "translated": "कैमरा पलटें"
-    },
-    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "शुरू करें"
@@ -23077,16 +23092,6 @@
       "id": "native.apple.f4473f79bb87b2fd",
       "source": "Refresh",
       "translated": "रीफ़्रेश करें"
-    },
-    {
-      "id": "native.apple.6c984c0e3ed3a69e",
-      "source": "Connecting...",
-      "translated": "कनेक्ट हो रहा है..."
-    },
-    {
-      "id": "native.apple.898849eb2bcb0b53",
-      "source": "Gateway connected",
-      "translated": "Gateway कनेक्ट हो गया"
     },
     {
       "id": "native.apple.b6adfcd17a6e73d7",

--- a/apps/.i18n/native/hi.json
+++ b/apps/.i18n/native/hi.json
@@ -23019,6 +23019,21 @@
       "translated": "रीयल-टाइम चैट बंद करें"
     },
     {
+      "id": "native.apple.e37904df667f350c",
+      "source": "Switch to back camera",
+      "translated": "पीछे वाले कैमरे पर स्विच करें"
+    },
+    {
+      "id": "native.apple.7849ca56b4b45e8f",
+      "source": "Switch to front camera",
+      "translated": "सामने वाले कैमरे पर स्विच करें"
+    },
+    {
+      "id": "native.apple.8bf42d1dd3bb2d7a",
+      "source": "Flip camera",
+      "translated": "कैमरा पलटें"
+    },
+    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "शुरू करें"

--- a/apps/.i18n/native/id.json
+++ b/apps/.i18n/native/id.json
@@ -23019,6 +23019,21 @@
       "translated": "Hentikan chat realtime"
     },
     {
+      "id": "native.apple.e37904df667f350c",
+      "source": "Switch to back camera",
+      "translated": "Beralih ke kamera belakang"
+    },
+    {
+      "id": "native.apple.7849ca56b4b45e8f",
+      "source": "Switch to front camera",
+      "translated": "Beralih ke kamera depan"
+    },
+    {
+      "id": "native.apple.8bf42d1dd3bb2d7a",
+      "source": "Flip camera",
+      "translated": "Balik kamera"
+    },
+    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "Mulai"

--- a/apps/.i18n/native/id.json
+++ b/apps/.i18n/native/id.json
@@ -22909,6 +22909,51 @@
       "translated": "<\\(tag)"
     },
     {
+      "id": "native.apple.fc5931c1f0a6bbec",
+      "source": "Switch to back camera",
+      "translated": "Beralih ke kamera belakang"
+    },
+    {
+      "id": "native.apple.cce3b539e31701c0",
+      "source": "Switch to front camera",
+      "translated": "Beralih ke kamera depan"
+    },
+    {
+      "id": "native.apple.f397daffdfd02ee0",
+      "source": "Flip camera",
+      "translated": "Balik kamera"
+    },
+    {
+      "id": "native.apple.11f8de87ca3fcb11",
+      "source": "Stop",
+      "translated": "Berhenti"
+    },
+    {
+      "id": "native.apple.7c92bec1c8a83e43",
+      "source": "Talk",
+      "translated": "Bicara"
+    },
+    {
+      "id": "native.apple.dae61543f9b416ca",
+      "source": "Start realtime chat",
+      "translated": "Mulai obrolan waktu nyata"
+    },
+    {
+      "id": "native.apple.d376b015a90792a9",
+      "source": "Stop realtime chat",
+      "translated": "Hentikan obrolan waktu nyata"
+    },
+    {
+      "id": "native.apple.ac48dbe25ac4d40d",
+      "source": "Connecting...",
+      "translated": "Menghubungkan..."
+    },
+    {
+      "id": "native.apple.ccce98756eb1dacd",
+      "source": "Gateway connected",
+      "translated": "Gateway terhubung"
+    },
+    {
       "id": "native.apple.03aca5cfee32f12d",
       "source": "Context %@%% used",
       "translated": "Konteks yang digunakan %@%%"
@@ -23004,36 +23049,6 @@
       "translated": "Lampiran"
     },
     {
-      "id": "native.apple.ee2c0d22f5861159",
-      "source": "Talk",
-      "translated": "Bicara"
-    },
-    {
-      "id": "native.apple.5d5041aefe6dfddd",
-      "source": "Start realtime chat",
-      "translated": "Mulai chat realtime"
-    },
-    {
-      "id": "native.apple.21a7d3a3386a2218",
-      "source": "Stop realtime chat",
-      "translated": "Hentikan chat realtime"
-    },
-    {
-      "id": "native.apple.e37904df667f350c",
-      "source": "Switch to back camera",
-      "translated": "Beralih ke kamera belakang"
-    },
-    {
-      "id": "native.apple.7849ca56b4b45e8f",
-      "source": "Switch to front camera",
-      "translated": "Beralih ke kamera depan"
-    },
-    {
-      "id": "native.apple.8bf42d1dd3bb2d7a",
-      "source": "Flip camera",
-      "translated": "Balik kamera"
-    },
-    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "Mulai"
@@ -23077,16 +23092,6 @@
       "id": "native.apple.f4473f79bb87b2fd",
       "source": "Refresh",
       "translated": "Segarkan"
-    },
-    {
-      "id": "native.apple.6c984c0e3ed3a69e",
-      "source": "Connecting...",
-      "translated": "Menghubungkan..."
-    },
-    {
-      "id": "native.apple.898849eb2bcb0b53",
-      "source": "Gateway connected",
-      "translated": "Gateway terhubung"
     },
     {
       "id": "native.apple.b6adfcd17a6e73d7",

--- a/apps/.i18n/native/it.json
+++ b/apps/.i18n/native/it.json
@@ -23019,6 +23019,21 @@
       "translated": "Interrompi chat in tempo reale"
     },
     {
+      "id": "native.apple.e37904df667f350c",
+      "source": "Switch to back camera",
+      "translated": "Passa alla fotocamera posteriore"
+    },
+    {
+      "id": "native.apple.7849ca56b4b45e8f",
+      "source": "Switch to front camera",
+      "translated": "Passa alla fotocamera anteriore"
+    },
+    {
+      "id": "native.apple.8bf42d1dd3bb2d7a",
+      "source": "Flip camera",
+      "translated": "Inverti fotocamera"
+    },
+    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "Avvia"

--- a/apps/.i18n/native/it.json
+++ b/apps/.i18n/native/it.json
@@ -22909,6 +22909,51 @@
       "translated": "<\\(tag)"
     },
     {
+      "id": "native.apple.fc5931c1f0a6bbec",
+      "source": "Switch to back camera",
+      "translated": "Passa alla fotocamera posteriore"
+    },
+    {
+      "id": "native.apple.cce3b539e31701c0",
+      "source": "Switch to front camera",
+      "translated": "Passa alla fotocamera anteriore"
+    },
+    {
+      "id": "native.apple.f397daffdfd02ee0",
+      "source": "Flip camera",
+      "translated": "Capovolgi fotocamera"
+    },
+    {
+      "id": "native.apple.11f8de87ca3fcb11",
+      "source": "Stop",
+      "translated": "Interrompi"
+    },
+    {
+      "id": "native.apple.7c92bec1c8a83e43",
+      "source": "Talk",
+      "translated": "Parla"
+    },
+    {
+      "id": "native.apple.dae61543f9b416ca",
+      "source": "Start realtime chat",
+      "translated": "Avvia chat in tempo reale"
+    },
+    {
+      "id": "native.apple.d376b015a90792a9",
+      "source": "Stop realtime chat",
+      "translated": "Interrompi chat in tempo reale"
+    },
+    {
+      "id": "native.apple.ac48dbe25ac4d40d",
+      "source": "Connecting...",
+      "translated": "Connessione..."
+    },
+    {
+      "id": "native.apple.ccce98756eb1dacd",
+      "source": "Gateway connected",
+      "translated": "Gateway connesso"
+    },
+    {
       "id": "native.apple.03aca5cfee32f12d",
       "source": "Context %@%% used",
       "translated": "Contesto utilizzato: %@%%"
@@ -23004,36 +23049,6 @@
       "translated": "Allegati"
     },
     {
-      "id": "native.apple.ee2c0d22f5861159",
-      "source": "Talk",
-      "translated": "Parla"
-    },
-    {
-      "id": "native.apple.5d5041aefe6dfddd",
-      "source": "Start realtime chat",
-      "translated": "Avvia chat in tempo reale"
-    },
-    {
-      "id": "native.apple.21a7d3a3386a2218",
-      "source": "Stop realtime chat",
-      "translated": "Interrompi chat in tempo reale"
-    },
-    {
-      "id": "native.apple.e37904df667f350c",
-      "source": "Switch to back camera",
-      "translated": "Passa alla fotocamera posteriore"
-    },
-    {
-      "id": "native.apple.7849ca56b4b45e8f",
-      "source": "Switch to front camera",
-      "translated": "Passa alla fotocamera anteriore"
-    },
-    {
-      "id": "native.apple.8bf42d1dd3bb2d7a",
-      "source": "Flip camera",
-      "translated": "Inverti fotocamera"
-    },
-    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "Avvia"
@@ -23077,16 +23092,6 @@
       "id": "native.apple.f4473f79bb87b2fd",
       "source": "Refresh",
       "translated": "Aggiorna"
-    },
-    {
-      "id": "native.apple.6c984c0e3ed3a69e",
-      "source": "Connecting...",
-      "translated": "Connessione in corso..."
-    },
-    {
-      "id": "native.apple.898849eb2bcb0b53",
-      "source": "Gateway connected",
-      "translated": "Gateway connesso"
     },
     {
       "id": "native.apple.b6adfcd17a6e73d7",

--- a/apps/.i18n/native/ja-JP.json
+++ b/apps/.i18n/native/ja-JP.json
@@ -22909,6 +22909,51 @@
       "translated": "<\\(tag)"
     },
     {
+      "id": "native.apple.fc5931c1f0a6bbec",
+      "source": "Switch to back camera",
+      "translated": "背面カメラに切り替え"
+    },
+    {
+      "id": "native.apple.cce3b539e31701c0",
+      "source": "Switch to front camera",
+      "translated": "前面カメラに切り替え"
+    },
+    {
+      "id": "native.apple.f397daffdfd02ee0",
+      "source": "Flip camera",
+      "translated": "カメラを反転"
+    },
+    {
+      "id": "native.apple.11f8de87ca3fcb11",
+      "source": "Stop",
+      "translated": "停止"
+    },
+    {
+      "id": "native.apple.7c92bec1c8a83e43",
+      "source": "Talk",
+      "translated": "話す"
+    },
+    {
+      "id": "native.apple.dae61543f9b416ca",
+      "source": "Start realtime chat",
+      "translated": "リアルタイムチャットを開始"
+    },
+    {
+      "id": "native.apple.d376b015a90792a9",
+      "source": "Stop realtime chat",
+      "translated": "リアルタイムチャットを停止"
+    },
+    {
+      "id": "native.apple.ac48dbe25ac4d40d",
+      "source": "Connecting...",
+      "translated": "接続中..."
+    },
+    {
+      "id": "native.apple.ccce98756eb1dacd",
+      "source": "Gateway connected",
+      "translated": "Gatewayに接続済み"
+    },
+    {
       "id": "native.apple.03aca5cfee32f12d",
       "source": "Context %@%% used",
       "translated": "コンテキストの%@%%を使用"
@@ -23004,36 +23049,6 @@
       "translated": "添付ファイル"
     },
     {
-      "id": "native.apple.ee2c0d22f5861159",
-      "source": "Talk",
-      "translated": "トーク"
-    },
-    {
-      "id": "native.apple.5d5041aefe6dfddd",
-      "source": "Start realtime chat",
-      "translated": "リアルタイムチャットを開始"
-    },
-    {
-      "id": "native.apple.21a7d3a3386a2218",
-      "source": "Stop realtime chat",
-      "translated": "リアルタイムチャットを停止"
-    },
-    {
-      "id": "native.apple.e37904df667f350c",
-      "source": "Switch to back camera",
-      "translated": "背面カメラに切り替える"
-    },
-    {
-      "id": "native.apple.7849ca56b4b45e8f",
-      "source": "Switch to front camera",
-      "translated": "前面カメラに切り替える"
-    },
-    {
-      "id": "native.apple.8bf42d1dd3bb2d7a",
-      "source": "Flip camera",
-      "translated": "カメラを切り替える"
-    },
-    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "開始"
@@ -23077,16 +23092,6 @@
       "id": "native.apple.f4473f79bb87b2fd",
       "source": "Refresh",
       "translated": "更新"
-    },
-    {
-      "id": "native.apple.6c984c0e3ed3a69e",
-      "source": "Connecting...",
-      "translated": "接続中..."
-    },
-    {
-      "id": "native.apple.898849eb2bcb0b53",
-      "source": "Gateway connected",
-      "translated": "Gateway に接続しました"
     },
     {
       "id": "native.apple.b6adfcd17a6e73d7",

--- a/apps/.i18n/native/ja-JP.json
+++ b/apps/.i18n/native/ja-JP.json
@@ -23019,6 +23019,21 @@
       "translated": "リアルタイムチャットを停止"
     },
     {
+      "id": "native.apple.e37904df667f350c",
+      "source": "Switch to back camera",
+      "translated": "背面カメラに切り替える"
+    },
+    {
+      "id": "native.apple.7849ca56b4b45e8f",
+      "source": "Switch to front camera",
+      "translated": "前面カメラに切り替える"
+    },
+    {
+      "id": "native.apple.8bf42d1dd3bb2d7a",
+      "source": "Flip camera",
+      "translated": "カメラを切り替える"
+    },
+    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "開始"

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -22909,6 +22909,51 @@
       "translated": "<\\(tag)"
     },
     {
+      "id": "native.apple.fc5931c1f0a6bbec",
+      "source": "Switch to back camera",
+      "translated": "후면 카메라로 전환"
+    },
+    {
+      "id": "native.apple.cce3b539e31701c0",
+      "source": "Switch to front camera",
+      "translated": "전면 카메라로 전환"
+    },
+    {
+      "id": "native.apple.f397daffdfd02ee0",
+      "source": "Flip camera",
+      "translated": "카메라 전환"
+    },
+    {
+      "id": "native.apple.11f8de87ca3fcb11",
+      "source": "Stop",
+      "translated": "중지"
+    },
+    {
+      "id": "native.apple.7c92bec1c8a83e43",
+      "source": "Talk",
+      "translated": "말하기"
+    },
+    {
+      "id": "native.apple.dae61543f9b416ca",
+      "source": "Start realtime chat",
+      "translated": "실시간 채팅 시작"
+    },
+    {
+      "id": "native.apple.d376b015a90792a9",
+      "source": "Stop realtime chat",
+      "translated": "실시간 채팅 중지"
+    },
+    {
+      "id": "native.apple.ac48dbe25ac4d40d",
+      "source": "Connecting...",
+      "translated": "연결 중..."
+    },
+    {
+      "id": "native.apple.ccce98756eb1dacd",
+      "source": "Gateway connected",
+      "translated": "Gateway 연결됨"
+    },
+    {
       "id": "native.apple.03aca5cfee32f12d",
       "source": "Context %@%% used",
       "translated": "컨텍스트 %@%% 사용됨"
@@ -23004,36 +23049,6 @@
       "translated": "첨부 파일"
     },
     {
-      "id": "native.apple.ee2c0d22f5861159",
-      "source": "Talk",
-      "translated": "대화"
-    },
-    {
-      "id": "native.apple.5d5041aefe6dfddd",
-      "source": "Start realtime chat",
-      "translated": "실시간 채팅 시작"
-    },
-    {
-      "id": "native.apple.21a7d3a3386a2218",
-      "source": "Stop realtime chat",
-      "translated": "실시간 채팅 중지"
-    },
-    {
-      "id": "native.apple.e37904df667f350c",
-      "source": "Switch to back camera",
-      "translated": "후면 카메라로 전환"
-    },
-    {
-      "id": "native.apple.7849ca56b4b45e8f",
-      "source": "Switch to front camera",
-      "translated": "전면 카메라로 전환"
-    },
-    {
-      "id": "native.apple.8bf42d1dd3bb2d7a",
-      "source": "Flip camera",
-      "translated": "카메라 전환"
-    },
-    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "시작"
@@ -23077,16 +23092,6 @@
       "id": "native.apple.f4473f79bb87b2fd",
       "source": "Refresh",
       "translated": "새로 고침"
-    },
-    {
-      "id": "native.apple.6c984c0e3ed3a69e",
-      "source": "Connecting...",
-      "translated": "연결 중..."
-    },
-    {
-      "id": "native.apple.898849eb2bcb0b53",
-      "source": "Gateway connected",
-      "translated": "Gateway 연결됨"
     },
     {
       "id": "native.apple.b6adfcd17a6e73d7",

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -23019,6 +23019,21 @@
       "translated": "실시간 채팅 중지"
     },
     {
+      "id": "native.apple.e37904df667f350c",
+      "source": "Switch to back camera",
+      "translated": "후면 카메라로 전환"
+    },
+    {
+      "id": "native.apple.7849ca56b4b45e8f",
+      "source": "Switch to front camera",
+      "translated": "전면 카메라로 전환"
+    },
+    {
+      "id": "native.apple.8bf42d1dd3bb2d7a",
+      "source": "Flip camera",
+      "translated": "카메라 전환"
+    },
+    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "시작"

--- a/apps/.i18n/native/nl.json
+++ b/apps/.i18n/native/nl.json
@@ -23019,6 +23019,21 @@
       "translated": "Realtime chat stoppen"
     },
     {
+      "id": "native.apple.e37904df667f350c",
+      "source": "Switch to back camera",
+      "translated": "Schakel over naar de camera aan de achterkant"
+    },
+    {
+      "id": "native.apple.7849ca56b4b45e8f",
+      "source": "Switch to front camera",
+      "translated": "Schakel over naar de camera aan de voorkant"
+    },
+    {
+      "id": "native.apple.8bf42d1dd3bb2d7a",
+      "source": "Flip camera",
+      "translated": "Wissel van camera"
+    },
+    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "Starten"

--- a/apps/.i18n/native/nl.json
+++ b/apps/.i18n/native/nl.json
@@ -22909,6 +22909,51 @@
       "translated": "<\\(tag)"
     },
     {
+      "id": "native.apple.fc5931c1f0a6bbec",
+      "source": "Switch to back camera",
+      "translated": "Schakel over naar de camera aan de achterkant"
+    },
+    {
+      "id": "native.apple.cce3b539e31701c0",
+      "source": "Switch to front camera",
+      "translated": "Schakel over naar de camera aan de voorkant"
+    },
+    {
+      "id": "native.apple.f397daffdfd02ee0",
+      "source": "Flip camera",
+      "translated": "Camera omdraaien"
+    },
+    {
+      "id": "native.apple.11f8de87ca3fcb11",
+      "source": "Stop",
+      "translated": "Stoppen"
+    },
+    {
+      "id": "native.apple.7c92bec1c8a83e43",
+      "source": "Talk",
+      "translated": "Praten"
+    },
+    {
+      "id": "native.apple.dae61543f9b416ca",
+      "source": "Start realtime chat",
+      "translated": "Realtimechat starten"
+    },
+    {
+      "id": "native.apple.d376b015a90792a9",
+      "source": "Stop realtime chat",
+      "translated": "Realtimechat stoppen"
+    },
+    {
+      "id": "native.apple.ac48dbe25ac4d40d",
+      "source": "Connecting...",
+      "translated": "Verbinding maken..."
+    },
+    {
+      "id": "native.apple.ccce98756eb1dacd",
+      "source": "Gateway connected",
+      "translated": "Gateway verbonden"
+    },
+    {
       "id": "native.apple.03aca5cfee32f12d",
       "source": "Context %@%% used",
       "translated": "Context voor %@%% gebruikt"
@@ -23004,36 +23049,6 @@
       "translated": "Bijlagen"
     },
     {
-      "id": "native.apple.ee2c0d22f5861159",
-      "source": "Talk",
-      "translated": "Praten"
-    },
-    {
-      "id": "native.apple.5d5041aefe6dfddd",
-      "source": "Start realtime chat",
-      "translated": "Realtime chat starten"
-    },
-    {
-      "id": "native.apple.21a7d3a3386a2218",
-      "source": "Stop realtime chat",
-      "translated": "Realtime chat stoppen"
-    },
-    {
-      "id": "native.apple.e37904df667f350c",
-      "source": "Switch to back camera",
-      "translated": "Schakel over naar de camera aan de achterkant"
-    },
-    {
-      "id": "native.apple.7849ca56b4b45e8f",
-      "source": "Switch to front camera",
-      "translated": "Schakel over naar de camera aan de voorkant"
-    },
-    {
-      "id": "native.apple.8bf42d1dd3bb2d7a",
-      "source": "Flip camera",
-      "translated": "Wissel van camera"
-    },
-    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "Starten"
@@ -23077,16 +23092,6 @@
       "id": "native.apple.f4473f79bb87b2fd",
       "source": "Refresh",
       "translated": "Vernieuwen"
-    },
-    {
-      "id": "native.apple.6c984c0e3ed3a69e",
-      "source": "Connecting...",
-      "translated": "Verbinden..."
-    },
-    {
-      "id": "native.apple.898849eb2bcb0b53",
-      "source": "Gateway connected",
-      "translated": "Gateway verbonden"
     },
     {
       "id": "native.apple.b6adfcd17a6e73d7",

--- a/apps/.i18n/native/pl.json
+++ b/apps/.i18n/native/pl.json
@@ -22909,6 +22909,51 @@
       "translated": "<\\(tag)"
     },
     {
+      "id": "native.apple.fc5931c1f0a6bbec",
+      "source": "Switch to back camera",
+      "translated": "Przełącz na tylny aparat"
+    },
+    {
+      "id": "native.apple.cce3b539e31701c0",
+      "source": "Switch to front camera",
+      "translated": "Przełącz na przedni aparat"
+    },
+    {
+      "id": "native.apple.f397daffdfd02ee0",
+      "source": "Flip camera",
+      "translated": "Odwróć aparat"
+    },
+    {
+      "id": "native.apple.11f8de87ca3fcb11",
+      "source": "Stop",
+      "translated": "Zatrzymaj"
+    },
+    {
+      "id": "native.apple.7c92bec1c8a83e43",
+      "source": "Talk",
+      "translated": "Mów"
+    },
+    {
+      "id": "native.apple.dae61543f9b416ca",
+      "source": "Start realtime chat",
+      "translated": "Rozpocznij czat w czasie rzeczywistym"
+    },
+    {
+      "id": "native.apple.d376b015a90792a9",
+      "source": "Stop realtime chat",
+      "translated": "Zatrzymaj czat w czasie rzeczywistym"
+    },
+    {
+      "id": "native.apple.ac48dbe25ac4d40d",
+      "source": "Connecting...",
+      "translated": "Łączenie..."
+    },
+    {
+      "id": "native.apple.ccce98756eb1dacd",
+      "source": "Gateway connected",
+      "translated": "Połączono z Gateway"
+    },
+    {
       "id": "native.apple.03aca5cfee32f12d",
       "source": "Context %@%% used",
       "translated": "Wykorzystano %@%% kontekstu"
@@ -23004,36 +23049,6 @@
       "translated": "Załączniki"
     },
     {
-      "id": "native.apple.ee2c0d22f5861159",
-      "source": "Talk",
-      "translated": "Rozmawiaj"
-    },
-    {
-      "id": "native.apple.5d5041aefe6dfddd",
-      "source": "Start realtime chat",
-      "translated": "Rozpocznij czat w czasie rzeczywistym"
-    },
-    {
-      "id": "native.apple.21a7d3a3386a2218",
-      "source": "Stop realtime chat",
-      "translated": "Zatrzymaj czat w czasie rzeczywistym"
-    },
-    {
-      "id": "native.apple.e37904df667f350c",
-      "source": "Switch to back camera",
-      "translated": "Przełącz na tylny aparat"
-    },
-    {
-      "id": "native.apple.7849ca56b4b45e8f",
-      "source": "Switch to front camera",
-      "translated": "Przełącz na przedni aparat"
-    },
-    {
-      "id": "native.apple.8bf42d1dd3bb2d7a",
-      "source": "Flip camera",
-      "translated": "Odwróć aparat"
-    },
-    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "Rozpocznij"
@@ -23077,16 +23092,6 @@
       "id": "native.apple.f4473f79bb87b2fd",
       "source": "Refresh",
       "translated": "Odśwież"
-    },
-    {
-      "id": "native.apple.6c984c0e3ed3a69e",
-      "source": "Connecting...",
-      "translated": "Łączenie..."
-    },
-    {
-      "id": "native.apple.898849eb2bcb0b53",
-      "source": "Gateway connected",
-      "translated": "Gateway połączony"
     },
     {
       "id": "native.apple.b6adfcd17a6e73d7",

--- a/apps/.i18n/native/pl.json
+++ b/apps/.i18n/native/pl.json
@@ -23019,6 +23019,21 @@
       "translated": "Zatrzymaj czat w czasie rzeczywistym"
     },
     {
+      "id": "native.apple.e37904df667f350c",
+      "source": "Switch to back camera",
+      "translated": "Przełącz na tylny aparat"
+    },
+    {
+      "id": "native.apple.7849ca56b4b45e8f",
+      "source": "Switch to front camera",
+      "translated": "Przełącz na przedni aparat"
+    },
+    {
+      "id": "native.apple.8bf42d1dd3bb2d7a",
+      "source": "Flip camera",
+      "translated": "Odwróć aparat"
+    },
+    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "Rozpocznij"

--- a/apps/.i18n/native/pt-BR.json
+++ b/apps/.i18n/native/pt-BR.json
@@ -22909,6 +22909,51 @@
       "translated": "<\\(tag)"
     },
     {
+      "id": "native.apple.fc5931c1f0a6bbec",
+      "source": "Switch to back camera",
+      "translated": "Alternar para a câmera traseira"
+    },
+    {
+      "id": "native.apple.cce3b539e31701c0",
+      "source": "Switch to front camera",
+      "translated": "Alternar para a câmera frontal"
+    },
+    {
+      "id": "native.apple.f397daffdfd02ee0",
+      "source": "Flip camera",
+      "translated": "Inverter câmera"
+    },
+    {
+      "id": "native.apple.11f8de87ca3fcb11",
+      "source": "Stop",
+      "translated": "Parar"
+    },
+    {
+      "id": "native.apple.7c92bec1c8a83e43",
+      "source": "Talk",
+      "translated": "Falar"
+    },
+    {
+      "id": "native.apple.dae61543f9b416ca",
+      "source": "Start realtime chat",
+      "translated": "Iniciar conversa em tempo real"
+    },
+    {
+      "id": "native.apple.d376b015a90792a9",
+      "source": "Stop realtime chat",
+      "translated": "Encerrar conversa em tempo real"
+    },
+    {
+      "id": "native.apple.ac48dbe25ac4d40d",
+      "source": "Connecting...",
+      "translated": "Conectando..."
+    },
+    {
+      "id": "native.apple.ccce98756eb1dacd",
+      "source": "Gateway connected",
+      "translated": "Gateway conectado"
+    },
+    {
       "id": "native.apple.03aca5cfee32f12d",
       "source": "Context %@%% used",
       "translated": "%@%% do contexto usado"
@@ -23004,36 +23049,6 @@
       "translated": "Anexos"
     },
     {
-      "id": "native.apple.ee2c0d22f5861159",
-      "source": "Talk",
-      "translated": "Falar"
-    },
-    {
-      "id": "native.apple.5d5041aefe6dfddd",
-      "source": "Start realtime chat",
-      "translated": "Iniciar chat em tempo real"
-    },
-    {
-      "id": "native.apple.21a7d3a3386a2218",
-      "source": "Stop realtime chat",
-      "translated": "Parar chat em tempo real"
-    },
-    {
-      "id": "native.apple.e37904df667f350c",
-      "source": "Switch to back camera",
-      "translated": "Alternar para a câmera traseira"
-    },
-    {
-      "id": "native.apple.7849ca56b4b45e8f",
-      "source": "Switch to front camera",
-      "translated": "Alternar para a câmera frontal"
-    },
-    {
-      "id": "native.apple.8bf42d1dd3bb2d7a",
-      "source": "Flip camera",
-      "translated": "Inverter câmera"
-    },
-    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "Iniciar"
@@ -23077,16 +23092,6 @@
       "id": "native.apple.f4473f79bb87b2fd",
       "source": "Refresh",
       "translated": "Atualizar"
-    },
-    {
-      "id": "native.apple.6c984c0e3ed3a69e",
-      "source": "Connecting...",
-      "translated": "Conectando..."
-    },
-    {
-      "id": "native.apple.898849eb2bcb0b53",
-      "source": "Gateway connected",
-      "translated": "Gateway conectado"
     },
     {
       "id": "native.apple.b6adfcd17a6e73d7",

--- a/apps/.i18n/native/pt-BR.json
+++ b/apps/.i18n/native/pt-BR.json
@@ -23019,6 +23019,21 @@
       "translated": "Parar chat em tempo real"
     },
     {
+      "id": "native.apple.e37904df667f350c",
+      "source": "Switch to back camera",
+      "translated": "Alternar para a câmera traseira"
+    },
+    {
+      "id": "native.apple.7849ca56b4b45e8f",
+      "source": "Switch to front camera",
+      "translated": "Alternar para a câmera frontal"
+    },
+    {
+      "id": "native.apple.8bf42d1dd3bb2d7a",
+      "source": "Flip camera",
+      "translated": "Inverter câmera"
+    },
+    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "Iniciar"

--- a/apps/.i18n/native/ru.json
+++ b/apps/.i18n/native/ru.json
@@ -22909,6 +22909,51 @@
       "translated": "<\\(tag)"
     },
     {
+      "id": "native.apple.fc5931c1f0a6bbec",
+      "source": "Switch to back camera",
+      "translated": "Переключиться на заднюю камеру"
+    },
+    {
+      "id": "native.apple.cce3b539e31701c0",
+      "source": "Switch to front camera",
+      "translated": "Переключиться на фронтальную камеру"
+    },
+    {
+      "id": "native.apple.f397daffdfd02ee0",
+      "source": "Flip camera",
+      "translated": "Сменить камеру"
+    },
+    {
+      "id": "native.apple.11f8de87ca3fcb11",
+      "source": "Stop",
+      "translated": "Остановить"
+    },
+    {
+      "id": "native.apple.7c92bec1c8a83e43",
+      "source": "Talk",
+      "translated": "Говорить"
+    },
+    {
+      "id": "native.apple.dae61543f9b416ca",
+      "source": "Start realtime chat",
+      "translated": "Начать чат в реальном времени"
+    },
+    {
+      "id": "native.apple.d376b015a90792a9",
+      "source": "Stop realtime chat",
+      "translated": "Остановить чат в реальном времени"
+    },
+    {
+      "id": "native.apple.ac48dbe25ac4d40d",
+      "source": "Connecting...",
+      "translated": "Подключение..."
+    },
+    {
+      "id": "native.apple.ccce98756eb1dacd",
+      "source": "Gateway connected",
+      "translated": "Gateway подключён"
+    },
+    {
       "id": "native.apple.03aca5cfee32f12d",
       "source": "Context %@%% used",
       "translated": "Использовано %@%% контекста"
@@ -23004,36 +23049,6 @@
       "translated": "Вложения"
     },
     {
-      "id": "native.apple.ee2c0d22f5861159",
-      "source": "Talk",
-      "translated": "Разговор"
-    },
-    {
-      "id": "native.apple.5d5041aefe6dfddd",
-      "source": "Start realtime chat",
-      "translated": "Начать чат в реальном времени"
-    },
-    {
-      "id": "native.apple.21a7d3a3386a2218",
-      "source": "Stop realtime chat",
-      "translated": "Остановить чат в реальном времени"
-    },
-    {
-      "id": "native.apple.e37904df667f350c",
-      "source": "Switch to back camera",
-      "translated": "Переключиться на заднюю камеру"
-    },
-    {
-      "id": "native.apple.7849ca56b4b45e8f",
-      "source": "Switch to front camera",
-      "translated": "Переключиться на фронтальную камеру"
-    },
-    {
-      "id": "native.apple.8bf42d1dd3bb2d7a",
-      "source": "Flip camera",
-      "translated": "Сменить камеру"
-    },
-    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "Начать"
@@ -23077,16 +23092,6 @@
       "id": "native.apple.f4473f79bb87b2fd",
       "source": "Refresh",
       "translated": "Обновить"
-    },
-    {
-      "id": "native.apple.6c984c0e3ed3a69e",
-      "source": "Connecting...",
-      "translated": "Подключение..."
-    },
-    {
-      "id": "native.apple.898849eb2bcb0b53",
-      "source": "Gateway connected",
-      "translated": "Gateway подключен"
     },
     {
       "id": "native.apple.b6adfcd17a6e73d7",

--- a/apps/.i18n/native/ru.json
+++ b/apps/.i18n/native/ru.json
@@ -23019,6 +23019,21 @@
       "translated": "Остановить чат в реальном времени"
     },
     {
+      "id": "native.apple.e37904df667f350c",
+      "source": "Switch to back camera",
+      "translated": "Переключиться на заднюю камеру"
+    },
+    {
+      "id": "native.apple.7849ca56b4b45e8f",
+      "source": "Switch to front camera",
+      "translated": "Переключиться на фронтальную камеру"
+    },
+    {
+      "id": "native.apple.8bf42d1dd3bb2d7a",
+      "source": "Flip camera",
+      "translated": "Сменить камеру"
+    },
+    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "Начать"

--- a/apps/.i18n/native/sv.json
+++ b/apps/.i18n/native/sv.json
@@ -22909,6 +22909,51 @@
       "translated": "<\\(tag)"
     },
     {
+      "id": "native.apple.fc5931c1f0a6bbec",
+      "source": "Switch to back camera",
+      "translated": "Byt till bakre kameran"
+    },
+    {
+      "id": "native.apple.cce3b539e31701c0",
+      "source": "Switch to front camera",
+      "translated": "Byt till främre kameran"
+    },
+    {
+      "id": "native.apple.f397daffdfd02ee0",
+      "source": "Flip camera",
+      "translated": "Vänd kameran"
+    },
+    {
+      "id": "native.apple.11f8de87ca3fcb11",
+      "source": "Stop",
+      "translated": "Stoppa"
+    },
+    {
+      "id": "native.apple.7c92bec1c8a83e43",
+      "source": "Talk",
+      "translated": "Prata"
+    },
+    {
+      "id": "native.apple.dae61543f9b416ca",
+      "source": "Start realtime chat",
+      "translated": "Starta realtidschatt"
+    },
+    {
+      "id": "native.apple.d376b015a90792a9",
+      "source": "Stop realtime chat",
+      "translated": "Stoppa realtidschatt"
+    },
+    {
+      "id": "native.apple.ac48dbe25ac4d40d",
+      "source": "Connecting...",
+      "translated": "Ansluter..."
+    },
+    {
+      "id": "native.apple.ccce98756eb1dacd",
+      "source": "Gateway connected",
+      "translated": "Gateway ansluten"
+    },
+    {
       "id": "native.apple.03aca5cfee32f12d",
       "source": "Context %@%% used",
       "translated": "Kontext: %@%% används"
@@ -23004,36 +23049,6 @@
       "translated": "Bilagor"
     },
     {
-      "id": "native.apple.ee2c0d22f5861159",
-      "source": "Talk",
-      "translated": "Prata"
-    },
-    {
-      "id": "native.apple.5d5041aefe6dfddd",
-      "source": "Start realtime chat",
-      "translated": "Starta realtidschatt"
-    },
-    {
-      "id": "native.apple.21a7d3a3386a2218",
-      "source": "Stop realtime chat",
-      "translated": "Stoppa realtidschatt"
-    },
-    {
-      "id": "native.apple.e37904df667f350c",
-      "source": "Switch to back camera",
-      "translated": "Byt till den bakre kameran"
-    },
-    {
-      "id": "native.apple.7849ca56b4b45e8f",
-      "source": "Switch to front camera",
-      "translated": "Byt till den främre kameran"
-    },
-    {
-      "id": "native.apple.8bf42d1dd3bb2d7a",
-      "source": "Flip camera",
-      "translated": "Vänd kameran"
-    },
-    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "Starta"
@@ -23077,16 +23092,6 @@
       "id": "native.apple.f4473f79bb87b2fd",
       "source": "Refresh",
       "translated": "Uppdatera"
-    },
-    {
-      "id": "native.apple.6c984c0e3ed3a69e",
-      "source": "Connecting...",
-      "translated": "Ansluter..."
-    },
-    {
-      "id": "native.apple.898849eb2bcb0b53",
-      "source": "Gateway connected",
-      "translated": "Gateway ansluten"
     },
     {
       "id": "native.apple.b6adfcd17a6e73d7",

--- a/apps/.i18n/native/sv.json
+++ b/apps/.i18n/native/sv.json
@@ -23019,6 +23019,21 @@
       "translated": "Stoppa realtidschatt"
     },
     {
+      "id": "native.apple.e37904df667f350c",
+      "source": "Switch to back camera",
+      "translated": "Byt till den bakre kameran"
+    },
+    {
+      "id": "native.apple.7849ca56b4b45e8f",
+      "source": "Switch to front camera",
+      "translated": "Byt till den främre kameran"
+    },
+    {
+      "id": "native.apple.8bf42d1dd3bb2d7a",
+      "source": "Flip camera",
+      "translated": "Vänd kameran"
+    },
+    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "Starta"

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -23019,6 +23019,21 @@
       "translated": "หยุดแชทแบบเรียลไทม์"
     },
     {
+      "id": "native.apple.e37904df667f350c",
+      "source": "Switch to back camera",
+      "translated": "สลับไปใช้กล้องหลัง"
+    },
+    {
+      "id": "native.apple.7849ca56b4b45e8f",
+      "source": "Switch to front camera",
+      "translated": "สลับไปใช้กล้องหน้า"
+    },
+    {
+      "id": "native.apple.8bf42d1dd3bb2d7a",
+      "source": "Flip camera",
+      "translated": "สลับกล้อง"
+    },
+    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "เริ่ม"

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -22909,6 +22909,51 @@
       "translated": "<\\(tag)"
     },
     {
+      "id": "native.apple.fc5931c1f0a6bbec",
+      "source": "Switch to back camera",
+      "translated": "สลับไปใช้กล้องหลัง"
+    },
+    {
+      "id": "native.apple.cce3b539e31701c0",
+      "source": "Switch to front camera",
+      "translated": "สลับไปใช้กล้องหน้า"
+    },
+    {
+      "id": "native.apple.f397daffdfd02ee0",
+      "source": "Flip camera",
+      "translated": "สลับกล้อง"
+    },
+    {
+      "id": "native.apple.11f8de87ca3fcb11",
+      "source": "Stop",
+      "translated": "หยุด"
+    },
+    {
+      "id": "native.apple.7c92bec1c8a83e43",
+      "source": "Talk",
+      "translated": "พูด"
+    },
+    {
+      "id": "native.apple.dae61543f9b416ca",
+      "source": "Start realtime chat",
+      "translated": "เริ่มแชทแบบเรียลไทม์"
+    },
+    {
+      "id": "native.apple.d376b015a90792a9",
+      "source": "Stop realtime chat",
+      "translated": "หยุดแชทแบบเรียลไทม์"
+    },
+    {
+      "id": "native.apple.ac48dbe25ac4d40d",
+      "source": "Connecting...",
+      "translated": "กำลังเชื่อมต่อ..."
+    },
+    {
+      "id": "native.apple.ccce98756eb1dacd",
+      "source": "Gateway connected",
+      "translated": "เชื่อมต่อ Gateway แล้ว"
+    },
+    {
       "id": "native.apple.03aca5cfee32f12d",
       "source": "Context %@%% used",
       "translated": "ใช้บริบทไปแล้ว %@%%"
@@ -23004,36 +23049,6 @@
       "translated": "ไฟล์แนบ"
     },
     {
-      "id": "native.apple.ee2c0d22f5861159",
-      "source": "Talk",
-      "translated": "พูดคุย"
-    },
-    {
-      "id": "native.apple.5d5041aefe6dfddd",
-      "source": "Start realtime chat",
-      "translated": "เริ่มแชทแบบเรียลไทม์"
-    },
-    {
-      "id": "native.apple.21a7d3a3386a2218",
-      "source": "Stop realtime chat",
-      "translated": "หยุดแชทแบบเรียลไทม์"
-    },
-    {
-      "id": "native.apple.e37904df667f350c",
-      "source": "Switch to back camera",
-      "translated": "สลับไปใช้กล้องหลัง"
-    },
-    {
-      "id": "native.apple.7849ca56b4b45e8f",
-      "source": "Switch to front camera",
-      "translated": "สลับไปใช้กล้องหน้า"
-    },
-    {
-      "id": "native.apple.8bf42d1dd3bb2d7a",
-      "source": "Flip camera",
-      "translated": "สลับกล้อง"
-    },
-    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "เริ่ม"
@@ -23077,16 +23092,6 @@
       "id": "native.apple.f4473f79bb87b2fd",
       "source": "Refresh",
       "translated": "รีเฟรช"
-    },
-    {
-      "id": "native.apple.6c984c0e3ed3a69e",
-      "source": "Connecting...",
-      "translated": "กำลังเชื่อมต่อ..."
-    },
-    {
-      "id": "native.apple.898849eb2bcb0b53",
-      "source": "Gateway connected",
-      "translated": "เชื่อมต่อ Gateway แล้ว"
     },
     {
       "id": "native.apple.b6adfcd17a6e73d7",

--- a/apps/.i18n/native/tr.json
+++ b/apps/.i18n/native/tr.json
@@ -23019,6 +23019,21 @@
       "translated": "Gerçek zamanlı sohbeti durdur"
     },
     {
+      "id": "native.apple.e37904df667f350c",
+      "source": "Switch to back camera",
+      "translated": "Arka kameraya geç"
+    },
+    {
+      "id": "native.apple.7849ca56b4b45e8f",
+      "source": "Switch to front camera",
+      "translated": "Ön kameraya geç"
+    },
+    {
+      "id": "native.apple.8bf42d1dd3bb2d7a",
+      "source": "Flip camera",
+      "translated": "Kamerayı çevir"
+    },
+    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "Başlat"

--- a/apps/.i18n/native/tr.json
+++ b/apps/.i18n/native/tr.json
@@ -22909,6 +22909,51 @@
       "translated": "<\\(tag)"
     },
     {
+      "id": "native.apple.fc5931c1f0a6bbec",
+      "source": "Switch to back camera",
+      "translated": "Arka kameraya geç"
+    },
+    {
+      "id": "native.apple.cce3b539e31701c0",
+      "source": "Switch to front camera",
+      "translated": "Ön kameraya geç"
+    },
+    {
+      "id": "native.apple.f397daffdfd02ee0",
+      "source": "Flip camera",
+      "translated": "Kamerayı çevir"
+    },
+    {
+      "id": "native.apple.11f8de87ca3fcb11",
+      "source": "Stop",
+      "translated": "Durdur"
+    },
+    {
+      "id": "native.apple.7c92bec1c8a83e43",
+      "source": "Talk",
+      "translated": "Konuş"
+    },
+    {
+      "id": "native.apple.dae61543f9b416ca",
+      "source": "Start realtime chat",
+      "translated": "Gerçek zamanlı sohbeti başlat"
+    },
+    {
+      "id": "native.apple.d376b015a90792a9",
+      "source": "Stop realtime chat",
+      "translated": "Gerçek zamanlı sohbeti durdur"
+    },
+    {
+      "id": "native.apple.ac48dbe25ac4d40d",
+      "source": "Connecting...",
+      "translated": "Bağlanıyor..."
+    },
+    {
+      "id": "native.apple.ccce98756eb1dacd",
+      "source": "Gateway connected",
+      "translated": "Gateway bağlandı"
+    },
+    {
       "id": "native.apple.03aca5cfee32f12d",
       "source": "Context %@%% used",
       "translated": "Bağlamın %@%% kadarı kullanıldı"
@@ -23004,36 +23049,6 @@
       "translated": "Ekler"
     },
     {
-      "id": "native.apple.ee2c0d22f5861159",
-      "source": "Talk",
-      "translated": "Konuş"
-    },
-    {
-      "id": "native.apple.5d5041aefe6dfddd",
-      "source": "Start realtime chat",
-      "translated": "Gerçek zamanlı sohbeti başlat"
-    },
-    {
-      "id": "native.apple.21a7d3a3386a2218",
-      "source": "Stop realtime chat",
-      "translated": "Gerçek zamanlı sohbeti durdur"
-    },
-    {
-      "id": "native.apple.e37904df667f350c",
-      "source": "Switch to back camera",
-      "translated": "Arka kameraya geç"
-    },
-    {
-      "id": "native.apple.7849ca56b4b45e8f",
-      "source": "Switch to front camera",
-      "translated": "Ön kameraya geç"
-    },
-    {
-      "id": "native.apple.8bf42d1dd3bb2d7a",
-      "source": "Flip camera",
-      "translated": "Kamerayı çevir"
-    },
-    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "Başlat"
@@ -23077,16 +23092,6 @@
       "id": "native.apple.f4473f79bb87b2fd",
       "source": "Refresh",
       "translated": "Yenile"
-    },
-    {
-      "id": "native.apple.6c984c0e3ed3a69e",
-      "source": "Connecting...",
-      "translated": "Bağlanıyor..."
-    },
-    {
-      "id": "native.apple.898849eb2bcb0b53",
-      "source": "Gateway connected",
-      "translated": "Gateway bağlı"
     },
     {
       "id": "native.apple.b6adfcd17a6e73d7",

--- a/apps/.i18n/native/uk.json
+++ b/apps/.i18n/native/uk.json
@@ -22909,6 +22909,51 @@
       "translated": "<\\(tag)"
     },
     {
+      "id": "native.apple.fc5931c1f0a6bbec",
+      "source": "Switch to back camera",
+      "translated": "Перемкнути на задню камеру"
+    },
+    {
+      "id": "native.apple.cce3b539e31701c0",
+      "source": "Switch to front camera",
+      "translated": "Перемкнути на фронтальну камеру"
+    },
+    {
+      "id": "native.apple.f397daffdfd02ee0",
+      "source": "Flip camera",
+      "translated": "Змінити камеру"
+    },
+    {
+      "id": "native.apple.11f8de87ca3fcb11",
+      "source": "Stop",
+      "translated": "Зупинити"
+    },
+    {
+      "id": "native.apple.7c92bec1c8a83e43",
+      "source": "Talk",
+      "translated": "Говорити"
+    },
+    {
+      "id": "native.apple.dae61543f9b416ca",
+      "source": "Start realtime chat",
+      "translated": "Почати чат у реальному часі"
+    },
+    {
+      "id": "native.apple.d376b015a90792a9",
+      "source": "Stop realtime chat",
+      "translated": "Зупинити чат у реальному часі"
+    },
+    {
+      "id": "native.apple.ac48dbe25ac4d40d",
+      "source": "Connecting...",
+      "translated": "Підключення..."
+    },
+    {
+      "id": "native.apple.ccce98756eb1dacd",
+      "source": "Gateway connected",
+      "translated": "Gateway підключено"
+    },
+    {
       "id": "native.apple.03aca5cfee32f12d",
       "source": "Context %@%% used",
       "translated": "Використано %@%% контексту"
@@ -23004,36 +23049,6 @@
       "translated": "Вкладення"
     },
     {
-      "id": "native.apple.ee2c0d22f5861159",
-      "source": "Talk",
-      "translated": "Говорити"
-    },
-    {
-      "id": "native.apple.5d5041aefe6dfddd",
-      "source": "Start realtime chat",
-      "translated": "Почати чат у реальному часі"
-    },
-    {
-      "id": "native.apple.21a7d3a3386a2218",
-      "source": "Stop realtime chat",
-      "translated": "Зупинити чат у реальному часі"
-    },
-    {
-      "id": "native.apple.e37904df667f350c",
-      "source": "Switch to back camera",
-      "translated": "Перемкнутися на задню камеру"
-    },
-    {
-      "id": "native.apple.7849ca56b4b45e8f",
-      "source": "Switch to front camera",
-      "translated": "Перемкнутися на фронтальну камеру"
-    },
-    {
-      "id": "native.apple.8bf42d1dd3bb2d7a",
-      "source": "Flip camera",
-      "translated": "Змінити камеру"
-    },
-    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "Почати"
@@ -23077,16 +23092,6 @@
       "id": "native.apple.f4473f79bb87b2fd",
       "source": "Refresh",
       "translated": "Оновити"
-    },
-    {
-      "id": "native.apple.6c984c0e3ed3a69e",
-      "source": "Connecting...",
-      "translated": "Підключення..."
-    },
-    {
-      "id": "native.apple.898849eb2bcb0b53",
-      "source": "Gateway connected",
-      "translated": "Gateway підключено"
     },
     {
       "id": "native.apple.b6adfcd17a6e73d7",

--- a/apps/.i18n/native/uk.json
+++ b/apps/.i18n/native/uk.json
@@ -23019,6 +23019,21 @@
       "translated": "Зупинити чат у реальному часі"
     },
     {
+      "id": "native.apple.e37904df667f350c",
+      "source": "Switch to back camera",
+      "translated": "Перемкнутися на задню камеру"
+    },
+    {
+      "id": "native.apple.7849ca56b4b45e8f",
+      "source": "Switch to front camera",
+      "translated": "Перемкнутися на фронтальну камеру"
+    },
+    {
+      "id": "native.apple.8bf42d1dd3bb2d7a",
+      "source": "Flip camera",
+      "translated": "Змінити камеру"
+    },
+    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "Почати"

--- a/apps/.i18n/native/vi.json
+++ b/apps/.i18n/native/vi.json
@@ -22909,6 +22909,51 @@
       "translated": "<\\(tag)"
     },
     {
+      "id": "native.apple.fc5931c1f0a6bbec",
+      "source": "Switch to back camera",
+      "translated": "Chuyển sang camera sau"
+    },
+    {
+      "id": "native.apple.cce3b539e31701c0",
+      "source": "Switch to front camera",
+      "translated": "Chuyển sang camera trước"
+    },
+    {
+      "id": "native.apple.f397daffdfd02ee0",
+      "source": "Flip camera",
+      "translated": "Đổi chiều camera"
+    },
+    {
+      "id": "native.apple.11f8de87ca3fcb11",
+      "source": "Stop",
+      "translated": "Dừng"
+    },
+    {
+      "id": "native.apple.7c92bec1c8a83e43",
+      "source": "Talk",
+      "translated": "Nói"
+    },
+    {
+      "id": "native.apple.dae61543f9b416ca",
+      "source": "Start realtime chat",
+      "translated": "Bắt đầu trò chuyện theo thời gian thực"
+    },
+    {
+      "id": "native.apple.d376b015a90792a9",
+      "source": "Stop realtime chat",
+      "translated": "Dừng trò chuyện theo thời gian thực"
+    },
+    {
+      "id": "native.apple.ac48dbe25ac4d40d",
+      "source": "Connecting...",
+      "translated": "Đang kết nối..."
+    },
+    {
+      "id": "native.apple.ccce98756eb1dacd",
+      "source": "Gateway connected",
+      "translated": "Đã kết nối Gateway"
+    },
+    {
       "id": "native.apple.03aca5cfee32f12d",
       "source": "Context %@%% used",
       "translated": "Đã sử dụng %@%% ngữ cảnh"
@@ -23004,36 +23049,6 @@
       "translated": "Tệp đính kèm"
     },
     {
-      "id": "native.apple.ee2c0d22f5861159",
-      "source": "Talk",
-      "translated": "Nói chuyện"
-    },
-    {
-      "id": "native.apple.5d5041aefe6dfddd",
-      "source": "Start realtime chat",
-      "translated": "Bắt đầu trò chuyện thời gian thực"
-    },
-    {
-      "id": "native.apple.21a7d3a3386a2218",
-      "source": "Stop realtime chat",
-      "translated": "Dừng trò chuyện thời gian thực"
-    },
-    {
-      "id": "native.apple.e37904df667f350c",
-      "source": "Switch to back camera",
-      "translated": "Chuyển sang camera sau"
-    },
-    {
-      "id": "native.apple.7849ca56b4b45e8f",
-      "source": "Switch to front camera",
-      "translated": "Chuyển sang camera trước"
-    },
-    {
-      "id": "native.apple.8bf42d1dd3bb2d7a",
-      "source": "Flip camera",
-      "translated": "Đổi camera"
-    },
-    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "Bắt đầu"
@@ -23077,16 +23092,6 @@
       "id": "native.apple.f4473f79bb87b2fd",
       "source": "Refresh",
       "translated": "Làm mới"
-    },
-    {
-      "id": "native.apple.6c984c0e3ed3a69e",
-      "source": "Connecting...",
-      "translated": "Đang kết nối..."
-    },
-    {
-      "id": "native.apple.898849eb2bcb0b53",
-      "source": "Gateway connected",
-      "translated": "Gateway đã kết nối"
     },
     {
       "id": "native.apple.b6adfcd17a6e73d7",

--- a/apps/.i18n/native/vi.json
+++ b/apps/.i18n/native/vi.json
@@ -23019,6 +23019,21 @@
       "translated": "Dừng trò chuyện thời gian thực"
     },
     {
+      "id": "native.apple.e37904df667f350c",
+      "source": "Switch to back camera",
+      "translated": "Chuyển sang camera sau"
+    },
+    {
+      "id": "native.apple.7849ca56b4b45e8f",
+      "source": "Switch to front camera",
+      "translated": "Chuyển sang camera trước"
+    },
+    {
+      "id": "native.apple.8bf42d1dd3bb2d7a",
+      "source": "Flip camera",
+      "translated": "Đổi camera"
+    },
+    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "Bắt đầu"

--- a/apps/.i18n/native/zh-CN.json
+++ b/apps/.i18n/native/zh-CN.json
@@ -23019,6 +23019,21 @@
       "translated": "停止实时聊天"
     },
     {
+      "id": "native.apple.e37904df667f350c",
+      "source": "Switch to back camera",
+      "translated": "切换到后置摄像头"
+    },
+    {
+      "id": "native.apple.7849ca56b4b45e8f",
+      "source": "Switch to front camera",
+      "translated": "切换到前置摄像头"
+    },
+    {
+      "id": "native.apple.8bf42d1dd3bb2d7a",
+      "source": "Flip camera",
+      "translated": "翻转摄像头"
+    },
+    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "开始"

--- a/apps/.i18n/native/zh-CN.json
+++ b/apps/.i18n/native/zh-CN.json
@@ -22909,6 +22909,51 @@
       "translated": "<\\(tag)"
     },
     {
+      "id": "native.apple.fc5931c1f0a6bbec",
+      "source": "Switch to back camera",
+      "translated": "切换到后置摄像头"
+    },
+    {
+      "id": "native.apple.cce3b539e31701c0",
+      "source": "Switch to front camera",
+      "translated": "切换到前置摄像头"
+    },
+    {
+      "id": "native.apple.f397daffdfd02ee0",
+      "source": "Flip camera",
+      "translated": "翻转摄像头"
+    },
+    {
+      "id": "native.apple.11f8de87ca3fcb11",
+      "source": "Stop",
+      "translated": "停止"
+    },
+    {
+      "id": "native.apple.7c92bec1c8a83e43",
+      "source": "Talk",
+      "translated": "说话"
+    },
+    {
+      "id": "native.apple.dae61543f9b416ca",
+      "source": "Start realtime chat",
+      "translated": "开始实时聊天"
+    },
+    {
+      "id": "native.apple.d376b015a90792a9",
+      "source": "Stop realtime chat",
+      "translated": "停止实时聊天"
+    },
+    {
+      "id": "native.apple.ac48dbe25ac4d40d",
+      "source": "Connecting...",
+      "translated": "正在连接..."
+    },
+    {
+      "id": "native.apple.ccce98756eb1dacd",
+      "source": "Gateway connected",
+      "translated": "Gateway 已连接"
+    },
+    {
       "id": "native.apple.03aca5cfee32f12d",
       "source": "Context %@%% used",
       "translated": "已使用上下文的 %@%%"
@@ -23004,36 +23049,6 @@
       "translated": "附件"
     },
     {
-      "id": "native.apple.ee2c0d22f5861159",
-      "source": "Talk",
-      "translated": "对话"
-    },
-    {
-      "id": "native.apple.5d5041aefe6dfddd",
-      "source": "Start realtime chat",
-      "translated": "开始实时聊天"
-    },
-    {
-      "id": "native.apple.21a7d3a3386a2218",
-      "source": "Stop realtime chat",
-      "translated": "停止实时聊天"
-    },
-    {
-      "id": "native.apple.e37904df667f350c",
-      "source": "Switch to back camera",
-      "translated": "切换到后置摄像头"
-    },
-    {
-      "id": "native.apple.7849ca56b4b45e8f",
-      "source": "Switch to front camera",
-      "translated": "切换到前置摄像头"
-    },
-    {
-      "id": "native.apple.8bf42d1dd3bb2d7a",
-      "source": "Flip camera",
-      "translated": "翻转摄像头"
-    },
-    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "开始"
@@ -23077,16 +23092,6 @@
       "id": "native.apple.f4473f79bb87b2fd",
       "source": "Refresh",
       "translated": "刷新"
-    },
-    {
-      "id": "native.apple.6c984c0e3ed3a69e",
-      "source": "Connecting...",
-      "translated": "正在连接..."
-    },
-    {
-      "id": "native.apple.898849eb2bcb0b53",
-      "source": "Gateway connected",
-      "translated": "Gateway 已连接"
     },
     {
       "id": "native.apple.b6adfcd17a6e73d7",

--- a/apps/.i18n/native/zh-TW.json
+++ b/apps/.i18n/native/zh-TW.json
@@ -23019,6 +23019,21 @@
       "translated": "停止即時聊天"
     },
     {
+      "id": "native.apple.e37904df667f350c",
+      "source": "Switch to back camera",
+      "translated": "切換至後置相機"
+    },
+    {
+      "id": "native.apple.7849ca56b4b45e8f",
+      "source": "Switch to front camera",
+      "translated": "切換至前置相機"
+    },
+    {
+      "id": "native.apple.8bf42d1dd3bb2d7a",
+      "source": "Flip camera",
+      "translated": "翻轉相機"
+    },
+    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "開始"

--- a/apps/.i18n/native/zh-TW.json
+++ b/apps/.i18n/native/zh-TW.json
@@ -22909,6 +22909,51 @@
       "translated": "<\\(tag)"
     },
     {
+      "id": "native.apple.fc5931c1f0a6bbec",
+      "source": "Switch to back camera",
+      "translated": "切換至後置相機"
+    },
+    {
+      "id": "native.apple.cce3b539e31701c0",
+      "source": "Switch to front camera",
+      "translated": "切換至前置相機"
+    },
+    {
+      "id": "native.apple.f397daffdfd02ee0",
+      "source": "Flip camera",
+      "translated": "翻轉相機"
+    },
+    {
+      "id": "native.apple.11f8de87ca3fcb11",
+      "source": "Stop",
+      "translated": "停止"
+    },
+    {
+      "id": "native.apple.7c92bec1c8a83e43",
+      "source": "Talk",
+      "translated": "說話"
+    },
+    {
+      "id": "native.apple.dae61543f9b416ca",
+      "source": "Start realtime chat",
+      "translated": "開始即時聊天"
+    },
+    {
+      "id": "native.apple.d376b015a90792a9",
+      "source": "Stop realtime chat",
+      "translated": "停止即時聊天"
+    },
+    {
+      "id": "native.apple.ac48dbe25ac4d40d",
+      "source": "Connecting...",
+      "translated": "連線中..."
+    },
+    {
+      "id": "native.apple.ccce98756eb1dacd",
+      "source": "Gateway connected",
+      "translated": "Gateway 已連線"
+    },
+    {
       "id": "native.apple.03aca5cfee32f12d",
       "source": "Context %@%% used",
       "translated": "已使用 %@%% 的上下文"
@@ -23004,36 +23049,6 @@
       "translated": "附件"
     },
     {
-      "id": "native.apple.ee2c0d22f5861159",
-      "source": "Talk",
-      "translated": "說話"
-    },
-    {
-      "id": "native.apple.5d5041aefe6dfddd",
-      "source": "Start realtime chat",
-      "translated": "開始即時聊天"
-    },
-    {
-      "id": "native.apple.21a7d3a3386a2218",
-      "source": "Stop realtime chat",
-      "translated": "停止即時聊天"
-    },
-    {
-      "id": "native.apple.e37904df667f350c",
-      "source": "Switch to back camera",
-      "translated": "切換至後置相機"
-    },
-    {
-      "id": "native.apple.7849ca56b4b45e8f",
-      "source": "Switch to front camera",
-      "translated": "切換至前置相機"
-    },
-    {
-      "id": "native.apple.8bf42d1dd3bb2d7a",
-      "source": "Flip camera",
-      "translated": "翻轉相機"
-    },
-    {
       "id": "native.apple.88c2de261ddae511",
       "source": "Start",
       "translated": "開始"
@@ -23077,16 +23092,6 @@
       "id": "native.apple.f4473f79bb87b2fd",
       "source": "Refresh",
       "translated": "重新整理"
-    },
-    {
-      "id": "native.apple.6c984c0e3ed3a69e",
-      "source": "Connecting...",
-      "translated": "正在連線..."
-    },
-    {
-      "id": "native.apple.898849eb2bcb0b53",
-      "source": "Gateway connected",
-      "translated": "Gateway 已連線"
     },
     {
       "id": "native.apple.b6adfcd17a6e73d7",

--- a/apps/android/app/src/main/res/values-ar/strings.xml
+++ b/apps/android/app/src/main/res/values-ar/strings.xml
@@ -412,7 +412,7 @@
     <string name="native_4441146b0fe1d5c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screenshot"</string>
     <string name="native_4481c2190a1b4bca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تعبير Cron، مثل 0 9 * * *"</string>
     <string name="native_4499e7b7e1c9ddbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"العودة إلى الصوت"</string>
-    <string name="native_449f5a775762cdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تحدث"</string>
+    <string name="native_449f5a775762cdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"تحدّث"</string>
     <string name="native_45a64dc17588f2ca" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s متصلة"</string>
     <string name="native_45a8847c4a6b2c81" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"يُسمح لـ %1$s تطبيقات بإعادة التوجيه."</string>
     <string name="native_460b3a7da007b7af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"الدردشة"</string>

--- a/apps/android/app/src/main/res/values-fa/strings.xml
+++ b/apps/android/app/src/main/res/values-fa/strings.xml
@@ -412,7 +412,7 @@
     <string name="native_4441146b0fe1d5c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screenshot"</string>
     <string name="native_4481c2190a1b4bca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"عبارت cron، مثلاً 0 9 * * *"</string>
     <string name="native_4499e7b7e1c9ddbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"بازگشت به صدا"</string>
-    <string name="native_449f5a775762cdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"گفتگو"</string>
+    <string name="native_449f5a775762cdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"صحبت"</string>
     <string name="native_45a64dc17588f2ca" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s آنلاین"</string>
     <string name="native_45a8847c4a6b2c81" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s برنامه مجاز به بازارسال."</string>
     <string name="native_460b3a7da007b7af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"گفت‌وگو"</string>

--- a/apps/android/app/src/main/res/values-in/strings.xml
+++ b/apps/android/app/src/main/res/values-in/strings.xml
@@ -1183,7 +1183,7 @@
     <string name="native_ca1fd4548524cb2e" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Folder kosong"</string>
     <string name="native_ca7981b46ecf2c17" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nonaktif"</string>
     <string name="native_cab94aba84f97f7f" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Tipografi"</string>
-    <string name="native_cae7d57bc067a514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Hentikan"</string>
+    <string name="native_cae7d57bc067a514" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Berhenti"</string>
     <string name="native_cae98462b30650eb" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Belum ada utas yang cocok."</string>
     <string name="native_cba62d81f910c7f0" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Pemasangan Gateway berhasil.\nSetujui kapabilitas node ponsel ini dari UI operator."</string>
     <string name="native_cc4b66e7e22230c3" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Skill ini sudah terinstal, tetapi saat ini belum memenuhi syarat untuk dijalankan. Gunakan desktop atau CLI untuk mengubah konfigurasi."</string>

--- a/apps/android/app/src/main/res/values-pl/strings.xml
+++ b/apps/android/app/src/main/res/values-pl/strings.xml
@@ -412,7 +412,7 @@
     <string name="native_4441146b0fe1d5c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screenshot"</string>
     <string name="native_4481c2190a1b4bca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Wyrażenie cron, np. 0 9 * * *"</string>
     <string name="native_4499e7b7e1c9ddbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Powrót do głosu"</string>
-    <string name="native_449f5a775762cdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Rozmawiaj"</string>
+    <string name="native_449f5a775762cdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Mów"</string>
     <string name="native_45a64dc17588f2ca" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s online"</string>
     <string name="native_45a8847c4a6b2c81" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Zezwolono %1$s aplikacjom na przekazywanie."</string>
     <string name="native_460b3a7da007b7af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Czat"</string>

--- a/apps/android/app/src/main/res/values-ru/strings.xml
+++ b/apps/android/app/src/main/res/values-ru/strings.xml
@@ -412,7 +412,7 @@
     <string name="native_4441146b0fe1d5c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screenshot"</string>
     <string name="native_4481c2190a1b4bca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Cron-выражение, например 0 9 * * *"</string>
     <string name="native_4499e7b7e1c9ddbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Вернуться к голосу"</string>
-    <string name="native_449f5a775762cdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Разговор"</string>
+    <string name="native_449f5a775762cdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Говорить"</string>
     <string name="native_45a64dc17588f2ca" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"В сети: %1$s/%2$s"</string>
     <string name="native_45a8847c4a6b2c81" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Разрешена переадресация для %1$s приложений."</string>
     <string name="native_460b3a7da007b7af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Чат"</string>

--- a/apps/android/app/src/main/res/values-th/strings.xml
+++ b/apps/android/app/src/main/res/values-th/strings.xml
@@ -412,7 +412,7 @@
     <string name="native_4441146b0fe1d5c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screenshot"</string>
     <string name="native_4481c2190a1b4bca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"นิพจน์ cron เช่น 0 9 * * *"</string>
     <string name="native_4499e7b7e1c9ddbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"กลับไปที่เสียง"</string>
-    <string name="native_449f5a775762cdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"พูดคุย"</string>
+    <string name="native_449f5a775762cdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"พูด"</string>
     <string name="native_45a64dc17588f2ca" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"ออนไลน์ %1$s/%2$s"</string>
     <string name="native_45a8847c4a6b2c81" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"อนุญาตให้ส่งต่อ %1$s แอป"</string>
     <string name="native_460b3a7da007b7af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"แชท"</string>

--- a/apps/android/app/src/main/res/values-vi/strings.xml
+++ b/apps/android/app/src/main/res/values-vi/strings.xml
@@ -412,7 +412,7 @@
     <string name="native_4441146b0fe1d5c6" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"screenshot"</string>
     <string name="native_4481c2190a1b4bca" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Biểu thức cron, ví dụ 0 9 * * *"</string>
     <string name="native_4499e7b7e1c9ddbc" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Quay lại giọng nói"</string>
-    <string name="native_449f5a775762cdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nói chuyện"</string>
+    <string name="native_449f5a775762cdc5" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Nói"</string>
     <string name="native_45a64dc17588f2ca" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s/%2$s đang trực tuyến"</string>
     <string name="native_45a8847c4a6b2c81" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"%1$s ứng dụng được phép chuyển tiếp."</string>
     <string name="native_460b3a7da007b7af" formatted="false" tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"Trò chuyện"</string>

--- a/apps/ios/Sources/Camera/CameraController.swift
+++ b/apps/ios/Sources/Camera/CameraController.swift
@@ -37,13 +37,15 @@ actor CameraController {
         }
     }
 
-    func snap(params: OpenClawCameraSnapParams) async throws -> (
+    func snap(
+        params: OpenClawCameraSnapParams,
+        defaultFacing: OpenClawCameraFacing = .front) async throws -> (
         format: String,
         base64: String,
         width: Int,
         height: Int)
     {
-        let facing = params.facing ?? .front
+        let facing = Self.resolveFacing(params.facing, defaultFacing: defaultFacing)
         let format = params.format ?? .jpg
         // Default to a reasonable max width to keep gateway payload sizes manageable.
         // If you need the full-res photo, explicitly request a larger maxWidth.
@@ -102,13 +104,15 @@ actor CameraController {
             height: res.heightPx)
     }
 
-    func clip(params: OpenClawCameraClipParams) async throws -> (
+    func clip(
+        params: OpenClawCameraClipParams,
+        defaultFacing: OpenClawCameraFacing = .front) async throws -> (
         format: String,
         base64: String,
         durationMs: Int,
         hasAudio: Bool)
     {
-        let facing = params.facing ?? .front
+        let facing = Self.resolveFacing(params.facing, defaultFacing: defaultFacing)
         let durationMs = Self.clampDurationMs(params.durationMs)
         let includeAudio = params.includeAudio ?? true
         let format = params.format ?? .mp4
@@ -245,6 +249,13 @@ actor CameraController {
         let v = ms ?? 3000
         // Keep clips short by default; avoid huge base64 payloads on the gateway.
         return min(60000, max(250, v))
+    }
+
+    nonisolated static func resolveFacing(
+        _ explicitFacing: OpenClawCameraFacing?,
+        defaultFacing: OpenClawCameraFacing) -> OpenClawCameraFacing
+    {
+        explicitFacing ?? defaultFacing
     }
 
     private nonisolated static func exportToMP4(inputURL: URL, outputURL: URL) async throws {

--- a/apps/ios/Sources/Design/ChatProTab.swift
+++ b/apps/ios/Sources/Design/ChatProTab.swift
@@ -1,3 +1,4 @@
+import AVFAudio
 import OpenClawChatUI
 import OpenClawProtocol
 import SwiftUI
@@ -499,10 +500,32 @@ struct ChatProTab: View {
             statusText: self.appModel.talkMode.statusText,
             providerLabel: self.appModel.talkMode.gatewayTalkProviderLabel,
             level: self.talkLevel,
+            inputDevices: self.talkInputDevices,
+            selectedInputDeviceID: self.selectedTalkInputDeviceID,
+            selectInputDevice: { deviceID in
+                self.appModel.talkMode.selectInputDevice(deviceID)
+            },
+            cameraFacing: self.appModel.preferredCameraFacing == .front ? .front : .back,
+            flipCamera: {
+                self.appModel.flipPreferredCameraFacing()
+            },
             toggle: { sessionKey in
                 self.appModel.focusChatSession(sessionKey)
                 self.appModel.setTalkEnabled(!self.appModel.talkMode.isEnabled)
             })
+    }
+
+    private var talkInputDevices: [OpenClawChatAudioInputDevice] {
+        (AVAudioSession.sharedInstance().availableInputs ?? []).map { input in
+            OpenClawChatAudioInputDevice(id: input.uid, name: input.portName)
+        }
+    }
+
+    private var selectedTalkInputDeviceID: String? {
+        guard let preferredID = self.appModel.talkMode.preferredInputDeviceID,
+              self.talkInputDevices.contains(where: { $0.id == preferredID })
+        else { return nil }
+        return preferredID
     }
 
     private var dictationControl: OpenClawChatDictationControl {

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -405,6 +405,7 @@ final class NodeAppModel {
     var isBackgrounded: Bool = false
     let screen: ScreenController
     private let camera: any CameraServicing
+    private(set) var preferredCameraFacing: OpenClawCameraFacing
     private let screenRecorder: any ScreenRecordingServicing
     private var watchGatewayConnectionStatus: OpenClawWatchAppStatusCode?
     var gatewayStatusText: String = "Offline" {
@@ -804,6 +805,7 @@ final class NodeAppModel {
     private static let watchExecApprovalBridgeStateKey = "watch.execApproval.bridge.state.v1"
     private static let backgroundAliveLastSuccessAtMsKey = "gateway.backgroundAlive.lastSuccessAtMs"
     private static let backgroundAliveLastTriggerKey = "gateway.backgroundAlive.lastTrigger"
+    private static let preferredCameraFacingKey = "camera.preferredFacing"
     private static let foregroundResumeHealthTimeoutSeconds = 1
     private static let watchChatCompletionWaitMs = 75000
     private static let watchChatRunWaitSliceMs = 60000
@@ -839,6 +841,8 @@ final class NodeAppModel {
     {
         self.screen = screen
         self.camera = camera
+        self.preferredCameraFacing = Self.cameraFacingPreference(
+            rawValue: UserDefaults.standard.string(forKey: Self.preferredCameraFacingKey))
         self.screenRecorder = screenRecorder
         self.locationService = locationService
         self.notificationCenter = notificationCenter
@@ -2391,8 +2395,11 @@ final class NodeAppModel {
             triggerCameraFlash()
             let params = (try? Self.decodeParams(OpenClawCameraSnapParams.self, from: req.paramsJSON)) ??
                 OpenClawCameraSnapParams()
+            let defaultFacing = self.preferredCameraFacing
             let res = try await self.withForegroundCapture {
-                try await self.camera.snap(params: params)
+                try await self.camera.snap(
+                    params: params,
+                    defaultFacing: defaultFacing)
             }
 
             struct Payload: Codable {
@@ -2415,11 +2422,14 @@ final class NodeAppModel {
                 OpenClawCameraClipParams()
 
             let includeAudio = params.includeAudio ?? true
+            let defaultFacing = self.preferredCameraFacing
             showCameraHUD(ownerID: req.id, text: "Recording…", kind: .recording)
             let res = try await self.withForegroundCapture(
                 audioOwner: includeAudio ? .cameraClip : nil)
             {
-                try await self.camera.clip(params: params)
+                try await self.camera.clip(
+                    params: params,
+                    defaultFacing: defaultFacing)
             }
 
             struct Payload: Codable {
@@ -3438,6 +3448,21 @@ extension NodeAppModel {
         // Default-on: if the key doesn't exist yet, treat it as enabled.
         if UserDefaults.standard.object(forKey: "camera.enabled") == nil { return true }
         return UserDefaults.standard.bool(forKey: "camera.enabled")
+    }
+
+    nonisolated static func cameraFacingPreference(rawValue: String?) -> OpenClawCameraFacing {
+        rawValue.flatMap(OpenClawCameraFacing.init(rawValue:)) ?? .front
+    }
+
+    func setPreferredCameraFacing(_ facing: OpenClawCameraFacing) {
+        guard self.preferredCameraFacing != facing else { return }
+        self.preferredCameraFacing = facing
+        UserDefaults.standard.set(facing.rawValue, forKey: Self.preferredCameraFacingKey)
+    }
+
+    func flipPreferredCameraFacing() {
+        self.setPreferredCameraFacing(self.preferredCameraFacing == .front ? .back : .front)
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
     }
 
     private func triggerCameraFlash() {

--- a/apps/ios/Sources/Services/NodeServiceProtocols.swift
+++ b/apps/ios/Sources/Services/NodeServiceProtocols.swift
@@ -8,8 +8,12 @@ typealias OpenClawCameraClipResult = (format: String, base64: String, durationMs
 
 protocol CameraServicing: Sendable {
     func listDevices() async -> [CameraController.CameraDeviceInfo]
-    func snap(params: OpenClawCameraSnapParams) async throws -> OpenClawCameraSnapResult
-    func clip(params: OpenClawCameraClipParams) async throws -> OpenClawCameraClipResult
+    func snap(
+        params: OpenClawCameraSnapParams,
+        defaultFacing: OpenClawCameraFacing) async throws -> OpenClawCameraSnapResult
+    func clip(
+        params: OpenClawCameraClipParams,
+        defaultFacing: OpenClawCameraFacing) async throws -> OpenClawCameraClipResult
 }
 
 protocol ScreenRecordingServicing: Sendable {

--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -133,6 +133,7 @@ final class TalkModeManager: NSObject {
     private static let defaultSilenceTimeoutMs = TalkDefaults.silenceTimeoutMs
     private static let redactedConfigSentinel = "__OPENCLAW_REDACTED__"
     private static let realtimePrefetchExpiryLeewaySeconds: TimeInterval = 30
+    private static let preferredInputDeviceIDKey = "talk.preferredInputDeviceID"
     var isEnabled: Bool = false
     var isListening: Bool = false
     var isSpeaking: Bool = false
@@ -156,6 +157,7 @@ final class TalkModeManager: NSObject {
     /// voice path exposes no real level (system voice, compressed streaming); the
     /// waveform then falls back to a synthetic pulse.
     var playbackLevel: Double?
+    private(set) var preferredInputDeviceID: String?
     var gatewayTalkConfigLoaded: Bool = false
     var gatewayTalkApiKeyConfigured: Bool = false
     var gatewayTalkDefaultModelId: String?
@@ -480,7 +482,22 @@ final class TalkModeManager: NSObject {
         self.allowSimulatorCapture = allowSimulatorCapture
         self.gatewaySpeechSynthesizerOverride = gatewaySpeechSynthesizer
         self.audioSessionDeactivationAction = audioSessionDeactivationAction
+        self.preferredInputDeviceID = UserDefaults.standard.string(
+            forKey: Self.preferredInputDeviceIDKey)
         super.init()
+    }
+
+    func selectInputDevice(_ deviceID: String?) {
+        let normalizedID = deviceID.flatMap { $0.isEmpty ? nil : $0 }
+        self.preferredInputDeviceID = normalizedID
+        if let normalizedID {
+            UserDefaults.standard.set(normalizedID, forKey: Self.preferredInputDeviceIDKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: Self.preferredInputDeviceIDKey)
+        }
+
+        guard self.audioSessionIsActive else { return }
+        Self.applyPreferredInput(normalizedID, to: AVAudioSession.sharedInstance())
     }
 
     func attachGateway(_ gateway: GatewayNodeSession) {
@@ -2200,6 +2217,9 @@ final class TalkModeManager: NSObject {
                 session.stop()
                 return .ignored
             }
+            // WebRTC configures the shared session and may force speaker + built-in mic.
+            // Apply the user's input last so the explicit microphone selection wins.
+            Self.applyPreferredInput(self.preferredInputDeviceID, to: AVAudioSession.sharedInstance())
             self.markRealtimeSessionReady()
             GatewayDiagnostics.log(
                 "talk.timeline realtime start ready elapsedMs=\(Self.elapsedMs(since: startedAt))")
@@ -4287,12 +4307,12 @@ extension TalkModeManager {
     }
 
     private func configureOwnedAudioSession() throws {
-        try Self.configureAudioSession()
+        try Self.configureAudioSession(preferredInputDeviceID: self.preferredInputDeviceID)
         self.audioSessionIsActive = true
     }
 
     private func configureOwnedRealtimeAudioSession() throws {
-        try Self.configureRealtimeAudioSession()
+        try Self.configureRealtimeAudioSession(preferredInputDeviceID: self.preferredInputDeviceID)
         self.audioSessionIsActive = true
     }
 
@@ -4320,7 +4340,7 @@ extension TalkModeManager {
         }
     }
 
-    static func configureAudioSession() throws {
+    static func configureAudioSession(preferredInputDeviceID: String? = nil) throws {
         let session = AVAudioSession.sharedInstance()
         let forceSpeaker = TalkDefaults.speakerphoneEnabled()
         let options = TalkAudioRoute.categoryOptions(speakerphoneEnabled: forceSpeaker)
@@ -4337,10 +4357,12 @@ extension TalkModeManager {
         } else {
             try? session.overrideOutputAudioPort(.none)
         }
+        // A speaker override also forces the built-in microphone; apply an explicit input last.
+        self.applyPreferredInput(preferredInputDeviceID, to: session)
         GatewayDiagnostics.log("talk audio: session speakerphone=\(forceSpeaker) \(Self.describeAudioSession())")
     }
 
-    static func configureRealtimeAudioSession() throws {
+    static func configureRealtimeAudioSession(preferredInputDeviceID: String? = nil) throws {
         let session = AVAudioSession.sharedInstance()
         let forceSpeaker = TalkDefaults.speakerphoneEnabled()
         let options = TalkAudioRoute.categoryOptions(speakerphoneEnabled: forceSpeaker)
@@ -4358,8 +4380,22 @@ extension TalkModeManager {
         } else {
             try? session.overrideOutputAudioPort(.none)
         }
+        // A speaker override also forces the built-in microphone; apply an explicit input last.
+        self.applyPreferredInput(preferredInputDeviceID, to: session)
         GatewayDiagnostics.log(
             "talk realtime audio: session speakerphone=\(forceSpeaker) \(Self.describeAudioSession())")
+    }
+
+    private static func applyPreferredInput(_ deviceID: String?, to session: AVAudioSession) {
+        let input = deviceID.flatMap { id in
+            session.availableInputs?.first(where: { $0.uid == id })
+        }
+        do {
+            try session.setPreferredInput(input)
+        } catch {
+            try? session.setPreferredInput(nil)
+            GatewayDiagnostics.log("talk audio: preferred input update failed: \(error.localizedDescription)")
+        }
     }
 
     private static func describeAudioSession() -> String {

--- a/apps/ios/Tests/CameraControllerClampTests.swift
+++ b/apps/ios/Tests/CameraControllerClampTests.swift
@@ -1,8 +1,8 @@
 import Testing
 @testable import OpenClaw
 
-@Suite struct CameraControllerClampTests {
-    @Test func clampQualityDefaultsAndBounds() {
+struct CameraControllerClampTests {
+    @Test func `clamp quality defaults and bounds`() {
         #expect(CameraController.clampQuality(nil) == 0.9)
         #expect(CameraController.clampQuality(0.0) == 0.05)
         #expect(CameraController.clampQuality(0.049) == 0.05)
@@ -12,7 +12,7 @@ import Testing
         #expect(CameraController.clampQuality(1.1) == 1.0)
     }
 
-    @Test func clampDurationDefaultsAndBounds() {
+    @Test func `clamp duration defaults and bounds`() {
         #expect(CameraController.clampDurationMs(nil) == 3000)
         #expect(CameraController.clampDurationMs(0) == 250)
         #expect(CameraController.clampDurationMs(249) == 250)
@@ -20,5 +20,12 @@ import Testing
         #expect(CameraController.clampDurationMs(1000) == 1000)
         #expect(CameraController.clampDurationMs(60000) == 60000)
         #expect(CameraController.clampDurationMs(60001) == 60000)
+    }
+
+    @Test func `preferred facing defaults and explicit override`() {
+        #expect(NodeAppModel.cameraFacingPreference(rawValue: nil) == .front)
+        #expect(NodeAppModel.cameraFacingPreference(rawValue: "back") == .back)
+        #expect(CameraController.resolveFacing(nil, defaultFacing: .back) == .back)
+        #expect(CameraController.resolveFacing(.front, defaultFacing: .back) == .front)
     }
 }

--- a/apps/ios/Tests/NodeAppModelInvokeTests.swift
+++ b/apps/ios/Tests/NodeAppModelInvokeTests.swift
@@ -34,11 +34,17 @@ private actor CancellingCameraService: CameraServicing {
         []
     }
 
-    func snap(params _: OpenClawCameraSnapParams) async throws -> OpenClawCameraSnapResult {
+    func snap(
+        params _: OpenClawCameraSnapParams,
+        defaultFacing _: OpenClawCameraFacing) async throws -> OpenClawCameraSnapResult
+    {
         throw CancellationError()
     }
 
-    func clip(params _: OpenClawCameraClipParams) async throws -> OpenClawCameraClipResult {
+    func clip(
+        params _: OpenClawCameraClipParams,
+        defaultFacing _: OpenClawCameraFacing) async throws -> OpenClawCameraClipResult
+    {
         throw CancellationError()
     }
 }
@@ -50,11 +56,17 @@ private actor RecordingCameraService: CameraServicing {
         []
     }
 
-    func snap(params _: OpenClawCameraSnapParams) async throws -> OpenClawCameraSnapResult {
+    func snap(
+        params _: OpenClawCameraSnapParams,
+        defaultFacing _: OpenClawCameraFacing) async throws -> OpenClawCameraSnapResult
+    {
         (format: "jpg", base64: "", width: 1, height: 1)
     }
 
-    func clip(params _: OpenClawCameraClipParams) async throws -> OpenClawCameraClipResult {
+    func clip(
+        params _: OpenClawCameraClipParams,
+        defaultFacing _: OpenClawCameraFacing) async throws -> OpenClawCameraClipResult
+    {
         self.clipCalls += 1
         return (format: "mp4", base64: "", durationMs: 1, hasAudio: true)
     }
@@ -105,11 +117,17 @@ private actor BlockingAudioCameraService: CameraServicing {
         []
     }
 
-    func snap(params _: OpenClawCameraSnapParams) async throws -> OpenClawCameraSnapResult {
+    func snap(
+        params _: OpenClawCameraSnapParams,
+        defaultFacing _: OpenClawCameraFacing) async throws -> OpenClawCameraSnapResult
+    {
         (format: "jpg", base64: "", width: 1, height: 1)
     }
 
-    func clip(params _: OpenClawCameraClipParams) async throws -> OpenClawCameraClipResult {
+    func clip(
+        params _: OpenClawCameraClipParams,
+        defaultFacing _: OpenClawCameraFacing) async throws -> OpenClawCameraClipResult
+    {
         await self.barrier.suspendFirstPreparation()
         try Task.checkCancellation()
         return (format: "mp4", base64: "", durationMs: 1, hasAudio: true)
@@ -186,7 +204,10 @@ private actor OverlappingCameraService: CameraServicing {
         []
     }
 
-    func snap(params _: OpenClawCameraSnapParams) async throws -> OpenClawCameraSnapResult {
+    func snap(
+        params _: OpenClawCameraSnapParams,
+        defaultFacing _: OpenClawCameraFacing) async throws -> OpenClawCameraSnapResult
+    {
         self.snapCount += 1
         if self.snapCount == 1 {
             self.firstStarted.yield()
@@ -201,7 +222,10 @@ private actor OverlappingCameraService: CameraServicing {
         return (format: "jpg", base64: "", width: 1, height: 1)
     }
 
-    func clip(params _: OpenClawCameraClipParams) async throws -> OpenClawCameraClipResult {
+    func clip(
+        params _: OpenClawCameraClipParams,
+        defaultFacing _: OpenClawCameraFacing) async throws -> OpenClawCameraClipResult
+    {
         throw CancellationError()
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift
@@ -25,13 +25,13 @@ struct ChatCameraFlipButton: View {
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .accessibilityLabel(accessibilityLabel)
+        .accessibilityLabel(self.accessibilityLabel)
         .accessibilityIdentifier("chat-camera-flip")
-        .help(accessibilityLabel)
+        .help(self.accessibilityLabel)
     }
 
     private var accessibilityLabel: String {
-        switch control.cameraFacing {
+        switch self.control.cameraFacing {
         case .front:
             String(localized: "Switch to back camera")
         case .back:
@@ -54,22 +54,12 @@ struct ChatTalkButton: View {
     let helpText: String
     let style: Style
 
-    /// Local capture and realtime Talk share one microphone, so the Talk affordance
-    /// must yield until dictation or voice-note capture releases audio ownership.
-    nonisolated static func showsCompactControl(
-        hasDraftToSend: Bool,
-        hasBlockingRunActivity: Bool,
-        isLocalVoiceCaptureActive: Bool
-    ) -> Bool {
-        !hasDraftToSend && !hasBlockingRunActivity && !isLocalVoiceCaptureActive
-    }
-
     var body: some View {
-        switch style {
+        switch self.style {
         case .full:
-            fullButton
+            self.fullButton
         case let .compact(controlHeight, iconControlSize):
-            compactButton(controlHeight: controlHeight, iconControlSize: iconControlSize)
+            self.compactButton(controlHeight: controlHeight, iconControlSize: iconControlSize)
         }
     }
 
@@ -97,12 +87,12 @@ struct ChatTalkButton: View {
             }
         }
         .buttonStyle(.plain)
-        .disabled(!control.isGatewayConnected && !control.isEnabled)
-        .accessibilityLabel(control.isEnabled ? "Stop realtime chat" : "Start realtime chat")
-        .accessibilityValue(accessibilityValue)
+        .disabled(!self.control.isGatewayConnected && !self.control.isEnabled)
+        .accessibilityLabel(self.control.isEnabled ? "Stop realtime chat" : "Start realtime chat")
+        .accessibilityValue(self.accessibilityValue)
         .accessibilityIdentifier("chat-realtime-control")
-        .help(helpText)
-        .chatTalkInputDeviceMenu(control)
+        .help(self.helpText)
+        .chatTalkInputDeviceMenu(self.control)
     }
 
     private func compactButton(controlHeight: CGFloat, iconControlSize: CGFloat) -> some View {
@@ -124,35 +114,47 @@ struct ChatTalkButton: View {
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .disabled(!control.isGatewayConnected && !control.isEnabled)
-        .accessibilityLabel(control.isEnabled ? "Stop realtime chat" : "Start realtime chat")
-        .accessibilityValue(accessibilityValue)
+        .disabled(!self.control.isGatewayConnected && !self.control.isEnabled)
+        .accessibilityLabel(self.control.isEnabled ? "Stop realtime chat" : "Start realtime chat")
+        .accessibilityValue(self.accessibilityValue)
         .accessibilityIdentifier("chat-realtime-control")
-        .help(helpText)
-        .chatTalkInputDeviceMenu(control)
+        .help(self.helpText)
+        .chatTalkInputDeviceMenu(self.control)
     }
 
     private var fill: AnyShapeStyle {
-        if control.isEnabled {
+        if self.control.isEnabled {
             return AnyShapeStyle(OpenClawChatTheme.userBubble)
         }
-        if !control.isGatewayConnected {
+        if !self.control.isGatewayConnected {
             return AnyShapeStyle(Color.secondary.opacity(0.12))
         }
         return OpenClawChatTheme.subtleCard
     }
 
     private var stroke: Color {
-        if control.isEnabled {
+        if self.control.isEnabled {
             return Color.white.opacity(0.18)
         }
         return OpenClawChatTheme.composerBorder
     }
 
     private var accessibilityValue: String {
-        let status = control.statusText.trimmingCharacters(in: .whitespacesAndNewlines)
-        let provider = control.providerLabel.trimmingCharacters(in: .whitespacesAndNewlines)
+        let status = self.control.statusText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let provider = self.control.providerLabel.trimmingCharacters(in: .whitespacesAndNewlines)
         return [status, provider].filter { !$0.isEmpty }.joined(separator: ", ")
+    }
+}
+
+extension OpenClawChatComposer {
+    /// Local capture and realtime Talk share one microphone, so the Talk affordance
+    /// must yield until dictation or voice-note capture releases audio ownership.
+    nonisolated static func showsCompactTalkControl(
+        hasDraftToSend: Bool,
+        hasBlockingRunActivity: Bool,
+        isLocalVoiceCaptureActive: Bool) -> Bool
+    {
+        !hasDraftToSend && !hasBlockingRunActivity && !isLocalVoiceCaptureActive
     }
 }
 
@@ -161,8 +163,8 @@ enum ChatDictationActions {
     static func start(
         _ control: OpenClawChatDictationControl,
         task: Binding<Task<Void, Never>?>,
-        viewModel: OpenClawChatViewModel
-    ) {
+        viewModel: OpenClawChatViewModel)
+    {
         guard task.wrappedValue == nil else { return }
         let session = viewModel.currentSessionSnapshot()
         task.wrappedValue = Task { @MainActor in
@@ -182,8 +184,8 @@ enum ChatDictationActions {
 
     static func cancel(
         task: Binding<Task<Void, Never>?>,
-        control: OpenClawChatDictationControl?
-    ) {
+        control: OpenClawChatDictationControl?)
+    {
         guard task.wrappedValue != nil else { return }
         task.wrappedValue?.cancel()
         control?.cancel()

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatCameraFlipButton.swift
@@ -1,0 +1,212 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+struct ChatCameraFlipButton: View {
+    let control: OpenClawChatTalkControl
+    let size: CGFloat
+
+    static func isAvailable(for control: OpenClawChatTalkControl) -> Bool {
+        control.isEnabled && control.cameraFacing != nil && control.flipCamera != nil
+    }
+
+    var body: some View {
+        Button {
+            self.control.flipCamera?()
+        } label: {
+            Image(systemName: "arrow.triangle.2.circlepath.camera")
+                .font(OpenClawChatTypography.body(size: 14, weight: .semibold, relativeTo: .subheadline))
+                .foregroundStyle(.primary)
+                .frame(width: self.size, height: self.size)
+                .background {
+                    Circle()
+                        .fill(OpenClawChatTheme.accent.opacity(0.12))
+                }
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityIdentifier("chat-camera-flip")
+        .help(accessibilityLabel)
+    }
+
+    private var accessibilityLabel: String {
+        switch control.cameraFacing {
+        case .front:
+            String(localized: "Switch to back camera")
+        case .back:
+            String(localized: "Switch to front camera")
+        case nil:
+            String(localized: "Flip camera")
+        }
+    }
+}
+
+@MainActor
+struct ChatTalkButton: View {
+    enum Style {
+        case full
+        case compact(controlHeight: CGFloat, iconControlSize: CGFloat)
+    }
+
+    let control: OpenClawChatTalkControl
+    let sessionKey: String
+    let helpText: String
+    let style: Style
+
+    /// Local capture and realtime Talk share one microphone, so the Talk affordance
+    /// must yield until dictation or voice-note capture releases audio ownership.
+    nonisolated static func showsCompactControl(
+        hasDraftToSend: Bool,
+        hasBlockingRunActivity: Bool,
+        isLocalVoiceCaptureActive: Bool
+    ) -> Bool {
+        !hasDraftToSend && !hasBlockingRunActivity && !isLocalVoiceCaptureActive
+    }
+
+    var body: some View {
+        switch style {
+        case .full:
+            fullButton
+        case let .compact(controlHeight, iconControlSize):
+            compactButton(controlHeight: controlHeight, iconControlSize: iconControlSize)
+        }
+    }
+
+    private var fullButton: some View {
+        Button {
+            self.control.toggle(self.sessionKey)
+        } label: {
+            HStack(spacing: 6) {
+                ChatTalkButtonGlyph(control: self.control)
+                    .font(OpenClawChatTypography.captionSemiBold)
+                Text(self.control.isEnabled ? "Stop" : "Talk")
+                    .font(OpenClawChatTypography.captionSemiBold)
+                    .lineLimit(1)
+            }
+            .foregroundStyle(self.control.isEnabled ? .white : .primary)
+            .padding(.horizontal, 10)
+            .frame(height: 32)
+            .background {
+                Capsule()
+                    .fill(self.fill)
+            }
+            .overlay {
+                Capsule()
+                    .strokeBorder(self.stroke, lineWidth: 1)
+            }
+        }
+        .buttonStyle(.plain)
+        .disabled(!control.isGatewayConnected && !control.isEnabled)
+        .accessibilityLabel(control.isEnabled ? "Stop realtime chat" : "Start realtime chat")
+        .accessibilityValue(accessibilityValue)
+        .accessibilityIdentifier("chat-realtime-control")
+        .help(helpText)
+        .chatTalkInputDeviceMenu(control)
+    }
+
+    private func compactButton(controlHeight: CGFloat, iconControlSize: CGFloat) -> some View {
+        Button {
+            self.control.toggle(self.sessionKey)
+        } label: {
+            ChatTalkButtonGlyph(control: self.control)
+                .font(OpenClawChatTypography.body(size: 14, weight: .semibold, relativeTo: .subheadline))
+                .foregroundStyle(.white)
+                .frame(width: iconControlSize, height: iconControlSize)
+                // Prominent filled circle so the mic reads as the primary action,
+                // mirroring the send button it swaps with once a draft exists.
+                .background {
+                    Circle()
+                        .fill(self.control.isEnabled ? self.fill : AnyShapeStyle(OpenClawChatTheme.accent))
+                        .opacity(self.control.isGatewayConnected || self.control.isEnabled ? 1 : 0.4)
+                }
+                .frame(width: controlHeight, height: controlHeight)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!control.isGatewayConnected && !control.isEnabled)
+        .accessibilityLabel(control.isEnabled ? "Stop realtime chat" : "Start realtime chat")
+        .accessibilityValue(accessibilityValue)
+        .accessibilityIdentifier("chat-realtime-control")
+        .help(helpText)
+        .chatTalkInputDeviceMenu(control)
+    }
+
+    private var fill: AnyShapeStyle {
+        if control.isEnabled {
+            return AnyShapeStyle(OpenClawChatTheme.userBubble)
+        }
+        if !control.isGatewayConnected {
+            return AnyShapeStyle(Color.secondary.opacity(0.12))
+        }
+        return OpenClawChatTheme.subtleCard
+    }
+
+    private var stroke: Color {
+        if control.isEnabled {
+            return Color.white.opacity(0.18)
+        }
+        return OpenClawChatTheme.composerBorder
+    }
+
+    private var accessibilityValue: String {
+        let status = control.statusText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let provider = control.providerLabel.trimmingCharacters(in: .whitespacesAndNewlines)
+        return [status, provider].filter { !$0.isEmpty }.joined(separator: ", ")
+    }
+}
+
+@MainActor
+enum ChatDictationActions {
+    static func start(
+        _ control: OpenClawChatDictationControl,
+        task: Binding<Task<Void, Never>?>,
+        viewModel: OpenClawChatViewModel
+    ) {
+        guard task.wrappedValue == nil else { return }
+        let session = viewModel.currentSessionSnapshot()
+        task.wrappedValue = Task { @MainActor in
+            defer { task.wrappedValue = nil }
+            do {
+                guard let transcript = try await control.start(), !transcript.isEmpty else { return }
+                try Task.checkCancellation()
+                viewModel.appendDictationTranscript(transcript, for: session)
+            } catch is CancellationError {
+                return
+            } catch {
+                guard !Task.isCancelled else { return }
+                viewModel.setDictationError(error, for: session)
+            }
+        }
+    }
+
+    static func cancel(
+        task: Binding<Task<Void, Never>?>,
+        control: OpenClawChatDictationControl?
+    ) {
+        guard task.wrappedValue != nil else { return }
+        task.wrappedValue?.cancel()
+        control?.cancel()
+    }
+}
+
+struct ChatConnectionPill: View {
+    let isConnected: Bool
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(self.isConnected ? .green : .orange)
+                .frame(width: 7, height: 7)
+            Text(self.isConnected ? "Gateway connected" : "Connecting...")
+                .font(OpenClawChatTypography.caption2)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background {
+            Capsule()
+                .fill(OpenClawChatTheme.subtleCard)
+        }
+    }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -186,7 +186,7 @@ struct OpenClawChatComposer: View {
     private var lifecycleComposer: some View {
         self.recorderLifecycleComposer
             .onChange(of: self.presentationOwner) { _, _ in
-                self.cancelActiveDictation()
+                ChatDictationActions.cancel(task: self.$dictationTask, control: self.dictationControl)
                 #if !os(macOS)
                 self.showsPhotoPicker = false
                 self.showsFileImporter = false
@@ -204,7 +204,7 @@ struct OpenClawChatComposer: View {
                 self.stageCompletedVoiceNoteIfNeeded()
             }
             .onDisappear {
-                self.cancelActiveDictation()
+                ChatDictationActions.cancel(task: self.$dictationTask, control: self.dictationControl)
                 #if !os(macOS)
                 self.showsPhotoPicker = false
                 self.showsFileImporter = false
@@ -696,13 +696,18 @@ struct OpenClawChatComposer: View {
 
             HStack(alignment: .center, spacing: 8) {
                 if let talkControl {
-                    self.talkButton(talkControl)
-                    if self.showsCameraFlip(talkControl) {
-                        self.cameraFlipButton(talkControl, compact: false)
+                    ChatTalkButton(
+                        control: talkControl,
+                        sessionKey: self.viewModel.sessionKey,
+                        helpText: self.talkHelpText(talkControl),
+                        style: .full)
+                    if ChatCameraFlipButton.isAvailable(for: talkControl) {
+                        ChatCameraFlipButton(control: talkControl, size: 32)
                     }
                 }
                 if self.showsConnectionPill {
-                    self.connectionPill
+                    ChatConnectionPill(
+                        isConnected: self.viewModel.healthOK || (self.talkControl?.isGatewayConnected ?? false))
                 }
                 Spacer(minLength: 0)
                 self.sendButton
@@ -759,17 +764,20 @@ struct OpenClawChatComposer: View {
                     isComposerEnabled: self.isComposerEnabled,
                     isAttachmentInputEnabled: self.isAttachmentInputEnabled,
                     onCancelDictation: {
-                        self.cancelActiveDictation()
+                        ChatDictationActions.cancel(task: self.$dictationTask, control: self.dictationControl)
                     },
                     onStartDictation: {
                         if let dictationControl = self.dictationControl {
-                            self.startDictation(dictationControl)
+                            ChatDictationActions.start(
+                                dictationControl,
+                                task: self.$dictationTask,
+                                viewModel: self.viewModel)
                         }
                     })
             }
 
-            if let talkControl, self.showsCameraFlip(talkControl) {
-                self.cameraFlipButton(talkControl, compact: true)
+            if let talkControl, ChatCameraFlipButton.isAvailable(for: talkControl) {
+                ChatCameraFlipButton(control: talkControl, size: self.cleanControlHeight)
             }
 
             self.cleanTrailingControl
@@ -780,13 +788,19 @@ struct OpenClawChatComposer: View {
     /// draft is empty, swapping to the send button once the user types.
     @ViewBuilder
     private var cleanTrailingControl: some View {
-        if Self.showsCompactTalkControl(
+        if ChatTalkButton.showsCompactControl(
             hasDraftToSend: self.viewModel.hasDraftToSend,
             hasBlockingRunActivity: self.viewModel.hasBlockingRunActivity,
             isLocalVoiceCaptureActive: self.isLocalVoiceCaptureActive),
             let talkControl
         {
-            self.compactTalkButton(talkControl)
+            ChatTalkButton(
+                control: talkControl,
+                sessionKey: self.viewModel.sessionKey,
+                helpText: self.talkHelpText(talkControl),
+                style: .compact(
+                    controlHeight: self.cleanControlHeight,
+                    iconControlSize: self.cleanIconControlSize))
         } else {
             sendButton
                 .frame(width: cleanControlHeight, height: cleanControlHeight)
@@ -800,183 +814,12 @@ struct OpenClawChatComposer: View {
             self.voiceNoteControl?.recorder.isRequestingPermission == true
     }
 
-    /// Local capture and realtime Talk share one microphone, so the Talk affordance
-    /// must yield until dictation or voice-note capture releases audio ownership.
-    nonisolated static func showsCompactTalkControl(
-        hasDraftToSend: Bool,
-        hasBlockingRunActivity: Bool,
-        isLocalVoiceCaptureActive: Bool) -> Bool
-    {
-        !hasDraftToSend && !hasBlockingRunActivity && !isLocalVoiceCaptureActive
-    }
-
-    private func talkButton(_ talkControl: OpenClawChatTalkControl) -> some View {
-        Button {
-            talkControl.toggle(self.viewModel.sessionKey)
-        } label: {
-            HStack(spacing: 6) {
-                ChatTalkButtonGlyph(control: talkControl)
-                    .font(OpenClawChatTypography.captionSemiBold)
-                Text(talkControl.isEnabled ? "Stop" : "Talk")
-                    .font(OpenClawChatTypography.captionSemiBold)
-                    .lineLimit(1)
-            }
-            .foregroundStyle(talkControl.isEnabled ? .white : .primary)
-            .padding(.horizontal, 10)
-            .frame(height: 32)
-            .background {
-                Capsule()
-                    .fill(self.talkButtonFill(talkControl))
-            }
-            .overlay {
-                Capsule()
-                    .strokeBorder(self.talkButtonStroke(talkControl), lineWidth: 1)
-            }
-        }
-        .buttonStyle(.plain)
-        .disabled(!talkControl.isGatewayConnected && !talkControl.isEnabled)
-        .accessibilityLabel(talkControl.isEnabled ? "Stop realtime chat" : "Start realtime chat")
-        .accessibilityValue(self.talkAccessibilityValue(talkControl))
-        .accessibilityIdentifier("chat-realtime-control")
-        .help(self.talkHelpText(talkControl))
-        .chatTalkInputDeviceMenu(talkControl)
-    }
-
-    private func startDictation(_ control: OpenClawChatDictationControl) {
-        guard self.dictationTask == nil else { return }
-        let session = self.viewModel.currentSessionSnapshot()
-        self.dictationTask = Task { @MainActor in
-            defer { self.dictationTask = nil }
-            do {
-                guard let transcript = try await control.start(), !transcript.isEmpty else { return }
-                try Task.checkCancellation()
-                self.viewModel.appendDictationTranscript(transcript, for: session)
-            } catch is CancellationError {
-                return
-            } catch {
-                guard !Task.isCancelled else { return }
-                self.viewModel.setDictationError(error, for: session)
-            }
-        }
-    }
-
-    private func cancelActiveDictation() {
-        guard self.dictationTask != nil else { return }
-        self.dictationTask?.cancel()
-        self.dictationControl?.cancel()
-    }
-
-    private func compactTalkButton(_ talkControl: OpenClawChatTalkControl) -> some View {
-        Button {
-            talkControl.toggle(self.viewModel.sessionKey)
-        } label: {
-            ChatTalkButtonGlyph(control: talkControl)
-                .font(OpenClawChatTypography.body(size: 14, weight: .semibold, relativeTo: .subheadline))
-                .foregroundStyle(.white)
-                .frame(width: self.cleanIconControlSize, height: self.cleanIconControlSize)
-                // Prominent filled circle so the mic reads as the primary action,
-                // mirroring the send button it swaps with once a draft exists.
-                .background {
-                    Circle()
-                        .fill(talkControl.isEnabled
-                            ? self.talkButtonFill(talkControl)
-                            : AnyShapeStyle(OpenClawChatTheme.accent))
-                        .opacity(talkControl.isGatewayConnected || talkControl.isEnabled ? 1 : 0.4)
-                }
-                .frame(width: self.cleanControlHeight, height: self.cleanControlHeight)
-                .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .disabled(!talkControl.isGatewayConnected && !talkControl.isEnabled)
-        .accessibilityLabel(talkControl.isEnabled ? "Stop realtime chat" : "Start realtime chat")
-        .accessibilityValue(self.talkAccessibilityValue(talkControl))
-        .accessibilityIdentifier("chat-realtime-control")
-        .help(self.talkHelpText(talkControl))
-        .chatTalkInputDeviceMenu(talkControl)
-    }
-
-    private func showsCameraFlip(_ talkControl: OpenClawChatTalkControl) -> Bool {
-        talkControl.isEnabled && talkControl.cameraFacing != nil && talkControl.flipCamera != nil
-    }
-
-    private func cameraFlipButton(_ talkControl: OpenClawChatTalkControl, compact: Bool) -> some View {
-        let size = compact ? self.cleanControlHeight : 32
-        let label = switch talkControl.cameraFacing {
-        case .front:
-            String(localized: "Switch to back camera")
-        case .back:
-            String(localized: "Switch to front camera")
-        case nil:
-            String(localized: "Flip camera")
-        }
-
-        return Button {
-            talkControl.flipCamera?()
-        } label: {
-            Image(systemName: "arrow.triangle.2.circlepath.camera")
-                .font(OpenClawChatTypography.body(size: 14, weight: .semibold, relativeTo: .subheadline))
-                .foregroundStyle(.primary)
-                .frame(width: size, height: size)
-                .background {
-                    Circle()
-                        .fill(OpenClawChatTheme.accent.opacity(0.12))
-                }
-                .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel(label)
-        .accessibilityIdentifier("chat-camera-flip")
-        .help(label)
-    }
-
-    private func talkButtonFill(_ talkControl: OpenClawChatTalkControl) -> AnyShapeStyle {
-        if talkControl.isEnabled {
-            return AnyShapeStyle(OpenClawChatTheme.userBubble)
-        }
-        if !talkControl.isGatewayConnected {
-            return AnyShapeStyle(Color.secondary.opacity(0.12))
-        }
-        return OpenClawChatTheme.subtleCard
-    }
-
-    private func talkButtonStroke(_ talkControl: OpenClawChatTalkControl) -> Color {
-        if talkControl.isEnabled {
-            return Color.white.opacity(0.18)
-        }
-        return OpenClawChatTheme.composerBorder
-    }
-
-    private func talkAccessibilityValue(_ talkControl: OpenClawChatTalkControl) -> String {
-        let status = talkControl.statusText.trimmingCharacters(in: .whitespacesAndNewlines)
-        let provider = talkControl.providerLabel.trimmingCharacters(in: .whitespacesAndNewlines)
-        return [status, provider].filter { !$0.isEmpty }.joined(separator: ", ")
-    }
-
     private func talkHelpText(_ talkControl: OpenClawChatTalkControl) -> String {
         if !talkControl.isGatewayConnected, !talkControl.isEnabled {
             return "Connect the gateway before starting realtime chat"
         }
         let action = talkControl.isEnabled ? "Stop" : "Start"
         return "\(action) realtime chat for \(self.activeSessionLabel)"
-    }
-
-    private var connectionPill: some View {
-        HStack(spacing: 6) {
-            Circle()
-                .fill(self.connectionOK ? .green : .orange)
-                .frame(width: 7, height: 7)
-            Text(self.connectionStatusText)
-                .font(OpenClawChatTypography.caption2)
-                .foregroundStyle(.secondary)
-        }
-        .padding(.horizontal, self.composerChrome == .clean ? 0 : 8)
-        .padding(.vertical, self.composerChrome == .clean ? 0 : 4)
-        .background {
-            if self.composerChrome == .full {
-                Capsule()
-                    .fill(OpenClawChatTheme.subtleCard)
-            }
-        }
     }
 
     private var activeSessionLabel: String {
@@ -1493,14 +1336,6 @@ extension OpenClawChatComposer {
         // The app-owned recorder outlives this view. Release the microphone
         // when its only recording UI disappears so capture never runs hidden.
         recorder.cancel()
-    }
-
-    private var connectionStatusText: String {
-        self.connectionOK ? "Gateway connected" : "Connecting..."
-    }
-
-    private var connectionOK: Bool {
-        self.viewModel.healthOK || (self.talkControl?.isGatewayConnected ?? false)
     }
 
     private var placeholderText: String {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -788,7 +788,7 @@ struct OpenClawChatComposer: View {
     /// draft is empty, swapping to the send button once the user types.
     @ViewBuilder
     private var cleanTrailingControl: some View {
-        if ChatTalkButton.showsCompactControl(
+        if Self.showsCompactTalkControl(
             hasDraftToSend: self.viewModel.hasDraftToSend,
             hasBlockingRunActivity: self.viewModel.hasBlockingRunActivity,
             isLocalVoiceCaptureActive: self.isLocalVoiceCaptureActive),

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -697,6 +697,9 @@ struct OpenClawChatComposer: View {
             HStack(alignment: .center, spacing: 8) {
                 if let talkControl {
                     self.talkButton(talkControl)
+                    if self.showsCameraFlip(talkControl) {
+                        self.cameraFlipButton(talkControl, compact: false)
+                    }
                 }
                 if self.showsConnectionPill {
                     self.connectionPill
@@ -763,6 +766,10 @@ struct OpenClawChatComposer: View {
                             self.startDictation(dictationControl)
                         }
                     })
+            }
+
+            if let talkControl, self.showsCameraFlip(talkControl) {
+                self.cameraFlipButton(talkControl, compact: true)
             }
 
             self.cleanTrailingControl
@@ -886,6 +893,40 @@ struct OpenClawChatComposer: View {
         .accessibilityIdentifier("chat-realtime-control")
         .help(self.talkHelpText(talkControl))
         .chatTalkInputDeviceMenu(talkControl)
+    }
+
+    private func showsCameraFlip(_ talkControl: OpenClawChatTalkControl) -> Bool {
+        talkControl.isEnabled && talkControl.cameraFacing != nil && talkControl.flipCamera != nil
+    }
+
+    private func cameraFlipButton(_ talkControl: OpenClawChatTalkControl, compact: Bool) -> some View {
+        let size = compact ? self.cleanControlHeight : 32
+        let label = switch talkControl.cameraFacing {
+        case .front:
+            String(localized: "Switch to back camera")
+        case .back:
+            String(localized: "Switch to front camera")
+        case nil:
+            String(localized: "Flip camera")
+        }
+
+        return Button {
+            talkControl.flipCamera?()
+        } label: {
+            Image(systemName: "arrow.triangle.2.circlepath.camera")
+                .font(OpenClawChatTypography.body(size: 14, weight: .semibold, relativeTo: .subheadline))
+                .foregroundStyle(.primary)
+                .frame(width: size, height: size)
+                .background {
+                    Circle()
+                        .fill(OpenClawChatTheme.accent.opacity(0.12))
+                }
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(label)
+        .accessibilityIdentifier("chat-camera-flip")
+        .help(label)
     }
 
     private func talkButtonFill(_ talkControl: OpenClawChatTalkControl) -> AnyShapeStyle {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/OpenClawChatTalkControl.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/OpenClawChatTalkControl.swift
@@ -8,6 +8,11 @@ public struct OpenClawChatAudioInputDevice: Equatable, Identifiable, Sendable {
     }
 }
 
+public enum OpenClawCameraFacingSelection: String, Equatable, Sendable {
+    case back
+    case front
+}
+
 public struct OpenClawChatTalkControl {
     public var isEnabled: Bool
     public var isListening: Bool
@@ -21,6 +26,8 @@ public struct OpenClawChatTalkControl {
     public var inputDevices: [OpenClawChatAudioInputDevice]
     public var selectedInputDeviceID: String?
     public var selectInputDevice: (@MainActor (_ deviceID: String?) -> Void)?
+    public var cameraFacing: OpenClawCameraFacingSelection?
+    public var flipCamera: (@MainActor () -> Void)?
     public var toggle: @MainActor (_ sessionKey: String) -> Void
 
     public init(
@@ -36,6 +43,8 @@ public struct OpenClawChatTalkControl {
         inputDevices: [OpenClawChatAudioInputDevice] = [],
         selectedInputDeviceID: String? = nil,
         selectInputDevice: (@MainActor (_ deviceID: String?) -> Void)? = nil,
+        cameraFacing: OpenClawCameraFacingSelection? = nil,
+        flipCamera: (@MainActor () -> Void)? = nil,
         toggle: @escaping @MainActor (_ sessionKey: String) -> Void)
     {
         self.isEnabled = isEnabled
@@ -50,6 +59,8 @@ public struct OpenClawChatTalkControl {
         self.inputDevices = inputDevices
         self.selectedInputDeviceID = selectedInputDeviceID
         self.selectInputDevice = selectInputDevice
+        self.cameraFacing = cameraFacing
+        self.flipCamera = flipCamera
         self.toggle = toggle
     }
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatTalkActivityTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatTalkActivityTests.swift
@@ -19,10 +19,13 @@ struct ChatTalkControlTests {
         #expect(control.inputDevices.isEmpty)
         #expect(control.selectedInputDeviceID == nil)
         #expect(control.selectInputDevice == nil)
+        #expect(control.cameraFacing == nil)
+        #expect(control.flipCamera == nil)
     }
 
     @Test func `feedback and input selection fields preserve supplied values`() {
         var selectedID: String? = "unchanged"
+        var flipCount = 0
         let devices = [OpenClawChatAudioInputDevice(id: "mic-1", name: "Desk Mic")]
         let control = OpenClawChatTalkControl(
             isEnabled: true,
@@ -37,9 +40,12 @@ struct ChatTalkControlTests {
             inputDevices: devices,
             selectedInputDeviceID: "mic-1",
             selectInputDevice: { selectedID = $0 },
+            cameraFacing: .back,
+            flipCamera: { flipCount += 1 },
             toggle: { _ in })
 
         control.selectInputDevice?(nil)
+        control.flipCamera?()
 
         #expect(control.level == 0.6)
         #expect(control.partialTranscript == "hello")
@@ -47,6 +53,8 @@ struct ChatTalkControlTests {
         #expect(control.inputDevices == devices)
         #expect(control.selectedInputDeviceID == "mic-1")
         #expect(selectedID == nil)
+        #expect(control.cameraFacing == .back)
+        #expect(flipCount == 1)
     }
 }
 


### PR DESCRIPTION
## What Problem This Solves

On iOS, the agent "sees" through `camera.snap`/`camera.clip` node commands that hardcode the front camera whenever the agent omits `facing` — the user holding the phone cannot make the agent look at the world instead of their face. Separately, the Talk mic input-device menu that macOS populates is empty on iOS.

## Why This Change Was Made

Holding the phone during a Talk session, the user — not a hardcoded default — should decide which way the agent looks. The user preference becomes the default facing for capture commands; an agent explicitly requesting `facing` or `deviceId` still wins, so "look at what I'm pointing at" keeps working. The mic gap was pure missing wiring: the shared UI already supports input selection.

## User Impact

- New camera-flip button beside the Talk button while a Talk session is active (SF Symbol, haptic feedback, VoiceOver labels naming the target camera). It toggles the persisted front/back preference used as the default for agent captures.
- The Talk mic menu now lists `AVAudioSession` inputs on iOS; selection persists, applies immediately to a live session, and stale/unplugged devices fall back to system default.
- Preferred mic is applied after WebRTC/speaker routing configuration because the speaker override can force the built-in microphone (per Apple AVAudioSession docs) — the explicit user choice wins.
- macOS is unchanged (new shared-UI fields are optional with defaults); its capture default remains front — sibling follow-up if desired.

## Evidence

- `swift build` of `apps/shared/OpenClawKit` (all shared UI changes): passing. Focused `ChatTalkControlTests`: 2 passing. SwiftFormat lint + `git diff --check`: clean.
- Facing-default resolution covered in `NodeAppModelInvokeTests`/`CameraControllerClampTests` (explicit param wins; preference used when omitted; unset defaults to front).
- Full iOS app xcodebuild deferred to hosted CI on this PR (Xcode project generation not available in the authoring worktree); no protocol changes (`facing`/`deviceId` already flow through the open node-command params bag).
