### PR TITLE
fix(nextcloud-talk): reject unsupported channel add URL schemes

### DIFF
--- a/extensions/nextcloud-talk/src/setup-core.ts
+++ b/extensions/nextcloud-talk/src/setup-core.ts
@@ -217,8 +217,13 @@ export const nextcloudTalkSetupAdapter: ChannelSetupAdapter = {
       if (!setupInput.useEnv && !setupInput.secret && !setupInput.secretFile) {
         return "Nextcloud Talk requires bot secret or --secret-file (or --use-env).";
       }
-      if (!setupInput.baseUrl) {
+      const normalizedBaseUrl = normalizeNextcloudTalkBaseUrl(setupInput.baseUrl);
+      if (!normalizedBaseUrl) {
         return "Nextcloud Talk requires --base-url.";
+      }
+      const baseUrlError = validateNextcloudTalkBaseUrl(normalizedBaseUrl);
+      if (baseUrlError) {
+        return baseUrlError;
       }
       return null;
     },

--- a/extensions/nextcloud-talk/src/setup.test.ts
+++ b/extensions/nextcloud-talk/src/setup.test.ts
@@ -240,6 +240,38 @@ describe("nextcloud talk setup", () => {
     ).toBe("Nextcloud Talk requires --base-url.");
 
     expect(
+      validateInput({
+        accountId: DEFAULT_ACCOUNT_ID,
+        input: { useEnv: false, secret: "secret", baseUrl: "ftp://cloud.example.com" },
+      } as never),
+    ).toBe("URL must start with http:// or https://");
+
+    expect(
+      validateInput({
+        accountId: DEFAULT_ACCOUNT_ID,
+        input: { useEnv: false, secret: "secret", baseUrl: "cloud.example.com" },
+      } as never),
+    ).toBe("URL must start with http:// or https://");
+
+    expect(
+      validateInput({
+        accountId: DEFAULT_ACCOUNT_ID,
+        input: {
+          useEnv: false,
+          secret: "secret",
+          baseUrl: " https://cloud.example.com/talk/// ",
+        },
+      } as never),
+    ).toBeNull();
+
+    expect(
+      validateInput({
+        accountId: DEFAULT_ACCOUNT_ID,
+        input: { useEnv: false, secret: "secret", baseUrl: "http://cloud.example.com" },
+      } as never),
+    ).toBeNull();
+
+    expect(
       applyAccountConfig({
         cfg: {
           channels: {
@@ -249,7 +281,7 @@ describe("nextcloud talk setup", () => {
         accountId: DEFAULT_ACCOUNT_ID,
         input: {
           name: "Default",
-          baseUrl: "https://cloud.example.com///",
+          baseUrl: " https://cloud.example.com/// ",
           secret: "bot-secret",
         },
       } as never),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running non-interactive `openclaw channels add` for Nextcloud Talk could save a bare host or unsupported URL scheme even though guided setup rejects the same value. The resulting account configuration could not reach the Nextcloud instance.

## Why This Change Was Made

The non-interactive setup adapter now normalizes `baseUrl` before its required-value check and applies the same existing HTTP(S)-scheme validator used by the Nextcloud Talk wizard. This deliberately aligns the two setup surfaces; it does not introduce or claim a complete URL parser.

## User Impact

Nextcloud Talk channel setup now rejects bare hosts and non-HTTP(S) schemes before writing config, while preserving supported HTTP(S) instance URLs, subpaths, surrounding whitespace normalization, and the existing `--url`/`--token` aliases.

## Evidence

- Added adapter tests for bare hosts, `ftp://`, HTTP, HTTPS subpaths, surrounding whitespace, and normalized config writes.
- Exact-head CI passed on `83cfd652f668f2f73ecc6ead86d68b0112203b37`: [CI run 29666540156](https://github.com/openclaw/openclaw/actions/runs/29666540156).
- `git diff --check` passes at the same exact head.
- Frozen binary diff hash after rebasing to current `main`: `cc46a94249169f9c4a6940759642db83db0ccb20074753dd254a4df42f9e03ff`.

### Real non-interactive CLI proof

A secretless fork-only workflow ran the real `pnpm openclaw channels add --channel nextcloud-talk` entry point in isolated `HOME`, state, and config directories. The proof workflow has `permissions: {}`, receives no repository secrets, fetches only the immutable public refs below, and is not part of this PR diff.

- Before/current main: `b550c2cf9a8afff68958f98d71aa7e3c939f3e39`
- After/PR head: `83cfd652f668f2f73ecc6ead86d68b0112203b37`
- [Successful proof run 29666691146](https://github.com/Alix-007/openclaw/actions/runs/29666691146)
- [Proof job 88138173179](https://github.com/Alix-007/openclaw/actions/runs/29666691146/job/88138173179)

Redacted terminal outcomes:

```text
BEFORE invalid exit=0 baseUrl=ftp://cloud.example.invalid/talk account=[written] credential=[REDACTED]
AFTER invalid exit=nonzero configHash=[unchanged] account=[absent]
AFTER valid exit=0 baseUrl=https://cloud.example.invalid/talk account=[written] credential=[REDACTED]
```

### Exact-head proof refresh (2026-07-20)

- Reviewed head: 6ddcf83df4fb0a5b2790fb8e27cec6392d8b612d.
- Secretless public-runner proof: [workflow run](https://github.com/Alix-007/openclaw/actions/runs/29719318426) · [proof job](https://github.com/Alix-007/openclaw/actions/runs/29719318426/job/88278755642).
- Immutable refs checked: before b550c2cf9a8afff68958f98d71aa7e3c939f3e39; after 6ddcf83df4fb0a5b2790fb8e27cec6392d8b612d.

Redacted console proof:
~~~text
BEFORE invalid exit=0 baseUrl=ftp://cloud.example.invalid/talk account=[written] credential=[REDACTED]
AFTER invalid exit=nonzero configHash=[unchanged] account=[absent]
AFTER valid exit=0 baseUrl=https://cloud.example.invalid/talk account=[written] credential=[REDACTED]
~~~

The run verifies the current PR head, preserves the pre-fix reproduction, rejects the unsupported scheme without a config write, and persists the normalized valid subpath.

### Current-head proof continuity (patch-equivalent rebase, 2026-07-27)

- Current PR head: `6149d49b99560b6d1037992e7577d139c0662c3d`; current rebase parent: `0951d0dd307d5008276714679c62459293d3b619`.
- Previously proven CLI head: `6ddcf83df4fb0a5b2790fb8e27cec6392d8b612d`; its parent: `25d6f13a1ff864e241d28f4540494ecba43a6421`.
- `git range-diff 25d6f13a..6ddcf83d 0951d0dd..6149d49b` maps the sole PR commit with `=`, proving the rebase replayed the exact same patch.
- Current-head repository checks are complete with zero failures and zero pending checks.
- The secretless non-interactive CLI proof above therefore transfers across the rebase with no PR-authored behavior change. This is patch-equivalence proof, not a claim of a new CLI execution. `PROOF_RESULT=PASS`.