### PR TITLE
fix(gateway): reject unsafe explicit approval IDs

### DIFF
--- a/src/gateway/exec-approval-manager.test.ts
+++ b/src/gateway/exec-approval-manager.test.ts
@@ -597,6 +597,7 @@ describe("ExecApprovalManager", () => {
   });
 
   it.each([
+    ["empty value", ""],
     ["ANSI escape", "approval-\u001b[31mred"],
     ["Unicode control", "approval-\u202Ehidden"],
     ["trailing line feed", "approval-safe\n"],

--- a/src/gateway/exec-approval-manager.test.ts
+++ b/src/gateway/exec-approval-manager.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../state/openclaw-state-db.js";
 import {
   ExecApprovalManager,
+  InvalidApprovalIdError,
   type OperatorApprovalLifecycleEvent,
 } from "./exec-approval-manager.js";
 import { getOperatorApprovalDetailed, resolveOperatorApproval } from "./operator-approval-store.js";
@@ -584,17 +585,27 @@ describe("ExecApprovalManager", () => {
     await expect(decisionPromise).resolves.toBe("deny");
   });
 
-  it("preserves a protocol-valid provided approval id byte-for-byte", async () => {
-    const { manager, databaseOptions } = createPersistentManager();
-    const id = "\uFEFF";
-    const record = manager.create({ command: "echo exact" }, 60_000, id);
-    const decisionPromise = manager.register(record, 60_000);
+  it.each([
+    ["UUID", "12345678-1234-1234-1234-123456789abc"],
+    ["plugin UUID", "plugin:12345678-1234-1234-1234-123456789abc"],
+    ["system-agent UUID", "system-agent:12345678-1234-1234-1234-123456789abc"],
+    ["node id", "node:mac-studio_1.local"],
+  ])("preserves a safe explicit %s byte-for-byte", (_label, id) => {
+    const manager = new ExecApprovalManager();
 
-    expect(record.id).toBe(id);
-    expect(manager.lookupApprovalId(id)).toEqual({ kind: "exact", id });
-    expect(getOperatorApproval({ id, databaseOptions })).toMatchObject({ id, status: "pending" });
-    manager.resolveDetailed(id, "deny", { kind: "system", id: null });
-    await expect(decisionPromise).resolves.toBe("deny");
+    expect(manager.create({ command: "echo exact" }, 60_000, id).id).toBe(id);
+  });
+
+  it.each([
+    ["ANSI escape", "approval-\u001b[31mred"],
+    ["Unicode control", "approval-\u202Ehidden"],
+    ["overlong value", "a".repeat(129)],
+  ])("rejects an explicit approval id containing an %s", (_label, id) => {
+    const manager = new ExecApprovalManager();
+
+    expect(() => manager.create({ command: "echo unsafe" }, 60_000, id)).toThrow(
+      InvalidApprovalIdError,
+    );
   });
 
   it("rejects unrenderable persistent plugin requests before creating a row or waiter", () => {

--- a/src/gateway/exec-approval-manager.test.ts
+++ b/src/gateway/exec-approval-manager.test.ts
@@ -599,6 +599,10 @@ describe("ExecApprovalManager", () => {
   it.each([
     ["ANSI escape", "approval-\u001b[31mred"],
     ["Unicode control", "approval-\u202Ehidden"],
+    ["trailing line feed", "approval-safe\n"],
+    ["trailing carriage return", "approval-safe\r"],
+    ["trailing line separator", "approval-safe\u2028"],
+    ["trailing paragraph separator", "approval-safe\u2029"],
     ["overlong value", "a".repeat(129)],
   ])("rejects an explicit approval id containing an %s", (_label, id) => {
     const manager = new ExecApprovalManager();

--- a/src/gateway/exec-approval-manager.test.ts
+++ b/src/gateway/exec-approval-manager.test.ts
@@ -598,6 +598,8 @@ describe("ExecApprovalManager", () => {
 
   it.each([
     ["empty value", ""],
+    ["URL dot segment", "."],
+    ["URL parent segment", ".."],
     ["ANSI escape", "approval-\u001b[31mred"],
     ["Unicode control", "approval-\u202Ehidden"],
     ["trailing line feed", "approval-safe\n"],

--- a/src/gateway/exec-approval-manager.ts
+++ b/src/gateway/exec-approval-manager.ts
@@ -53,7 +53,7 @@ function resolveApprovalTimeoutMs(timeoutMs: number): number {
 
 // Approval IDs cross terminal, UI, push, and channel surfaces unchanged. Keep
 // unsafe display bytes and unbounded identifiers out at the creation boundary.
-const EXPLICIT_APPROVAL_ID_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/;
+const EXPLICIT_APPROVAL_ID_INVALID_CHAR_PATTERN = /[^A-Za-z0-9._:-]/;
 
 /** Typed creation failure for an explicit approval id outside the shared safe format. */
 export class InvalidApprovalIdError extends Error {
@@ -238,7 +238,10 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
       throw new Error("approval expiry is unavailable");
     }
     const hasExplicitId = id !== null && id !== undefined && id.length > 0;
-    if (hasExplicitId && !EXPLICIT_APPROVAL_ID_PATTERN.test(id)) {
+    if (
+      hasExplicitId &&
+      (id.length > 128 || EXPLICIT_APPROVAL_ID_INVALID_CHAR_PATTERN.test(id))
+    ) {
       throw new InvalidApprovalIdError();
     }
     const resolvedId = hasExplicitId ? id : randomUUID();

--- a/src/gateway/exec-approval-manager.ts
+++ b/src/gateway/exec-approval-manager.ts
@@ -51,6 +51,22 @@ function resolveApprovalTimeoutMs(timeoutMs: number): number {
   return resolveTimerTimeoutMs(timeoutMs, 1);
 }
 
+// Approval IDs cross terminal, UI, push, and channel surfaces unchanged. Keep
+// unsafe display bytes and unbounded identifiers out at the creation boundary.
+const EXPLICIT_APPROVAL_ID_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/;
+
+/** Typed creation failure for an explicit approval id outside the shared safe format. */
+export class InvalidApprovalIdError extends Error {
+  readonly reason = "INVALID_APPROVAL_ID";
+
+  constructor() {
+    super(
+      "approval id must be 1-128 characters using only letters, numbers, '.', '_', ':', or '-'",
+    );
+    this.name = "InvalidApprovalIdError";
+  }
+}
+
 type ExecApprovalRequestPayload = InfraExecApprovalRequestPayload;
 
 // Distinguishes operator decisions from trusted auto-review resolutions.
@@ -221,7 +237,11 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
     if (expiresAtMs === undefined) {
       throw new Error("approval expiry is unavailable");
     }
-    const resolvedId = id === null || id === undefined || id.length === 0 ? randomUUID() : id;
+    const hasExplicitId = id !== null && id !== undefined && id.length > 0;
+    if (hasExplicitId && !EXPLICIT_APPROVAL_ID_PATTERN.test(id)) {
+      throw new InvalidApprovalIdError();
+    }
+    const resolvedId = hasExplicitId ? id : randomUUID();
     const record: ExecApprovalRecord<TPayload> = {
       id: resolvedId,
       request,

--- a/src/gateway/exec-approval-manager.ts
+++ b/src/gateway/exec-approval-manager.ts
@@ -237,10 +237,12 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
     if (expiresAtMs === undefined) {
       throw new Error("approval expiry is unavailable");
     }
-    const hasExplicitId = id !== null && id !== undefined && id.length > 0;
+    const hasExplicitId = id !== null && id !== undefined;
     if (
       hasExplicitId &&
-      (id.length > 128 || EXPLICIT_APPROVAL_ID_INVALID_CHAR_PATTERN.test(id))
+      (id.length === 0 ||
+        id.length > 128 ||
+        EXPLICIT_APPROVAL_ID_INVALID_CHAR_PATTERN.test(id))
     ) {
       throw new InvalidApprovalIdError();
     }

--- a/src/gateway/exec-approval-manager.ts
+++ b/src/gateway/exec-approval-manager.ts
@@ -61,7 +61,7 @@ export class InvalidApprovalIdError extends Error {
 
   constructor() {
     super(
-      "approval id must be 1-128 characters using only letters, numbers, '.', '_', ':', or '-'",
+      "approval id must be 1-128 characters using only letters, numbers, '.', '_', ':', or '-', and cannot be '.' or '..'",
     );
     this.name = "InvalidApprovalIdError";
   }
@@ -240,7 +240,11 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
     const hasExplicitId = id !== null && id !== undefined;
     if (
       hasExplicitId &&
-      (id.length === 0 || id.length > 128 || EXPLICIT_APPROVAL_ID_INVALID_CHAR_PATTERN.test(id))
+      (id.length === 0 ||
+        id.length > 128 ||
+        id === "." ||
+        id === ".." ||
+        EXPLICIT_APPROVAL_ID_INVALID_CHAR_PATTERN.test(id))
     ) {
       throw new InvalidApprovalIdError();
     }

--- a/src/gateway/exec-approval-manager.ts
+++ b/src/gateway/exec-approval-manager.ts
@@ -240,9 +240,7 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
     const hasExplicitId = id !== null && id !== undefined;
     if (
       hasExplicitId &&
-      (id.length === 0 ||
-        id.length > 128 ||
-        EXPLICIT_APPROVAL_ID_INVALID_CHAR_PATTERN.test(id))
+      (id.length === 0 || id.length > 128 || EXPLICIT_APPROVAL_ID_INVALID_CHAR_PATTERN.test(id))
     ) {
       throw new InvalidApprovalIdError();
     }

--- a/src/gateway/server-methods/approval.test.ts
+++ b/src/gateway/server-methods/approval.test.ts
@@ -371,7 +371,7 @@ describe("unified approval handlers", () => {
   it("returns an exact-id, deep-linkable exec projection without execution bindings", async () => {
     const databaseOptions = createDatabaseOptions();
     const managers = createManagers(databaseOptions);
-    const id = "exec:approval/with?reserved";
+    const id = "exec:approval.with_safe-punctuation";
     registerExec(managers.exec, {
       id,
       reviewerDeviceIds: ["reviewer-a"],
@@ -406,7 +406,7 @@ describe("unified approval handlers", () => {
     expect(approvalFromResult(response.result)).toMatchObject({
       id,
       status: "pending",
-      urlPath: "/operator/approve/exec%3Aapproval%2Fwith%3Freserved",
+      urlPath: "/operator/approve/exec%3Aapproval.with_safe-punctuation",
       presentation: {
         kind: "exec",
         commandText: "printf approval-handler",
@@ -1318,11 +1318,11 @@ describe("unified approval handlers", () => {
     expect(context.broadcastToConnIds).toHaveBeenCalledTimes(1);
   });
 
-  it("resolves an overlong canonical id through its fixed-size transport reference", async () => {
+  it("resolves a maximum-length canonical id through its fixed-size transport reference", async () => {
     const databaseOptions = createDatabaseOptions();
     const managers = createManagers(databaseOptions);
     const pending = registerExec(managers.exec, {
-      id: `approval/${"\u{1F4F1}".repeat(40)}/transport-limit`,
+      id: `approval-${"a".repeat(119)}`,
       reviewerDeviceIds: ["telegram"],
     });
     const durable = getOperatorApproval({ id: pending.record.id, databaseOptions });

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -32,7 +32,7 @@ import {
 } from "../../infra/system-run-approval-binding.js";
 import { resolveSystemRunApprovalRequestContext } from "../../infra/system-run-approval-context.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
-import type { ExecApprovalManager } from "../exec-approval-manager.js";
+import { InvalidApprovalIdError, type ExecApprovalManager } from "../exec-approval-manager.js";
 import {
   handleApprovalWaitDecision,
   handlePendingApprovalRequest,
@@ -356,7 +356,22 @@ export function createExecApprovalHandlers(
         );
         return;
       }
-      const record = manager.create(request, timeoutMs, explicitId);
+      let record: ReturnType<typeof manager.create>;
+      try {
+        record = manager.create(request, timeoutMs, explicitId);
+      } catch (error) {
+        if (error instanceof InvalidApprovalIdError) {
+          respond(
+            false,
+            undefined,
+            errorShape(ErrorCodes.INVALID_REQUEST, error.message, {
+              details: { reason: error.reason },
+            }),
+          );
+          return;
+        }
+        throw error;
+      }
       bindApprovalRequesterMetadata({ record, client });
       if (client?.internal?.approvalRuntime === true) {
         // Reviewer ids widen approval visibility, so only the server-trusted

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -4405,7 +4405,7 @@ describe("exec approval handlers", () => {
   it.each([
     ["ANSI escape", "approval-\u001b[31mred"],
     ["Unicode control", "approval-\u202Ehidden"],
-    ["trailing line feed", "approval-safe\n"],
+    ["embedded line feed", "approval-\nunsafe"],
     ["overlong value", "a".repeat(129)],
   ])("rejects an unsafe explicit approval id containing an %s", async (_label, id) => {
     const { manager, handlers, broadcasts, respond, context } = createExecApprovalFixture();

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -4405,6 +4405,7 @@ describe("exec approval handlers", () => {
   it.each([
     ["ANSI escape", "approval-\u001b[31mred"],
     ["Unicode control", "approval-\u202Ehidden"],
+    ["trailing line feed", "approval-safe\n"],
     ["overlong value", "a".repeat(129)],
   ])("rejects an unsafe explicit approval id containing an %s", async (_label, id) => {
     const { manager, handlers, broadcasts, respond, context } = createExecApprovalFixture();

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -4402,6 +4402,30 @@ describe("exec approval handlers", () => {
     expect(resolveRespond).toHaveBeenCalledWith(true, { ok: true }, undefined);
   });
 
+  it.each([
+    ["ANSI escape", "approval-\u001b[31mred"],
+    ["Unicode control", "approval-\u202Ehidden"],
+    ["overlong value", "a".repeat(129)],
+  ])("rejects an unsafe explicit approval id containing an %s", async (_label, id) => {
+    const { manager, handlers, broadcasts, respond, context } = createExecApprovalFixture();
+
+    await requestExecApproval({
+      handlers,
+      respond,
+      context,
+      params: { id, host: "gateway" },
+    });
+
+    expect(mockCallArg(respond)).toBe(false);
+    expect(mockCallArg(respond, 0, 1)).toBeUndefined();
+    expect(mockCallArg(respond, 0, 2)).toMatchObject({
+      code: "INVALID_REQUEST",
+      details: { reason: "INVALID_APPROVAL_ID" },
+    });
+    expect(manager.getSnapshot(id)).toBeNull();
+    expect(broadcasts).toEqual([]);
+  });
+
   it("rejects explicit approval ids with the reserved plugin prefix", async () => {
     const { handlers, respond, context } = createExecApprovalFixture();
 

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -4403,6 +4403,7 @@ describe("exec approval handlers", () => {
   });
 
   it.each([
+    ["URL dot segment", ".."],
     ["ANSI escape", "approval-\u001b[31mred"],
     ["Unicode control", "approval-\u202Ehidden"],
     ["embedded line feed", "approval-\nunsafe"],


### PR DESCRIPTION
Related implementation: #103579

## What Problem This Solves

Fixes an issue where operators reviewing command approvals could receive attacker-controlled explicit approval identifiers containing terminal escapes, Unicode controls, or unbounded text when an agent host requested approval.

## Why This Change Was Made

The gateway approval manager now enforces one shared ASCII identifier format (1-128 characters from letters, digits, `.`, `_`, `:`, and `-`) before any explicit ID can be registered, persisted, or broadcast. Invalid IDs raise a typed `InvalidApprovalIdError`, which `exec.approval.request` returns as `INVALID_REQUEST`; generated UUID behavior remains unchanged when no ID is supplied.

The producer audit covered the bash-tools two-phase UUID flow, `plugin:<uuid>` approvals, `system-agent:<uuid>` approvals, and node `system.run` replay IDs. Every legitimate producer fits the selected format.

## User Impact

Approval IDs that reach CLI tables, the Control UI, push notifications, and channel messages are now bounded and display-safe. Existing UUID, plugin, system-agent, and node approval flows continue to work without changes.

## Evidence

- Focused Blacksmith Testbox run: `src/gateway/exec-approval-manager.test.ts` and `src/gateway/server-methods/server-methods.test.ts` passed (220 tests) on the implementation baseline.
- Blacksmith Testbox `pnpm check:changed` passed, including core/core-test tsgo, Oxlint, formatting, and import-cycle guards.
- Blacksmith Testbox `pnpm build` passed.
- Final branch contract probe covers UUID/plugin/node acceptance plus empty, ANSI, line-control, Unicode-separator, and 129-character rejection.
- Final whole-branch autoreview against current `origin/main`: clean, no accepted/actionable findings.
- A fresh exact-head Testbox rerun was attempted twice, but workspace sync timed out before tests started. Hosted PR CI remains the exact-head landing gate.

## Release Note

- Gateway approval creation now rejects unsafe explicit approval IDs before they can reach operator display surfaces.

## AI Assistance

- [x] AI-assisted implementation and review; the maintainer inspected the owner boundary, all known explicit-ID producers, tests, and validation output.
