### PR TITLE
fix(openrouter): preserve completed music when stream cleanup fails

### DIFF
--- a/extensions/openrouter/music-generation-provider.test.ts
+++ b/extensions/openrouter/music-generation-provider.test.ts
@@ -211,7 +211,10 @@ describe("openrouter music generation provider", () => {
     expect(release).toHaveBeenCalledOnce();
   });
 
-  it("releases OpenRouter audio stream readers after completion", async () => {
+  it("preserves completed OpenRouter audio when reader cleanup fails", async () => {
+    const cancel = vi.fn(() => {
+      throw new Error("cancel failed");
+    });
     const releaseLock = vi.fn();
     postJsonRequestMock.mockResolvedValue({
       response: sseResponse(
@@ -219,7 +222,7 @@ describe("openrouter music generation provider", () => {
           audio: Buffer.from("wav-bytes").toString("base64"),
           done: true,
         }),
-        { releaseLock },
+        { cancel, releaseLock },
       ),
       release: vi.fn(async () => {}),
     });
@@ -234,6 +237,7 @@ describe("openrouter music generation provider", () => {
     ).resolves.toMatchObject({
       tracks: [{ mimeType: "audio/wav" }],
     });
+    expect(cancel).toHaveBeenCalledTimes(1);
     expect(releaseLock).toHaveBeenCalledTimes(1);
   });
 

--- a/extensions/openrouter/music-generation-provider.test.ts
+++ b/extensions/openrouter/music-generation-provider.test.ts
@@ -59,7 +59,7 @@ function sseResponse(
           controller.enqueue(encodeLine(line));
         },
         cancel() {
-          options?.cancel?.();
+          return options?.cancel?.();
         },
       }),
       { status: 200, headers: { "content-type": "text/event-stream" } },

--- a/extensions/openrouter/music-generation-provider.test.ts
+++ b/extensions/openrouter/music-generation-provider.test.ts
@@ -41,7 +41,7 @@ vi.mock("openclaw/plugin-sdk/provider-http", async (importOriginal) => {
 
 function sseResponse(
   lines: Array<string | Uint8Array>,
-  options?: { cancel?: () => void; releaseLock?: () => void },
+  options?: { cancel?: () => void | Promise<void>; releaseLock?: () => void },
 ): Response {
   const encoder = new TextEncoder();
   const encodeLine = (line: string | Uint8Array) =>
@@ -212,7 +212,7 @@ describe("openrouter music generation provider", () => {
   });
 
   it("preserves completed OpenRouter audio when reader cleanup fails", async () => {
-    const cancel = vi.fn(() => {
+    const cancel = vi.fn(async () => {
       throw new Error("cancel failed");
     });
     const releaseLock = vi.fn();
@@ -407,8 +407,10 @@ describe("openrouter music generation provider", () => {
     ).rejects.toThrow("OpenRouter music generation stream ended before completion");
   });
 
-  it("surfaces and cancels OpenRouter mid-stream errors", async () => {
-    const cancel = vi.fn();
+  it("preserves OpenRouter mid-stream errors when reader cleanup fails", async () => {
+    const cancel = vi.fn(async () => {
+      throw new Error("cancel failed");
+    });
     postJsonRequestMock.mockResolvedValue({
       response: sseResponse(
         [

--- a/extensions/openrouter/music-generation-provider.ts
+++ b/extensions/openrouter/music-generation-provider.ts
@@ -295,6 +295,8 @@ async function readOpenRouterAudioStream(
       for (const line of lines) {
         if (processOpenRouterSseLine(line.trim(), result)) {
           flushOpenRouterMusicAudio(result);
+          // Once [DONE] is observed, the generated result is authoritative.
+          // Cancellation is cleanup and must not replace it with a transport error.
           await reader.cancel().catch(() => {});
           return {
             audioBuffer: Buffer.concat(result.audioBuffers, result.audioBytes),

--- a/extensions/openrouter/music-generation-provider.ts
+++ b/extensions/openrouter/music-generation-provider.ts
@@ -295,7 +295,7 @@ async function readOpenRouterAudioStream(
       for (const line of lines) {
         if (processOpenRouterSseLine(line.trim(), result)) {
           flushOpenRouterMusicAudio(result);
-          await reader.cancel();
+          await reader.cancel().catch(() => {});
           return {
             audioBuffer: Buffer.concat(result.audioBuffers, result.audioBytes),
             transcript: result.transcriptChunks.join(""),


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Allow edits from maintainers is enabled for this PR.

</details>

## What Problem This Solves

Fixes an issue where OpenRouter music generation could return a failure after a complete audio stream and [DONE] marker had already been received, when best-effort stream cancellation rejected.

## Why This Change Was Made

The completed audio result now remains authoritative while reader cancellation is still attempted and awaited. Risk: cleanup must still run exactly once and release the reader lock; the regression and runtime proof cover both conditions.

## User Impact

Users keep successfully generated OpenRouter music instead of seeing a cleanup error after generation has completed.

## Evidence

Node v24.18.0 production-entry proof used buildOpenRouterMusicGenerationProvider(), a native Response/ReadableStream, and only replaced the network transport seam. The underlying cancel callback rejected after [DONE].

Before on ec998a0f3fc:

    {"outcome":"rejected","error":"cancel failed","cancelCalls":1}

After on current upstream main plus this commit:

    {"outcome":"resolved","audio":"live-audio","lyrics":["live lyrics"],"cancelCalls":1}

Focused regression:

    node scripts/run-vitest.mjs extensions/openrouter/music-generation-provider.test.ts
    Test Files  1 passed (1)
    Tests  14 passed (14)

The same test failed before the production change with promise rejected Error: cancel failed. Targeted oxfmt, direct oxlint, and git diff --check passed. The changed-check wrapper was blocked before reaching these files by current checkout plugin-SDK boundary DTS errors in packages/net-policy/src/ip.ts; full build/check/test are left to fork CI.

AI-assisted: Codex helped implement and review the change; the behavior proof was run manually.
