### PR TITLE
fix(gateway): preserve MCP body-limit errors when cleanup fails

### DIFF
--- a/src/gateway/gateway-cli-backend.live-probe-helpers.test.ts
+++ b/src/gateway/gateway-cli-backend.live-probe-helpers.test.ts
@@ -68,6 +68,7 @@ describe("gateway CLI backend live probe helpers", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.unstubAllGlobals();
     clearActiveMcpLoopbackRuntimeByOwnerToken(ownerToken);
   });
 
@@ -147,5 +148,34 @@ describe("gateway CLI backend live probe helpers", () => {
     } finally {
       server.close();
     }
+  });
+
+  it("preserves the loopback body-limit error when reader cleanup fails", async () => {
+    const cancel = vi.fn(async () => {
+      throw new Error("cancel failed");
+    });
+    const reader = {
+      read: vi
+        .fn()
+        .mockResolvedValueOnce({ done: false, value: new Uint8Array(65) })
+        .mockResolvedValue({ done: true, value: undefined }),
+      cancel,
+    } as unknown as ReadableStreamDefaultReader<Uint8Array>;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        body: { getReader: () => reader },
+      })),
+    );
+    activateLoopbackRuntime(12345);
+
+    await expect(
+      verifyCliCronMcpLoopbackPreflight(
+        preflightParams({ OPENCLAW_MCP_LOOPBACK_PROBE_MAX_BODY_BYTES: "64" }),
+      ),
+    ).rejects.toThrow("mcp loopback response body exceeded 64 bytes");
+    expect(cancel).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/gateway/gateway-cli-backend.live-probe-helpers.ts
+++ b/src/gateway/gateway-cli-backend.live-probe-helpers.ts
@@ -255,7 +255,7 @@ async function readBoundedResponseText(response: Response, byteLimit: number): P
     }
     totalBytes += value.byteLength;
     if (totalBytes > byteLimit) {
-      await reader.cancel();
+      await reader.cancel().catch(() => undefined);
       throw new Error(`mcp loopback response body exceeded ${byteLimit} bytes`);
     }
     chunks.push(Buffer.from(value));


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Allow edits from maintainers is enabled for this PR.

</details>

## What Problem This Solves

Fixes an issue where an MCP loopback response over the configured byte limit could report a reader cleanup failure instead of the stable body-limit diagnostic.

## Why This Change Was Made

The bounded reader still cancels and awaits the oversized response body, while preserving the already-determined limit error if cancellation rejects. Risk: the byte cap and cleanup attempt must remain active; the regression and runtime proof assert both.

## User Impact

Operators receive the actionable MCP loopback body-limit error rather than an unrelated cleanup failure.

## Evidence

Node v24.18.0 production-entry proof called verifyCliCronMcpLoopbackPreflight() with a 64-byte limit through the active loopback runtime. A native-style reader returned 65 bytes and rejected cancellation.

Before on ec998a0f3fc:

    {"outcome":"rejected","error":"cancel failed","cancelCalls":1}

After on current upstream main plus this commit:

    {"outcome":"rejected","error":"mcp loopback response body exceeded 64 bytes","cancelCalls":1}

Focused regression:

    node scripts/run-vitest.mjs src/gateway/gateway-cli-backend.live-probe-helpers.test.ts
    Test Files  1 passed (1)
    Tests  4 passed (4)

The same test failed before the production change because cancel failed replaced the 64-byte diagnostic. Targeted oxfmt, direct oxlint, and git diff --check passed. The changed-check wrapper was blocked before reaching these files by current checkout plugin-SDK boundary DTS errors in packages/net-policy/src/ip.ts; full build/check/test are left to fork CI.

AI-assisted: Codex helped implement and review the change; the behavior proof was run manually.
