### PR TITLE
fix(telegram): polling worker pins a CPU core when the Bot API answers empty getUpdates instantly

### DIFF
--- a/extensions/telegram/src/telegram-ingress-worker.runtime.test.ts
+++ b/extensions/telegram/src/telegram-ingress-worker.runtime.test.ts
@@ -43,6 +43,13 @@ function createRuntime(
   const port: RuntimePort = {
     postMessage(message) {
       messages.push(message);
+      if (message.type === "update") {
+        sendCommand({
+          type: "spool-ack",
+          requestId: message.requestId,
+          result: { ok: true, updateId: 42 },
+        });
+      }
       if (message.type === "poll-success") {
         pollSuccesses += 1;
         if (pollSuccesses >= (options.stopAfterPollSuccesses ?? 1)) {
@@ -87,25 +94,48 @@ afterEach(() => {
 });
 
 describe("telegram ingress worker poll cadence", () => {
-  it("paces fast successful empty getUpdates responses", async () => {
+  it("backs off consecutive empty polls without hot spinning", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-01T12:00:00.000Z"));
     const runtime = createRuntime(
-      [jsonResponse(200, { ok: true, result: [] }), jsonResponse(200, { ok: true, result: [] })],
-      { stopAfterPollSuccesses: 2 },
+      Array.from({ length: 9 }, () => jsonResponse(200, { ok: true, result: [] })),
+      { stopAfterPollSuccesses: 9 },
     );
 
     expect(runtime.calls).toHaveLength(1);
     await flushRuntime();
-    await vi.advanceTimersByTimeAsync(999);
-    expect(runtime.calls).toHaveLength(1);
-    await vi.advanceTimersByTimeAsync(1);
+    expect(runtime.calls).toHaveLength(2);
+    await vi.advanceTimersByTimeAsync(3_550);
     await runtime.done;
 
-    expect(runtime.calls).toHaveLength(2);
-    const secondCall = expectDefined(runtime.calls[1], "second Telegram poll call");
     const firstCall = expectDefined(runtime.calls[0], "first Telegram poll call");
-    expect(secondCall - firstCall).toBe(1000);
+    expect(runtime.calls.map((calledAt) => calledAt - firstCall)).toEqual([
+      0, 0, 50, 150, 350, 750, 1_550, 2_550, 3_550,
+    ]);
+  });
+
+  it("resets to immediate polling when activity resumes", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-01T12:00:00.000Z"));
+    const runtime = createRuntime(
+      [
+        jsonResponse(200, { ok: true, result: [] }),
+        jsonResponse(200, { ok: true, result: [] }),
+        jsonResponse(200, { ok: true, result: [{ update_id: 42 }] }),
+        jsonResponse(200, { ok: true, result: [] }),
+      ],
+      { stopAfterPollSuccesses: 4 },
+    );
+
+    await flushRuntime();
+    await vi.advanceTimersByTimeAsync(50);
+    await runtime.done;
+
+    const firstCall = expectDefined(runtime.calls[0], "first Telegram poll call");
+    expect(runtime.calls.map((calledAt) => calledAt - firstCall)).toEqual([0, 0, 50, 50]);
+    expect(runtime.messages).toContainEqual(
+      expect.objectContaining({ type: "spooled", updateId: 42 }),
+    );
   });
 });
 

--- a/extensions/telegram/src/telegram-ingress-worker.runtime.test.ts
+++ b/extensions/telegram/src/telegram-ingress-worker.runtime.test.ts
@@ -23,7 +23,10 @@ function htmlResponse(status: number, body: string): Response {
   });
 }
 
-function createRuntime(responses: Response[]): {
+function createRuntime(
+  responses: Response[],
+  options: { stopAfterPollSuccesses?: number } = {},
+): {
   calls: number[];
   messages: TelegramIngressWorkerMessage[];
   done: Promise<void>;
@@ -31,6 +34,7 @@ function createRuntime(responses: Response[]): {
   const calls: number[] = [];
   const messages: TelegramIngressWorkerMessage[] = [];
   const listeners = new Set<(message: TelegramIngressWorkerCommand) => void>();
+  let pollSuccesses = 0;
   const sendCommand = (message: TelegramIngressWorkerCommand) => {
     for (const listener of listeners) {
       listener(message);
@@ -40,7 +44,10 @@ function createRuntime(responses: Response[]): {
     postMessage(message) {
       messages.push(message);
       if (message.type === "poll-success") {
-        sendCommand({ type: "stop" });
+        pollSuccesses += 1;
+        if (pollSuccesses >= (options.stopAfterPollSuccesses ?? 1)) {
+          sendCommand({ type: "stop" });
+        }
       }
     },
     onMessage(listener) {
@@ -77,6 +84,29 @@ async function flushRuntime(): Promise<void> {
 
 afterEach(() => {
   vi.useRealTimers();
+});
+
+describe("telegram ingress worker poll cadence", () => {
+  it("paces fast successful empty getUpdates responses", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-01T12:00:00.000Z"));
+    const runtime = createRuntime(
+      [jsonResponse(200, { ok: true, result: [] }), jsonResponse(200, { ok: true, result: [] })],
+      { stopAfterPollSuccesses: 2 },
+    );
+
+    expect(runtime.calls).toHaveLength(1);
+    await flushRuntime();
+    await vi.advanceTimersByTimeAsync(999);
+    expect(runtime.calls).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(1);
+    await runtime.done;
+
+    expect(runtime.calls).toHaveLength(2);
+    const secondCall = expectDefined(runtime.calls[1], "second Telegram poll call");
+    const firstCall = expectDefined(runtime.calls[0], "first Telegram poll call");
+    expect(secondCall - firstCall).toBe(1000);
+  });
 });
 
 describe("telegram ingress worker durable-before-offset", () => {

--- a/extensions/telegram/src/telegram-ingress-worker.runtime.ts
+++ b/extensions/telegram/src/telegram-ingress-worker.runtime.ts
@@ -21,6 +21,7 @@ const pollLimit = 100;
 // getUpdates can return up to 100 updates; 4 MiB is a generous bound that no legitimate
 // Telegram Bot API response will reach, guarding against misbehaving/hostile endpoints.
 const TELEGRAM_GET_UPDATES_MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
+const emptyPollMinIntervalMs = 1000;
 const retryInitialMs = 1000;
 const retryMaxMs = 30_000;
 
@@ -284,6 +285,14 @@ export async function runTelegramIngressWorkerRuntime(params: {
           count: result.length,
           finishedAt: Date.now(),
         });
+        if (result.length === 0) {
+          // A Bot API endpoint or proxy can return before the requested long-poll timeout.
+          // Pace empty successes so that behavior cannot spin this worker in a tight loop.
+          const elapsedMs = Math.max(0, Date.now() - startedAt);
+          if (elapsedMs < emptyPollMinIntervalMs) {
+            await sleep(emptyPollMinIntervalMs - elapsedMs, stopController.signal);
+          }
+        }
       } catch (err) {
         if (stopped) {
           break;

--- a/extensions/telegram/src/telegram-ingress-worker.runtime.ts
+++ b/extensions/telegram/src/telegram-ingress-worker.runtime.ts
@@ -1,6 +1,11 @@
 // Telegram plugin module implements telegram ingress worker behavior.
 import { parentPort, workerData } from "node:worker_threads";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
+import {
+  computeBackoff,
+  sleepWithAbort,
+  type BackoffPolicy,
+} from "openclaw/plugin-sdk/runtime-env";
 import { resolveTelegramAllowedUpdates } from "./allowed-updates.js";
 import { normalizeTelegramApiRoot } from "./api-root.js";
 import { resolveTelegramTransport } from "./fetch.js";
@@ -21,9 +26,18 @@ const pollLimit = 100;
 // getUpdates can return up to 100 updates; 4 MiB is a generous bound that no legitimate
 // Telegram Bot API response will reach, guarding against misbehaving/hostile endpoints.
 const TELEGRAM_GET_UPDATES_MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
-const emptyPollMinIntervalMs = 1000;
-const retryInitialMs = 1000;
-const retryMaxMs = 30_000;
+const TELEGRAM_EMPTY_POLL_BACKOFF_POLICY: BackoffPolicy = {
+  initialMs: 50,
+  maxMs: 1_000,
+  factor: 2,
+  jitter: 0,
+};
+const TELEGRAM_RETRY_BACKOFF_POLICY: BackoffPolicy = {
+  initialMs: 1_000,
+  maxMs: 30_000,
+  factor: 2,
+  jitter: 0,
+};
 
 type TelegramGetUpdatesJson = {
   ok?: unknown;
@@ -56,22 +70,6 @@ type TelegramIngressWorkerRuntimeData = TelegramIngressWorkerOptions & {
   runtime: typeof TELEGRAM_INGRESS_WORKER_RUNTIME_MARKER;
 };
 
-function sleep(ms: number, signal: AbortSignal): Promise<void> {
-  if (signal.aborted) {
-    return Promise.resolve();
-  }
-  return new Promise((resolve) => {
-    const done = () => {
-      clearTimeout(timeout);
-      signal.removeEventListener("abort", done);
-      resolve();
-    };
-    const timeout = setTimeout(done, ms);
-    timeout.unref?.();
-    signal.addEventListener("abort", done, { once: true });
-  });
-}
-
 function formatErrorMessage(err: unknown): string {
   if (err instanceof Error) {
     return err.message || err.name;
@@ -97,10 +95,6 @@ function postPollError(port: TelegramIngressRuntimePort, err: unknown): void {
     ...(errorCode === undefined ? {} : { errorCode }),
     finishedAt: Date.now(),
   });
-}
-
-function resolveBackoff(attempt: number): number {
-  return Math.min(retryMaxMs, retryInitialMs * 2 ** Math.max(0, attempt - 1));
 }
 
 function createTelegramGetUpdatesError(params: {
@@ -201,6 +195,7 @@ export async function runTelegramIngressWorkerRuntime(params: {
   const pollTimeoutSeconds = resolveTelegramLongPollTimeoutSeconds(options.timeoutSeconds);
   let lastUpdateId = options.initialUpdateId;
   let failures = 0;
+  let consecutiveEmptyPolls = 0;
 
   port.onMessage((message) => {
     if (message?.type === "stop") {
@@ -285,18 +280,30 @@ export async function runTelegramIngressWorkerRuntime(params: {
           count: result.length,
           finishedAt: Date.now(),
         });
-        if (result.length === 0) {
-          // A Bot API endpoint or proxy can return before the requested long-poll timeout.
-          // Pace empty successes so that behavior cannot spin this worker in a tight loop.
+        if (result.length > 0) {
+          consecutiveEmptyPolls = 0;
+          continue;
+        }
+        consecutiveEmptyPolls += 1;
+        if (consecutiveEmptyPolls > 1) {
+          // Some Bot API endpoints return empty long polls immediately. Escalate only
+          // while idle, then reset above so active chats keep draining without delay.
+          const minIntervalMs = computeBackoff(
+            TELEGRAM_EMPTY_POLL_BACKOFF_POLICY,
+            consecutiveEmptyPolls - 1,
+          );
           const elapsedMs = Math.max(0, Date.now() - startedAt);
-          if (elapsedMs < emptyPollMinIntervalMs) {
-            await sleep(emptyPollMinIntervalMs - elapsedMs, stopController.signal);
+          if (elapsedMs < minIntervalMs) {
+            await sleepWithAbort(minIntervalMs - elapsedMs, stopController.signal, {
+              ref: false,
+            });
           }
         }
       } catch (err) {
         if (stopped) {
           break;
         }
+        consecutiveEmptyPolls = 0;
         failures += 1;
         postPollError(port, err);
         // 409 must propagate to the parent: it owns duplicate-poller/webhook
@@ -304,10 +311,18 @@ export async function runTelegramIngressWorkerRuntime(params: {
         if (!isRetryableTelegramApiError(err, { context: "polling" })) {
           throw err;
         }
-        await sleep(
-          readTelegramRetryAfterMs(err) ?? resolveBackoff(failures),
-          stopController.signal,
-        );
+        try {
+          await sleepWithAbort(
+            readTelegramRetryAfterMs(err) ??
+              computeBackoff(TELEGRAM_RETRY_BACKOFF_POLICY, failures),
+            stopController.signal,
+            { ref: false },
+          );
+        } catch (sleepErr) {
+          if (!stopped) {
+            throw sleepErr;
+          }
+        }
       }
     }
   } finally {


### PR DESCRIPTION
Closes #111062

## What Problem This Solves

Some Telegram Bot API deployments, notably self-hosted endpoints and intermediary proxies, can answer an empty `getUpdates` request immediately instead of holding it for the requested long-poll timeout. The polling worker then starts another request immediately and busy-spins while the chat is idle, pinning a CPU core and flooding the endpoint.

## Why This Change Was Made

The submitted fix correctly diagnosed the missing success-path pacing, but a fixed one-second floor would add up to one second of delivery latency when traffic resumes after idle. This maintainer rework uses the canonical plugin-runtime backoff and abortable-sleep helpers instead:

- the first empty result retries immediately;
- later consecutive empty results ramp through 50, 100, 200, 400, 800, then 1000 ms minimum poll intervals;
- any non-empty result resets the idle backoff and starts the next poll immediately;
- errors keep the existing `retry_after` and exponential-backoff behavior;
- worker stop aborts either sleep without keeping the process alive.

No config, environment variable, or public API surface is added.

## User Impact

Fast-empty endpoints no longer pin a CPU core while idle. Active chats keep the existing immediate drain behavior, and endpoints that honor Telegram's long-poll timeout receive no extra delay.

## Evidence

- `node scripts/run-vitest.mjs extensions/telegram/src/telegram-ingress-worker.runtime.test.ts` — 9/9 passed. Regressions prove both the bounded adaptive empty-poll schedule and immediate polling after activity resumes.
- `node scripts/run-vitest.mjs extensions/telegram/src/polling-session.test.ts` — 75/75 passed.
- `node scripts/check-changed.mjs -- extensions/telegram/src/telegram-ingress-worker.runtime.ts extensions/telegram/src/telegram-ingress-worker.runtime.test.ts` — passed on Blacksmith Testbox, including format, extension production/test typechecks, lint, boundaries, dependency pins, and cycle checks: https://github.com/openclaw/openclaw/actions/runs/29670273240
- The original controlled endpoint proof reproduced 4,800 empty polls in 10 seconds on `origin/main`, confirming the production diagnosis. The reworked fake-timer regression now locks the adaptive schedule and reset behavior deterministically.
- Real Telegram proof could not start the SUT: local Crabbox machine acquisition returned coordinator HTTP 401, and hosted Mantis run 29670751498 could not resolve the temporary candidate ref after fetching only `main`. A merged-main Mantis run remains the issue-close proof.

This fix was developed with AI assistance; the change and its validation were reviewed by the submitting author and OpenClaw maintainers.

Co-authored-by: Arseniy Palagin <valeradzigurda3@gmail.com>
