### PR TITLE
fix(scripts): sync release-candidate-checklist.d.mts with validateTrustedToolingPin

### DIFF
--- a/scripts/release-candidate-checklist.d.mts
+++ b/scripts/release-candidate-checklist.d.mts
@@ -167,6 +167,17 @@ export function validateCandidateChangelogProvenance({
       shippedBaselines: ShippedBaselineExclusion[];
       reason?: undefined;
     };
+export function validateTrustedToolingPin({
+  toolingSha,
+  pinnedToolingSha,
+  latestTrustedToolingSha,
+  isAncestor,
+}: {
+  toolingSha: unknown;
+  pinnedToolingSha: unknown;
+  latestTrustedToolingSha: unknown;
+  isAncestor?: ((ancestor: string, target: string) => boolean) | undefined;
+}): unknown;
 /**
  * Chooses the expected artifact name, allowing one same-prefix fallback per run.
  */


### PR DESCRIPTION
## What Problem This Solves

`pnpm check:test-types` (specifically `tsgo:test:root`) currently fails on `main` itself with:

```
test/scripts/release-candidate-checklist.test.ts(28,3): error TS2305: Module '"../../scripts/release-candidate-checklist.mjs"' has no exported member 'validateTrustedToolingPin'.
```

`pnpm check:script-declarations` reports the same drift: `scripts/release-candidate-checklist.d.mts: value-export contract drift; missing validateTrustedToolingPin`.

## Why This Change Was Made

#26e7575780be743ba3aea9bd5880070229967965 ("fix(release): pin trusted candidate tooling across main advances") added `validateTrustedToolingPin` to `scripts/release-candidate-checklist.mjs` and a test importing it, but didn't regenerate the adjacent `.d.mts` declaration contract. Since `check:test-types` type-checks the whole `test/tsconfig/tsconfig.test.root.json` project regardless of what a given PR touches, this currently fails CI for any PR based on current `main` — including unrelated ones. Verified reproducing on a clean `upstream/main` checkout with no other changes.

Fix: add the missing declaration, matching the existing style for other optional-callback params in this file (see `validateCandidateChangelogProvenance`'s `isAncestor`).

## User Impact

None — type-only declaration fix, no runtime behavior change. Unblocks `check:test-types` and `check:script-declarations` for `main` and every PR based on it.

## Evidence

- Reproduced and fixed on an isolated clean `upstream/main` checkout (no other diffs).
- `node scripts/check-script-declarations.mjs` no longer reports drift for this file.
- `pnpm check:test-types` (all three lanes: `tsgo:core:test`, `tsgo:extensions:test`, `tsgo:test:root`) passes clean with this change, cache cleared.
