### PR TITLE
fix(i18n): add missing zh-CN glossary entries for new docs

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -1554,5 +1554,41 @@
   {
     "source": "Baseten (Inkling + Model APIs)",
     "target": "Baseten（Inkling + Model APIs）"
+  },
+  {
+    "source": "The main session",
+    "target": "主会话"
+  },
+  {
+    "source": "Session management",
+    "target": "会话管理"
+  },
+  {
+    "source": "Memory",
+    "target": "记忆"
+  },
+  {
+    "source": "Multi-agent",
+    "target": "多 Agent"
+  },
+  {
+    "source": "Screen",
+    "target": "屏幕"
+  },
+  {
+    "source": "Gateway protocol",
+    "target": "网关协议"
+  },
+  {
+    "source": "Browser tool",
+    "target": "浏览器工具"
+  },
+  {
+    "source": "Canvas node controls",
+    "target": "Canvas 节点控件"
+  },
+  {
+    "source": "Dashboard Architecture",
+    "target": "仪表盘架构"
   }
 ]


### PR DESCRIPTION
## What Problem This Solves

The `check-docs-i18n-glossary` check was failing because 10 doc labels (titles and link labels) from recently added or updated doc pages were missing from `docs/.i18n/glossary.zh-CN.json`.

## Why This Change Was Made

Each missing entry was added with its Chinese translation matching the existing glossary pattern. This allows the docs-i18n check to pass again.

## User Impact

No user-visible impact. The glossary coverage check can validate future doc changes.

## Evidence

- `node scripts/check-docs-i18n-glossary.mjs` — exit 0 (previously exit 1 with 10 missing entries).