### PR TITLE
fix(daemon): replace redundant dynamic import with static import of probe-auth

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -1590,5 +1590,41 @@
   {
     "source": "Baseten (Inkling + Model APIs)",
     "target": "Baseten（Inkling + Model APIs）"
+  },
+  {
+    "source": "The main session",
+    "target": "主会话"
+  },
+  {
+    "source": "Session management",
+    "target": "会话管理"
+  },
+  {
+    "source": "Memory",
+    "target": "记忆"
+  },
+  {
+    "source": "Multi-agent",
+    "target": "多 Agent"
+  },
+  {
+    "source": "Screen",
+    "target": "屏幕"
+  },
+  {
+    "source": "Gateway protocol",
+    "target": "网关协议"
+  },
+  {
+    "source": "Browser tool",
+    "target": "浏览器工具"
+  },
+  {
+    "source": "Canvas node controls",
+    "target": "Canvas 节点控件"
+  },
+  {
+    "source": "Dashboard Architecture",
+    "target": "仪表盘架构"
   }
 ]

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -25,7 +25,10 @@ import { resolveGatewayService } from "../../daemon/service.js";
 import { resolveAdvertisedControlUiLinks } from "../../gateway/control-ui-links.js";
 import { gatewaySecretInputPathCanWin } from "../../gateway/credentials-secret-inputs.js";
 import { trimToUndefined } from "../../gateway/credentials.js";
-import { resolveGatewayProbeCredentialConfig } from "../../gateway/probe-auth.js";
+import {
+  resolveGatewayProbeAuthSafeWithSecretInputs,
+  resolveGatewayProbeCredentialConfig,
+} from "../../gateway/probe-auth.js";
 import {
   ALL_GATEWAY_SECRET_INPUT_PATHS,
   readGatewaySecretInputValue,
@@ -119,9 +122,6 @@ type CliStatusSummary = {
   entrypoint?: string;
 };
 
-const gatewayProbeAuthModuleLoader = createLazyImportLoader(
-  () => import("../../gateway/probe-auth.js"),
-);
 const daemonInspectModuleLoader = createLazyImportLoader(() => import("../../daemon/inspect.js"));
 const launchdModuleLoader = createLazyImportLoader(() => import("../../daemon/launchd.js"));
 const serviceAuditModuleLoader = createLazyImportLoader(
@@ -130,10 +130,6 @@ const serviceAuditModuleLoader = createLazyImportLoader(
 const gatewayTlsModuleLoader = createLazyImportLoader(() => import("../../infra/tls/gateway.js"));
 const daemonProbeModuleLoader = createLazyImportLoader(() => import("./probe.js"));
 const restartHealthModuleLoader = createLazyImportLoader(() => import("./restart-health.js"));
-
-function loadGatewayProbeAuthModule() {
-  return gatewayProbeAuthModuleLoader.load();
-}
 
 function loadDaemonInspectModule() {
   return daemonInspectModuleLoader.load();
@@ -674,15 +670,12 @@ export async function gatherDaemonStatus(
         mode: probeMode,
       });
     if (canResolveProbeAuth) {
-      const probeAuthResolution = await loadGatewayProbeAuthModule().then(
-        ({ resolveGatewayProbeAuthSafeWithSecretInputs }) =>
-          resolveGatewayProbeAuthSafeWithSecretInputs({
-            cfg: daemonCfg,
-            mode: probeMode,
-            env: mergedDaemonEnv as NodeJS.ProcessEnv,
-            explicitAuth,
-          }),
-      );
+      const probeAuthResolution = await resolveGatewayProbeAuthSafeWithSecretInputs({
+        cfg: daemonCfg,
+        mode: probeMode,
+        env: mergedDaemonEnv as NodeJS.ProcessEnv,
+        explicitAuth,
+      });
       daemonProbeAuth = probeAuthResolution.auth;
       rpcAuthWarning = probeAuthResolution.warning;
     } else {


### PR DESCRIPTION
## What Problem This Solves

`check-dynamic-import-warts` reported a `runtime static + dynamic import` advisory for `../../gateway/probe-auth.js`: the module was already statically imported on line 28, but a separate lazy dynamic import loaded it again for a different export.

## Why This Change Was Made

Both `resolveGatewayProbeCredentialConfig` (static import) and `resolveGatewayProbeAuthSafeWithSecretInputs` (dynamic import) live in the same module. Since the static import already loads the module, the lazy loader added no benefit. Consolidated both exports into the static import and removed the redundant lazy loader and wrapper function.

## User Impact

No user-visible impact. One less advisory in `check-dynamic-import-warts`.

## Evidence

**Environment**: Local run on `fix/consolidate-probe-auth-import` branch (Linux, Node 22).

### 1. Dynamic import check — probe-auth.js advisory is gone

```
$ npm run lint:tmp:dynamic-import-warts 2>&1 | grep -i "probe-auth"
(no output — no advisory for probe-auth.js)
```

No advisory for `probe-auth.js` or `src/cli/daemon-cli/status.gather.ts` in the complete output.

### 2. Glossary validation passes

```
$ npm run docs:check-i18n-glossary
$ echo $?
0
```

No errors from the added zh-CN glossary entries.