### PR TITLE
fix(agents): honor Anthropic Retry-After cooldowns

### DIFF
--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -15,6 +15,10 @@ const { buildGuardedModelFetchMock, guardedFetchMock } = vi.hoisted(() => ({
 
 vi.mock("./provider-transport-fetch.js", () => ({
   buildGuardedModelFetch: buildGuardedModelFetchMock,
+  parseRetryAfterSeconds: (headers: Headers) => {
+    const value = headers.get("retry-after");
+    return value && /^\d+$/.test(value) ? Number(value) : undefined;
+  },
 }));
 
 let createAnthropicMessagesTransportStreamFn: typeof import("./anthropic-transport-stream.js").createAnthropicMessagesTransportStreamFn;
@@ -876,6 +880,37 @@ describe("anthropic transport stream", () => {
     expect(headers.get("X-Provider")).toBe("foundry");
   });
 
+  it("preserves HTTP status and Retry-After in Anthropic error messages", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          type: "error",
+          error: {
+            type: "rate_limit_error",
+            message: "Number of request tokens exceeded the per-minute rate limit.",
+          },
+        }),
+        {
+          status: 429,
+          headers: { "retry-after": "30" },
+        },
+      ),
+    );
+
+    const result = await runTransportStream(
+      makeAnthropicTransportModel(),
+      {
+        messages: [{ role: "user", content: "hello" }],
+      } as AnthropicStreamContext,
+      { apiKey: "test-api-key" } as AnthropicStreamOptions,
+    );
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toBe(
+      'HTTP 429: {"type":"error","error":{"type":"rate_limit_error","message":"Number of request tokens exceeded the per-minute rate limit."}}; Retry-After: 30 seconds',
+    );
+  });
+
   it("bounds streamed Anthropic error responses without content-length", async () => {
     const encoder = new TextEncoder();
     let pullCount = 0;
@@ -908,7 +943,7 @@ describe("anthropic transport stream", () => {
     );
 
     expect(result.stopReason).toBe("error");
-    expect(result.errorMessage).toBe(`${"x".repeat(400)}…`);
+    expect(result.errorMessage).toBe(`HTTP 500: ${"x".repeat(400)}…`);
     expect(pullCount).toBeGreaterThanOrEqual(2);
     expect(cancelCount).toBe(1);
   });
@@ -945,10 +980,12 @@ describe("anthropic transport stream", () => {
 
     expect(result.stopReason).toBe("error");
     expect(result.errorMessage).toBe(
-      "Anthropic Messages error response stalled: no data received for 10000ms",
+      "HTTP 500: Anthropic Messages error response stalled: no data received for 10000ms",
     );
     expect(cancelReason).toBeInstanceOf(Error);
-    expect((cancelReason as Error).message).toBe(result.errorMessage);
+    expect((cancelReason as Error).message).toBe(
+      "Anthropic Messages error response stalled: no data received for 10000ms",
+    );
   });
 
   it("rejects oversized Anthropic SSE frames before buffering without bound", async () => {

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -73,7 +73,7 @@ import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./copilot-dyn
 import { parseJsonObjectPreservingUnsafeIntegers } from "./json-unsafe-integers.js";
 import { resolveProviderEndpoint } from "./provider-attribution.js";
 import { unwrapModelHeaderSentinelsForProviderEgress } from "./provider-secret-egress.js";
-import { buildGuardedModelFetch } from "./provider-transport-fetch.js";
+import { buildGuardedModelFetch, parseRetryAfterSeconds } from "./provider-transport-fetch.js";
 import type { StreamFn } from "./runtime/index.js";
 import { transformTransportMessages } from "./transport-message-transform.js";
 import {
@@ -852,9 +852,7 @@ function createAnthropicMessagesClient(params: {
         });
         if (!response.ok) {
           const detail = await readAnthropicMessagesErrorBodySnippet(response);
-          throw new Error(
-            detail || `Anthropic Messages request failed with HTTP ${response.status}`,
-          );
+          throw new Error(formatAnthropicMessagesHttpError(response, detail));
         }
         if (!response.body) {
           return;
@@ -863,6 +861,16 @@ function createAnthropicMessagesClient(params: {
       },
     },
   };
+}
+
+function formatAnthropicMessagesHttpError(response: Response, detail: string): string {
+  const retryAfterSeconds = parseRetryAfterSeconds(response.headers);
+  // Keep retry timing in the canonical error text so every retry owner sees the
+  // same bounded signal without extending the public AssistantMessage contract.
+  const retryAfterSuffix = Number.isFinite(retryAfterSeconds)
+    ? `; Retry-After: ${Math.ceil(retryAfterSeconds ?? 0)} seconds`
+    : "";
+  return `HTTP ${response.status}: ${detail || "Anthropic Messages request failed"}${retryAfterSuffix}`;
 }
 
 async function readAnthropicMessagesErrorBodySnippet(response: Response): Promise<string> {

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -461,7 +461,7 @@ async function requestBodyHasStreamTrue(
   }
 }
 
-function parseRetryAfterSeconds(headers: Headers): number | undefined {
+export function parseRetryAfterSeconds(headers: Headers): number | undefined {
   const retryAfterMs = headers.get("retry-after-ms");
   if (retryAfterMs) {
     const trimmedRetryAfterMs = retryAfterMs.trim();

--- a/src/agents/sessions/agent-session-execution.ts
+++ b/src/agents/sessions/agent-session-execution.ts
@@ -1,5 +1,6 @@
 import { isContextOverflow } from "@openclaw/ai/internal/runtime";
 import type { AssistantMessage } from "../../llm/types.js";
+import { classifyRateLimitWindow } from "../../llm/utils/rate-limit-window.js";
 import { isRetryableAssistantError } from "../../llm/utils/retry.js";
 import { sleep } from "../utils/sleep.js";
 import { AgentSessionExtensions } from "./agent-session-extensions.js";
@@ -49,7 +50,13 @@ export abstract class AgentSessionExecution extends AgentSessionExtensions {
       return false;
     }
 
-    const delayMs = settings.baseDelayMs * 2 ** (this.retryCount - 1);
+    const backoffDelayMs = settings.baseDelayMs * 2 ** (this.retryCount - 1);
+    const rateLimitWindow = classifyRateLimitWindow(message.errorMessage);
+    const retryAfterDelayMs =
+      rateLimitWindow.kind === "short" && rateLimitWindow.retryAfterSeconds !== undefined
+        ? Math.ceil(rateLimitWindow.retryAfterSeconds * 1000)
+        : 0;
+    const delayMs = Math.max(backoffDelayMs, retryAfterDelayMs);
 
     this.emit({
       type: "auto_retry_start",

--- a/src/agents/sessions/sdk.test.ts
+++ b/src/agents/sessions/sdk.test.ts
@@ -725,7 +725,7 @@ describe("createAgentSession thinking level defaults", () => {
 });
 
 describe("AgentSession retry behavior", () => {
-  async function createRetrySession() {
+  async function createRetrySession(retry?: { baseDelayMs: number; maxRetries: number }) {
     const authStorage = AuthStorage.inMemory();
     authStorage.setRuntimeApiKey(testModel.provider, "test-api-key");
     return await createAgentSession({
@@ -733,7 +733,7 @@ describe("AgentSession retry behavior", () => {
       resourceLoader: createEmptyResourceLoader(),
       sessionManager: SessionManager.inMemory(),
       settingsManager: SettingsManager.inMemory({
-        retry: { baseDelayMs: 0, maxRetries: 1 },
+        retry: retry ?? { baseDelayMs: 0, maxRetries: 1 },
       }),
       modelRegistry: ModelRegistry.inMemory(authStorage),
     });
@@ -775,5 +775,44 @@ describe("AgentSession retry behavior", () => {
     expect(streamMocks.streamSimple.mock.calls.length).toBeGreaterThan(1);
     expect(transientEvents).toContain("auto_retry_start");
     expect(transientEvents).toContain("auto_retry_end");
+  });
+
+  it("uses a short server Retry-After as the auto-retry delay floor", async () => {
+    vi.useFakeTimers();
+    try {
+      streamMocks.streamSimple.mockReset();
+      streamMocks.streamSimple
+        .mockImplementationOnce(() =>
+          createAssistantResultStream(
+            createAssistantError("HTTP 429: rate limited; Retry-After: 30 seconds"),
+          ),
+        )
+        .mockImplementationOnce(() =>
+          createAssistantResultStream({
+            ...createAssistantError(""),
+            content: [{ type: "text", text: "recovered" }],
+            stopReason: "stop",
+            errorMessage: undefined,
+          }),
+        );
+      const { session } = await createRetrySession({ baseDelayMs: 2_000, maxRetries: 1 });
+      const retryDelays: number[] = [];
+      session.subscribe((event) => {
+        if (event.type === "auto_retry_start") {
+          retryDelays.push(event.delayMs);
+        }
+      });
+
+      const promptPromise = session.prompt("test Retry-After");
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(retryDelays).toEqual([30_000]);
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      await promptPromise;
+      expect(streamMocks.streamSimple).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
Closes #103849

## What Problem This Solves

Fixes an issue where Anthropic Messages users could exhaust every automatic retry inside a provider-requested cooldown because HTTP status and Retry-After were discarded before session retry policy ran.

## Why This Change Was Made

Anthropic HTTP failures now retain the status and a validated Retry-After value in the canonical bounded error text. AgentSession uses an existing short-window classification as a delay floor while preserving exponential fallback, so the fix adds no config or Plugin SDK surface. Thanks to @yetval for the precise production-path report and reproduction.

## User Impact

Short Anthropic rate-limit cooldowns are now respected instead of retrying too early at the default 2s, 4s, and 8s intervals. Invalid or long cooldown values do not gain control over session sleep.

## Evidence

- `node scripts/run-vitest.mjs src/agents/anthropic-transport-stream.test.ts src/agents/provider-transport-fetch.test.ts src/agents/sessions/sdk.test.ts src/llm/utils/retry.test.ts` — 266 tests passed across two shards.
- `node scripts/check-changed.mjs -- src/agents/anthropic-transport-stream.ts src/agents/anthropic-transport-stream.test.ts src/agents/provider-transport-fetch.ts src/agents/sessions/agent-session-execution.ts src/agents/sessions/sdk.test.ts` — passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29666663083
- Autoreview: clean, no accepted/actionable findings.
