### PR TITLE
fix(qa): prevent live scenarios from racing config restarts

### DIFF
--- a/extensions/qa-lab/src/live-transports/shared/live-gateway-config.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/shared/live-gateway-config.runtime.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   patchLiveQaGatewayConfig,
   readLiveQaGatewayConfig,
 } from "./live-gateway-config.runtime.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe("live QA gateway config", () => {
   it("requires both config and hash from config.get", async () => {
@@ -20,7 +24,12 @@ describe("live QA gateway config", () => {
       .mockResolvedValueOnce({ config: { channels: {} }, hash: "old" })
       .mockRejectedValueOnce(new Error("config changed since last load"))
       .mockResolvedValueOnce({ config: { channels: {} }, hash: "current" })
-      .mockResolvedValueOnce({});
+      .mockResolvedValueOnce({ hash: "applied" })
+      .mockResolvedValueOnce({
+        hash: "applied",
+        configRevisionHash: "applied",
+        appliedConfigHash: "applied",
+      });
 
     await patchLiveQaGatewayConfig({
       gateway: { call },
@@ -45,6 +54,38 @@ describe("live QA gateway config", () => {
       restartDelayMs: 0,
       timeoutMs: 45_000,
     });
+  });
+
+  it("waits for the active Gateway to apply the persisted config revision", async () => {
+    vi.useFakeTimers();
+    const waitForConfigRestartSettle = vi.fn();
+    const call = vi
+      .fn()
+      .mockResolvedValueOnce({ config: { channels: {} }, hash: "current" })
+      .mockResolvedValueOnce({ hash: "next" })
+      .mockResolvedValueOnce({
+        hash: "next",
+        configRevisionHash: "current",
+        appliedConfigHash: "current",
+      })
+      .mockResolvedValueOnce({
+        hash: "next",
+        configRevisionHash: "next",
+        appliedConfigHash: "next",
+      });
+
+    const patching = patchLiveQaGatewayConfig({
+      gateway: { call },
+      patch: { channels: { slack: { enabled: true } } },
+      timeoutMs: 45_000,
+      waitForConfigRestartSettle,
+    });
+
+    await vi.advanceTimersByTimeAsync(250);
+    await patching;
+
+    expect(call).toHaveBeenCalledTimes(4);
+    expect(waitForConfigRestartSettle).toHaveBeenCalledTimes(1);
   });
 
   it("does not wait for a no-op config patch", async () => {

--- a/extensions/qa-lab/src/live-transports/shared/live-gateway-config.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/shared/live-gateway-config.runtime.ts
@@ -1,3 +1,4 @@
+import { setTimeout as sleep } from "node:timers/promises";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 
 type GatewayConfigClient = {
@@ -6,6 +7,52 @@ type GatewayConfigClient = {
 
 function isStaleConfigPatchError(error: unknown) {
   return formatErrorMessage(error).toLowerCase().includes("config changed since last load");
+}
+
+async function waitForLiveQaGatewayConfigApplied(params: {
+  expectedHash: string;
+  gateway: GatewayConfigClient;
+  timeoutMs: number;
+}) {
+  const deadline = Date.now() + params.timeoutMs;
+  let lastStatus:
+    | {
+        appliedConfigHash?: string;
+        configRevisionHash?: string;
+        hash?: string;
+      }
+    | undefined;
+  while (Date.now() < deadline) {
+    try {
+      const status = (await params.gateway.call(
+        "config.get",
+        {},
+        { timeoutMs: Math.max(1, Math.min(5_000, deadline - Date.now())) },
+      )) as {
+        appliedConfigHash?: string;
+        configRevisionHash?: string;
+        hash?: string;
+      };
+      lastStatus = {
+        appliedConfigHash: status.appliedConfigHash,
+        configRevisionHash: status.configRevisionHash,
+        hash: status.hash,
+      };
+      if (
+        status.hash === params.expectedHash &&
+        status.configRevisionHash === params.expectedHash &&
+        status.appliedConfigHash === params.expectedHash
+      ) {
+        return;
+      }
+    } catch {
+      // A restart can disconnect the control client before the new Gateway is ready.
+    }
+    await sleep(Math.min(250, Math.max(1, deadline - Date.now())));
+  }
+  throw new Error(
+    `live QA config was not applied by the active Gateway; last status: ${JSON.stringify(lastStatus ?? {})}`,
+  );
 }
 
 export async function readLiveQaGatewayConfig(gateway: GatewayConfigClient) {
@@ -31,7 +78,7 @@ export async function patchLiveQaGatewayConfig(params: {
 }) {
   for (let attempt = 0; attempt < 2; attempt += 1) {
     const snapshot = await readLiveQaGatewayConfig(params.gateway);
-    let patchResult: { noop?: boolean };
+    let patchResult: { hash?: string; noop?: boolean };
     try {
       patchResult =
         ((await params.gateway.call(
@@ -53,6 +100,16 @@ export async function patchLiveQaGatewayConfig(params: {
     if (patchResult.noop !== true) {
       await params.waitForConfigRestartSettle({
         restartDelayMs: 0,
+        timeoutMs: params.timeoutMs,
+      });
+      if (!patchResult.hash) {
+        throw new Error("live QA config patch returned no persisted hash");
+      }
+      // Restart-required writes acknowledge before SIGUSR1 completes. The old
+      // Gateway can still look healthy, so require the active runtime revision.
+      await waitForLiveQaGatewayConfigApplied({
+        expectedHash: patchResult.hash,
+        gateway: params.gateway,
         timeoutMs: params.timeoutMs,
       });
     }


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where live QA scenarios could start against the old Gateway process after a restart-required config patch. The scheduled restart then aborted the newly started scenario; in the complete maturity run, both Slack Codex approval scenarios timed out and no `qa-evidence.json` was produced.

Failure evidence: https://github.com/openclaw/openclaw/actions/runs/29663733324

## Why This Change Was Made

After a non-noop live QA config patch, require the active Gateway's persisted, loaded, and applied config hashes to all match the patch acknowledgement before the scenario proceeds. Timeout diagnostics retain only those non-sensitive hashes.

Matrix already enforced the equivalent active-revision invariant independently. This shared helper covers Slack, Discord, and WhatsApp live scenario preparation.

## User Impact

No end-user runtime behavior changes. Complete QA and maturity-scorecard runs no longer race restart-required live scenario configuration.

AI-assisted: yes. I reviewed the implementation and the upstream Codex app-server approval contract.

## Evidence

- Before: complete `all` profile reached 81/81 Matrix passes, then both Slack Codex approval scenarios were aborted by a scheduled config restart and timed out: https://github.com/openclaw/openclaw/actions/runs/29663733324
- `node scripts/run-vitest.mjs extensions/qa-lab/src/live-transports/shared/live-gateway-config.runtime.test.ts` — 4 tests passed.
- `node scripts/check-changed.mjs` — passed remotely, including extension production/test typechecks, lint, formatting, plugin boundaries, and import-cycle checks: https://github.com/openclaw/openclaw/actions/runs/29666710564
- `autoreview --mode uncommitted` — clean after addressing its applied-hash and redacted-diagnostics findings.
- `git diff --check` — passed.
