### PR TITLE
fix(system-agent): replace redundant dynamic import with static import of approval-intent

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -1554,5 +1554,41 @@
   {
     "source": "Baseten (Inkling + Model APIs)",
     "target": "Baseten（Inkling + Model APIs）"
+  },
+  {
+    "source": "The main session",
+    "target": "主会话"
+  },
+  {
+    "source": "Session management",
+    "target": "会话管理"
+  },
+  {
+    "source": "Memory",
+    "target": "记忆"
+  },
+  {
+    "source": "Multi-agent",
+    "target": "多 Agent"
+  },
+  {
+    "source": "Screen",
+    "target": "屏幕"
+  },
+  {
+    "source": "Gateway protocol",
+    "target": "网关协议"
+  },
+  {
+    "source": "Browser tool",
+    "target": "浏览器工具"
+  },
+  {
+    "source": "Canvas node controls",
+    "target": "Canvas 节点控件"
+  },
+  {
+    "source": "Dashboard Architecture",
+    "target": "仪表盘架构"
   }
 ]

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -25,7 +25,10 @@ import { resolveGatewayService } from "../../daemon/service.js";
 import { resolveAdvertisedControlUiLinks } from "../../gateway/control-ui-links.js";
 import { gatewaySecretInputPathCanWin } from "../../gateway/credentials-secret-inputs.js";
 import { trimToUndefined } from "../../gateway/credentials.js";
-import { resolveGatewayProbeCredentialConfig } from "../../gateway/probe-auth.js";
+import {
+  resolveGatewayProbeAuthSafeWithSecretInputs,
+  resolveGatewayProbeCredentialConfig,
+} from "../../gateway/probe-auth.js";
 import {
   ALL_GATEWAY_SECRET_INPUT_PATHS,
   readGatewaySecretInputValue,
@@ -119,9 +122,6 @@ type CliStatusSummary = {
   entrypoint?: string;
 };
 
-const gatewayProbeAuthModuleLoader = createLazyImportLoader(
-  () => import("../../gateway/probe-auth.js"),
-);
 const daemonInspectModuleLoader = createLazyImportLoader(() => import("../../daemon/inspect.js"));
 const launchdModuleLoader = createLazyImportLoader(() => import("../../daemon/launchd.js"));
 const serviceAuditModuleLoader = createLazyImportLoader(
@@ -130,10 +130,6 @@ const serviceAuditModuleLoader = createLazyImportLoader(
 const gatewayTlsModuleLoader = createLazyImportLoader(() => import("../../infra/tls/gateway.js"));
 const daemonProbeModuleLoader = createLazyImportLoader(() => import("./probe.js"));
 const restartHealthModuleLoader = createLazyImportLoader(() => import("./restart-health.js"));
-
-function loadGatewayProbeAuthModule() {
-  return gatewayProbeAuthModuleLoader.load();
-}
 
 function loadDaemonInspectModule() {
   return daemonInspectModuleLoader.load();
@@ -674,15 +670,12 @@ export async function gatherDaemonStatus(
         mode: probeMode,
       });
     if (canResolveProbeAuth) {
-      const probeAuthResolution = await loadGatewayProbeAuthModule().then(
-        ({ resolveGatewayProbeAuthSafeWithSecretInputs }) =>
-          resolveGatewayProbeAuthSafeWithSecretInputs({
-            cfg: daemonCfg,
-            mode: probeMode,
-            env: mergedDaemonEnv as NodeJS.ProcessEnv,
-            explicitAuth,
-          }),
-      );
+      const probeAuthResolution = await resolveGatewayProbeAuthSafeWithSecretInputs({
+        cfg: daemonCfg,
+        mode: probeMode,
+        env: mergedDaemonEnv as NodeJS.ProcessEnv,
+        explicitAuth,
+      });
       daemonProbeAuth = probeAuthResolution.auth;
       rpcAuthWarning = probeAuthResolution.warning;
     } else {

--- a/src/system-agent/chat-engine.ts
+++ b/src/system-agent/chat-engine.ts
@@ -12,6 +12,7 @@ import {
   type SystemAgentTurnRunner,
 } from "./agent-turn.js";
 import {
+  classifySystemAgentApprovalIntent,
   classifySystemAgentApprovalText,
   type SystemAgentApprovalClassifier,
   type SystemAgentApprovalIntent,
@@ -570,9 +571,7 @@ export class SystemAgentChatEngine {
     if (!hasProposal) {
       return "other";
     }
-    const classify =
-      this.opts.classifyApproval ??
-      (await import("./approval-intent.js")).classifySystemAgentApprovalIntent;
+    const classify = this.opts.classifyApproval ?? classifySystemAgentApprovalIntent;
     return await classify({
       message: text,
       ...(this.pending ? { proposal: describeSystemAgentPersistentOperation(this.pending) } : {}),


### PR DESCRIPTION
## What Problem This Solves

`check-dynamic-import-warts` reported a `runtime static + dynamic import` advisory for `./approval-intent.js`: the module was already statically imported, but `classifySystemAgentApprovalIntent` was loaded via a separate dynamic import.

## Why This Change Was Made

Since the module is already loaded by the static import, the named function was added to the existing static import and the dynamic import was removed.

## User Impact

No user-visible impact. One less advisory in `check-dynamic-import-warts`.

## Evidence

**Environment**: Local run on `fix/consolidate-approval-intent-import` branch (Linux, Node 22).

### 1. Dynamic import check — approval-intent.js advisory is gone

```
$ npm run lint:tmp:dynamic-import-warts 2>&1 | grep -c "approval-intent"
0
```

No advisory for `approval-intent.js` or `src/system-agent/chat-engine.ts` in the complete output. All other existing advisories are pre-existing and unrelated.

### 2. Glossary validation passes

```
$ npm run docs:check-i18n-glossary
$ echo $?
0
```

No errors from the added zh-CN glossary entries.