### PR TITLE
fix: worktree mode checks pass under cooperative umask

### DIFF
--- a/src/agents/worktrees/service.test.ts
+++ b/src/agents/worktrees/service.test.ts
@@ -456,9 +456,7 @@ describe("ManagedWorktreeService", () => {
     });
 
     expect(await fs.readFile(path.join(created.path, "collision.txt"), "utf8")).toBe("from base\n");
-    if (process.platform !== "win32") {
-      expect((await fs.stat(path.join(created.path, "collision.txt"))).mode & 0o777).toBe(0o644);
-    }
+    expect((await fs.stat(path.join(created.path, "collision.txt"))).mode & 0o111).toBe(0);
     expect(getRegistryWorktreeProvisionedPaths(env, created.id)).toEqual([]);
   });
 
@@ -514,6 +512,7 @@ describe("ManagedWorktreeService", () => {
     await git(repo, "add", ".gitignore", ".worktreeinclude");
     await git(repo, "commit", "-m", "configure worktree provisioning");
     await fs.writeFile(path.join(repo, "provisioned.env"), "source value\n");
+    const mode = (await fs.stat(path.join(repo, "provisioned.env"))).mode & 0o7777;
     const created = await service.create({ repoRoot: repo, name: "roundtrip" });
     const originalHead = await git(created.path, "rev-parse", "HEAD");
     await fs.writeFile(path.join(created.path, "README.md"), "changed\n");
@@ -525,7 +524,7 @@ describe("ManagedWorktreeService", () => {
     await expect(fs.stat(created.path)).rejects.toMatchObject({ code: "ENOENT" });
     expect(await git(repo, "show-ref", "--verify", removed.snapshotRef!)).not.toBe("");
     const provisionedState = getRegistryWorktreeProvisionedState(env, created.id)!;
-    expect(provisionedState).toEqual([{ path: "provisioned.env", mode: 0o644, chunks: 1 }]);
+    expect(provisionedState).toEqual([{ path: "provisioned.env", mode, chunks: 1 }]);
     const snapshotFiles = await git(repo, "ls-tree", "-r", "--name-only", removed.snapshotRef!);
     expect(snapshotFiles).not.toContain("ignored.txt");
     expect(snapshotFiles).not.toContain("provisioned.env");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the managed-worktree test suite fails on hosts using a cooperative `0002` umask, even though worktree provisioning correctly preserves the file modes those hosts actually create.

## Why This Change Was Made

The collision regression now checks the Git-relevant executable-bit invariant instead of requiring an exact `0644` mode. The snapshot regression derives its expected mode from the source file, preserving the exact-mode contract without encoding the runner's group-write policy.

## User Impact

No runtime behavior changes. CI and hosted Testbox runs no longer fail solely because the host permits group writes.

## Evidence

- Reproduced on Blacksmith Testbox with cooperative umask: expected `0644`, received `0664` in two assertions: https://github.com/openclaw/openclaw/actions/runs/29666419816
- `umask 0002; node scripts/run-vitest.mjs src/agents/worktrees/service.test.ts` — 48/48 passed locally.
- Five hosted repetitions of the complete worktree suite — 240/240 tests passed: https://github.com/openclaw/openclaw/actions/runs/29666912506
- `node scripts/check-changed.mjs -- src/agents/worktrees/service.test.ts` — formatting, core-test typecheck, and lint passed: https://github.com/openclaw/openclaw/actions/runs/29666795750
- Mandatory structured autoreview completed with no accepted or actionable findings.
