### PR TITLE
fix(wizard): honor process locale when overrides are blank

### DIFF
--- a/docs/cli/onboard.md
+++ b/docs/cli/onboard.md
@@ -179,7 +179,7 @@ openclaw onboard --reset --reset-scope full
 
 ## Locale
 
-Interactive onboarding uses the CLI wizard locale for fixed setup copy. Resolve order:
+Interactive onboarding uses the CLI wizard locale for fixed setup copy. It uses the first nonblank value in this order:
 
 1. `OPENCLAW_LOCALE`
 2. `LC_ALL`
@@ -191,6 +191,7 @@ Supported wizard locales are `en`, `zh-CN`, and `zh-TW`. Locale values may use u
 
 ```bash
 OPENCLAW_LOCALE=zh-CN openclaw onboard
+OPENCLAW_LOCALE=en openclaw onboard # Explicit English override
 ```
 
 ## Non-interactive setup

--- a/docs/plugins/sdk-setup.md
+++ b/docs/plugins/sdk-setup.md
@@ -351,7 +351,7 @@ For hot setup-only paths, prefer the narrow setup helper seams over the broader 
 
 Use the broader `plugin-sdk/setup` seam when you want the full shared setup toolbox, including config-patch helpers such as `moveSingleAccountChannelSectionToDefaultAccount(...)`.
 
-Use `createSetupTranslator(...)` for fixed setup wizard copy. It follows the CLI wizard locale (`OPENCLAW_LOCALE`, then system locale variables) and falls back to English. Keep plugin-specific setup text in plugin-owned code and use shared catalog keys only for common setup labels, status text, and official bundled plugin setup copy.
+Use `createSetupTranslator(...)` for fixed setup wizard copy. It uses the first nonblank value from `OPENCLAW_LOCALE`, `LC_ALL`, `LC_MESSAGES`, and `LANG`, in that order, then falls back to English. Set `OPENCLAW_LOCALE=en` for an explicit English override. Keep plugin-specific setup text in plugin-owned code and use shared catalog keys only for common setup labels, status text, and official bundled plugin setup copy.
 
 The setup patch adapters stay hot-path safe on import. Their bundled single-account promotion contract-surface lookup is lazy, so importing `plugin-sdk/setup-runtime` does not eagerly load bundled contract-surface discovery before the adapter is actually used.
 

--- a/docs/start/wizard.md
+++ b/docs/start/wizard.md
@@ -38,12 +38,13 @@ the browser through the Control UI. Docs: [Dashboard](/web/dashboard).
 
 ## Locale
 
-The wizard localizes fixed onboarding copy. Resolve order: `OPENCLAW_LOCALE`,
-`LC_ALL`, `LC_MESSAGES`, `LANG`, then English. Supported locales: `en`,
-`zh-CN`, `zh-TW`.
+The wizard localizes fixed onboarding copy. It uses the first nonblank value from
+`OPENCLAW_LOCALE`, `LC_ALL`, `LC_MESSAGES`, and `LANG`, in that order, then
+falls back to English. Supported locales: `en`, `zh-CN`, `zh-TW`.
 
 ```bash
 OPENCLAW_LOCALE=zh-CN openclaw onboard
+OPENCLAW_LOCALE=en openclaw onboard # Explicit English override
 ```
 
 Product names, commands, config keys, URLs, provider IDs, model IDs, and

--- a/src/wizard/i18n/index.test.ts
+++ b/src/wizard/i18n/index.test.ts
@@ -36,10 +36,10 @@ describe("wizard i18n", () => {
   });
 
   it("uses OPENCLAW_LOCALE before process locale variables", () => {
-    vi.stubEnv("OPENCLAW_LOCALE", "zh-TW");
+    vi.stubEnv("OPENCLAW_LOCALE", "en");
     vi.stubEnv("LC_ALL", "zh-CN");
-    vi.stubEnv("LANG", "en-US");
-    expect(t("wizard.gateway.port")).toBe("Gateway 連接埠");
+    vi.stubEnv("LANG", "zh-TW");
+    expect(t("wizard.gateway.port")).toBe("Gateway port");
   });
 
   it("ignores blank locale overrides when a process locale is available", () => {
@@ -48,6 +48,22 @@ describe("wizard i18n", () => {
     vi.stubEnv("LC_MESSAGES", "zh-CN");
     vi.stubEnv("LANG", "en-US");
     expect(t("wizard.gateway.port")).toBe("Gateway 端口");
+  });
+
+  it("continues through a blank LC_MESSAGES value to LANG", () => {
+    vi.stubEnv("OPENCLAW_LOCALE", "");
+    vi.stubEnv("LC_ALL", " ");
+    vi.stubEnv("LC_MESSAGES", "\t");
+    vi.stubEnv("LANG", "zh-TW");
+    expect(t("wizard.gateway.port")).toBe("Gateway 連接埠");
+  });
+
+  it("uses English when every locale variable is blank", () => {
+    vi.stubEnv("OPENCLAW_LOCALE", " ");
+    vi.stubEnv("LC_ALL", "");
+    vi.stubEnv("LC_MESSAGES", "\t");
+    vi.stubEnv("LANG", "  ");
+    expect(t("wizard.gateway.port")).toBe("Gateway port");
   });
 
   it("falls back to English and interpolates params", () => {

--- a/src/wizard/i18n/index.test.ts
+++ b/src/wizard/i18n/index.test.ts
@@ -42,6 +42,14 @@ describe("wizard i18n", () => {
     expect(t("wizard.gateway.port")).toBe("Gateway 連接埠");
   });
 
+  it("ignores blank locale overrides when a process locale is available", () => {
+    vi.stubEnv("OPENCLAW_LOCALE", "   ");
+    vi.stubEnv("LC_ALL", "");
+    vi.stubEnv("LC_MESSAGES", "zh-CN");
+    vi.stubEnv("LANG", "en-US");
+    expect(t("wizard.gateway.port")).toBe("Gateway 端口");
+  });
+
   it("falls back to English and interpolates params", () => {
     expect(t("wizard.gateway.port", undefined, { locale: "zh-CN" })).toBe("Gateway 端口");
     expect(t("wizard.gateway.missing", undefined, { locale: "zh-CN" })).toBe(

--- a/src/wizard/i18n/index.ts
+++ b/src/wizard/i18n/index.ts
@@ -49,7 +49,10 @@ function resolveWizardLocale(value: string | undefined): WizardLocale {
 }
 
 function resolveWizardLocaleFromEnv(env: NodeJS.ProcessEnv = process.env): WizardLocale {
-  return resolveWizardLocale(env.OPENCLAW_LOCALE ?? env.LC_ALL ?? env.LC_MESSAGES ?? env.LANG);
+  const locale = [env.OPENCLAW_LOCALE, env.LC_ALL, env.LC_MESSAGES, env.LANG].find((value) =>
+    value?.trim(),
+  );
+  return resolveWizardLocale(locale);
 }
 
 function readKey(map: WizardTranslationMap, key: string): string | undefined {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Allow edits from maintainers is enabled for this PR.

</details>

## What Problem This Solves

Fixes an issue where users with a blank `OPENCLAW_LOCALE` or higher-priority process locale variable would get English setup copy even when a valid lower-priority locale such as `LC_MESSAGES=zh-CN` was available.

## Why This Change Was Made

Locale selection now skips blank environment values while preserving the existing priority order and locale normalization. No locale, config, or translation surface is added.

## User Impact

The setup wizard honors the first configured non-blank locale instead of silently falling back to English because an earlier variable is empty.

## Evidence

Exact base: `ec740e79a48c1d7879fe3e8f211b4f0719d5ec0e`
Exact head: `e1e9a67ec3b96b414952c30f0c4f224a254c15c4`
Node: `v24.18.0`

Before the production change, the added regression failed on the same entry point:

    expected "Gateway ??"
    received "Gateway port"
    Tests  1 failed | 10 passed (11)

After:

    node scripts/run-vitest.mjs src/wizard/i18n/index.test.ts
    Test Files  1 passed (1)
    Tests  11 passed (11)

Targeted oxfmt and `git diff --check` also passed. The regression covers two consecutive blank overrides and confirms the next valid process locale wins.

AI-assisted: Codex helped identify, implement, and validate this fix; I verified the code and evidence.


### Production setup-entry proof

On Windows at exact head `e1e9a67ec3b96b414952c30f0c4f224a254c15c4`, I invoked the production `configureGatewayForSetup()` entry with the real process environment and stopped the prompter immediately after capturing its first user-visible prompt, before any config write:

    {"head":"e1e9a67ec3b96b414952c30f0c4f224a254c15c4","entry":"configureGatewayForSetup","env":{"OPENCLAW_LOCALE":"   ","LC_ALL":"   ","LC_MESSAGES":"zh-CN","LANG":"en-US"},"prompt":"Gateway ??"}

This exercises the same setup entry that renders the advanced Gateway port prompt. No translation helper or environment lookup was mocked; only the prompt response was intentionally withheld so the proof could not mutate local configuration.
