### PR TITLE
fix(mxc): preserve Windows path fallbacks for blank env values

### DIFF
--- a/extensions/mxc/src/sandbox-baseline.ts
+++ b/extensions/mxc/src/sandbox-baseline.ts
@@ -63,6 +63,10 @@ export const DEFAULT_SANDBOX_BASELINE: SandboxBaselinePolicy = {
   },
 };
 
+function firstNonBlankEnv(...values: Array<string | undefined>): string | undefined {
+  return values.find((value) => value?.trim());
+}
+
 export function resolveSandboxBaseline(
   input: SandboxBaselinePolicyInput = {},
 ): SandboxBaselinePolicy {
@@ -86,13 +90,13 @@ export function resolveSandboxBaseline(
 }
 
 export function resolveSandboxTempDir(env: BaselineTempEnv = {}): string {
-  return env.TEMP ?? env.TMP ?? "C:\\Windows\\Temp";
+  return firstNonBlankEnv(env.TEMP, env.TMP) ?? "C:\\Windows\\Temp";
 }
 
 export function resolveBaselineReadonlyPaths(env: BaselineReadonlyEnv): string[] {
-  const systemRoot = env.SystemRoot ?? env.WINDIR ?? "C:\\Windows";
-  const programFiles = env.ProgramFiles ?? env.ProgramW6432 ?? "C:\\Program Files";
-  const programFilesX86 = env["ProgramFiles(x86)"] ?? "C:\\Program Files (x86)";
+  const systemRoot = firstNonBlankEnv(env.SystemRoot, env.WINDIR) ?? "C:\\Windows";
+  const programFiles = firstNonBlankEnv(env.ProgramFiles, env.ProgramW6432) ?? "C:\\Program Files";
+  const programFilesX86 = firstNonBlankEnv(env["ProgramFiles(x86)"]) ?? "C:\\Program Files (x86)";
   return dedupeStable([
     programFiles,
     programFilesX86,

--- a/extensions/mxc/test/sandbox-baseline.test.ts
+++ b/extensions/mxc/test/sandbox-baseline.test.ts
@@ -68,11 +68,32 @@ describe("effective filesystem policy", () => {
     ]);
   });
 
+  test("ignores blank Windows env paths when deriving readonly directories", () => {
+    expect(
+      resolveBaselineReadonlyPaths({
+        SystemRoot: " ",
+        WINDIR: "D:\\Windows",
+        ProgramFiles: "",
+        ProgramW6432: "D:\\Program Files",
+        "ProgramFiles(x86)": "   ",
+      }),
+    ).toEqual([
+      "D:\\Program Files",
+      "C:\\Program Files (x86)",
+      "D:\\Windows\\System32",
+      "D:\\Windows\\SysWOW64",
+    ]);
+  });
+
   test("prefers the configured Windows temp directory", () => {
     expect(resolveSandboxTempDir({ TEMP: "C:\\Temp" })).toBe("C:\\Temp");
   });
 
   test("uses Windows temp when TEMP and TMP are absent", () => {
     expect(resolveSandboxTempDir({})).toBe("C:\\Windows\\Temp");
+  });
+
+  test("ignores a blank TEMP value when TMP is available", () => {
+    expect(resolveSandboxTempDir({ TEMP: "  ", TMP: "D:\\Temp" })).toBe("D:\\Temp");
   });
 });

--- a/extensions/mxc/test/sandbox-baseline.test.ts
+++ b/extensions/mxc/test/sandbox-baseline.test.ts
@@ -85,6 +85,23 @@ describe("effective filesystem policy", () => {
     ]);
   });
 
+  test("uses deterministic readonly fallbacks when Windows env paths are blank", () => {
+    expect(
+      resolveBaselineReadonlyPaths({
+        SystemRoot: "",
+        WINDIR: "  ",
+        ProgramFiles: " ",
+        ProgramW6432: "",
+        "ProgramFiles(x86)": "\t",
+      }),
+    ).toEqual([
+      "C:\\Program Files",
+      "C:\\Program Files (x86)",
+      "C:\\Windows\\System32",
+      "C:\\Windows\\SysWOW64",
+    ]);
+  });
+
   test("prefers the configured Windows temp directory", () => {
     expect(resolveSandboxTempDir({ TEMP: "C:\\Temp" })).toBe("C:\\Temp");
   });
@@ -95,5 +112,9 @@ describe("effective filesystem policy", () => {
 
   test("ignores a blank TEMP value when TMP is available", () => {
     expect(resolveSandboxTempDir({ TEMP: "  ", TMP: "D:\\Temp" })).toBe("D:\\Temp");
+  });
+
+  test("uses Windows temp when TEMP and TMP are blank", () => {
+    expect(resolveSandboxTempDir({ TEMP: "", TMP: "\t" })).toBe("C:\\Windows\\Temp");
   });
 });


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Allow edits from maintainers is enabled for this PR.

</details>

## What Problem This Solves

Fixes an issue where MXC Windows sandbox startup could inherit unusable temp or read-only paths when a higher-priority Windows environment variable was present but blank, even though a valid fallback variable or deterministic default existed.

## Why This Change Was Made

The existing Windows path priority order now selects the first non-blank value for TEMP/TMP, SystemRoot/WINDIR, and ProgramFiles/ProgramW6432. The sandbox policy and its defaults are otherwise unchanged.

## User Impact

MXC sandbox runs keep valid Windows temp and system read-only paths in environments that define empty path variables, instead of producing empty or relative entries such as ` \\System32`.

## Evidence

Exact base: `ec740e79a48c1d7879fe3e8f211b4f0719d5ec0e`
Exact head: `94e735fad235b3a8515db97303bda222fc3d3c63`
Node: `v24.18.0`

Before the production change, both added regressions failed:

    expected D:\\Temp; received two spaces
    expected D:\\Windows\\System32; received " \\System32"
    Tests  2 failed | 7 passed (9)

After:

    node scripts/run-vitest.mjs extensions/mxc/test/sandbox-baseline.test.ts
    Test Files  1 passed (1)
    Tests  9 passed (9)

Targeted oxfmt and `git diff --check` also passed. The tests cover both fallback-to-next-variable and fallback-to-deterministic-default behavior.

AI-assisted: Codex helped identify, implement, and validate this fix; I verified the code and evidence.


### Live Windows effective-policy proof

On a real `win32` process at exact head `94e735fad235b3a8515db97303bda222fc3d3c63`, I populated the process environment with blank primary Windows path variables and invoked the production `resolveCurrentBaselineContext()` entry, then its existing temp and readonly policy resolvers:

    {"head":"94e735fad235b3a8515db97303bda222fc3d3c63","platform":"win32","entry":"resolveCurrentBaselineContext","hostEnv":{"SystemRoot":"   ","WINDIR":"C:\\Windows","ProgramFiles":"","ProgramW6432":"C:\\Program Files","ProgramFiles(x86)":"   ","TEMP":"   ","TMP":"C:\\Windows\\Temp"},"tempDir":"C:\\Windows\\Temp","readonlyPaths":["C:\\Program Files","C:\\Program Files (x86)","C:\\Windows\\System32","C:\\Windows\\SysWOW64"]}

The transcript confirms the runtime context retains the real fallback temp directory and absolute Windows system policy paths; no private user path or identifier is included.
