### PR TITLE
fix(clawhub): preserve legacy telemetry opt-out behind blank primary env

### DIFF
--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -22,6 +22,7 @@ import {
   normalizeClawHubSha256Integrity,
   normalizeClawHubSha256Hex,
   parseClawHubPluginSpec,
+  reportClawHubSkillInstallTelemetry,
   resolveLatestVersionFromPackage,
   satisfiesGatewayMinimum,
   satisfiesPluginApiRange,
@@ -179,6 +180,8 @@ describe("clawhub helpers", () => {
     delete process.env.CLAWHUB_AUTH_TOKEN;
     delete process.env.CLAWHUB_CONFIG_PATH;
     delete process.env.CLAWDHUB_CONFIG_PATH;
+    delete process.env.CLAWHUB_DISABLE_TELEMETRY;
+    delete process.env.CLAWDHUB_DISABLE_TELEMETRY;
     originalEnv.restore();
   });
 
@@ -403,6 +406,20 @@ describe("clawhub helpers", () => {
     };
 
     await expect(searchClawHubSkills({ query: "calendar", fetchImpl })).resolves.toStrictEqual([]);
+  });
+
+  it("preserves the legacy telemetry opt-out when the primary env is blank", async () => {
+    process.env.CLAWHUB_DISABLE_TELEMETRY = "   ";
+    process.env.CLAWDHUB_DISABLE_TELEMETRY = "true";
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+
+    await reportClawHubSkillInstallTelemetry({
+      token: "token-123",
+      slug: "calendar",
+      fetchImpl,
+    });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
   });
 
   it("preserves the configured ClawHub base URL path prefix", async () => {

--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -445,6 +445,34 @@ describe("clawhub helpers", () => {
     expect(url.searchParams.get("q")).toBe("calendar");
   });
 
+  it("treats an empty primary telemetry setting as absent", async () => {
+    process.env.CLAWHUB_DISABLE_TELEMETRY = "";
+    process.env.CLAWDHUB_DISABLE_TELEMETRY = "true";
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+
+    await reportClawHubSkillInstallTelemetry({
+      token: "test-token",
+      slug: "calendar",
+      fetchImpl,
+    });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("lets a nonblank primary telemetry setting override the legacy opt-out", async () => {
+    process.env.CLAWHUB_DISABLE_TELEMETRY = "false";
+    process.env.CLAWDHUB_DISABLE_TELEMETRY = "true";
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+
+    await reportClawHubSkillInstallTelemetry({
+      token: "test-token",
+      slug: "calendar",
+      fetchImpl,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
   it("sends owner-qualified skill detail lookups as slug plus ownerHandle", async () => {
     let requestedUrl = "";
 

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -1625,7 +1625,9 @@ export async function reportClawHubSkillInstallTelemetry(params: {
 }
 
 function isClawHubTelemetryDisabled(): boolean {
-  const raw = process.env.CLAWHUB_DISABLE_TELEMETRY ?? process.env.CLAWDHUB_DISABLE_TELEMETRY;
+  const raw =
+    normalizeOptionalString(process.env.CLAWHUB_DISABLE_TELEMETRY) ??
+    normalizeOptionalString(process.env.CLAWDHUB_DISABLE_TELEMETRY);
   if (!raw) {
     return false;
   }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Allow edits from maintainers is enabled for this PR.

</details>

## What Problem This Solves

Fixes an issue where users opting out of ClawHub install telemetry through the supported legacy `CLAWDHUB_DISABLE_TELEMETRY` variable could still send an install event when `CLAWHUB_DISABLE_TELEMETRY` was also present but blank.

## Why This Change Was Made

Telemetry opt-out resolution now ignores blank values before applying the existing primary-then-legacy precedence. The accepted opt-out values and telemetry payload remain unchanged.

## User Impact

A valid legacy telemetry opt-out remains effective even when an empty primary variable is injected by an environment file or launcher.

## Evidence

Exact base: `ec740e79a48c1d7879fe3e8f211b4f0719d5ec0e`
Exact head: `d68ff63d982b00eb9d1a13bc3c52b6790cdd7a31`
Node: `v24.18.0`

The regression calls `reportClawHubSkillInstallTelemetry()` with a real request seam. Before the production change:

    expected fetchImpl not to be called
    received one POST /api/cli/telemetry/install
    Tests  1 failed | 79 passed | 2 skipped (82)

After:

    node scripts/run-vitest.mjs src/infra/clawhub.test.ts
    Test Files  1 passed (1)
    Tests  80 passed | 2 skipped (82)

Targeted oxfmt and `git diff --check` also passed. The test asserts that the request is never emitted when the primary value is blank and the supported legacy opt-out is true.

AI-assisted: Codex helped identify, implement, and validate this fix; I verified the code and evidence.


### Native request-path proof

At exact head `d68ff63d982b00eb9d1a13bc3c52b6790cdd7a31`, I invoked the production `reportClawHubSkillInstallTelemetry()` entry with its default native `fetch` transport against a loopback HTTP server. The first run used a blank primary variable plus the legacy opt-out; the control run removed both variables to prove the real endpoint and transport were active:

    {"head":"d68ff63d982b00eb9d1a13bc3c52b6790cdd7a31","entry":"reportClawHubSkillInstallTelemetry","transport":"native fetch to loopback HTTP server","blankPrimary":"   ","legacyOptOut":"true","optedOutRequests":0,"controlRequests":[{"method":"POST","path":"/api/cli/telemetry/install"}]}

The opt-out run emitted zero requests. The control immediately reached the same server with one `POST /api/cli/telemetry/install`, demonstrating that the zero count came from the production opt-out path rather than a disconnected request seam. The proof used only a synthetic token and loopback traffic.
