### PR TITLE
fix(tlon): account checks leave streaming responses open

### DIFF
--- a/extensions/tlon/src/channel.runtime.test.ts
+++ b/extensions/tlon/src/channel.runtime.test.ts
@@ -1,0 +1,82 @@
+// Tlon tests cover channel runtime behavior.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { authenticate } from "./urbit/auth.js";
+import { urbitFetch } from "./urbit/fetch.js";
+
+vi.mock("./urbit/auth.js", () => ({
+  authenticate: vi.fn(),
+}));
+
+vi.mock("./urbit/fetch.js", () => ({
+  urbitFetch: vi.fn(),
+}));
+
+import { probeTlonAccount } from "./channel.runtime.js";
+
+const account = {
+  accountId: "default",
+  configured: true,
+  ship: "~zod",
+  url: "https://example.com",
+  code: "sample-code",
+} as never;
+
+function responseWithCancelableBody(
+  status: number,
+  cancelBody: () => void | PromiseLike<void>,
+): Response {
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      cancel: cancelBody,
+    }),
+    { status },
+  );
+}
+
+describe("probeTlonAccount", () => {
+  beforeEach(() => {
+    vi.mocked(authenticate).mockReset();
+    vi.mocked(urbitFetch).mockReset();
+    vi.mocked(authenticate).mockResolvedValue("urbauth-~zod=fake-cookie");
+  });
+
+  it.each([
+    { status: 200, expected: { ok: true } },
+    { status: 503, expected: { ok: false, error: "Name request failed: 503" } },
+  ])("cancels a $status response before releasing the guard", async ({ status, expected }) => {
+    const events: string[] = [];
+    const cancelBody = vi.fn(() => {
+      events.push("cancel");
+    });
+    const release = vi.fn(async () => {
+      events.push("release");
+    });
+    vi.mocked(urbitFetch).mockResolvedValue({
+      response: responseWithCancelableBody(status, cancelBody),
+      finalUrl: "https://example.com/~/name",
+      release,
+      refreshTimeout: vi.fn(),
+    });
+
+    await expect(probeTlonAccount(account)).resolves.toEqual(expected);
+
+    expect(cancelBody).toHaveBeenCalledOnce();
+    expect(release).toHaveBeenCalledOnce();
+    expect(events).toEqual(["cancel", "release"]);
+  });
+
+  it("still releases the guard when response cancellation fails", async () => {
+    const response = new Response(new ReadableStream<Uint8Array>());
+    vi.spyOn(response.body!, "cancel").mockRejectedValueOnce(new Error("cancel failed"));
+    const release = vi.fn(async () => {});
+    vi.mocked(urbitFetch).mockResolvedValue({
+      response,
+      finalUrl: "https://example.com/~/name",
+      release,
+      refreshTimeout: vi.fn(),
+    });
+
+    await expect(probeTlonAccount(account)).resolves.toEqual({ ok: true });
+    expect(release).toHaveBeenCalledOnce();
+  });
+});

--- a/extensions/tlon/src/channel.runtime.test.ts
+++ b/extensions/tlon/src/channel.runtime.test.ts
@@ -66,9 +66,15 @@ describe("probeTlonAccount", () => {
   });
 
   it("still releases the guard when response cancellation fails", async () => {
+    const events: string[] = [];
     const response = new Response(new ReadableStream<Uint8Array>());
-    vi.spyOn(response.body!, "cancel").mockRejectedValueOnce(new Error("cancel failed"));
-    const release = vi.fn(async () => {});
+    const cancel = vi.spyOn(response.body!, "cancel").mockImplementationOnce(async () => {
+      events.push("cancel");
+      throw new Error("cancel failed");
+    });
+    const release = vi.fn(async () => {
+      events.push("release");
+    });
     vi.mocked(urbitFetch).mockResolvedValue({
       response,
       finalUrl: "https://example.com/~/name",
@@ -77,6 +83,8 @@ describe("probeTlonAccount", () => {
     });
 
     await expect(probeTlonAccount(account)).resolves.toEqual({ ok: true });
+    expect(cancel).toHaveBeenCalledOnce();
     expect(release).toHaveBeenCalledOnce();
+    expect(events).toEqual(["cancel", "release"]);
   });
 });

--- a/extensions/tlon/src/channel.runtime.ts
+++ b/extensions/tlon/src/channel.runtime.ts
@@ -233,6 +233,11 @@ export async function probeTlonAccount(account: ConfiguredTlonAccount) {
       }
       return { ok: true };
     } finally {
+      // Guard release does not settle unread response streams; cancel first so
+      // the probe cannot leave its pinned connection open.
+      if (!response.bodyUsed) {
+        await response.body?.cancel().catch(() => undefined);
+      }
       await release();
     }
   } catch (error) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where probing a Tlon account could leave the unread name response stream open after the account check returned.

## Why This Change Was Made

The Tlon account probe now cancels an unread `/~/name` response body before releasing its guarded dispatcher. Cancellation remains best-effort so dispatcher cleanup still runs if the response stream rejects cancellation.

### Lifecycle contract verification

Verified against current main at [`0a588fa79527`](https://github.com/openclaw/openclaw/commit/0a588fa7952722063a1937c0ca1e41bbb73035c2):

- [`urbitFetch`](https://github.com/openclaw/openclaw/blob/0a588fa7952722063a1937c0ca1e41bbb73035c2/extensions/tlon/src/urbit/fetch.ts#L24-L42) directly returns the guarded fetch result without wrapping its response lifecycle.
- The guard's [`release()` implementation](https://github.com/openclaw/openclaw/blob/0a588fa7952722063a1937c0ca1e41bbb73035c2/src/infra/net/fetch-guard.ts#L503-L510) clears timeout state and closes the dispatcher; it does not consume or cancel `response.body`.
- Tlon's existing [`releaseUploadResponse`](https://github.com/openclaw/openclaw/blob/0a588fa7952722063a1937c0ca1e41bbb73035c2/extensions/tlon/src/tlon-api.ts#L61-L77) establishes the same owner-local contract: cancel an unread body best-effort, then release the guard unconditionally.
- The current [`probeTlonAccount`](https://github.com/openclaw/openclaw/blob/0a588fa7952722063a1937c0ca1e41bbb73035c2/extensions/tlon/src/channel.runtime.ts#L213-L236) returns from both status branches without reading the body. Applying the established Tlon cleanup ordering at this caller is therefore the narrow contract-preserving fix.

## User Impact

Tlon account checks release the response stream and guarded network resources even when an Urbit name endpoint sends a streaming or otherwise unfinished body.

## Evidence

- Real-path loopback proof: `pnpm exec tsx proof-live.ts` imported the production `probeTlonAccount` entrypoint against a localhost Urbit boundary with an unfinished `/~/name` body. On the pinned base, both the 200 and 503 streams remained open after the probe returned; with this change, both streams closed while preserving their results.
- Focused test: `node scripts/run-vitest.mjs extensions/tlon/src/channel.runtime.test.ts` passes 3 tests covering successful and non-2xx responses plus cancellation failure cleanup.

```text
$ pnpm exec tsx proof-live.ts
base 200: {"result":{"ok":true},"responseClosedBeforeTeardown":false}
base 503: {"result":{"ok":false,"error":"Name request failed: 503"},"responseClosedBeforeTeardown":false}
fix  200: {"result":{"ok":true},"responseClosedBeforeTeardown":true}
fix  503: {"result":{"ok":false,"error":"Name request failed: 503"},"responseClosedBeforeTeardown":true}
```

<details>
<summary>proof-live.ts</summary>

```ts
import http from "node:http";
import path from "node:path";
import { pathToFileURL } from "node:url";

async function runProbe(
  probeTlonAccount: (account: never) => Promise<unknown>,
  status: number,
) {
  let nameResponseClosed = false;
  let resolveNameResponseClosed: (() => void) | undefined;
  const nameResponseClosedPromise = new Promise<void>((resolve) => {
    resolveNameResponseClosed = resolve;
  });

  const server = http.createServer((request, response) => {
    if (request.url === "/~/login") {
      response.writeHead(200, {
        "content-type": "text/plain",
        "set-cookie": "urbauth-~zod=proof-cookie",
      });
      response.end("ok");
      return;
    }

    if (request.url === "/~/name") {
      response.writeHead(status, { "content-type": "text/plain" });
      response.write("stream remains open");
      const heartbeat = setInterval(() => response.write("."), 100);
      response.on("close", () => {
        clearInterval(heartbeat);
        nameResponseClosed = true;
        resolveNameResponseClosed?.();
      });
      return;
    }

    response.writeHead(404).end();
  });

  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
  const address = server.address();
  if (!address || typeof address === "string") {
    throw new Error("loopback server did not expose a TCP port");
  }

  const probePromise = probeTlonAccount({
    accountId: "default",
    configured: true,
    ship: "~zod",
    url: `http://127.0.0.1:${address.port}`,
    code: "proof-code",
    dangerouslyAllowPrivateNetwork: true,
  } as never);

  const outcome = await Promise.race([
    probePromise.then((result: unknown) => ({ kind: "returned" as const, result })),
    new Promise<{ kind: "timeout" }>((resolve) =>
      setTimeout(() => resolve({ kind: "timeout" }), 1_000),
    ),
  ]);

  if (outcome.kind === "timeout") {
    server.closeAllConnections();
    await probePromise;
  } else {
    await Promise.race([
      nameResponseClosedPromise,
      new Promise<void>((resolve) => setTimeout(resolve, 500)),
    ]);
  }

  const responseClosedBeforeTeardown = nameResponseClosed;
  console.log(
    JSON.stringify({
      status,
      outcome: outcome.kind,
      result: outcome.kind === "returned" ? outcome.result : undefined,
      responseClosedBeforeTeardown,
    }),
  );

  server.closeAllConnections();
  await new Promise<void>((resolve, reject) => {
    server.close((error) => (error ? reject(error) : resolve()));
  });
}

async function main() {
  const runtimeUrl = pathToFileURL(
    path.resolve(process.cwd(), "extensions/tlon/src/channel.runtime.ts"),
  ).href;
  const { probeTlonAccount } = await import(runtimeUrl);

  console.log("entrypoint: probeTlonAccount");
  console.log("dependency-boundary: localhost Urbit HTTP server with an unfinished /~/name body");
  await runProbe(probeTlonAccount, 200);
  await runProbe(probeTlonAccount, 503);
}

void main().catch((error) => {
  console.error(error);
  process.exitCode = 1;
});
```

</details>

AI-assisted: built with Codex
