### PR TITLE
fix(tasks): skip session pruning when cron-state read fails (#110935)

### DIFF
--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetConfigRuntimeState } from "../config/config.js";
 import { loadSessionEntry, replaceSessionEntry } from "../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../config/sessions/types.js";
-import { saveCronStore } from "../cron/store.js";
+import { loadCronJobsStoreSync, saveCronStore } from "../cron/store.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { createManagedTaskFlow as createManagedTaskFlowOrNull } from "../tasks/task-flow-registry.js";
@@ -584,6 +584,41 @@ describe("tasks commands", () => {
       expect(loadSessionEntry({ sessionKey: rawKey, storePath })).toBeDefined();
       expect(loadSessionEntry({ sessionKey: retiredKey, storePath })).toBeUndefined();
     });
+  });
+
+  it("does not prune cron-run sessions when the cron-state read fails (#110935)", async () => {
+    const spy = vi
+      .spyOn(await import("../cron/store.js"), "loadCronJobsStoreSync")
+      .mockImplementation(() => {
+        throw new Error("SQLITE_IOERR: cron state unavailable");
+      });
+    try {
+      await withTaskCommandStateDir(async (state) => {
+        const now = Date.now();
+        const old = now - 8 * 24 * 60 * 60_000;
+        const sessionsDir = state.sessionsDir("main");
+        const storePath = path.join(sessionsDir, "sessions.json");
+        const agedKey = "agent:main:cron:running-job:run:old-run";
+        await writeSessionEntries(storePath, {
+          [agedKey]: { sessionId: "old-run", updatedAt: old },
+        });
+
+        const runtime = createRuntime();
+        await tasksMaintenanceCommand({ json: true, apply: true }, runtime);
+
+        // The aged cron-run entry must survive: with the read failing we must
+        // not pretend "nothing is running" and prune it.
+        expect(loadSessionEntry({ sessionKey: agedKey, storePath })).toBeDefined();
+
+        const payload = readFirstJsonLog(runtime) as {
+          maintenance: { sessions: { pruned: number; cronStateError: boolean } };
+        };
+        expect(payload.maintenance.sessions.cronStateError).toBe(true);
+        expect(payload.maintenance.sessions.pruned).toBe(0);
+      });
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it("preserves a running cron session with an explicit session key", async () => {

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -58,6 +58,7 @@ const RUN_PAD = 10;
 const SESSION_REGISTRY_RETENTION_MS = 7 * 24 * 60 * 60_000;
 
 const info = theme.info;
+const warn = theme.warn;
 
 function formatTaskLookupMiss(lookup: string): string {
   return formatLookupMiss({
@@ -134,6 +135,7 @@ type SessionRegistryMaintenanceSummary = {
   retentionMs: number;
   runningCronJobs: number;
   pruned: number;
+  cronStateError: boolean;
   stores: SessionRegistryMaintenanceStoreSummary[];
 };
 
@@ -142,7 +144,11 @@ function resolveExplicitCronSessionSegment(sessionKey: string | undefined): stri
   return match?.[1]?.toLowerCase();
 }
 
-function readRunningCronJobIds(): { ids: Set<string>; count: number } {
+function readRunningCronJobIds(): {
+  ids: Set<string>;
+  count: number;
+  readError: unknown;
+} {
   try {
     const cronStorePath = resolveCronJobsStorePath(getRuntimeConfig().cron?.store);
     const runningJobs = loadCronJobsStoreSync(cronStorePath).jobs.filter(
@@ -164,9 +170,14 @@ function readRunningCronJobIds(): { ids: Set<string>; count: number } {
         ]),
       ),
       count: runningJobs.length,
+      readError: null,
     };
-  } catch {
-    return { ids: new Set(), count: 0 };
+  } catch (error) {
+    // The cron-state read failed (e.g. SQLITE_IOERR). Do NOT fall back to an
+    // empty running-job set: pruning decisions depend on knowing which cron
+    // jobs are running, so a failed read must be surfaced to the caller rather
+    // than silently letting aged cron-run sessions be pruned. (#110935)
+    return { ids: new Set(), count: 0, readError: error };
   }
 }
 
@@ -176,6 +187,20 @@ async function runSessionRegistryMaintenance(params: {
   const cfg = getRuntimeConfig();
   const runningCronJobs = readRunningCronJobIds();
   const stores: SessionRegistryMaintenanceStoreSummary[] = [];
+  if (runningCronJobs.readError) {
+    // The cron-state read failed (e.g. SQLITE_IOERR). Pruning decisions depend
+    // on knowing which cron jobs are running, so a failed read must NOT be
+    // treated as "nothing is running". Leave the session registry unchanged
+    // and report the failure instead of silently pruning aged cron-run
+    // sessions. (#110935)
+    return {
+      retentionMs: SESSION_REGISTRY_RETENTION_MS,
+      runningCronJobs: 0,
+      pruned: 0,
+      cronStateError: true,
+      stores,
+    };
+  }
   for (const target of resolveAllAgentSessionStoreTargetsSync(cfg)) {
     const result = await runSessionRegistryMaintenanceForStore({
       apply: params.apply,
@@ -196,6 +221,7 @@ async function runSessionRegistryMaintenance(params: {
     retentionMs: SESSION_REGISTRY_RETENTION_MS,
     runningCronJobs: runningCronJobs.count,
     pruned: stores.reduce((total, store) => total + store.pruned, 0),
+    cronStateError: false,
     stores,
   };
 }
@@ -628,6 +654,13 @@ export async function tasksMaintenanceCommand(
       `Session registry: ${sessionMaintenance.pruned} prune · ${sessionMaintenance.runningCronJobs} running cron jobs`,
     ),
   );
+  if (sessionMaintenance.cronStateError) {
+    runtime.log(
+      warn(
+        "Session registry: cron-state read failed; skipping session pruning to avoid removing live cron-run sessions. Fix the cron store before re-running maintenance.",
+      ),
+    );
+  }
   runtime.log(
     info(
       `${opts.apply ? "Tasks health after apply" : "Tasks health"}: ${summary.byStatus.queued} queued · ${summary.byStatus.running} running · ${auditAfter.errors + flowAuditAfter.errors} audit errors · ${auditAfter.warnings + flowAuditAfter.warnings} audit warnings`,


### PR DESCRIPTION
## Summary
Fixes #110935 — when the cron-state SQLite read fails, `tasks maintenance --apply` continued with an empty running-cron-job set and pruned aged cron-run session entries that should be preserved.

## Root cause
src/commands/tasks.ts::readRunningCronJobIds() wrapped loadCronJobsStoreSync() in try/catch and silently returned an empty set on error. The running-job set gates whether aged cron-run session entries are pruned, so a failed read was wrongly treated as 'nothing is running', letting maintenance delete live cron-run transcripts.

## Fix
- readRunningCronJobIds() now returns { ids, count, readError }. On read failure it records readError instead of an empty set.
- runSessionRegistryMaintenance() returns early (no pruning, registry unchanged) when readError is set, with cronStateError: true in the summary.
- The command logs a warning so the failure is visible rather than silent.

## Changes
- src/commands/tasks.ts: cron-state failure handling + summary field + warning log.
- src/commands/tasks.test.ts: regression test — an aged cron-run session survives a loadCronJobsStoreSync() throw and cronStateError is true/pruned is 0.

## Validation
- node scripts/run-vitest.mjs run src/commands/tasks.test.ts -> 20 passed.
- tsc --noEmit project check: no tasks.ts errors.
- git diff --check passed.

Closes #110935.