### PR TITLE
fix(acp): exit help and EOF cleanly

### DIFF
--- a/src/acp/server.startup.test.ts
+++ b/src/acp/server.startup.test.ts
@@ -1,5 +1,6 @@
 /** Tests ACP server startup readiness, Gateway bootstrap, and shutdown wiring. */
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { ReadableStream as NodeReadableStream } from "node:stream/web";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 type GatewayClientCallbacks = {
   onEvent?: (evt: { event: string; payload?: unknown }) => void;
@@ -30,10 +31,13 @@ type MockAcpStream = {
 const mockState = vi.hoisted(() => ({
   acpProtocolVersion: 1,
   acpInputMessages: [] as unknown[],
+  rawInputChunks: [] as Uint8Array[],
   gateways: [] as MockGatewayClient[],
   gatewayAuth: [] as GatewayClientAuth[],
   gatewayOptions: [] as GatewayClientOptions[],
   agentSideConnectionCtor: vi.fn(),
+  closeAgentSideConnection: null as (() => void) | null,
+  closeAcpInput: null as (() => void) | null,
   agentHandleGatewayEvent: vi.fn(async (_evt: unknown) => {}),
   agentStart: vi.fn(),
   agentShutdown: vi.fn(),
@@ -54,6 +58,21 @@ const mockState = vi.hoisted(() => ({
     },
   })),
 }));
+
+vi.mock("node:stream", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:stream")>();
+  vi.spyOn(actual.Readable, "toWeb").mockImplementation(
+    () =>
+      new NodeReadableStream<Uint8Array>({
+        start(controller) {
+          for (const chunk of mockState.rawInputChunks) {
+            controller.enqueue(chunk);
+          }
+        },
+      }),
+  );
+  return actual;
+});
 
 class MockGatewayClient {
   private callbacks: GatewayClientCallbacks;
@@ -100,6 +119,11 @@ vi.mock("@agentclientprotocol/sdk", () => ({
   ) {
     mockState.agentSideConnectionCtor(factory, stream);
     factory({});
+    return {
+      closed: new Promise<void>((resolve) => {
+        mockState.closeAgentSideConnection = resolve;
+      }),
+    };
   },
   PROTOCOL_VERSION: mockState.acpProtocolVersion,
   ndJsonStream: vi.fn(() => ({
@@ -109,7 +133,7 @@ vi.mock("@agentclientprotocol/sdk", () => ({
         for (const message of mockState.acpInputMessages) {
           controller.enqueue(message);
         }
-        controller.close();
+        mockState.closeAcpInput = () => controller.close();
       },
     }),
   })),
@@ -293,6 +317,7 @@ describe("serveAcpGateway startup", () => {
 
     try {
       await emitHelloAndWaitForAgentSideConnection();
+      mockState.closeAcpInput?.();
       return await readCapturedAcpMessages();
     } finally {
       signalHandlers.get("SIGINT")?.();
@@ -310,15 +335,37 @@ describe("serveAcpGateway startup", () => {
   }
 
   beforeAll(async () => {
+    // Vitest workers have closed stdin; model the open ACP transport used by
+    // these startup tests. Closed-stdin behavior has process-level coverage.
+    Object.defineProperty(process.stdin, "readableEnded", {
+      configurable: true,
+      value: false,
+    });
+    Object.defineProperty(process.stdin, "readableLength", {
+      configurable: true,
+      value: 1,
+    });
     ({ serveAcpGateway } = await import("./server.js"));
+  });
+
+  afterAll(() => {
+    const testStdin = process.stdin as unknown as {
+      readableEnded?: boolean;
+      readableLength?: number;
+    };
+    delete testStdin.readableEnded;
+    delete testStdin.readableLength;
   });
 
   beforeEach(async () => {
     mockState.acpInputMessages.length = 0;
+    mockState.rawInputChunks.length = 0;
     mockState.gateways.length = 0;
     mockState.gatewayAuth.length = 0;
     mockState.gatewayOptions.length = 0;
     mockState.agentSideConnectionCtor.mockReset();
+    mockState.closeAgentSideConnection = null;
+    mockState.closeAcpInput = null;
     mockState.agentHandleGatewayEvent.mockReset();
     mockState.agentStart.mockReset();
     mockState.agentShutdown.mockReset();
@@ -459,6 +506,23 @@ describe("serveAcpGateway startup", () => {
     }
   });
 
+  it("shuts down when buffered pre-hello ACP input exceeds its limit", async () => {
+    mockState.rawInputChunks.push(new Uint8Array(1024 * 1024 + 1));
+    const onceSpy = vi
+      .spyOn(process, "once")
+      .mockImplementation(
+        ((_signal: NodeJS.Signals, _handler: () => void) => process) as typeof process.once,
+      );
+
+    try {
+      await serveAcpGateway({});
+      expect(mockState.agentSideConnectionCtor).not.toHaveBeenCalled();
+      expect(mockState.closeOpenClawStateDatabase).toHaveBeenCalledOnce();
+    } finally {
+      onceSpy.mockRestore();
+    }
+  });
+
   it("passes resolved SecretInput gateway credentials to the ACP gateway client", async () => {
     mockState.resolveGatewayClientBootstrap.mockResolvedValue({
       url: "ws://127.0.0.1:18789",
@@ -567,6 +631,27 @@ describe("serveAcpGateway startup", () => {
     }
   });
 
+  it("shuts down when the ACP client closes its stdio stream", async () => {
+    const { onceSpy } = captureProcessSignalHandlers();
+
+    try {
+      const servePromise = serveAcpGateway({});
+      await emitHelloAndWaitForAgentSideConnection();
+      const closeConnection = mockState.closeAgentSideConnection;
+      if (!closeConnection) {
+        throw new Error("Expected mocked ACP connection close handler");
+      }
+
+      closeConnection();
+      await servePromise;
+
+      expect(mockState.agentShutdown).toHaveBeenCalledOnce();
+      expect(mockState.closeOpenClawStateDatabase).toHaveBeenCalledOnce();
+    } finally {
+      onceSpy.mockRestore();
+    }
+  });
+
   it("waits for Gateway transport teardown before closing the shared state database", async () => {
     let resolveStop!: () => void;
     const stopPromise = new Promise<void>((resolve) => {
@@ -625,6 +710,21 @@ describe("serveAcpGateway startup", () => {
       actualStateDb.closeOpenClawStateDatabase();
       onceSpy.mockRestore();
     }
+  });
+
+  it("replays an ACP frame read before Gateway hello to AgentSideConnection", async () => {
+    const initializeRequest = {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: mockState.acpProtocolVersion,
+        clientCapabilities: {},
+      },
+    };
+
+    const [message] = await captureAcpMessagesAfterStartup([initializeRequest]);
+    expect(message).toBe(initializeRequest);
   });
 
   it("coerces MCP date-string initialize protocol versions", async () => {

--- a/src/acp/server.ts
+++ b/src/acp/server.ts
@@ -30,6 +30,65 @@ import { normalizeAcpProvenanceMode } from "./types.js";
 
 type JsonObject = Record<string, unknown>;
 
+const MAX_STARTUP_ACP_BUFFER_BYTES = 1024 * 1024;
+
+function createStartupInputMonitor(input: ReadableStream<Uint8Array>): {
+  dispose: () => void;
+  ended: Promise<void>;
+  takeReadable: () => ReadableStream<Uint8Array>;
+} {
+  const [monitor, readable] = input.tee();
+  const reader = monitor.getReader();
+  let readableTaken = false;
+  let monitorCancelled = false;
+  const cancelMonitor = (reason?: unknown) => {
+    if (monitorCancelled) {
+      return;
+    }
+    monitorCancelled = true;
+    void reader.cancel(reason).catch(() => {});
+  };
+  const cancelBoth = (reason?: unknown) => {
+    cancelMonitor(reason);
+    void readable.cancel(reason).catch(() => {});
+  };
+  const ended = (async () => {
+    try {
+      let bufferedBytes = 0;
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          return;
+        }
+        // Drain raw stdin so EOF remains observable before Gateway hello. The
+        // other branch retains the same bytes for the eventual SDK reader.
+        bufferedBytes += value.byteLength;
+        if (bufferedBytes > MAX_STARTUP_ACP_BUFFER_BYTES) {
+          const error = new Error("ACP startup input exceeded the 1 MiB buffer limit");
+          cancelBoth(error);
+          throw error;
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  })();
+  return {
+    dispose: () => {
+      if (!readableTaken) {
+        cancelBoth();
+      } else {
+        cancelMonitor();
+      }
+    },
+    ended,
+    takeReadable: () => {
+      readableTaken = true;
+      return readable;
+    },
+  };
+}
+
 /** Starts the ACP Gateway bridge and serves AgentSideConnection over stdio. */
 export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void> {
   routeLogsToStderr();
@@ -49,7 +108,9 @@ export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void
   const closed = new Promise<void>((resolve) => {
     onClosed = resolve;
   });
+  const startupAbortController = new AbortController();
   let stopped = false;
+  let gatewayConnected = false;
   let onGatewayReadyResolve!: () => void;
   let onGatewayReadyReject!: (err: Error) => void;
   let gatewayReadySettled = false;
@@ -103,6 +164,7 @@ export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void
       });
     },
     onHelloOk: () => {
+      gatewayConnected = true;
       resolveGatewayReady();
       agent?.handleGatewayReconnect();
     },
@@ -117,12 +179,20 @@ export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void
       agent?.handleGatewayDisconnect(`${code}: ${reason}`);
     },
   });
+  // Construct the sole stdin reader before waiting for Gateway hello. The raw
+  // monitor branch actively detects EOF while the bounded replay branch retains
+  // every byte until the SDK is ready to consume it.
+  const rawInput = Readable.toWeb(process.stdin) as unknown as ReadableStream<Uint8Array>;
+  const startupInput = createStartupInputMonitor(rawInput);
 
   const shutdown = async () => {
     if (stopped) {
       return;
     }
     stopped = true;
+    startupAbortController.abort();
+    startupInput.dispose();
+    process.stdin.pause();
     resolveGatewayReady();
     // Revoke ledger access before transport teardown. ACP requests and Gateway
     // events can both resume asynchronously, and must not reopen the shared DB.
@@ -137,6 +207,12 @@ export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void
     onClosed();
   };
 
+  void startupInput.ended.then(() => {
+    if (!gatewayConnected) {
+      void shutdown();
+    }
+  }, shutdown);
+
   process.once("SIGINT", () => {
     void shutdown();
   });
@@ -144,9 +220,10 @@ export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void
     void shutdown();
   });
 
-  // Start gateway first and wait for hello before accepting ACP requests.
+  // Wait for Gateway hello before dispatching buffered ACP requests.
   const readiness = await startGatewayClientWhenEventLoopReady(gateway, {
     clientOptions: { preauthHandshakeTimeoutMs: bootstrap.preauthHandshakeTimeoutMs },
+    signal: startupAbortController.signal,
   });
   if (!readiness.ready) {
     rejectGatewayReady(new Error("gateway event loop readiness timeout"));
@@ -159,9 +236,10 @@ export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void
     return closed;
   }
 
-  const input = Writable.toWeb(process.stdout);
-  const output = Readable.toWeb(process.stdin) as unknown as ReadableStream<Uint8Array>;
-  const stream = ndJsonStream(input, output);
+  const bufferedInput = startupInput.takeReadable();
+  startupInput.dispose();
+  const output = Writable.toWeb(process.stdout);
+  const stream = ndJsonStream(output, bufferedInput);
   const readable = stream.readable.pipeThrough(
     new TransformStream<AnyMessage, AnyMessage>({
       transform(message, controller) {
@@ -171,7 +249,7 @@ export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void
   );
   const eventLedger = createSqliteAcpEventLedger();
 
-  void new AgentSideConnection(
+  const connection = new AgentSideConnection(
     (conn: AgentSideConnection) => {
       agent = new AcpGatewayAgent(conn, gateway, { ...opts, eventLedger });
       agent.start();
@@ -179,6 +257,9 @@ export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void
     },
     { ...stream, readable },
   );
+  // The SDK closes the connection when stdin reaches EOF. Reuse the normal
+  // shutdown path so the Gateway and shared database cannot keep the bridge alive.
+  void connection.closed.then(shutdown, shutdown);
 
   return closed;
 }

--- a/src/cli/acp-cli-exit.process.test.ts
+++ b/src/cli/acp-cli-exit.process.test.ts
@@ -1,0 +1,260 @@
+// Process regression coverage for ACP help commands returning without loading runtime transports.
+import {
+  execFile,
+  spawn,
+  spawnSync,
+  type ChildProcessWithoutNullStreams,
+} from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+import { type RawData, WebSocketServer } from "ws";
+
+const execFileAsync = promisify(execFile);
+
+const INITIALIZE_FRAME = {
+  jsonrpc: "2.0",
+  id: 1,
+  method: "initialize",
+  params: {
+    protocolVersion: 1,
+    clientCapabilities: {
+      fs: { readTextFile: false, writeTextFile: false },
+      terminal: false,
+    },
+  },
+};
+
+function createAcpProcessEnv(stateDir?: string): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    NODE_ENV: undefined,
+    NODE_OPTIONS: "--use-openssl-ca",
+    NODE_USE_SYSTEM_CA: "0",
+    OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+    OPENCLAW_CONFIG_PATH: stateDir ? path.join(stateDir, "openclaw.json") : undefined,
+    OPENCLAW_NO_RESPAWN: "1",
+    OPENCLAW_STATE_DIR: stateDir,
+    VITEST: undefined,
+  };
+}
+
+function waitForExit(child: ChildProcessWithoutNullStreams) {
+  return new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", (code, signal) => resolve({ code, signal }));
+  });
+}
+
+function waitForJsonLine(child: ChildProcessWithoutNullStreams, id: number) {
+  return new Promise<Record<string, unknown>>((resolve, reject) => {
+    let stdout = "";
+    const timeout = setTimeout(
+      () => reject(new Error("timed out waiting for ACP response")),
+      10_000,
+    );
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      reject(new Error(`ACP process exited before response (code=${code}, signal=${signal})`));
+    };
+    const finish = (response: Record<string, unknown>) => {
+      clearTimeout(timeout);
+      child.off("exit", onExit);
+      resolve(response);
+    };
+
+    child.once("exit", onExit);
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+      const lines = stdout.split("\n");
+      stdout = lines.pop() ?? "";
+      for (const line of lines) {
+        if (!line.trim()) {
+          continue;
+        }
+        const response = JSON.parse(line) as Record<string, unknown>;
+        if (response.id === id) {
+          finish(response);
+          return;
+        }
+      }
+    });
+  });
+}
+
+function rawDataToText(data: RawData): string {
+  if (Array.isArray(data)) {
+    return Buffer.concat(data).toString("utf8");
+  }
+  if (data instanceof ArrayBuffer) {
+    return Buffer.from(new Uint8Array(data)).toString("utf8");
+  }
+  return Buffer.from(data).toString("utf8");
+}
+
+describe("ACP CLI process exit", () => {
+  it.each([
+    { args: ["acp", "--help"], usage: "Usage: openclaw acp [options] [command]" },
+    { args: ["acp", "client", "--help"], usage: "Usage: openclaw acp client [options]" },
+  ])(
+    "exits promptly after $args",
+    async ({ args, usage }) => {
+      const result = await execFileAsync(
+        process.execPath,
+        ["--import", "tsx", "src/entry.ts", ...args],
+        {
+          cwd: path.resolve("."),
+          encoding: "utf8",
+          env: {
+            ...createAcpProcessEnv(),
+            NODE_OPTIONS: process.platform === "darwin" ? "--use-system-ca" : undefined,
+            NODE_USE_SYSTEM_CA: undefined,
+          },
+          killSignal: "SIGKILL",
+          timeout: 5_000,
+        },
+      );
+
+      expect(result.stderr).toBe("");
+      expect(result.stdout).toContain(usage);
+    },
+    10_000,
+  );
+
+  it.each([
+    { name: "empty stdin", input: "" },
+    {
+      name: "an initialize frame",
+      input: `${JSON.stringify(INITIALIZE_FRAME)}\n`,
+    },
+  ])("exits when the bridge starts with $name and the client disconnects", ({ input }) => {
+    const result = spawnSync(
+      process.execPath,
+      ["--import", "tsx", "src/entry.ts", "acp", "--require-existing"],
+      {
+        cwd: path.resolve("."),
+        encoding: "utf8",
+        env: createAcpProcessEnv(),
+        input,
+        killSignal: "SIGKILL",
+        timeout: 10_000,
+      },
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.signal).toBeNull();
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+  });
+
+  it("processes an initialize frame buffered before Gateway hello", async () => {
+    const stateDir = mkdtempSync(path.join(tmpdir(), "openclaw-acp-exit-"));
+    const server = createServer();
+    const wss = new WebSocketServer({ server });
+    let child: ChildProcessWithoutNullStreams | undefined;
+
+    try {
+      wss.on("connection", (socket) => {
+        socket.send(
+          JSON.stringify({
+            type: "event",
+            event: "connect.challenge",
+            seq: 1,
+            payload: { nonce: "acp-process-test" },
+          }),
+        );
+        socket.on("message", (data) => {
+          const frame = JSON.parse(rawDataToText(data)) as { id: string; method: string };
+          if (frame.method !== "connect") {
+            return;
+          }
+          socket.send(
+            JSON.stringify({
+              type: "res",
+              id: frame.id,
+              ok: true,
+              payload: {
+                type: "hello-ok",
+                protocol: 4,
+                server: { version: "acp-process-test", connId: "acp-process-test" },
+                features: { methods: [], events: [] },
+                snapshot: {
+                  presence: [],
+                  health: {},
+                  stateVersion: { presence: 1, health: 1 },
+                  uptimeMs: 1,
+                },
+                auth: { role: "operator", scopes: ["operator.admin"] },
+                policy: {
+                  maxPayload: 512 * 1024,
+                  maxBufferedBytes: 1024 * 1024,
+                  tickIntervalMs: 1000,
+                },
+              },
+            }),
+          );
+        });
+      });
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("ACP process test Gateway did not get a TCP address");
+      }
+
+      child = spawn(
+        process.execPath,
+        [
+          "--import",
+          "tsx",
+          "src/entry.ts",
+          "acp",
+          "--require-existing",
+          "--url",
+          `ws://127.0.0.1:${address.port}`,
+        ],
+        {
+          cwd: path.resolve("."),
+          env: createAcpProcessEnv(stateDir),
+          stdio: ["pipe", "pipe", "pipe"],
+        },
+      );
+      let stderr = "";
+      child.stderr.on("data", (chunk: Buffer) => {
+        stderr += chunk.toString();
+      });
+      const exitPromise = waitForExit(child);
+      const responsePromise = waitForJsonLine(child, INITIALIZE_FRAME.id);
+
+      // Write before the Gateway handshake completes. Startup monitoring must
+      // retain this frame for the eventual AgentSideConnection reader.
+      child.stdin.write(`${JSON.stringify(INITIALIZE_FRAME)}\n`);
+      const response = await responsePromise;
+      expect(response).toMatchObject({
+        jsonrpc: "2.0",
+        id: INITIALIZE_FRAME.id,
+        result: { protocolVersion: INITIALIZE_FRAME.params.protocolVersion },
+      });
+
+      child.stdin.end();
+      const exit = await exitPromise;
+      expect(exit).toEqual({ code: 0, signal: null });
+      expect(stderr).toBe("");
+    } finally {
+      child?.kill("SIGKILL");
+      for (const socket of wss.clients) {
+        socket.terminate();
+      }
+      await new Promise<void>((resolve) => {
+        wss.close(() => resolve());
+      });
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+      rmSync(stateDir, { force: true, recursive: true });
+    }
+  }, 20_000);
+});

--- a/src/cli/acp-cli.ts
+++ b/src/cli/acp-cli.ts
@@ -2,8 +2,6 @@
 import type { Command } from "commander";
 import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
-import { runAcpClientInteractive } from "../acp/client.js";
-import { serveAcpGateway } from "../acp/server.js";
 import { normalizeAcpProvenanceMode } from "../acp/types.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { defaultRuntime } from "../runtime.js";
@@ -37,6 +35,7 @@ export function registerAcpCli(program: Command) {
         if (opts.provenance && !provenanceMode) {
           throw new Error('Invalid --provenance. Use "off", "meta", or "meta+receipt".');
         }
+        const { serveAcpGateway } = await import("../acp/server.js");
         await serveAcpGateway({
           gatewayUrl: opts.url as string | undefined,
           gatewayToken,
@@ -66,6 +65,7 @@ export function registerAcpCli(program: Command) {
     .action(async (opts, command) => {
       const inheritedVerbose = inheritOptionFromParent<boolean>(command, "verbose");
       try {
+        const { runAcpClientInteractive } = await import("../acp/client.js");
         await runAcpClientInteractive({
           cwd: opts.cwd as string | undefined,
           serverCommand: opts.server as string | undefined,


### PR DESCRIPTION
## What Problem This Solves

Two `acp` exit hangs. (1) `openclaw acp --help` and `openclaw acp client --help` printed their help and then never exited (>8s / >18s, needed killing) — every other command tree's `--help` exits cleanly. (2) The ACP bridge (`acp … --require-existing`) did not exit on stdin EOF while waiting for the Gateway. Found by the R7 QA campaign.

## Why This Change Was Made

- The help hang: importing the `acp` command module eagerly pulled in the ACP client/server runtime (which opens a handle), so even `--help` — which never runs the command — kept the process alive.
- The EOF hang: the startup EOF monitor left stdin paused and only did `read(0)`, but Node doesn't emit `end` until buffered data is consumed, so a client that wrote an initialize/request frame and then closed was never detected.

## User Impact

- `acp --help` / `acp client --help` now exit in <0.5s (rc 0) — the ACP runtime is imported lazily inside the action handler, so help/registration doesn't load it. No `[INEFFECTIVE_DYNAMIC_IMPORT]`.
- The bridge now detects stdin closure losslessly: it reads/buffers pre-handshake input while watching for EOF, so both a zero-byte disconnect AND a disconnect after a real ACP frame exit cleanly if the Gateway never arrives — without dropping the client's frames when the Gateway does connect.

## Evidence

- Exit proof: `acp --help` 0.48s, `acp client --help` 0.47s (rc 0).
- Tests: process-exit tests for both help commands and the non-empty-disconnect EOF case, plus ACP startup/shutdown/lifecycle units — 39/39 focused (incl. `src/acp/translator.lifecycle.test.ts`); happy-path assertion confirms buffered frames reach the SDK reader.
- Autoreview (codex gpt-5.6-sol, xhigh): clean — "patch is correct (0.88)".
