### PR TITLE
fix: notify users when stalled-session recovery interrupts a turn

### DIFF
--- a/src/auto-reply/reply/agent-runner-error-handler.ts
+++ b/src/auto-reply/reply/agent-runner-error-handler.ts
@@ -39,6 +39,7 @@ import {
   buildAuthProfileFailoverFailureText,
   buildExternalRunFailureReply,
   buildRateLimitCooldownMessage,
+  buildStalledRunReplyPayload,
   hasBillingAttemptSummary,
   isNonDirectConversationContext,
   isPureTransientRateLimitSummary,
@@ -49,10 +50,12 @@ import {
 } from "./agent-runner-failure-reply.js";
 import type { AgentFallbackCycleState } from "./agent-runner-fallback-cycle.js";
 import type { AgentTurnTimingTracker } from "./agent-runner-turn-timing.js";
+import { drainPendingToolTasks } from "./pending-tool-task-drain.js";
 import { classifyProviderRequestError } from "./provider-request-error-classifier.js";
 import {
   buildRestartLifecycleReplyText,
   isReplyOperationRestartAbort,
+  isReplyOperationStalled,
   isReplyOperationUserAbort,
   resolveRestartLifecycleError,
 } from "./reply-operation-abort.js";
@@ -128,6 +131,16 @@ export async function handleAgentExecutionError(params: {
     params.state.pendingLifecycleTerminal = undefined;
     return terminal;
   };
+  const resolveStalledReplyOperationAction = (stalledError: unknown): ErrorAction | undefined => {
+    if (!isReplyOperationStalled(turn.replyOperation)) {
+      return undefined;
+    }
+    takePendingLifecycleTerminal()?.emit("error", stalledError);
+    // Keep observing late tool settlement, but do not let a non-cooperative tool
+    // delay the user-facing stalled-run terminal reply.
+    void drainPendingToolTasks({ tasks: turn.pendingToolTasks, onTimeout: logVerbose });
+    return { kind: "final", payload: buildStalledRunReplyPayload(turn.isHeartbeat) };
+  };
   const resolveReplyOperationAbortAction = (abortError: unknown): ErrorAction | undefined => {
     if (isReplyOperationRestartAbort(turn.replyOperation)) {
       takePendingLifecycleTerminal()?.emit("end", abortError);
@@ -149,6 +162,10 @@ export async function handleAgentExecutionError(params: {
     try {
       await sleepWithAbort(delayMs, abortSignal);
     } catch (error) {
+      const stalledAction = resolveStalledReplyOperationAction(error);
+      if (stalledAction) {
+        return stalledAction;
+      }
       const abortAction = resolveReplyOperationAbortAction(error);
       if (!abortAction) {
         throw error;
@@ -229,6 +246,13 @@ export async function handleAgentExecutionError(params: {
   const isTransientHttp =
     isTransientHttpError(message) ||
     (isFailoverError(err) && (err.reason === "timeout" || err.reason === "server_error"));
+
+  // Stale recovery records run_stalled before aborting this operation.
+  // Handle it before the broad user-abort predicate so the interruption remains visible.
+  const stalledAction = resolveStalledReplyOperationAction(err);
+  if (stalledAction) {
+    return stalledAction;
+  }
 
   const replyOperationAbortAction = resolveReplyOperationAbortAction(err);
   if (replyOperationAbortAction) {

--- a/src/auto-reply/reply/agent-runner-execution-stalled-recovery.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-stalled-recovery.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createMinimalRunAgentTurnParams,
+  getRunAgentTurnWithFallback,
+  setupAgentRunnerExecutionTestState,
+} from "./agent-runner-execution.test-support.js";
+import { HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT } from "./agent-runner-failure-copy.js";
+import { createReplyOperation, expireStaleReplyOperation } from "./reply-run-registry.js";
+
+const state = setupAgentRunnerExecutionTestState();
+
+function createStalledReplyOperation(sessionId: string) {
+  const replyOperation = createReplyOperation({
+    sessionKey: `agent:main:${sessionId}`,
+    sessionId,
+    resetTriggered: false,
+  });
+  replyOperation.setPhase("running");
+  return replyOperation;
+}
+
+describe("runAgentTurnWithFallback: stalled recovery", () => {
+  it("surfaces a stalled reply operation after the embedded run returns no payload", async () => {
+    const replyOperation = createStalledReplyOperation("stalled-empty-reply");
+    state.runEmbeddedAgentMock.mockImplementationOnce(async () => {
+      expect(expireStaleReplyOperation(replyOperation, "no_activity")).toBe(true);
+      expect(replyOperation.abortSignal.aborted).toBe(true);
+      return { payloads: [], meta: {} };
+    });
+    let releaseToolTask: () => void = () => undefined;
+    const pendingToolTask = new Promise<void>((resolve) => {
+      releaseToolTask = resolve;
+    });
+    let toolTaskSettled = false;
+    void pendingToolTask.then(() => {
+      toolTaskSettled = true;
+    });
+    const pendingToolTasks = new Set([pendingToolTask]);
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const pending = runAgentTurnWithFallback({
+      ...createMinimalRunAgentTurnParams({ replyOperation }),
+      pendingToolTasks,
+    });
+    let result: Awaited<typeof pending> | undefined;
+    void pending.then((value) => {
+      result = value;
+    });
+    await vi.waitFor(() => {
+      expect(result).toEqual({
+        kind: "final",
+        payload: {
+          text: "⚠️ This turn was interrupted because it stopped making progress. Please try again.",
+          isError: true,
+        },
+      });
+    });
+    expect(toolTaskSettled).toBe(false);
+    releaseToolTask();
+    await pendingToolTask;
+    await vi.waitFor(() => {
+      expect(pendingToolTasks.size).toBe(0);
+    });
+  });
+
+  it("surfaces a stalled reply operation after its aborted embedded run rejects", async () => {
+    const replyOperation = createStalledReplyOperation("stalled-rejected-reply");
+    state.runEmbeddedAgentMock.mockImplementationOnce(async () => {
+      expect(expireStaleReplyOperation(replyOperation, "no_activity")).toBe(true);
+      expect(replyOperation.abortSignal.aborted).toBe(true);
+      throw new Error("embedded run aborted after stale recovery");
+    });
+    let releaseToolTask: () => void = () => undefined;
+    const pendingToolTask = new Promise<void>((resolve) => {
+      releaseToolTask = resolve;
+    });
+    let toolTaskSettled = false;
+    void pendingToolTask.then(() => {
+      toolTaskSettled = true;
+    });
+    const pendingToolTasks = new Set([pendingToolTask]);
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const pending = runAgentTurnWithFallback({
+      ...createMinimalRunAgentTurnParams({ replyOperation }),
+      pendingToolTasks,
+    });
+    let result: Awaited<typeof pending> | undefined;
+    void pending.then((value) => {
+      result = value;
+    });
+    await vi.waitFor(() => {
+      expect(result).toEqual({
+        kind: "final",
+        payload: {
+          text: "⚠️ This turn was interrupted because it stopped making progress. Please try again.",
+          isError: true,
+        },
+      });
+    });
+    expect(toolTaskSettled).toBe(false);
+    releaseToolTask();
+    await pendingToolTask;
+    await vi.waitFor(() => {
+      expect(pendingToolTasks.size).toBe(0);
+    });
+  });
+
+  it("surfaces a stalled reply operation when stale recovery interrupts retry backoff", async () => {
+    vi.useFakeTimers();
+    const replyOperation = createStalledReplyOperation("stalled-retry-backoff");
+    state.runEmbeddedAgentMock.mockRejectedValue(new Error("model is overloaded"));
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const pending = runAgentTurnWithFallback(createMinimalRunAgentTurnParams({ replyOperation }));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(state.runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
+
+    expect(expireStaleReplyOperation(replyOperation, "no_activity")).toBe(true);
+    await vi.advanceTimersByTimeAsync(0);
+
+    await expect(pending).resolves.toEqual({
+      kind: "final",
+      payload: {
+        text: "⚠️ This turn was interrupted because it stopped making progress. Please try again.",
+        isError: true,
+      },
+    });
+    expect(state.runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses heartbeat failure copy for a stalled heartbeat operation", async () => {
+    const replyOperation = createStalledReplyOperation("stalled-heartbeat");
+    state.runEmbeddedAgentMock.mockImplementationOnce(async () => {
+      expect(expireStaleReplyOperation(replyOperation, "no_activity")).toBe(true);
+      return { payloads: [], meta: {} };
+    });
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      ...createMinimalRunAgentTurnParams({ replyOperation }),
+      isHeartbeat: true,
+    });
+
+    expect(result).toEqual({
+      kind: "final",
+      payload: {
+        text: HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT,
+        isError: true,
+      },
+    });
+  });
+});

--- a/src/auto-reply/reply/agent-runner-failure-copy.ts
+++ b/src/auto-reply/reply/agent-runner-failure-copy.ts
@@ -13,6 +13,9 @@ export function buildControlUiAgentFailureText(errorText: string): string {
   return `⚠️ Agent failed before reply: ${trimmedError}.\n${CONTROL_UI_LOG_HINT}`;
 }
 
+export const STALLED_RUN_FAILURE_TEXT =
+  "⚠️ This turn was interrupted because it stopped making progress. Please try again.";
+
 /** True when text is exactly the generic external run failure copy. */
 function isGenericExternalRunFailureText(text: string | undefined): boolean {
   return text?.trim() === GENERIC_EXTERNAL_RUN_FAILURE_TEXT;

--- a/src/auto-reply/reply/agent-runner-failure-reply.ts
+++ b/src/auto-reply/reply/agent-runner-failure-reply.ts
@@ -36,6 +36,7 @@ import type { ReplyPayload } from "../types.js";
 import {
   GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
   HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT,
+  STALLED_RUN_FAILURE_TEXT,
 } from "./agent-runner-failure-copy.js";
 import { classifyProviderRequestError } from "./provider-request-error-classifier.js";
 
@@ -471,6 +472,12 @@ export function markAgentRunFailureReplyPayload<T extends ReplyPayload>(payload:
     marked.isError = true;
   }
   return marked;
+}
+
+export function buildStalledRunReplyPayload(isHeartbeat: boolean): ReplyPayload {
+  return markAgentRunFailureReplyPayload({
+    text: isHeartbeat ? HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT : STALLED_RUN_FAILURE_TEXT,
+  });
 }
 
 export function buildTerminalAgentRunFailureReplyPayload(params: {

--- a/src/auto-reply/reply/agent-runner-fallback-settlement.ts
+++ b/src/auto-reply/reply/agent-runner-fallback-settlement.ts
@@ -10,7 +10,10 @@ import { defaultRuntime } from "../../runtime.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import { buildContextOverflowRecoveryText } from "./agent-runner-context-recovery.js";
 import { buildControlUiAgentFailureText } from "./agent-runner-failure-copy.js";
-import { markAgentRunFailureReplyPayload } from "./agent-runner-failure-reply.js";
+import {
+  buildStalledRunReplyPayload,
+  markAgentRunFailureReplyPayload,
+} from "./agent-runner-failure-reply.js";
 import type { AgentFallbackCandidatesResult } from "./agent-runner-fallback-candidate.js";
 import type {
   AgentFallbackCycleParams,
@@ -23,6 +26,7 @@ import {
 } from "./provider-request-error-classifier.js";
 import {
   isReplyOperationRestartAbort,
+  isReplyOperationStalled,
   isReplyOperationUserAbort,
 } from "./reply-operation-abort.js";
 
@@ -48,6 +52,18 @@ export async function settleAgentFallbackCycle(params: {
     throw isAgentRunRestartAbortReason(cycle.runAbortSignal?.reason)
       ? cycle.runAbortSignal?.reason
       : createAgentRunRestartAbortError();
+  }
+  // Stale recovery records run_stalled before aborting this operation.
+  // Prefer that terminal cause so the broader abort-signal fallback does not hide its reply.
+  if (isReplyOperationStalled(turn.replyOperation)) {
+    settledLifecycleTerminal?.emit(
+      "error",
+      new Error("Reply operation expired after making no progress"),
+    );
+    // Keep observing late tool settlement, but do not let a non-cooperative tool
+    // delay the user-facing stalled-run terminal reply.
+    void drainPendingToolTasks({ tasks: turn.pendingToolTasks, onTimeout: logVerbose });
+    return { kind: "final", payload: buildStalledRunReplyPayload(turn.isHeartbeat) };
   }
   if (isReplyOperationUserAbort(turn.replyOperation)) {
     settledLifecycleTerminal?.emit("end", runResult);

--- a/src/auto-reply/reply/reply-operation-abort.ts
+++ b/src/auto-reply/reply/reply-operation-abort.ts
@@ -29,6 +29,10 @@ export function isReplyOperationRestartAbort(replyOperation?: ReplyOperation): b
   return abortSignal?.aborted === true && isAgentRunRestartAbortReason(abortSignal.reason);
 }
 
+export function isReplyOperationStalled(replyOperation?: ReplyOperation): boolean {
+  return replyOperation?.result?.kind === "failed" && replyOperation.result.code === "run_stalled";
+}
+
 export function resolveRestartLifecycleError(
   error: unknown,
 ): GatewayDrainingError | CommandLaneClearedError | undefined {


### PR DESCRIPTION
Refs #103905

Complements #110704. This PR covers only the user-visible terminal-notice half;
it intentionally contains no tool-wrapper changes.

## What Problem This Solves

When stale-session recovery aborts a turn, the reply operation records
`run_stalled`, but later terminal projection can treat the same operation as a
generic user abort and return no payload. The user can therefore see a draft
disappear without any explanation or retry guidance.

## Why This Change Was Made

Stalled reply operations now retain their recorded `run_stalled` cause ahead of
the broader abort projection in both terminal paths. The same ordering is also
applied when recovery interrupts transient-error retry backoff, which otherwise
bypasses the top-level error check.

The visible stalled-run payload is returned without waiting for pending tool
tasks. Late tool settlement continues to be observed and drained in the
background, so a non-cooperative tool cannot delay the user-facing interruption.
Explicit user and restart abort behavior is unchanged.

This is a current-main, terminal-reply-only successor to the useful direction in
closed PR #103990. The in-flight tool-promise half is deliberately left to open
PR #110704 to avoid duplicate implementation and review surface.

## User Impact

Users whose stalled turn is reclaimed receive a clear interruption message and
retry guidance instead of silence. Heartbeat operations retain their existing
heartbeat-specific failure copy.

## Evidence

Behavior addressed: stale-session recovery silently projecting a recorded
`run_stalled` result as a generic abort, or delaying its visible interruption
until a non-cooperative pending tool settles.

Real setup tested: isolated current-main source checkout exercising the
production reply runner and real reply-operation registry expiry seam. Provider
execution was stubbed to trigger recovery deterministically; no live Gateway or
channel deployment was used.

Exact steps or command run after this patch:

- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution-stalled-recovery.test.ts`
- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution-*.test.ts`
- targeted `oxfmt --check` and `oxlint` on all changed files
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- `git diff --check origin/main...HEAD`

Evidence after fix: the focused suite passed 1 file / 4 tests. Both empty-result
and rejected-run projections produced the visible `final` payload while an
abort-ignoring tool promise was still unresolved; after the promise was released,
the pending-task set drained to zero. Retry-backoff interruption and heartbeat
copy are also covered. Both typecheck lanes, formatting, lint, and diff hygiene
passed.

The split execution suite passed 192 / 193 tests locally. Its single failure is
an unchanged thinking-level expectation (`ultra` versus `high`) in
`agent-runner-execution-lifecycle.test.ts`; the identical failure reproduces in
a disposable current-main worktree, so it is baseline drift rather than this
patch.

The current-main negative control reproduced the original silent projection
through the same terminal seam:

```text
PRE_FIX_TERMINAL {"kind":"final","payload":{"text":"NO_REPLY"}}
```

Observed result after fix: the patched seam returned a `final`, error-marked
visible interruption payload instead of `NO_REPLY`, without waiting for the
unresolved pending tool. Late task settlement remained observed and was removed
from the pending set after release.

What was not tested: no full Gateway-plus-channel reproduction with a
multi-minute stalled turn. The validated boundary is the current-main
reply-operation settlement path immediately before outbound delivery.

AI-assisted: implementation and tests were produced with Codex assistance, then
manually reviewed against the current caller graph and validated in an isolated
checkout.
