### PR TITLE
fix(whatsapp): prevent concurrent source account startup failures

### DIFF
--- a/extensions/whatsapp/src/channel-runtime-loader.test.ts
+++ b/extensions/whatsapp/src/channel-runtime-loader.test.ts
@@ -1,0 +1,72 @@
+// Whatsapp tests cover the source-safe channel runtime loading boundary.
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { describe, expect, it, vi } from "vitest";
+import { isWhatsAppAuthConfigured, loadWhatsAppChannelRuntime } from "./channel-runtime-loader.js";
+
+const runtimeLoads = vi.hoisted(() => ({
+  order: [] as string[],
+  readWebAuthState: vi.fn(async () => "linked" as const),
+}));
+
+vi.mock("./auth-store.js", () => {
+  runtimeLoads.order.push("auth-store");
+  return { readWebAuthState: runtimeLoads.readWebAuthState };
+});
+
+vi.mock("./channel.runtime.js", () => {
+  runtimeLoads.order.push("channel-runtime");
+  return { monitorWebChannel: vi.fn() };
+});
+
+const sourceDir = fileURLToPath(new URL(".", import.meta.url));
+
+function listChannelRuntimeImportOwners(): string[] {
+  const owners: string[] = [];
+  for (const relativePath of readdirSync(sourceDir, { encoding: "utf8", recursive: true })) {
+    if (!relativePath.endsWith(".ts") || relativePath.includes(".test")) {
+      continue;
+    }
+    const filePath = path.join(sourceDir, relativePath);
+    const sourceFile = ts.createSourceFile(
+      filePath,
+      readFileSync(filePath, "utf8"),
+      ts.ScriptTarget.Latest,
+      true,
+    );
+    const visit = (node: ts.Node) => {
+      if (
+        ts.isCallExpression(node) &&
+        node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+        node.arguments.some(
+          (argument) =>
+            ts.isStringLiteral(argument) && argument.text.endsWith("channel.runtime.js"),
+        )
+      ) {
+        owners.push(relativePath);
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+  }
+  return owners.toSorted();
+}
+
+describe("WhatsApp channel runtime loader", () => {
+  it("shares imports and resolves auth before the channel runtime", async () => {
+    const firstRuntimeLoad = loadWhatsAppChannelRuntime();
+
+    expect(loadWhatsAppChannelRuntime()).toBe(firstRuntimeLoad);
+    await expect(
+      Promise.all([isWhatsAppAuthConfigured("/tmp/default"), firstRuntimeLoad]),
+    ).resolves.toEqual([true, expect.any(Object)]);
+    expect(runtimeLoads.order).toEqual(["auth-store", "channel-runtime"]);
+    expect(runtimeLoads.readWebAuthState).toHaveBeenCalledOnce();
+  });
+
+  it("keeps one production owner for the channel runtime import", () => {
+    expect(listChannelRuntimeImportOwners()).toEqual(["channel-runtime-loader.ts"]);
+  });
+});

--- a/extensions/whatsapp/src/channel-runtime-loader.ts
+++ b/extensions/whatsapp/src/channel-runtime-loader.ts
@@ -1,0 +1,16 @@
+// Whatsapp plugin module owns the source-safe channel runtime loading boundary.
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
+
+const loadWhatsAppAuthStore = createLazyRuntimeModule(() => import("./auth-store.js"));
+
+export async function isWhatsAppAuthConfigured(authDir: string): Promise<boolean> {
+  const authStore = await loadWhatsAppAuthStore();
+  return (await authStore.readWebAuthState(authDir)) === "linked";
+}
+
+// Source-loaded entry points must share this promise. Preloading auth-store keeps
+// Jiti from exposing its partially evaluated exports through channel.runtime.
+export const loadWhatsAppChannelRuntime = createLazyRuntimeModule(async () => {
+  await loadWhatsAppAuthStore();
+  return await import("./channel.runtime.js");
+});

--- a/extensions/whatsapp/src/channel.setup.ts
+++ b/extensions/whatsapp/src/channel.setup.ts
@@ -1,6 +1,7 @@
 // Whatsapp plugin module implements channel.setup behavior.
 import type { ChannelPlugin } from "openclaw/plugin-sdk/core";
 import type { ResolvedWhatsAppAccount } from "./accounts.js";
+import { isWhatsAppAuthConfigured } from "./channel-runtime-loader.js";
 import {
   resolveWhatsAppGroupRequireMention,
   resolveWhatsAppGroupToolPolicy,
@@ -8,11 +9,6 @@ import {
 import { whatsappSetupAdapter } from "./setup-core.js";
 import { createWhatsAppPluginBase, whatsappSetupWizardProxy } from "./shared.js";
 import { detectWhatsAppLegacyStateMigrations } from "./state-migrations.js";
-
-async function isWhatsAppAuthConfigured(account: ResolvedWhatsAppAccount): Promise<boolean> {
-  const { readWebAuthState } = await import("./auth-store.js");
-  return (await readWebAuthState(account.authDir)) === "linked";
-}
 
 export const whatsappSetupPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
   ...createWhatsAppPluginBase({
@@ -22,7 +18,7 @@ export const whatsappSetupPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
     },
     setupWizard: whatsappSetupWizardProxy,
     setup: whatsappSetupAdapter,
-    isConfigured: isWhatsAppAuthConfigured,
+    isConfigured: async (account) => await isWhatsAppAuthConfigured(account.authDir),
   }),
   lifecycle: {
     detectLegacyStateMigrations: ({ oauthDir }) =>

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -16,6 +16,7 @@ import {
   resolveWhatsAppAgentReactionGuidance,
 } from "./channel-actions.js";
 import { whatsappChannelOutbound, whatsappMessageAdapter } from "./channel-outbound.js";
+import { isWhatsAppAuthConfigured, loadWhatsAppChannelRuntime } from "./channel-runtime-loader.js";
 import { whatsappCommandPolicy } from "./command-policy.js";
 import { formatWhatsAppConfigAllowFromEntries } from "./config-accessors.js";
 import { resolveWhatsAppMentionStripRegexes } from "./group-intro.js";
@@ -36,11 +37,7 @@ import { getWhatsAppRuntime } from "./runtime.js";
 import { sendTypingWhatsApp } from "./send.js";
 import { resolveWhatsAppOutboundSessionRoute } from "./session-route.js";
 import { whatsappSetupAdapter } from "./setup-core.js";
-import {
-  createWhatsAppPluginBase,
-  loadWhatsAppChannelRuntime,
-  whatsappSetupWizardProxy,
-} from "./shared.js";
+import { createWhatsAppPluginBase, whatsappSetupWizardProxy } from "./shared.js";
 import { detectWhatsAppLegacyStateMigrations } from "./state-migrations.js";
 import { collectWhatsAppStatusIssues } from "./status-issues.js";
 
@@ -85,10 +82,7 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> =
         },
         setupWizard: whatsappSetupWizardProxy,
         setup: whatsappSetupAdapter,
-        isConfigured: async (account) => {
-          const channelRuntime = await loadWhatsAppChannelRuntime();
-          return (await channelRuntime.readWebAuthState(account.authDir)) === "linked";
-        },
+        isConfigured: async (account) => await isWhatsAppAuthConfigured(account.authDir),
       }),
       agentTools: () => [createWhatsAppLoginTool()],
       allowlist: buildDmGroupAccountAllowlistAdapter({

--- a/extensions/whatsapp/src/heartbeat.ts
+++ b/extensions/whatsapp/src/heartbeat.ts
@@ -1,8 +1,8 @@
 // Whatsapp plugin module implements heartbeat behavior.
 import { resolveWhatsAppAccount } from "./accounts.js";
 import { readWebAuthExistsForDecision, WHATSAPP_AUTH_UNSTABLE_CODE } from "./auth-store.js";
+import { loadWhatsAppChannelRuntime } from "./channel-runtime-loader.js";
 import type { OpenClawConfig } from "./runtime-api.js";
-import { loadWhatsAppChannelRuntime } from "./shared.js";
 
 export async function checkWhatsAppHeartbeatReady(params: {
   cfg: OpenClawConfig;

--- a/extensions/whatsapp/src/runtime-api.ts
+++ b/extensions/whatsapp/src/runtime-api.ts
@@ -1,4 +1,3 @@
-import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 // Whatsapp API module exposes the plugin public contract.
 export { getChatChannelMeta, type ChannelPlugin } from "openclaw/plugin-sdk/core";
 export { buildChannelConfigSchema, WhatsAppConfigSchema } from "../config-api.js";
@@ -18,6 +17,7 @@ export {
 export { normalizeE164 } from "openclaw/plugin-sdk/account-resolution";
 export type { DmPolicy, GroupPolicy } from "openclaw/plugin-sdk/config-contracts";
 import type { OpenClawConfig as RuntimeOpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { loadWhatsAppChannelRuntime } from "./channel-runtime-loader.js";
 
 export { type ChannelMessageActionName } from "openclaw/plugin-sdk/channel-contract";
 export { loadOutboundMediaFromUrl } from "./outbound-media.runtime.js";
@@ -46,11 +46,9 @@ export type { WhatsAppAccountConfig } from "./account-types.js";
 
 type MonitorWebChannel = typeof import("./channel.runtime.js").monitorWebChannel;
 
-const loadChannelRuntime = createLazyRuntimeModule(() => import("./channel.runtime.js"));
-
 export async function monitorWebChannel(
   ...args: Parameters<MonitorWebChannel>
 ): ReturnType<MonitorWebChannel> {
-  const { monitorWebChannel: monitorWebChannelLocal } = await loadChannelRuntime();
+  const { monitorWebChannel: monitorWebChannelLocal } = await loadWhatsAppChannelRuntime();
   return await monitorWebChannelLocal(...args);
 }

--- a/extensions/whatsapp/src/shared.ts
+++ b/extensions/whatsapp/src/shared.ts
@@ -41,10 +41,6 @@ import {
 
 const WHATSAPP_CHANNEL = "whatsapp" as const;
 
-export async function loadWhatsAppChannelRuntime() {
-  return await import("./channel.runtime.js");
-}
-
 async function loadWhatsAppSetupSurface() {
   return await import("./setup-surface.js");
 }


### PR DESCRIPTION
Related: #109526

## What Problem This Solves

When multiple WhatsApp accounts start concurrently from a TypeScript source checkout, Jiti 2.7.0 can expose an incompletely evaluated auth module. One account can then fail with a `readWebAuthState` error and remain stopped while another account starts normally.

## Why This Change Was Made

The WhatsApp plugin previously had separate lazy-import owners for the full channel runtime. Concurrent first imports could therefore reach `channel.runtime` before its auth dependency had finished evaluating.

This change gives the plugin one private, cached loading boundary shared by channel startup, setup, heartbeat, and the public runtime facade. The loader resolves the auth store before importing `channel.runtime`, while keeping the full runtime lazy. This addresses the loader race without retries or gateway-wide account serialization.

A regression test covers promise sharing, auth-before-runtime ordering, and the invariant that production code has exactly one dynamic import owner for `channel.runtime`.

## User Impact

Multiple configured WhatsApp accounts can start concurrently from a TypeScript source checkout without one account being left stopped by this loader race. Packaged installations are unaffected by the source-loader failure mode, and no configuration or migration is required.

## Evidence

- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs extensions/whatsapp/src/channel-runtime-loader.test.ts extensions/whatsapp/src/channel.setup.test.ts`
- `pnpm check:changed` on Blacksmith Testbox — passed
- `pnpm build` on the same Testbox — passed with no `[INEFFECTIVE_DYNAMIC_IMPORT]` warning
- Autoreview (`--mode uncommitted`) — clean, with no accepted or actionable findings

Remote proof: https://github.com/openclaw/openclaw/actions/runs/29667226547

Not run: credentialed two-account live WhatsApp startup.
