### PR TITLE
fix(model-pricing): add DNS-resolution safety to pricing cache endpoint guard

### DIFF
--- a/src/gateway/model-pricing-cache.test.ts
+++ b/src/gateway/model-pricing-cache.test.ts
@@ -352,9 +352,9 @@ describe("model-pricing-cache", () => {
     ).toBeUndefined();
   });
 
-  it("skips remote pricing for .local DNS hostnames (fail-closed DNS-rebinding guard)", async () => {
-    // .local DNS hostnames are classified as private without DNS resolution
-    // by isPrivateOrLoopbackResolvedHost — prevents DNS-rebinding SSRF where
+  it("skips remote pricing for .local DNS hostnames (static host-classifier guard)", async () => {
+    // .local DNS hostnames are classified as private by the canonical
+    // isPrivateOrLoopbackHost — prevents DNS-rebinding SSRF where
     // a .local name could resolve to a loopback address on the host.
     const config = {
       agents: {
@@ -385,9 +385,9 @@ describe("model-pricing-cache", () => {
     ).toBeUndefined();
   });
 
-  it("skips remote pricing for .localhost DNS hostnames (fail-closed DNS-rebinding guard)", async () => {
-    // .localhost DNS hostnames are classified as private without DNS
-    // resolution — same fail-closed boundary as .local.
+  it("skips remote pricing for .localhost DNS hostnames (static host-classifier guard)", async () => {
+    // .localhost DNS hostnames are classified as private by the canonical
+    // isPrivateOrLoopbackHost — same static boundary as .local.
     const config = {
       agents: {
         defaults: {

--- a/src/gateway/model-pricing-cache.test.ts
+++ b/src/gateway/model-pricing-cache.test.ts
@@ -352,6 +352,65 @@ describe("model-pricing-cache", () => {
     ).toBeUndefined();
   });
 
+  it("skips remote pricing for .local DNS hostnames (fail-closed DNS-rebinding guard)", async () => {
+    // .local DNS hostnames are classified as private without DNS resolution
+    // by isPrivateOrLoopbackResolvedHost — prevents DNS-rebinding SSRF where
+    // a .local name could resolve to a loopback address on the host.
+    const config = {
+      agents: {
+        defaults: {
+          model: { primary: "local-model/qwen2.5-coder:7b" },
+        },
+      },
+      models: {
+        providers: {
+          "local-model": {
+            baseUrl: "http://my-gpu.internal.local:8000/v1",
+            api: "openai-completions",
+            models: [{ id: "qwen2.5-coder:7b" }],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const fetchImpl = vi.fn<typeof fetch>();
+
+    await runGatewayModelPricingRefresh({ config, fetchImpl });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(
+      getCachedGatewayModelPricing({
+        provider: "local-model",
+        model: "qwen2.5-coder:7b",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("skips remote pricing for .localhost DNS hostnames (fail-closed DNS-rebinding guard)", async () => {
+    // .localhost DNS hostnames are classified as private without DNS
+    // resolution — same fail-closed boundary as .local.
+    const config = {
+      agents: {
+        defaults: {
+          model: { primary: "local-model/qwen2.5-coder:7b" },
+        },
+      },
+      models: {
+        providers: {
+          "local-model": {
+            baseUrl: "http://llm.internal.localhost:11434",
+            api: "ollama",
+            models: [{ id: "qwen2.5-coder:7b" }],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const fetchImpl = vi.fn<typeof fetch>();
+
+    await runGatewayModelPricingRefresh({ config, fetchImpl });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
   it("records and clears remote pricing source failures for health surfaces", async () => {
     const config = {
       agents: {

--- a/src/gateway/model-pricing-cache.ts
+++ b/src/gateway/model-pricing-cache.ts
@@ -786,30 +786,11 @@ function addConfiguredWebSearchPluginModels(params: {
   }
 }
 
-function isPrivateOrLoopbackHost(hostname: string): boolean {
-  const host = hostname
-    .trim()
-    .toLowerCase()
-    .replace(/^\[|\]$/g, "");
-  if (
-    host === "localhost" ||
-    host === "localhost.localdomain" ||
-    host.endsWith(".localhost") ||
-    host.endsWith(".local")
-  ) {
-    return true;
-  }
-  if (host === "::1" || host === "0:0:0:0:0:0:0:1" || host.startsWith("fe80:")) {
-    return true;
-  }
-  if (host.startsWith("fc") || host.startsWith("fd")) {
-    return true;
-  }
-  if (host.startsWith("127.") || host.startsWith("10.") || host.startsWith("192.168.")) {
-    return true;
-  }
-  return /^172\.(1[6-9]|2\d|3[0-1])\./u.test(host) || host.startsWith("169.254.");
-}
+import { isPrivateOrLoopbackHost } from "./net.js";
+
+// Removed local isPrivateOrLoopbackHost — canonical implementation in net.ts
+// handles all hostname formats (bracketed IPv6, localhost variants) and uses
+// proper IP-based classification instead of string-prefix matching.
 
 function isPrivateOrLoopbackBaseUrl(baseUrl: string | undefined): boolean {
   if (!baseUrl) {

--- a/src/gateway/model-pricing-cache.ts
+++ b/src/gateway/model-pricing-cache.ts
@@ -41,6 +41,7 @@ import {
   type CachedPricingTier,
 } from "./model-pricing-cache-state.js";
 import { isGatewayModelPricingEnabled } from "./model-pricing-config.js";
+import { isPrivateOrLoopbackHost } from "./net.js";
 
 type OpenRouterPricingEntry = {
   id: string;
@@ -786,24 +787,12 @@ function addConfiguredWebSearchPluginModels(params: {
   }
 }
 
-import { isPrivateOrLoopbackResolvedHost } from "./net.js";
-
-// Pricing-cache endpoint safety boundary: resolves DNS hostnames and checks
-// whether any resolved address is private/loopback.  IP literals are delegated
-// to the canonical isPrivateOrLoopbackHost; DNS failures are fail-closed (treat
-// as private) to prevent DNS-rebinding SSRF bypasses.
-// Replaces the former 25-line local isPrivateOrLoopbackHost duplicate, which
-// used bare string-prefix checks that were vulnerable to DNS hostnames
-// resembling private-IP prefixes (e.g. "127.evil.com").
-
-async function isPrivateOrLoopbackBaseUrl(
-  baseUrl: string | undefined,
-): Promise<boolean> {
+function isPrivateOrLoopbackBaseUrl(baseUrl: string | undefined): boolean {
   if (!baseUrl) {
     return false;
   }
   try {
-    return await isPrivateOrLoopbackResolvedHost(new URL(baseUrl).hostname);
+    return isPrivateOrLoopbackHost(new URL(baseUrl).hostname);
   } catch {
     return false;
   }
@@ -839,24 +828,23 @@ function getConfiguredModelPricing(
   return toCachedModelPricing(findConfiguredProviderModel(config, ref, options)?.cost);
 }
 
-async function hasPrivateOrLoopbackConfiguredEndpoint(
+function hasPrivateOrLoopbackConfiguredEndpoint(
   config: OpenClawConfig,
   ref: ModelRef,
   options: PricingModelNormalizationOptions = {
     allowManifestNormalization: true,
     allowPluginNormalization: true,
   },
-): Promise<boolean> {
+): boolean {
   const providerConfig = config.models?.providers?.[ref.provider];
   const model = findConfiguredProviderModel(config, ref, options);
-  const [modelPrivate, providerPrivate] = await Promise.all([
-    isPrivateOrLoopbackBaseUrl(model?.baseUrl),
-    isPrivateOrLoopbackBaseUrl(providerConfig?.baseUrl),
-  ]);
-  return modelPrivate || providerPrivate;
+  return (
+    isPrivateOrLoopbackBaseUrl(model?.baseUrl) ||
+    isPrivateOrLoopbackBaseUrl(providerConfig?.baseUrl)
+  );
 }
 
-async function shouldFetchExternalPricingForRef(params: {
+function shouldFetchExternalPricingForRef(params: {
   config: OpenClawConfig;
   ref: ModelRef;
   policies: ReadonlyMap<string, ExternalPricingPolicy>;
@@ -864,12 +852,12 @@ async function shouldFetchExternalPricingForRef(params: {
   allowManifestNormalization: boolean;
   allowPluginNormalization: boolean;
   manifestPlugins?: PluginManifestRegistry["plugins"];
-}): Promise<boolean> {
+}): boolean {
   if (params.seededPricing.has(modelKey(params.ref.provider, params.ref.model))) {
     return false;
   }
   if (
-    await hasPrivateOrLoopbackConfiguredEndpoint(params.config, params.ref, {
+    hasPrivateOrLoopbackConfiguredEndpoint(params.config, params.ref, {
       allowManifestNormalization: params.allowManifestNormalization,
       allowPluginNormalization: params.allowPluginNormalization,
       manifestPlugins: params.manifestPlugins,
@@ -883,7 +871,7 @@ async function shouldFetchExternalPricingForRef(params: {
   return true;
 }
 
-async function filterExternalPricingRefs(params: {
+function filterExternalPricingRefs(params: {
   config: OpenClawConfig;
   refs: ModelRef[];
   policies: ReadonlyMap<string, ExternalPricingPolicy>;
@@ -891,21 +879,18 @@ async function filterExternalPricingRefs(params: {
   allowManifestNormalization: boolean;
   allowPluginNormalization: boolean;
   manifestPlugins?: PluginManifestRegistry["plugins"];
-}): Promise<ModelRef[]> {
-  const results = await Promise.all(
-    params.refs.map((ref) =>
-      shouldFetchExternalPricingForRef({
-        config: params.config,
-        ref,
-        policies: params.policies,
-        seededPricing: params.seededPricing,
-        allowManifestNormalization: params.allowManifestNormalization,
-        allowPluginNormalization: params.allowPluginNormalization,
-        manifestPlugins: params.manifestPlugins,
-      }),
-    ),
+}): ModelRef[] {
+  return params.refs.filter((ref) =>
+    shouldFetchExternalPricingForRef({
+      config: params.config,
+      ref,
+      policies: params.policies,
+      seededPricing: params.seededPricing,
+      allowManifestNormalization: params.allowManifestNormalization,
+      allowPluginNormalization: params.allowPluginNormalization,
+      manifestPlugins: params.manifestPlugins,
+    }),
   );
-  return params.refs.filter((_, i) => results[i]);
 }
 
 function collectConfiguredModelPricingRefs(
@@ -1257,7 +1242,7 @@ async function refreshGatewayModelPricingCache(
       catalogPricing: pricingContext.catalogPricing,
       ...normalizationParams,
     });
-    const refs = await filterExternalPricingRefs({
+    const refs = filterExternalPricingRefs({
       config: params.config,
       refs: allRefs,
       policies: pricingContext.policies,

--- a/src/gateway/model-pricing-cache.ts
+++ b/src/gateway/model-pricing-cache.ts
@@ -792,7 +792,26 @@ function isPrivateOrLoopbackBaseUrl(baseUrl: string | undefined): boolean {
     return false;
   }
   try {
-    return isPrivateOrLoopbackHost(new URL(baseUrl).hostname);
+    const hostname = new URL(baseUrl).hostname;
+    // Canonical IP/loopback classifier (shared gateway predicate).
+    if (isPrivateOrLoopbackHost(hostname)) {
+      return true;
+    }
+    // Pricing-specific local-DNS hostname patterns that conventionally
+    // resolve to loopback or link-local addresses.  Kept out of the
+    // shared isPrivateOrLoopbackHost predicate because local-DNS
+    // treatment is context-specific — e.g. the plaintext-WebSocket
+    // trust path handles .local separately as an explicit policy
+    // choice rather than a universal address-classification rule.
+    const lower = hostname.toLowerCase();
+    if (
+      lower === "localhost.localdomain" ||
+      lower.endsWith(".localhost") ||
+      lower.endsWith(".local")
+    ) {
+      return true;
+    }
+    return false;
   } catch {
     return false;
   }

--- a/src/gateway/model-pricing-cache.ts
+++ b/src/gateway/model-pricing-cache.ts
@@ -786,18 +786,24 @@ function addConfiguredWebSearchPluginModels(params: {
   }
 }
 
-import { isPrivateOrLoopbackHost } from "./net.js";
+import { isPrivateOrLoopbackResolvedHost } from "./net.js";
 
-// Removed local isPrivateOrLoopbackHost — canonical implementation in net.ts
-// handles all hostname formats (bracketed IPv6, localhost variants) and uses
-// proper IP-based classification instead of string-prefix matching.
+// Pricing-cache endpoint safety boundary: resolves DNS hostnames and checks
+// whether any resolved address is private/loopback.  IP literals are delegated
+// to the canonical isPrivateOrLoopbackHost; DNS failures are fail-closed (treat
+// as private) to prevent DNS-rebinding SSRF bypasses.
+// Replaces the former 25-line local isPrivateOrLoopbackHost duplicate, which
+// used bare string-prefix checks that were vulnerable to DNS hostnames
+// resembling private-IP prefixes (e.g. "127.evil.com").
 
-function isPrivateOrLoopbackBaseUrl(baseUrl: string | undefined): boolean {
+async function isPrivateOrLoopbackBaseUrl(
+  baseUrl: string | undefined,
+): Promise<boolean> {
   if (!baseUrl) {
     return false;
   }
   try {
-    return isPrivateOrLoopbackHost(new URL(baseUrl).hostname);
+    return await isPrivateOrLoopbackResolvedHost(new URL(baseUrl).hostname);
   } catch {
     return false;
   }
@@ -833,23 +839,24 @@ function getConfiguredModelPricing(
   return toCachedModelPricing(findConfiguredProviderModel(config, ref, options)?.cost);
 }
 
-function hasPrivateOrLoopbackConfiguredEndpoint(
+async function hasPrivateOrLoopbackConfiguredEndpoint(
   config: OpenClawConfig,
   ref: ModelRef,
   options: PricingModelNormalizationOptions = {
     allowManifestNormalization: true,
     allowPluginNormalization: true,
   },
-): boolean {
+): Promise<boolean> {
   const providerConfig = config.models?.providers?.[ref.provider];
   const model = findConfiguredProviderModel(config, ref, options);
-  return (
-    isPrivateOrLoopbackBaseUrl(model?.baseUrl) ||
-    isPrivateOrLoopbackBaseUrl(providerConfig?.baseUrl)
-  );
+  const [modelPrivate, providerPrivate] = await Promise.all([
+    isPrivateOrLoopbackBaseUrl(model?.baseUrl),
+    isPrivateOrLoopbackBaseUrl(providerConfig?.baseUrl),
+  ]);
+  return modelPrivate || providerPrivate;
 }
 
-function shouldFetchExternalPricingForRef(params: {
+async function shouldFetchExternalPricingForRef(params: {
   config: OpenClawConfig;
   ref: ModelRef;
   policies: ReadonlyMap<string, ExternalPricingPolicy>;
@@ -857,12 +864,12 @@ function shouldFetchExternalPricingForRef(params: {
   allowManifestNormalization: boolean;
   allowPluginNormalization: boolean;
   manifestPlugins?: PluginManifestRegistry["plugins"];
-}): boolean {
+}): Promise<boolean> {
   if (params.seededPricing.has(modelKey(params.ref.provider, params.ref.model))) {
     return false;
   }
   if (
-    hasPrivateOrLoopbackConfiguredEndpoint(params.config, params.ref, {
+    await hasPrivateOrLoopbackConfiguredEndpoint(params.config, params.ref, {
       allowManifestNormalization: params.allowManifestNormalization,
       allowPluginNormalization: params.allowPluginNormalization,
       manifestPlugins: params.manifestPlugins,
@@ -876,7 +883,7 @@ function shouldFetchExternalPricingForRef(params: {
   return true;
 }
 
-function filterExternalPricingRefs(params: {
+async function filterExternalPricingRefs(params: {
   config: OpenClawConfig;
   refs: ModelRef[];
   policies: ReadonlyMap<string, ExternalPricingPolicy>;
@@ -884,18 +891,21 @@ function filterExternalPricingRefs(params: {
   allowManifestNormalization: boolean;
   allowPluginNormalization: boolean;
   manifestPlugins?: PluginManifestRegistry["plugins"];
-}): ModelRef[] {
-  return params.refs.filter((ref) =>
-    shouldFetchExternalPricingForRef({
-      config: params.config,
-      ref,
-      policies: params.policies,
-      seededPricing: params.seededPricing,
-      allowManifestNormalization: params.allowManifestNormalization,
-      allowPluginNormalization: params.allowPluginNormalization,
-      manifestPlugins: params.manifestPlugins,
-    }),
+}): Promise<ModelRef[]> {
+  const results = await Promise.all(
+    params.refs.map((ref) =>
+      shouldFetchExternalPricingForRef({
+        config: params.config,
+        ref,
+        policies: params.policies,
+        seededPricing: params.seededPricing,
+        allowManifestNormalization: params.allowManifestNormalization,
+        allowPluginNormalization: params.allowPluginNormalization,
+        manifestPlugins: params.manifestPlugins,
+      }),
+    ),
   );
+  return params.refs.filter((_, i) => results[i]);
 }
 
 function collectConfiguredModelPricingRefs(
@@ -1247,7 +1257,7 @@ async function refreshGatewayModelPricingCache(
       catalogPricing: pricingContext.catalogPricing,
       ...normalizationParams,
     });
-    const refs = filterExternalPricingRefs({
+    const refs = await filterExternalPricingRefs({
       config: params.config,
       refs: allRefs,
       policies: pricingContext.policies,

--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -559,13 +559,6 @@ describe("isPrivateOrLoopbackHost", () => {
     expect(isPrivateOrLoopbackHost("")).toBe(false);
   });
 
-  it("accepts local-DNS patterns that conventionally resolve to loopback/link-local", () => {
-    expect(isPrivateOrLoopbackHost("my-gpu.local")).toBe(true);
-    expect(isPrivateOrLoopbackHost("foo.local")).toBe(true);
-    expect(isPrivateOrLoopbackHost("bar.localhost")).toBe(true);
-    expect(isPrivateOrLoopbackHost("localhost.localdomain")).toBe(true);
-  });
-
   it("rejects DNS hostnames that resemble private-IP prefixes (SSRF bypass guard)", () => {
     // DNS hostnames like 127.evil.com must NOT be matched by string-prefix
     // checks.  The canonical function uses isIP() which returns 0 for these.

--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -13,7 +13,6 @@ import {
   isLoopbackHost,
   isPrivateOrLoopbackAddress,
   isPrivateOrLoopbackHost,
-  isPrivateOrLoopbackResolvedHost,
   isSecureWebSocketUrl,
   isTrustedProxyAddress,
   pickPrimaryLanIPv4,
@@ -559,103 +558,21 @@ describe("isPrivateOrLoopbackHost", () => {
   it("rejects empty/falsy input", () => {
     expect(isPrivateOrLoopbackHost("")).toBe(false);
   });
-});
 
-describe("isPrivateOrLoopbackResolvedHost", () => {
-  it("delegates IP literals to the synchronous classifier", async () => {
-    // Private IPv4
-    await expect(isPrivateOrLoopbackResolvedHost("127.0.0.1")).resolves.toBe(true);
-    await expect(isPrivateOrLoopbackResolvedHost("10.0.0.1")).resolves.toBe(true);
-    await expect(isPrivateOrLoopbackResolvedHost("192.168.1.1")).resolves.toBe(true);
-    await expect(isPrivateOrLoopbackResolvedHost("172.16.0.1")).resolves.toBe(true);
-    // Public IPv4
-    await expect(isPrivateOrLoopbackResolvedHost("1.1.1.1")).resolves.toBe(false);
-    await expect(isPrivateOrLoopbackResolvedHost("8.8.8.8")).resolves.toBe(false);
-    // Private IPv6
-    await expect(isPrivateOrLoopbackResolvedHost("[::1]")).resolves.toBe(true);
-    await expect(isPrivateOrLoopbackResolvedHost("[fc00::1]")).resolves.toBe(true);
+  it("accepts local-DNS patterns that conventionally resolve to loopback/link-local", () => {
+    expect(isPrivateOrLoopbackHost("my-gpu.local")).toBe(true);
+    expect(isPrivateOrLoopbackHost("foo.local")).toBe(true);
+    expect(isPrivateOrLoopbackHost("bar.localhost")).toBe(true);
+    expect(isPrivateOrLoopbackHost("localhost.localdomain")).toBe(true);
   });
 
-  it("classifies localhost DNS patterns as private without resolution", async () => {
-    await expect(isPrivateOrLoopbackResolvedHost("localhost")).resolves.toBe(true);
-    await expect(isPrivateOrLoopbackResolvedHost("localhost.localdomain")).resolves.toBe(
-      true,
-    );
-    await expect(isPrivateOrLoopbackResolvedHost("foo.localhost")).resolves.toBe(true);
-    await expect(isPrivateOrLoopbackResolvedHost("foo.local")).resolves.toBe(true);
-    await expect(isPrivateOrLoopbackResolvedHost("bar.local")).resolves.toBe(true);
-  });
-
-  it("returns false for public DNS hostnames with no private resolved addresses", async () => {
-    const dns = await import("node:dns");
-    const resolve4 = vi
-      .spyOn(dns.promises, "resolve4")
-      .mockResolvedValue(["93.184.216.34"]);
-    const resolve6 = vi
-      .spyOn(dns.promises, "resolve6")
-      .mockResolvedValue(["2606:2800:220:1:248:1893:25c8:1946"]);
-
-    await expect(
-      isPrivateOrLoopbackResolvedHost("example.com"),
-    ).resolves.toBe(false);
-
-    resolve4.mockRestore();
-    resolve6.mockRestore();
-  });
-
-  it("returns true (private) when a resolved address is private", async () => {
-    const dns = await import("node:dns");
-    const resolve4 = vi
-      .spyOn(dns.promises, "resolve4")
-      .mockResolvedValue(["10.0.0.5"]);
-    const resolve6 = vi
-      .spyOn(dns.promises, "resolve6")
-      .mockRejectedValue(new Error("ENODATA"));
-
-    await expect(
-      isPrivateOrLoopbackResolvedHost("internal.example.com"),
-    ).resolves.toBe(true);
-
-    resolve4.mockRestore();
-    resolve6.mockRestore();
-  });
-
-  it("fails closed — DNS resolution failure is treated as private", async () => {
-    const dns = await import("node:dns");
-    const resolve4 = vi
-      .spyOn(dns.promises, "resolve4")
-      .mockRejectedValue(new Error("ENOTFOUND"));
-    const resolve6 = vi
-      .spyOn(dns.promises, "resolve6")
-      .mockRejectedValue(new Error("ENOTFOUND"));
-
-    await expect(
-      isPrivateOrLoopbackResolvedHost("nonexistent.internal"),
-    ).resolves.toBe(true);
-
-    resolve4.mockRestore();
-    resolve6.mockRestore();
-  });
-
-  it("fails closed — empty DNS resolution result is treated as private", async () => {
-    const dns = await import("node:dns");
-    const resolve4 = vi
-      .spyOn(dns.promises, "resolve4")
-      .mockResolvedValue([]);
-    const resolve6 = vi
-      .spyOn(dns.promises, "resolve6")
-      .mockRejectedValue(new Error("ENODATA"));
-
-    await expect(
-      isPrivateOrLoopbackResolvedHost("no-addresses.example.com"),
-    ).resolves.toBe(true);
-
-    resolve4.mockRestore();
-    resolve6.mockRestore();
-  });
-
-  it("rejects empty/falsy input", async () => {
-    await expect(isPrivateOrLoopbackResolvedHost("")).resolves.toBe(false);
+  it("rejects DNS hostnames that resemble private-IP prefixes (SSRF bypass guard)", () => {
+    // DNS hostnames like 127.evil.com must NOT be matched by string-prefix
+    // checks.  The canonical function uses isIP() which returns 0 for these.
+    expect(isPrivateOrLoopbackHost("127.evil.com")).toBe(false);
+    expect(isPrivateOrLoopbackHost("10.evil.com")).toBe(false);
+    expect(isPrivateOrLoopbackHost("192.168.evil.com")).toBe(false);
+    expect(isPrivateOrLoopbackHost("172.16.evil.com")).toBe(false);
   });
 });
 

--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -13,6 +13,7 @@ import {
   isLoopbackHost,
   isPrivateOrLoopbackAddress,
   isPrivateOrLoopbackHost,
+  isPrivateOrLoopbackResolvedHost,
   isSecureWebSocketUrl,
   isTrustedProxyAddress,
   pickPrimaryLanIPv4,
@@ -557,6 +558,104 @@ describe("isPrivateOrLoopbackHost", () => {
 
   it("rejects empty/falsy input", () => {
     expect(isPrivateOrLoopbackHost("")).toBe(false);
+  });
+});
+
+describe("isPrivateOrLoopbackResolvedHost", () => {
+  it("delegates IP literals to the synchronous classifier", async () => {
+    // Private IPv4
+    await expect(isPrivateOrLoopbackResolvedHost("127.0.0.1")).resolves.toBe(true);
+    await expect(isPrivateOrLoopbackResolvedHost("10.0.0.1")).resolves.toBe(true);
+    await expect(isPrivateOrLoopbackResolvedHost("192.168.1.1")).resolves.toBe(true);
+    await expect(isPrivateOrLoopbackResolvedHost("172.16.0.1")).resolves.toBe(true);
+    // Public IPv4
+    await expect(isPrivateOrLoopbackResolvedHost("1.1.1.1")).resolves.toBe(false);
+    await expect(isPrivateOrLoopbackResolvedHost("8.8.8.8")).resolves.toBe(false);
+    // Private IPv6
+    await expect(isPrivateOrLoopbackResolvedHost("[::1]")).resolves.toBe(true);
+    await expect(isPrivateOrLoopbackResolvedHost("[fc00::1]")).resolves.toBe(true);
+  });
+
+  it("classifies localhost DNS patterns as private without resolution", async () => {
+    await expect(isPrivateOrLoopbackResolvedHost("localhost")).resolves.toBe(true);
+    await expect(isPrivateOrLoopbackResolvedHost("localhost.localdomain")).resolves.toBe(
+      true,
+    );
+    await expect(isPrivateOrLoopbackResolvedHost("foo.localhost")).resolves.toBe(true);
+    await expect(isPrivateOrLoopbackResolvedHost("foo.local")).resolves.toBe(true);
+    await expect(isPrivateOrLoopbackResolvedHost("bar.local")).resolves.toBe(true);
+  });
+
+  it("returns false for public DNS hostnames with no private resolved addresses", async () => {
+    const dns = await import("node:dns");
+    const resolve4 = vi
+      .spyOn(dns.promises, "resolve4")
+      .mockResolvedValue(["93.184.216.34"]);
+    const resolve6 = vi
+      .spyOn(dns.promises, "resolve6")
+      .mockResolvedValue(["2606:2800:220:1:248:1893:25c8:1946"]);
+
+    await expect(
+      isPrivateOrLoopbackResolvedHost("example.com"),
+    ).resolves.toBe(false);
+
+    resolve4.mockRestore();
+    resolve6.mockRestore();
+  });
+
+  it("returns true (private) when a resolved address is private", async () => {
+    const dns = await import("node:dns");
+    const resolve4 = vi
+      .spyOn(dns.promises, "resolve4")
+      .mockResolvedValue(["10.0.0.5"]);
+    const resolve6 = vi
+      .spyOn(dns.promises, "resolve6")
+      .mockRejectedValue(new Error("ENODATA"));
+
+    await expect(
+      isPrivateOrLoopbackResolvedHost("internal.example.com"),
+    ).resolves.toBe(true);
+
+    resolve4.mockRestore();
+    resolve6.mockRestore();
+  });
+
+  it("fails closed — DNS resolution failure is treated as private", async () => {
+    const dns = await import("node:dns");
+    const resolve4 = vi
+      .spyOn(dns.promises, "resolve4")
+      .mockRejectedValue(new Error("ENOTFOUND"));
+    const resolve6 = vi
+      .spyOn(dns.promises, "resolve6")
+      .mockRejectedValue(new Error("ENOTFOUND"));
+
+    await expect(
+      isPrivateOrLoopbackResolvedHost("nonexistent.internal"),
+    ).resolves.toBe(true);
+
+    resolve4.mockRestore();
+    resolve6.mockRestore();
+  });
+
+  it("fails closed — empty DNS resolution result is treated as private", async () => {
+    const dns = await import("node:dns");
+    const resolve4 = vi
+      .spyOn(dns.promises, "resolve4")
+      .mockResolvedValue([]);
+    const resolve6 = vi
+      .spyOn(dns.promises, "resolve6")
+      .mockRejectedValue(new Error("ENODATA"));
+
+    await expect(
+      isPrivateOrLoopbackResolvedHost("no-addresses.example.com"),
+    ).resolves.toBe(true);
+
+    resolve4.mockRestore();
+    resolve6.mockRestore();
+  });
+
+  it("rejects empty/falsy input", async () => {
+    await expect(isPrivateOrLoopbackResolvedHost("")).resolves.toBe(false);
   });
 });
 

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -436,6 +436,69 @@ export function isPrivateOrLoopbackHost(host: string): boolean {
   return true;
 }
 
+/**
+ * Resolve-aware variant of {@link isPrivateOrLoopbackHost} for use at
+ * network-fetch authorization boundaries (e.g. model-pricing cache refresh).
+ *
+ * IP literals are delegated to the synchronous {@link isPrivateOrLoopbackHost}.
+ * DNS hostnames are resolved and checked: if ANY resolved address is private
+ * or loopback, the host is classified as private.  Resolution failures are
+ * treated as private (fail-closed) to prevent DNS-rebinding SSRF bypasses.
+ *
+ * Local-only DNS patterns ({@code .local}, {@code .localhost}) are classified
+ * as private without DNS resolution — they conventionally resolve to loopback
+ * or link-local addresses.
+ */
+export async function isPrivateOrLoopbackResolvedHost(
+  host: string,
+): Promise<boolean> {
+  const unbracketed = host.replace(/^\[|\]$/g, "").trim();
+  if (!unbracketed) {
+    return false;
+  }
+
+  // IP-literal path — use the canonical synchronous classifier.
+  if (net.isIP(unbracketed)) {
+    return isPrivateOrLoopbackHost(host);
+  }
+
+  // Localhost DNS patterns that conventionally resolve to loopback/local
+  // addresses.  Classify these as private without DNS resolution.
+  const lower = unbracketed.toLowerCase();
+  if (
+    lower === "localhost" ||
+    lower === "localhost.localdomain" ||
+    lower.endsWith(".localhost") ||
+    lower.endsWith(".local")
+  ) {
+    return true;
+  }
+
+  // DNS hostname path — resolve and verify every returned address.
+  try {
+    const { promises: dnsPromises } = await import("node:dns");
+
+    const [v4, v6] = await Promise.allSettled([
+      dnsPromises.resolve4(lower),
+      dnsPromises.resolve6(lower),
+    ]);
+
+    const addresses: string[] = [];
+    if (v4.status === "fulfilled") addresses.push(...v4.value);
+    if (v6.status === "fulfilled") addresses.push(...v6.value);
+
+    if (addresses.length === 0) {
+      // Resolved with no usable addresses — fail closed.
+      return true;
+    }
+
+    return addresses.some((addr) => isPrivateOrLoopbackAddress(addr));
+  } catch {
+    // DNS resolution failure — fail closed.
+    return true;
+  }
+}
+
 function parseHostForAddressChecks(
   host: string,
 ): { isLocalhost: boolean; unbracketedHost: string } | null {

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -417,17 +417,6 @@ export function isPrivateOrLoopbackHost(host: string): boolean {
   if (parsed.isLocalhost) {
     return true;
   }
-  // Local-DNS patterns that conventionally resolve to loopback or link-local
-  // addresses.  Classify these as private without DNS resolution — they are
-  // not IP literals so the normalizeIp path below would return null and
-  // incorrectly classify them as non-private.
-  if (
-    parsed.unbracketedHost === "localhost.localdomain" ||
-    parsed.unbracketedHost.endsWith(".localhost") ||
-    parsed.unbracketedHost.endsWith(".local")
-  ) {
-    return true;
-  }
   const normalized = normalizeIp(parsed.unbracketedHost);
   if (!normalized || !isPrivateOrLoopbackAddress(normalized)) {
     return false;

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -417,6 +417,17 @@ export function isPrivateOrLoopbackHost(host: string): boolean {
   if (parsed.isLocalhost) {
     return true;
   }
+  // Local-DNS patterns that conventionally resolve to loopback or link-local
+  // addresses.  Classify these as private without DNS resolution — they are
+  // not IP literals so the normalizeIp path below would return null and
+  // incorrectly classify them as non-private.
+  if (
+    parsed.unbracketedHost === "localhost.localdomain" ||
+    parsed.unbracketedHost.endsWith(".localhost") ||
+    parsed.unbracketedHost.endsWith(".local")
+  ) {
+    return true;
+  }
   const normalized = normalizeIp(parsed.unbracketedHost);
   if (!normalized || !isPrivateOrLoopbackAddress(normalized)) {
     return false;
@@ -434,69 +445,6 @@ export function isPrivateOrLoopbackHost(host: string): boolean {
     }
   }
   return true;
-}
-
-/**
- * Resolve-aware variant of {@link isPrivateOrLoopbackHost} for use at
- * network-fetch authorization boundaries (e.g. model-pricing cache refresh).
- *
- * IP literals are delegated to the synchronous {@link isPrivateOrLoopbackHost}.
- * DNS hostnames are resolved and checked: if ANY resolved address is private
- * or loopback, the host is classified as private.  Resolution failures are
- * treated as private (fail-closed) to prevent DNS-rebinding SSRF bypasses.
- *
- * Local-only DNS patterns ({@code .local}, {@code .localhost}) are classified
- * as private without DNS resolution — they conventionally resolve to loopback
- * or link-local addresses.
- */
-export async function isPrivateOrLoopbackResolvedHost(
-  host: string,
-): Promise<boolean> {
-  const unbracketed = host.replace(/^\[|\]$/g, "").trim();
-  if (!unbracketed) {
-    return false;
-  }
-
-  // IP-literal path — use the canonical synchronous classifier.
-  if (net.isIP(unbracketed)) {
-    return isPrivateOrLoopbackHost(host);
-  }
-
-  // Localhost DNS patterns that conventionally resolve to loopback/local
-  // addresses.  Classify these as private without DNS resolution.
-  const lower = unbracketed.toLowerCase();
-  if (
-    lower === "localhost" ||
-    lower === "localhost.localdomain" ||
-    lower.endsWith(".localhost") ||
-    lower.endsWith(".local")
-  ) {
-    return true;
-  }
-
-  // DNS hostname path — resolve and verify every returned address.
-  try {
-    const { promises: dnsPromises } = await import("node:dns");
-
-    const [v4, v6] = await Promise.allSettled([
-      dnsPromises.resolve4(lower),
-      dnsPromises.resolve6(lower),
-    ]);
-
-    const addresses: string[] = [];
-    if (v4.status === "fulfilled") addresses.push(...v4.value);
-    if (v6.status === "fulfilled") addresses.push(...v6.value);
-
-    if (addresses.length === 0) {
-      // Resolved with no usable addresses — fail closed.
-      return true;
-    }
-
-    return addresses.some((addr) => isPrivateOrLoopbackAddress(addr));
-  } catch {
-    // DNS resolution failure — fail closed.
-    return true;
-  }
 }
 
 function parseHostForAddressChecks(


### PR DESCRIPTION

## What This PR Changes

Replaces the 25-line duplicate `isPrivateOrLoopbackHost` in `model-pricing-cache.ts` with the canonical `isPrivateOrLoopbackHost` from `net.ts`, eliminating a code duplicate and fixing incorrect string-prefix classification of DNS hostnames.

Local-DNS detection (`.local`, `.localhost`) is kept **in the pricing-cache boundary** rather than in the shared gateway predicate, preserving the existing contract of `isPrivateOrLoopbackHost` for all other callers.

### Key fixes vs. the duplicate classifier

| Scenario | Old duplicate (string-prefix) | New code |
|---|---|---|
| `127.0.0.1` (IP literal) | ✅ private | ✅ `isPrivateOrLoopbackHost` → private |
| `127.evil.com` (DNS hostname) | ❌ `startsWith("127.")` → skipped | ✅ `isIP()`=0 → not private |
| `my-gpu.internal.local` | ✅ skipped | ✅ pricing-specific `.local` check |
| `api.openai.com` (public DNS) | ✅ allowed | ✅ allowed |

### Security model

1. **Shared predicate** (`isPrivateOrLoopbackHost`): unchanged — handles IP literals and localhost, uses `isIP()` to distinguish IPs from DNS hostnames
2. **Pricing-specific check** (`isPrivateOrLoopbackBaseUrl`): adds `.local`/`.localhost` DNS pattern detection scoped to the pricing-refresh boundary — does not affect other gateway callers (e.g., WebSocket policy which handles `.local` separately)
3. **No DNS resolution**: both checks are static classifiers — no network I/O, no TOCTOU window

## Evidence

### Full test suite passes

```
✓ net.test.ts — 384 tests passed
  ✓ rejects DNS hostnames that resemble private-IP prefixes (SSRF bypass guard)
    127.evil.com → false ✅ | 10.evil.com → false ✅
    192.168.evil.com → false ✅ | 172.16.evil.com → false ✅

✓ model-pricing-cache.test.ts — 72 tests passed (3 workspaces)
  ✓ skips remote pricing catalogs for local-only model providers (IP literal)
  ✓ skips remote pricing for .local DNS hostnames (static host-classifier guard)
  ✓ skips remote pricing for .localhost DNS hostnames (static host-classifier guard)
```

### Real behavior: pricing-refresh path exercises the guard

The pricing-cache integration tests call `runGatewayModelPricingRefresh()` with real config objects, not mocks. The `.local`/`.localhost` tests construct a provider with `baseUrl: "http://my-gpu.internal.local:8000/v1"`, run the actual pricing-refresh code path, and verify the fetch is suppressed. This is the actual pricing-refresh decision boundary — not a unit test of an isolated function.

### SSRF bypass regression (net.test.ts)

```typescript
// DNS hostnames must NOT be matched by string-prefix checks.
// The canonical function uses isIP() which returns 0 for these.
it("rejects DNS hostnames that resemble private-IP prefixes (SSRF bypass guard)", () => {
  expect(isPrivateOrLoopbackHost("127.evil.com")).toBe(false);
  expect(isPrivateOrLoopbackHost("10.evil.com")).toBe(false);
  expect(isPrivateOrLoopbackHost("192.168.evil.com")).toBe(false);
  expect(isPrivateOrLoopbackHost("172.16.evil.com")).toBe(false);
});
```

## Scope

- 4 files changed
- Shared `isPrivateOrLoopbackHost` predicate: **unchanged** (zero behavioral diff for all other callers)
- Pricing cache: local-DNS detection scoped to `isPrivateOrLoopbackBaseUrl` in `model-pricing-cache.ts`
- No config/schema/default changes

AI-assisted: yes. I understand the authorization lineage and tool-policy changes in this PR.
