### PR TITLE
fix(tlon): reject unusable setup URLs

### DIFF
--- a/extensions/tlon/src/setup-core.test.ts
+++ b/extensions/tlon/src/setup-core.test.ts
@@ -8,8 +8,11 @@ import { tlonSetupAdapter } from "./setup-core.js";
 const validInput = {
   ship: "~sampel-palnet",
   url: "https://urbit.example.com",
-  code: "lidlut-tabwed-pillex-ridrup",
+  code: "test-code",
 };
+const urlWithCredentials = new URL(validInput.url);
+urlWithCredentials.username = "test-user";
+urlWithCredentials.password = "test-password";
 
 function validate(params: {
   cfg?: OpenClawConfig;
@@ -24,9 +27,10 @@ function validate(params: {
 
 async function prepare(
   input: Parameters<NonNullable<typeof tlonSetupAdapter.prepareAccountConfigInput>>[0]["input"],
+  cfg: OpenClawConfig = {},
 ) {
-  return await tlonSetupAdapter.prepareAccountConfigInput?.({
-    cfg: {},
+  return await tlonSetupAdapter.prepareAccountConfigInput!({
+    cfg,
     accountId: DEFAULT_ACCOUNT_ID,
     input,
     runtime: createNonExitingRuntimeEnv(),
@@ -36,8 +40,10 @@ async function prepare(
 describe("Tlon setup adapter", () => {
   it.each([
     ["file:///etc/passwd", "Invalid URL: URL must use http:// or https://"],
-    ["https://user:password@urbit.example.com", "Invalid URL: URL must not include credentials"],
+    ["ftp://urbit.example.com", "Invalid URL: URL must use http:// or https://"],
+    [urlWithCredentials.href, "Invalid URL: URL must not include credentials"],
     ["https://", "Invalid URL: Invalid URL"],
+    ["", "Tlon requires --url."],
   ])("rejects a URL the runtime cannot use: %s", (url, expected) => {
     expect(validate({ input: { ...validInput, url } })).toBe(expected);
   });
@@ -48,14 +54,30 @@ describe("Tlon setup adapter", () => {
     ).toBe(null);
   });
 
-  it("validates the resolved URL when an existing account supplies it", () => {
+  it("validates a config-resolved URL without rewriting it for a code-only update", async () => {
+    const existingUrl = "urbit.example.com/~/login?redirect=1";
     const cfg = {
       channels: {
-        tlon: validInput,
+        tlon: { ...validInput, url: existingUrl },
       },
     } as OpenClawConfig;
+    const codeOnlyInput = { code: "replacement-code" };
 
-    expect(validate({ cfg, input: { code: "replacement-code" } })).toBeNull();
+    expect(validate({ cfg, input: codeOnlyInput })).toBeNull();
+    const prepared = await prepare(codeOnlyInput, cfg);
+    expect(prepared).toEqual(codeOnlyInput);
+
+    const next = tlonSetupAdapter.applyAccountConfig({
+      cfg,
+      accountId: DEFAULT_ACCOUNT_ID,
+      input: prepared,
+    });
+    expect(next.channels?.tlon).toMatchObject({
+      url: existingUrl,
+      code: "replacement-code",
+    });
+    expect(validate({ cfg, input: { ...codeOnlyInput, url: "   " } })).toBe("Tlon requires --url.");
+
     expect(
       validate({
         cfg: {
@@ -76,7 +98,7 @@ describe("Tlon setup adapter", () => {
     const cfg = tlonSetupAdapter.applyAccountConfig({
       cfg: {},
       accountId: DEFAULT_ACCOUNT_ID,
-      input: input ?? {},
+      input,
     });
     expect(cfg.channels?.tlon?.url).toBe("https://urbit.example.com");
   });

--- a/extensions/tlon/src/setup-core.test.ts
+++ b/extensions/tlon/src/setup-core.test.ts
@@ -1,0 +1,83 @@
+// Tlon tests cover non-interactive setup validation and config writes.
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { createNonExitingRuntimeEnv } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { describe, expect, it } from "vitest";
+import { tlonSetupAdapter } from "./setup-core.js";
+
+const validInput = {
+  ship: "~sampel-palnet",
+  url: "https://urbit.example.com",
+  code: "lidlut-tabwed-pillex-ridrup",
+};
+
+function validate(params: {
+  cfg?: OpenClawConfig;
+  input: Parameters<NonNullable<typeof tlonSetupAdapter.validateInput>>[0]["input"];
+}) {
+  return tlonSetupAdapter.validateInput?.({
+    cfg: params.cfg ?? {},
+    accountId: DEFAULT_ACCOUNT_ID,
+    input: params.input,
+  });
+}
+
+async function prepare(
+  input: Parameters<NonNullable<typeof tlonSetupAdapter.prepareAccountConfigInput>>[0]["input"],
+) {
+  return await tlonSetupAdapter.prepareAccountConfigInput?.({
+    cfg: {},
+    accountId: DEFAULT_ACCOUNT_ID,
+    input,
+    runtime: createNonExitingRuntimeEnv(),
+  });
+}
+
+describe("Tlon setup adapter", () => {
+  it.each([
+    ["file:///etc/passwd", "Invalid URL: URL must use http:// or https://"],
+    ["https://user:password@urbit.example.com", "Invalid URL: URL must not include credentials"],
+    ["https://", "Invalid URL: Invalid URL"],
+  ])("rejects a URL the runtime cannot use: %s", (url, expected) => {
+    expect(validate({ input: { ...validInput, url } })).toBe(expected);
+  });
+
+  it("accepts the same bare-host and path URL forms as the runtime", () => {
+    expect(
+      validate({ input: { ...validInput, url: "urbit.example.com/~/login?redirect=1" } }),
+    ).toBe(null);
+  });
+
+  it("validates the resolved URL when an existing account supplies it", () => {
+    const cfg = {
+      channels: {
+        tlon: validInput,
+      },
+    } as OpenClawConfig;
+
+    expect(validate({ cfg, input: { code: "replacement-code" } })).toBeNull();
+    expect(
+      validate({
+        cfg: {
+          channels: { tlon: { ...validInput, url: "ftp://urbit.example.com" } },
+        } as OpenClawConfig,
+        input: { code: "replacement-code" },
+      }),
+    ).toBe("Invalid URL: URL must use http:// or https://");
+  });
+
+  it("normalizes an explicit URL before the adapter writes config", async () => {
+    const input = await prepare({
+      ...validInput,
+      url: " urbit.example.com/~/login?redirect=1 ",
+    });
+    expect(input?.url).toBe("https://urbit.example.com");
+
+    const cfg = tlonSetupAdapter.applyAccountConfig({
+      cfg: {},
+      accountId: DEFAULT_ACCOUNT_ID,
+      input: input ?? {},
+    });
+    expect(cfg.channels?.tlon?.url).toBe("https://urbit.example.com");
+  });
+});

--- a/extensions/tlon/src/setup-core.ts
+++ b/extensions/tlon/src/setup-core.ts
@@ -196,8 +196,18 @@ export function applyTlonSetupConfig(params: {
   });
 }
 
+function normalizeTlonSetupInputUrl(input: ChannelSetupInput): ChannelSetupInput {
+  const url = normalizeOptionalString(input.url);
+  if (!url) {
+    return input;
+  }
+  const validated = validateUrbitBaseUrl(url);
+  return validated.ok ? { ...input, url: validated.baseUrl } : input;
+}
+
 export const tlonSetupAdapter: ChannelSetupAdapter = {
   resolveAccountId: ({ accountId }) => normalizeAccountId(accountId),
+  prepareAccountConfigInput: ({ input }) => normalizeTlonSetupInputUrl(input),
   applyAccountName: ({ cfg, accountId, name }) =>
     prepareScopedSetupConfig({
       cfg,
@@ -216,6 +226,10 @@ export const tlonSetupAdapter: ChannelSetupAdapter = {
       }
       if (!url) {
         return "Tlon requires --url.";
+      }
+      const validatedUrl = validateUrbitBaseUrl(url);
+      if (!validatedUrl.ok) {
+        return `Invalid URL: ${validatedUrl.error}`;
       }
       if (!code) {
         return "Tlon requires --code.";

--- a/extensions/tlon/src/setup-core.ts
+++ b/extensions/tlon/src/setup-core.ts
@@ -196,18 +196,16 @@ export function applyTlonSetupConfig(params: {
   });
 }
 
-function normalizeTlonSetupInputUrl(input: ChannelSetupInput): ChannelSetupInput {
-  const url = normalizeOptionalString(input.url);
-  if (!url) {
-    return input;
-  }
-  const validated = validateUrbitBaseUrl(url);
-  return validated.ok ? { ...input, url: validated.baseUrl } : input;
-}
-
 export const tlonSetupAdapter: ChannelSetupAdapter = {
   resolveAccountId: ({ accountId }) => normalizeAccountId(accountId),
-  prepareAccountConfigInput: ({ input }) => normalizeTlonSetupInputUrl(input),
+  prepareAccountConfigInput: ({ input }) => {
+    const url = normalizeOptionalString(input.url);
+    if (!url) {
+      return input;
+    }
+    const validatedUrl = validateUrbitBaseUrl(url);
+    return validatedUrl.ok ? { ...input, url: validatedUrl.baseUrl } : input;
+  },
   applyAccountName: ({ cfg, accountId, name }) =>
     prepareScopedSetupConfig({
       cfg,
@@ -218,9 +216,9 @@ export const tlonSetupAdapter: ChannelSetupAdapter = {
   validateInput: createSetupInputPresenceValidator({
     validate: ({ cfg, accountId, input }) => {
       const resolved = resolveTlonAccount(cfg, accountId ?? undefined);
-      const ship = normalizeOptionalString(input.ship) || resolved.ship;
-      const url = normalizeOptionalString(input.url) || resolved.url;
-      const code = normalizeOptionalString(input.code) || resolved.code;
+      const ship = normalizeOptionalString(input.ship ?? resolved.ship);
+      const url = normalizeOptionalString(input.url ?? resolved.url);
+      const code = normalizeOptionalString(input.code ?? resolved.code);
       if (!ship) {
         return "Tlon requires --ship.";
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running non-interactive `openclaw channels add --channel tlon` could save an unusable ship URL, then encounter a runtime startup failure because the Tlon runtime rejects that same URL.

## Why This Change Was Made

The non-interactive setup adapter now reuses the runtime-owned `validateUrbitBaseUrl` contract before config is written. Valid bare-host, path, and query forms remain accepted and are normalized to their origin; schemes, credentials, and malformed URLs that the runtime already rejects now fail during setup.

## User Impact

Tlon setup reports an actionable URL error before modifying configuration, while existing accepted URL forms keep working.

## Evidence

- Immutable before/after real CLI proof: https://github.com/Alix-007/openclaw/actions/runs/29668300298
  - Before `d96a87e8e9b567fe57afde34c1438b8af27ca14a`: `channels add` exited 0 and persisted `file:///etc/passwd`.
  - After `3fe59c2524231f25f4176f3f3a03baa32b30c71a`: the same command exited 1 with `Invalid URL: URL must use http:// or https://`, and no Tlon config was written.
  - The fixed revision then accepted `urbit.example.com/~/login?redirect=1` and persisted the normalized origin `https://urbit.example.com`.
  - Focused adapter tests on the fixed revision: 1 file, 6 tests passed.
- Before artifact: https://github.com/Alix-007/openclaw/actions/runs/29668300298/artifacts/8436462376
- After artifact: https://github.com/Alix-007/openclaw/actions/runs/29668300298/artifacts/8436464995
- `git diff --check` and targeted formatting pass on the exact head.
- Fresh independent Codex adversarial review: GO, zero actionable findings.

AI-assisted: implementation and review were performed with Codex; the behavior and owner boundaries were manually verified.