### PR TITLE
fix(codex): guard loopback WebSocket URL host checks with isIP to prevent DNS SSRF bypass

### DIFF
--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -1,5 +1,6 @@
 // Codex helper module supports config behavior.
 import { createHash, createHmac, randomBytes } from "node:crypto";
+import { isIP } from "node:net";
 import { readFileSync } from "node:fs";
 import { homedir as readHomeDir, hostname as readHostName } from "node:os";
 import path from "node:path";
@@ -1344,7 +1345,7 @@ function isLoopbackWebSocketUrl(value: string): boolean {
     host === "127.0.0.1" ||
     host === "::1" ||
     host === "[::1]" ||
-    host.startsWith("127.")
+    (isIP(host) === 4 && host.startsWith("127."))
   );
 }
 

--- a/proof-codex-ws-loopback.js
+++ b/proof-codex-ws-loopback.js
@@ -1,0 +1,31 @@
+// Proof: DNS SSRF bypass in isLoopbackWebSocketUrl (codex config.ts)
+// isIP correctly distinguishes real IPv4 literals from DNS names like 127.evil.com.
+import { isIP } from "node:net";
+
+const BEFORE = (host) =>
+  host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "[::1]" || host.startsWith("127.");
+
+const AFTER = (host) =>
+  host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "[::1]" || (isIP(host) === 4 && host.startsWith("127."));
+
+const cases = [
+  ["127.0.0.1", true, true, "localhost"],
+  ["127.evil.com", true, false, "DNS name 127.evil.com — BYPASS FIXED"],
+  ["10.0.0.1", false, false, "non-loopback IP"],
+  ["example.com", false, false, "normal hostname"],
+  ["::1", true, true, "IPv6 loopback"],
+];
+
+let failed = false;
+for (const [host, expBefore, expAfter, desc] of cases) {
+  const before = BEFORE(host);
+  const after = AFTER(host);
+  if (before !== expBefore || after !== expAfter) {
+    failed = true;
+    console.error(`FAIL: ${desc} | host="${host}" | before=${before} after=${after}`);
+  } else {
+    console.log(`PASS: ${desc} | host="${host}"`);
+  }
+}
+console.log(`\n${failed ? "FAILED" : "All tests passed"}`);
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
## What Problem This Solves

`extensions/codex/src/app-server/config.ts` `isLoopbackWebSocketUrl` used `host.startsWith("127.")` without first verifying the value is an IPv4 literal via `isIP()`. A WebSocket URL targeting `ws://127.evil.com:4000` would be misclassified as loopback, bypassing the remote/local transport-security decision in Codex app-server config.

This is the same class of DNS SSRF bypass as:
- #110693 (litellm image generation)
- #111098 (model-pricing-cache)

## Why This Change Was Made

Add `isIP(host) === 4` guard before the `startsWith("127.")` check so only real IPv4 addresses match the 127/8 loopback prefix. The exact-match branches (`127.0.0.1`, `::1`, `[::1]`, `localhost`) are unchanged.

## Evidence

Base: 74880cb56f9 (origin/main). Head: 3e924922997.

```
$ node proof-codex-ws-loopback.js
PASS: localhost | host="127.0.0.1"
PASS: DNS name 127.evil.com — BYPASS FIXED | host="127.evil.com"
PASS: non-loopback IP | host="10.0.0.1"
PASS: normal hostname | host="example.com"
PASS: IPv6 loopback | host="::1"

All tests passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)