### PR TITLE
refactor(agents): unify Responses tool-call id resolver

### DIFF
--- a/src/agents/embedded-agent-helpers/openai.ts
+++ b/src/agents/embedded-agent-helpers/openai.ts
@@ -156,37 +156,20 @@ function shouldNormalizeOpenAIResponsesToolCallId(id: string): boolean {
   return !OPENAI_RESPONSES_FUNCTION_CALL_ITEM_ID_RE.test(pairing.itemId);
 }
 
-function createOpenAIResponsesToolCallIdResolver(): {
-  resolveAssistantId: (id: string) => string;
-  resolveToolResultId: (id: string) => string;
-} {
+function createOpenAIResponsesToolCallIdResolver(): (id: string) => string {
   const rewrittenByOriginalId = new Map<string, string>();
 
-  return {
-    resolveAssistantId(id: string): string {
-      const rewritten = rewrittenByOriginalId.get(id);
-      if (rewritten) {
-        return rewritten;
-      }
-      if (!shouldNormalizeOpenAIResponsesToolCallId(id)) {
-        return id;
-      }
-      const normalized = normalizeOpenAIResponsesFunctionCallId(id);
-      rewrittenByOriginalId.set(id, normalized);
-      return normalized;
-    },
-    resolveToolResultId(id: string): string {
-      const rewritten = rewrittenByOriginalId.get(id);
-      if (rewritten) {
-        return rewritten;
-      }
-      if (!shouldNormalizeOpenAIResponsesToolCallId(id)) {
-        return id;
-      }
-      const normalized = normalizeOpenAIResponsesFunctionCallId(id);
-      rewrittenByOriginalId.set(id, normalized);
-      return normalized;
-    },
+  return (id) => {
+    const rewritten = rewrittenByOriginalId.get(id);
+    if (rewritten) {
+      return rewritten;
+    }
+    if (!shouldNormalizeOpenAIResponsesToolCallId(id)) {
+      return id;
+    }
+    const normalized = normalizeOpenAIResponsesFunctionCallId(id);
+    rewrittenByOriginalId.set(id, normalized);
+    return normalized;
   };
 }
 
@@ -199,7 +182,7 @@ function createOpenAIResponsesToolCallIdResolver(): {
  */
 export function normalizeOpenAIResponsesToolCallIds(messages: AgentMessage[]): AgentMessage[] {
   let changed = false;
-  const resolver = createOpenAIResponsesToolCallIdResolver();
+  const resolveId = createOpenAIResponsesToolCallIdResolver();
   const rewrittenMessages: AgentMessage[] = [];
 
   for (const msg of messages) {
@@ -226,7 +209,7 @@ export function normalizeOpenAIResponsesToolCallIds(messages: AgentMessage[]): A
           return block;
         }
 
-        const nextId = resolver.resolveAssistantId(toolCallBlock.id);
+        const nextId = resolveId(toolCallBlock.id);
         if (nextId === toolCallBlock.id) {
           return block;
         }
@@ -254,7 +237,7 @@ export function normalizeOpenAIResponsesToolCallIds(messages: AgentMessage[]): A
       const updates: Record<string, string> = {};
 
       if (typeof toolResult.toolCallId === "string") {
-        const nextToolCallId = resolver.resolveToolResultId(toolResult.toolCallId);
+        const nextToolCallId = resolveId(toolResult.toolCallId);
         if (nextToolCallId !== toolResult.toolCallId) {
           updates.toolCallId = nextToolCallId;
           toolResultChanged = true;
@@ -262,7 +245,7 @@ export function normalizeOpenAIResponsesToolCallIds(messages: AgentMessage[]): A
       }
 
       if (typeof toolResult.toolUseId === "string") {
-        const nextToolUseId = resolver.resolveToolResultId(toolResult.toolUseId);
+        const nextToolUseId = resolveId(toolResult.toolUseId);
         if (nextToolUseId !== toolResult.toolUseId) {
           updates.toolUseId = nextToolUseId;
           toolResultChanged = true;


### PR DESCRIPTION
Follow-up to #110956.

## What Problem This Solves

The Responses replay normalizer exposed separate assistant and tool-result resolver methods even though both methods shared the same cache and implemented identical normalization policy. Keeping two copies makes this pairing invariant easier to change inconsistently.

## Why This Change Was Made

Replace the duplicated resolver object with one stateful resolver function and route all three call sites through it. This is a behavior-neutral, 17-line net reduction requested during the maintainer follow-up pass for #110956.

## User Impact

No user-visible behavior changes. The existing Responses replay pairing behavior is preserved with less duplicated internal policy.

## Evidence

- `node scripts/run-vitest.mjs src/agents/embedded-agent-helpers/openai.test.ts` — 4 tests passed.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner.openai-tool-id-preservation.test.ts` — 5 tests passed.
- `CRABBOX_BLACKSMITH_SYNC_TIMEOUT_MS=0 node scripts/check-changed.mjs -- src/agents/embedded-agent-helpers/openai.ts` — Testbox `tbx_01kxvymm7t931rh66e4zmn5b7b` passed typechecks, lint, formatting, boundary, import-cycle, and runtime guards: https://github.com/openclaw/openclaw/actions/runs/29668095757
- Fresh branch autoreview: clean, no findings, confidence 0.99.

AI-assisted: yes. I reviewed the complete diff and verified the behavior and tests above.
