### PR TITLE
fix(matrix): preserve redirects when body cancellation fails

### DIFF
--- a/extensions/matrix/src/matrix/sdk/transport.test.ts
+++ b/extensions/matrix/src/matrix/sdk/transport.test.ts
@@ -477,6 +477,44 @@ describe("createMatrixGuardedFetch", () => {
     clearTestUndiciRuntimeDepsOverride();
   });
 
+  it("preserves redirect success when the discarded body fails to cancel", async () => {
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledRejections.push(reason);
+    };
+    const cancel = vi.fn(() => {
+      throw new Error("cancel failed");
+    });
+    const runtimeFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(new ReadableStream<Uint8Array>({ cancel }), {
+          status: 302,
+          headers: { location: "/final" },
+        }),
+      )
+      .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+    stubRuntimeFetch(runtimeFetch);
+    process.on("unhandledRejection", onUnhandledRejection);
+
+    try {
+      const guardedFetch = createMatrixGuardedFetch({
+        ssrfPolicy: { allowPrivateNetwork: true },
+      });
+      const response = await guardedFetch("http://127.0.0.1:8008/start");
+
+      await expect(response.json()).resolves.toEqual({});
+      expect(runtimeFetch).toHaveBeenCalledTimes(2);
+      expect(cancel).toHaveBeenCalledOnce();
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(unhandledRejections).toStrictEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection);
+    }
+  });
+
   it("rejects and cancels SDK responses above the declared size limit", async () => {
     const cancel = vi.fn();
     const stream = new ReadableStream<Uint8Array>({ cancel });

--- a/extensions/matrix/src/matrix/sdk/transport.test.ts
+++ b/extensions/matrix/src/matrix/sdk/transport.test.ts
@@ -512,6 +512,7 @@ describe("createMatrixGuardedFetch", () => {
       expect(unhandledRejections).toStrictEqual([]);
     } finally {
       process.off("unhandledRejection", onUnhandledRejection);
+      expect(process.listeners("unhandledRejection")).not.toContain(onUnhandledRejection);
     }
   });
 

--- a/extensions/matrix/src/matrix/sdk/transport.ts
+++ b/extensions/matrix/src/matrix/sdk/transport.ts
@@ -250,7 +250,7 @@ async function fetchWithMatrixGuardedRedirects(params: {
         headers.delete("content-length");
       }
 
-      void response.body?.cancel();
+      void response.body?.cancel().catch(() => undefined);
       await closeDispatcher(dispatcher);
       currentUrl = nextUrl;
     } catch (error) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Matrix SDK requests could follow a valid redirect successfully but still emit a process-level unhandled rejection when cancellation of the discarded redirect response body failed.

## Why This Change Was Made

The discarded body cancellation now observes and suppresses its own cleanup failure while preserving the existing detached cancellation and dispatcher-close order. The risk is limited to Matrix redirect cleanup; the runtime proof verifies the second hop, cancellation count, final response, and rejection handling.

## User Impact

Matrix sync and media requests can complete valid redirects without a secondary body-cleanup failure surfacing as an unhandled rejection.

## Evidence

Real runtime proof was run locally with Node `v24.18.0` through the production `createMatrixGuardedFetch()` entry. It used real `Response` and `ReadableStream` objects with a rejecting underlying `cancel()` and injected only the HTTP transport response sequence (302 then 200); live Matrix credentials were not available.

The same `node --import tsx --input-type=module` harness produced this before the fix:

```text
{"calls":2,"cancelCount":1,"status":200,"body":{"ok":true},"unhandled":["cancel failed"]}
```

After the fix:

```text
{"calls":2,"cancelCount":1,"status":200,"body":{"ok":true},"unhandled":[]}
```

The negative control also failed the new regression test with `expected [ Error: cancel failed ] to strictly equal []` when the observer was temporarily removed.

Focused validation and final review after rebasing to `upstream/main` (`c3adaa3195b`):

```text
node scripts/run-vitest.mjs extensions/matrix/src/matrix/sdk/transport.test.ts
Test Files  1 passed (1)
Tests       19 passed (19)

.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main
autoreview clean: no accepted/actionable findings reported
```

Broader validation completed before the final unrelated `main` advances:

```text
upstream/main 62c5a8b8881

OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test:extension matrix
Test Files  118 passed (118)
Tests       1468 passed (1468)

upstream/main c17a81b4704
CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm check:changed --base upstream/main -- extensions/matrix/src/matrix/sdk/transport.ts extensions/matrix/src/matrix/sdk/transport.test.ts
passed
```

AI-assisted: OpenAI Codex helped implement and review the patch; the proof and validation above were run manually.
