### PR TITLE
fix(tlon): preserve shutdown when body cancellation fails

### DIFF
--- a/extensions/tlon/src/urbit/sse-client.test.ts
+++ b/extensions/tlon/src/urbit/sse-client.test.ts
@@ -184,10 +184,14 @@ describe("UrbitSSEClient", () => {
           },
         };
       });
+      const [unsubscribeResponse, deleteResponse] = shutdownResponses;
+      if (!unsubscribeResponse || !deleteResponse) {
+        throw new Error("Expected both shutdown response fixtures");
+      }
       const mockUrbitFetch = vi.mocked(urbitFetch);
       mockUrbitFetch
-        .mockResolvedValueOnce(shutdownResponses[0].result)
-        .mockResolvedValueOnce(shutdownResponses[1].result);
+        .mockResolvedValueOnce(unsubscribeResponse.result)
+        .mockResolvedValueOnce(deleteResponse.result);
       const client = new UrbitSSEClient("https://example.com", "urbauth-~zod=123", {
         autoReconnect: false,
       });

--- a/extensions/tlon/src/urbit/sse-client.test.ts
+++ b/extensions/tlon/src/urbit/sse-client.test.ts
@@ -159,6 +159,57 @@ describe("UrbitSSEClient", () => {
     });
   });
 
+  describe("close", () => {
+    it("releases shutdown responses without leaking cancellation failures", async () => {
+      const unhandledRejections: unknown[] = [];
+      const onUnhandledRejection = (reason: unknown) => {
+        unhandledRejections.push(reason);
+      };
+      const unsubscribeCancel = vi.fn(() => {
+        throw new Error("unsubscribe cancel failed");
+      });
+      const deleteCancel = vi.fn(() => {
+        throw new Error("delete cancel failed");
+      });
+      const unsubscribeRelease = vi.fn().mockResolvedValue(undefined);
+      const deleteRelease = vi.fn().mockResolvedValue(undefined);
+      const mockUrbitFetch = vi.mocked(urbitFetch);
+      mockUrbitFetch
+        .mockResolvedValueOnce({
+          response: new Response(new ReadableStream<Uint8Array>({ cancel: unsubscribeCancel })),
+          finalUrl: "https://example.com",
+          release: unsubscribeRelease,
+        })
+        .mockResolvedValueOnce({
+          response: new Response(new ReadableStream<Uint8Array>({ cancel: deleteCancel })),
+          finalUrl: "https://example.com",
+          release: deleteRelease,
+        });
+      const client = new UrbitSSEClient("https://example.com", "urbauth-~zod=123", {
+        autoReconnect: false,
+      });
+      process.on("unhandledRejection", onUnhandledRejection);
+
+      try {
+        await client.close();
+
+        expect(mockUrbitFetch).toHaveBeenCalledTimes(2);
+        expect(mockUrbitFetch.mock.calls[0]?.[0].init?.method).toBe("PUT");
+        expect(mockUrbitFetch.mock.calls[1]?.[0].init?.method).toBe("DELETE");
+        expect(unsubscribeCancel).toHaveBeenCalledOnce();
+        expect(deleteCancel).toHaveBeenCalledOnce();
+        expect(unsubscribeRelease).toHaveBeenCalledOnce();
+        expect(deleteRelease).toHaveBeenCalledOnce();
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+        expect(unhandledRejections).toStrictEqual([]);
+      } finally {
+        process.off("unhandledRejection", onUnhandledRejection);
+      }
+    });
+  });
+
   describe("reconnection", () => {
     it("has autoReconnect enabled by default", () => {
       const client = new UrbitSSEClient("https://example.com", "urbauth-~zod=123");

--- a/extensions/tlon/src/urbit/sse-client.test.ts
+++ b/extensions/tlon/src/urbit/sse-client.test.ts
@@ -165,26 +165,29 @@ describe("UrbitSSEClient", () => {
       const onUnhandledRejection = (reason: unknown) => {
         unhandledRejections.push(reason);
       };
-      const unsubscribeCancel = vi.fn(() => {
-        throw new Error("unsubscribe cancel failed");
+      const shutdownResponses = [
+        { method: "PUT", label: "unsubscribe" },
+        { method: "DELETE", label: "delete" },
+      ].map(({ method, label }) => {
+        const cancel = vi.fn(() => {
+          throw new Error(`${label} cancel failed`);
+        });
+        const release = vi.fn().mockResolvedValue(undefined);
+        return {
+          method,
+          cancel,
+          release,
+          result: {
+            response: new Response(new ReadableStream<Uint8Array>({ cancel })),
+            finalUrl: "https://example.com",
+            release,
+          },
+        };
       });
-      const deleteCancel = vi.fn(() => {
-        throw new Error("delete cancel failed");
-      });
-      const unsubscribeRelease = vi.fn().mockResolvedValue(undefined);
-      const deleteRelease = vi.fn().mockResolvedValue(undefined);
       const mockUrbitFetch = vi.mocked(urbitFetch);
       mockUrbitFetch
-        .mockResolvedValueOnce({
-          response: new Response(new ReadableStream<Uint8Array>({ cancel: unsubscribeCancel })),
-          finalUrl: "https://example.com",
-          release: unsubscribeRelease,
-        })
-        .mockResolvedValueOnce({
-          response: new Response(new ReadableStream<Uint8Array>({ cancel: deleteCancel })),
-          finalUrl: "https://example.com",
-          release: deleteRelease,
-        });
+        .mockResolvedValueOnce(shutdownResponses[0].result)
+        .mockResolvedValueOnce(shutdownResponses[1].result);
       const client = new UrbitSSEClient("https://example.com", "urbauth-~zod=123", {
         autoReconnect: false,
       });
@@ -194,18 +197,18 @@ describe("UrbitSSEClient", () => {
         await client.close();
 
         expect(mockUrbitFetch).toHaveBeenCalledTimes(2);
-        expect(mockUrbitFetch.mock.calls[0]?.[0].init?.method).toBe("PUT");
-        expect(mockUrbitFetch.mock.calls[1]?.[0].init?.method).toBe("DELETE");
-        expect(unsubscribeCancel).toHaveBeenCalledOnce();
-        expect(deleteCancel).toHaveBeenCalledOnce();
-        expect(unsubscribeRelease).toHaveBeenCalledOnce();
-        expect(deleteRelease).toHaveBeenCalledOnce();
+        for (const [index, { method, cancel, release }] of shutdownResponses.entries()) {
+          expect(mockUrbitFetch.mock.calls[index]?.[0].init?.method).toBe(method);
+          expect(cancel).toHaveBeenCalledOnce();
+          expect(release).toHaveBeenCalledOnce();
+        }
         await new Promise<void>((resolve) => {
           setImmediate(resolve);
         });
         expect(unhandledRejections).toStrictEqual([]);
       } finally {
         process.off("unhandledRejection", onUnhandledRejection);
+        expect(process.listeners("unhandledRejection")).not.toContain(onUnhandledRejection);
       }
     });
   });

--- a/extensions/tlon/src/urbit/sse-client.ts
+++ b/extensions/tlon/src/urbit/sse-client.ts
@@ -547,7 +547,7 @@ export class UrbitSSEClient {
           auditContext: "tlon-urbit-unsubscribe",
         });
         try {
-          void response.body?.cancel();
+          void response.body?.cancel().catch(() => undefined);
         } finally {
           await release();
         }
@@ -570,7 +570,7 @@ export class UrbitSSEClient {
           auditContext: "tlon-urbit-channel-close",
         });
         try {
-          void response.body?.cancel();
+          void response.body?.cancel().catch(() => undefined);
         } finally {
           await release();
         }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where closing a Tlon client could leave two process-level unhandled rejections if cancellation of the unsubscribe and channel-delete response bodies failed, even though shutdown and guarded response release otherwise completed.

## Why This Change Was Made

Both shutdown response cancellations now observe and suppress their own cleanup failures while retaining the existing fire-and-forget timing and `finally`-owned releases. The risk is limited to Tlon shutdown cleanup; open PR #108168 touches reconnect-delay cancellation in the same module but not these two response cleanup sites.

## User Impact

Tlon channel shutdown can finish cleanly without secondary response-body cancellation failures leaking into the process.

## Evidence

Real runtime proof was run locally with Node `v24.18.0` through public `UrbitSSEClient.close()`, the production `urbitFetch` and SSRF guard, and real `Response`/`ReadableStream` objects. Only the remote Urbit transport was injected; live Tlon credentials were not available.

Before the fix, the public close path performed both requests and cancellations but leaked both failures:

```text
{"methods":["PUT","DELETE"],"cancels":[1,2],"unhandled":["cancel 1 failed","cancel 2 failed"],"aborted":true,"connected":false}
```

After the fix, the same path retained both requests, both cancellation attempts, and terminal client state without an unhandled rejection:

```text
{"methods":["PUT","DELETE"],"cancels":[1,2],"unhandled":[],"aborted":true,"connected":false}
```

The negative control also failed the new regression test with both cancellation errors when the two observers were temporarily removed. The test asserts that both guarded releases still execute exactly once.

Focused validation and final review after rebasing to `upstream/main` (`c3adaa3195b`):

```text
node scripts/run-vitest.mjs extensions/tlon/src/urbit/sse-client.test.ts
Test Files  1 passed (1)
Tests       31 passed (31)

.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main
autoreview clean: no accepted/actionable findings reported
```

Broader validation completed before the final unrelated `main` advances:

```text
upstream/main 62c5a8b8881

OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test:extension tlon
Test Files  19 passed (19)
Tests       178 passed (178)

upstream/main c17a81b4704
CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm check:changed --base upstream/main -- extensions/tlon/src/urbit/sse-client.ts extensions/tlon/src/urbit/sse-client.test.ts
passed
```

AI-assisted: OpenAI Codex helped implement and review the patch; the proof and validation above were run manually.
