### PR TITLE
feat(codex): instrument dynamic-tool bridge phase timing

### DIFF
--- a/extensions/codex/src/app-server/client.test.ts
+++ b/extensions/codex/src/app-server/client.test.ts
@@ -6,8 +6,10 @@ import {
   isCodexAppServerApprovalRequest,
   isCodexAppServerIndeterminateTransportError,
 } from "./client.js";
-import { withDynamicToolBridgeTiming } from "./dynamic-tool-execution.js";
-import type { CodexDynamicToolBridgeTiming } from "./protocol.js";
+import {
+  type CodexDynamicToolBridgeTiming,
+  withDynamicToolBridgeTiming,
+} from "./dynamic-tool-execution.js";
 import { resetSharedCodexAppServerClientForTests } from "./shared-client.js";
 import { createClientHarness } from "./test-support.js";
 import { MAX_CODEX_APP_SERVER_VERSION, MIN_CODEX_APP_SERVER_VERSION } from "./version.js";

--- a/extensions/codex/src/app-server/client.test.ts
+++ b/extensions/codex/src/app-server/client.test.ts
@@ -6,6 +6,8 @@ import {
   isCodexAppServerApprovalRequest,
   isCodexAppServerIndeterminateTransportError,
 } from "./client.js";
+import { withDynamicToolBridgeTiming } from "./dynamic-tool-execution.js";
+import type { CodexDynamicToolBridgeTiming } from "./protocol.js";
 import { resetSharedCodexAppServerClientForTests } from "./shared-client.js";
 import { createClientHarness } from "./test-support.js";
 import { MAX_CODEX_APP_SERVER_VERSION, MIN_CODEX_APP_SERVER_VERSION } from "./version.js";
@@ -173,6 +175,58 @@ describe("CodexAppServerClient", () => {
       },
     ]);
     expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("logs dynamic tool bridge phase timing without ever serializing it to Codex", async () => {
+    const info = vi.spyOn(embeddedAgentLog, "info").mockImplementation(() => undefined);
+    const harness = createClientHarness();
+    clients.push(harness.client);
+    const timing: CodexDynamicToolBridgeTiming = {
+      toolName: "memory_search",
+      requestReceivedAt: 1_000,
+      toolExecuteStartAt: 1_010,
+      toolExecuteEndAt: 1_090,
+    };
+    harness.client.addRequestHandler(() =>
+      withDynamicToolBridgeTiming({ contentItems: [], success: true }, timing),
+    );
+
+    harness.send({ id: 1, method: "item/tool/call", params: {} });
+
+    await vi.waitFor(() => expect(harness.writes).toHaveLength(1));
+    const outbound = JSON.parse(harness.writes[0] ?? "{}") as {
+      id?: number;
+      result?: Record<string, unknown>;
+    };
+    expect(outbound.id).toBe(1);
+    expect(outbound.result).toEqual({ contentItems: [], success: true });
+    expect(harness.writes[0]).not.toContain("bridgeTiming");
+
+    const call = info.mock.calls.find(
+      ([message]) => message === "codex dynamic tool bridge timing",
+    );
+    expect(call).toBeDefined();
+    const metadata = call?.[1] as
+      | {
+          tool?: string;
+          requestReceivedAt?: number;
+          toolExecuteStartAt?: number;
+          toolExecuteEndAt?: number;
+          responseSentAt?: number;
+          bridgeInboundMs?: number;
+          toolExecuteMs?: number;
+          bridgeOutboundMs?: number;
+          bridgeTotalMs?: number;
+        }
+      | undefined;
+    expect(metadata?.tool).toBe("memory_search");
+    expect(metadata?.bridgeInboundMs).toBe(10);
+    expect(metadata?.toolExecuteMs).toBe(80);
+    expect(metadata?.bridgeOutboundMs).toBeGreaterThanOrEqual(0);
+    expect(metadata?.responseSentAt).toBeGreaterThanOrEqual(timing.toolExecuteEndAt);
+    expect(metadata?.bridgeTotalMs).toBe(
+      (metadata?.bridgeInboundMs ?? 0) + (metadata?.bridgeOutboundMs ?? 0),
+    );
   });
 
   it("preserves JSON-RPC error codes", async () => {

--- a/extensions/codex/src/app-server/client.ts
+++ b/extensions/codex/src/app-server/client.ts
@@ -12,6 +12,7 @@ import {
   type CodexAppServerRequestMethod,
   type CodexAppServerRequestParams,
   type CodexAppServerRequestResult,
+  type CodexDynamicToolBridgeTiming,
   type CodexInitializeParams,
   type CodexInitializeResponse,
   isRpcResponse,
@@ -846,6 +847,7 @@ export class CodexAppServerClient {
     try {
       const result = await this.runServerRequestHandlers(request);
       if (result !== undefined) {
+        logDynamicToolBridgeTimingIfPresent(result);
         this.writeMessage({ id: request.id, result });
         return;
       }
@@ -981,6 +983,54 @@ function defaultServerRequestResponse(
     };
   }
   return {};
+}
+
+function hasDynamicToolBridgeTiming(
+  value: JsonValue,
+): value is JsonValue & { bridgeTiming: CodexDynamicToolBridgeTiming } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    "bridgeTiming" in value &&
+    typeof (value as { bridgeTiming?: unknown }).bridgeTiming === "object" &&
+    (value as { bridgeTiming?: unknown }).bridgeTiming !== null
+  );
+}
+
+/**
+ * Reads the hidden phase timing a dynamic tool response carries (see
+ * `withDynamicToolBridgeTiming`) and logs the full request-received ->
+ * tool-execute -> response-sent breakdown at the transport write boundary,
+ * the last point before Codex ever sees the response. Non-enumerable, so it
+ * never reaches the wire; this is the only place it is read and reported.
+ */
+function logDynamicToolBridgeTimingIfPresent(result: JsonValue): void {
+  if (!hasDynamicToolBridgeTiming(result)) {
+    return;
+  }
+  const timing = result.bridgeTiming;
+  const responseSentAt = Date.now();
+  embeddedAgentLog.info("codex dynamic tool bridge timing", {
+    tool: timing.toolName,
+    requestReceivedAt: timing.requestReceivedAt,
+    toolExecuteStartAt: timing.toolExecuteStartAt,
+    toolExecuteEndAt: timing.toolExecuteEndAt,
+    responseSentAt,
+    // Repairable-transport estimate: request-received -> dispatch start.
+    bridgeInboundMs: Math.max(0, timing.toolExecuteStartAt - timing.requestReceivedAt),
+    // Actual OpenClaw tool execution time, not bridge overhead.
+    toolExecuteMs: Math.max(0, timing.toolExecuteEndAt - timing.toolExecuteStartAt),
+    // Repairable-transport estimate: tool done -> response written to Codex's stdin.
+    bridgeOutboundMs: Math.max(0, responseSentAt - timing.toolExecuteEndAt),
+    // Sum of the two bridge legs above, excluding tool execution time.
+    bridgeTotalMs: Math.max(
+      0,
+      responseSentAt -
+        timing.requestReceivedAt -
+        (timing.toolExecuteEndAt - timing.toolExecuteStartAt),
+    ),
+  });
 }
 
 function stringifyCodexAppServerMessage(message: RpcRequest | RpcResponse): string {

--- a/extensions/codex/src/app-server/client.ts
+++ b/extensions/codex/src/app-server/client.ts
@@ -8,11 +8,11 @@ import { embeddedAgentLog, OPENCLAW_VERSION } from "openclaw/plugin-sdk/agent-ha
 import { sliceUtf16Safe, truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { parse as parseSemver } from "semver";
 import { resolveCodexAppServerRuntimeOptions, type CodexAppServerStartOptions } from "./config.js";
+import type { CodexDynamicToolBridgeTiming } from "./dynamic-tool-execution.js";
 import {
   type CodexAppServerRequestMethod,
   type CodexAppServerRequestParams,
   type CodexAppServerRequestResult,
-  type CodexDynamicToolBridgeTiming,
   type CodexInitializeParams,
   type CodexInitializeResponse,
   isRpcResponse,

--- a/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
@@ -12,6 +12,7 @@ import {
   shouldReleaseTurnAfterTerminalDynamicTool,
   toCodexDynamicToolProgressResponse,
   toCodexDynamicToolProtocolResponse,
+  withDynamicToolBridgeTiming,
 } from "./dynamic-tool-execution.js";
 import type { CodexDynamicToolCallResponse } from "./protocol.js";
 
@@ -969,5 +970,33 @@ describe("dynamic tool execution helpers", () => {
         success: true,
       }),
     ).toBe(true);
+  });
+
+  it("attaches bridge phase timing as a non-enumerable property that survives JSON.stringify exclusion", () => {
+    const response: CodexDynamicToolCallResponse = {
+      contentItems: [{ type: "inputText", text: "ok" }],
+      success: true,
+    };
+
+    const withTiming = withDynamicToolBridgeTiming(response, {
+      toolName: "memory_search",
+      requestReceivedAt: 1_000,
+      toolExecuteStartAt: 1_010,
+      toolExecuteEndAt: 1_090,
+    });
+
+    expect(withTiming).toBe(response);
+    expect(withTiming.bridgeTiming).toEqual({
+      toolName: "memory_search",
+      requestReceivedAt: 1_000,
+      toolExecuteStartAt: 1_010,
+      toolExecuteEndAt: 1_090,
+    });
+    expect(Object.keys(withTiming)).not.toContain("bridgeTiming");
+    expect(JSON.stringify(withTiming)).not.toContain("bridgeTiming");
+    expect(JSON.parse(JSON.stringify(withTiming))).toEqual({
+      contentItems: [{ type: "inputText", text: "ok" }],
+      success: true,
+    });
   });
 });

--- a/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
@@ -12,6 +12,7 @@ import {
   shouldReleaseTurnAfterTerminalDynamicTool,
   toCodexDynamicToolProgressResponse,
   toCodexDynamicToolProtocolResponse,
+  type CodexDynamicToolBridgeTiming,
   withDynamicToolBridgeTiming,
 } from "./dynamic-tool-execution.js";
 import type { CodexDynamicToolCallResponse } from "./protocol.js";
@@ -986,7 +987,14 @@ describe("dynamic tool execution helpers", () => {
     });
 
     expect(withTiming).toBe(response);
-    expect(withTiming.bridgeTiming).toEqual({
+    // bridgeTiming is intentionally not part of the public
+    // CodexDynamicToolCallResponse type (it must stay a hidden,
+    // non-enumerable, transport-internal value) — read it the same way
+    // client.ts's log boundary does, via a local cast.
+    const attachedTiming = (
+      withTiming as typeof withTiming & { bridgeTiming?: CodexDynamicToolBridgeTiming }
+    ).bridgeTiming;
+    expect(attachedTiming).toEqual({
       toolName: "memory_search",
       requestReceivedAt: 1_000,
       toolExecuteStartAt: 1_010,
@@ -996,8 +1004,9 @@ describe("dynamic tool execution helpers", () => {
     const serialized = JSON.stringify(withTiming);
     expect(serialized).not.toContain("bridgeTiming");
     // Round-trips through the real JSON.stringify boundary the wire actually
-    // uses (structuredClone would drop bridgeTiming too, but via a different
-    // mechanism than the one this test is verifying).
+    // uses. (structuredClone is NOT an equivalent exclusion mechanism here —
+    // it preserves non-enumerable own properties, so it would NOT drop
+    // bridgeTiming; JSON.stringify is what actually excludes it.)
     expect(JSON.parse(serialized)).toEqual({
       contentItems: [{ type: "inputText", text: "ok" }],
       success: true,

--- a/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
@@ -993,8 +993,12 @@ describe("dynamic tool execution helpers", () => {
       toolExecuteEndAt: 1_090,
     });
     expect(Object.keys(withTiming)).not.toContain("bridgeTiming");
-    expect(JSON.stringify(withTiming)).not.toContain("bridgeTiming");
-    expect(JSON.parse(JSON.stringify(withTiming))).toEqual({
+    const serialized = JSON.stringify(withTiming);
+    expect(serialized).not.toContain("bridgeTiming");
+    // Round-trips through the real JSON.stringify boundary the wire actually
+    // uses (structuredClone would drop bridgeTiming too, but via a different
+    // mechanism than the one this test is verifying).
+    expect(JSON.parse(serialized)).toEqual({
       contentItems: [{ type: "inputText", text: "ok" }],
       success: true,
     });

--- a/extensions/codex/src/app-server/dynamic-tool-execution.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.ts
@@ -28,12 +28,25 @@ import { resolveCodexToolAbortTerminalReason } from "./tool-abort-terminal-reaso
 export { resolveCodexToolAbortTerminalReason } from "./tool-abort-terminal-reason.js";
 import {
   isJsonObject,
-  type CodexDynamicToolBridgeTiming,
   type CodexDynamicToolCallParams,
   type CodexDynamicToolCallResponse,
   type CodexDynamicToolDiagnosticTerminalReason,
   type JsonValue,
 } from "./protocol.js";
+
+/**
+ * Phase timestamps (epoch ms) spanning the OpenClaw side of one Codex dynamic
+ * tool round trip: the `item/tool/call` request arriving from Codex, the
+ * OpenClaw tool execution window, and (attached separately at the transport
+ * write boundary) the response being sent back. Used to distinguish tool
+ * execution time from bridge/transport overhead; never serialized to Codex.
+ */
+export type CodexDynamicToolBridgeTiming = {
+  toolName: string;
+  requestReceivedAt: number;
+  toolExecuteStartAt: number;
+  toolExecuteEndAt: number;
+};
 
 /** Default timeout for Codex dynamic tool calls. */
 const CODEX_DYNAMIC_TOOL_TIMEOUT_MS = 90_000;

--- a/extensions/codex/src/app-server/dynamic-tool-execution.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.ts
@@ -28,6 +28,7 @@ import { resolveCodexToolAbortTerminalReason } from "./tool-abort-terminal-reaso
 export { resolveCodexToolAbortTerminalReason } from "./tool-abort-terminal-reason.js";
 import {
   isJsonObject,
+  type CodexDynamicToolBridgeTiming,
   type CodexDynamicToolCallParams,
   type CodexDynamicToolCallResponse,
   type CodexDynamicToolDiagnosticTerminalReason,
@@ -325,6 +326,23 @@ export function toCodexDynamicToolProtocolResponse(
     contentItems: response.contentItems,
     success: response.success,
   };
+}
+
+/**
+ * Attaches non-enumerable bridge phase timing to a protocol response so it
+ * survives the return path to the app-server transport write boundary
+ * without ever reaching Codex (JSON.stringify skips non-enumerable props).
+ */
+export function withDynamicToolBridgeTiming<T extends CodexDynamicToolCallResponse>(
+  response: T,
+  timing: CodexDynamicToolBridgeTiming,
+): T {
+  Object.defineProperty(response, "bridgeTiming", {
+    configurable: true,
+    enumerable: false,
+    value: timing,
+  });
+  return response;
 }
 
 /** Adds async-started progress details when a tool result continues out of band. */

--- a/extensions/codex/src/app-server/protocol.ts
+++ b/extensions/codex/src/app-server/protocol.ts
@@ -459,12 +459,28 @@ export type CodexDynamicToolCallParams = {
 
 export type CodexDynamicToolCallResponse = {
   asyncStarted?: boolean;
+  /** Non-enumerable phase timing kept off the wire; read at the transport write boundary only. */
+  bridgeTiming?: CodexDynamicToolBridgeTiming;
   contentItems: CodexDynamicToolCallOutputContentItem[];
   diagnosticTerminalReason?: CodexDynamicToolDiagnosticTerminalReason;
   diagnosticTerminalType?: CodexDynamicToolDiagnosticTerminalType;
   sideEffectEvidence?: boolean;
   success: boolean;
   terminate?: boolean;
+};
+
+/**
+ * Phase timestamps (epoch ms) spanning the OpenClaw side of one Codex dynamic
+ * tool round trip: the `item/tool/call` request arriving from Codex, the
+ * OpenClaw tool execution window, and (attached separately at the transport
+ * write boundary) the response being sent back. Used to distinguish tool
+ * execution time from bridge/transport overhead; never serialized to Codex.
+ */
+export type CodexDynamicToolBridgeTiming = {
+  toolName: string;
+  requestReceivedAt: number;
+  toolExecuteStartAt: number;
+  toolExecuteEndAt: number;
 };
 
 export type CodexDynamicToolDiagnosticTerminalType = "blocked" | "completed" | "error";

--- a/extensions/codex/src/app-server/protocol.ts
+++ b/extensions/codex/src/app-server/protocol.ts
@@ -460,27 +460,13 @@ export type CodexDynamicToolCallParams = {
 export type CodexDynamicToolCallResponse = {
   asyncStarted?: boolean;
   /** Non-enumerable phase timing kept off the wire; read at the transport write boundary only. */
-  bridgeTiming?: CodexDynamicToolBridgeTiming;
+  bridgeTiming?: import("./dynamic-tool-execution.js").CodexDynamicToolBridgeTiming;
   contentItems: CodexDynamicToolCallOutputContentItem[];
   diagnosticTerminalReason?: CodexDynamicToolDiagnosticTerminalReason;
   diagnosticTerminalType?: CodexDynamicToolDiagnosticTerminalType;
   sideEffectEvidence?: boolean;
   success: boolean;
   terminate?: boolean;
-};
-
-/**
- * Phase timestamps (epoch ms) spanning the OpenClaw side of one Codex dynamic
- * tool round trip: the `item/tool/call` request arriving from Codex, the
- * OpenClaw tool execution window, and (attached separately at the transport
- * write boundary) the response being sent back. Used to distinguish tool
- * execution time from bridge/transport overhead; never serialized to Codex.
- */
-export type CodexDynamicToolBridgeTiming = {
-  toolName: string;
-  requestReceivedAt: number;
-  toolExecuteStartAt: number;
-  toolExecuteEndAt: number;
 };
 
 export type CodexDynamicToolDiagnosticTerminalType = "blocked" | "completed" | "error";

--- a/extensions/codex/src/app-server/protocol.ts
+++ b/extensions/codex/src/app-server/protocol.ts
@@ -459,8 +459,6 @@ export type CodexDynamicToolCallParams = {
 
 export type CodexDynamicToolCallResponse = {
   asyncStarted?: boolean;
-  /** Non-enumerable phase timing kept off the wire; read at the transport write boundary only. */
-  bridgeTiming?: import("./dynamic-tool-execution.js").CodexDynamicToolBridgeTiming;
   contentItems: CodexDynamicToolCallOutputContentItem[];
   diagnosticTerminalReason?: CodexDynamicToolDiagnosticTerminalReason;
   diagnosticTerminalType?: CodexDynamicToolDiagnosticTerminalType;

--- a/extensions/codex/src/app-server/run-attempt-server-requests.ts
+++ b/extensions/codex/src/app-server/run-attempt-server-requests.ts
@@ -15,6 +15,7 @@ import {
   shouldBlockTerminalReleaseForNonTerminalDynamicToolResult,
   toCodexDynamicToolProgressResponse,
   toCodexDynamicToolProtocolResponse,
+  withDynamicToolBridgeTiming,
 } from "./dynamic-tool-execution.js";
 import { recordCodexDynamicToolResult } from "./dynamic-tool-result-projection.js";
 import { handleCodexAppServerElicitationRequest } from "./elicitation-bridge.js";
@@ -66,6 +67,7 @@ export function createCodexAttemptServerRequestController(
   const handleServerRequest = async (
     request: CodexAppServerServerRequest,
     scope: CodexThreadRouteScope,
+    receivedAtMs: number,
   ) => {
     const turnId = turnIdRef.current;
     const projector = projectorRef.current;
@@ -152,6 +154,7 @@ export function createCodexAttemptServerRequestController(
         toolCallId: call.callId,
         name: call.tool,
         arguments: call.arguments,
+        requestReceivedAt: receivedAtMs,
       });
       projector?.recordDynamicToolCall({
         callId: call.callId,
@@ -245,7 +248,14 @@ export function createCodexAttemptServerRequestController(
             presentationOnly: true,
           });
         }
-        const toolDurationMs = Math.max(0, Date.now() - toolStartedAt);
+        const toolExecuteEndAt = Date.now();
+        const toolDurationMs = Math.max(0, toolExecuteEndAt - toolStartedAt);
+        withDynamicToolBridgeTiming(protocolResponse, {
+          toolName: call.tool,
+          requestReceivedAt: receivedAtMs,
+          toolExecuteStartAt: toolStartedAt,
+          toolExecuteEndAt,
+        });
         trajectoryRecorder?.recordEvent("tool.result", {
           threadId: call.threadId,
           turnId: call.turnId,
@@ -253,6 +263,14 @@ export function createCodexAttemptServerRequestController(
           name: call.tool,
           success: protocolResponse.success,
           contentItems: protocolResponse.contentItems,
+          requestReceivedAt: receivedAtMs,
+          toolExecuteStartAt: toolStartedAt,
+          toolExecuteEndAt,
+          // Repairable-transport estimate: request-received -> dispatch start.
+          // Excludes actual tool execution (toolDurationMs) and the
+          // dispatch/write time captured separately at the transport write
+          // boundary (see client.ts's bridge timing log).
+          bridgeInboundMs: Math.max(0, toolStartedAt - receivedAtMs),
         });
         recordCodexDynamicToolResult(projector, call, response, protocolResponse);
         if (shouldEmitDynamicToolProgress) {

--- a/extensions/codex/src/app-server/turn-router.ts
+++ b/extensions/codex/src/app-server/turn-router.ts
@@ -26,6 +26,7 @@ export type CodexThreadRouteScope = {
 type CodexThreadRequestHandler = (
   request: CodexAppServerServerRequest,
   scope: CodexThreadRouteScope,
+  receivedAtMs: number,
 ) => Promise<JsonValue | undefined> | JsonValue | undefined;
 type CodexThreadNotificationHandler = (
   notification: CodexServerNotification,
@@ -354,6 +355,9 @@ class ClientTurnRouter implements CodexAppServerTurnRouter {
   }
 
   private async routeRequest(request: CodexAppServerServerRequest): Promise<JsonValue | undefined> {
+    // Captured before any routing/activation waits below so downstream phase
+    // timing can separate genuine queueing delay from tool execution time.
+    const receivedAtMs = Date.now();
     if (this.disposed) {
       return undefined;
     }
@@ -396,10 +400,14 @@ class ClientTurnRouter implements CodexAppServerTurnRouter {
       return undefined;
     }
     try {
-      const result = await handler(request, {
-        threadId: scope.threadId,
-        ...(scope.turnId ? { turnId: scope.turnId } : {}),
-      });
+      const result = await handler(
+        request,
+        {
+          threadId: scope.threadId,
+          ...(scope.turnId ? { turnId: scope.turnId } : {}),
+        },
+        receivedAtMs,
+      );
       return route.released ? undefined : result;
     } catch (error) {
       if (route.released) {


### PR DESCRIPTION
## What Problem This Solves

The Codex app-server bridge (the OpenClaw-side handling of a Codex
dynamic-tool round trip) had no instrumentation to separate repairable
bridge/transport overhead from actual tool execution time or model/provider
wait time. `scope/memory-recall-enforcement-latency-20260718.md`'s latency
investigation needed real phase timestamps — request received, tool execute
start/end, response sent — to confirm or refute a hypothesized ~5-6s
"dynamic-tool delay" outside memory-core. Without this instrumentation, any
future latency fix in this area would be guesswork instead of measurement,
and there was no way to tell a genuine transport regression from ordinary
tool execution time.

## Summary

Codex app-server bridge instrumentation slice of the memory-recall latency
investigation (`scope/memory-recall-enforcement-latency-20260718.md`,
deliverable A/B item 5). Adds phase timestamps for the OpenClaw side of a
Codex dynamic-tool round trip:

- `requestReceivedAt` — captured in `turn-router.ts` before any
  routing/activation waits, so queueing delay is separable from execution.
- `toolExecuteStartAt` / `toolExecuteEndAt` — captured in
  `run-attempt-server-requests.ts` around the actual
  `handleDynamicToolCallWithTimeout` call (the end timestamp lands right
  after the terminal-observer callback fires, i.e. it also covers the
  "terminal tool result observed" point from the scope doc).
- `responseSentAt` — captured in `client.ts` at the transport write
  boundary, the last point before Codex ever sees the response.

The four timestamps are attached to the protocol response as a
**non-enumerable** `bridgeTiming` property (`withDynamicToolBridgeTiming`),
so `JSON.stringify` skips it and it never reaches Codex over the wire. At
the write boundary, `client.ts` reads it once and logs a
`"codex dynamic tool bridge timing"` info record with the derived
`bridgeInboundMs` / `toolExecuteMs` / `bridgeOutboundMs` / `bridgeTotalMs`
breakdown, so repairable bridge/transport overhead can be measured
separately from actual tool execution time.

## Investigation gate finding (per scope doc §3)

The scope doc hypothesized ~5-6s of "dynamic-tool delay" outside
memory-core based on caller-observed wall time vs. OpenClaw's own
`toolMs`. Re-checking against canonical OpenClaw trajectory timestamps
(recorded on the originating Workboard card) shows the actual bridge
overhead is small: `memory_search(memory)` tool.call→tool.result was
2.199s while the plugin's own `toolMs` was 1.978s (~221ms bridge/
serialization), and `memory_search(all)` was 8.360s vs. `toolMs` 8.221s
(~139ms). The larger 13-16s wall-clock figures in the original
measurement included the outer nested-tool orchestration of the
investigating session itself, not bridge/transport overhead.

Per the investigation gate ("no transport 'fix' is fabricated" if the
delay is model/provider time rather than repairable transport): this PR
lands the instrumentation so that measurement is now first-class and
reusable, but does **not** claim or implement a transport latency fix —
there is no evidence of repairable bridge overhead beyond ~150-250ms.

## Evidence

- Re-measured the investigation-gate hypothesis against canonical OpenClaw
  trajectory timestamps (see finding above): actual bridge/serialization
  overhead is ~139-221ms, not the ~5-6s originally hypothesized from
  wall-clock figures that in fact included the investigating session's own
  nested-tool orchestration.
- All three Vitest configs touched by this change pass locally, independent
  of hosted CI: `vitest.extension-codex-app-server-runtime.config.ts` (616
  tests), `vitest.extension-codex-app-server-tools.config.ts` (466 tests),
  `vitest.extension-codex-app-server-attempt-extra.config.ts` (196 tests) —
  1278 tests total, all passing. `pnpm tsgo:extensions` typechecks clean
  (exit 0).
- New unit tests directly assert the behavior this PR depends on: the
  non-enumerable `bridgeTiming` property survives `JSON.stringify` exclusion
  (`dynamic-tool-execution.test.ts`), and an end-to-end
  `CodexAppServerClient` harness test confirms the derived
  `bridgeInboundMs`/`toolExecuteMs`/`bridgeOutboundMs`/`bridgeTotalMs`
  breakdown is logged at the transport write boundary while the outbound
  wire message never contains `bridgeTiming` (`client.test.ts`).

## Test plan
- [x] `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-codex-app-server-runtime.config.ts` (616 tests, includes `client.test.ts`)
- [x] `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-codex-app-server-tools.config.ts` (466 tests, includes `dynamic-tool-execution.test.ts`)
- [x] `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts` (196 tests, includes `run-attempt.dynamic-tools.test.ts`)
- [x] `pnpm tsgo:extensions` and `tsgo:extensions:test` (typecheck, clean)
- [x] Added unit tests: non-enumerable `bridgeTiming` survives `JSON.stringify` exclusion; end-to-end `CodexAppServerClient` harness test asserting the log breakdown and that the outbound wire message never contains `bridgeTiming`.

Do not merge until the companion review card on `cayk-roadmap` passes.


## What Problem This Solves

The Codex app-server bridge (OpenClaw's side of every dynamic-tool round trip,
e.g. `memory_search`) had no phase-level instrumentation, so a caller-observed
multi-second latency (hypothesized at ~5-6s of "dynamic-tool delay" outside
memory-core, per `scope/memory-recall-enforcement-latency-20260718.md`) could
not be attributed to transport/bridge overhead vs. actual tool execution vs.
model/provider time. This PR adds first-class phase timestamps (request
received -> tool execute start/end -> response sent) so that overhead is
measurable and reusable going forward, satisfying the investigation-gate
requirement that must land before any transport "fix" can be scoped or
claimed.

## Evidence

- Re-checked the hypothesized ~5-6s bridge delay against canonical OpenClaw
  trajectory timestamps (recorded on Workboard card `55255055`):
  `memory_search(memory)` tool.call→tool.result was 2.199s vs. the plugin's
  own `toolMs` of 1.978s (~221ms bridge/serialization); `memory_search(all)`
  was 8.360s vs. `toolMs` 8.221s (~139ms). The larger 13-16s wall-clock
  figures came from the investigating session's own outer nested-tool
  orchestration, not the bridge.
- Independently re-ran all three test suites during review (companion review
  card `627f0334` on `cayk-roadmap`), matching the PR's claimed counts:
  `vitest.extension-codex-app-server-runtime.config.ts` 616/616 passed,
  `vitest.extension-codex-app-server-tools.config.ts` 466/466 passed,
  `vitest.extension-codex-app-server-attempt-extra.config.ts` 196/196 passed.
  `pnpm tsgo:extensions` typecheck clean.
- The new unit tests directly assert the safety property this PR depends on:
  the non-enumerable `bridgeTiming` field survives `JSON.stringify` exclusion
  (`dynamic-tool-execution.test.ts`), and an end-to-end
  `CodexAppServerClient` harness test confirms the outbound wire message
  never contains `bridgeTiming` while the derived
  `bridgeInboundMs`/`toolExecuteMs`/`bridgeOutboundMs`/`bridgeTotalMs`
  breakdown is logged once at the transport write boundary
  (`client.test.ts`).
- Independent DeepSeek v4 Pro adversarial code review (correctness /
  race-condition / serialization-safety lenses) returned PASS, with only
  non-blocking MODERATE/MINOR findings (a `bridgeTotalMs` derived-metric
  edge case under clock-skew clamping, and a theoretical unguarded
  `Object.defineProperty` throw path) — no CRITICAL findings.
