### PR TITLE
feat(ui): hold-to-record dictation on the composer mic button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 - **iOS offline chat:** pre-paint recent sessions and canonical transcripts from a protected, bounded per-gateway cache, keep sending disabled offline, and purge cached conversation text when pairing is reset. (#100194)
 - **Slack progress indicators:** use Slack's native assistant thread status and rotating loading messages by default while keeping acknowledgement reactions static; lifecycle reaction updates now require `messages.statusReactions.enabled: true`.
 - **Control UI Talk controls:** keep voice, model, sensitivity, and other realtime defaults in Settings → Communications → Talk, and use the composer microphone caret to select any browser audio input. (#101046)
+- **Control UI dictation:** hold the composer microphone button to stream speech transcription, preview partial text, and insert the final transcript at the cursor without sending.
 - **Control UI session workspace shortcut:** expand or collapse the active Chat pane's session workspace rail with ⇧⌘B without changing the main app sidebar or the separate detail and Canvas preview panel. Thanks @shakkernerd.
 - **Control UI Settings shortcut:** open Settings with ⇧⌘, while leaving the browser-owned ⌘, shortcut unchanged. Thanks @shakkernerd.
 - **Control UI chat layout:** center the transcript on the composer axis, keep assistant and tool output left and user bubbles right within the same readable frame, and preserve custom message-width overrides. (#104474) Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ Docs: https://docs.openclaw.ai
 - **iOS offline chat:** pre-paint recent sessions and canonical transcripts from a protected, bounded per-gateway cache, keep sending disabled offline, and purge cached conversation text when pairing is reset. (#100194)
 - **Slack progress indicators:** use Slack's native assistant thread status and rotating loading messages by default while keeping acknowledgement reactions static; lifecycle reaction updates now require `messages.statusReactions.enabled: true`.
 - **Control UI Talk controls:** keep voice, model, sensitivity, and other realtime defaults in Settings → Communications → Talk, and use the composer microphone caret to select any browser audio input. (#101046)
-- **Control UI dictation:** hold the composer microphone button to stream speech transcription, preview partial text, and insert the final transcript at the cursor without sending.
 - **Control UI session workspace shortcut:** expand or collapse the active Chat pane's session workspace rail with ⇧⌘B without changing the main app sidebar or the separate detail and Canvas preview panel. Thanks @shakkernerd.
 - **Control UI Settings shortcut:** open Settings with ⇧⌘, while leaving the browser-owned ⌘, shortcut unchanged. Thanks @shakkernerd.
 - **Control UI chat layout:** center the transcript on the composer axis, keep assistant and tool output left and user bubbles right within the same readable frame, and preserve custom message-width overrides. (#104474) Thanks @shakkernerd.

--- a/ui/src/app/settings.node.test.ts
+++ b/ui/src/app/settings.node.test.ts
@@ -639,6 +639,28 @@ describe("loadSettings default gateway URL derivation", () => {
     );
   });
 
+  it("defaults composer hold-to-record on and persists only the opt-out", () => {
+    setTestLocation({
+      protocol: "https:",
+      host: "gateway.example:8443",
+      pathname: "/",
+    });
+
+    const gwUrl = expectedGatewayUrl("");
+    const scopedKey = `openclaw.control.settings.v1:${gwUrl}`;
+    expect(loadSettings().composerHoldToRecord).toBe(true);
+
+    saveSettings({ ...loadSettings(), composerHoldToRecord: false });
+    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}").composerHoldToRecord).toBe(false);
+    expect(loadSettings().composerHoldToRecord).toBe(false);
+
+    saveSettings({ ...loadSettings(), composerHoldToRecord: true });
+    expect(JSON.parse(localStorage.getItem(scopedKey) ?? "{}")).not.toHaveProperty(
+      "composerHoldToRecord",
+    );
+    expect(loadSettings().composerHoldToRecord).toBe(true);
+  });
+
   it("normalizes and persists the device-local talk camera preference", () => {
     setTestLocation({
       protocol: "https:",

--- a/ui/src/app/settings.ts
+++ b/ui/src/app/settings.ts
@@ -115,6 +115,7 @@ export type UiSettings = {
   catalogOpenTarget?: CatalogOpenTarget;
   realtimeTalkInputDeviceId?: string;
   realtimeTalkVideoDeviceId?: string;
+  composerHoldToRecord?: boolean;
   // Camera intent is device-local, not per-agent or synced through config ui.prefs.
   talkCameraAutoEnable?: boolean;
   splitRatio: number; // Sidebar split ratio (0.4 to 0.7, default 0.6)
@@ -358,6 +359,7 @@ export function loadSettings(): UiSettings {
     sidebarEntries: [...DEFAULT_SIDEBAR_ENTRIES],
     pinnedAgentIds: [],
     textScale: 100,
+    composerHoldToRecord: true,
   };
 
   try {
@@ -425,6 +427,10 @@ export function loadSettings(): UiSettings {
       catalogOpenTarget: normalizeCatalogOpenTarget(parsed.catalogOpenTarget),
       realtimeTalkInputDeviceId: normalizeOptionalString(parsed.realtimeTalkInputDeviceId),
       realtimeTalkVideoDeviceId: normalizeOptionalString(parsed.realtimeTalkVideoDeviceId),
+      composerHoldToRecord:
+        typeof parsed.composerHoldToRecord === "boolean"
+          ? parsed.composerHoldToRecord
+          : defaults.composerHoldToRecord,
       talkCameraAutoEnable:
         typeof parsed.talkCameraAutoEnable === "boolean" ? parsed.talkCameraAutoEnable : undefined,
       splitRatio:
@@ -572,6 +578,7 @@ function persistSettings(next: UiSettings, options: { selectGateway?: boolean } 
     ...(normalizeOptionalString(next.realtimeTalkVideoDeviceId)
       ? { realtimeTalkVideoDeviceId: normalizeOptionalString(next.realtimeTalkVideoDeviceId) }
       : {}),
+    ...(next.composerHoldToRecord === false ? { composerHoldToRecord: false } : {}),
     ...(typeof next.talkCameraAutoEnable === "boolean"
       ? { talkCameraAutoEnable: next.talkCameraAutoEnable }
       : {}),

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3904,6 +3904,20 @@ export const en: TranslationMap = {
       microphonePageInactive: "Microphone inputs are unavailable while this page is inactive.",
       microphonePermissionBlocked:
         "Microphone access is blocked. Allow it in browser site settings to list inputs.",
+      holdToRecordSetting: "Hold microphone button to dictate",
+      holdToRecordSettingDescription:
+        "Hold the composer microphone button, speak, then release to insert text without sending.",
+      dictationAudioUnsupported: "The Gateway returned an unsupported dictation audio format.",
+      dictationBrowserAudioUnsupported: "This browser cannot capture dictation audio at 8 kHz.",
+      dictationConnecting: "Starting dictation…",
+      dictationDisconnected: "Dictation stopped because the Gateway disconnected.",
+      dictationFailed: "Dictation failed.",
+      dictationFinalizing: "Finishing dictation…",
+      dictationFinalizationTimedOut:
+        "Dictation stopped before the last partial transcript could be finalized.",
+      dictationProviderUnavailable: "No transcription provider is configured for dictation.",
+      dictationRecording: "Recording {elapsed}",
+      dictationReleaseToInsert: "Release to insert dictation",
       realtimeTalkRequiresMicrophone: "Realtime voice input requires browser microphone access.",
       selectedMicrophoneUnavailable:
         "The selected microphone is unavailable. Choose another input or System default.",

--- a/ui/src/pages/chat/chat-composer.test.ts
+++ b/ui/src/pages/chat/chat-composer.test.ts
@@ -11,7 +11,11 @@ import { renderChatComposer, resetChatComposerState } from "./components/chat-co
 const discoverRealtimeTalkInputsMock = vi.hoisted(() => vi.fn());
 const openRealtimeTalkInputMock = vi.hoisted(() => vi.fn());
 
-vi.mock("./realtime-talk-input.ts", () => ({
+// Keep every real export present: shared-registry workers (isolate:false) can
+// evaluate sibling modules (e.g. chat-realtime's camera discovery) against this
+// factory, and a missing binding breaks unrelated files in the same worker.
+vi.mock("./realtime-talk-input.ts", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./realtime-talk-input.ts")>()),
   discoverRealtimeTalkInputs: discoverRealtimeTalkInputsMock,
   openRealtimeTalkInput: openRealtimeTalkInputMock,
   describeRealtimeTalkInputError: () => "Microphone access failed.",

--- a/ui/src/pages/chat/chat-composer.test.ts
+++ b/ui/src/pages/chat/chat-composer.test.ts
@@ -2,15 +2,19 @@
 
 import { html, render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { QuestionPrompt } from "../../app/question-prompt.ts";
 import { loadSettings, patchSettings } from "../../app/settings.ts";
 import { i18n, t } from "../../i18n/index.ts";
 import { renderChatComposer, resetChatComposerState } from "./components/chat-composer.ts";
 
 const discoverRealtimeTalkInputsMock = vi.hoisted(() => vi.fn());
+const openRealtimeTalkInputMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./realtime-talk-input.ts", () => ({
   discoverRealtimeTalkInputs: discoverRealtimeTalkInputsMock,
+  openRealtimeTalkInput: openRealtimeTalkInputMock,
+  describeRealtimeTalkInputError: () => "Microphone access failed.",
 }));
 
 vi.mock("../../components/icons.ts", async () => {
@@ -92,11 +96,48 @@ function button(container: Element, label: string): HTMLButtonElement {
   return result;
 }
 
+class DictationAudioContext {
+  readonly destination = {};
+  readonly sampleRate = 8000;
+  readonly close = vi.fn(async () => undefined);
+
+  createMediaStreamSource() {
+    return { connect: vi.fn(), disconnect: vi.fn() };
+  }
+
+  createScriptProcessor() {
+    return { connect: vi.fn(), disconnect: vi.fn(), onaudioprocess: null };
+  }
+
+  createGain() {
+    return { connect: vi.fn(), disconnect: vi.fn(), gain: { value: 1 } };
+  }
+
+  createAnalyser() {
+    return {
+      fftSize: 0,
+      smoothingTimeConstant: 0,
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      getFloatTimeDomainData: (samples: Float32Array) => samples.fill(0),
+    };
+  }
+}
+
+function dictationPointerDown(pointerId: number): PointerEvent {
+  const event = new MouseEvent("pointerdown", { bubbles: true, cancelable: true, button: 0 });
+  Object.defineProperty(event, "pointerId", { value: pointerId });
+  return event as PointerEvent;
+}
+
 afterEach(async () => {
   resetChatComposerState();
   discoverRealtimeTalkInputsMock.mockReset();
+  openRealtimeTalkInputMock.mockReset();
   localStorage.clear();
   document.body.replaceChildren();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
   await i18n.setLocale("en");
   vi.restoreAllMocks();
 });
@@ -378,6 +419,64 @@ describe("renderChatComposer controls", () => {
     expect(
       container.querySelector(`button[aria-label="${t("chat.composer.startVoiceInput")}"]`),
     ).not.toBeNull();
+  });
+
+  it("keeps the captured dictation button through the hold-start rerender", async () => {
+    vi.useFakeTimers();
+    openRealtimeTalkInputMock.mockResolvedValue({ getTracks: () => [{ stop: vi.fn() }] });
+    vi.stubGlobal("AudioContext", DictationAudioContext);
+    const request = vi.fn(async (method: string) => {
+      if (method === "talk.catalog") {
+        return { transcription: { ready: true } };
+      }
+      if (method === "talk.session.create") {
+        return {
+          sessionId: "dictation-1",
+          transcriptionSessionId: "dictation-1",
+          audio: { inputEncoding: "g711_ulaw", inputSampleRateHz: 8000 },
+        };
+      }
+      return { ok: true };
+    });
+    const gatewayClient = {
+      addEventListener: vi.fn(() => () => undefined),
+      request,
+    } as unknown as GatewayBrowserClient;
+    const container = document.createElement("div");
+    document.body.append(container);
+    const composerProps = props({
+      draft: "Keep this text",
+      gatewayClient,
+      onToggleRealtimeTalk: vi.fn(),
+    });
+    const draw = () => render(renderChatComposer(composerProps), container);
+    composerProps.onRequestUpdate = draw;
+    draw();
+
+    const capturedButton = container.querySelector<HTMLButtonElement>(
+      ".chat-talk-control > openclaw-tooltip > button",
+    );
+    expect(capturedButton).not.toBeNull();
+    const captures = new Set<number>();
+    Object.defineProperties(capturedButton!, {
+      setPointerCapture: { value: (pointerId: number) => captures.add(pointerId) },
+      hasPointerCapture: { value: (pointerId: number) => captures.has(pointerId) },
+      releasePointerCapture: { value: (pointerId: number) => captures.delete(pointerId) },
+    });
+
+    capturedButton!.dispatchEvent(dictationPointerDown(9));
+    expect(capturedButton!.hasPointerCapture(9)).toBe(true);
+    await vi.advanceTimersByTimeAsync(250);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const rerenderedButton = container.querySelector<HTMLButtonElement>(
+      ".chat-talk-control > openclaw-tooltip > button",
+    );
+    expect(request).toHaveBeenCalledWith("talk.session.create", expect.anything());
+    expect(rerenderedButton).toBe(capturedButton);
+    expect(rerenderedButton?.hasPointerCapture(9)).toBe(true);
   });
 
   it("keeps voice and generation stop controls distinct when both are active", () => {

--- a/ui/src/pages/chat/chat-composer.test.ts
+++ b/ui/src/pages/chat/chat-composer.test.ts
@@ -4,46 +4,22 @@ import { html, render } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { QuestionPrompt } from "../../app/question-prompt.ts";
+import { loadSettings, patchSettings } from "../../app/settings.ts";
+import { icons } from "../../components/icons.ts";
+import { i18n, t } from "../../i18n/index.ts";
+import { renderChatComposer, resetChatComposerState } from "./components/chat-composer.ts";
+import * as realtimeTalkInput from "./realtime-talk-input.ts";
 
-const discoverRealtimeTalkInputsMock = vi.hoisted(() => vi.fn());
-const openRealtimeTalkInputMock = vi.hoisted(() => vi.fn());
+const discoverRealtimeTalkInputsMock = vi.fn();
+const openRealtimeTalkInputMock = vi.fn();
 
-// Keep every real export present: shared-registry workers (isolate:false) can
-// evaluate sibling modules (e.g. chat-realtime's camera discovery) against this
-// factory, and a missing binding breaks unrelated files in the same worker.
-vi.mock("./realtime-talk-input.ts", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("./realtime-talk-input.ts")>()),
-  discoverRealtimeTalkInputs: discoverRealtimeTalkInputsMock,
-  openRealtimeTalkInput: openRealtimeTalkInputMock,
-  describeRealtimeTalkInputError: () => "Microphone access failed.",
-}));
+type ComposerProps = Parameters<typeof renderChatComposer>[0];
 
-vi.mock("../../components/icons.ts", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../components/icons.ts")>();
-  const { html: litHtml } = await import("lit");
-  return {
-    ...actual,
-    icons: {
-      ...actual.icons,
-      camera: litHtml`<svg data-icon="camera"></svg>`,
-      cameraOff: litHtml`<svg data-icon="camera-off"></svg>`,
-      switchCamera: litHtml`<svg data-icon="switch-camera"></svg>`,
-      check: litHtml`<svg data-icon="check"></svg>`,
-      chevronDown: litHtml`<svg data-icon="chevron-down"></svg>`,
-    },
-  };
-});
-
-type ComposerProps = Parameters<
-  typeof import("./components/chat-composer.ts").renderChatComposer
->[0];
-
-let loadSettings: typeof import("../../app/settings.ts").loadSettings;
-let patchSettings: typeof import("../../app/settings.ts").patchSettings;
-let i18n: typeof import("../../i18n/index.ts").i18n;
-let t: typeof import("../../i18n/index.ts").t;
-let renderChatComposer: typeof import("./components/chat-composer.ts").renderChatComposer;
-let resetChatComposerState: typeof import("./components/chat-composer.ts").resetChatComposerState;
+function iconMarkup(icon: unknown): string | undefined {
+  const container = document.createElement("div");
+  render(icon, container);
+  return container.querySelector("svg")?.innerHTML;
+}
 
 function props(overrides: Partial<ComposerProps> = {}): ComposerProps {
   return {
@@ -143,13 +119,15 @@ function dictationPointerDown(pointerId: number): PointerEvent {
   return event as PointerEvent;
 }
 
-beforeEach(async () => {
-  // isolate:false keeps a worker's module registry across test files. chat-view
-  // eagerly imports the composer, so reload it after this file's mocks are active.
-  vi.resetModules();
-  ({ loadSettings, patchSettings } = await import("../../app/settings.ts"));
-  ({ i18n, t } = await import("../../i18n/index.ts"));
-  ({ renderChatComposer, resetChatComposerState } = await import("./components/chat-composer.ts"));
+beforeEach(() => {
+  // ESM imports remain live when the composer was cached by another test file.
+  // Patch the shared dependencies instead of clearing isolate:false's registry.
+  vi.spyOn(realtimeTalkInput, "discoverRealtimeTalkInputs").mockImplementation(
+    discoverRealtimeTalkInputsMock,
+  );
+  vi.spyOn(realtimeTalkInput, "openRealtimeTalkInput").mockImplementation(
+    openRealtimeTalkInputMock,
+  );
 });
 
 afterEach(async () => {
@@ -278,9 +256,9 @@ describe("renderChatComposer controls", () => {
     expect(items.find((item) => item.value === "studio-mic")?.getAttribute("aria-checked")).toBe(
       "true",
     );
-    expect(
-      items.find((item) => item.value === "studio-mic")?.querySelector('[data-icon="check"]'),
-    ).not.toBeNull();
+    expect(items.find((item) => item.value === "studio-mic")?.querySelector("svg")?.innerHTML).toBe(
+      iconMarkup(icons.check),
+    );
 
     items.find((item) => item.value === "headset")?.click();
     await dropdown?.updateComplete;
@@ -371,8 +349,8 @@ describe("renderChatComposer controls", () => {
     });
 
     const cameraToggle = button(container, t("chat.composer.turnCameraOff"));
-    expect(cameraToggle.querySelector('[data-icon="camera-off"]')).not.toBeNull();
-    expect(cameraToggle.querySelector('[data-icon="camera"]')).toBeNull();
+    expect(cameraToggle.querySelector("svg")?.innerHTML).toBe(iconMarkup(icons.cameraOff));
+    expect(cameraToggle.querySelector("svg")?.innerHTML).not.toBe(iconMarkup(icons.camera));
   });
 
   it("offers camera switching only for a live preview with multiple cameras", () => {

--- a/ui/src/pages/chat/chat-composer.test.ts
+++ b/ui/src/pages/chat/chat-composer.test.ts
@@ -151,6 +151,15 @@ describe("renderChatComposer controls", () => {
     });
     expect(button(view.container, t("chat.runControls.queueMessage")).disabled).toBe(false);
 
+    const onToggleWithDraft = vi.fn();
+    view = renderComposer({
+      draft: "Keep this text",
+      onToggleRealtimeTalk: onToggleWithDraft,
+    });
+    button(view.container, t("chat.composer.startVoiceInput")).click();
+    expect(onToggleWithDraft).toHaveBeenCalledOnce();
+    expect(button(view.container, t("chat.runControls.sendMessage"))).toBeTruthy();
+
     view = renderComposer({
       canAbort: true,
       draft: "Replace the current run",
@@ -354,7 +363,7 @@ describe("renderChatComposer controls", () => {
     );
   });
 
-  it("sends attachment-only drafts instead of starting voice", () => {
+  it("keeps send and dictation distinct for attachment-only drafts", () => {
     const onSend = vi.fn();
     const onToggleRealtimeTalk = vi.fn();
     const { container } = renderComposer({
@@ -368,7 +377,7 @@ describe("renderChatComposer controls", () => {
     expect(onToggleRealtimeTalk).not.toHaveBeenCalled();
     expect(
       container.querySelector(`button[aria-label="${t("chat.composer.startVoiceInput")}"]`),
-    ).toBeNull();
+    ).not.toBeNull();
   });
 
   it("keeps voice and generation stop controls distinct when both are active", () => {

--- a/ui/src/pages/chat/chat-composer.test.ts
+++ b/ui/src/pages/chat/chat-composer.test.ts
@@ -1,12 +1,9 @@
 /* @vitest-environment jsdom */
 
 import { html, render } from "lit";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { QuestionPrompt } from "../../app/question-prompt.ts";
-import { loadSettings, patchSettings } from "../../app/settings.ts";
-import { i18n, t } from "../../i18n/index.ts";
-import { renderChatComposer, resetChatComposerState } from "./components/chat-composer.ts";
 
 const discoverRealtimeTalkInputsMock = vi.hoisted(() => vi.fn());
 const openRealtimeTalkInputMock = vi.hoisted(() => vi.fn());
@@ -21,10 +18,13 @@ vi.mock("./realtime-talk-input.ts", async (importOriginal) => ({
   describeRealtimeTalkInputError: () => "Microphone access failed.",
 }));
 
-vi.mock("../../components/icons.ts", async () => {
+vi.mock("../../components/icons.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../components/icons.ts")>();
   const { html: litHtml } = await import("lit");
   return {
+    ...actual,
     icons: {
+      ...actual.icons,
       camera: litHtml`<svg data-icon="camera"></svg>`,
       cameraOff: litHtml`<svg data-icon="camera-off"></svg>`,
       switchCamera: litHtml`<svg data-icon="switch-camera"></svg>`,
@@ -34,7 +34,16 @@ vi.mock("../../components/icons.ts", async () => {
   };
 });
 
-type ComposerProps = Parameters<typeof renderChatComposer>[0];
+type ComposerProps = Parameters<
+  typeof import("./components/chat-composer.ts").renderChatComposer
+>[0];
+
+let loadSettings: typeof import("../../app/settings.ts").loadSettings;
+let patchSettings: typeof import("../../app/settings.ts").patchSettings;
+let i18n: typeof import("../../i18n/index.ts").i18n;
+let t: typeof import("../../i18n/index.ts").t;
+let renderChatComposer: typeof import("./components/chat-composer.ts").renderChatComposer;
+let resetChatComposerState: typeof import("./components/chat-composer.ts").resetChatComposerState;
 
 function props(overrides: Partial<ComposerProps> = {}): ComposerProps {
   return {
@@ -133,6 +142,15 @@ function dictationPointerDown(pointerId: number): PointerEvent {
   Object.defineProperty(event, "pointerId", { value: pointerId });
   return event as PointerEvent;
 }
+
+beforeEach(async () => {
+  // isolate:false keeps a worker's module registry across test files. chat-view
+  // eagerly imports the composer, so reload it after this file's mocks are active.
+  vi.resetModules();
+  ({ loadSettings, patchSettings } = await import("../../app/settings.ts"));
+  ({ i18n, t } = await import("../../i18n/index.ts"));
+  ({ renderChatComposer, resetChatComposerState } = await import("./components/chat-composer.ts"));
+});
 
 afterEach(async () => {
   resetChatComposerState();

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -2852,6 +2852,8 @@ class ChatPane extends OpenClawLightDomElement {
       realtimeTalkVideoPending: state.realtimeTalkVideoPending,
       realtimeTalkCameraError: state.realtimeTalkCameraError,
       connected: state.connected,
+      gatewayClient: state.client,
+      composerHoldToRecord: state.settings.composerHoldToRecord,
       canSend: catalogKey ? this.catalogSession?.canContinue === true : !selectedSessionArchived,
       disabledReason: catalogDisabledReason ?? disabledReason,
       disabledActionLabel:
@@ -2982,6 +2984,11 @@ class ChatPane extends OpenClawLightDomElement {
       },
       onDismissRealtimeTalkError: () => {
         dismissRealtimeTalkError(state as never);
+        state.requestUpdate?.();
+      },
+      onDictationError: (message) => {
+        state.lastError = message;
+        state.chatError = message;
         state.requestUpdate?.();
       },
       onAbort: () => void state.handleAbortChat({ preserveDraft: true }),

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -173,31 +173,26 @@ const buildChatItemsMock = vi.hoisted(() =>
     },
   ),
 );
-const renderMessageGroupMock = vi.hoisted(() =>
-  vi.fn(
-    (
-      group: { messages: Array<{ message: unknown }> },
-      _opts?: { onAssistantAttachmentLoaded?: () => void },
-    ) => {
-      const element = document.createElement("div");
-      element.className = "chat-group";
-      element.textContent = group.messages
-        .map(({ message }) => {
-          if (typeof message === "object" && message !== null && "content" in message) {
-            const content = (message as { content?: unknown }).content;
-            if (typeof content === "string") {
-              return content;
-            }
-            return content == null ? "" : JSON.stringify(content);
+const renderMessageGroupMock = vi.fn(
+  (
+    ...[group, _opts]: Parameters<typeof chatMessage.renderMessageGroup>
+  ): ReturnType<typeof chatMessage.renderMessageGroup> => {
+    const text = group.messages
+      .map(({ message }) => {
+        if (typeof message === "object" && message !== null && "content" in message) {
+          const content = (message as { content?: unknown }).content;
+          if (typeof content === "string") {
+            return content;
           }
-          return String(message);
-        })
-        .join("\n");
-      return element;
-    },
-  ),
+          return content == null ? "" : JSON.stringify(content);
+        }
+        return String(message);
+      })
+      .join("\n");
+    return html`<div class="chat-group">${text}</div>`;
+  },
 );
-const assistantAttachmentRenderVersionMock = vi.hoisted(() => ({ value: 0 }));
+const assistantAttachmentRenderVersionMock = { value: 0 };
 
 type ChatHeaderTestState = {
   basePath?: string;
@@ -272,26 +267,22 @@ vi.mock("../../lib/agents/tools-effective.ts", () => ({
   refreshVisibleToolsEffectiveForCurrentSession: refreshVisibleToolsEffectiveForCurrentSessionMock,
 }));
 
-function renderStreamGroupMock(parts: Array<{ kind: string; text?: string }>) {
-  const group = document.createElement("div");
-  group.className = "chat-stream-run";
-  for (const part of parts) {
-    const bubble = document.createElement("div");
-    if (part.kind === "reading-indicator") {
-      bubble.className = "chat-reading-indicator";
-    } else {
-      bubble.className = "chat-stream";
-      bubble.textContent = part.text ?? "";
-    }
-    group.appendChild(bubble);
-  }
-  return group;
+function renderStreamGroupMock(
+  ...[parts, _opts]: Parameters<typeof chatMessage.renderStreamGroup>
+): ReturnType<typeof chatMessage.renderStreamGroup> {
+  return html`<div class="chat-stream-run">
+    ${parts.map((part) =>
+      part.kind === "reading-indicator"
+        ? html`<div class="chat-reading-indicator"></div>`
+        : html`<div class="chat-stream">${part.kind === "stream" ? part.text : ""}</div>`,
+    )}
+  </div>`;
 }
 
-function renderWorkGroupSummaryMock() {
-  const summary = document.createElement("div");
-  summary.className = "chat-work-group";
-  return summary;
+function renderWorkGroupSummaryMock(
+  ..._args: Parameters<typeof chatMessage.renderWorkGroupSummary>
+): ReturnType<typeof chatMessage.renderWorkGroupSummary> {
+  return html`<div class="chat-work-group"></div>`;
 }
 
 beforeEach(() => {

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -2,7 +2,7 @@
 
 import { expectDefined } from "@openclaw/normalization-core";
 import { html, render, type ReactiveControllerHost } from "lit";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type {
   GatewaySessionRow,
@@ -30,6 +30,7 @@ import {
 import { switchChatFastMode, switchChatModel, switchChatThinkingLevel } from "./chat-session.ts";
 import { renderChat, resetChatViewState } from "./chat-view.ts";
 import { resetChatComposerState } from "./components/chat-composer.ts";
+import * as chatMessage from "./components/chat-message.ts";
 import {
   renderChatModelControls,
   type ChatModelControlsProps,
@@ -253,9 +254,9 @@ function requireFirstAttachmentsChange(
   return attachments as ChatAttachment[];
 }
 
-vi.mock("../../components/icons.ts", () => ({
-  icons: {},
-}));
+vi.mock("../../components/icons.ts", async (importOriginal) =>
+  importOriginal<typeof import("../../components/icons.ts")>(),
+);
 
 vi.mock("./chat-thread.ts", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./chat-thread.ts")>();
@@ -267,34 +268,40 @@ vi.mock("./chat-thread.ts", async (importOriginal) => {
   };
 });
 
-vi.mock("./components/chat-message.ts", () => ({
-  getAssistantAttachmentAvailabilityRenderVersion: () => assistantAttachmentRenderVersionMock.value,
-  renderMessageGroup: renderMessageGroupMock,
-  renderStreamGroup: (parts: Array<{ kind: string; text?: string }>) => {
-    const group = document.createElement("div");
-    group.className = "chat-stream-run";
-    for (const part of parts) {
-      const bubble = document.createElement("div");
-      if (part.kind === "reading-indicator") {
-        bubble.className = "chat-reading-indicator";
-      } else {
-        bubble.className = "chat-stream";
-        bubble.textContent = part.text ?? "";
-      }
-      group.appendChild(bubble);
-    }
-    return group;
-  },
-  renderWorkGroupSummary: () => {
-    const summary = document.createElement("div");
-    summary.className = "chat-work-group";
-    return summary;
-  },
-}));
-
 vi.mock("../../lib/agents/tools-effective.ts", () => ({
   refreshVisibleToolsEffectiveForCurrentSession: refreshVisibleToolsEffectiveForCurrentSessionMock,
 }));
+
+function renderStreamGroupMock(parts: Array<{ kind: string; text?: string }>) {
+  const group = document.createElement("div");
+  group.className = "chat-stream-run";
+  for (const part of parts) {
+    const bubble = document.createElement("div");
+    if (part.kind === "reading-indicator") {
+      bubble.className = "chat-reading-indicator";
+    } else {
+      bubble.className = "chat-stream";
+      bubble.textContent = part.text ?? "";
+    }
+    group.appendChild(bubble);
+  }
+  return group;
+}
+
+function renderWorkGroupSummaryMock() {
+  const summary = document.createElement("div");
+  summary.className = "chat-work-group";
+  return summary;
+}
+
+beforeEach(() => {
+  vi.spyOn(chatMessage, "getAssistantAttachmentAvailabilityRenderVersion").mockImplementation(
+    () => assistantAttachmentRenderVersionMock.value,
+  );
+  vi.spyOn(chatMessage, "renderMessageGroup").mockImplementation(renderMessageGroupMock);
+  vi.spyOn(chatMessage, "renderStreamGroup").mockImplementation(renderStreamGroupMock);
+  vi.spyOn(chatMessage, "renderWorkGroupSummary").mockImplementation(renderWorkGroupSummaryMock);
+});
 
 function createSessionsResultFromRows(
   sessions: GatewaySessionRow[],
@@ -1619,6 +1626,7 @@ afterEach(() => {
   refreshVisibleToolsEffectiveForCurrentSessionMock.mockClear();
   resetChatViewState();
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 describe("per-pane chat presentation state", () => {

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -7,6 +7,7 @@ import type {
   ControlUiSessionBranch,
   ControlUiSessionPullRequest,
 } from "../../../../src/gateway/control-ui-contract.js";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { SessionsListResult } from "../../api/types.ts";
 import type { QuestionPrompt } from "../../app/question-prompt.ts";
 import type { ChatSendShortcut } from "../../app/settings.ts";
@@ -112,6 +113,8 @@ export type ChatProps = {
   realtimeTalkVideoPending?: boolean;
   realtimeTalkCameraError?: boolean;
   connected: boolean;
+  gatewayClient?: GatewayBrowserClient | null;
+  composerHoldToRecord?: boolean;
   canSend: boolean;
   disabledReason: string | null;
   disabledActionLabel?: string | null;
@@ -165,6 +168,7 @@ export type ChatProps = {
   onSwitchRealtimeCamera?: () => void;
   onDismissError?: () => void;
   onDismissRealtimeTalkError?: () => void;
+  onDictationError?: (message: string) => void;
   onAbort?: () => void;
   onQueueRemove: (id: string) => void;
   onQueueRetry?: (id: string) => void;
@@ -402,6 +406,8 @@ export function renderChat(props: ChatProps) {
     realtimeTalkVideoCapable: props.realtimeTalkVideoCapable,
     realtimeTalkVideoPending: props.realtimeTalkVideoPending,
     realtimeTalkCameraError: props.realtimeTalkCameraError,
+    gatewayClient: props.gatewayClient,
+    composerHoldToRecord: props.composerHoldToRecord,
     composerControls: props.composerControls,
     getDraft: props.getDraft,
     onDraftChange: props.onDraftChange,
@@ -414,6 +420,7 @@ export function renderChat(props: ChatProps) {
     onToggleRealtimeCamera: props.onToggleRealtimeCamera,
     onSwitchRealtimeCamera: props.onSwitchRealtimeCamera,
     onDismissRealtimeTalkError: props.onDismissRealtimeTalkError,
+    onDictationError: props.onDictationError,
     onAbort: props.onAbort,
     onQueueRemove: props.onQueueRemove,
     onQueueRetry: props.onQueueRetry,

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -1871,41 +1871,48 @@ function renderMicrophonePicker(props: MicrophonePickerProps) {
 function renderComposerVoiceButton(props: ChatRunControlsProps) {
   const active = props.dictation?.active === true;
   const finalizing = props.dictation?.finalizing === true;
+  const holding = props.dictation?.locksComposer === true;
   const label = finalizing
     ? t("chat.composer.dictationFinalizing")
     : active
       ? t("chat.composer.dictationReleaseToInsert")
       : t("chat.composer.startVoiceInput");
+  // This shape owns pointer capture. Keep it stable while dictation rerenders,
+  // or replacing the button releases capture and cancels the active hold.
   return html`
-    <openclaw-tooltip .content=${label}>
-      <button
-        class=${active
-          ? `chat-send-btn chat-send-btn--dictating${finalizing ? " chat-send-btn--dictation-finalizing" : ""}`
-          : `chat-send-btn chat-send-btn--voice${props.dictation ? " chat-send-btn--hold-enabled" : ""}`}
-        type="button"
-        @pointerdown=${(event: PointerEvent) => props.onDictationPointerDown?.(event)}
-        @click=${(event: MouseEvent) =>
-          props.dictation ? props.dictation.handleClick(event) : props.onToggleVoice?.()}
-        @contextmenu=${(event: MouseEvent) => props.dictation?.handleContextMenu(event)}
-        ?disabled=${finalizing || (!active && (!props.connected || props.sending || props.isBusy))}
-        aria-label=${label}
-      >
-        ${finalizing
-          ? icons.loader
-          : active
-            ? html`
-                ${renderMicrophoneActivity({
-                  status: props.dictation?.connecting ? "connecting" : "listening",
-                  inputLevel: props.dictation?.inputLevel,
-                })}
-                <span class="chat-send-btn__dictation-time">${props.dictation?.elapsed}</span>
-              `
-            : html`
-                ${icons.mic}
-                <span class="agent-chat__control-label">${label}</span>
-              `}
-      </button>
-    </openclaw-tooltip>
+    <span class="chat-talk-control">
+      <openclaw-tooltip .content=${label}>
+        <button
+          class=${active
+            ? `chat-send-btn chat-send-btn--dictating${finalizing ? " chat-send-btn--dictation-finalizing" : ""}`
+            : `chat-send-btn chat-send-btn--voice${props.dictation ? " chat-send-btn--hold-enabled" : ""}`}
+          type="button"
+          @pointerdown=${(event: PointerEvent) => props.onDictationPointerDown?.(event)}
+          @click=${(event: MouseEvent) =>
+            props.dictation ? props.dictation.handleClick(event) : props.onToggleVoice?.()}
+          @contextmenu=${(event: MouseEvent) => props.dictation?.handleContextMenu(event)}
+          ?disabled=${finalizing ||
+          (!active && (!props.connected || props.sending || props.isBusy))}
+          aria-label=${label}
+        >
+          ${finalizing
+            ? icons.loader
+            : active
+              ? html`
+                  ${renderMicrophoneActivity({
+                    status: props.dictation?.connecting ? "connecting" : "listening",
+                    inputLevel: props.dictation?.inputLevel,
+                  })}
+                  <span class="chat-send-btn__dictation-time">${props.dictation?.elapsed}</span>
+                `
+              : html`
+                  ${icons.mic}
+                  <span class="agent-chat__control-label">${label}</span>
+                `}
+        </button>
+      </openclaw-tooltip>
+      ${holding ? nothing : props.microphonePicker}
+    </span>
   `;
 }
 
@@ -1956,9 +1963,6 @@ function renderChatPrimaryActions(props: ChatRunControlsProps) {
   // duplicate announcement.
   const voiceErrored = props.voiceStatus === "error";
   const voiceButton = renderComposerVoiceButton(props);
-  const dictationControl = html`
-    <span class="chat-talk-control">${voiceButton}${props.microphonePicker}</span>
-  `;
   const sendAction = html`
     <openclaw-tooltip
       .content=${props.isBusy ? t("chat.runControls.queue") : t("chat.runControls.send")}
@@ -1978,9 +1982,9 @@ function renderChatPrimaryActions(props: ChatRunControlsProps) {
       </button>
     </openclaw-tooltip>
   `;
-  if (props.dictation?.active) {
-    return hasComposedContent ? html`${voiceButton}` : voiceButton;
-  }
+  const dictationPrimaryAction = html`
+    ${props.dictation?.active || !hasComposedContent ? nothing : sendAction} ${voiceButton}
+  `;
   return html`
     ${props.voiceActive && props.onToggleVoice
       ? html`
@@ -2073,11 +2077,11 @@ function renderChatPrimaryActions(props: ChatRunControlsProps) {
               </button>
             </openclaw-tooltip>
           `
-        : hasComposedContent || !props.onToggleVoice
-          ? props.dictation
-            ? html`${sendAction} ${dictationControl}`
-            : sendAction
-          : dictationControl}
+        : props.dictation
+          ? dictationPrimaryAction
+          : hasComposedContent || !props.onToggleVoice
+            ? sendAction
+            : voiceButton}
   `;
 }
 

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -2075,7 +2075,7 @@ function renderChatPrimaryActions(props: ChatRunControlsProps) {
           `
         : hasComposedContent || !props.onToggleVoice
           ? props.dictation
-            ? html`${dictationControl} ${sendAction}`
+            ? html`${sendAction} ${dictationControl}`
             : sendAction
           : dictationControl}
   `;
@@ -2574,7 +2574,13 @@ export function renderChatComposer(props: ChatComposerProps) {
     },
     onError: (message: string) => props.onDictationError?.(message),
     onStateChange: requestUpdate,
-    onTap: () => props.onToggleRealtimeTalk?.(),
+    // With an initial empty composer, this button retains the existing
+    // send-after-typing behavior until the host rerenders the primary actions.
+    // Once a draft is rendered, the separate voice control starts Talk directly.
+    onTap:
+      actionDraft.trim() || props.attachments?.length
+        ? () => props.onToggleRealtimeTalk?.()
+        : handleVoicePrimaryAction,
   };
   state.dictation ??= new ComposerDictationController(dictationOptions);
   state.dictation.update(dictationOptions);

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -3,6 +3,7 @@ import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { html, nothing, type TemplateResult } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { ref } from "lit/directives/ref.js";
+import type { GatewayBrowserClient } from "../../../api/gateway.ts";
 import type { GatewaySessionRow, SessionGoal, SessionsListResult } from "../../../api/types.ts";
 import { normalizeBasePath } from "../../../app-route-paths.ts";
 import type { QuestionPrompt } from "../../../app/question-prompt.ts";
@@ -46,6 +47,7 @@ import {
 } from "../../../lib/session-goal.ts";
 import { areUiSessionKeysEquivalent } from "../../../lib/sessions/session-key.ts";
 import { detectTextDirection } from "../../../lib/text-direction.ts";
+import { ComposerDictationController, insertComposerDictation } from "../composer-dictation.ts";
 import { exportChatMarkdown } from "../export.ts";
 import type { ChatInputHistoryKeyInput, ChatInputHistoryKeyResult } from "../input-history.ts";
 import type { RealtimeTalkConversationEntry } from "../realtime-talk-conversation.ts";
@@ -134,6 +136,8 @@ type ChatComposerProps = {
   realtimeTalkVideoCapable?: boolean;
   realtimeTalkVideoPending?: boolean;
   realtimeTalkCameraError?: boolean;
+  gatewayClient?: GatewayBrowserClient | null;
+  composerHoldToRecord?: boolean;
   composerControls?: TemplateResult | typeof nothing;
   getDraft?: () => string;
   onDraftChange: (next: string) => void;
@@ -146,6 +150,7 @@ type ChatComposerProps = {
   onToggleRealtimeCamera?: () => void;
   onSwitchRealtimeCamera?: () => void;
   onDismissRealtimeTalkError?: () => void;
+  onDictationError?: (message: string) => void;
   onAbort?: () => void;
   onQueueRemove: (id: string) => void;
   onQueueRetry?: (id: string) => void;
@@ -196,6 +201,9 @@ type ChatComposerState = {
   // Stable Lit ref: an inline arrow would change identity per render and force
   // a layout re-measure of the textarea on every chat render, not just attach.
   textareaRef: ((element?: Element) => void) | null;
+  dictation: ComposerDictationController | null;
+  dictationDraftKey: string | null;
+  dictationSelection: { start: number; end: number } | null;
 };
 
 function createChatComposerState(): ChatComposerState {
@@ -224,6 +232,9 @@ function createChatComposerState(): ChatComposerState {
     microphoneWarning: null,
     microphoneDiscoveryRequest: 0,
     textareaRef: null,
+    dictation: null,
+    dictationDraftKey: null,
+    dictationSelection: null,
   };
 }
 
@@ -328,8 +339,12 @@ export function resetChatComposerState(paneId?: string) {
   if (paneId) {
     // Goal elapsed timers are keyed by element and cleaned up when their
     // element leaves the DOM, so a per-pane reset does not need to touch them.
+    composerStates.get(paneId)?.dictation?.dispose();
     composerStates.delete(paneId);
     return;
+  }
+  for (const state of composerStates.values()) {
+    state.dictation?.dispose();
   }
   composerStates.clear();
   for (const timer of goalElapsedTimers.values()) {
@@ -1762,6 +1777,8 @@ type ChatRunControlsProps = {
   voiceVideoCapable?: boolean;
   voiceVideoEnabled?: boolean;
   voiceVideoPending?: boolean;
+  dictation?: ComposerDictationController;
+  onDictationPointerDown?: (event: PointerEvent) => void;
   onAbort?: () => void;
   onExport: () => void;
   onNewSession: () => void;
@@ -1851,6 +1868,47 @@ function renderMicrophonePicker(props: MicrophonePickerProps) {
   `;
 }
 
+function renderComposerVoiceButton(props: ChatRunControlsProps) {
+  const active = props.dictation?.active === true;
+  const finalizing = props.dictation?.finalizing === true;
+  const label = finalizing
+    ? t("chat.composer.dictationFinalizing")
+    : active
+      ? t("chat.composer.dictationReleaseToInsert")
+      : t("chat.composer.startVoiceInput");
+  return html`
+    <openclaw-tooltip .content=${label}>
+      <button
+        class=${active
+          ? `chat-send-btn chat-send-btn--dictating${finalizing ? " chat-send-btn--dictation-finalizing" : ""}`
+          : `chat-send-btn chat-send-btn--voice${props.dictation ? " chat-send-btn--hold-enabled" : ""}`}
+        type="button"
+        @pointerdown=${(event: PointerEvent) => props.onDictationPointerDown?.(event)}
+        @click=${(event: MouseEvent) =>
+          props.dictation ? props.dictation.handleClick(event) : props.onToggleVoice?.()}
+        @contextmenu=${(event: MouseEvent) => props.dictation?.handleContextMenu(event)}
+        ?disabled=${finalizing || (!active && (!props.connected || props.sending || props.isBusy))}
+        aria-label=${label}
+      >
+        ${finalizing
+          ? icons.loader
+          : active
+            ? html`
+                ${renderMicrophoneActivity({
+                  status: props.dictation?.connecting ? "connecting" : "listening",
+                  inputLevel: props.dictation?.inputLevel,
+                })}
+                <span class="chat-send-btn__dictation-time">${props.dictation?.elapsed}</span>
+              `
+            : html`
+                ${icons.mic}
+                <span class="agent-chat__control-label">${label}</span>
+              `}
+      </button>
+    </openclaw-tooltip>
+  `;
+}
+
 function renderChatPrimaryActions(props: ChatRunControlsProps) {
   const hasComposedContent = Boolean(props.draft.trim() || props.hasAttachments);
   const steersActiveRun = props.followUpMode === "steer";
@@ -1897,6 +1955,32 @@ function renderChatPrimaryActions(props: ChatRunControlsProps) {
   // only its stop affordance instead of a fake listening meter plus a
   // duplicate announcement.
   const voiceErrored = props.voiceStatus === "error";
+  const voiceButton = renderComposerVoiceButton(props);
+  const dictationControl = html`
+    <span class="chat-talk-control">${voiceButton}${props.microphonePicker}</span>
+  `;
+  const sendAction = html`
+    <openclaw-tooltip
+      .content=${props.isBusy ? t("chat.runControls.queue") : t("chat.runControls.send")}
+    >
+      <button
+        class="chat-send-btn"
+        @click=${storeDraftAndSend}
+        ?disabled=${!props.canSend || props.sending}
+        aria-label=${props.isBusy
+          ? t("chat.runControls.queueMessage")
+          : t("chat.runControls.sendMessage")}
+      >
+        ${icons.arrowUp}
+        <span class="agent-chat__control-label"
+          >${props.isBusy ? t("chat.runControls.queue") : t("chat.runControls.send")}</span
+        >
+      </button>
+    </openclaw-tooltip>
+  `;
+  if (props.dictation?.active) {
+    return hasComposedContent ? html`${voiceButton}` : voiceButton;
+  }
   return html`
     ${props.voiceActive && props.onToggleVoice
       ? html`
@@ -1990,45 +2074,10 @@ function renderChatPrimaryActions(props: ChatRunControlsProps) {
             </openclaw-tooltip>
           `
         : hasComposedContent || !props.onToggleVoice
-          ? html`
-              <openclaw-tooltip
-                .content=${props.isBusy ? t("chat.runControls.queue") : t("chat.runControls.send")}
-              >
-                <button
-                  class="chat-send-btn"
-                  @click=${storeDraftAndSend}
-                  ?disabled=${!props.canSend || props.sending}
-                  aria-label=${props.isBusy
-                    ? t("chat.runControls.queueMessage")
-                    : t("chat.runControls.sendMessage")}
-                >
-                  ${icons.arrowUp}
-                  <span class="agent-chat__control-label"
-                    >${props.isBusy
-                      ? t("chat.runControls.queue")
-                      : t("chat.runControls.send")}</span
-                  >
-                </button>
-              </openclaw-tooltip>
-            `
-          : html`
-              <span class="chat-talk-control">
-                <openclaw-tooltip .content=${t("chat.composer.startVoiceInput")}>
-                  <button
-                    class="chat-send-btn chat-send-btn--voice"
-                    @click=${props.onToggleVoice}
-                    ?disabled=${!props.connected || props.sending || props.isBusy}
-                    aria-label=${t("chat.composer.startVoiceInput")}
-                  >
-                    ${icons.mic}
-                    <span class="agent-chat__control-label"
-                      >${t("chat.composer.startVoiceInput")}</span
-                    >
-                  </button>
-                </openclaw-tooltip>
-                ${props.microphonePicker}
-              </span>
-            `}
+          ? props.dictation
+            ? html`${dictationControl} ${sendAction}`
+            : sendAction
+          : dictationControl}
   `;
 }
 
@@ -2051,6 +2100,12 @@ export function renderChatComposer(props: ChatComposerProps) {
     props.compactionStatus?.phase === "active" || props.compactionStatus?.phase === "retrying";
   const activeSession = props.sessions?.sessions?.find((row) => row.key === props.sessionKey);
   const draftKey = composerDraftKey(props);
+  if (state.dictationDraftKey !== null && state.dictationDraftKey !== draftKey) {
+    state.dictation?.dispose();
+    state.dictation = null;
+    state.dictationSelection = null;
+  }
+  state.dictationDraftKey = draftKey;
   const visibleDraft =
     state.composingDraft?.key === draftKey ? state.composingDraft.value : props.draft;
   const actionDraft = visibleDraft;
@@ -2482,6 +2537,61 @@ export function renderChatComposer(props: ChatComposerProps) {
         onSelect: selectMicrophone,
       })
     : nothing;
+  const dictationOptions = {
+    client: props.gatewayClient ?? null,
+    connected: props.connected,
+    enabled: props.composerHoldToRecord !== false,
+    realtimeTalkActive: props.realtimeTalkActive === true,
+    onCommit: (transcript: string) => {
+      const target = state.composerTextarea;
+      const selection = state.dictationSelection ?? {
+        start: target?.selectionStart ?? visibleDraft.length,
+        end: target?.selectionEnd ?? visibleDraft.length,
+      };
+      const currentDraft = target?.value ?? props.getDraft?.() ?? props.draft;
+      const insertion = insertComposerDictation(
+        currentDraft,
+        transcript,
+        selection.start,
+        selection.end,
+      );
+      if (target) {
+        target.value = insertion.value;
+        adjustTextareaHeight(target);
+      }
+      commitComposerDraft(props, insertion.value);
+      state.dictationSelection = null;
+      requestUpdate();
+      queueMicrotask(() => {
+        const textarea = state.composerTextarea;
+        if (!textarea) {
+          return;
+        }
+        textarea.focus({ preventScroll: true });
+        textarea.selectionStart = insertion.caret;
+        textarea.selectionEnd = insertion.caret;
+      });
+    },
+    onError: (message: string) => props.onDictationError?.(message),
+    onStateChange: requestUpdate,
+    onTap: () => props.onToggleRealtimeTalk?.(),
+  };
+  state.dictation ??= new ComposerDictationController(dictationOptions);
+  state.dictation.update(dictationOptions);
+  const dictation =
+    props.onToggleRealtimeTalk && props.composerHoldToRecord !== false
+      ? state.dictation
+      : undefined;
+  const handleDictationPointerDown = (event: PointerEvent) => {
+    const target = state.composerTextarea;
+    state.dictationSelection = {
+      start: target?.selectionStart ?? visibleDraft.length,
+      end: target?.selectionEnd ?? visibleDraft.length,
+    };
+    if (dictation?.handlePointerDown(event) && target) {
+      target.readOnly = true;
+    }
+  };
   const runControlsProps: ChatRunControlsProps = {
     canAbort: showAbortableUi,
     canSend: canSubmitDraft(actionDraft),
@@ -2507,6 +2617,8 @@ export function renderChatComposer(props: ChatComposerProps) {
     onToggleVoice: props.onToggleRealtimeTalk ? handleVoicePrimaryAction : undefined,
     onToggleCamera: props.onToggleRealtimeCamera,
     microphonePicker,
+    dictation,
+    onDictationPointerDown: handleDictationPointerDown,
   };
   const cameraFacingMode = props.realtimeTalkVideoStream
     ?.getVideoTracks?.()[0]
@@ -2581,6 +2693,31 @@ export function renderChatComposer(props: ChatComposerProps) {
                 `
               : nothing}
             <div class="agent-chat__composer-status-stack">
+              ${dictation?.active
+                ? html`
+                    <div
+                      class=${`agent-chat__dictation-status${dictation.finalizing ? " agent-chat__dictation-status--finalizing" : ""}`}
+                      role="status"
+                      aria-live="polite"
+                      aria-atomic="true"
+                    >
+                      <span class="agent-chat__dictation-label"
+                        >${dictation.finalizing
+                          ? t("chat.composer.dictationFinalizing")
+                          : dictation.connecting
+                            ? t("chat.composer.dictationConnecting")
+                            : t("chat.composer.dictationRecording", {
+                                elapsed: dictation.elapsed,
+                              })}</span
+                      >
+                      ${dictation.partial
+                        ? html`<span class="agent-chat__dictation-partial"
+                            >${dictation.partial}</span
+                          >`
+                        : nothing}
+                    </div>
+                  `
+                : nothing}
               ${renderChatPlanChecklist(props.planStatus, {
                 active: showAbortableUi,
                 variant: "bar",
@@ -2672,6 +2809,7 @@ export function renderChatComposer(props: ChatComposerProps) {
                   .value=${visibleDraft}
                   dir=${detectTextDirection(visibleDraft)}
                   ?disabled=${!canCompose}
+                  ?readonly=${dictation?.locksComposer === true}
                   aria-autocomplete="list"
                   aria-controls=${ifDefined(slashMenuVisible ? slashMenuListboxId : undefined)}
                   aria-activedescendant=${ifDefined(activeSlashMenuOptionId ?? undefined)}

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -18,18 +18,23 @@ const streamingMarkdownRenderMock = vi.fn(
     `<div class="streaming-markdown">${value}</div>`,
 );
 
-function getSafeLocalStorageMock() {
+function getSafeLocalStorageMock(): Storage {
   return {
+    get length() {
+      return localStorageValues.size;
+    },
+    clear: () => localStorageValues.clear(),
     getItem: (key: string) => localStorageValues.get(key) ?? null,
+    key: (index: number) => [...localStorageValues.keys()][index] ?? null,
     removeItem: (key: string) => localStorageValues.delete(key),
     setItem: (key: string, value: string) => localStorageValues.set(key, value),
   };
 }
 
-function renderChatAvatarMock(role: string) {
-  const element = document.createElement("div");
-  element.className = `chat-avatar ${role}`;
-  return element;
+function renderChatAvatarMock(
+  ...[role]: Parameters<typeof chatAvatar.renderChatAvatar>
+): ReturnType<typeof chatAvatar.renderChatAvatar> {
+  return html`<div class="chat-avatar ${role}"></div>`;
 }
 
 function requireFirstMockArg(
@@ -561,19 +566,19 @@ describe("grouped chat rendering", () => {
 
   it("renders user markdown without code-block copy chrome", () => {
     const container = document.createElement("div");
-    const markdown = "```bash\npython3 - <<'PY'\nprint('ok')\nPY\n```";
+    const markdownContent = "```bash\npython3 - <<'PY'\nprint('ok')\nPY\n```";
 
     renderGroupedMessage(
       container,
       {
         role: "user",
-        content: markdown,
+        content: markdownContent,
         timestamp: 1001,
       },
       "user",
     );
 
-    expect(markdownRenderMock).toHaveBeenCalledWith(markdown, {
+    expect(markdownRenderMock).toHaveBeenCalledWith(markdownContent, {
       assistantTranscriptRoleHeaders: false,
       codeBlockChrome: "none",
       fileLinks: true,
@@ -582,15 +587,15 @@ describe("grouped chat rendering", () => {
 
   it("keeps assistant markdown code-block copy chrome enabled", () => {
     const container = document.createElement("div");
-    const markdown = "```bash\necho ok\n```";
+    const markdownContent = "```bash\necho ok\n```";
 
     renderAssistantMessage(container, {
       role: "assistant",
-      content: markdown,
+      content: markdownContent,
       timestamp: 1000,
     });
 
-    expect(markdownRenderMock).toHaveBeenCalledWith(markdown, {
+    expect(markdownRenderMock).toHaveBeenCalledWith(markdownContent, {
       assistantTranscriptRoleHeaders: true,
       codeBlockChrome: "copy",
       fileLinks: true,

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -1,44 +1,36 @@
 /* @vitest-environment jsdom */
 
 import { html, render } from "lit";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as markdown from "../../../components/markdown.ts";
 import type { MessageGroup } from "../../../lib/chat/chat-types.ts";
 import { setUiTimeFormatPreference } from "../../../lib/format.ts";
+import * as localStorageModule from "../../../local-storage.ts";
+import * as chatAvatar from "../chat-avatar.ts";
 import { renderMessageGroup, renderStreamGroup } from "./chat-message.ts";
 
-const localStorageValues = vi.hoisted(() => new Map<string, string>());
-const markdownRenderMock = vi.hoisted(() =>
-  vi.fn(
-    (value: string, _options?: { codeBlockChrome?: "copy" | "none"; fileLinks?: boolean }) => value,
-  ),
+const localStorageValues = new Map<string, string>();
+const markdownRenderMock = vi.fn(
+  (value: string, _options?: { codeBlockChrome?: "copy" | "none"; fileLinks?: boolean }) => value,
 );
-const streamingMarkdownRenderMock = vi.hoisted(() =>
-  vi.fn(
-    (value: string, _options?: { codeBlockChrome?: "copy" | "none"; fileLinks?: boolean }) =>
-      `<div class="streaming-markdown">${value}</div>`,
-  ),
+const streamingMarkdownRenderMock = vi.fn(
+  (value: string, _options?: { codeBlockChrome?: "copy" | "none"; fileLinks?: boolean }) =>
+    `<div class="streaming-markdown">${value}</div>`,
 );
 
-vi.mock("../../../local-storage.ts", () => ({
-  getSafeLocalStorage: () => ({
+function getSafeLocalStorageMock() {
+  return {
     getItem: (key: string) => localStorageValues.get(key) ?? null,
     removeItem: (key: string) => localStorageValues.delete(key),
     setItem: (key: string, value: string) => localStorageValues.set(key, value),
-  }),
-}));
-
-vi.mock("../../../components/markdown.ts", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../../components/markdown.ts")>();
-  return {
-    ...actual,
-    toSanitizedMarkdownHtml: markdownRenderMock,
-    toStreamingMarkdownHtml: streamingMarkdownRenderMock,
   };
-});
+}
 
-vi.mock("../../../components/icons.ts", () => ({
-  icons: {},
-}));
+function renderChatAvatarMock(role: string) {
+  const element = document.createElement("div");
+  element.className = `chat-avatar ${role}`;
+  return element;
+}
 
 function requireFirstMockArg(
   mock: ReturnType<typeof vi.fn>,
@@ -67,13 +59,12 @@ function pointerClick(element: Element) {
   element.dispatchEvent(new MouseEvent("click", { bubbles: true, detail: 1 }));
 }
 
-vi.mock("./chat-avatar.ts", () => ({
-  renderChatAvatar: (role: string) => {
-    const element = document.createElement("div");
-    element.className = `chat-avatar ${role}`;
-    return element;
-  },
-}));
+beforeEach(() => {
+  vi.spyOn(localStorageModule, "getSafeLocalStorage").mockImplementation(getSafeLocalStorageMock);
+  vi.spyOn(markdown, "toSanitizedMarkdownHtml").mockImplementation(markdownRenderMock);
+  vi.spyOn(markdown, "toStreamingMarkdownHtml").mockImplementation(streamingMarkdownRenderMock);
+  vi.spyOn(chatAvatar, "renderChatAvatar").mockImplementation(renderChatAvatarMock);
+});
 
 type RenderMessageGroupOptions = Parameters<typeof renderMessageGroup>[1];
 

--- a/ui/src/pages/chat/composer-dictation.test.ts
+++ b/ui/src/pages/chat/composer-dictation.test.ts
@@ -1,0 +1,654 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient, GatewayEventFrame } from "../../api/gateway.ts";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
+import { ComposerDictationController, insertComposerDictation } from "./composer-dictation.ts";
+
+type GatewayListener = (event: GatewayEventFrame) => void;
+type MockProcessor = {
+  connect: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+  onaudioprocess: ((event: { inputBuffer: { getChannelData: () => Float32Array } }) => void) | null;
+};
+
+const listeners = new Set<GatewayListener>();
+const processors: MockProcessor[] = [];
+let request: ReturnType<typeof vi.fn>;
+let getUserMedia: ReturnType<typeof vi.fn>;
+
+class MockAudioContext {
+  readonly destination = {};
+  readonly sampleRate = 8000;
+  readonly close = vi.fn(async () => undefined);
+
+  createMediaStreamSource() {
+    return { connect: vi.fn(), disconnect: vi.fn() };
+  }
+
+  createScriptProcessor() {
+    const processor: MockProcessor = {
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      onaudioprocess: null,
+    };
+    processors.push(processor);
+    return processor;
+  }
+
+  createGain() {
+    return { connect: vi.fn(), disconnect: vi.fn(), gain: { value: 1 } };
+  }
+
+  createAnalyser() {
+    return {
+      fftSize: 0,
+      smoothingTimeConstant: 0,
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      getFloatTimeDomainData: (samples: Float32Array) => samples.fill(0),
+    };
+  }
+}
+
+function createClient(): GatewayBrowserClient {
+  return {
+    addEventListener: vi.fn((listener: GatewayListener) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    }),
+    request,
+  } as unknown as GatewayBrowserClient;
+}
+
+function emit(payload: Record<string, unknown>): void {
+  for (const listener of listeners) {
+    listener({ event: "talk.event", payload } as GatewayEventFrame);
+  }
+}
+
+function pointer(type: string, pointerId = 7, x = 50, y = 50): Event {
+  const event = new MouseEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    clientX: x,
+    clientY: y,
+    button: 0,
+  });
+  Object.defineProperty(event, "pointerId", { value: pointerId });
+  return event;
+}
+
+function createHarness(overrides: { enabled?: boolean; realtimeTalkActive?: boolean } = {}) {
+  const onCommit = vi.fn();
+  const onError = vi.fn();
+  const onStateChange = vi.fn();
+  const onTap = vi.fn();
+  const options = {
+    client: createClient(),
+    connected: true,
+    enabled: overrides.enabled ?? true,
+    realtimeTalkActive: overrides.realtimeTalkActive ?? false,
+    onCommit,
+    onError,
+    onStateChange,
+    onTap,
+  };
+  const controller = new ComposerDictationController(options);
+  const target = document.createElement("button");
+  target.getBoundingClientRect = () => ({ left: 0, right: 100, top: 0, bottom: 100 }) as DOMRect;
+  target.setPointerCapture = vi.fn();
+  target.releasePointerCapture = vi.fn();
+  target.addEventListener("pointerdown", (event) =>
+    controller.handlePointerDown(event as PointerEvent),
+  );
+  target.addEventListener("click", (event) => controller.handleClick(event));
+  document.body.append(target);
+  return { controller, onCommit, onError, onStateChange, onTap, options, target };
+}
+
+async function startHold(target: HTMLElement): Promise<void> {
+  target.dispatchEvent(pointer("pointerdown"));
+  await vi.advanceTimersByTimeAsync(250);
+  await waitForFast(() =>
+    expect(request).toHaveBeenCalledWith("talk.session.create", expect.anything()),
+  );
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  listeners.clear();
+  processors.length = 0;
+  request = vi.fn(async (method: string) => {
+    if (method === "talk.catalog") {
+      return {
+        modes: ["transcription"],
+        transports: ["gateway-relay"],
+        brains: ["none"],
+        speech: { providers: [] },
+        realtime: { providers: [] },
+        transcription: { ready: true, activeProvider: "deepgram", providers: [] },
+      };
+    }
+    if (method === "talk.session.create") {
+      return {
+        sessionId: "dictation-1",
+        transcriptionSessionId: "dictation-1",
+        audio: { inputEncoding: "g711_ulaw", inputSampleRateHz: 8000 },
+      };
+    }
+    return { ok: true };
+  });
+  getUserMedia = vi.fn(async () => ({
+    getTracks: () => [{ stop: vi.fn() }],
+  }));
+  Object.defineProperty(globalThis.navigator, "mediaDevices", {
+    configurable: true,
+    value: { getUserMedia },
+  });
+  vi.stubGlobal("AudioContext", MockAudioContext);
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+  listeners.clear();
+  processors.length = 0;
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("ComposerDictationController", () => {
+  it("keeps a quick pointer gesture as the existing tap action", async () => {
+    const { controller, onTap, target } = createHarness();
+
+    target.dispatchEvent(pointer("pointerdown"));
+    expect(controller.locksComposer).toBe(true);
+    document.dispatchEvent(pointer("pointerup"));
+    target.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    await vi.advanceTimersByTimeAsync(300);
+
+    expect(onTap).toHaveBeenCalledOnce();
+    expect(request).not.toHaveBeenCalled();
+    expect(controller.locksComposer).toBe(false);
+    controller.dispose();
+  });
+
+  it("streams g711_ulaw audio and commits final transcript on release", async () => {
+    const order: string[] = [];
+    getUserMedia = vi.fn(async () => {
+      order.push("microphone");
+      return { getTracks: () => [{ stop: vi.fn() }] };
+    });
+    Object.defineProperty(navigator.mediaDevices, "getUserMedia", { value: getUserMedia });
+    request = vi.fn(async (method: string, params: unknown) => {
+      order.push(method);
+      if (method === "talk.catalog") {
+        return {
+          transcription: { ready: true, providers: [] },
+          realtime: { providers: [] },
+          speech: { providers: [] },
+          modes: [],
+          transports: [],
+          brains: [],
+        };
+      }
+      if (method === "talk.session.create") {
+        return {
+          sessionId: "dictation-1",
+          transcriptionSessionId: "dictation-1",
+          audio: { inputEncoding: "g711_ulaw", inputSampleRateHz: 8000 },
+        };
+      }
+      return params;
+    });
+    const { controller, onCommit, target } = createHarness();
+
+    await startHold(target);
+    expect(order.slice(0, 3)).toEqual(["talk.catalog", "microphone", "talk.session.create"]);
+    const processor = processors.at(-1);
+    if (!processor) {
+      throw new Error("expected microphone processor");
+    }
+    processor.onaudioprocess?.({
+      inputBuffer: { getChannelData: () => new Float32Array([0, 1, -1]) },
+    });
+    await waitForFast(() =>
+      expect(request).toHaveBeenCalledWith("talk.session.appendAudio", {
+        sessionId: "dictation-1",
+        audioBase64: "/4AA",
+      }),
+    );
+    emit({
+      transcriptionSessionId: "dictation-1",
+      type: "partial",
+      text: "hello wor",
+    });
+    expect(controller.partial).toBe("hello wor");
+    emit({
+      transcriptionSessionId: "dictation-1",
+      type: "transcript",
+      text: "hello world",
+      final: true,
+    });
+    document.dispatchEvent(pointer("pointerup"));
+    expect(controller.finalizing).toBe(true);
+    await waitForFast(() =>
+      expect(request).toHaveBeenCalledWith("talk.session.close", { sessionId: "dictation-1" }),
+    );
+    await vi.advanceTimersByTimeAsync(1500);
+
+    await waitForFast(() => expect(onCommit).toHaveBeenCalledWith("hello world"));
+    expect(request).toHaveBeenCalledWith("talk.session.close", { sessionId: "dictation-1" });
+    expect(order.indexOf("talk.session.appendAudio")).toBeLessThan(
+      order.indexOf("talk.session.close"),
+    );
+    controller.dispose();
+  });
+
+  it("preserves repeated final transcript segments", async () => {
+    const { controller, onCommit, target } = createHarness();
+    await startHold(target);
+    emit({ transcriptionSessionId: "dictation-1", type: "transcript", text: "yes", final: true });
+    emit({ transcriptionSessionId: "dictation-1", type: "transcript", text: "yes", final: true });
+
+    document.dispatchEvent(pointer("pointerup"));
+    await waitForFast(() =>
+      expect(request).toHaveBeenCalledWith("talk.session.close", { sessionId: "dictation-1" }),
+    );
+    await vi.advanceTimersByTimeAsync(1500);
+
+    await waitForFast(() => expect(onCommit).toHaveBeenCalledWith("yes yes"));
+    controller.dispose();
+  });
+
+  it("previews non-final transcript frames without committing them", async () => {
+    const { controller, onCommit, target } = createHarness();
+    await startHold(target);
+    emit({
+      transcriptionSessionId: "dictation-1",
+      type: "transcript",
+      text: "hello",
+      final: false,
+    });
+    expect(controller.partial).toBe("hello");
+    emit({
+      transcriptionSessionId: "dictation-1",
+      type: "transcript",
+      text: "hello world",
+      final: true,
+    });
+
+    document.dispatchEvent(pointer("pointerup"));
+    await waitForFast(() =>
+      expect(request).toHaveBeenCalledWith("talk.session.close", { sessionId: "dictation-1" }),
+    );
+    await vi.advanceTimersByTimeAsync(1500);
+
+    await waitForFast(() => expect(onCommit).toHaveBeenCalledWith("hello world"));
+    controller.dispose();
+  });
+
+  it("keeps listening for a final transcript after close is acknowledged", async () => {
+    const { controller, onCommit, target } = createHarness();
+    await startHold(target);
+
+    document.dispatchEvent(pointer("pointerup"));
+    await waitForFast(() =>
+      expect(request).toHaveBeenCalledWith("talk.session.close", { sessionId: "dictation-1" }),
+    );
+    emit({
+      transcriptionSessionId: "dictation-1",
+      type: "transcript",
+      text: "late final",
+      final: true,
+    });
+    await vi.advanceTimersByTimeAsync(1000);
+    emit({
+      transcriptionSessionId: "dictation-1",
+      type: "transcript",
+      text: "second late",
+      final: true,
+    });
+    await vi.advanceTimersByTimeAsync(1499);
+    expect(onCommit).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+
+    await waitForFast(() => expect(onCommit).toHaveBeenCalledWith("late final second late"));
+    controller.dispose();
+  });
+
+  it("waits beyond the quiet interval for the first post-close transcript", async () => {
+    const { controller, onCommit, target } = createHarness();
+    await startHold(target);
+
+    document.dispatchEvent(pointer("pointerup"));
+    await waitForFast(() =>
+      expect(request).toHaveBeenCalledWith("talk.session.close", { sessionId: "dictation-1" }),
+    );
+    await vi.advanceTimersByTimeAsync(1600);
+    expect(onCommit).not.toHaveBeenCalled();
+    emit({
+      transcriptionSessionId: "dictation-1",
+      type: "transcript",
+      text: "slow first final",
+      final: true,
+    });
+    await vi.advanceTimersByTimeAsync(1500);
+
+    await waitForFast(() => expect(onCommit).toHaveBeenCalledWith("slow first final"));
+    expect(controller.finalizing).toBe(false);
+    expect(controller.locksComposer).toBe(false);
+    controller.dispose();
+  });
+
+  it("extends the finalization window while partial transcript activity continues", async () => {
+    const { controller, onCommit, target } = createHarness();
+    await startHold(target);
+
+    document.dispatchEvent(pointer("pointerup"));
+    await waitForFast(() =>
+      expect(request).toHaveBeenCalledWith("talk.session.close", { sessionId: "dictation-1" }),
+    );
+    await vi.advanceTimersByTimeAsync(1400);
+    emit({ transcriptionSessionId: "dictation-1", type: "partial", text: "still finalizing" });
+    await vi.advanceTimersByTimeAsync(200);
+    emit({
+      transcriptionSessionId: "dictation-1",
+      type: "transcript",
+      text: "still finalizing",
+      final: true,
+    });
+    await vi.advanceTimersByTimeAsync(1499);
+    expect(onCommit).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+
+    await waitForFast(() => expect(onCommit).toHaveBeenCalledWith("still finalizing"));
+    controller.dispose();
+  });
+
+  it("surfaces provider errors raised while final text is draining", async () => {
+    const { controller, onCommit, onError, target } = createHarness();
+    await startHold(target);
+
+    document.dispatchEvent(pointer("pointerup"));
+    await waitForFast(() =>
+      expect(request).toHaveBeenCalledWith("talk.session.close", { sessionId: "dictation-1" }),
+    );
+    emit({
+      transcriptionSessionId: "dictation-1",
+      type: "error",
+      message: "provider drain failed",
+    });
+    await vi.advanceTimersByTimeAsync(1500);
+
+    expect(onError).toHaveBeenCalledWith("provider drain failed");
+    expect(onCommit).not.toHaveBeenCalled();
+    controller.dispose();
+  });
+
+  it("ignores extra clicks while final text is draining", async () => {
+    const { controller, onTap, target } = createHarness();
+    await startHold(target);
+    document.dispatchEvent(pointer("pointerup"));
+    target.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    target.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+
+    expect(onTap).not.toHaveBeenCalled();
+    await waitForFast(() =>
+      expect(request).toHaveBeenCalledWith("talk.session.close", { sessionId: "dictation-1" }),
+    );
+    await vi.advanceTimersByTimeAsync(10_000);
+    controller.dispose();
+  });
+
+  it("buffers microphone audio while the transcription session is being created", async () => {
+    const order: string[] = [];
+    let resolveCreate: (result: {
+      sessionId: string;
+      transcriptionSessionId: string;
+      audio: { inputEncoding: string; inputSampleRateHz: number };
+    }) => void = () => undefined;
+    const createResult = new Promise<{
+      sessionId: string;
+      transcriptionSessionId: string;
+      audio: { inputEncoding: string; inputSampleRateHz: number };
+    }>((resolve) => {
+      resolveCreate = resolve;
+    });
+    request = vi.fn(async (method: string, params: unknown) => {
+      order.push(method);
+      if (method === "talk.catalog") {
+        return {
+          transcription: { ready: true, providers: [] },
+          realtime: { providers: [] },
+          speech: { providers: [] },
+          modes: [],
+          transports: [],
+          brains: [],
+        };
+      }
+      if (method === "talk.session.create") {
+        return createResult;
+      }
+      return params;
+    });
+    const { controller, onCommit, target } = createHarness();
+    await startHold(target);
+    const processor = processors.at(-1);
+    if (!processor) {
+      throw new Error("expected microphone processor before session creation completes");
+    }
+    processor.onaudioprocess?.({
+      inputBuffer: { getChannelData: () => new Float32Array([0, 1, -1]) },
+    });
+    expect(request).not.toHaveBeenCalledWith("talk.session.appendAudio", expect.anything());
+
+    document.dispatchEvent(pointer("pointerup"));
+    resolveCreate({
+      sessionId: "late-session",
+      transcriptionSessionId: "late-session",
+      audio: { inputEncoding: "g711_ulaw", inputSampleRateHz: 8000 },
+    });
+
+    await waitForFast(() =>
+      expect(request).toHaveBeenCalledWith("talk.session.appendAudio", {
+        sessionId: "late-session",
+        audioBase64: "/4AA",
+      }),
+    );
+    await waitForFast(() =>
+      expect(request).toHaveBeenCalledWith("talk.session.close", { sessionId: "late-session" }),
+    );
+    expect(order.indexOf("talk.session.appendAudio")).toBeLessThan(
+      order.indexOf("talk.session.close"),
+    );
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(onCommit).not.toHaveBeenCalled();
+    controller.dispose();
+  });
+
+  it("closes a session created after the held pointer was released", async () => {
+    let resolveCreate: (result: {
+      sessionId: string;
+      transcriptionSessionId: string;
+      audio: { inputEncoding: string; inputSampleRateHz: number };
+    }) => void = () => undefined;
+    const createResult = new Promise<{
+      sessionId: string;
+      transcriptionSessionId: string;
+      audio: { inputEncoding: string; inputSampleRateHz: number };
+    }>((resolve) => {
+      resolveCreate = resolve;
+    });
+    request = vi.fn(async (method: string) => {
+      if (method === "talk.catalog") {
+        return {
+          transcription: { ready: true, providers: [] },
+          realtime: { providers: [] },
+          speech: { providers: [] },
+          modes: [],
+          transports: [],
+          brains: [],
+        };
+      }
+      if (method === "talk.session.create") {
+        return createResult;
+      }
+      return { ok: true };
+    });
+    const { controller, onError, target } = createHarness();
+    await startHold(target);
+
+    document.dispatchEvent(pointer("pointerup"));
+    resolveCreate({
+      sessionId: "late-session",
+      transcriptionSessionId: "late-session",
+      audio: { inputEncoding: "unsupported", inputSampleRateHz: 48_000 },
+    });
+
+    await waitForFast(() =>
+      expect(request).toHaveBeenCalledWith("talk.session.close", { sessionId: "late-session" }),
+    );
+    expect(onError).toHaveBeenCalledWith(
+      "The Gateway returned an unsupported dictation audio format.",
+    );
+    controller.dispose();
+  });
+
+  it("closes and discards transcript when Escape cancels", async () => {
+    const { controller, onCommit, target } = createHarness();
+    await startHold(target);
+    emit({
+      transcriptionSessionId: "dictation-1",
+      type: "transcript",
+      text: "discard me",
+      final: true,
+    });
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+
+    await waitForFast(() =>
+      expect(request).toHaveBeenCalledWith("talk.session.close", { sessionId: "dictation-1" }),
+    );
+    expect(onCommit).not.toHaveBeenCalled();
+    controller.dispose();
+  });
+
+  it("cancels when the held pointer slides off the button", async () => {
+    const { controller, onCommit, target } = createHarness();
+    await startHold(target);
+    emit({
+      transcriptionSessionId: "dictation-1",
+      type: "transcript",
+      text: "discard me too",
+      final: true,
+    });
+
+    document.dispatchEvent(pointer("pointermove", 7, 150, 50));
+
+    await waitForFast(() =>
+      expect(request).toHaveBeenCalledWith("talk.session.close", { sessionId: "dictation-1" }),
+    );
+    expect(onCommit).not.toHaveBeenCalled();
+    controller.dispose();
+  });
+
+  it("cancels if the browser unexpectedly releases pointer capture", async () => {
+    const { controller, onCommit, target } = createHarness();
+    await startHold(target);
+
+    target.dispatchEvent(pointer("lostpointercapture"));
+
+    await waitForFast(() =>
+      expect(request).toHaveBeenCalledWith("talk.session.close", { sessionId: "dictation-1" }),
+    );
+    expect(onCommit).not.toHaveBeenCalled();
+    controller.dispose();
+  });
+
+  it("fails before microphone acquisition when transcription is unavailable", async () => {
+    request = vi.fn(async (method: string) => {
+      if (method === "talk.catalog") {
+        return {
+          transcription: { ready: false, providers: [] },
+          realtime: { providers: [] },
+          speech: { providers: [] },
+          modes: [],
+          transports: [],
+          brains: [],
+        };
+      }
+      return { ok: true };
+    });
+    const { controller, onError, onTap, target } = createHarness();
+
+    target.dispatchEvent(pointer("pointerdown"));
+    await vi.advanceTimersByTimeAsync(250);
+
+    await waitForFast(() =>
+      expect(onError).toHaveBeenCalledWith(
+        "No transcription provider is configured for dictation.",
+      ),
+    );
+    expect(getUserMedia).not.toHaveBeenCalled();
+    expect(request).not.toHaveBeenCalledWith("talk.session.create", expect.anything());
+    document.dispatchEvent(pointer("pointerup"));
+    target.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    expect(onTap).not.toHaveBeenCalled();
+    controller.dispose();
+  });
+
+  it("keeps final text and closes when the Gateway disconnects", async () => {
+    const harness = createHarness();
+    await startHold(harness.target);
+    emit({
+      transcriptionSessionId: "dictation-1",
+      type: "transcript",
+      text: "keep this",
+      final: true,
+    });
+
+    harness.controller.update({ ...harness.options, connected: false });
+    await waitForFast(() =>
+      expect(request).toHaveBeenCalledWith("talk.session.close", { sessionId: "dictation-1" }),
+    );
+    await vi.advanceTimersByTimeAsync(1500);
+
+    await waitForFast(() => expect(harness.onCommit).toHaveBeenCalledWith("keep this"));
+    expect(harness.onError).toHaveBeenCalledWith(
+      "Dictation stopped because the Gateway disconnected.",
+    );
+    expect(request).toHaveBeenCalledWith("talk.session.close", { sessionId: "dictation-1" });
+    harness.controller.dispose();
+  });
+
+  it("disables hold while Talk owns the microphone and when the setting is off", async () => {
+    const talk = createHarness({ realtimeTalkActive: true });
+    talk.target.dispatchEvent(pointer("pointerdown"));
+    await vi.advanceTimersByTimeAsync(300);
+    expect(request).not.toHaveBeenCalled();
+    expect(talk.onTap).not.toHaveBeenCalled();
+    talk.controller.dispose();
+
+    const settingOff = createHarness({ enabled: false });
+    settingOff.target.dispatchEvent(pointer("pointerdown"));
+    settingOff.target.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await vi.advanceTimersByTimeAsync(300);
+    expect(settingOff.onTap).toHaveBeenCalledOnce();
+    expect(request).not.toHaveBeenCalled();
+    settingOff.controller.dispose();
+  });
+});
+
+describe("insertComposerDictation", () => {
+  it("inserts at the selection and joins surrounding text with sensible spaces", () => {
+    expect(insertComposerDictation("hello world", "brave new", 6, 6)).toEqual({
+      value: "hello brave new world",
+      caret: 16,
+    });
+    expect(insertComposerDictation("hello world", "there", 6, 11)).toEqual({
+      value: "hello there",
+      caret: 11,
+    });
+  });
+});

--- a/ui/src/pages/chat/composer-dictation.test.ts
+++ b/ui/src/pages/chat/composer-dictation.test.ts
@@ -173,6 +173,19 @@ describe("ComposerDictationController", () => {
     controller.dispose();
   });
 
+  it("does not swallow the next click after a hold is cancelled by blur", async () => {
+    const { controller, onTap, target } = createHarness();
+
+    target.dispatchEvent(pointer("pointerdown"));
+    window.dispatchEvent(new Event("blur"));
+    await Promise.resolve();
+    target.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+
+    expect(onTap).toHaveBeenCalledOnce();
+    expect(controller.locksComposer).toBe(false);
+    controller.dispose();
+  });
+
   it("streams g711_ulaw audio and commits final transcript on release", async () => {
     const order: string[] = [];
     getUserMedia = vi.fn(async () => {
@@ -598,7 +611,7 @@ describe("ComposerDictationController", () => {
     controller.dispose();
   });
 
-  it("keeps final text and closes when the Gateway disconnects", async () => {
+  it("commits final text promptly when the Gateway disconnects during a partial drain", async () => {
     const harness = createHarness();
     await startHold(harness.target);
     emit({
@@ -607,17 +620,27 @@ describe("ComposerDictationController", () => {
       text: "keep this",
       final: true,
     });
+    emit({
+      transcriptionSessionId: "dictation-1",
+      type: "partial",
+      text: "unfinished",
+    });
 
+    const disconnectedAt = Date.now();
     harness.controller.update({ ...harness.options, connected: false });
     await waitForFast(() =>
       expect(request).toHaveBeenCalledWith("talk.session.close", { sessionId: "dictation-1" }),
     );
-    await vi.advanceTimersByTimeAsync(1500);
-
     await waitForFast(() => expect(harness.onCommit).toHaveBeenCalledWith("keep this"));
+    expect(Date.now() - disconnectedAt).toBeLessThan(1000);
     expect(harness.onError).toHaveBeenCalledWith(
       "Dictation stopped because the Gateway disconnected.",
     );
+    expect(harness.onError).toHaveBeenCalledTimes(1);
+    expect(harness.controller.finalizing).toBe(false);
+    expect(harness.controller.locksComposer).toBe(false);
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(harness.onError).toHaveBeenCalledTimes(1);
     expect(request).toHaveBeenCalledWith("talk.session.close", { sessionId: "dictation-1" });
     harness.controller.dispose();
   });

--- a/ui/src/pages/chat/composer-dictation.ts
+++ b/ui/src/pages/chat/composer-dictation.ts
@@ -122,6 +122,7 @@ class ComposerDictationSession {
   private discarded = false;
   private closed = false;
   private failed = false;
+  private gatewayDisconnected = false;
 
   constructor(
     private readonly client: GatewayBrowserClient,
@@ -202,7 +203,7 @@ class ComposerDictationSession {
       this.cleanupEvents();
       return "";
     }
-    if (this.failed) {
+    if (this.gatewayDisconnected || this.failed) {
       this.cleanupEvents();
       return this.finalTranscripts.join(" ").trim();
     }
@@ -223,6 +224,13 @@ class ComposerDictationSession {
     await this.appendChain;
     await this.closeRemote();
     this.cleanupEvents();
+  }
+
+  markGatewayDisconnected(): void {
+    // The relay cannot emit another transcript after its transport is gone.
+    // Resolving any drain avoids retaining the composer in finalization.
+    this.gatewayDisconnected = true;
+    this.resolveTrailingFinalDrain();
   }
 
   private appendAudio(samples: Float32Array): void {
@@ -443,6 +451,9 @@ export class ComposerDictationController {
     }
     if ((this.phase !== "idle" && !this.canHold()) || (this.active && !options.connected)) {
       const keepFinal = this.active && !options.connected;
+      if (keepFinal) {
+        this.session?.markGatewayDisconnected();
+      }
       void this.stop({ commit: keepFinal });
       if (keepFinal) {
         options.onError(t("chat.composer.dictationDisconnected"));
@@ -561,11 +572,13 @@ export class ComposerDictationController {
 
   private readonly handleVisibilityChange = (): void => {
     if (document.visibilityState === "hidden") {
+      this.clearClickSuppression();
       void this.stop({ commit: false });
     }
   };
 
   private readonly handleWindowBlur = (): void => {
+    this.clearClickSuppression();
     void this.stop({ commit: false });
   };
 

--- a/ui/src/pages/chat/composer-dictation.ts
+++ b/ui/src/pages/chat/composer-dictation.ts
@@ -1,0 +1,718 @@
+import type { TalkCatalogResult } from "@openclaw/gateway-protocol";
+import type { GatewayBrowserClient, GatewayEventFrame } from "../../api/gateway.ts";
+import { loadSettings } from "../../app/settings.ts";
+import { t } from "../../i18n/index.ts";
+import {
+  bytesToBase64,
+  floatToG711Ulaw,
+  RealtimeTalkMediaStreamMeter,
+  RealtimeTalkPcmInputPump,
+} from "./realtime-talk-audio.ts";
+import { describeRealtimeTalkInputError, openRealtimeTalkInput } from "./realtime-talk-input.ts";
+import { RealtimeTalkLevelSignal } from "./realtime-talk-level.ts";
+
+const HOLD_THRESHOLD_MS = 250;
+const FINAL_TRANSCRIPT_QUIET_MS = 1500;
+const FINAL_TRANSCRIPT_MAX_WAIT_MS = 10_000;
+const DICTATION_ENCODING = "g711_ulaw";
+const DICTATION_SAMPLE_RATE_HZ = 8000;
+const MAX_PENDING_AUDIO_SAMPLES = DICTATION_SAMPLE_RATE_HZ * 10;
+
+type DictationPhase = "idle" | "holding" | "connecting" | "recording" | "stopping";
+
+type DictationEvent = {
+  transcriptionSessionId?: unknown;
+  type?: unknown;
+  text?: unknown;
+  final?: unknown;
+  message?: unknown;
+  reason?: unknown;
+};
+
+type DictationSessionResult = {
+  sessionId: string;
+  transcriptionSessionId?: string;
+  audio?: {
+    inputEncoding?: unknown;
+    inputSampleRateHz?: unknown;
+  };
+};
+
+type ComposerDictationSessionCallbacks = {
+  onError: (message: string) => void;
+  onLevel: (level: number) => void;
+  onPartial: (text: string) => void;
+  onReady: () => void;
+};
+
+type ComposerDictationControllerOptions = {
+  client: GatewayBrowserClient | null;
+  connected: boolean;
+  enabled: boolean;
+  realtimeTalkActive: boolean;
+  onCommit: (text: string) => void;
+  onError: (message: string) => void;
+  onStateChange: () => void;
+  onTap: () => void;
+};
+
+function eventPayload(frame: GatewayEventFrame): DictationEvent | null {
+  if (frame.event !== "talk.event" || !frame.payload || typeof frame.payload !== "object") {
+    return null;
+  }
+  return frame.payload as DictationEvent;
+}
+
+function messageFromError(error: unknown): string {
+  if (error instanceof DOMException) {
+    return describeRealtimeTalkInputError(error);
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
+}
+
+export function insertComposerDictation(
+  value: string,
+  transcript: string,
+  selectionStart: number,
+  selectionEnd: number,
+): { value: string; caret: number } {
+  const spoken = transcript.trim();
+  if (!spoken) {
+    return { value, caret: selectionEnd };
+  }
+  const start = Math.max(0, Math.min(selectionStart, value.length));
+  const end = Math.max(start, Math.min(selectionEnd, value.length));
+  const before = value.slice(0, start);
+  const after = value.slice(end);
+  const leadingSpace = before && !/\s$/.test(before) && !/^\s|^[,.;:!?)]/.test(spoken) ? " " : "";
+  const trailingSpace =
+    after && !/^\s|^[,.;:!?)]/.test(after) && !/[\s([{]$/.test(spoken) ? " " : "";
+  const inserted = `${leadingSpace}${spoken}${trailingSpace}`;
+  return {
+    value: `${before}${inserted}${after}`,
+    caret: before.length + inserted.length,
+  };
+}
+
+class ComposerDictationSession {
+  private media: MediaStream | null = null;
+  private context: AudioContext | null = null;
+  private readonly inputPump = new RealtimeTalkPcmInputPump();
+  private inputMeter: RealtimeTalkMediaStreamMeter | null = null;
+  private unsubscribe: (() => void) | null = null;
+  private sessionId: string | null = null;
+  private transcriptionSessionId: string | null = null;
+  private readonly finalTranscripts: string[] = [];
+  private currentPartial = "";
+  private trailingFinalDrain: {
+    resolve: () => void;
+    quietTimer: ReturnType<typeof globalThis.setTimeout> | null;
+    maxTimer: ReturnType<typeof globalThis.setTimeout>;
+  } | null = null;
+  private startPromise: Promise<void> | null = null;
+  private readonly pendingAudio: Float32Array[] = [];
+  private pendingAudioSamples = 0;
+  private appendChain: Promise<void> = Promise.resolve();
+  private closePromise: Promise<void> | null = null;
+  private stopped = false;
+  private discarded = false;
+  private closed = false;
+  private failed = false;
+
+  constructor(
+    private readonly client: GatewayBrowserClient,
+    private readonly callbacks: ComposerDictationSessionCallbacks,
+    private readonly abortController = new AbortController(),
+  ) {}
+
+  start(): Promise<void> {
+    this.startPromise ??= this.startInternal();
+    return this.startPromise;
+  }
+
+  private async startInternal(): Promise<void> {
+    const catalog = await this.client.request<TalkCatalogResult>("talk.catalog", {});
+    if (catalog.transcription?.ready !== true) {
+      throw new Error(t("chat.composer.dictationProviderUnavailable"));
+    }
+
+    const inputDeviceId = loadSettings().realtimeTalkInputDeviceId?.trim() || undefined;
+    const media = await openRealtimeTalkInput(inputDeviceId, {
+      signal: this.abortController.signal,
+    });
+    if (this.stopped) {
+      media.getTracks().forEach((track) => track.stop());
+      return;
+    }
+    this.media = media;
+    this.unsubscribe = this.client.addEventListener((frame) => this.handleEvent(frame));
+    try {
+      this.context = new AudioContext({ sampleRate: DICTATION_SAMPLE_RATE_HZ });
+    } catch {
+      throw new Error(t("chat.composer.dictationBrowserAudioUnsupported"));
+    }
+    if (this.context.sampleRate !== DICTATION_SAMPLE_RATE_HZ) {
+      throw new Error(t("chat.composer.dictationBrowserAudioUnsupported"));
+    }
+    this.inputMeter = new RealtimeTalkMediaStreamMeter(this.callbacks.onLevel);
+    this.inputMeter.start(media, this.context);
+    this.inputPump.start(media, this.context, (samples) => this.appendAudio(samples));
+    this.callbacks.onReady();
+
+    const result = await this.client.request<DictationSessionResult>("talk.session.create", {
+      mode: "transcription",
+      transport: "gateway-relay",
+      brain: "none",
+    });
+    this.sessionId = result.sessionId;
+    this.transcriptionSessionId = result.transcriptionSessionId ?? result.sessionId;
+    if (
+      result.audio?.inputEncoding !== DICTATION_ENCODING ||
+      result.audio.inputSampleRateHz !== DICTATION_SAMPLE_RATE_HZ
+    ) {
+      await this.closeRemote();
+      throw new Error(t("chat.composer.dictationAudioUnsupported"));
+    }
+    if (this.discarded) {
+      this.pendingAudio.length = 0;
+      this.pendingAudioSamples = 0;
+    } else {
+      this.flushPendingAudio();
+    }
+    if (this.stopped) {
+      await this.appendChain;
+      await this.closeRemote();
+    }
+  }
+
+  async finish(): Promise<string> {
+    await this.stopCapture();
+    await this.startPromise?.catch((error: unknown) => {
+      if (!isAbortError(error)) {
+        this.reportFailure(messageFromError(error));
+      }
+    });
+    await this.appendChain;
+    await this.closeRemote();
+    if (!this.sessionId) {
+      this.cleanupEvents();
+      return "";
+    }
+    if (this.failed) {
+      this.cleanupEvents();
+      return this.finalTranscripts.join(" ").trim();
+    }
+    // A provider can emit several final utterances after close is acknowledged.
+    // Keep listening until the final stream has stayed quiet for a bounded span.
+    await this.waitForTrailingFinalDrain();
+    if (this.currentPartial) {
+      this.reportFailure(t("chat.composer.dictationFinalizationTimedOut"));
+    }
+    this.cleanupEvents();
+    return this.finalTranscripts.join(" ").trim();
+  }
+
+  async cancel(): Promise<void> {
+    this.discarded = true;
+    await this.stopCapture();
+    await this.startPromise?.catch(() => undefined);
+    await this.appendChain;
+    await this.closeRemote();
+    this.cleanupEvents();
+  }
+
+  private appendAudio(samples: Float32Array): void {
+    if (this.closed) {
+      return;
+    }
+    if (!this.sessionId) {
+      const remaining = MAX_PENDING_AUDIO_SAMPLES - this.pendingAudioSamples;
+      if (remaining <= 0) {
+        return;
+      }
+      const buffered = samples.slice(0, remaining);
+      this.pendingAudio.push(buffered);
+      this.pendingAudioSamples += buffered.length;
+      return;
+    }
+    this.queueAudio(samples);
+  }
+
+  private flushPendingAudio(): void {
+    const pending = this.pendingAudio.splice(0);
+    this.pendingAudioSamples = 0;
+    for (const samples of pending) {
+      this.queueAudio(samples);
+    }
+  }
+
+  private queueAudio(samples: Float32Array): void {
+    if (!this.sessionId) {
+      return;
+    }
+    const sessionId = this.sessionId;
+    const audioBase64 = bytesToBase64(floatToG711Ulaw(samples));
+    this.appendChain = this.appendChain
+      .then(async () => {
+        await this.client.request("talk.session.appendAudio", { sessionId, audioBase64 });
+      })
+      .catch((error: unknown) => {
+        this.reportFailure(messageFromError(error));
+      });
+  }
+
+  private handleEvent(frame: GatewayEventFrame): void {
+    const payload = eventPayload(frame);
+    if (!payload || payload.transcriptionSessionId !== this.transcriptionSessionId || this.closed) {
+      return;
+    }
+    if (payload.type === "partial" && typeof payload.text === "string") {
+      this.currentPartial = payload.text.trim();
+      this.callbacks.onPartial(this.currentPartial);
+      this.resetTrailingFinalDrain();
+      return;
+    }
+    if (payload.type === "transcript" && typeof payload.text === "string") {
+      const text = payload.text.trim();
+      if (payload.final !== true) {
+        this.currentPartial = text;
+        this.callbacks.onPartial(text);
+        this.resetTrailingFinalDrain();
+        return;
+      }
+      if (text) {
+        this.finalTranscripts.push(text);
+        this.currentPartial = "";
+        this.resetTrailingFinalDrain();
+      }
+      this.callbacks.onPartial("");
+      return;
+    }
+    if (payload.type === "error") {
+      this.reportFailure(
+        typeof payload.message === "string" && payload.message.trim()
+          ? payload.message.trim()
+          : t("chat.composer.dictationFailed"),
+      );
+      return;
+    }
+    if (payload.type === "close" && payload.reason === "error") {
+      this.reportFailure(t("chat.composer.dictationDisconnected"));
+    }
+  }
+
+  private reportFailure(message: string): void {
+    if (this.failed) {
+      return;
+    }
+    this.failed = true;
+    this.resolveTrailingFinalDrain();
+    this.callbacks.onError(message);
+  }
+
+  private async stopCapture(): Promise<void> {
+    if (this.stopped) {
+      return;
+    }
+    this.stopped = true;
+    this.abortController.abort();
+    this.inputPump.stop();
+    this.inputMeter?.stop();
+    this.inputMeter = null;
+    this.media?.getTracks().forEach((track) => track.stop());
+    this.media = null;
+    await this.context?.close();
+    this.context = null;
+  }
+
+  private cleanupEvents(): void {
+    this.resolveTrailingFinalDrain();
+    this.closed = true;
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+  }
+
+  private closeRemote(): Promise<void> {
+    if (!this.sessionId) {
+      return Promise.resolve();
+    }
+    this.closePromise ??= this.client
+      .request("talk.session.close", { sessionId: this.sessionId })
+      .then(() => undefined)
+      .catch(() => undefined);
+    return this.closePromise;
+  }
+
+  private waitForTrailingFinalDrain(): Promise<void> {
+    return new Promise((resolve) => {
+      const hasCompleteTranscript = this.finalTranscripts.length > 0 && !this.currentPartial;
+      this.trailingFinalDrain = {
+        resolve,
+        quietTimer: hasCompleteTranscript
+          ? globalThis.setTimeout(() => this.resolveTrailingFinalDrain(), FINAL_TRANSCRIPT_QUIET_MS)
+          : null,
+        maxTimer: globalThis.setTimeout(
+          () => this.resolveTrailingFinalDrain(),
+          FINAL_TRANSCRIPT_MAX_WAIT_MS,
+        ),
+      };
+    });
+  }
+
+  private resetTrailingFinalDrain(): void {
+    if (!this.trailingFinalDrain) {
+      return;
+    }
+    if (this.trailingFinalDrain.quietTimer !== null) {
+      globalThis.clearTimeout(this.trailingFinalDrain.quietTimer);
+    }
+    this.trailingFinalDrain.quietTimer = globalThis.setTimeout(
+      () => this.resolveTrailingFinalDrain(),
+      FINAL_TRANSCRIPT_QUIET_MS,
+    );
+  }
+
+  private resolveTrailingFinalDrain(): void {
+    if (!this.trailingFinalDrain) {
+      return;
+    }
+    if (this.trailingFinalDrain.quietTimer !== null) {
+      globalThis.clearTimeout(this.trailingFinalDrain.quietTimer);
+    }
+    globalThis.clearTimeout(this.trailingFinalDrain.maxTimer);
+    this.trailingFinalDrain.resolve();
+    this.trailingFinalDrain = null;
+  }
+}
+
+export class ComposerDictationController {
+  readonly inputLevel = new RealtimeTalkLevelSignal();
+  private options: ComposerDictationControllerOptions;
+  private phase: DictationPhase = "idle";
+  private partialTranscript = "";
+  private elapsedSeconds = 0;
+  private pointerId: number | null = null;
+  private pointerTarget: HTMLElement | null = null;
+  private pointerBounds: DOMRect | null = null;
+  private holdTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
+  private elapsedTimer: ReturnType<typeof globalThis.setInterval> | null = null;
+  private session: ComposerDictationSession | null = null;
+  private suppressClick = false;
+  private suppressedPointerId: number | null = null;
+  private suppressClickTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
+  private disposed = false;
+
+  constructor(options: ComposerDictationControllerOptions) {
+    this.options = options;
+  }
+
+  get active(): boolean {
+    return this.phase === "connecting" || this.phase === "recording" || this.phase === "stopping";
+  }
+
+  get connecting(): boolean {
+    return this.phase === "connecting";
+  }
+
+  get finalizing(): boolean {
+    return this.phase === "stopping";
+  }
+
+  get locksComposer(): boolean {
+    return this.phase !== "idle";
+  }
+
+  get partial(): string {
+    return this.partialTranscript;
+  }
+
+  get elapsed(): string {
+    const minutes = Math.floor(this.elapsedSeconds / 60);
+    const seconds = String(this.elapsedSeconds % 60).padStart(2, "0");
+    return `${minutes}:${seconds}`;
+  }
+
+  update(options: ComposerDictationControllerOptions): void {
+    this.options = options;
+    if (this.phase === "stopping") {
+      return;
+    }
+    if ((this.phase !== "idle" && !this.canHold()) || (this.active && !options.connected)) {
+      const keepFinal = this.active && !options.connected;
+      void this.stop({ commit: keepFinal });
+      if (keepFinal) {
+        options.onError(t("chat.composer.dictationDisconnected"));
+      }
+    }
+  }
+
+  handlePointerDown(event: PointerEvent): boolean {
+    if (event.button !== 0 || this.phase !== "idle" || !this.canHold()) {
+      return false;
+    }
+    event.preventDefault();
+    this.pointerId = event.pointerId;
+    this.pointerTarget = event.currentTarget instanceof HTMLElement ? event.currentTarget : null;
+    this.pointerBounds = this.pointerTarget?.getBoundingClientRect() ?? null;
+    this.pointerTarget?.setPointerCapture?.(event.pointerId);
+    this.pointerTarget?.addEventListener("lostpointercapture", this.handleLostPointerCapture);
+    this.suppressClick = true;
+    this.suppressedPointerId = event.pointerId;
+    this.setPhase("holding");
+    this.holdTimer = globalThis.setTimeout(() => {
+      this.holdTimer = null;
+      void this.start();
+    }, HOLD_THRESHOLD_MS);
+    document.addEventListener("pointermove", this.handleDocumentPointerMove);
+    document.addEventListener("pointerup", this.handleDocumentPointerUp);
+    document.addEventListener("pointercancel", this.handleDocumentPointerCancel);
+    document.addEventListener("pointerup", this.handleSuppressedPointerRelease);
+    document.addEventListener("pointercancel", this.handleSuppressedPointerRelease);
+    document.addEventListener("keydown", this.handleDocumentKeyDown);
+    document.addEventListener("visibilitychange", this.handleVisibilityChange);
+    window.addEventListener("blur", this.handleWindowBlur);
+    return true;
+  }
+
+  handleClick(event: MouseEvent): void {
+    if (this.suppressClick) {
+      this.clearClickSuppression();
+      event.preventDefault();
+      return;
+    }
+    if (this.phase !== "idle") {
+      event.preventDefault();
+      return;
+    }
+    this.options.onTap();
+  }
+
+  handleContextMenu(event: MouseEvent): void {
+    if (this.phase !== "idle") {
+      event.preventDefault();
+    }
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    this.clearClickSuppression();
+    void this.stop({ commit: false });
+  }
+
+  private readonly handleDocumentPointerMove = (event: PointerEvent): void => {
+    if (event.pointerId !== this.pointerId || !this.pointerBounds) {
+      return;
+    }
+    const rect = this.pointerBounds;
+    const outside =
+      event.clientX < rect.left ||
+      event.clientX > rect.right ||
+      event.clientY < rect.top ||
+      event.clientY > rect.bottom;
+    if (outside) {
+      void this.stop({ commit: false });
+    }
+  };
+
+  private readonly handleDocumentPointerUp = (event: PointerEvent): void => {
+    if (event.pointerId !== this.pointerId) {
+      return;
+    }
+    if (this.phase === "holding") {
+      this.clearGesture();
+      this.setPhase("idle");
+      this.options.onTap();
+      this.expireClickSuppression();
+      return;
+    }
+    void this.stop({ commit: true });
+  };
+
+  private readonly handleDocumentPointerCancel = (event: PointerEvent): void => {
+    if (event.pointerId === this.pointerId) {
+      void this.stop({ commit: false });
+    }
+  };
+
+  private readonly handleSuppressedPointerRelease = (event: PointerEvent): void => {
+    if (event.pointerId === this.suppressedPointerId) {
+      this.expireClickSuppression();
+    }
+  };
+
+  private readonly handleDocumentKeyDown = (event: KeyboardEvent): void => {
+    if (event.key !== "Escape" || this.phase === "idle") {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    void this.stop({ commit: false });
+  };
+
+  private readonly handleLostPointerCapture = (event: Event): void => {
+    if ((event as PointerEvent).pointerId === this.pointerId) {
+      void this.stop({ commit: false });
+    }
+  };
+
+  private readonly handleVisibilityChange = (): void => {
+    if (document.visibilityState === "hidden") {
+      void this.stop({ commit: false });
+    }
+  };
+
+  private readonly handleWindowBlur = (): void => {
+    void this.stop({ commit: false });
+  };
+
+  private canHold(): boolean {
+    return (
+      this.options.enabled &&
+      this.options.connected &&
+      !this.options.realtimeTalkActive &&
+      this.options.client !== null
+    );
+  }
+
+  private async start(): Promise<void> {
+    const client = this.options.client;
+    if (this.phase !== "holding" || !client || !this.canHold()) {
+      await this.stop({ commit: false });
+      return;
+    }
+    this.setPhase("connecting");
+    this.startElapsedTimer();
+    const session = new ComposerDictationSession(client, {
+      onError: (message) => {
+        if (this.session !== session) {
+          return;
+        }
+        this.options.onError(message);
+        void this.stop({ commit: true });
+      },
+      onLevel: (level) => this.inputLevel.set(level),
+      onPartial: (text) => {
+        this.partialTranscript = text;
+        this.options.onStateChange();
+      },
+      onReady: () => {
+        if (this.session === session && this.phase === "connecting") {
+          this.setPhase("recording");
+        }
+      },
+    });
+    this.session = session;
+    try {
+      await session.start();
+    } catch (error) {
+      if (this.session !== session || this.disposed || this.isStopping()) {
+        return;
+      }
+      this.options.onError(messageFromError(error));
+      await this.stop({ commit: false });
+    }
+  }
+
+  private async stop(options: { commit: boolean }): Promise<void> {
+    if (this.phase === "idle" || this.phase === "stopping") {
+      return;
+    }
+    const wasActive = this.active;
+    this.clearGesture();
+    this.stopElapsedTimer();
+    const session = this.session;
+    if (!session) {
+      this.reset();
+      return;
+    }
+    this.setPhase("stopping");
+    const transcript = options.commit ? await session.finish() : (await session.cancel(), "");
+    if (this.session === session) {
+      this.session = null;
+    }
+    if (options.commit && transcript && wasActive && !this.disposed) {
+      this.options.onCommit(transcript);
+    }
+    this.reset();
+  }
+
+  private reset(): void {
+    this.partialTranscript = "";
+    this.elapsedSeconds = 0;
+    this.inputLevel.set(0);
+    this.setPhase("idle");
+  }
+
+  private clearGesture(): void {
+    if (this.holdTimer !== null) {
+      globalThis.clearTimeout(this.holdTimer);
+      this.holdTimer = null;
+    }
+    if (this.pointerId !== null) {
+      this.pointerTarget?.removeEventListener("lostpointercapture", this.handleLostPointerCapture);
+      try {
+        this.pointerTarget?.releasePointerCapture?.(this.pointerId);
+      } catch {
+        // A reactive render can replace the button and implicitly release capture first.
+      }
+    }
+    this.pointerId = null;
+    this.pointerTarget = null;
+    this.pointerBounds = null;
+    document.removeEventListener("pointermove", this.handleDocumentPointerMove);
+    document.removeEventListener("pointerup", this.handleDocumentPointerUp);
+    document.removeEventListener("pointercancel", this.handleDocumentPointerCancel);
+    document.removeEventListener("keydown", this.handleDocumentKeyDown);
+    document.removeEventListener("visibilitychange", this.handleVisibilityChange);
+    window.removeEventListener("blur", this.handleWindowBlur);
+  }
+
+  private startElapsedTimer(): void {
+    this.elapsedSeconds = 0;
+    this.elapsedTimer = globalThis.setInterval(() => {
+      this.elapsedSeconds += 1;
+      this.options.onStateChange();
+    }, 1000);
+  }
+
+  private stopElapsedTimer(): void {
+    if (this.elapsedTimer !== null) {
+      globalThis.clearInterval(this.elapsedTimer);
+      this.elapsedTimer = null;
+    }
+  }
+
+  private expireClickSuppression(): void {
+    if (!this.suppressClick || this.suppressClickTimer !== null) {
+      return;
+    }
+    this.suppressClickTimer = globalThis.setTimeout(() => this.clearClickSuppression(), 0);
+  }
+
+  private clearClickSuppression(): void {
+    if (this.suppressClickTimer !== null) {
+      globalThis.clearTimeout(this.suppressClickTimer);
+      this.suppressClickTimer = null;
+    }
+    document.removeEventListener("pointerup", this.handleSuppressedPointerRelease);
+    document.removeEventListener("pointercancel", this.handleSuppressedPointerRelease);
+    this.suppressedPointerId = null;
+    this.suppressClick = false;
+  }
+
+  private isStopping(): boolean {
+    return this.phase === "stopping";
+  }
+
+  private setPhase(phase: DictationPhase): void {
+    if (this.phase === phase) {
+      return;
+    }
+    this.phase = phase;
+    this.options.onStateChange();
+  }
+}

--- a/ui/src/pages/chat/composer-dictation.ts
+++ b/ui/src/pages/chat/composer-dictation.ts
@@ -20,6 +20,9 @@ const MAX_PENDING_AUDIO_SAMPLES = DICTATION_SAMPLE_RATE_HZ * 10;
 
 type DictationPhase = "idle" | "holding" | "connecting" | "recording" | "stopping";
 
+// Transcription relay talk.event payload (src/gateway/talk-transcription-relay.ts):
+// the transcriptionSessionId envelope is the relay's emission shape, shared with the
+// Android dictation client; the canonical TalkEvent rides alongside as `talkEvent`.
 type DictationEvent = {
   transcriptionSessionId?: unknown;
   type?: unknown;

--- a/ui/src/pages/chat/realtime-talk-audio.ts
+++ b/ui/src/pages/chat/realtime-talk-audio.ts
@@ -28,6 +28,31 @@ export function floatToPcm16(samples: Float32Array): Uint8Array {
   return bytes;
 }
 
+export function floatToG711Ulaw(samples: Float32Array): Uint8Array {
+  const bytes = new Uint8Array(samples.length);
+  for (let i = 0; i < samples.length; i += 1) {
+    const clamped = Math.max(-1, Math.min(1, samples[i] ?? 0));
+    const pcm16 = Math.round(clamped < 0 ? clamped * 0x8000 : clamped * 0x7fff);
+    let sign = 0;
+    let magnitude = pcm16;
+    if (magnitude < 0) {
+      sign = 0x80;
+      magnitude = -magnitude;
+    }
+    magnitude = Math.min(magnitude, 32635) + 0x84;
+
+    let exponent = 7;
+    let mask = 0x4000;
+    while ((magnitude & mask) === 0 && exponent > 0) {
+      exponent -= 1;
+      mask >>= 1;
+    }
+    const mantissa = (magnitude >> (exponent + 3)) & 0x0f;
+    bytes[i] = ~(sign | (exponent << 4) | mantissa) & 0xff;
+  }
+  return bytes;
+}
+
 export type RealtimeTalkAudioFrame = {
   peak: number;
   rms: number;

--- a/ui/src/pages/chat/realtime-talk-input.ts
+++ b/ui/src/pages/chat/realtime-talk-input.ts
@@ -88,6 +88,10 @@ function describeDeviceError(error: unknown, kind: RealtimeTalkDeviceKind): stri
   );
 }
 
+export function describeRealtimeTalkInputError(error: unknown): string {
+  return describeDeviceError(error, "audioinput");
+}
+
 async function discoverRealtimeTalkDevices(
   requestPermission: boolean,
   kind: RealtimeTalkDeviceKind,

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -65,7 +65,8 @@ type ConfigPageSetting =
   | "textScale"
   | "chatSendShortcut"
   | "chatFollowUpMode"
-  | "catalogOpenTarget";
+  | "catalogOpenTarget"
+  | "composerHoldToRecord";
 
 const CONFIG_PAGE_I18N_KEYS = {
   config: "config",
@@ -618,6 +619,7 @@ export class ConfigPage extends OpenClawLightDomElement {
       catalogOpenTarget: next.catalogOpenTarget,
       realtimeTalkInputDeviceId: next.realtimeTalkInputDeviceId,
       realtimeTalkVideoDeviceId: next.realtimeTalkVideoDeviceId,
+      composerHoldToRecord: next.composerHoldToRecord,
       lobsterPetVisits: next.lobsterPetVisits,
       lobsterPetSounds: next.lobsterPetSounds,
     });
@@ -850,6 +852,8 @@ export class ConfigPage extends OpenClawLightDomElement {
         loading: this.microphoneLoading,
         error: this.microphoneError,
       },
+      composerHoldToRecord: this.settings.composerHoldToRecord !== false,
+      setComposerHoldToRecord: (enabled) => this.setSetting("composerHoldToRecord", enabled),
       onMicrophoneRefresh: () => void this.refreshMicrophones(true),
       onMicrophoneSelect: (deviceId) => this.selectMicrophone(deviceId),
       camera: {

--- a/ui/src/pages/config/view.browser.test.ts
+++ b/ui/src/pages/config/view.browser.test.ts
@@ -1309,6 +1309,8 @@ describe("config view", () => {
       },
       onCameraSelect: vi.fn(),
       onCameraRefresh: vi.fn(),
+      composerHoldToRecord: true,
+      setComposerHoldToRecord: vi.fn(),
     });
 
     const shortcutSelect = queryRequired(
@@ -1342,6 +1344,7 @@ describe("config view", () => {
       "System default",
       "Desk Camera",
     ]);
+    expect(container.textContent).toContain("Hold microphone button to dictate");
   });
 
   it("marks browser follow-up overrides and resets them to the server", () => {

--- a/ui/src/pages/config/view.ts
+++ b/ui/src/pages/config/view.ts
@@ -192,6 +192,8 @@ export type ConfigProps = {
   camera?: SettingsMediaDeviceState;
   onCameraRefresh?: () => void;
   onCameraSelect?: (deviceId: string) => void;
+  composerHoldToRecord?: boolean;
+  setComposerHoldToRecord?: (enabled: boolean) => void;
   gatewayUrl: string;
   assistantName: string;
   configPath?: string | null;
@@ -1082,7 +1084,16 @@ function renderChatPreferencesSection(props: ConfigProps) {
           ],
           onChange: (value) => props.setCatalogOpenTarget(normalizeCatalogOpenTarget(value)),
         })}
-        ${renderSettingsMicrophoneField(props)} ${renderSettingsCameraField(props)}
+        ${renderSettingsMicrophoneField(props)}
+        ${renderSettingsCameraField(props)}
+         ${props.setComposerHoldToRecord
+           ? renderSettingsToggleRow({
+              title: t("chat.composer.holdToRecordSetting"),
+              description: t("chat.composer.holdToRecordSettingDescription"),
+              checked: props.composerHoldToRecord !== false,
+              onChange: props.setComposerHoldToRecord,
+           })
+           : nothing}
       </div>
     </section>
   `;

--- a/ui/src/pages/config/view.ts
+++ b/ui/src/pages/config/view.ts
@@ -1084,16 +1084,15 @@ function renderChatPreferencesSection(props: ConfigProps) {
           ],
           onChange: (value) => props.setCatalogOpenTarget(normalizeCatalogOpenTarget(value)),
         })}
-        ${renderSettingsMicrophoneField(props)}
-        ${renderSettingsCameraField(props)}
-         ${props.setComposerHoldToRecord
-           ? renderSettingsToggleRow({
+        ${renderSettingsMicrophoneField(props)} ${renderSettingsCameraField(props)}
+        ${props.setComposerHoldToRecord
+          ? renderSettingsToggleRow({
               title: t("chat.composer.holdToRecordSetting"),
               description: t("chat.composer.holdToRecordSettingDescription"),
               checked: props.composerHoldToRecord !== false,
               onChange: props.setComposerHoldToRecord,
-           })
-           : nothing}
+            })
+          : nothing}
       </div>
     </section>
   `;

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -2414,6 +2414,63 @@ openclaw-chat-page {
   padding-top: 8px;
 }
 
+.chat-send-btn--hold-enabled {
+  touch-action: none;
+  -webkit-touch-callout: none;
+  user-select: none;
+}
+
+.chat-send-btn--dictating {
+  width: auto;
+  min-width: 76px;
+  gap: 8px;
+  padding: 0 12px;
+  border-radius: var(--radius-full);
+  color: var(--danger, #ef4444);
+  background: color-mix(in srgb, var(--danger, #ef4444) 14%, transparent);
+  box-shadow: 0 0 16px color-mix(in srgb, var(--danger, #ef4444) 24%, transparent);
+  touch-action: none;
+  -webkit-touch-callout: none;
+  user-select: none;
+}
+
+.chat-send-btn--dictating .agent-chat__voice-activity-bar {
+  background: color-mix(in srgb, var(--danger, #ef4444) 88%, var(--text));
+  box-shadow: 0 0 5px color-mix(in srgb, var(--danger, #ef4444) 30%, transparent);
+}
+
+.chat-send-btn__dictation-time {
+  min-width: 3ch;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.agent-chat__dictation-status {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+  color: var(--danger, #ef4444);
+  font-size: 12px;
+}
+
+.agent-chat__dictation-status--finalizing {
+  color: var(--muted);
+}
+
+.agent-chat__dictation-label {
+  flex: 0 0 auto;
+  font-variant-numeric: tabular-nums;
+}
+
+.agent-chat__dictation-partial {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .agent-chat__video-preview {
   position: relative;
   align-self: flex-end;


### PR DESCRIPTION
## What Problem This Solves

The web composer has no dictation: the mic button only toggles a full realtime Talk session. Users who want to speak a message into the composer — without starting a live conversation — have no path, even though the gateway already ships a transcription relay that Android's dictation uses.

## Why This Change Was Made

Press-and-hold is the natural quick-dictation gesture (design reference: Claude desktop's composer). A hold ≥250ms records; release inserts the transcript into the composer at the cursor without sending; a quick tap keeps starting realtime Talk exactly as before. The pipeline rides the existing gateway transcription relay as-is — `talk.session.create { mode: "transcription", transport: "gateway-relay", brain: "none" }`, G.711 μ-law @ 8kHz (`src/gateway/talk-transcription-relay.ts`), the same envelope Android's dictation consumes. No server or protocol changes.

## User Impact

- Hold the mic button, speak, release: transcribed text lands at your cursor, ready to edit — never auto-sent. Slide off, press Escape, or lose focus to cancel.
- Recording honors your selected microphone; live level + partial transcript show while recording; a distinct finishing state covers final-transcript drain.
- Robust failure modes: no transcription provider → immediate clear error; mic permission denied → existing mic error strings; gateway disconnect mid-recording → keeps already-final text, single disconnect error, no hang; hold gesture disabled while a Talk session owns the mic.
- New `composerHoldToRecord` setting (default on) with a Settings toggle; turning it off restores the exact previous button behavior.

Release-note context: **Composer hold-to-record dictation** — hold the web composer's mic button to dictate into the message box via the gateway transcription provider; tap still starts realtime Talk.

## Evidence

- 290 tests passing across composer-dictation (new), chat-composer, chat-view, settings, and config view suites — includes gesture threshold, session lifecycle ordering (mic acquire → session create → append → close), buffered startup audio, pointer-capture retention across the hold-start rerender, disconnect/blur/Escape cancellation, insertion/caret behavior, and setting-off paths.
- Three structured review rounds: pointer-capture loss on rerender (fixed via stable template identity + regression test), disconnect drain lock + armed click suppression (fixed + regression tests), and one final finding rejected with gateway-source evidence (the transcription relay intentionally emits the `transcriptionSessionId` envelope this client parses; Android consumes the same shape — documented inline).
- Audio contract verified against `src/gateway/talk-transcription-relay.ts` (encoding, sample rate, event shapes) rather than assumed.
- Testbox UI typecheck + type-aware UI lint: green. Focused oxfmt/oxlint, `git diff --check`: clean.
- Gap: live end-to-end browser dictation against a configured provider not exercised in CI (requires real mic + provider); covered by mocked gateway-frame tests mirroring the relay's emission shapes.
