### PR TITLE
fix(memory-core): unify QMD multi-collection search, add phase timings, fix archived-session identity loss

### DIFF
--- a/extensions/memory-core/src/memory/qmd-command-client.test.ts
+++ b/extensions/memory-core/src/memory/qmd-command-client.test.ts
@@ -1,0 +1,166 @@
+// Covers scope/memory-recall-enforcement-latency-20260718.md Deliverable B.1/B.4
+// (card ff37a4e4-e002-4fb2-93ad-8b5e0a2fd3d3): QmdCommandClient.searchAcrossCollections
+// must issue exactly one mcporter process for a multi-collection v2 query, preserve the
+// v1 per-collection fallback unchanged, and fall back once to per-collection degraded
+// mode (reporting which collections failed) when the unified attempt itself errors for
+// a non-tool-version reason.
+import type { ResolvedQmdConfig } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  runCliCommand: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/memory-core-host-engine-qmd", () => ({
+  parseQmdQueryJson: vi.fn(() => []),
+  resolveCliSpawnInvocation: vi.fn((params: { command: string; args: string[] }) => ({
+    command: params.command,
+    argv: params.args,
+  })),
+  runCliCommand: mocks.runCliCommand,
+}));
+
+import { QmdCommandClient } from "./qmd-command-client.js";
+
+function buildQmd(): ResolvedQmdConfig {
+  return {
+    command: "qmd",
+    mcporter: { enabled: true, serverName: "qmd", startDaemon: false },
+    searchMode: "search",
+    collections: [],
+    sessions: {} as never,
+    update: {} as never,
+    limits: { timeoutMs: 4_000, maxResults: 10, maxSnippetChars: 400 } as never,
+    includeDefaultMemory: false,
+  } as unknown as ResolvedQmdConfig;
+}
+
+function mcporterResult(entries: Array<{ docid: string; score: number; collection?: string }>) {
+  return {
+    stdout: JSON.stringify({ structuredContent: { results: entries } }),
+    stderr: "",
+  };
+}
+
+describe("QmdCommandClient.searchAcrossCollections", () => {
+  beforeEach(() => {
+    mocks.runCliCommand.mockReset();
+  });
+
+  function makeClient(): QmdCommandClient {
+    return new QmdCommandClient(buildQmd(), process.env, "/tmp/workspace", 100_000);
+  }
+
+  const baseParams = {
+    tool: "query" as const,
+    searchCommand: "search" as const,
+    explicitToolOverride: false as const,
+    query: "test query",
+    limit: 10,
+    minScore: 0,
+    collectionNames: ["memory", "sessions", "wiki"],
+  };
+
+  it("issues exactly one mcporter process for a v2 unified multi-collection call", async () => {
+    mocks.runCliCommand.mockResolvedValueOnce(
+      mcporterResult([
+        { docid: "a", score: 0.9, collection: "memory" },
+        { docid: "b", score: 0.8, collection: "sessions" },
+      ]),
+    );
+
+    const client = makeClient();
+    const result = await client.searchAcrossCollections(baseParams);
+
+    expect(mocks.runCliCommand).toHaveBeenCalledTimes(1);
+    const callArgsJson = mocks.runCliCommand.mock.calls[0]?.[0]?.commandSummary as string;
+    expect(callArgsJson).toContain("call qmd.query");
+    expect(result.callPlan).toEqual({ mode: "unified", collectionCount: 3, processCount: 1 });
+    expect(
+      result.results.map((r) => r.docid).toSorted((a, b) => (a ?? "").localeCompare(b ?? "")),
+    ).toEqual(["a", "b"]);
+  });
+
+  it("falls back to the v1 per-collection loop, unchanged, when the server has no v2 query tool", async () => {
+    // First call: unified attempt fails with a "Tool 'query' not found" style error.
+    mocks.runCliCommand.mockRejectedValueOnce(
+      new Error("mcporter call failed (code 1): Tool 'query' not found"),
+    );
+    // Per-collection v1 fallback: one call per collection (search command resolves to v1 "search" tool).
+    mocks.runCliCommand
+      .mockResolvedValueOnce(mcporterResult([{ docid: "a", score: 0.9 }]))
+      .mockResolvedValueOnce(mcporterResult([{ docid: "b", score: 0.8 }]))
+      .mockResolvedValueOnce(mcporterResult([{ docid: "c", score: 0.7 }]));
+
+    const client = makeClient();
+    const result = await client.searchAcrossCollections(baseParams);
+
+    // 1 failed unified attempt + 3 per-collection v1 calls.
+    expect(mocks.runCliCommand).toHaveBeenCalledTimes(4);
+    expect(result.callPlan).toEqual({
+      mode: "per-collection",
+      collectionCount: 3,
+      processCount: 3,
+    });
+    expect(
+      result.results.map((r) => r.docid).toSorted((a, b) => (a ?? "").localeCompare(b ?? "")),
+    ).toEqual(["a", "b", "c"]);
+  });
+
+  it("falls back once to per-collection degraded mode when the unified call errors for a non-version reason", async () => {
+    mocks.runCliCommand.mockRejectedValueOnce(new Error("mcporter call failed (code 1): timeout"));
+    mocks.runCliCommand
+      .mockResolvedValueOnce(mcporterResult([{ docid: "a", score: 0.9 }]))
+      .mockResolvedValueOnce(mcporterResult([{ docid: "b", score: 0.8 }]))
+      .mockRejectedValueOnce(new Error("mcporter call failed (code 1): server unavailable"));
+
+    const client = makeClient();
+    const result = await client.searchAcrossCollections(baseParams);
+
+    expect(mocks.runCliCommand).toHaveBeenCalledTimes(4);
+    expect(result.callPlan).toEqual({
+      mode: "degraded",
+      collectionCount: 3,
+      processCount: 4,
+      succeededCollections: ["memory", "sessions"],
+      failedCollections: ["wiki"],
+    });
+    expect(
+      result.results.map((r) => r.docid).toSorted((a, b) => (a ?? "").localeCompare(b ?? "")),
+    ).toEqual(["a", "b"]);
+  });
+
+  it("throws when every collection fails in degraded mode instead of returning an empty success", async () => {
+    mocks.runCliCommand.mockRejectedValueOnce(new Error("mcporter call failed (code 1): timeout"));
+    mocks.runCliCommand
+      .mockRejectedValueOnce(new Error("mcporter call failed (code 1): down"))
+      .mockRejectedValueOnce(new Error("mcporter call failed (code 1): down"))
+      .mockRejectedValueOnce(new Error("mcporter call failed (code 1): down"));
+
+    const client = makeClient();
+    await expect(client.searchAcrossCollections(baseParams)).rejects.toThrow(
+      /degraded-mode search failed for all 3 collections/,
+    );
+  });
+
+  it("issues one process per collection for an explicit tool override, never attempting the unified call", async () => {
+    mocks.runCliCommand
+      .mockResolvedValueOnce(mcporterResult([{ docid: "a", score: 0.9 }]))
+      .mockResolvedValueOnce(mcporterResult([{ docid: "b", score: 0.8 }]))
+      .mockResolvedValueOnce(mcporterResult([{ docid: "c", score: 0.7 }]));
+
+    const client = makeClient();
+    const result = await client.searchAcrossCollections({
+      ...baseParams,
+      tool: "vector_search",
+      explicitToolOverride: true,
+    });
+
+    expect(mocks.runCliCommand).toHaveBeenCalledTimes(3);
+    expect(result.callPlan).toEqual({
+      mode: "per-collection",
+      collectionCount: 3,
+      processCount: 3,
+    });
+  });
+});

--- a/extensions/memory-core/src/memory/qmd-command-client.ts
+++ b/extensions/memory-core/src/memory/qmd-command-client.ts
@@ -40,6 +40,7 @@ type QmdMcporterSearchParams =
       limit: number;
       minScore: number;
       collection?: string;
+      collections?: string[];
       timeoutMs: number;
       signal?: AbortSignal;
       reportCommandPhase?: QmdCommandPhaseReporter;
@@ -53,10 +54,47 @@ type QmdMcporterSearchParams =
       limit: number;
       minScore: number;
       collection?: string;
+      collections?: string[];
       timeoutMs: number;
       signal?: AbortSignal;
       reportCommandPhase?: QmdCommandPhaseReporter;
     };
+
+/**
+ * Thrown by {@link QmdCommandClient.searchViaMcporter} when a unified v2
+ * multi-collection call turns out to need the v1 tool fallback. v1 tools take
+ * one `collection` string, not an array, so the caller (searchAcrossCollections)
+ * must retry per-collection itself rather than have this method recurse with an
+ * unsupported shape.
+ */
+class QmdV1MultiCollectionUnsupportedError extends Error {
+  constructor() {
+    super("qmd v1 tools do not support multi-collection calls; retry per collection");
+    this.name = "QmdV1MultiCollectionUnsupportedError";
+  }
+}
+
+/**
+ * Observability for how searchAcrossCollections actually reached the server.
+ * "unified" is the v2 happy path: exactly one `mcporter call` process covers
+ * every requested collection. "per-collection" is either the v1 fallback or
+ * an explicit tool override, both of which spawn one process per collection.
+ * "degraded" means the unified attempt itself failed for a non-tool-version
+ * reason (timeout, transient server error) and results were salvaged by
+ * retrying collections in isolation.
+ */
+export type QmdMcporterCallPlanDebug = {
+  mode: "unified" | "per-collection" | "degraded";
+  collectionCount: number;
+  processCount: number;
+  failedCollections?: string[];
+  succeededCollections?: string[];
+};
+
+type QmdSearchAcrossCollectionsResult = {
+  results: QmdQueryResult[];
+  callPlan: QmdMcporterCallPlanDebug;
+};
 
 type QmdMcporterAcrossCollectionsParams =
   | {
@@ -177,12 +215,25 @@ export class QmdCommandClient {
     }
     await this.ensureMcporterDaemonStarted(params.mcporter);
 
+    const collections = params.collections?.length
+      ? params.collections
+      : params.collection
+        ? [params.collection]
+        : undefined;
     const effectiveTool =
       params.tool === "query" && this.qmdMcpToolVersion === "v1"
         ? this.resolveMcpTool(params.searchCommand ?? "query")
         : params.tool;
     const selector = `${params.mcporter.serverName}.${effectiveTool}`;
     const useUnifiedQueryTool = effectiveTool === "query";
+    if (!useUnifiedQueryTool && (collections?.length ?? 0) > 1) {
+      // v1 tools (search/vector_search/deep_search) only accept a single
+      // `collection` string. The caller is responsible for not reaching this
+      // state (searchAcrossCollections retries per collection once it learns
+      // the server is v1), but fail loudly instead of silently querying only
+      // the first collection if it ever does.
+      throw new QmdV1MultiCollectionUnsupportedError();
+    }
     const callArgs: Record<string, unknown> = useUnifiedQueryTool
       ? {
           searches: this.buildV2Searches(params.query, params.searchCommand),
@@ -196,11 +247,11 @@ export class QmdCommandClient {
           limit: params.limit,
           minScore: params.minScore,
         };
-    if (params.collection) {
+    if (collections?.length) {
       if (useUnifiedQueryTool) {
-        callArgs.collections = [params.collection];
+        callArgs.collections = collections;
       } else {
-        callArgs.collection = params.collection;
+        callArgs.collection = collections[0];
       }
     }
     if (
@@ -238,6 +289,9 @@ export class QmdCommandClient {
     } catch (err) {
       if (useUnifiedQueryTool && this.isQueryToolNotFoundError(err)) {
         this.markQmdV1Fallback();
+        if ((collections?.length ?? 0) > 1) {
+          throw new QmdV1MultiCollectionUnsupportedError();
+        }
         const v1Tool = this.resolveMcpTool(params.searchCommand ?? "query");
         return this.searchViaMcporter({
           mcporter: params.mcporter,
@@ -247,7 +301,7 @@ export class QmdCommandClient {
           query: params.query,
           limit: params.limit,
           minScore: params.minScore,
-          collection: params.collection,
+          collection: collections?.[0],
           timeoutMs: params.timeoutMs,
           signal: params.signal,
           reportCommandPhase: params.reportCommandPhase,
@@ -259,51 +313,143 @@ export class QmdCommandClient {
     return this.parseMcporterResults(result.stdout);
   }
 
+  /**
+   * Searches every managed collection for a query. When the server advertises
+   * (or hasn't yet ruled out) the v2 unified `query` tool, this issues exactly
+   * one `mcporter call` process covering all collections via the tool's
+   * `collections` array, instead of one process per collection. Preserves the
+   * v1 fallback (one process per collection, unchanged) and an explicit tool
+   * override (also one process per collection, since a caller-named tool's
+   * multi-collection support is never assumed).
+   */
   async searchAcrossCollections(
     params: QmdMcporterAcrossCollectionsParams,
-  ): Promise<QmdQueryResult[]> {
-    const bestByDocId = new Map<string, QmdQueryResult>();
-    for (const collectionName of params.collectionNames) {
-      const parsed = params.explicitToolOverride
-        ? await this.searchViaMcporter({
-            mcporter: this.qmd.mcporter,
-            tool: params.tool,
-            searchCommand: params.searchCommand,
-            explicitToolOverride: true,
-            query: params.query,
-            limit: params.limit,
-            minScore: params.minScore,
-            collection: collectionName,
-            timeoutMs: this.qmd.limits.timeoutMs,
-            signal: params.signal,
-            reportCommandPhase: params.reportCommandPhase,
-          })
-        : await this.searchViaMcporter({
-            mcporter: this.qmd.mcporter,
-            tool: params.tool,
-            searchCommand: params.searchCommand,
-            explicitToolOverride: false,
-            query: params.query,
-            limit: params.limit,
-            minScore: params.minScore,
-            collection: collectionName,
-            timeoutMs: this.qmd.limits.timeoutMs,
-            signal: params.signal,
-            reportCommandPhase: params.reportCommandPhase,
-          });
-      for (const entry of parsed) {
-        if (typeof entry.docid !== "string" || !entry.docid.trim()) {
-          continue;
+  ): Promise<QmdSearchAcrossCollectionsResult> {
+    if (!params.explicitToolOverride && params.tool === "query") {
+      try {
+        const parsed = await this.searchViaMcporter({
+          mcporter: this.qmd.mcporter,
+          tool: params.tool,
+          searchCommand: params.searchCommand,
+          explicitToolOverride: false,
+          query: params.query,
+          limit: params.limit,
+          minScore: params.minScore,
+          collections: params.collectionNames,
+          timeoutMs: this.qmd.limits.timeoutMs,
+          signal: params.signal,
+          reportCommandPhase: params.reportCommandPhase,
+        });
+        return {
+          results: dedupeQmdResultsByDocId(parsed),
+          callPlan: {
+            mode: "unified",
+            collectionCount: params.collectionNames.length,
+            processCount: 1,
+          },
+        };
+      } catch (err) {
+        if (!(err instanceof QmdV1MultiCollectionUnsupportedError)) {
+          // Non-tool-version failure (timeout, transient server error): the
+          // unified attempt still counts as one process. Salvage whatever
+          // collections we can rather than fail the whole search.
+          return await this.searchPerCollectionDegraded(params, 1);
         }
-        const prev = bestByDocId.get(entry.docid);
-        const prevScore = typeof prev?.score === "number" ? prev.score : Number.NEGATIVE_INFINITY;
-        const nextScore = typeof entry.score === "number" ? entry.score : Number.NEGATIVE_INFINITY;
-        if (!prev || nextScore > prevScore) {
-          bestByDocId.set(entry.docid, entry);
-        }
+        // v1 confirmed by the failed attempt; fall through to the loop below,
+        // which now resolves each call to a v1 tool name directly.
       }
     }
-    return [...bestByDocId.values()].toSorted((a, b) => (b.score ?? 0) - (a.score ?? 0));
+    return await this.searchPerCollectionLoop(params);
+  }
+
+  private async searchPerCollectionLoop(
+    params: QmdMcporterAcrossCollectionsParams,
+  ): Promise<QmdSearchAcrossCollectionsResult> {
+    const bestByDocId = new Map<string, QmdQueryResult>();
+    for (const collectionName of params.collectionNames) {
+      const parsed = await this.searchOneCollection(params, collectionName);
+      mergeQmdResultsByDocId(bestByDocId, parsed);
+    }
+    return {
+      results: sortQmdResultsByScore(bestByDocId),
+      callPlan: {
+        mode: "per-collection",
+        collectionCount: params.collectionNames.length,
+        processCount: params.collectionNames.length,
+      },
+    };
+  }
+
+  private async searchPerCollectionDegraded(
+    params: QmdMcporterAcrossCollectionsParams,
+    priorProcessCount: number,
+  ): Promise<QmdSearchAcrossCollectionsResult> {
+    const bestByDocId = new Map<string, QmdQueryResult>();
+    const succeededCollections: string[] = [];
+    const failedCollections: string[] = [];
+    for (const collectionName of params.collectionNames) {
+      if (params.signal?.aborted) {
+        throw asQmdAbortError(params.signal);
+      }
+      try {
+        const parsed = await this.searchOneCollection(params, collectionName);
+        mergeQmdResultsByDocId(bestByDocId, parsed);
+        succeededCollections.push(collectionName);
+      } catch (err) {
+        log.warn(
+          `qmd degraded-mode per-collection search failed for "${collectionName}": ${String(err)}`,
+        );
+        failedCollections.push(collectionName);
+      }
+    }
+    if (succeededCollections.length === 0) {
+      throw new Error(
+        `qmd degraded-mode search failed for all ${params.collectionNames.length} collections`,
+      );
+    }
+    return {
+      results: sortQmdResultsByScore(bestByDocId),
+      callPlan: {
+        mode: "degraded",
+        collectionCount: params.collectionNames.length,
+        processCount: priorProcessCount + params.collectionNames.length,
+        succeededCollections,
+        failedCollections,
+      },
+    };
+  }
+
+  private async searchOneCollection(
+    params: QmdMcporterAcrossCollectionsParams,
+    collectionName: string,
+  ): Promise<QmdQueryResult[]> {
+    return params.explicitToolOverride
+      ? await this.searchViaMcporter({
+          mcporter: this.qmd.mcporter,
+          tool: params.tool,
+          searchCommand: params.searchCommand,
+          explicitToolOverride: true,
+          query: params.query,
+          limit: params.limit,
+          minScore: params.minScore,
+          collection: collectionName,
+          timeoutMs: this.qmd.limits.timeoutMs,
+          signal: params.signal,
+          reportCommandPhase: params.reportCommandPhase,
+        })
+      : await this.searchViaMcporter({
+          mcporter: this.qmd.mcporter,
+          tool: params.tool,
+          searchCommand: params.searchCommand,
+          explicitToolOverride: false,
+          query: params.query,
+          limit: params.limit,
+          minScore: params.minScore,
+          collection: collectionName,
+          timeoutMs: this.qmd.limits.timeoutMs,
+          signal: params.signal,
+          reportCommandPhase: params.reportCommandPhase,
+        });
   }
 
   private buildV2Searches(
@@ -445,4 +591,31 @@ function normalizeSnippetLine(value: unknown): number | undefined {
 
 function normalizeQmdSemanticQuery(query: string): string {
   return query.replace(/(\w)-(?=\w)/g, "$1 ");
+}
+
+function mergeQmdResultsByDocId(
+  bestByDocId: Map<string, QmdQueryResult>,
+  parsed: QmdQueryResult[],
+): void {
+  for (const entry of parsed) {
+    if (typeof entry.docid !== "string" || !entry.docid.trim()) {
+      continue;
+    }
+    const prev = bestByDocId.get(entry.docid);
+    const prevScore = typeof prev?.score === "number" ? prev.score : Number.NEGATIVE_INFINITY;
+    const nextScore = typeof entry.score === "number" ? entry.score : Number.NEGATIVE_INFINITY;
+    if (!prev || nextScore > prevScore) {
+      bestByDocId.set(entry.docid, entry);
+    }
+  }
+}
+
+function sortQmdResultsByScore(bestByDocId: Map<string, QmdQueryResult>): QmdQueryResult[] {
+  return [...bestByDocId.values()].toSorted((a, b) => (b.score ?? 0) - (a.score ?? 0));
+}
+
+function dedupeQmdResultsByDocId(parsed: QmdQueryResult[]): QmdQueryResult[] {
+  const bestByDocId = new Map<string, QmdQueryResult>();
+  mergeQmdResultsByDocId(bestByDocId, parsed);
+  return sortQmdResultsByScore(bestByDocId);
 }

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -64,7 +64,11 @@ import {
   type ManagedQmdCollection as ManagedCollection,
   type QmdSearchRuntimeDebugContext,
 } from "./qmd-collection-controller.js";
-import { QmdCommandClient, type QmdCommandPhaseReporter } from "./qmd-command-client.js";
+import {
+  QmdCommandClient,
+  type QmdCommandPhaseReporter,
+  type QmdMcporterCallPlanDebug,
+} from "./qmd-command-client.js";
 import {
   asQmdAbortError,
   isMissingCollectionSearchError,
@@ -651,6 +655,25 @@ export class QmdMemoryManager implements MemorySearchManager {
     if (debugContext.searchPlan) {
       debug.searchPlan = debugContext.searchPlan;
     }
+    if (debugContext.mcporterCallPlan) {
+      debug.mcporterCallPlan = debugContext.mcporterCallPlan;
+    }
+    if (
+      debugContext.dirtySyncWaitMs !== undefined ||
+      debugContext.pendingUpdateWaitMs !== undefined ||
+      debugContext.collectionQueryMs !== undefined ||
+      debugContext.resultResolutionMs !== undefined
+    ) {
+      debug.phaseTimings = {
+        dirtySyncWaitMs: debugContext.dirtySyncWaitMs,
+        pendingUpdateWaitMs: debugContext.pendingUpdateWaitMs,
+        collectionQueryMs: debugContext.collectionQueryMs,
+        resultResolutionMs: debugContext.resultResolutionMs,
+      };
+    }
+    if (debugContext.hitsDroppedAtDocResolution !== undefined) {
+      debug.hitsDroppedAtDocResolution = debugContext.hitsDroppedAtDocResolution;
+    }
     return Object.keys(debug).length > 0 ? debug : undefined;
   }
 
@@ -727,9 +750,13 @@ export class QmdMemoryManager implements MemorySearchManager {
     if (!trimmed) {
       return [];
     }
+    const dirtySyncWaitStartedAt = Date.now();
     await this.maybeWarmSession(opts?.sessionKey);
     await this.maybeSyncDirtySearchState();
+    debugContext.dirtySyncWaitMs = Math.max(0, Date.now() - dirtySyncWaitStartedAt);
+    const pendingUpdateWaitStartedAt = Date.now();
     await this.waitForPendingUpdateBeforeSearch();
+    debugContext.pendingUpdateWaitMs = Math.max(0, Date.now() - pendingUpdateWaitStartedAt);
     const resultLimit = Math.min(
       this.qmd.limits.maxResults,
       opts?.maxResults ?? this.qmd.limits.maxResults,
@@ -753,6 +780,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     let searchFallbackReason: string | undefined;
     const explicitSearchTool = this.qmd.searchTool;
     const mcporterEnabled = this.qmd.mcporter.enabled;
+    let mcporterCallPlan: QmdMcporterCallPlanDebug | undefined;
     const runSearchAttempt = async (
       allowMissingCollectionRepair: boolean,
     ): Promise<QmdQueryResult[]> => {
@@ -762,7 +790,7 @@ export class QmdMemoryManager implements MemorySearchManager {
           const minScore = opts?.minScore ?? 0;
           if (explicitSearchTool) {
             if (collectionNames.length > 1) {
-              return await this.commands.searchAcrossCollections({
+              const across = await this.commands.searchAcrossCollections({
                 tool: explicitSearchTool,
                 searchCommand: qmdSearchCommand,
                 explicitToolOverride: true,
@@ -773,6 +801,8 @@ export class QmdMemoryManager implements MemorySearchManager {
                 signal: searchSignal,
                 reportCommandPhase,
               });
+              mcporterCallPlan = across.callPlan;
+              return across.results;
             }
             return await this.commands.searchViaMcporter({
               mcporter: this.qmd.mcporter,
@@ -790,7 +820,7 @@ export class QmdMemoryManager implements MemorySearchManager {
           }
           const tool = this.commands.resolveMcpTool(qmdSearchCommand);
           if (collectionNames.length > 1) {
-            return await this.commands.searchAcrossCollections({
+            const across = await this.commands.searchAcrossCollections({
               tool,
               searchCommand: qmdSearchCommand,
               explicitToolOverride: false,
@@ -801,6 +831,8 @@ export class QmdMemoryManager implements MemorySearchManager {
               signal: searchSignal,
               reportCommandPhase,
             });
+            mcporterCallPlan = across.callPlan;
+            return across.results;
           }
           return await this.commands.searchViaMcporter({
             mcporter: this.qmd.mcporter,
@@ -896,15 +928,25 @@ export class QmdMemoryManager implements MemorySearchManager {
       }
     };
 
+    const collectionQueryStartedAt = Date.now();
     let parsed: QmdQueryResult[];
     try {
       parsed = await runSearchAttempt(true);
+      if (mcporterCallPlan) {
+        debugContext.mcporterCallPlan = mcporterCallPlan;
+      }
     } catch (err) {
       if (!(await this.tryRepairMissingCollectionSearch(err, debugContext, searchSignal))) {
         throw err instanceof Error ? err : new Error(String(err));
       }
       parsed = await runSearchAttempt(false);
+      if (mcporterCallPlan) {
+        debugContext.mcporterCallPlan = mcporterCallPlan;
+      }
     }
+    debugContext.collectionQueryMs = Math.max(0, Date.now() - collectionQueryStartedAt);
+    const resultResolutionStartedAt = Date.now();
+    let droppedAtDocResolution = 0;
     const results: MemorySearchResult[] = [];
     for (const entry of parsed) {
       const docHints = this.normalizeDocHints({
@@ -913,6 +955,7 @@ export class QmdMemoryManager implements MemorySearchManager {
       });
       const doc = await this.resolveDocLocation(entry.docid, docHints);
       if (!doc) {
+        droppedAtDocResolution += 1;
         continue;
       }
       const snippet = truncateUtf16Safe(entry.snippet ?? "", this.qmd.limits.maxSnippetChars);
@@ -943,6 +986,16 @@ export class QmdMemoryManager implements MemorySearchManager {
       results.push(
         artifactIdentity ? attachQmdSessionArtifactHit(result, artifactIdentity) : result,
       );
+    }
+    debugContext.resultResolutionMs = Math.max(0, Date.now() - resultResolutionStartedAt);
+    if (droppedAtDocResolution > 0) {
+      // Source is unknown for these — resolveDocLocation failed before a
+      // MemorySource could be attached. This is one of the two silent
+      // hit-loss points the recall-latency scope's diagnosis targets (the
+      // other is filterMemorySearchHitsBySessionVisibility, instrumented
+      // separately); a nonzero count here on a corpus=sessions query that
+      // returns zero results is the first thing to check.
+      debugContext.hitsDroppedAtDocResolution = droppedAtDocResolution;
     }
     opts?.onDebug?.({
       backend: "qmd",

--- a/extensions/memory-core/src/memory/qmd-runtime-debug.ts
+++ b/extensions/memory-core/src/memory/qmd-runtime-debug.ts
@@ -7,8 +7,17 @@ type QmdMultiCollectionProbeDebug = NonNullable<
   NonNullable<MemorySearchRuntimeDebug["qmd"]>["multiCollectionProbe"]
 >;
 type QmdSearchPlanDebug = NonNullable<NonNullable<MemorySearchRuntimeDebug["qmd"]>["searchPlan"]>;
+type QmdMcporterCallPlanDebug = NonNullable<
+  NonNullable<MemorySearchRuntimeDebug["qmd"]>["mcporterCallPlan"]
+>;
 export type QmdSearchRuntimeDebugContext = {
   collectionValidation?: QmdCollectionValidationDebug;
   multiCollectionProbe?: QmdMultiCollectionProbeDebug;
   searchPlan?: QmdSearchPlanDebug;
+  mcporterCallPlan?: QmdMcporterCallPlanDebug;
+  dirtySyncWaitMs?: number;
+  pendingUpdateWaitMs?: number;
+  collectionQueryMs?: number;
+  resultResolutionMs?: number;
+  hitsDroppedAtDocResolution?: number;
 };

--- a/extensions/memory-core/src/memory/qmd-session-exporter.test.ts
+++ b/extensions/memory-core/src/memory/qmd-session-exporter.test.ts
@@ -6,12 +6,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   buildSessionEntry: vi.fn(),
   corpusEntries: vi.fn(),
+  isSessionArchiveArtifactName: vi.fn(() => false),
   replaceArtifactMappings: vi.fn(),
 }));
 
 vi.mock("openclaw/plugin-sdk/memory-core-host-engine-qmd", () => ({
   buildSessionEntry: mocks.buildSessionEntry,
-  isSessionArchiveArtifactName: () => false,
+  isSessionArchiveArtifactName: mocks.isSessionArchiveArtifactName,
   listSessionTranscriptCorpusEntriesForAgent: mocks.corpusEntries,
   resolveSessionIdentityForTranscriptFile: () => null,
 }));
@@ -32,6 +33,7 @@ describe("QmdSessionExporter", () => {
   beforeEach(() => {
     mocks.buildSessionEntry.mockReset();
     mocks.corpusEntries.mockReset();
+    mocks.isSessionArchiveArtifactName.mockReset().mockReturnValue(false);
     mocks.replaceArtifactMappings.mockReset();
   });
 
@@ -136,6 +138,128 @@ describe("QmdSessionExporter", () => {
 
       expect(mocks.buildSessionEntry).toHaveBeenCalledTimes(3);
       await expect(fs.readFile(target, "utf8")).resolves.toContain("User: canonical");
+    });
+  });
+
+  // scope/memory-recall-enforcement-latency-20260718.md Deliverable A step 2a diagnosis
+  // + B.3 step 2b repair (card ff37a4e4-e002-4fb2-93ad-8b5e0a2fd3d3): an archived session's
+  // exported artifact name embeds a raw ISO timestamp (dots/colons). QMD's own indexer
+  // normalizes those to "-" in its `documents` table, so the stored artifact_path/search_path
+  // must match that normalized form or refreshQmdSessionArtifactDocIds()'s join on
+  // (collection, path) can never backfill a docid for it.
+  it("normalizes an archived session's artifact/search path to match QMD's own indexed name", async () => {
+    await withTempDir("qmd-session-exporter-", async (tempDir) => {
+      const exportDir = path.join(tempDir, "exports");
+      const rawStem = "abc123.jsonl.deleted.2026-07-18T12:00:00.000Z";
+      const corpusEntry = {
+        agentId: "main",
+        artifactKind: "archived-session" as const,
+        contentRevision: "sqlite:1:100:1:1",
+        sessionFile: `sqlite:main:${rawStem}`,
+        sessionId: rawStem,
+        transcriptSource: "sqlite" as const,
+        updatedAtMs: 1,
+      };
+      mocks.corpusEntries.mockResolvedValue([corpusEntry]);
+      mocks.isSessionArchiveArtifactName.mockReturnValue(true);
+      mocks.buildSessionEntry.mockResolvedValue({
+        absPath: corpusEntry.sessionFile,
+        content: "User: archived",
+        hash: "archived",
+        lineMap: [1],
+        messageTimestampsMs: [1],
+        mtimeMs: 1,
+        path: `sessions/main/${rawStem}.jsonl`,
+        size: 100,
+      });
+      // Echo the (possibly normalized) artifactPath back so the mapping's searchPath
+      // reflects whatever buildSessionArtifactMapping actually passed it.
+      const exporter = new QmdSessionExporter(
+        { collectionName: "sessions-main", dir: exportDir },
+        "main",
+        tempDir,
+        path.join(tempDir, "index.sqlite"),
+        (_collection, artifactPath) => `echo:${artifactPath}`,
+      );
+      const lease = createLease();
+
+      await exporter.exportSessions(lease);
+
+      expect(mocks.replaceArtifactMappings).toHaveBeenCalledTimes(1);
+      const firstCall = mocks.replaceArtifactMappings.mock.calls[0];
+      if (!firstCall) {
+        throw new Error("expected replaceArtifactMappings to be called");
+      }
+      const { mappings } = firstCall[0] as {
+        mappings: Array<{ artifactPath: string; searchPath: string; archived: boolean }>;
+      };
+      expect(mappings).toHaveLength(1);
+      const mapping = mappings[0];
+      if (!mapping) {
+        throw new Error("expected one artifact mapping");
+      }
+      expect(mapping.archived).toBe(true);
+      // Dots and colons in the stem become "-"; the ".md" extension is preserved.
+      expect(mapping.artifactPath).toBe("abc123-jsonl-deleted-2026-07-18T12-00-00-000Z.md");
+      expect(mapping.artifactPath).not.toContain(".jsonl.");
+      expect(mapping.artifactPath).not.toContain(":");
+      // The on-disk exported file itself keeps the raw, un-normalized name.
+      await expect(fs.readFile(path.join(exportDir, `${rawStem}.md`), "utf8")).resolves.toContain(
+        "User: archived",
+      );
+      // searchPath is derived from the (normalized) artifactPath, not the raw one.
+      expect(mapping.searchPath).toBe(`echo:${mapping.artifactPath}`);
+    });
+  });
+
+  it("leaves a live (non-archived) session's artifact path untouched", async () => {
+    await withTempDir("qmd-session-exporter-", async (tempDir) => {
+      const exportDir = path.join(tempDir, "exports");
+      const corpusEntry = {
+        agentId: "main",
+        artifactKind: "active-session" as const,
+        contentRevision: "sqlite:1:100:1:1",
+        sessionFile: "sqlite:main:session-1",
+        sessionId: "session-1",
+        transcriptSource: "sqlite" as const,
+        updatedAtMs: 1,
+      };
+      mocks.corpusEntries.mockResolvedValue([corpusEntry]);
+      mocks.isSessionArchiveArtifactName.mockReturnValue(false);
+      mocks.buildSessionEntry.mockResolvedValue({
+        absPath: corpusEntry.sessionFile,
+        content: "User: live",
+        hash: "live",
+        lineMap: [1],
+        messageTimestampsMs: [1],
+        mtimeMs: 1,
+        path: "sessions/main/session-1.jsonl",
+        size: 100,
+      });
+      const exporter = new QmdSessionExporter(
+        { collectionName: "sessions-main", dir: exportDir },
+        "main",
+        tempDir,
+        path.join(tempDir, "index.sqlite"),
+        (_collection, artifactPath) => `echo:${artifactPath}`,
+      );
+      const lease = createLease();
+
+      await exporter.exportSessions(lease);
+
+      const firstCall = mocks.replaceArtifactMappings.mock.calls[0];
+      if (!firstCall) {
+        throw new Error("expected replaceArtifactMappings to be called");
+      }
+      const { mappings } = firstCall[0] as {
+        mappings: Array<{ artifactPath: string; archived: boolean }>;
+      };
+      const mapping = mappings[0];
+      if (!mapping) {
+        throw new Error("expected one artifact mapping");
+      }
+      expect(mapping.archived).toBe(false);
+      expect(mapping.artifactPath).toBe("session-1.md");
     });
   });
 });

--- a/extensions/memory-core/src/memory/qmd-session-exporter.ts
+++ b/extensions/memory-core/src/memory/qmd-session-exporter.ts
@@ -68,6 +68,28 @@ function pathStatRevision(stat: {
   return `${stat.dev}:${stat.ino}:${stat.size}:${stat.mtimeMs}`;
 }
 
+/**
+ * QMD's own indexer normalizes every "." and ":" in a document's stem (all but
+ * the final extension) to "-" when it records that file's path in its
+ * `documents` table. An archived-session export name embeds a raw ISO
+ * timestamp with dots/colons (e.g. `<uuid>.jsonl.deleted.<ISO>.md`), so
+ * without this same normalization the artifact_path/search_path stored in
+ * `openclaw_qmd_session_artifacts` never matches QMD's indexed path and
+ * `refreshQmdSessionArtifactDocIds()`'s join on (collection, path) can never
+ * backfill a docid for it -- every archived-session hit then fails identity
+ * resolution and is dropped rather than visibility-checked. See
+ * `restoreQmdNormalizedArchiveName` in `session-transcript-hit.ts`, which
+ * already reverses this exact transform on the read side; this is the
+ * missing write-side counterpart. Only the stored mapping value is
+ * normalized here -- the on-disk exported filename is untouched.
+ */
+function normalizeQmdIndexedArtifactPath(name: string): string {
+  const ext = path.extname(name);
+  const stem = ext ? name.slice(0, -ext.length) : name;
+  const normalizedStem = stem.replace(/[.:]/g, "-");
+  return normalizedStem === stem ? name : `${normalizedStem}${ext}`;
+}
+
 export class QmdSessionExporter {
   private readonly exportedSessionState = new Map<string, ExportedSessionState>();
 
@@ -242,10 +264,11 @@ export class QmdSessionExporter {
     if (!identity?.agentId) {
       return null;
     }
+    const indexedArtifactPath = normalizeQmdIndexedArtifactPath(artifactPath);
     return {
       agentId: identity.agentId,
       archived: isSessionArchiveArtifactName(path.basename(sessionFile)),
-      artifactPath,
+      artifactPath: indexedArtifactPath,
       collection: this.config.collectionName,
       memoryKey: formatSessionTranscriptMemoryHitKey({
         agentId: identity.agentId,
@@ -253,7 +276,7 @@ export class QmdSessionExporter {
       }),
       searchPath: this.buildSearchPath(
         this.config.collectionName,
-        artifactPath,
+        indexedArtifactPath,
         path.relative(this.workspaceDir, target),
         target,
       ),

--- a/packages/memory-host-sdk/src/host/types.ts
+++ b/packages/memory-host-sdk/src/host/types.ts
@@ -73,10 +73,52 @@ export type MemorySearchRuntimeQmdCollectionValidationDebug = {
   sources?: MemorySource[];
 };
 
+/**
+ * How a multi-collection mcporter search actually reached the QMD server.
+ * "unified" is the v2 happy path (one `mcporter call` process for every
+ * collection via its `collections` array). "per-collection" is the v1
+ * fallback or an explicit tool override (one process per collection,
+ * unchanged from pre-unification behavior). "degraded" means the unified
+ * attempt failed for a non-tool-version reason and results were salvaged by
+ * retrying collections in isolation; `failedCollections`/`succeededCollections`
+ * name which ones.
+ */
+/** @public */ export type MemorySearchRuntimeQmdMcporterCallPlanDebug = {
+  mode: "unified" | "per-collection" | "degraded";
+  collectionCount: number;
+  processCount: number;
+  failedCollections?: string[];
+  succeededCollections?: string[];
+};
+
+/**
+ * Per-phase wall-clock timings inside a single QMD manager search() call.
+ * managerAcquisitionMs is reported separately (MemorySearchRuntimeDebug's
+ * sibling `managerMs`, computed at manager-context-resolution time, before a
+ * manager instance exists to attach this object to).
+ */
+/** @public */ export type MemorySearchRuntimeQmdPhaseTimingsDebug = {
+  dirtySyncWaitMs?: number;
+  pendingUpdateWaitMs?: number;
+  collectionQueryMs?: number;
+  resultResolutionMs?: number;
+};
+
 /** @public */ export type MemorySearchRuntimeQmdDebug = {
   collectionValidation?: MemorySearchRuntimeQmdCollectionValidationDebug;
   multiCollectionProbe?: MemorySearchRuntimeQmdMultiCollectionProbeDebug;
   searchPlan?: MemorySearchRuntimeQmdSearchPlanDebug;
+  mcporterCallPlan?: MemorySearchRuntimeQmdMcporterCallPlanDebug;
+  phaseTimings?: MemorySearchRuntimeQmdPhaseTimingsDebug;
+  /**
+   * Hits returned by QMD whose docid could not be resolved back to a document
+   * on disk (resolveDocLocation returned null) and were silently dropped
+   * before session-visibility filtering or source attribution. One of the two
+   * candidate loss points for the "direct QMD returns session hits that
+   * corpus=sessions doesn't" diagnosis in the recall-latency scope; the other
+   * is downstream in filterMemorySearchHitsBySessionVisibility.
+   */
+  hitsDroppedAtDocResolution?: number;
 };
 
 export type MemorySearchRuntimeDebug = {


### PR DESCRIPTION
## What Problem This Solves

Memory recall had two core failures in the QMD/session retrieval path:

- `memory_search(corpus=all)` fanned out through one `mcporter call` subprocess per collection even though QMD v2 accepts one unified query with a `collections` array. That inflated warm latency before the separate Codex bridge overhead was even considered.
- Direct QMD returned relevant archived-session hits, but OpenClaw later dropped them before visibility filtering. The live-index diagnosis showed the artifact mapping table stored raw archived stems with `.` and `:`, while QMD records normalized document paths with those characters converted to `-`; the join could not backfill docids for archived sessions.

This PR fixes only Deliverables A/B of the approved memory-recall core scope: phase timings, deterministic tests, proven archived-session identity repair, and unified QMD v2 multi-collection calls. It does not change visibility predicates, bridge transport, wiki hot-path behavior, or recall enforcement.

## Summary

- `QmdCommandClient.searchAcrossCollections` now issues exactly one `mcporter call` process for a multi-collection v2 `query` request.
- Existing QMD v1 behavior and explicit tool overrides remain per-collection.
- If the unified v2 call fails for a non-version reason, search falls back once to per-collection degraded mode and reports succeeded/failed collections in `callPlan`.
- `QmdMemoryManager.search()` reports additive phase timings and a `hitsDroppedAtDocResolution` counter through existing debug plumbing.
- Archived-session artifact mapping now stores the same normalized path shape QMD records in `documents`, while leaving on-disk exported artifact filenames unchanged.

## Evidence

- Focused memory-core regression: `node scripts/run-vitest.mjs run extensions/memory-core/src/memory/qmd-command-client.test.ts extensions/memory-core/src/memory/qmd-session-exporter.test.ts extensions/memory-core/src/memory/qmd-manager.test.ts` => 3 files / 171 tests passed.
- Test typecheck: `pnpm check:test-types` => passed after fixing strict undefined guards in the new tests.
- Lint: `node scripts/run-oxlint-shards.mjs --threads=8` => passed.
- Deadcode export scan: `pnpm deadcode:exports` => passed with 0 entries.
- Earlier full memory-core suite from the implementation worker: 69 files / 1005 tests passed.
- CI failures from the first push were investigated and fixed where related: unused public exports, array-sort lint, unsafe optional chaining, and strict test types. The remaining compact ACP shard timeout was in unrelated `src/cli/acp-cli-exit.process.test.ts`; this branch does not touch ACP code.