### PR TITLE
fix(update): keep repair JSON output parseable

### DIFF
--- a/packages/terminal-core/src/note.test.ts
+++ b/packages/terminal-core/src/note.test.ts
@@ -1,0 +1,26 @@
+// Terminal note output tests cover scoped stream routing for embedded CLI flows.
+import process from "node:process";
+import { describe, expect, it, vi } from "vitest";
+import { note, withNoteOutput } from "./note.js";
+
+describe("withNoteOutput", () => {
+  it("keeps note rendering on the scoped output across async work", async () => {
+    const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      await withNoteOutput(process.stderr, async () => {
+        await Promise.resolve();
+        note("Repaired deterministic test fixture.", "Doctor changes");
+      });
+
+      expect(stdoutWrite).not.toHaveBeenCalled();
+      expect(stderrWrite).toHaveBeenCalled();
+      expect(stderrWrite.mock.calls.map(([value]) => String(value)).join("\n")).toContain(
+        "Repaired deterministic test fixture.",
+      );
+    } finally {
+      stdoutWrite.mockRestore();
+      stderrWrite.mockRestore();
+    }
+  });
+});

--- a/packages/terminal-core/src/note.ts
+++ b/packages/terminal-core/src/note.ts
@@ -10,6 +10,7 @@ const URL_PREFIX_RE = /^(https?:\/\/|file:\/\/)/i;
 const WINDOWS_DRIVE_RE = /^[a-zA-Z]:[\\/]/;
 const FILE_LIKE_RE = /^[a-zA-Z0-9._-]+$/;
 const suppressNotesStorage = new AsyncLocalStorage<boolean>();
+const noteOutputStorage = new AsyncLocalStorage<NodeJS.WriteStream>();
 
 function isSuppressedByEnv(value: string | undefined): boolean {
   if (!value) {
@@ -206,17 +207,17 @@ export function resolveNoteOutputColumns(message: string, columns: number): numb
   return Math.max(columns, widestLine + 6);
 }
 
-function createNoteOutput(columns: number): NodeJS.WriteStream {
-  if (process.stdout.columns === columns) {
-    return process.stdout;
+function createNoteOutput(output: NodeJS.WriteStream, columns: number): NodeJS.WriteStream {
+  if (output.columns === columns) {
+    return output;
   }
-  const output = Object.create(process.stdout) as NodeJS.WriteStream;
-  Object.defineProperty(output, "columns", {
+  const columnAwareOutput = Object.create(output) as NodeJS.WriteStream;
+  Object.defineProperty(columnAwareOutput, "columns", {
     value: columns,
     configurable: true,
   });
-  output.write = process.stdout.write.bind(process.stdout);
-  return output;
+  columnAwareOutput.write = output.write.bind(output);
+  return columnAwareOutput;
 }
 
 export function note(message: unknown, title?: string) {
@@ -226,11 +227,16 @@ export function note(message: unknown, title?: string) {
   ) {
     return;
   }
-  const columns = resolveNoteColumns(process.stdout.columns);
+  const output = noteOutputStorage.getStore() ?? process.stdout;
+  const columns = resolveNoteColumns(output.columns);
   const wrappedMessage = wrapNoteMessage(message, { columns });
   clackNote(wrappedMessage, stylePromptTitle(title), {
-    output: createNoteOutput(resolveNoteOutputColumns(wrappedMessage, columns)),
+    output: createNoteOutput(output, resolveNoteOutputColumns(wrappedMessage, columns)),
   });
+}
+
+export function withNoteOutput<T>(output: NodeJS.WriteStream, callback: () => T): T {
+  return noteOutputStorage.run(output, callback);
 }
 
 export function withSuppressedNotes<T>(callback: () => T): T {

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -86,7 +86,12 @@ const execFile = vi.fn((...args: unknown[]) => {
   return new EventEmitter();
 });
 const spawn = vi.fn();
-const { defaultRuntime: runtimeCapture, resetRuntimeCapture } = createCliRuntimeCapture();
+const {
+  defaultRuntime: runtimeCapture,
+  resetRuntimeCapture,
+  runtimeErrors,
+  runtimeLogs,
+} = createCliRuntimeCapture();
 const serviceEnvSnapshot = captureEnv([
   "OPENCLAW_SERVICE_MARKER",
   "OPENCLAW_SERVICE_KIND",
@@ -2846,6 +2851,58 @@ describe("update-cli", () => {
     expect(syncPluginCall()?.acknowledgeClawHubRisk).toBe(true);
     expect(npmPluginUpdateCall()?.acknowledgeClawHubRisk).toBe(true);
   });
+
+  it.each([
+    {
+      name: "thrown finalization failure",
+      args: [] as string[],
+      prepare: () => {
+        vi.mocked(doctorCommand).mockRejectedValueOnce(new Error("finalization fixture failed"));
+      },
+      expectedError: "finalization fixture failed",
+    },
+    {
+      name: "invalid channel",
+      args: ["--channel", "invalid"],
+      prepare: () => {},
+      expectedError: '--channel must be "stable", "extended-stable", "beta", or "dev"',
+    },
+    {
+      name: "invalid timeout",
+      args: ["--timeout", "0"],
+      prepare: () => {},
+      expectedError: "--timeout must be a positive integer (seconds)",
+    },
+  ])(
+    "keeps update repair --json stdout parseable for $name",
+    async ({ args, prepare, expectedError }) => {
+      setStdoutTty(true);
+      const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+      const program = new Command();
+      program.name("openclaw");
+      program.exitOverride();
+      registerUpdateCli(program);
+      prepare();
+
+      try {
+        await program.parseAsync(["node", "openclaw", "update", "repair", "--json", ...args]);
+
+        expect(stdoutWrite).not.toHaveBeenCalled();
+        expect(runtimeLogs).toHaveLength(1);
+        const output = JSON.parse(runtimeLogs[0] ?? "null") as {
+          status?: string;
+          mode?: string;
+          error?: string;
+        };
+        expect(output).toMatchObject({ status: "error", mode: "finalize" });
+        expect(output.error).toContain(expectedError);
+        expect(defaultRuntime.exit).toHaveBeenCalledTimes(1);
+        expect(defaultRuntime.exit).toHaveBeenCalledWith(1, { resetStream: process.stderr });
+      } finally {
+        stdoutWrite.mockRestore();
+      }
+    },
+  );
 
   it.each([
     {
@@ -7787,11 +7844,15 @@ describe("update-cli", () => {
         expect(process.env.OPENCLAW_UPDATE_IN_PROGRESS).toBeUndefined();
         expect(process.env.OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR).toBeUndefined();
         expect(process.env.OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE).toBeUndefined();
-        expect(doctorCommand).toHaveBeenCalledWith(defaultRuntime, {
-          nonInteractive: true,
-          repair: true,
-          yes: true,
-        });
+        expect(doctorCommand).toHaveBeenCalledWith(
+          expect.objectContaining({ log: defaultRuntime.error }),
+          {
+            nonInteractive: true,
+            repair: true,
+            yes: true,
+            uiOutput: process.stderr,
+          },
+        );
         expect(syncPluginCall()?.channel).toBe("stable");
         expect(syncPluginCall()?.acknowledgeClawHubRisk).toBe(true);
         expect(lastNpmPluginUpdateCall()?.timeoutMs).toBe(9_000);
@@ -7818,7 +7879,83 @@ describe("update-cli", () => {
     );
   });
 
+  it("keeps doctor repair output off stdout during json finalization", async () => {
+    const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      vi.mocked(doctorCommand).mockImplementationOnce(async (runtime, options) => {
+        if (!runtime) {
+          throw new Error("expected update finalization to provide a Doctor runtime");
+        }
+        runtime.log("Repaired deterministic test fixture.");
+        const uiOutput = (options as { uiOutput?: NodeJS.WriteStream }).uiOutput ?? process.stdout;
+        uiOutput.write("Doctor UI fixture.\n");
+      });
+
+      await updateFinalizeCommand({ json: true, restart: false });
+
+      expect(stdoutWrite).not.toHaveBeenCalled();
+      expect(stderrWrite).toHaveBeenCalledWith("Doctor UI fixture.\n");
+      expect(runtimeLogs).toHaveLength(1);
+      expect(JSON.parse(runtimeLogs.join("\n"))).toEqual(lastWriteJsonCall());
+      expect(runtimeErrors).toContain("Repaired deterministic test fixture.");
+    } finally {
+      stdoutWrite.mockRestore();
+      stderrWrite.mockRestore();
+    }
+  });
+
+  it("routes Doctor terminal reset away from stdout during json finalization", async () => {
+    setStdoutTty(true);
+    vi.mocked(doctorCommand).mockImplementationOnce(async (runtime) => {
+      runtime?.exit(2);
+    });
+
+    await updateFinalizeCommand({ json: true, restart: false });
+
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(2, { resetStream: process.stderr });
+  });
+
+  it("routes terminal reset away from stdout when json finalization fails", async () => {
+    setStdoutTty(true);
+    runPostCorePluginConvergenceSpy.mockResolvedValueOnce({
+      changes: [],
+      warnings: [
+        {
+          pluginId: "demo",
+          reason: "plugin smoke failed",
+          message: "plugin smoke failed",
+          guidance: ["Run openclaw update repair."],
+        },
+      ],
+      errored: true,
+      smokeFailures: [],
+      installRecords: {},
+    });
+
+    await updateFinalizeCommand({ json: true, restart: false });
+
+    expect(lastWriteJsonCall()).toMatchObject({ status: "error" });
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1, { resetStream: process.stderr });
+  });
+
+  it("preserves the default Doctor runtime and UI output during human finalization", async () => {
+    vi.mocked(doctorCommand).mockImplementationOnce(async (runtime) => {
+      runtime?.log("Repaired deterministic test fixture.");
+    });
+
+    await updateFinalizeCommand({ restart: false });
+
+    expect(doctorCommand).toHaveBeenCalledWith(defaultRuntime, {
+      nonInteractive: true,
+      repair: true,
+      yes: false,
+    });
+    expect(runtimeLogs).toContain("Repaired deterministic test fixture.");
+  });
+
   it("updateFinalizeCommand rejects extended-stable on Git before persistence", async () => {
+    setStdoutTty(true);
     await updateFinalizeCommand({
       channel: "extended-stable",
       json: true,
@@ -7833,7 +7970,7 @@ describe("update-cli", () => {
       mode: "git",
       reason: "unsupported_git_channel",
     });
-    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1, { resetStream: process.stderr });
   });
 
   it("updateFinalizeCommand repairs doctor by default and refreshes plugin state after doctor", async () => {
@@ -7887,11 +8024,15 @@ describe("update-cli", () => {
 
     await updateFinalizeCommand({ json: true, timeout: "9", restart: false });
 
-    expect(doctorCommand).toHaveBeenCalledWith(defaultRuntime, {
-      nonInteractive: true,
-      repair: true,
-      yes: false,
-    });
+    expect(doctorCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ log: defaultRuntime.error }),
+      {
+        nonInteractive: true,
+        repair: true,
+        yes: false,
+        uiOutput: process.stderr,
+      },
+    );
     expect(syncPluginCall()?.channel).toBe("beta");
     expect(syncPluginCall()?.config).toEqual({
       ...postDoctorConfig,

--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -89,9 +89,10 @@ function registerUpdateFinalizationCommand(update: Command, name: string, hidden
         )} ${formatDocsLink("/cli/update", "docs.openclaw.ai/cli/update")}`,
     )
     .action(async (opts, actionCommand) => {
+      const json = Boolean(opts.json) || inheritedUpdateJson(actionCommand);
       try {
         await updateFinalizeCommand({
-          json: Boolean(opts.json) || inheritedUpdateJson(actionCommand),
+          json,
           channel: opts.channel as string | undefined,
           timeout: inheritedUpdateTimeout(opts, actionCommand),
           yes: Boolean(opts.yes),
@@ -100,8 +101,14 @@ function registerUpdateFinalizationCommand(update: Command, name: string, hidden
             normalizeCommanderClawHubRiskOption(opts) || inheritedUpdateClawHubRisk(actionCommand),
         });
       } catch (err) {
-        defaultRuntime.error(String(err));
-        defaultRuntime.exit(1);
+        const message = String(err);
+        defaultRuntime.error(message);
+        if (json) {
+          defaultRuntime.writeJson({ status: "error", mode: "finalize", error: message });
+          defaultRuntime.exit(1, { resetStream: process.stderr });
+        } else {
+          defaultRuntime.exit(1);
+        }
       }
     });
 }

--- a/src/cli/update-cli/shared.ts
+++ b/src/cli/update-cli/shared.ts
@@ -60,13 +60,20 @@ const INVALID_TIMEOUT_ERROR = "--timeout must be a positive integer (seconds)";
 const MAX_SAFE_TIMEOUT_SECONDS = Math.floor(Number.MAX_SAFE_INTEGER / 1000);
 
 /** Parse a CLI timeout in seconds, exiting through the runtime on invalid input. */
-export function parseTimeoutMsOrExit(timeout?: string): number | undefined | null {
+export function parseTimeoutMsOrExit(
+  timeout?: string,
+  options: { onInvalid?: (message: string) => void } = {},
+): number | undefined | null {
   if (timeout === undefined) {
     return undefined;
   }
   const trimmed = timeout.trim();
   const seconds = parseStrictPositiveInteger(trimmed);
   if (seconds === undefined || seconds > MAX_SAFE_TIMEOUT_SECONDS) {
+    if (options.onInvalid) {
+      options.onInvalid(INVALID_TIMEOUT_ERROR);
+      return null;
+    }
     defaultRuntime.error(INVALID_TIMEOUT_ERROR);
     defaultRuntime.exit(1);
     return null;

--- a/src/cli/update-cli/update-command-post-core.ts
+++ b/src/cli/update-cli/update-command-post-core.ts
@@ -110,7 +110,11 @@ export async function reportPreMutationUpdateFailure(params: {
     jsonMode: Boolean(params.opts.json),
   });
   printResult(result, params.opts);
-  defaultRuntime.exit(1);
+  if (params.opts.json) {
+    defaultRuntime.exit(1, { resetStream: process.stderr });
+  } else {
+    defaultRuntime.exit(1);
+  }
 }
 
 type UpdateFinalizeResult = {
@@ -159,7 +163,16 @@ function withUpdateFinalizationEnv<T>(run: () => Promise<T>): Promise<T> {
 
 export async function updateFinalizeCommand(opts: UpdateFinalizeOptions): Promise<void> {
   suppressDeprecations();
-  const timeoutMs = parseTimeoutMsOrExit(opts.timeout);
+  const timeoutMs = parseTimeoutMsOrExit(
+    opts.timeout,
+    opts.json
+      ? {
+          onInvalid: (message: string) => {
+            throw new Error(message);
+          },
+        }
+      : undefined,
+  );
   if (timeoutMs === null) {
     return;
   }
@@ -182,9 +195,11 @@ export async function updateFinalizeCommand(opts: UpdateFinalizeOptions): Promis
       : undefined);
   const requestedChannel = normalizeUpdateChannel(opts.channel);
   if (opts.channel && !requestedChannel) {
-    defaultRuntime.error(
-      `--channel must be "stable", "extended-stable", "beta", or "dev" (got "${opts.channel}")`,
-    );
+    const message = `--channel must be "stable", "extended-stable", "beta", or "dev" (got "${opts.channel}")`;
+    if (opts.json) {
+      throw new Error(message);
+    }
+    defaultRuntime.error(message);
     defaultRuntime.exit(1);
     return;
   }
@@ -226,10 +241,18 @@ export async function updateFinalizeCommand(opts: UpdateFinalizeOptions): Promis
 
   const pluginUpdate = await withUpdateFinalizationEnv(async () => {
     await createUpdateConfigSnapshot();
-    await doctorCommand(defaultRuntime, {
+    const doctorRuntime = opts.json
+      ? {
+          ...defaultRuntime,
+          log: defaultRuntime.error,
+          exit: (code: number) => defaultRuntime.exit(code, { resetStream: process.stderr }),
+        }
+      : defaultRuntime;
+    await doctorCommand(doctorRuntime, {
       nonInteractive: true,
       repair: true,
       yes: opts.yes === true,
+      ...(opts.json ? { uiOutput: process.stderr } : {}),
     });
     configSnapshot = await readConfigFileSnapshot({ skipPluginValidation: true });
     if (requestedChannel) {
@@ -299,7 +322,11 @@ export async function updateFinalizeCommand(opts: UpdateFinalizeOptions): Promis
     defaultRuntime.log(theme.muted("Update finalization completed."));
   }
   if (result.status === "error") {
-    defaultRuntime.exit(1);
+    if (opts.json) {
+      defaultRuntime.exit(1, { resetStream: process.stderr });
+    } else {
+      defaultRuntime.exit(1);
+    }
   }
 }
 

--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -182,6 +182,7 @@ async function runNonInteractiveRepair(params: {
   cfg?: OpenClawConfig;
   updateInProgress?: boolean;
   lastTouchedVersionOverride?: string;
+  uiOutput?: NodeJS.WriteStream;
 }) {
   Object.defineProperty(process.stdin, "isTTY", {
     value: false,
@@ -203,9 +204,12 @@ async function runNonInteractiveRepair(params: {
         nonInteractive: true,
       },
     }),
-    params.lastTouchedVersionOverride
-      ? { lastTouchedVersionOverride: params.lastTouchedVersionOverride }
-      : {},
+    {
+      ...(params.lastTouchedVersionOverride
+        ? { lastTouchedVersionOverride: params.lastTouchedVersionOverride }
+        : {}),
+      ...(params.uiOutput ? { uiOutput: params.uiOutput } : {}),
+    } as Parameters<typeof maybeRepairGatewayServiceConfig>[4],
   );
 }
 
@@ -894,6 +898,7 @@ describe("maybeRepairGatewayServiceConfig", () => {
     await runNonInteractiveRepair({
       cfg: { gateway: {} },
       updateInProgress: true,
+      uiOutput: process.stderr,
     });
 
     expectNoteContaining(
@@ -902,6 +907,7 @@ describe("maybeRepairGatewayServiceConfig", () => {
     );
     expectNoNoteContaining("left the live systemd unit unchanged", "Gateway service config");
     expect(mocks.stage).toHaveBeenCalledTimes(1);
+    expectCallField(mocks.stage, "stdout", process.stderr);
     expect(mocks.install).not.toHaveBeenCalled();
   });
 
@@ -1251,6 +1257,7 @@ describe("maybeRepairGatewayServiceConfig", () => {
         await runNonInteractiveRepair({
           updateInProgress: true,
           lastTouchedVersionOverride: "2026.5.14",
+          uiOutput: process.stderr,
         });
 
         expect(mocks.readRuntime.mock.invocationCallOrder[0]).toBeLessThan(
@@ -1272,6 +1279,7 @@ describe("maybeRepairGatewayServiceConfig", () => {
         expectCallConfigGatewayAuthToken(mocks.buildGatewayInstallPlan, "stale-token");
         expect(mocks.stage).not.toHaveBeenCalled();
         expect(mocks.install).toHaveBeenCalledTimes(1);
+        expectCallField(mocks.install, "stdout", process.stderr);
         expect(mocks.install).toHaveBeenCalledWith(
           expect.objectContaining({
             startupFallbackTakeoverRuntime: { status: "running", pid: 4242 },
@@ -1296,11 +1304,13 @@ describe("maybeRepairGatewayServiceConfig", () => {
     mocks.readRuntime.mockResolvedValue({ status: "running" });
     mocks.readWindowsStartupFallbackRuntimeForUpdate.mockResolvedValue(null);
 
-    await runNonInteractiveRepair({ updateInProgress: true });
+    await runNonInteractiveRepair({ updateInProgress: true, uiOutput: process.stderr });
 
     expect(mocks.install).toHaveBeenCalledWith(
       expect.objectContaining({ startupFallbackTakeoverRuntime: undefined }),
     );
+    expectCallField(mocks.install, "stdout", process.stderr);
+    expectCallField(mocks.restart, "stdout", process.stderr);
   });
 
   it("leaves embedded service tokens untouched during legacy Windows update handoffs", async () => {

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -64,6 +64,7 @@ type GatewayServiceConfigRepairOptions = {
   lastTouchedVersionOverride?: string;
   preservedLegacyRootKeys?: readonly string[];
   skipPluginValidation?: boolean;
+  uiOutput?: NodeJS.WriteStream;
 };
 
 function shouldSkipLegacyUpdateRepairConfigWrite(env: NodeJS.ProcessEnv): boolean {
@@ -824,10 +825,11 @@ export async function maybeRepairGatewayServiceConfig(
   // gateway and parent authorization so `update --no-restart` stays non-disruptive.
   const repairService =
     updateRepairMode && !updateRepairShouldInstall ? service.stage : service.install;
+  const serviceOutput = options.uiOutput ?? process.stdout;
   try {
     await repairService({
       env: serviceRepairEnv,
-      stdout: process.stdout,
+      stdout: serviceOutput,
       warn: (message) => note(message, "Gateway"),
       programArguments: updatedPlan.programArguments,
       workingDirectory: updatedPlan.workingDirectory,
@@ -850,7 +852,7 @@ export async function maybeRepairGatewayServiceConfig(
       }
       await service.restart({
         env: restartEnv,
-        stdout: process.stdout,
+        stdout: serviceOutput,
       });
       note("Restarted the repaired gateway for a legacy update parent.", "Gateway");
     }

--- a/src/commands/doctor.types.ts
+++ b/src/commands/doctor.types.ts
@@ -16,4 +16,6 @@ export type DoctorOptions = {
   sessionSqliteAllAgents?: boolean;
   sessionSqliteGithubIssue?: boolean;
   json?: boolean;
+  /** Internal stream override for Doctor UI embedded in another machine-readable command. */
+  uiOutput?: NodeJS.WriteStream;
 };

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -746,6 +746,7 @@ async function runGatewayServicesHealth(ctx: DoctorHealthFlowContext): Promise<v
       skipPluginValidation:
         ctx.configResult.skipPluginValidationOnWrite === true || updateDoctorRun,
       preservedLegacyRootKeys: ctx.configResult.preservedLegacyRootKeys,
+      uiOutput: ctx.options.uiOutput,
       ...resolveLegacyParentVersionOverride(ctx),
     },
   );

--- a/src/flows/doctor-health.output.test.ts
+++ b/src/flows/doctor-health.output.test.ts
@@ -1,0 +1,57 @@
+// Doctor embedded-output tests cover real Clack composition.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../runtime.js";
+
+const mocks = vi.hoisted(() => ({
+  maybeOfferUpdateBeforeDoctor: vi.fn().mockResolvedValue({ handled: true }),
+}));
+
+vi.mock("../config/config.js", () => ({
+  assertConfigWriteAllowedInCurrentMode: vi.fn(),
+}));
+
+vi.mock("../commands/doctor-prompter.js", () => ({
+  createDoctorPrompter: () => ({ confirm: vi.fn() }),
+}));
+
+vi.mock("../infra/openclaw-root.js", () => ({
+  resolveOpenClawPackageRoot: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("../commands/doctor-update.js", () => ({
+  maybeOfferUpdateBeforeDoctor: mocks.maybeOfferUpdateBeforeDoctor,
+}));
+
+const { doctorCommand } = await import("./doctor-health.js");
+
+const stdoutIsTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (stdoutIsTtyDescriptor) {
+    Object.defineProperty(process.stdout, "isTTY", stdoutIsTtyDescriptor);
+  } else {
+    delete (process.stdout as Partial<typeof process.stdout>).isTTY;
+  }
+});
+
+describe("doctorCommand embedded output", () => {
+  it("keeps real Doctor UI off rich-TTY stdout when uiOutput is stderr", async () => {
+    Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: true });
+    const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const runtime = {
+      log: (message: unknown) => process.stderr.write(`${String(message)}\n`),
+      error: vi.fn(),
+      exit: vi.fn(),
+    } as unknown as RuntimeEnv;
+
+    await doctorCommand(runtime, {
+      nonInteractive: true,
+      uiOutput: process.stderr,
+    });
+
+    expect(stdoutWrite).not.toHaveBeenCalled();
+    expect(stderrWrite).toHaveBeenCalled();
+  });
+});

--- a/src/flows/doctor-health.ts
+++ b/src/flows/doctor-health.ts
@@ -7,13 +7,24 @@ import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import type { DoctorHealthFlowContext } from "./doctor-health-contributions.js";
 
 // Interactive doctor entrypoint; lazy imports keep normal CLI startup light.
-const intro = (message: string) => clackIntro(stylePromptTitle(message) ?? message);
-const outro = (message: string) => clackOutro(stylePromptTitle(message) ?? message);
+const intro = (message: string, output?: NodeJS.WriteStream) =>
+  clackIntro(stylePromptTitle(message) ?? message, output ? { output } : undefined);
+const outro = (message: string, output?: NodeJS.WriteStream) =>
+  clackOutro(stylePromptTitle(message) ?? message, output ? { output } : undefined);
 
 const loadConfigModule = createLazyRuntimeModule(() => import("../config/config.js"));
 
 /** Runs the full interactive doctor flow against the provided or default runtime. */
 export async function doctorCommand(runtime?: RuntimeEnv, options: DoctorOptions = {}) {
+  const run = async () => await runDoctorCommand(runtime, options);
+  if (!options.uiOutput) {
+    return await run();
+  }
+  const { withNoteOutput } = await import("../../packages/terminal-core/src/note.js");
+  return await withNoteOutput(options.uiOutput, run);
+}
+
+async function runDoctorCommand(runtime?: RuntimeEnv, options: DoctorOptions = {}) {
   const effectiveRuntime = runtime ?? (await import("../runtime.js")).defaultRuntime;
   if (options.repair === true || options.yes === true || options.generateGatewayToken === true) {
     const { assertConfigWriteAllowedInCurrentMode } = await loadConfigModule();
@@ -22,7 +33,7 @@ export async function doctorCommand(runtime?: RuntimeEnv, options: DoctorOptions
 
   const { createDoctorPrompter } = await import("../commands/doctor-prompter.js");
   const prompter = createDoctorPrompter({ runtime: effectiveRuntime, options });
-  intro("OpenClaw doctor");
+  intro("OpenClaw doctor", options.uiOutput);
 
   const { resolveOpenClawPackageRoot } = await import("../infra/openclaw-root.js");
   const root = await resolveOpenClawPackageRoot({
@@ -37,7 +48,7 @@ export async function doctorCommand(runtime?: RuntimeEnv, options: DoctorOptions
     options,
     root,
     confirm: (p) => prompter.confirm(p),
-    outro,
+    outro: (message) => outro(message, options.uiOutput),
   });
   if (updateResult.handled) {
     return;
@@ -91,5 +102,5 @@ export async function doctorCommand(runtime?: RuntimeEnv, options: DoctorOptions
     }
   }
 
-  outro("Doctor complete.");
+  outro("Doctor complete.", options.uiOutput);
 }


### PR DESCRIPTION
## What Problem This Solves

`openclaw update repair --json` could emit Doctor, Clack, gateway-service, or terminal-reset bytes on stdout. Several reachable error paths also exited without emitting a JSON result. Automation parsing the complete stdout stream could therefore receive invalid or empty JSON.

## Why This Change Was Made

JSON update finalization now owns the output contract at the public command boundary. Thrown finalization errors, invalid channels, invalid timeouts, pre-mutation failures, and final convergence failures emit one structured JSON result and route terminal restoration to stderr.

The embedded Doctor run receives a stderr-backed runtime and UI stream. Doctor scopes terminal notes to that stream across async work and forwards it through gateway-service stage, install, and restart operations. Human and non-JSON Doctor callers retain their existing runtime and stdout defaults.

The routing stays at the update finalizer, Doctor UI/note, and gateway-service lifecycle boundaries instead of intercepting process-global stdout.

## User Impact

Automation can parse the complete stdout from `openclaw update repair --json` as one JSON value on success and on reachable command errors. Human update-repair behavior, Doctor repair decisions, gateway service policy, and fallback semantics are unchanged.

## Evidence

Final exact candidate: `c6e26379d6a68403bbd98025be91284436549155`

Exact public-main parent: `fe9e018045d4b332896d7d8160d1753eedc21fcd`

Tree: `47102b914d97c5a8a04647969703652774449f85`

Stable patch ID: `1352e1154b508f192a03ade11b2cebb744818b52`

Validated with Node `24.15.0` and pnpm `11.2.2`:

- RED: the new public Commander-entrypoint matrix failed 3/3 before the command-boundary fix for thrown finalization, invalid channel, and invalid timeout
- GREEN: command-entry and update-finalization matrix 8/8
- GREEN: terminal-note, Doctor/Clack composition, gateway-service lifecycle, and shared command-runner matrix 55/55
- final focused total 63/63
- rich-TTY tests verify complete JSON parseability, one result, no terminal-reset bytes on stdout, and stderr reset routing
- targeted oxfmt passed on all 12 changed paths
- targeted update-CLI oxlint passed with 0 warnings and 0 errors
- max-lines ratchet, conflict-marker, changelog-attribution, secret, dangerous-construct, and diff checks passed
- final worktree clean

The exact semantic patch was replayed onto current public `main` with an unchanged stable patch ID and no changed-path overlap. Cad reran all focused and static gates on this final SHA.

Independent read-only review approved the exact final candidate with no patch-attributable blockers and judged it the best bounded fix.

The full build, full test suite, tsgo, and tsgolint were not run for this focused refresh; GitHub CI remains the broad verification gate.

AI-assisted: Meles prepared and exercised the candidate. Cad independently replayed it onto current `main`, reran the evidence gates, and verified the public lease before updating this PR.
