### PR TITLE
fix(sessions): manual compaction deletes transcript history while claiming it was archived

### DIFF
--- a/src/commands/sessions-compact.test.ts
+++ b/src/commands/sessions-compact.test.ts
@@ -160,6 +160,23 @@ describe("sessionsCompactCommand", () => {
     expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 
+  it("prints the archive path exactly as returned by the RPC", async () => {
+    const archived = "/state/agents/main/sessions/sess-1.jsonl.bak.2026-07-19T00-00-00.000Z.zst";
+    callGatewayCli.mockResolvedValue({
+      ok: true,
+      key: "agent:main:main",
+      compacted: true,
+      kept: 50,
+      archived,
+    });
+    const runtime = createRuntime();
+
+    await sessionsCompactCommand({ key: "agent:main:main", maxLines: 50 }, runtime);
+
+    expect(runtime.exit).not.toHaveBeenCalled();
+    expect(joinedArgs(runtime.log)).toContain(`Archived transcript: ${archived}`);
+  });
+
   it("forwards agentId and maxLines to the RPC params", async () => {
     callGatewayCli.mockResolvedValue({
       ok: true,

--- a/src/config/sessions/session-accessor.sqlite-archive.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.ts
@@ -76,6 +76,7 @@ function findMatchingSqliteTranscriptArchive(params: {
   return null;
 }
 
+/** Writes or reuses a transcript archive and returns its durable path. */
 export function writeSqliteTranscriptArchive(params: {
   archiveDirectory: string;
   content: string;

--- a/src/config/sessions/session-accessor.sqlite-archive.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.ts
@@ -6,7 +6,7 @@ import {
   readSessionArchiveContentSync,
   SESSION_ARCHIVE_ZSTD_SUFFIX,
 } from "./archive-compression.js";
-import { formatSessionArchiveTimestamp } from "./artifacts.js";
+import { formatSessionArchiveTimestamp, type SessionArchiveReason } from "./artifacts.js";
 import type { SessionLifecycleArchivedTranscript } from "./session-accessor.sqlite-contract.js";
 
 export type SqliteSessionStateDeletePlan = {
@@ -24,7 +24,7 @@ export type MaterializedSqliteSessionStateDeletePlan = SqliteSessionStateDeleteP
 
 function resolveSqliteTranscriptArchivePath(params: {
   archiveDirectory: string;
-  reason: "deleted" | "reset";
+  reason: SessionArchiveReason;
   sessionId: string;
   nowMs?: number;
 }): string {
@@ -42,7 +42,7 @@ function resolveSqliteTranscriptArchivePath(params: {
 function findMatchingSqliteTranscriptArchive(params: {
   archiveDirectory: string;
   content: string;
-  reason: "deleted" | "reset";
+  reason: SessionArchiveReason;
   sessionId: string;
 }): string | null {
   let entries: string[];
@@ -76,10 +76,10 @@ function findMatchingSqliteTranscriptArchive(params: {
   return null;
 }
 
-function writeSqliteTranscriptArchive(params: {
+export function writeSqliteTranscriptArchive(params: {
   archiveDirectory: string;
   content: string;
-  reason: "deleted" | "reset";
+  reason: SessionArchiveReason;
   sessionId: string;
 }): string {
   fs.mkdirSync(params.archiveDirectory, { recursive: true });

--- a/src/config/sessions/session-accessor.sqlite-transcript-write.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-write.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import fs from "node:fs";
 import { resolveTimestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
 import {
   openOpenClawAgentDatabase,
@@ -163,15 +162,12 @@ export async function trimSqliteTranscriptForManualCompact(
       reason: "bak",
       sessionId: resolved.sessionId,
     });
-    try {
-      runOpenClawAgentWriteTransaction((writeDatabase) => {
-        assertSqliteTranscriptSnapshotUnchanged(writeDatabase, resolved.sessionId, snapshot.rows);
-        replaceSqliteTranscriptEventsInTransaction(writeDatabase, resolved, retainedEvents);
-      }, toDatabaseOptions(resolved));
-    } catch (error) {
-      fs.rmSync(archivedPath, { force: true });
-      throw error;
-    }
+    // Published archives can be reused by another process before this commit.
+    // Retain them on failure so a sibling operation never loses its durable proof.
+    runOpenClawAgentWriteTransaction((writeDatabase) => {
+      assertSqliteTranscriptSnapshotUnchanged(writeDatabase, resolved.sessionId, snapshot.rows);
+      replaceSqliteTranscriptEventsInTransaction(writeDatabase, resolved, retainedEvents);
+    }, toDatabaseOptions(resolved));
     return { archivedPath, kept: retainedLines.length, trimmed: true };
   });
 }

--- a/src/config/sessions/session-accessor.sqlite-transcript-write.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-write.ts
@@ -1,10 +1,12 @@
 import { randomUUID } from "node:crypto";
+import fs from "node:fs";
 import { resolveTimestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
 import {
   openOpenClawAgentDatabase,
   runOpenClawAgentWriteTransaction,
   type OpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
+import { writeSqliteTranscriptArchive } from "./session-accessor.sqlite-archive.js";
 import type {
   SessionTranscriptAccessScope,
   SessionTranscriptTurnMessageAppend,
@@ -32,6 +34,7 @@ import {
   cloneSessionEntry,
   formatSqliteSessionMarkerForScope,
   resolveSqliteScope,
+  resolveSqliteTranscriptArchiveDirectory,
   resolveSqliteTranscriptScope,
   runExclusiveSqliteSessionWrite,
   toDatabaseOptions,
@@ -60,6 +63,7 @@ import {
   buildExpectedTranscriptTurnSessionPatch,
   sessionMatchesExpectedTranscriptTurn,
 } from "./session-transcript-turn-state.js";
+import { serializeJsonlLines } from "./transcript-jsonl.js";
 import type { SessionEntry } from "./types.js";
 import { mergeSessionEntry } from "./types.js";
 
@@ -137,6 +141,39 @@ export function replaceSqliteTranscriptEventsSync(
     replaced = true;
   }, toDatabaseOptions(resolved));
   return replaced;
+}
+
+export async function trimSqliteTranscriptForManualCompact(
+  scope: SessionTranscriptAccessScope,
+  selectRetainedLines: (lines: readonly string[]) => readonly string[] | null,
+): Promise<{ trimmed: false } | { archivedPath: string; kept: number; trimmed: true }> {
+  const resolved = resolveSqliteTranscriptScope(scope);
+  return await runExclusiveSqliteSessionWrite(resolved, async () => {
+    const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+    const snapshot = readSqliteTranscriptSnapshot(database, resolved.sessionId);
+    const lines = snapshot.rows.map((row) => row.eventJson);
+    const retainedLines = selectRetainedLines(lines);
+    if (!retainedLines) {
+      return { trimmed: false };
+    }
+    const retainedEvents = retainedLines.map((line) => JSON.parse(line) as TranscriptEvent);
+    const archivedPath = writeSqliteTranscriptArchive({
+      archiveDirectory: resolveSqliteTranscriptArchiveDirectory(resolved),
+      content: serializeJsonlLines(lines),
+      reason: "bak",
+      sessionId: resolved.sessionId,
+    });
+    try {
+      runOpenClawAgentWriteTransaction((writeDatabase) => {
+        assertSqliteTranscriptSnapshotUnchanged(writeDatabase, resolved.sessionId, snapshot.rows);
+        replaceSqliteTranscriptEventsInTransaction(writeDatabase, resolved, retainedEvents);
+      }, toDatabaseOptions(resolved));
+    } catch (error) {
+      fs.rmSync(archivedPath, { force: true });
+      throw error;
+    }
+    return { archivedPath, kept: retainedLines.length, trimmed: true };
+  });
 }
 
 /** Imports one legacy session entry and its transcript rows for doctor migration. */

--- a/src/config/sessions/session-accessor.sqlite.ts
+++ b/src/config/sessions/session-accessor.sqlite.ts
@@ -54,6 +54,7 @@ export {
   importSqliteSessionRows,
   replaceSqliteTranscriptEvents,
   replaceSqliteTranscriptEventsSync,
+  trimSqliteTranscriptForManualCompact,
   withSqliteTranscriptWriteLock,
   withSqliteTranscriptWriteTransaction,
 } from "./session-accessor.sqlite-transcript-write.js";

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -9,6 +9,7 @@ import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import { appendSqliteTrajectoryRuntimeEvents } from "../../trajectory/runtime-store.sqlite.js";
 import type { TrajectoryEvent } from "../../trajectory/types.js";
+import { readSessionArchiveContentSync } from "./archive-compression.js";
 import {
   applySessionEntryReplacements,
   appendTranscriptMessage,
@@ -47,10 +48,12 @@ import {
   upsertSessionEntry,
 } from "./session-accessor.js";
 import {
+  appendSqliteTranscriptEventSync,
   importSqliteSessionRows,
   loadExactSqliteSessionEntry,
   replaceSqliteSessionEntrySync,
   replaceSqliteTranscriptEvents,
+  trimSqliteTranscriptForManualCompact,
 } from "./session-accessor.sqlite.js";
 import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
 import { withOwnedSessionTranscriptWrites } from "./transcript-write-context.js";
@@ -2246,7 +2249,16 @@ describe("session accessor seam", () => {
     unsubscribe();
     expect(result).toMatchObject({ compacted: true, kept: 3 });
     const archived = result.compacted ? result.archived : "";
-    expect(archived).toContain(`sqlite:main:${sessionId}:`);
+    expect(path.basename(archived)).toMatch(
+      new RegExp(`^${sessionId}\\.jsonl\\.bak\\.\\d{4}-\\d{2}-\\d{2}T`),
+    );
+    expect(fs.realpathSync(path.dirname(archived))).toBe(fs.realpathSync(tempDir));
+    expect(fs.existsSync(archived)).toBe(true);
+    const archivedRecords = readSessionArchiveContentSync(archived)
+      .split("\n")
+      .filter((line) => line.length > 0)
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(archivedRecords).toEqual(transcriptRecords);
     const trimmedRecords = (await loadTranscriptEvents(scope)) as Array<Record<string, unknown>>;
     expect(trimmedRecords).toMatchObject([
       { type: "session", id: sessionId },
@@ -2265,6 +2277,82 @@ describe("session accessor seam", () => {
     expect(updatedEntry?.totalTokens).toBeUndefined();
     expect(updatedEntry?.totalTokensFresh).toBeUndefined();
     expect(updates).toEqual([]);
+  });
+
+  it("keeps every transcript row when the manual compact backup cannot be written", async () => {
+    const sessionId = "44444444-4444-4444-8444-444444444444";
+    const stateDir = path.join(tempDir, "state-root");
+    const scope = {
+      agentId: "main",
+      env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+      sessionId,
+      sessionKey: "agent:main:main",
+    };
+    const records = [
+      { type: "session", version: 3, id: sessionId, timestamp: "2026-06-19T12:00:00.000Z" },
+      ...[1, 2, 3, 4].map((index) => ({
+        type: "message",
+        id: `entry-${index}`,
+        parentId: index === 1 ? null : `entry-${index - 1}`,
+        timestamp: `2026-06-19T12:00:0${index}.000Z`,
+        message: { role: "user", content: `message ${index}`, timestamp: index },
+      })),
+    ];
+    await upsertSessionEntry(scope, { sessionId, updatedAt: 1 });
+    await replaceSqliteTranscriptEvents(
+      scope,
+      records as Parameters<typeof replaceSqliteTranscriptEvents>[1],
+    );
+    const archiveDirPath = path.join(stateDir, "agents", "main", "sessions");
+    fs.writeFileSync(archiveDirPath, "not a directory");
+
+    await expect(trimSessionTranscriptForManualCompact(scope, { maxLines: 3 })).rejects.toThrow();
+
+    expect((await loadTranscriptEvents(scope)).length).toBe(5);
+    expect(await loadTranscriptEvents(scope)).toEqual(records);
+  });
+
+  it("does not delete rows written after the manual compact backup snapshot", async () => {
+    const sessionId = "55555555-5555-4555-8555-555555555555";
+    const scope = {
+      agentId: "main",
+      sessionId,
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+    const records = [
+      { type: "session", version: 3, id: sessionId, timestamp: "2026-06-19T12:00:00.000Z" },
+      ...[1, 2, 3, 4].map((index) => ({
+        type: "message",
+        id: `entry-${index}`,
+        parentId: index === 1 ? null : `entry-${index - 1}`,
+        timestamp: `2026-06-19T12:00:0${index}.000Z`,
+        message: { role: "user", content: `message ${index}`, timestamp: index },
+      })),
+    ];
+    const lateEvent = {
+      type: "custom",
+      id: "late-append",
+      timestamp: "2026-06-19T12:00:09.000Z",
+    };
+    await upsertSessionEntry(scope, { sessionId, updatedAt: 1 });
+    await replaceSqliteTranscriptEvents(
+      scope,
+      records as Parameters<typeof replaceSqliteTranscriptEvents>[1],
+    );
+
+    await expect(
+      trimSqliteTranscriptForManualCompact(scope, (lines) => {
+        appendSqliteTranscriptEventSync(scope, lateEvent);
+        return lines.slice(0, 1);
+      }),
+    ).rejects.toThrow(`SQLite transcript changed while preparing rewrite for ${sessionId}`);
+
+    const remaining = (await loadTranscriptEvents(scope)) as Array<Record<string, unknown>>;
+    expect(remaining).toHaveLength(6);
+    expect(remaining.slice(0, 5)).toEqual(records);
+    expect(remaining[5]).toMatchObject({ id: "late-append" });
+    expect(fs.readdirSync(tempDir).filter((name) => name.includes(".bak."))).toEqual([]);
   });
 
   it("repairs a retained compaction boundary when its first kept entry was trimmed", async () => {

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -2312,7 +2312,7 @@ describe("session accessor seam", () => {
     expect(await loadTranscriptEvents(scope)).toEqual(records);
   });
 
-  it("does not delete rows written after the manual compact backup snapshot", async () => {
+  it("preserves the backup and rows written after the manual compact snapshot", async () => {
     const sessionId = "55555555-5555-4555-8555-555555555555";
     const scope = {
       agentId: "main",
@@ -2352,7 +2352,55 @@ describe("session accessor seam", () => {
     expect(remaining).toHaveLength(6);
     expect(remaining.slice(0, 5)).toEqual(records);
     expect(remaining[5]).toMatchObject({ id: "late-append" });
-    expect(fs.readdirSync(tempDir).filter((name) => name.includes(".bak."))).toEqual([]);
+    const archiveNames = fs.readdirSync(tempDir).filter((name) => name.includes(".bak."));
+    expect(archiveNames).toHaveLength(1);
+    expect(
+      readSessionArchiveContentSync(
+        path.join(tempDir, expectDefined(archiveNames[0], "manual compact archive name")),
+      ),
+    ).toBe(`${records.map((record) => JSON.stringify(record)).join("\n")}\n`);
+  });
+
+  it("preserves a reused manual compact backup when the rewrite conflicts", async () => {
+    const sessionId = "66666666-6666-4666-8666-666666666666";
+    const scope = {
+      agentId: "main",
+      sessionId,
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+    const records = [
+      { type: "session", version: 3, id: sessionId, timestamp: "2026-06-19T12:00:00.000Z" },
+      ...[1, 2, 3, 4].map((index) => ({
+        type: "message",
+        id: `entry-${index}`,
+        parentId: index === 1 ? null : `entry-${index - 1}`,
+        timestamp: `2026-06-19T12:00:0${index}.000Z`,
+        message: { role: "user", content: `message ${index}`, timestamp: index },
+      })),
+    ];
+    const existingArchive = path.join(tempDir, `${sessionId}.jsonl.bak.preexisting`);
+    const archiveContent = `${records.map((record) => JSON.stringify(record)).join("\n")}\n`;
+    await upsertSessionEntry(scope, { sessionId, updatedAt: 1 });
+    await replaceSqliteTranscriptEvents(
+      scope,
+      records as Parameters<typeof replaceSqliteTranscriptEvents>[1],
+    );
+    fs.writeFileSync(existingArchive, archiveContent);
+
+    await expect(
+      trimSqliteTranscriptForManualCompact(scope, (lines) => {
+        appendSqliteTranscriptEventSync(scope, {
+          type: "custom",
+          id: "late-append",
+          timestamp: "2026-06-19T12:00:09.000Z",
+        });
+        return lines.slice(0, 1);
+      }),
+    ).rejects.toThrow(`SQLite transcript changed while preparing rewrite for ${sessionId}`);
+
+    expect(fs.existsSync(existingArchive)).toBe(true);
+    expect(readSessionArchiveContentSync(existingArchive)).toBe(archiveContent);
   });
 
   it("repairs a retained compaction boundary when its first kept entry was trimmed", async () => {

--- a/src/config/sessions/session-accessor.transcript.ts
+++ b/src/config/sessions/session-accessor.transcript.ts
@@ -1,6 +1,4 @@
-import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
-import { formatSessionArchiveTimestamp } from "./artifacts.js";
 import { patchSessionEntry } from "./session-accessor.entry.js";
 import {
   appendSqliteTranscriptEvent,
@@ -19,6 +17,7 @@ import {
   replaceSqliteTranscriptEvents,
   replaceSqliteTranscriptEventsSync,
   resolveSqliteSessionKeyBySessionId,
+  trimSqliteTranscriptForManualCompact,
   withSqliteTranscriptWriteLock,
   withSqliteTranscriptWriteTransaction,
 } from "./session-accessor.sqlite.js";
@@ -41,7 +40,6 @@ import type {
   SessionTranscriptManualTrimResult,
   SessionTranscriptManualTrimPreflightResult,
 } from "./session-accessor.types.js";
-import { formatSqliteSessionFileMarker } from "./sqlite-marker.js";
 import {
   scanSessionTranscriptTree,
   selectSessionTranscriptTreePathNodes,
@@ -235,37 +233,32 @@ export async function trimSessionTranscriptForManualCompact(
   scope: SessionTranscriptRuntimeScope,
   params: { maxLines: number; nowMs?: number; sessionFile?: string },
 ): Promise<SessionTranscriptManualTrimResult> {
-  const events = await loadTranscriptEvents(scope).catch(() => []);
-  if (events.length === 0) {
-    return { compacted: false, reason: "no transcript" };
-  }
-
   const maxLines = Math.max(1, Math.floor(params.maxLines));
-  const headerLine = JSON.stringify(events[0]);
-  const tailLines = events.slice(1).map((event) => JSON.stringify(event));
   const maxTailLines = Math.max(0, maxLines - 1);
-  if (events.length <= maxLines) {
-    return { compacted: false, kept: events.length };
+  let declined: SessionTranscriptManualTrimResult = { compacted: false, reason: "no transcript" };
+  const trimmed = await trimSqliteTranscriptForManualCompact(scope, (lines) => {
+    if (lines.length === 0) {
+      declined = { compacted: false, reason: "no transcript" };
+      return null;
+    }
+    if (lines.length <= maxLines) {
+      declined = { compacted: false, kept: lines.length };
+      return null;
+    }
+    const tailLines = lines.slice(1);
+    const retainedLines = normalizeManualCompactTranscriptLines(
+      lines[0],
+      maxTailLines > 0 ? tailLines.slice(-maxTailLines) : [],
+    );
+    if (!retainedLines) {
+      declined = { compacted: false, kept: 0 };
+      return null;
+    }
+    return retainedLines;
+  });
+  if (!trimmed.trimmed) {
+    return declined;
   }
-
-  const lines = normalizeManualCompactTranscriptLines(
-    headerLine,
-    maxTailLines > 0 ? tailLines.slice(-maxTailLines) : [],
-  );
-  if (!lines) {
-    return { compacted: false, kept: 0 };
-  }
-  const retainedEvents = lines.map((line) => JSON.parse(line) as TranscriptEvent);
-  await replaceSqliteTranscriptEvents(scope, retainedEvents);
-  const agentId = scope.agentId ?? resolveAgentIdFromSessionKey(scope.sessionKey);
-  if (!agentId) {
-    throw new Error(`Cannot resolve manual compact transcript scope: ${scope.sessionKey}`);
-  }
-  const archived = `${formatSqliteSessionFileMarker({
-    agentId,
-    sessionId: scope.sessionId,
-    storePath: scope.storePath ?? "",
-  })}.bak.${formatSessionArchiveTimestamp()}`;
   await patchSessionEntry(
     {
       ...scope,
@@ -284,7 +277,7 @@ export async function trimSessionTranscriptForManualCompact(
     { replaceEntry: true },
   );
 
-  return { archived, compacted: true, kept: lines.length };
+  return { archived: trimmed.archivedPath, compacted: true, kept: trimmed.kept };
 }
 
 function parseManualCompactTranscriptRecord(line: string): Record<string, unknown> | null {

--- a/src/gateway/server.sessions.compaction.test.ts
+++ b/src/gateway/server.sessions.compaction.test.ts
@@ -6,6 +6,7 @@ import os from "node:os";
 import path from "node:path";
 import { expect, test, vi } from "vitest";
 import type { SessionCompactionCheckpoint } from "../config/sessions.js";
+import { readSessionArchiveContentSync } from "../config/sessions/archive-compression.js";
 import {
   appendTranscriptMessage,
   appendTranscriptEvent,
@@ -1536,7 +1537,7 @@ test("sessions.patch rejects archive while terminal compaction owns the session"
   ws.close();
 });
 
-test("sessions.compact maxLines trims SQLite transcript rows and returns an archive marker", async () => {
+test("sessions.compact maxLines trims SQLite transcript rows and archives the full pre-compaction transcript", async () => {
   const { dir, storePath } = await createSessionStoreDir();
   await seedSessionEntry({
     entry: sessionStoreEntry("sess-main"),
@@ -1549,6 +1550,12 @@ test("sessions.compact maxLines trims SQLite transcript rows and returns an arch
     storePath,
     totalLines: 500,
   });
+  const original = await loadTranscriptRows({
+    sessionId: "sess-main",
+    sessionKey: "agent:main:main",
+    storePath,
+  });
+  expect(original).toHaveLength(500);
 
   const { ws } = await openClient();
   const compacted = await rpcReq<{
@@ -1577,7 +1584,15 @@ test("sessions.compact maxLines trims SQLite transcript rows and returns an arch
   expect(retained.at(-1)).toMatchObject({
     message: { content: "line-498" },
   });
-  expect(compacted.payload?.archived).toContain(`sqlite:main:sess-main:${storePath}.bak.`);
+  const archived = compacted.payload?.archived ?? "";
+  expect(path.basename(archived)).toMatch(/^sess-main\.jsonl\.bak\.\d{4}-\d{2}-\d{2}T/);
+  expect(await fs.realpath(path.dirname(archived))).toBe(await fs.realpath(dir));
+  await expect(fs.stat(archived)).resolves.toMatchObject({ mode: expect.any(Number) });
+  const archivedEvents = readSessionArchiveContentSync(archived)
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+  expect(archivedEvents).toEqual(original);
   await expect(fs.readdir(dir)).resolves.not.toContain("sess-main.jsonl");
 
   // No active run present, so the interrupt guard short-circuits without aborting.


### PR DESCRIPTION
Related: #98236

## What Problem This Solves

Fixes an issue where users running `openclaw sessions compact <key> --max-lines N` would permanently lose the trimmed part of their conversation history while the CLI told them it had been archived. Since the SQLite storage flip (#98236, commit 0a8e3604ba2), the manual compaction path deletes the trimmed transcript rows without writing any backup, then returns an `archived` value that is a fabricated marker string (`sqlite:<agent>:<session>:<store>.bak.<timestamp>`) pointing at nothing. The CLI prints `Archived transcript: <marker>`, so users believe the full history is recoverable when it is gone. Before the flip, manual compaction renamed the live JSONL transcript to a real `.bak.<timestamp>` file before writing the trimmed replacement, so the full pre-compaction history was always recoverable.

## Why This Change Was Made

The fix restores the pre-flip safety contract at the SQLite transcript writer boundary: before any rows are deleted, the complete pre-compaction transcript is exported to a real, durable archive file, and `archived` now returns that file's actual path. The archive reuses the existing session archive writer that the reset/delete lifecycle flows already use (exclusive create, 0o600, fsync file and directory, atomic rename, optional zstd), with the artifact named `<sessionId>.jsonl.bak.<timestamp>[.zst]` in the same per-agent sessions archive directory. The `.bak` shape is already recognized by the archive artifact classifiers, so cleanup and disk-budget treat it exactly like reset/delete archives. The backup is written outside any SQLite transaction; the destructive replacement then revalidates the row snapshot inside the write transaction and aborts while retaining the durable backup if the transcript changed after the snapshot, so concurrently appended rows can never be deleted. If backup creation fails, compaction aborts with an error and every original row stays in place. Active-run and lifecycle fencing in the `sessions.compact` RPC is unchanged.

## User Impact

`openclaw sessions compact <key> --max-lines N` is safe again: the printed `Archived transcript:` path is a real file containing every pre-compaction transcript event in order, recoverable with the same tooling that reads reset/delete archives. If the backup cannot be written, compaction fails without deleting anything instead of silently destroying history.

## Evidence

Live before/after against a real gateway and the real CLI, identical inputs. For each phase: fresh isolated `OPENCLAW_STATE_DIR`, a session seeded with 7 transcript events (session header plus messages `important message 1..6`) through the production accessor, gateway started from the built dist (`node openclaw.mjs gateway --port <port>`), then `node openclaw.mjs sessions compact main --max-lines 3 --url ws://127.0.0.1:<port> --token ...`. Nothing was mocked.

Before, on pristine main 62c5a8b888:

```
$ openclaw sessions compact main --max-lines 3
Compacted session agent:main:main (kept 3 lines).
Archived transcript: sqlite:main:aaaaaaaa-...:<state>/agents/main/sessions/sessions.json.bak.2026-07-19T01-52-43.722Z

authoritative transcript rows now: 3
sessions dir unreadable: ENOENT
backup artifacts in agents/main/sessions: []
claimed archive path exists: false
```

Four transcript events were deleted, the printed "archive" is a marker string, the archive directory was never created, and no backup exists anywhere. The trimmed history is unrecoverable.

After, this patch:

```
$ openclaw sessions compact main --max-lines 3
Compacted session agent:main:main (kept 3 lines).
Archived transcript: <state>/agents/main/sessions/aaaaaaaa-...jsonl.bak.2026-07-19T02-00-59.389Z.zst

authoritative transcript rows now: 3
backup artifacts in agents/main/sessions: ["aaaaaaaa-...jsonl.bak.2026-07-19T02-00-59.389Z.zst"]
backup aaaaaaaa-...jsonl.bak.2026-07-19T02-00-59.389Z.zst: 7 events, first=session, contents include: 6 messages
claimed archive path exists: true
```

The printed path is a real file (mode 0600), and decompressing it yields all 7 pre-compaction events in order, including the 4 trimmed ones, parsed back through the shared archive reader.

Validation on the changed surface (all green locally):

- `node scripts/run-vitest.mjs src/config/sessions/session-accessor.test.ts src/commands/sessions-compact.test.ts` (72 + 10 passed)
- `node scripts/run-vitest.mjs src/gateway/server.sessions.compaction.test.ts` (21 passed)
- `node scripts/run-vitest.mjs src/config/sessions/session-accessor.conformance.test.ts src/config/sessions/transcript.test.ts src/config/sessions/artifacts.test.ts` (123 passed)
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` and `-p test/tsconfig/tsconfig.core.test.json` clean
- `node scripts/run-oxlint.mjs` and `oxfmt --check` clean on all changed files; `git diff --check` clean

Control red: with only the four production files reverted to main, the updated trim test plus the two new tests fail in `session-accessor.test.ts` (3 failed) and the updated gateway archive test fails in `server.sessions.compaction.test.ts` (1 failed); with the patch they all pass.

New regression coverage:

- accessor: trim writes a `.bak` artifact holding every original event, parseable via the archive reader; backup-write failure (archive directory path occupied by a file) leaves all rows untouched and errors; a row appended after the backup snapshot aborts the replacement with a conflict error, deletes nothing, and preserves the durable backup.
- gateway RPC: `sessions.compact` with `maxLines` returns an `archived` path that exists on disk and contains all 500 seeded pre-compaction events.
- CLI: the printed `Archived transcript:` line is exactly the RPC's `archived` path.

Not tested live: Bun runtime (plain JSONL archive fallback path, exercised by the shared writer used unchanged by reset/delete flows) and Windows.

Siblings: session reset and delete flows already archive through the same writer and are unchanged. `sessions.compact` without `--max-lines` (LLM summarization) rewrites via compaction checkpoints, not row deletion, and is unaffected.
