### PR TITLE
fix(oauth): decode Anthropic token responses with fatal UTF-8 validation

### DIFF
--- a/src/llm/utils/oauth/anthropic.test.ts
+++ b/src/llm/utils/oauth/anthropic.test.ts
@@ -85,6 +85,22 @@ describe("Anthropic OAuth token responses", () => {
     }
   });
 
+  it("rejects a token refresh response with invalid UTF-8 bytes", async () => {
+    const body = new Uint8Array([
+      ...new TextEncoder().encode('{"access_token":"sk-ant-'),
+      0xff,
+      ...new TextEncoder().encode('","refresh_token":"rt-ok","expires_in":3600}'),
+    ]);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(body, { status: 200 })),
+    );
+
+    await expect(refreshThroughAnthropicProvider("old-refresh-token")).rejects.toThrow(
+      "Anthropic token refresh request failed.",
+    );
+  });
+
   it("rejects unsafe token lifetimes from refresh responses", async () => {
     vi.stubGlobal(
       "fetch",

--- a/src/llm/utils/oauth/anthropic.ts
+++ b/src/llm/utils/oauth/anthropic.ts
@@ -250,7 +250,7 @@ async function postJson(
   const buffer = await readResponseWithLimit(response, OAUTH_RESPONSE_MAX_BYTES, {
     onOverflow: ({ size }) => new Error(`Anthropic OAuth response too large: ${size} bytes`),
   });
-  const responseBody = new TextDecoder().decode(buffer);
+  const responseBody = new TextDecoder("utf-8", { fatal: true }).decode(buffer);
 
   if (!response.ok) {
     throw new Error(


### PR DESCRIPTION
## Summary

Decode Anthropic OAuth token endpoint responses with `TextDecoder("utf-8", { fatal: true })` so malformed UTF-8 bytes throw immediately, instead of silently becoming U+FFFD inside `access_token`/`refresh_token` values that are then persisted as credentials.

## What Problem This Solves

`postJson` in `src/llm/utils/oauth/anthropic.ts` reads the token endpoint response for both the **authorization-code exchange** (`exchangeAuthorizationCode`) and the **token refresh** (`refreshAnthropicToken`) flows. The response comes over the network, so proxies, middleboxes, or a misbehaving endpoint can deliver invalid UTF-8 byte sequences.

- The body is decoded with a forgiving `TextDecoder` (default `fatal: false`), so invalid bytes are silently replaced with U+FFFD.
- When the corruption lands inside a JSON string value (e.g. inside `access_token`), `JSON.parse` still succeeds and `parseTokenCredentials` accepts the fields — they are non-empty strings.
- The corrupted credential (e.g. `sk-ant-�`) is persisted and used for subsequent Anthropic API calls, which then fail with authentication errors that give no hint the real cause is a corrupted token from the OAuth handshake.

**Code evidence**: at [anthropic.ts:253](src/llm/utils/oauth/anthropic.ts#L253), `new TextDecoder().decode(buffer)` decodes the token endpoint response without UTF-8 validation.

## Root Cause

- Per the WHATWG Encoding standard, `TextDecoder()` defaults to `fatal: false`, which substitutes U+FFFD for malformed sequences instead of throwing.
- `parseTokenCredentials` validates field presence and types, but it operates on the already-decoded string, so it cannot detect byte-level corruption after U+FFFD substitution.
- Invariant violated: "token endpoint response bytes are always valid UTF-8" — not guaranteed for bytes traversing the network.

## Why This Fix

Add `{ fatal: true }` to the decoder in the single shared decode site (`postJson`), covering both token exchange and refresh:

- Invalid bytes now throw a `TypeError`, which each caller's existing `try/catch` wraps into the established error messages (`Token exchange request failed...` / `Anthropic token refresh request failed...`) with the decode error as `cause` — no corrupted credential is ever persisted, and behavior is otherwise unchanged.
- This is the same pattern already used for provider JSON bodies in `readProviderJsonResponse` ([provider-http-errors.ts:344](src/agents/provider-http-errors.ts#L344)).
- Alternative considered: rejecting credentials containing U+FFFD after parsing — rejected, because U+FFFD can be legitimate content and post-hoc scanning cannot distinguish corruption from real data.

## User Impact

- **Before**: a corrupted token response silently persists an `access_token` containing `�`; every later API call fails with an auth error, and the user must re-login with no explanation.
- **After**: the exchange/refresh fails immediately with a clear error (`... details=TypeError: The encoded data was not valid for encoding utf-8`), and no corrupted credential is stored.

## Evidence

- **Before** (upstream/main): `refresh accepted credentials: {"refresh":"rt-ok","access":"sk-ant-�",...}` — **FAIL**: invalid UTF-8 byte silently became U+FFFD in the persisted access token
- **After** (with fix): `refresh rejected: Anthropic token refresh request failed. ... TypeError: The encoded data was not valid for encoding utf-8` — **PASS**: corrupted token response rejected, no credential persisted

## Real Behavior Proof

Proof injects a token response containing a raw `0xFF` byte inside the `access_token` value (a real `Response` object delivered through the global `fetch` injection point used by the repo's own tests) and calls the real `anthropicOAuthProvider.refreshToken` — the full refresh path (`postJson` → byte-capped read → decode → `parseTokenCredentials`) runs unmodified.

### Before (on main)

```bash
$ node --import tsx proof.mjs
refresh accepted credentials: {"refresh":"rt-ok","access":"sk-ant-�","expires":1784430156609}
FAIL: invalid UTF-8 byte silently became U+FFFD in the persisted access token
```

### After (with fix)

```bash
$ node --import tsx proof.mjs
refresh rejected: Anthropic token refresh request failed. url=https://platform.claude.com/v1/oauth/token; details=TypeError: The encoded data was not valid for encoding utf-8; code=ERR_ENCODING_INVALID_ENCODED_DATA
PASS: corrupted token response rejected, no credential persisted
```

## Tests and Validation

- `npx vitest run src/llm/utils/oauth/anthropic.test.ts` — 8 passed (7 existing + 1 new)
- New regression test: `rejects a token refresh response with invalid UTF-8 bytes`
- `tsgo:core` typecheck passed; `oxlint` and `oxfmt --check` clean on the changed files
