### PR TITLE
fix(ui): teardown MCP Apps before unmount

### DIFF
--- a/ui/src/app/router-outlet.test.ts
+++ b/ui/src/app/router-outlet.test.ts
@@ -1,9 +1,10 @@
 import { createRouter, definePage, type Router } from "@openclaw/uirouter";
 import { html, type LitElement } from "lit";
+import { ref } from "lit/directives/ref.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import "./router-outlet.ts";
 
-type RouteId = "page";
+type RouteId = "page" | "next";
 type TestContext = { label: string };
 type TestData = { label: string };
 type TestModule = { render: (data: TestData | undefined) => unknown };
@@ -52,6 +53,57 @@ async function settleOutlet(outlet: RouterOutletElement): Promise<void> {
 }
 
 describe("openclaw-router-outlet", () => {
+  it("keeps the current route mounted until nested MCP Apps finish teardown", async () => {
+    const teardown = deferred<void>();
+    const teardownView = vi.fn(() => teardown.promise);
+    const context = { label: "loaded" };
+    const router = createRouter<RouteId, TestContext, TestModule, TestData>({
+      routes: [
+        definePage({
+          id: "page",
+          path: "/page",
+          component: () => ({
+            render: () => html`
+              <mcp-app-view
+                ${ref((element) => {
+                  if (element) {
+                    Reflect.set(element, "restartAfterTeardown", vi.fn());
+                    Reflect.set(element, "teardown", teardownView);
+                  }
+                })}
+              ></mcp-app-view>
+              <div data-testid="route-page">page</div>
+            `,
+          }),
+          loader: () => ({ label: "page" }),
+        }),
+        definePage({
+          id: "next",
+          path: "/next",
+          component: () => ({
+            render: () => html`<div data-testid="route-next">next</div>`,
+          }),
+          loader: () => ({ label: "next" }),
+        }),
+      ],
+    });
+    const outlet = createOutlet(router, context);
+    await router.navigate("page", context);
+    await settleOutlet(outlet);
+
+    await router.navigate("next", context);
+    await settleOutlet(outlet);
+    expect(teardownView).toHaveBeenCalledOnce();
+    expect(outlet.querySelector('[data-testid="route-page"]')).not.toBeNull();
+    expect(outlet.querySelector('[data-testid="route-next"]')).toBeNull();
+
+    teardown.resolve(undefined);
+    await expect.poll(() => outlet.querySelector('[data-testid="route-next"]')).not.toBeNull();
+    expect(outlet.querySelector("mcp-app-view")).toBeNull();
+    outlet.remove();
+    router.stop();
+  });
+
   it("renders route data through the public custom-element boundary", async () => {
     const context = { label: "loaded" };
     const router = createRouter<RouteId, TestContext, TestModule, TestData>({

--- a/ui/src/app/router-outlet.ts
+++ b/ui/src/app/router-outlet.ts
@@ -3,6 +3,7 @@ import { html, nothing } from "lit";
 import type { ReactiveController, ReactiveControllerHost } from "lit";
 import { property } from "lit/decorators.js";
 import { icon } from "../components/icons.ts";
+import { McpAppUnmountGate } from "../components/mcp-app-unmount.ts";
 import { t } from "../i18n/index.ts";
 import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
 import {
@@ -222,14 +223,22 @@ class OpenClawRouterOutlet<
     router: this.router,
     onNotFound: this.onNotFound,
   }));
+  private readonly mcpAppUnmountGate = new McpAppUnmountGate(this);
 
   override render() {
     if (!this.router) {
       return nothing;
     }
-    return renderRouterOutlet(this.router, this.outlet.snapshot, {
+    const snapshot = this.outlet.snapshot;
+    const renderedMatch = selectRenderedRouteMatch(snapshot.active, snapshot.pending);
+    const rendered = renderRouterOutlet(this.router, snapshot, {
       retryContext: this.retryContext,
     });
+    return this.mcpAppUnmountGate.render(
+      renderedMatch ? `${renderedMatch.routeId}:${renderedMatch.status}` : "empty",
+      rendered,
+      () => [this],
+    );
   }
 }
 

--- a/ui/src/components/mcp-app-security.test.ts
+++ b/ui/src/components/mcp-app-security.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildMcpAppHostCapabilities, resolveMcpAppSandboxUrl } from "./mcp-app-security.ts";
+import {
+  buildMcpAppHostCapabilities,
+  dispatchWidgetPrompt,
+  resolveMcpAppSandboxUrl,
+} from "./mcp-app-security.ts";
 
 describe("MCP App sandbox security", () => {
   it("advertises the CSP applied to MCP Apps", () => {
@@ -64,5 +68,28 @@ describe("MCP App sandbox security", () => {
         "MCP App sandbox URL is invalid",
       );
     }
+  });
+
+  it("keeps the per-view prompt budget across iframe remounts", () => {
+    const key = `agent:main:main\0view-${crypto.randomUUID()}`;
+    const first = document.createElement("iframe");
+    document.body.append(first);
+    first.checkVisibility = () => true;
+    Object.defineProperty(document, "activeElement", { get: () => first, configurable: true });
+    for (let index = 0; index < 10; index += 1) {
+      expect(dispatchWidgetPrompt(first, `Prompt ${index}`, key)).toBe(true);
+    }
+
+    first.remove();
+    const replacement = document.createElement("iframe");
+    document.body.append(replacement);
+    replacement.checkVisibility = () => true;
+    Object.defineProperty(document, "activeElement", {
+      get: () => replacement,
+      configurable: true,
+    });
+    expect(dispatchWidgetPrompt(replacement, "Prompt after remount", key)).toBe(false);
+    replacement.remove();
+    delete (document as unknown as Record<string, unknown>).activeElement;
   });
 });

--- a/ui/src/components/mcp-app-unmount.test.ts
+++ b/ui/src/components/mcp-app-unmount.test.ts
@@ -1,0 +1,158 @@
+import { LitElement, html, nothing } from "lit";
+import { html as staticHtml, unsafeStatic } from "lit/static-html.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { McpAppUnmountGate } from "./mcp-app-unmount.ts";
+
+type Deferred = {
+  promise: Promise<void>;
+  resolve: () => void;
+};
+
+function deferred(): Deferred {
+  let resolve!: () => void;
+  const promise = new Promise<void>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+const targetTag = `test-mcp-app-unmount-target-${crypto.randomUUID()}`;
+const ownerTag = `test-mcp-app-unmount-owner-${crypto.randomUUID()}`;
+const siblingOwnerTag = `test-mcp-app-unmount-sibling-owner-${crypto.randomUUID()}`;
+const staticTargetTag = unsafeStatic(targetTag);
+const teardown = vi.fn<() => Promise<void>>();
+
+class TestMcpAppUnmountTarget extends HTMLElement {
+  restartCalls = 0;
+
+  restartAfterTeardown() {
+    this.restartCalls += 1;
+  }
+
+  teardown() {
+    return teardown();
+  }
+}
+
+class TestMcpAppUnmountOwner extends LitElement {
+  key = "initial";
+  private readonly gate = new McpAppUnmountGate(this, targetTag);
+
+  show(key: string) {
+    this.key = key;
+    this.requestUpdate();
+  }
+
+  override render() {
+    const value =
+      this.key === "initial"
+        ? staticHtml`<${staticTargetTag}></${staticTargetTag}><span data-value="initial">initial</span>`
+        : html`<span data-value=${this.key}>${this.key}</span>`;
+    return this.gate.render(this.key, value, () => [this.renderRoot]);
+  }
+}
+
+class TestMcpAppUnmountSiblingOwner extends LitElement {
+  private includeLeaving = true;
+  private readonly gate = new McpAppUnmountGate(this, targetTag);
+
+  removeLeaving() {
+    this.includeLeaving = false;
+    this.requestUpdate();
+  }
+
+  override render() {
+    const value = staticHtml`
+      ${
+        this.includeLeaving
+          ? staticHtml`<div class="leaving"><${staticTargetTag}></${staticTargetTag}></div>`
+          : nothing
+      }
+      <${staticTargetTag} class="retained"></${staticTargetTag}>
+    `;
+    return this.gate.render(this.includeLeaving ? "both" : "retained", value, () =>
+      this.renderRoot.querySelectorAll(".leaving"),
+    );
+  }
+}
+
+customElements.define(targetTag, TestMcpAppUnmountTarget);
+customElements.define(ownerTag, TestMcpAppUnmountOwner);
+customElements.define(siblingOwnerTag, TestMcpAppUnmountSiblingOwner);
+
+afterEach(() => {
+  document.body.replaceChildren();
+  teardown.mockReset();
+});
+
+describe("McpAppUnmountGate", () => {
+  it("keeps the old subtree connected and coalesces replacements until teardown resolves", async () => {
+    const pending = deferred();
+    teardown.mockReturnValue(pending.promise);
+    const owner = document.createElement(ownerTag) as TestMcpAppUnmountOwner;
+    document.body.append(owner);
+    await owner.updateComplete;
+
+    const target = owner.shadowRoot!.querySelector(targetTag)!;
+    owner.show("intermediate");
+    await owner.updateComplete;
+    expect(teardown).toHaveBeenCalledOnce();
+    expect(target.isConnected).toBe(true);
+    expect(owner.shadowRoot!.querySelector("[data-value='initial']")).not.toBeNull();
+
+    owner.show("latest");
+    await owner.updateComplete;
+    expect(teardown).toHaveBeenCalledOnce();
+    expect(owner.shadowRoot!.querySelector("[data-value='latest']")).toBeNull();
+
+    pending.resolve();
+    await expect
+      .poll(() => owner.shadowRoot!.querySelector("[data-value='latest']"))
+      .not.toBeNull();
+    expect(owner.shadowRoot!.querySelector(targetTag)).toBeNull();
+    expect(owner.shadowRoot!.querySelector("[data-value='intermediate']")).toBeNull();
+  });
+
+  it("restarts the original target when a pending transition rebounds", async () => {
+    const pending = deferred();
+    teardown.mockReturnValueOnce(pending.promise).mockResolvedValue(undefined);
+    const owner = document.createElement(ownerTag) as TestMcpAppUnmountOwner;
+    document.body.append(owner);
+    await owner.updateComplete;
+    const original = owner.shadowRoot!.querySelector<TestMcpAppUnmountTarget>(targetTag)!;
+
+    owner.show("intermediate");
+    await owner.updateComplete;
+    owner.show("initial");
+    await owner.updateComplete;
+    expect(original.isConnected).toBe(true);
+
+    pending.resolve();
+    await expect.poll(() => original.restartCalls).toBe(1);
+    expect(owner.shadowRoot!.querySelector(targetTag)).toBe(original);
+    expect(teardown).toHaveBeenCalledOnce();
+  });
+
+  it("preserves retained siblings while removing a torn-down target", async () => {
+    const pending = deferred();
+    teardown.mockReturnValue(pending.promise);
+    const owner = document.createElement(siblingOwnerTag) as TestMcpAppUnmountSiblingOwner;
+    document.body.append(owner);
+    await owner.updateComplete;
+    const leaving = owner.shadowRoot!.querySelector<TestMcpAppUnmountTarget>(
+      `.leaving ${targetTag}`,
+    )!;
+    const retained = owner.shadowRoot!.querySelector<TestMcpAppUnmountTarget>(".retained")!;
+
+    owner.removeLeaving();
+    await owner.updateComplete;
+    expect(leaving.isConnected).toBe(true);
+    expect(retained.isConnected).toBe(true);
+
+    pending.resolve();
+    await expect.poll(() => owner.shadowRoot!.querySelector(".leaving")).toBeNull();
+    expect(owner.shadowRoot!.querySelector(".retained")).toBe(retained);
+    expect(retained.restartCalls).toBe(0);
+    expect(teardown).toHaveBeenCalledOnce();
+  });
+});

--- a/ui/src/components/mcp-app-unmount.ts
+++ b/ui/src/components/mcp-app-unmount.ts
@@ -1,6 +1,6 @@
 import type { ReactiveControllerHost } from "lit";
 
-export type McpAppUnmountTarget = Element & {
+type McpAppUnmountTarget = Element & {
   restartAfterTeardown(): void;
   teardown(): Promise<void>;
 };
@@ -12,7 +12,7 @@ function isMcpAppUnmountTarget(value: Element): value is McpAppUnmountTarget {
   );
 }
 
-export function findMcpAppUnmountTargets(
+function findMcpAppUnmountTargets(
   roots: Iterable<ParentNode>,
   selector = "mcp-app-view",
 ): McpAppUnmountTarget[] {

--- a/ui/src/components/mcp-app-unmount.ts
+++ b/ui/src/components/mcp-app-unmount.ts
@@ -1,0 +1,89 @@
+import type { ReactiveControllerHost } from "lit";
+
+export type McpAppUnmountTarget = Element & {
+  restartAfterTeardown(): void;
+  teardown(): Promise<void>;
+};
+
+function isMcpAppUnmountTarget(value: Element): value is McpAppUnmountTarget {
+  return (
+    typeof Reflect.get(value, "restartAfterTeardown") === "function" &&
+    typeof Reflect.get(value, "teardown") === "function"
+  );
+}
+
+export function findMcpAppUnmountTargets(
+  roots: Iterable<ParentNode>,
+  selector = "mcp-app-view",
+): McpAppUnmountTarget[] {
+  const targets = new Set<McpAppUnmountTarget>();
+  for (const root of roots) {
+    if (root instanceof Element && root.matches(selector) && isMcpAppUnmountTarget(root)) {
+      targets.add(root);
+    }
+    for (const candidate of root.querySelectorAll(selector)) {
+      if (isMcpAppUnmountTarget(candidate)) {
+        targets.add(candidate);
+      }
+    }
+  }
+  return [...targets];
+}
+
+/**
+ * Keeps the currently rendered subtree connected while MCP Apps acknowledge teardown.
+ * New renders coalesce behind one bounded component-owned teardown instead of queuing.
+ */
+export class McpAppUnmountGate {
+  private renderedKey: string | null = null;
+  private renderedValue: unknown;
+  private pending = false;
+  private restartTargets: McpAppUnmountTarget[] | null = null;
+
+  constructor(
+    private readonly host: ReactiveControllerHost,
+    private readonly selector = "mcp-app-view",
+  ) {}
+
+  private apply(key: string, value: unknown): unknown {
+    this.renderedKey = key;
+    this.renderedValue = value;
+    return this.renderedValue;
+  }
+
+  render(key: string, value: unknown, leavingRoots: () => Iterable<ParentNode>): unknown {
+    if (this.pending) {
+      return this.renderedValue;
+    }
+    if (this.restartTargets) {
+      const targets = this.restartTargets;
+      this.restartTargets = null;
+      // Lit commits the parent update synchronously after render. Restart only
+      // torn-down views that survived that commit; retained siblings stay intact.
+      queueMicrotask(() => {
+        for (const target of targets) {
+          if (target.isConnected) {
+            target.restartAfterTeardown();
+          }
+        }
+      });
+      return this.apply(key, value);
+    }
+    if (this.renderedKey === null || this.renderedKey === key) {
+      return this.apply(key, value);
+    }
+
+    const targets = findMcpAppUnmountTargets(leavingRoots(), this.selector);
+    if (targets.length === 0) {
+      return this.apply(key, value);
+    }
+
+    this.pending = true;
+    void Promise.allSettled(targets.map((target) => target.teardown())).then(() => {
+      this.pending = false;
+      this.restartTargets = targets;
+      this.host.requestUpdate();
+    });
+    return this.renderedValue;
+  }
+}

--- a/ui/src/components/mcp-app-view.test.ts
+++ b/ui/src/components/mcp-app-view.test.ts
@@ -2,7 +2,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { i18n } from "../i18n/index.ts";
 import { WIDGET_PROMPT_EVENT, type WidgetPromptEventDetail } from "./mcp-app-security.ts";
 
-const bridgeMocks = vi.hoisted(() => ({ instances: [] as Array<Record<string, unknown>> }));
+const bridgeMocks = vi.hoisted(() => ({
+  instances: [] as Array<Record<string, unknown>>,
+  transports: [] as Array<Record<string, unknown>>,
+}));
 
 vi.mock("@modelcontextprotocol/ext-apps/app-bridge", () => {
   class AppBridge {
@@ -17,6 +20,7 @@ vi.mock("@modelcontextprotocol/ext-apps/app-bridge", () => {
     sendSandboxResourceReady = vi.fn(async () => undefined);
     sendToolInput = vi.fn(async () => undefined);
     sendToolResult = vi.fn(async () => undefined);
+    onrequestteardown?: () => void;
 
     constructor(
       _client: unknown,
@@ -33,13 +37,23 @@ vi.mock("@modelcontextprotocol/ext-apps/app-bridge", () => {
 
     protected replaceRequestHandler() {}
 
+    emit(type: string) {
+      if (type === "requestteardown") {
+        this.onrequestteardown?.();
+      }
+    }
+
     async connect() {
       this.oninitialized?.();
     }
   }
 
   class PostMessageTransport {
-    async close() {}
+    close = vi.fn(async () => undefined);
+
+    constructor() {
+      bridgeMocks.transports.push(this as unknown as Record<string, unknown>);
+    }
   }
 
   return { AppBridge, PostMessageTransport };
@@ -47,6 +61,14 @@ vi.mock("@modelcontextprotocol/ext-apps/app-bridge", () => {
 
 const { McpAppView } = await import("./mcp-app-view.ts");
 type McpAppViewElement = InstanceType<typeof McpAppView>;
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
 
 const MCP_APP_VIEW_ELEMENT_NAME = `test-mcp-app-view-${crypto.randomUUID()}`;
 
@@ -59,6 +81,7 @@ customElements.define(MCP_APP_VIEW_ELEMENT_NAME, TestMcpAppView);
 describe("mcp-app-view localization", () => {
   afterEach(async () => {
     bridgeMocks.instances.length = 0;
+    bridgeMocks.transports.length = 0;
     document.body.replaceChildren();
     delete (document as unknown as Record<string, unknown>).activeElement;
     delete document.documentElement.dataset.themeMode;
@@ -79,7 +102,7 @@ describe("mcp-app-view localization", () => {
     });
     const themeListeners = new Set<() => void>();
     const unsubscribe = vi.fn();
-    const request = vi.fn(async () => ({
+    const request = vi.fn(async (_method: string, _params: Record<string, unknown>) => ({
       sandboxUrl: "/mcp-app-sandbox?ticket=test",
       sandboxPort: 8444,
       html: "<!doctype html><button>Send</button>",
@@ -133,11 +156,14 @@ describe("mcp-app-view localization", () => {
           content: Array<{ type: string; text?: string }>;
         }) => Promise<{ isError?: boolean }>;
         setHostContext: ReturnType<typeof vi.fn>;
+        teardownResource: ReturnType<typeof vi.fn>;
+        emit(type: string): void;
       },
       frame,
       request,
       themeListeners,
       unsubscribe,
+      transport: bridgeMocks.transports[0] as { close: ReturnType<typeof vi.fn> },
       view,
     };
   }
@@ -242,6 +268,62 @@ describe("mcp-app-view localization", () => {
     await expect.poll(() => disconnect).toHaveBeenCalledOnce();
     expect(unsubscribe).toHaveBeenCalledOnce();
     expect(themeListeners.size).toBe(0);
+  });
+
+  it("keeps the frame connected through teardown and installs only the latest replacement", async () => {
+    const pending = deferred<Record<string, never>>();
+    const { bridge, frame, request, transport, view } = await mountBridge(
+      `view-teardown-${crypto.randomUUID()}`,
+    );
+    bridge.teardownResource.mockReturnValueOnce(pending.promise);
+
+    view.viewId = `view-intermediate-${crypto.randomUUID()}`;
+    await view.updateComplete;
+    await expect.poll(() => bridge.teardownResource).toHaveBeenCalledOnce();
+    expect(frame.isConnected).toBe(true);
+    expect(transport.close).not.toHaveBeenCalled();
+
+    const latestViewId = `view-latest-${crypto.randomUUID()}`;
+    view.viewId = latestViewId;
+    await view.updateComplete;
+    pending.resolve({});
+
+    await expect.poll(() => frame.isConnected).toBe(false);
+    await expect.poll(() => request.mock.calls.at(-1)?.[1]).toMatchObject({ viewId: latestViewId });
+    expect(bridge.teardownResource).toHaveBeenCalledOnce();
+    expect(transport.close).toHaveBeenCalledOnce();
+  });
+
+  it("removes the frame after the bounded teardown timeout", async () => {
+    const { bridge, frame, transport, view } = await mountBridge(
+      `view-timeout-${crypto.randomUUID()}`,
+    );
+    bridge.teardownResource.mockReturnValueOnce(new Promise<void>(() => {}));
+
+    view.viewId = `view-after-timeout-${crypto.randomUUID()}`;
+    await view.updateComplete;
+    await expect.poll(() => bridge.teardownResource).toHaveBeenCalledOnce();
+    expect(frame.isConnected).toBe(true);
+
+    await expect.poll(() => transport.close, { timeout: 1_000 }).toHaveBeenCalledOnce();
+    expect(frame.isConnected).toBe(false);
+  });
+
+  it("honors an app-requested teardown before detaching its frame", async () => {
+    const pending = deferred<Record<string, never>>();
+    const { bridge, frame, transport } = await mountBridge(
+      `view-request-teardown-${crypto.randomUUID()}`,
+    );
+    bridge.teardownResource.mockReturnValueOnce(pending.promise);
+
+    bridge.emit("requestteardown");
+    await expect.poll(() => bridge.teardownResource).toHaveBeenCalledOnce();
+    expect(frame.isConnected).toBe(true);
+    expect(transport.close).not.toHaveBeenCalled();
+
+    pending.resolve({});
+    await expect.poll(() => frame.isConnected).toBe(false);
+    expect(transport.close).toHaveBeenCalledOnce();
   });
 
   it("renders gateway failures with localized copy", async () => {

--- a/ui/src/components/mcp-app-view.ts
+++ b/ui/src/components/mcp-app-view.ts
@@ -35,6 +35,14 @@ type HostContext = NonNullable<
 >;
 type ScheduleFrame = (callback: FrameRequestCallback) => number;
 type ScheduleFallback = (callback: () => void, delayMs: number) => number;
+type McpAppResources = {
+  bridge: OpenClawAppBridge | null;
+  cleanups: Set<() => void>;
+  iframe: HTMLIFrameElement;
+  transport: { close(): Promise<void> } | null;
+};
+
+const MCP_APP_TEARDOWN_TIMEOUT_MS = 250;
 
 async function waitForMcpAppHandlerRegistration(
   scheduleFrame: ScheduleFrame = window.requestAnimationFrame.bind(window),
@@ -127,24 +135,20 @@ export class McpAppView extends LitElement {
 
   protected readonly i18nController = new I18nController(this);
   private readonly mount = createRef<HTMLDivElement>();
-  private bridge: AppBridge | null = null;
-  private iframe: HTMLIFrameElement | null = null;
-  private transport: { close(): Promise<void> } | null = null;
-  private hostContextCleanup: (() => void) | null = null;
-  private hostResizeObserver: ResizeObserver | null = null;
+  private resources: McpAppResources | null = null;
+  private teardownPromise: Promise<void> | null = null;
   private setupKey = "";
   private setupClient: object | null = null;
   private setupGeneration = 0;
 
   override disconnectedCallback() {
-    this.setupGeneration += 1;
     void this.teardown();
     super.disconnectedCallback();
   }
 
   override updated() {
-    if (this.iframe) {
-      this.iframe.title = this.title || t("mcpApp.title");
+    if (this.resources) {
+      this.resources.iframe.title = this.title || t("mcpApp.title");
     }
     const nextKey = `${this.sessionKey}\0${this.viewId}`;
     const nextClient = this.context?.gateway.snapshot.client ?? null;
@@ -167,36 +171,79 @@ export class McpAppView extends LitElement {
     });
   }
 
-  private async teardown() {
-    const bridge = this.bridge;
-    const transport = this.transport;
-    const iframe = this.iframe;
-    const hostContextCleanup = this.hostContextCleanup;
-    const hostResizeObserver = this.hostResizeObserver;
-    this.bridge = null;
-    this.transport = null;
-    this.iframe = null;
-    this.hostContextCleanup = null;
-    this.hostResizeObserver = null;
-    // Clear ownership before awaiting: a stale teardown must never close a
-    // replacement setup that installs its resources during the handshake.
-    hostContextCleanup?.();
-    hostResizeObserver?.disconnect();
-    iframe?.remove();
-    if (bridge) {
-      await Promise.race([
-        bridge.teardownResource({}).catch(() => undefined),
-        new Promise((resolve) => {
-          setTimeout(resolve, 250);
-        }),
-      ]);
+  private addResourceCleanup(resources: McpAppResources, cleanup: () => void): () => void {
+    resources.cleanups.add(cleanup);
+    return () => {
+      if (resources.cleanups.delete(cleanup)) {
+        cleanup();
+      }
+    };
+  }
+
+  private runResourceCleanups(resources: McpAppResources) {
+    for (const cleanup of resources.cleanups) {
+      resources.cleanups.delete(cleanup);
+      cleanup();
     }
-    await transport?.close().catch(() => undefined);
+  }
+
+  private async teardownCurrentResources() {
+    const resources = this.resources;
+    if (!resources) {
+      await this.teardownPromise;
+      return;
+    }
+    // Release ownership before awaiting so this generation can never close a replacement.
+    this.resources = null;
+    this.runResourceCleanups(resources);
+    const teardown = (async () => {
+      if (resources.bridge) {
+        let timeout: number | undefined;
+        try {
+          await Promise.race([
+            resources.bridge.teardownResource({}).catch(() => undefined),
+            new Promise<void>((resolve) => {
+              timeout = window.setTimeout(resolve, MCP_APP_TEARDOWN_TIMEOUT_MS);
+            }),
+          ]);
+        } finally {
+          if (timeout !== undefined) {
+            window.clearTimeout(timeout);
+          }
+        }
+      }
+      await resources.transport?.close().catch(() => undefined);
+      resources.iframe.remove();
+    })();
+    this.teardownPromise = teardown;
+    try {
+      await teardown;
+    } finally {
+      if (this.teardownPromise === teardown) {
+        this.teardownPromise = null;
+      }
+    }
+  }
+
+  /** Parent render owners await this before removing the connected view. */
+  async teardown() {
+    this.setupGeneration += 1;
+    await this.teardownCurrentResources();
+  }
+
+  /** Restarts a torn-down view only when its parent kept the element connected. */
+  restartAfterTeardown() {
+    if (!this.isConnected || this.resources || this.teardownPromise) {
+      return;
+    }
+    this.setupKey = `${this.sessionKey}\0${this.viewId}`;
+    this.setupClient = this.context?.gateway.snapshot.client ?? null;
+    void this.setup();
   }
 
   private async setup() {
     const generation = ++this.setupGeneration;
-    await this.teardown();
+    await this.teardownCurrentResources();
     if (!this.sessionKey || !this.viewId || generation !== this.setupGeneration) {
       return;
     }
@@ -216,11 +263,17 @@ export class McpAppView extends LitElement {
       // so Apps retain their required origin capabilities without reaching Control UI.
       iframe.setAttribute("sandbox", "allow-scripts allow-same-origin allow-forms");
       mount.appendChild(iframe);
-      this.iframe = iframe;
+      const resources: McpAppResources = {
+        bridge: null,
+        cleanups: new Set(),
+        iframe,
+        transport: null,
+      };
+      this.resources = resources;
 
       const proxyReady = new Promise<void>((resolve, reject) => {
         const timeout = window.setTimeout(() => {
-          window.removeEventListener("message", onMessage);
+          cleanupProxyReady();
           reject(new Error("MCP App sandbox timed out"));
         }, 15_000);
         const onMessage = (event: MessageEvent) => {
@@ -228,11 +281,14 @@ export class McpAppView extends LitElement {
             event.source === iframe.contentWindow &&
             event.data?.method === "ui/notifications/sandbox-proxy-ready"
           ) {
-            window.clearTimeout(timeout);
-            window.removeEventListener("message", onMessage);
+            cleanupProxyReady();
             resolve();
           }
         };
+        const cleanupProxyReady = this.addResourceCleanup(resources, () => {
+          window.clearTimeout(timeout);
+          window.removeEventListener("message", onMessage);
+        });
         window.addEventListener("message", onMessage);
       });
       iframe.src = resolveMcpAppSandboxUrl(
@@ -254,6 +310,16 @@ export class McpAppView extends LitElement {
         buildMcpAppHostCapabilities(payload.csp, payload.messageSupported === true),
         { hostContext: hostContext(mount, this.height) },
       );
+      resources.bridge = bridge;
+      const handleRequestTeardown = () => {
+        void this.teardown();
+      };
+      bridge.onrequestteardown = handleRequestTeardown;
+      this.addResourceCleanup(resources, () => {
+        if (bridge.onrequestteardown === handleRequestTeardown) {
+          bridge.onrequestteardown = undefined;
+        }
+      });
       if (payload.messageSupported === true) {
         const promptRateKey = `${this.sessionKey}\0${this.viewId}`;
         bridge.setMessageHandler(async ({ content }) => {
@@ -302,27 +368,43 @@ export class McpAppView extends LitElement {
         bridge.oninitialized = () => resolve();
       });
       const transport = new PostMessageTransport(iframe.contentWindow, iframe.contentWindow);
-      this.bridge = bridge;
-      this.transport = transport;
+      resources.transport = transport;
       await bridge.connect(transport);
       await bridge.sendSandboxResourceReady({
         html: payload.html,
         csp: payload.csp,
       });
-      await Promise.race([
-        initialized,
-        new Promise<never>((_, reject) => {
-          window.setTimeout(() => reject(new Error("MCP App initialization timed out")), 15_000);
-        }),
-      ]);
+      let initializationTimeout: number | undefined;
+      const cleanupInitializationTimeout = this.addResourceCleanup(resources, () => {
+        if (initializationTimeout !== undefined) {
+          window.clearTimeout(initializationTimeout);
+        }
+      });
+      try {
+        await Promise.race([
+          initialized,
+          new Promise<never>((_, reject) => {
+            initializationTimeout = window.setTimeout(
+              () => reject(new Error("MCP App initialization timed out")),
+              15_000,
+            );
+          }),
+        ]);
+      } finally {
+        cleanupInitializationTimeout();
+      }
       if (generation !== this.setupGeneration) {
         return;
       }
       const updateHostContext = () => bridge.setHostContext(hostContext(mount, frameHeight));
-      this.hostContextCleanup = this.context?.theme.subscribe(updateHostContext) ?? null;
+      const hostContextCleanup = this.context?.theme.subscribe(updateHostContext);
+      if (hostContextCleanup) {
+        this.addResourceCleanup(resources, hostContextCleanup);
+      }
       if (typeof ResizeObserver !== "undefined") {
-        this.hostResizeObserver = new ResizeObserver(updateHostContext);
-        this.hostResizeObserver.observe(mount);
+        const hostResizeObserver = new ResizeObserver(updateHostContext);
+        hostResizeObserver.observe(mount);
+        this.addResourceCleanup(resources, () => hostResizeObserver.disconnect());
       }
       await waitForMcpAppHandlerRegistration();
       if (generation !== this.setupGeneration) {
@@ -342,7 +424,7 @@ export class McpAppView extends LitElement {
       }
     } catch (error) {
       if (generation === this.setupGeneration) {
-        await this.teardown();
+        await this.teardownCurrentResources();
         this.error = error instanceof Error ? error.message : String(error);
       }
     }

--- a/ui/src/e2e/mcp-app-conformance.e2e.test.ts
+++ b/ui/src/e2e/mcp-app-conformance.e2e.test.ts
@@ -90,6 +90,7 @@ function appHtml(appModuleUrl: string): string {
 <output id="app-tool"></output>
 <output id="model-tool"></output>
 <output id="resource"></output>
+<output id="teardown"></output>
 <output id="isolation"></output>
 <script type="module">
 import { App, McpUiResourceTeardownResultSchema } from ${JSON.stringify(appModuleUrl)};
@@ -98,7 +99,11 @@ try { void window.top.document; write("isolation", "failed"); } catch { write("i
 const app = new App({ name: "OpenClaw conformance fixture", version: "1.0.0" });
 app.ontoolinput = ({ arguments: args }) => write("input", JSON.stringify(args ?? {}));
 app.ontoolresult = (value) => write("result", JSON.stringify(value.structuredContent ?? value));
-app.onteardown = async () => ({});
+app.onteardown = async () => {
+  write("teardown", "received");
+  console.info("mcp-conformance-teardown-received");
+  return {};
+};
 app.onerror = (error) => console.error("mcp-conformance-app", error);
 document.getElementById("call-app").onclick = async () => {
   try {
@@ -224,6 +229,16 @@ async function mountControlUiHost(page: Page): Promise<void> {
 import { GatewayBrowserClient } from "/src/api/gateway.ts";
 import "/src/components/mcp-app-view-registration.ts";
 window.mcpConformanceGatewayBrowserClient = GatewayBrowserClient;
+window.mcpConformanceUnmount = async () => {
+  const mount = document.getElementById("mount");
+  const view = window.mcpConformanceView;
+  if (!mount || !view) return;
+  const frame = view.shadowRoot?.querySelector("iframe");
+  await view.teardown();
+  if (frame?.isConnected) throw new Error("MCP App frame remained mounted");
+  console.info("mcp-conformance-frame-detached");
+  mount.replaceChildren();
+};
 </script>`,
     });
   });
@@ -468,7 +483,21 @@ describeConformance("MCP App Control UI and standalone host conformance", () => 
     await waitForTextContaining(app.locator("#resource"), "resource-ok");
 
     const standaloneUrl = await requestStandaloneUrl(controlPage);
-    await controlPage.evaluate(() => Reflect.get(window, "mcpConformanceView")?.remove());
+    await controlPage.evaluate(async () => {
+      const unmount = Reflect.get(window, "mcpConformanceUnmount") as
+        | (() => Promise<void>)
+        | undefined;
+      await unmount?.();
+    });
+    const teardownDiagnostic = browserDiagnostics.findIndex((entry) =>
+      entry.includes("mcp-conformance-teardown-received"),
+    );
+    const detachedDiagnostic = browserDiagnostics.findIndex((entry) =>
+      entry.includes("mcp-conformance-frame-detached"),
+    );
+    expect(teardownDiagnostic).toBeGreaterThanOrEqual(0);
+    expect(detachedDiagnostic).toBeGreaterThan(teardownDiagnostic);
+    await expect.poll(() => controlPage.frames().length).toBe(1);
 
     const standaloneContext = await browser.newContext({ permissions: ["local-network-access"] });
     openContexts.add(standaloneContext);

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -7,6 +7,7 @@ import { applicationContext, type ApplicationContext } from "../../app/context.t
 import { mobileNavLayoutMediaQuery, shouldMergeChatChrome } from "../../app/mobile-nav-layout.ts";
 import { loadSettings, patchSettings } from "../../app/settings.ts";
 import "../../components/resizable-divider.ts";
+import { McpAppUnmountGate } from "../../components/mcp-app-unmount.ts";
 import { UI_COMMAND_EVENT, type UiCommandDetail } from "../../components/panel-toggle-contract.ts";
 import { t } from "../../i18n/index.ts";
 import { resolveSessionDisplayName } from "../../lib/session-display.ts";
@@ -56,7 +57,7 @@ type ChatRouteData = {
 const NARROW_SPLIT_QUERY = "(max-width: 1099px)";
 
 type DropIndicator = { paneId: string; zone: SplitDropZone; rect: SplitDropRect };
-type ChatPaneElement = HTMLElement & { paneId?: string };
+type ChatPaneElement = HTMLElement & { paneId?: string; sessionKey?: string };
 
 export class ChatPage extends OpenClawLightDomElement {
   @consume({ context: applicationContext, subscribe: true })
@@ -82,6 +83,7 @@ export class ChatPage extends OpenClawLightDomElement {
   private readonly chatMessagesBySession: ChatMessageCache = new Map();
   private classicColumnId = "c1";
   private classicPaneId = "p1";
+  private readonly mcpAppUnmountGate = new McpAppUnmountGate(this);
 
   override connectedCallback() {
     super.connectedCallback();
@@ -512,7 +514,13 @@ export class ChatPage extends OpenClawLightDomElement {
   /** Header + pane travel together so each pane owns its title bar in-flow —
    * no fixed toolbar layer mirroring the split geometry. The pane renders its
    * own header so the workspace toggle can read per-pane workspace state. */
-  private renderPaneCell(pane: ChatSplitPane, active: boolean, weight: number, splitMode: boolean) {
+  private renderPaneCell(
+    pane: ChatSplitPane,
+    active: boolean,
+    weight: number,
+    splitMode: boolean,
+    ownerKey: string,
+  ) {
     const sessions = this.context?.sessions?.state.result?.sessions ?? [];
     // Route keys can be unresolved aliases ("main"); resolve against the
     // hello defaults and match rows by equivalence like the pane itself
@@ -532,6 +540,7 @@ export class ChatPage extends OpenClawLightDomElement {
       >
         <openclaw-chat-pane
           class=${splitMode ? "chat-split-view__pane" : ""}
+          data-mcp-app-owner-key=${ownerKey}
           .paneId=${pane.id}
           .chatMessagesBySession=${this.chatMessagesBySession}
           .sessionKey=${pane.sessionKey}
@@ -603,6 +612,7 @@ export class ChatPage extends OpenClawLightDomElement {
                     pane.id === layout.activePaneId,
                     splitWeight(column.paneWeights, paneIndex, "rendered split pane weight"),
                     splitMode,
+                    JSON.stringify([column.id, pane.id, pane.sessionKey]),
                   )}
                   ${paneIndex < column.panes.length - 1
                     ? html`
@@ -660,10 +670,23 @@ export class ChatPage extends OpenClawLightDomElement {
 
   override render() {
     const indicator = this.dropIndicator;
-    const layout = this.layout;
-    return html`
+    const layout = this.layout ?? this.classicLayout();
+    const activeLocation = findPane(layout, layout.activePaneId);
+    const renderedPaneOwners = this.narrow
+      ? activeLocation
+        ? [{ columnId: activeLocation.column.id, pane: activeLocation.pane }]
+        : []
+      : layout.columns.flatMap((column) =>
+          column.panes.map((pane) => ({ columnId: column.id, pane })),
+        );
+    const nextPaneKeys = new Set(
+      renderedPaneOwners.map(({ columnId, pane }) =>
+        JSON.stringify([columnId, pane.id, pane.sessionKey]),
+      ),
+    );
+    const rendered = html`
       <div class="chat-split-view__drop-container">
-        ${this.renderSplitLayout(layout ?? this.classicLayout(), Boolean(layout))}
+        ${this.renderSplitLayout(layout, Boolean(this.layout))}
         ${indicator
           ? html`<div
               class="chat-split-view__drop-indicator ${indicator.zone.kind === "center"
@@ -680,6 +703,11 @@ export class ChatPage extends OpenClawLightDomElement {
           : nothing}
       </div>
     `;
+    return this.mcpAppUnmountGate.render(JSON.stringify([...nextPaneKeys]), rendered, () =>
+      [...this.querySelectorAll<ChatPaneElement>("openclaw-chat-pane")].filter(
+        (pane) => !nextPaneKeys.has(pane.dataset.mcpAppOwnerKey ?? ""),
+      ),
+    );
   }
 }
 

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -23,6 +23,7 @@ import {
   handleMarkdownCodeBlockCopy,
   markdownFileLinkFromEvent,
 } from "../../../components/markdown.ts";
+import { McpAppUnmountGate } from "../../../components/mcp-app-unmount.ts";
 import { i18n, t } from "../../../i18n/index.ts";
 import type {
   ChatQueueItem,
@@ -233,6 +234,7 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost {
   private announcementInitialized = false;
   private announcementKey: string | null = null;
   private currentAnnouncementText = "";
+  private readonly mcpAppUnmountGate = new McpAppUnmountGate(this);
 
   constructor(private readonly host: ReactiveControllerHost) {
     this.virtualizerController = new VirtualizerController(this, {
@@ -319,7 +321,13 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost {
     this.syncAnnouncement(announcement, announce);
     const virtualizer = this.virtualizerController.getVirtualizer();
     const virtualRows = virtualizer.getVirtualItems();
-    return html`
+    const nextRowKeys = new Set(
+      virtualRows.flatMap((virtualRow) => {
+        const row = rows[virtualRow.index];
+        return row ? [row.key] : [];
+      }),
+    );
+    const rendered = html`
       <div class="chat-thread-inner chat-thread-inner--virtual" ${ref(this.scrollElementRef)}>
         <div
           class="chat-virtual-sizer"
@@ -356,6 +364,13 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost {
         </div>
       </div>
     `;
+    return this.mcpAppUnmountGate.render(JSON.stringify([...nextRowKeys]), rendered, () =>
+      this.threadInnerElement
+        ? [...this.threadInnerElement.querySelectorAll<HTMLElement>(".chat-virtual-row")].filter(
+            (row) => !nextRowKeys.has(row.dataset.virtualRowKey ?? ""),
+          )
+        : [],
+    ) as TemplateResult;
   }
 
   scrollToEnd(options: { behavior?: ScrollBehavior } = {}): void {


### PR DESCRIPTION
Related: #110515

## What Problem This Solves

Fixes an issue where users leaving, replacing, or rerendering a Control UI MCP App view could have its iframe detached before the app acknowledged `ui/resource-teardown`. That could skip app cleanup during route changes, split-pane changes, virtualized transcript eviction, or explicit app teardown.

## Why This Change Was Made

The render owners now hold the outgoing subtree while each nested MCP App performs one bounded teardown, then commit the latest coalesced render. The component owns one resource generation, clears listeners/subscriptions exactly once, removes the iframe only after the teardown response or the named 250 ms timeout, and cannot let a stale teardown remove a replacement. Retained panes and rows stay mounted; only a torn-down view that survives the parent commit is restarted.

The change intentionally does not add a second host, detached-frame cache, compatibility shim, or unbounded render queue.

AI-assisted: yes. I reviewed the complete owner/caller/callee surface and the exact `@modelcontextprotocol/ext-apps@1.7.4` teardown contract, and addressed all accepted autoreview findings.

## User Impact

Control UI MCP Apps now receive their required teardown notification while still connected, including during rerender, view replacement, page changes, and explicit app teardown. Cleanup is bounded, replacement-safe, and does not reset the per-view prompt budget on remount. There is no visual change.

## Evidence

- `pnpm test ui/src/components/mcp-app-view.test.ts ui/src/components/mcp-app-unmount.test.ts ui/src/components/mcp-app-security.test.ts ui/src/app/router-outlet.test.ts ui/src/pages/chat/chat-page.test.ts ui/src/pages/chat/chat-thread.test.ts`: 159/159 passed on exact-head Testbox.
- `pnpm check:changed`: passed the `coreTests, ui` lanes, including formatting, core-test/UI typechecks, and full lint.
- `pnpm build`: passed, including the Control UI production build, sidecar verification, and performance budgets.
- `pnpm test:ui:e2e ui/src/e2e/mcp-app-conformance.e2e.test.ts`: real system Chromium passed. The conformance host observed the Control UI teardown response before iframe detachment; standalone teardown, reload, tool, and resource flows stayed green.
- Full exact-base proof: https://github.com/openclaw/openclaw/actions/runs/29669112533
- Post-commit focused/Chromium proof: https://github.com/openclaw/openclaw/actions/runs/29669621762
- Final post-rebase focused proof: https://github.com/openclaw/openclaw/actions/runs/29669698332
- Knip/deadcode fix plus 159 focused tests: https://github.com/openclaw/openclaw/actions/runs/29669886212
- Latest-main merge proof for deadcode plus 159 focused tests: https://github.com/openclaw/openclaw/actions/runs/29669956219
- Final exact-base retained-sibling gate proof: https://github.com/openclaw/openclaw/actions/runs/29670005514
- Fresh autoreview completed after the retained-sibling fix with no accepted or actionable findings.
