### PR TITLE
fix(agent): exit nonzero when gateway runs do not complete

### DIFF
--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -132,6 +132,7 @@ function createSignalProcess() {
   type SignalName = "SIGINT" | "SIGTERM";
   const listeners = new Map<SignalName, Set<() => void>>();
   const processLike = {
+    exitCode: undefined as NodeJS.Process["exitCode"],
     on(signal: SignalName, handler: () => void) {
       const current = listeners.get(signal) ?? new Set<() => void>();
       current.add(handler);

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -1581,23 +1581,58 @@ describe("agentCliCommand", () => {
     });
   });
 
-  it("logs non-ok gateway summaries when payloads are empty", async () => {
-    await withTempStore(async () => {
-      callGateway.mockResolvedValue({
-        runId: "idem-1",
-        status: "timeout",
-        summary: "aborted",
-        result: {
-          payloads: [],
-          meta: { aborted: true },
-        },
+  it.each(["timeout", "error", "cancelled"])(
+    "logs an empty-payload %s summary and marks the process unsuccessful",
+    async (status) => {
+      await withTempStore(async () => {
+        const signals = createSignalProcess();
+        callGateway.mockResolvedValue({
+          runId: "idem-1",
+          status,
+          summary: status,
+          result: {
+            payloads: [],
+            meta: { stopReason: status },
+          },
+        });
+
+        await agentCliCommand({ message: "hi", to: "+1555" }, runtime, {
+          process: signals.processLike,
+        });
+
+        expect(runtime.log).toHaveBeenCalledWith(status);
+        expect(runtime.exit).not.toHaveBeenCalled();
+        expect(signals.processLike.exitCode).toBe(1);
       });
+    },
+  );
 
-      await agentCliCommand({ message: "hi", to: "+1555" }, runtime);
+  it.each(["timeout", "error", "cancelled"])(
+    "writes a %s gateway result before exiting nonzero in JSON mode",
+    async (status) => {
+      await withTempStore(async () => {
+        const signals = createSignalProcess();
+        const response = {
+          runId: "idem-1",
+          status,
+          summary: status === "timeout" ? "aborted" : "failed",
+          result: {
+            payloads: [{ text: "Agent did not complete", isError: true }],
+            meta: { stopReason: status },
+          },
+        };
+        callGateway.mockResolvedValue(response);
 
-      expect(runtime.log).toHaveBeenCalledWith("aborted");
-    });
-  });
+        await agentCliCommand({ message: "hi", to: "+1555", json: true }, jsonRuntime, {
+          process: signals.processLike,
+        });
+
+        expect(jsonRuntime.writeJson).toHaveBeenCalledWith(response, 2);
+        expect(jsonRuntime.exit).not.toHaveBeenCalled();
+        expect(signals.processLike.exitCode).toBe(1);
+      });
+    },
+  );
 
   it("surfaces duplicate in-flight gateway runs without pretending a reply arrived", async () => {
     await withTempStore(async () => {

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -91,6 +91,7 @@ type AgentDispatchOpts = Omit<AgentCliOpts, "messageFile"> & {
 
 type AgentCliSignal = "SIGINT" | "SIGTERM";
 type AgentCliProcessLike = {
+  exitCode?: NodeJS.Process["exitCode"];
   on(signal: AgentCliSignal, handler: () => void): unknown;
   off(signal: AgentCliSignal, handler: () => void): unknown;
 };
@@ -441,6 +442,9 @@ function createAgentCliSignalBridge(processLike: AgentCliProcessLike = process) 
   return {
     signal: controller.signal,
     getReceivedSignal: () => receivedSignal,
+    setExitCode: (code: number) => {
+      processLike.exitCode = code;
+    },
     dispose: detachHandlers,
   };
 }
@@ -635,6 +639,20 @@ function isInFlightGatewayAgentResponse(response: GatewayAgentResponse): boolean
   return response.status === "in_flight";
 }
 
+function markFailedGatewayAgentResponse(
+  response: GatewayAgentResponse,
+  signalBridge: ReturnType<typeof createAgentCliSignalBridge>,
+): void {
+  if (
+    response.status === "timeout" ||
+    response.status === "error" ||
+    response.status === "cancelled"
+  ) {
+    // Let Node drain structured or text stdout before the process exits.
+    signalBridge.setExitCode(1);
+  }
+}
+
 function formatInFlightGatewayAgentMessage(response: GatewayAgentResponse): string {
   return response.runId
     ? `Agent run ${response.runId} is already in flight; not starting a duplicate run.`
@@ -813,6 +831,7 @@ async function agentViaGatewayCommand(
 
   if (opts.json) {
     writeRuntimeJson(runtime, buildGatewayJsonResponse(response));
+    markFailedGatewayAgentResponse(response, signalBridge);
     return response;
   }
 
@@ -828,6 +847,7 @@ async function agentViaGatewayCommand(
     if (response?.status !== "ok") {
       runtime.log(response?.summary ? response.summary : "No reply from agent.");
     }
+    markFailedGatewayAgentResponse(response, signalBridge);
     return response;
   }
 
@@ -837,6 +857,8 @@ async function agentViaGatewayCommand(
       runtime.log(out);
     }
   }
+
+  markFailedGatewayAgentResponse(response, signalBridge);
 
   return response;
 }

--- a/src/gateway/server-methods/agent-run-dispatch.ts
+++ b/src/gateway/server-methods/agent-run-dispatch.ts
@@ -23,6 +23,23 @@ import {
 } from "./agent-task-tracking.js";
 import type { GatewayRequestContext, GatewayRequestHandlerOptions } from "./types.js";
 
+function resolveResolvedAgentAbortStopReason(
+  meta: unknown,
+  signal: AbortSignal,
+): "restart" | "rpc" | "timeout" | undefined {
+  if (!signal.aborted) {
+    return undefined;
+  }
+  const record =
+    meta && typeof meta === "object" && !Array.isArray(meta)
+      ? (meta as Record<string, unknown>)
+      : undefined;
+  if (record?.aborted !== true && record?.stopReason !== "toolUse") {
+    return undefined;
+  }
+  return resolveGatewayAgentAbortStopReason(signal);
+}
+
 function isGatewayAbortSignalReason(reason: unknown): boolean {
   return reason === undefined || isAbortError(reason) || readErrorName(reason) === "TimeoutError";
 }
@@ -135,8 +152,16 @@ export function dispatchAgentRunFromGateway(params: {
     restoreAdmittedRecovery: params.restoreAdmittedRecovery,
   })
     .then(async (result) => {
-      const aborted = result?.meta?.aborted === true;
-      const stopReason = aborted ? (result?.meta?.stopReason ?? "rpc") : undefined;
+      const signalStopReason = resolveResolvedAgentAbortStopReason(
+        result?.meta,
+        params.abortController.signal,
+      );
+      const aborted = result?.meta?.aborted === true || signalStopReason !== undefined;
+      const stopReason = signalStopReason
+        ? signalStopReason
+        : aborted
+          ? (result?.meta?.stopReason ?? "rpc")
+          : undefined;
       const timeoutPhase = normalizeAgentRunTimeoutPhase(result?.meta?.timeoutPhase);
       const terminalOutcome = buildAgentRunTerminalOutcome({
         status:
@@ -146,7 +171,7 @@ export function dispatchAgentRunFromGateway(params: {
               ? "error"
               : "ok",
         error: result?.meta?.error,
-        stopReason: result?.meta?.stopReason,
+        stopReason: stopReason ?? result?.meta?.stopReason,
         livenessState: result?.meta?.livenessState,
         timeoutPhase,
         providerStarted: result?.meta?.providerStarted,

--- a/src/gateway/server-methods/agent-run-dispatch.ts
+++ b/src/gateway/server-methods/agent-run-dispatch.ts
@@ -23,10 +23,10 @@ import {
 } from "./agent-task-tracking.js";
 import type { GatewayRequestContext, GatewayRequestHandlerOptions } from "./types.js";
 
-function resolveResolvedAgentAbortStopReason(
+function resolveResolvedAgentTimeoutStopReason(
   meta: unknown,
   signal: AbortSignal,
-): "restart" | "rpc" | "timeout" | undefined {
+): "timeout" | undefined {
   if (!signal.aborted) {
     return undefined;
   }
@@ -37,7 +37,7 @@ function resolveResolvedAgentAbortStopReason(
   if (record?.aborted !== true && record?.stopReason !== "toolUse") {
     return undefined;
   }
-  return resolveGatewayAgentAbortStopReason(signal);
+  return resolveGatewayAgentAbortStopReason(signal) === "timeout" ? "timeout" : undefined;
 }
 
 function isGatewayAbortSignalReason(reason: unknown): boolean {
@@ -152,7 +152,7 @@ export function dispatchAgentRunFromGateway(params: {
     restoreAdmittedRecovery: params.restoreAdmittedRecovery,
   })
     .then(async (result) => {
-      const signalStopReason = resolveResolvedAgentAbortStopReason(
+      const signalStopReason = resolveResolvedAgentTimeoutStopReason(
         result?.meta,
         params.abortController.signal,
       );
@@ -176,30 +176,42 @@ export function dispatchAgentRunFromGateway(params: {
         timeoutPhase,
         providerStarted: result?.meta?.providerStarted,
       });
-      const responseTimedOut = aborted || terminalOutcome.status === "timeout";
+      const responseStatus = aborted ? "timeout" : terminalOutcome.status;
       if (taskTracked) {
         tryFinalizeTrackedAgentTask({
           runId: params.runId,
           status: aborted
             ? resolveAbortedAgentTaskStatus(stopReason)
-            : responseTimedOut
+            : responseStatus === "timeout"
               ? "timed_out"
-              : "succeeded",
-          terminalSummary: responseTimedOut ? "aborted" : "completed",
+              : responseStatus === "error"
+                ? "failed"
+                : "succeeded",
+          terminalSummary:
+            responseStatus === "timeout"
+              ? "aborted"
+              : responseStatus === "error"
+                ? "failed"
+                : "completed",
           log: params.context.logGateway,
         });
       }
       const payload = {
         runId: params.runId,
-        status: responseTimedOut ? ("timeout" as const) : ("ok" as const),
-        summary: responseTimedOut ? "aborted" : "completed",
-        ...(responseTimedOut && terminalOutcome.stopReason
+        status: responseStatus,
+        summary:
+          responseStatus === "timeout"
+            ? "aborted"
+            : responseStatus === "error"
+              ? "failed"
+              : "completed",
+        ...(responseStatus !== "ok" && terminalOutcome.stopReason
           ? { stopReason: terminalOutcome.stopReason }
           : {}),
-        ...(responseTimedOut && terminalOutcome.timeoutPhase
+        ...(responseStatus === "timeout" && terminalOutcome.timeoutPhase
           ? { timeoutPhase: terminalOutcome.timeoutPhase }
           : {}),
-        ...(responseTimedOut && terminalOutcome.providerStarted !== undefined
+        ...(responseStatus === "timeout" && terminalOutcome.providerStarted !== undefined
           ? { providerStarted: terminalOutcome.providerStarted }
           : {}),
         result,

--- a/src/gateway/server-methods/agent-run-dispatch.ts
+++ b/src/gateway/server-methods/agent-run-dispatch.ts
@@ -176,23 +176,30 @@ export function dispatchAgentRunFromGateway(params: {
         timeoutPhase,
         providerStarted: result?.meta?.providerStarted,
       });
+      const responseTimedOut = aborted || terminalOutcome.status === "timeout";
       if (taskTracked) {
         tryFinalizeTrackedAgentTask({
           runId: params.runId,
-          status: aborted ? resolveAbortedAgentTaskStatus(stopReason) : "succeeded",
-          terminalSummary: aborted ? "aborted" : "completed",
+          status: aborted
+            ? resolveAbortedAgentTaskStatus(stopReason)
+            : responseTimedOut
+              ? "timed_out"
+              : "succeeded",
+          terminalSummary: responseTimedOut ? "aborted" : "completed",
           log: params.context.logGateway,
         });
       }
       const payload = {
         runId: params.runId,
-        status: aborted ? ("timeout" as const) : ("ok" as const),
-        summary: aborted ? "aborted" : "completed",
-        ...(aborted ? { stopReason } : {}),
-        ...(aborted && terminalOutcome.timeoutPhase
+        status: responseTimedOut ? ("timeout" as const) : ("ok" as const),
+        summary: responseTimedOut ? "aborted" : "completed",
+        ...(responseTimedOut && terminalOutcome.stopReason
+          ? { stopReason: terminalOutcome.stopReason }
+          : {}),
+        ...(responseTimedOut && terminalOutcome.timeoutPhase
           ? { timeoutPhase: terminalOutcome.timeoutPhase }
           : {}),
-        ...(aborted && terminalOutcome.providerStarted !== undefined
+        ...(responseTimedOut && terminalOutcome.providerStarted !== undefined
           ? { providerStarted: terminalOutcome.providerStarted }
           : {}),
         result,

--- a/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
+++ b/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
@@ -467,6 +467,138 @@ describe("gateway agent handler", () => {
     });
   });
 
+  it("projects a nonterminal tool-use result past the explicit deadline as timed out", async () => {
+    const abortController = new AbortController();
+    const timeoutReason = new Error("chat run timed out");
+    timeoutReason.name = "TimeoutError";
+    mocks.agentCommand.mockImplementationOnce(async () => {
+      abortController.abort(timeoutReason);
+      return {
+        payloads: [{ text: "Exec failed", isError: true }],
+        meta: {
+          durationMs: 602_530,
+          aborted: false,
+          replayInvalid: true,
+          livenessState: "working",
+          stopReason: "toolUse",
+          completion: { stopReason: "toolUse", finishReason: "toolUse" },
+        },
+      };
+    });
+    const context = makeContext();
+    const respond = vi.fn();
+    const onSettled = vi.fn(() => true);
+
+    dispatchAgentRunFromGateway({
+      ingressOpts: {
+        message: "review the repository",
+        sessionKey: "agent:main:main",
+        timeout: "600",
+        allowModelOverride: false,
+      },
+      runId: "agent-run-tool-use-deadline",
+      dedupeKeys: ["agent:agent-run-tool-use-deadline"],
+      abortController,
+      cleanupAbortController: vi.fn(),
+      respond,
+      context,
+      taskTrackingMode: "none",
+      onSettled,
+    });
+
+    await waitForAssertion(() => {
+      expect(onSettled).toHaveBeenCalledWith({
+        terminalOutcome: expect.objectContaining({
+          status: "timeout",
+          stopReason: "timeout",
+        }),
+        onRecovered: expect.any(Function),
+      });
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({
+          runId: "agent-run-tool-use-deadline",
+          status: "timeout",
+          summary: "aborted",
+          stopReason: "timeout",
+        }),
+        undefined,
+        { runId: "agent-run-tool-use-deadline" },
+      );
+    });
+  });
+
+  it.each([
+    {
+      label: "tool use past the nominal deadline without an abort signal",
+      durationMs: 602_530,
+      stopReason: "toolUse",
+      timeout: "600",
+    },
+    {
+      label: "tool use before the deadline",
+      durationMs: 599_999,
+      stopReason: "toolUse",
+      timeout: "600",
+    },
+    {
+      label: "tool use with the deadline disabled",
+      durationMs: 602_530,
+      stopReason: "toolUse",
+      timeout: "0",
+    },
+    {
+      label: "final assistant reply after deadline cleanup",
+      durationMs: 602_530,
+      stopReason: "stop",
+      timeout: "600",
+      abortBeforeResolve: true,
+    },
+  ])(
+    "keeps $label successful",
+    async ({ durationMs, stopReason, timeout, abortBeforeResolve = false }) => {
+      const abortController = new AbortController();
+      mocks.agentCommand.mockImplementationOnce(async () => {
+        if (abortBeforeResolve) {
+          const reason = new Error("chat run timed out");
+          reason.name = "TimeoutError";
+          abortController.abort(reason);
+        }
+        return {
+          payloads: [{ text: "done" }],
+          meta: { durationMs, aborted: false, stopReason },
+        };
+      });
+      const context = makeContext();
+      const respond = vi.fn();
+
+      dispatchAgentRunFromGateway({
+        ingressOpts: {
+          message: "review the repository",
+          sessionKey: "agent:main:main",
+          timeout,
+          allowModelOverride: false,
+        },
+        runId: `agent-run-deadline-control-${stopReason}-${durationMs}`,
+        dedupeKeys: [`agent:deadline-control-${stopReason}-${durationMs}`],
+        abortController,
+        cleanupAbortController: vi.fn(),
+        respond,
+        context,
+        taskTrackingMode: "none",
+      });
+
+      await waitForAssertion(() => {
+        expect(respond).toHaveBeenCalledWith(
+          true,
+          expect.objectContaining({ status: "ok", summary: "completed" }),
+          undefined,
+          expect.any(Object),
+        );
+      });
+    },
+  );
+
   it("classifies RPC-aborted async gateway agent rejections as cancelled", async () => {
     await withTempDir({ prefix: "openclaw-gateway-agent-task-abort-error-" }, async (root) => {
       useTestStateDir(root);

--- a/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
+++ b/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
@@ -528,6 +528,68 @@ describe("gateway agent handler", () => {
     });
   });
 
+  it("projects a provider timeout result without an abort flag or stop reason as timed out", async () => {
+    mocks.agentCommand.mockResolvedValueOnce({
+      payloads: [{ text: "Request timed out before a response was generated.", isError: true }],
+      meta: {
+        durationMs: 30_454,
+        aborted: false,
+        replayInvalid: true,
+        livenessState: "working",
+        timeoutPhase: "provider",
+        providerStarted: true,
+        error: {
+          kind: "incomplete_turn",
+          message: "Request timed out before a response was generated.",
+        },
+      },
+    });
+    const context = makeContext();
+    const respond = vi.fn();
+    const onSettled = vi.fn(() => true);
+
+    dispatchAgentRunFromGateway({
+      ingressOpts: {
+        message: "run a command that exceeds the provider deadline",
+        sessionKey: "agent:main:main",
+        timeout: "10",
+        allowModelOverride: false,
+      },
+      runId: "agent-run-provider-timeout-result",
+      dedupeKeys: ["agent:agent-run-provider-timeout-result"],
+      abortController: new AbortController(),
+      cleanupAbortController: vi.fn(),
+      respond,
+      context,
+      taskTrackingMode: "none",
+      onSettled,
+    });
+
+    await waitForAssertion(() => {
+      expect(onSettled).toHaveBeenCalledWith({
+        terminalOutcome: expect.objectContaining({
+          status: "timeout",
+          reason: "hard_timeout",
+          timeoutPhase: "provider",
+          providerStarted: true,
+        }),
+        onRecovered: expect.any(Function),
+      });
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({
+          runId: "agent-run-provider-timeout-result",
+          status: "timeout",
+          summary: "aborted",
+          timeoutPhase: "provider",
+          providerStarted: true,
+        }),
+        undefined,
+        { runId: "agent-run-provider-timeout-result" },
+      );
+    });
+  });
+
   it.each([
     {
       label: "tool use past the nominal deadline without an abort signal",

--- a/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
+++ b/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
@@ -590,76 +590,146 @@ describe("gateway agent handler", () => {
     });
   });
 
+  it("projects a resolved agent error as a failed gateway response", async () => {
+    mocks.agentCommand.mockResolvedValueOnce({
+      payloads: [{ text: "Provider rejected the request.", isError: true }],
+      meta: {
+        error: "provider rejected the request",
+        stopReason: "error",
+      },
+    });
+    const context = makeContext();
+    const respond = vi.fn();
+    const onSettled = vi.fn(() => true);
+
+    dispatchAgentRunFromGateway({
+      ingressOpts: {
+        message: "run the agent",
+        sessionKey: "agent:main:main",
+        timeout: "600",
+        allowModelOverride: false,
+      },
+      runId: "agent-run-resolved-error",
+      dedupeKeys: ["agent:agent-run-resolved-error"],
+      abortController: new AbortController(),
+      cleanupAbortController: vi.fn(),
+      respond,
+      context,
+      taskTrackingMode: "none",
+      onSettled,
+    });
+
+    await waitForAssertion(() => {
+      expect(onSettled).toHaveBeenCalledWith({
+        terminalOutcome: expect.objectContaining({
+          status: "error",
+          reason: "failed",
+          stopReason: "error",
+        }),
+        onRecovered: expect.any(Function),
+      });
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({
+          runId: "agent-run-resolved-error",
+          status: "error",
+          summary: "failed",
+          stopReason: "error",
+        }),
+        undefined,
+        { runId: "agent-run-resolved-error" },
+      );
+    });
+  });
+
   it.each([
     {
       label: "tool use past the nominal deadline without an abort signal",
       durationMs: 602_530,
       stopReason: "toolUse",
       timeout: "600",
+      abortReason: undefined,
     },
     {
       label: "tool use before the deadline",
       durationMs: 599_999,
       stopReason: "toolUse",
       timeout: "600",
+      abortReason: undefined,
     },
     {
       label: "tool use with the deadline disabled",
       durationMs: 602_530,
       stopReason: "toolUse",
       timeout: "0",
+      abortReason: undefined,
     },
     {
       label: "final assistant reply after deadline cleanup",
       durationMs: 602_530,
       stopReason: "stop",
       timeout: "600",
-      abortBeforeResolve: true,
+      abortReason: "timeout" as const,
     },
-  ])(
-    "keeps $label successful",
-    async ({ durationMs, stopReason, timeout, abortBeforeResolve = false }) => {
-      const abortController = new AbortController();
-      mocks.agentCommand.mockImplementationOnce(async () => {
-        if (abortBeforeResolve) {
-          const reason = new Error("chat run timed out");
-          reason.name = "TimeoutError";
-          abortController.abort(reason);
-        }
-        return {
-          payloads: [{ text: "done" }],
-          meta: { durationMs, aborted: false, stopReason },
-        };
-      });
-      const context = makeContext();
-      const respond = vi.fn();
-
-      dispatchAgentRunFromGateway({
-        ingressOpts: {
-          message: "review the repository",
-          sessionKey: "agent:main:main",
-          timeout,
-          allowModelOverride: false,
-        },
-        runId: `agent-run-deadline-control-${stopReason}-${durationMs}`,
-        dedupeKeys: [`agent:deadline-control-${stopReason}-${durationMs}`],
-        abortController,
-        cleanupAbortController: vi.fn(),
-        respond,
-        context,
-        taskTrackingMode: "none",
-      });
-
-      await waitForAssertion(() => {
-        expect(respond).toHaveBeenCalledWith(
-          true,
-          expect.objectContaining({ status: "ok", summary: "completed" }),
-          undefined,
-          expect.any(Object),
-        );
-      });
+    {
+      label: "nonterminal tool use after RPC abort cleanup",
+      durationMs: 100,
+      stopReason: "toolUse",
+      timeout: "600",
+      abortReason: "rpc" as const,
     },
-  );
+    {
+      label: "nonterminal tool use after restart abort cleanup",
+      durationMs: 100,
+      stopReason: "toolUse",
+      timeout: "600",
+      abortReason: "restart" as const,
+    },
+  ])("keeps $label successful", async ({ durationMs, stopReason, timeout, abortReason }) => {
+    const abortController = new AbortController();
+    mocks.agentCommand.mockImplementationOnce(async () => {
+      if (abortReason === "timeout") {
+        const timeoutReason = new Error("chat run timed out");
+        timeoutReason.name = "TimeoutError";
+        abortController.abort(timeoutReason);
+      } else if (abortReason === "rpc") {
+        abortController.abort();
+      } else if (abortReason === "restart") {
+        abortController.abort(createAgentRunRestartAbortError());
+      }
+      return {
+        payloads: [{ text: "done" }],
+        meta: { durationMs, aborted: false, stopReason },
+      };
+    });
+    const context = makeContext();
+    const respond = vi.fn();
+
+    dispatchAgentRunFromGateway({
+      ingressOpts: {
+        message: "review the repository",
+        sessionKey: "agent:main:main",
+        timeout,
+        allowModelOverride: false,
+      },
+      runId: `agent-run-deadline-control-${stopReason}-${durationMs}`,
+      dedupeKeys: [`agent:deadline-control-${stopReason}-${durationMs}`],
+      abortController,
+      cleanupAbortController: vi.fn(),
+      respond,
+      context,
+      taskTrackingMode: "none",
+    });
+
+    await waitForAssertion(() => {
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({ status: "ok", summary: "completed" }),
+        undefined,
+        expect.any(Object),
+      );
+    });
+  });
 
   it("classifies RPC-aborted async gateway agent rejections as cancelled", async () => {
     await withTempDir({ prefix: "openclaw-gateway-agent-task-abort-error-" }, async (root) => {


### PR DESCRIPTION
Fixes #110946

## What Problem This Solves

`openclaw agent --json` could report `status: "ok"`, `summary: "completed"`, and exit code 0 after the agent had already reached a terminal provider timeout. The same success projection was possible for resolved agent errors.

This made shell scripts and CI jobs treat an incomplete agent run as successful even though the nested result contained structured failure evidence such as `timeoutPhase: "provider"`, `error.kind: "incomplete_turn"`, or `stopReason: "error"`.

## Why This Change Was Made

### Root Cause

The gateway already built a normalized terminal outcome, but its resolved-result response used a separate success/timeout decision. Those two classifications could disagree: the normalized outcome was terminal while the public gateway envelope still said `ok`.

The CLI also preserved the failed gateway response in stdout but did not make the process unsuccessful.

### What Changed

- Resolved gateway results now derive the response and tracked-task state from the normalized terminal outcome, including provider timeouts and resolved errors.
- The late nonterminal `toolUse` race is reclassified only when the actual abort signal carries a `TimeoutError`. Elapsed duration alone is not trusted, and RPC/restart cleanup is not newly treated as a deadline timeout.
- `timeout`, `error`, and `cancelled` gateway responses set `process.exitCode = 1` after text or JSON output is written, allowing stdout to drain completely.
- Successful, in-flight, disabled-timeout, and final `stop` results keep their existing behavior.

## User Impact

Automation can trust both parts of the contract:

- terminal gateway failures have a non-success status;
- the CLI exits nonzero without truncating structured output;
- valid slow completions and cleanup races remain successful.

The response schema is unchanged. This only corrects terminal status projection and process outcome.

Contributor contract intent: `cancelled` is intentionally nonzero alongside `timeout` and `error`, because a cancelled run is terminal but incomplete. Text or JSON is written before the exit code changes, so callers can still parse the complete terminal response. Maintainer acceptance of this compatibility choice remains required.

## Evidence

### Real-provider behavior

I ran feature commit `973da4ec` on an isolated loopback port with a temporary config, state directory, workspace, token, and session key. The gateway startup banner reported `973da4e`. Channels were disabled, delivery was not requested, and the existing gateway and user config were not modified. The runtime used the bundled Codex app-server with `openai/gpt-5.6-sol`.

The test prompt requested a local `sleep 30`, with a 10-second CLI deadline and no network, credential, file, or external-service access.

### Falsification run before the final classifier fix

The first implementation was not sufficient. The real gateway still returned:

```text
shell exit:        0
status:            ok
summary:           completed
durationMs:        30454
aborted:           false
replayInvalid:     true
livenessState:     working
timeoutPhase:      provider
providerStarted:   true
error.kind:        incomplete_turn
stderr:            empty
```

That run directly exposed the disagreement between the normalized terminal outcome and the public response.

### After-fix rerun

Feature commit `973da4ec` first passed a real-provider success control:

```text
shell exit:        0
status:            ok
summary:           completed
stopReason:        stop
payload:           LIVE_SUCCESS
durationMs:        19098
aborted:           false
stderr:            empty
```

The forced-timeout run on that same `973da4e` gateway then produced:

```text
shell exit:        1
status:            timeout
summary:           aborted
durationMs:        28593
aborted:           false
replayInvalid:     true
livenessState:     working
timeoutPhase:      provider
providerStarted:   true
error.kind:        incomplete_turn
payload count:     2
stderr:            empty
```

The full timeout JSON remained parseable on stdout. Both commands were run after the final implementation commits and rebase, not from an earlier candidate revision.

The live provider proof above is tied to feature commit `973da4ec`. The current PR head is `b75cfb62c` after a July 28 conflict refresh onto current `main`. The refresh retained main's canonical terminal-outcome normalization while preserving this PR's timeout, error, cancellation, output-drain, and tracked-task behavior. The feature-commit temporary gateway shut down cleanly, and the temporary directory containing copied config/auth state was removed after recording the redacted fields above.

Current-head static and hosted evidence is clean, but I am not claiming an equivalent live-provider rerun from `b75cfb62c`; that remains the contributor proof needed to raise the overall ClawSweeper rating.

## Validation

Node 24.15.0:

- Gateway method suite: 2 files, 508 passed.
- CLI gateway suite: 84 passed, 1 pre-existing skip.
- `pnpm tsgo:core` — passed.
- `pnpm tsgo:test:root` — passed.
- Type-aware `oxlint` and `oxfmt --check` for all four changed files — passed.
- `pnpm build` — passed, including CLI bootstrap, plugin SDK export, Control UI build, and performance-budget checks.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean on current head `b75cfb62c`, with 0 findings, patch correct at 0.89 confidence, and a clean secret scan.
- Exact current-head GitHub CI — 80 passed, 35 skipped, 0 failed, 0 cancelled, and 0 pending.

The regression coverage includes:

- the real provider-timeout result with no abort flag or stop reason;
- a late nonterminal `toolUse` result with a real timeout signal;
- resolved agent errors;
- text and JSON output for timeout, error, and cancellation;
- long runs without an abort signal;
- runs before the deadline and with timeouts disabled;
- RPC/restart cleanup controls;
- a final assistant `stop` after timeout cleanup.

A full local `pnpm check` attempt completed preflight, shrinkwrap validation, and core/test typechecks, then exceeded the 10-minute local wrapper budget during the final lint phase without diagnostics. The focused exact-head lint above passed; hosted CI is the authoritative full-matrix result.

AI-assisted: yes, with Codex. I reviewed the implementation and tests and understand the changes.


