### PR TITLE
fix(clawhub): decode promotions feed with fatal UTF-8 validation

### DIFF
--- a/src/infra/clawhub.promotions.test.ts
+++ b/src/infra/clawhub.promotions.test.ts
@@ -190,6 +190,22 @@ describe("fetchClawHubPromotionsFeed", () => {
     }
   });
 
+  it("rejects a promotions feed response with invalid UTF-8 bytes", async () => {
+    const feedJson = JSON.stringify(validFeed);
+    const pivot = feedJson.indexOf("Free Example");
+    mockHttp.intercept({
+      url: `${CLAWHUB_URL}/api/v1/feeds/promotions`,
+      reply: {
+        body: new Uint8Array([
+          ...new TextEncoder().encode(feedJson.slice(0, pivot)),
+          0xff,
+          ...new TextEncoder().encode(feedJson.slice(pivot)),
+        ]),
+      },
+    });
+    await expect(fetchClawHubPromotionsFeed()).rejects.toThrow(/not valid for encoding/);
+  });
+
   it("sends If-None-Match and maps 304 to not-modified", async () => {
     mockHttp.intercept({
       url: `${CLAWHUB_URL}/api/v1/feeds/promotions`,

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -1947,7 +1947,7 @@ export async function fetchClawHubPromotionsFeed(
     timeoutMs: params.timeoutMs,
     resourceLabel: "promotions feed",
   });
-  const payload = new TextDecoder().decode(buffer);
+  const payload = new TextDecoder("utf-8", { fatal: true }).decode(buffer);
   let parsedJson: unknown;
   try {
     parsedJson = JSON.parse(payload);


### PR DESCRIPTION
## Summary

Decode the ClawHub promotions feed with `TextDecoder("utf-8", { fatal: true })` so malformed UTF-8 bytes throw immediately, instead of silently becoming U+FFFD in a payload that is then written to the local cache and reused via etag revalidation.

## What Problem This Solves

`fetchClawHubPromotionsFeed` downloads the promotions feed (`/api/v1/feeds/promotions`) and returns both the parsed feed and the raw `payload` string. The caller (`maybeRefreshPromotionsFeed` in `src/infra/promotions-feed.ts`) persists that payload together with the response etag into the local state store, and later revalidates with `If-None-Match`.

- The body is decoded with a forgiving `TextDecoder` (default `fatal: false`), so invalid bytes are silently replaced with U+FFFD.
- When the corruption lands inside a JSON string value, `JSON.parse` still succeeds and the feed passes schema validation.
- The corrupted payload is written to the cache with the etag; subsequent `304 Not-Modified` revalidations keep reusing the corrupted snapshot — one transient corruption becomes permanently cached, and corrupted promotion text can surface to users.

**Code evidence**: at [clawhub.ts:1950](src/infra/clawhub.ts#L1950), `new TextDecoder().decode(buffer)` decodes the feed response without UTF-8 validation.

## Root Cause

- Per the WHATWG Encoding standard, `TextDecoder()` defaults to `fatal: false`, which substitutes U+FFFD for malformed sequences instead of throwing.
- Feed schema validation (`parseClawHubPromotionsFeed`) checks structure and field types, but operates on the already-decoded string, so it cannot detect byte-level corruption after U+FFFD substitution.
- Invariant violated: "feed response bytes are always valid UTF-8" — not guaranteed for bytes served through a CDN edge or proxy.

## Why This Fix

Add `{ fatal: true }` to the decoder:

- Invalid bytes now throw a `TypeError` before parsing and before the payload can be cached. The caller's established fail-silent catch treats it exactly like an offline or malformed response: cached state stays untouched (only the attempt timestamp advances), so a corrupted snapshot is never persisted and the next cadence retries cleanly.
- This is the same pattern already used for provider JSON bodies in `readProviderJsonResponse` ([provider-http-errors.ts:344](src/agents/provider-http-errors.ts#L344)).
- Alternative considered: validating the decoded payload for U+FFFD before caching — rejected, because U+FFFD can be legitimate content and post-hoc scanning cannot distinguish corruption from real data.

## User Impact

- **Before**: a corrupted feed response is cached with its etag and reused indefinitely; promotion text containing `�` can be shown to users until the etag changes upstream.
- **After**: the corrupted response is rejected before caching; the previous cached snapshot (if any) stays in effect and the next check retries the download.

## Evidence

- **Before** (upstream/main): `feed accepted, first entry title: "�Free Example models"` — **FAIL**: invalid UTF-8 byte silently became U+FFFD in the cached feed payload
- **After** (with fix): `feed rejected: The encoded data was not valid for encoding utf-8` — **PASS**: corrupted feed response rejected before caching

## Real Behavior Proof

Proof serves a promotions feed body containing a raw `0xFF` byte inside a promotion title from a real local HTTP server, then calls the real `fetchClawHubPromotionsFeed` against it via its `baseUrl` override.

### Before (on main)

```bash
$ node --import tsx proof.mjs
feed accepted, first entry title: "�Free Example models"
FAIL: invalid UTF-8 byte silently became U+FFFD in the cached feed payload
```

### After (with fix)

```bash
$ node --import tsx proof.mjs
feed rejected: The encoded data was not valid for encoding utf-8
PASS: corrupted feed response rejected before caching
```

## Tests and Validation

- `npx vitest run src/infra/clawhub.promotions.test.ts` — 21 passed (20 existing + 1 new)
- New regression test: `rejects a promotions feed response with invalid UTF-8 bytes`
- `tsgo:core` typecheck passed; `oxlint` and `oxfmt --check` clean on the changed files
