### PR TITLE
fix(nostr): setup keeps the selected account label

### DIFF
--- a/src/channels/plugins/setup-wizard.ts
+++ b/src/channels/plugins/setup-wizard.ts
@@ -267,11 +267,21 @@ export function buildChannelSetupWizardAdapterFromSetupWizard(params: {
             defaultAccountId,
           }));
 
-      const accountScope = createWizardAccountScope({
-        cfg,
-        channelKey: plugin.id,
-        accountId,
-      });
+      const channel = getChannelSection(cfg, plugin.id);
+      // Wizards that explicitly own account selection may use defaultAccount as a
+      // top-level routing label. Only inject temporary scope when generic selection
+      // owns the account or an accounts map proves that scoped storage is in use.
+      const shouldScopeAccount =
+        wizard.resolveShouldPromptAccountIds === undefined ||
+        resolvedShouldPromptAccountIds ||
+        channel.accounts !== undefined;
+      const accountScope = shouldScopeAccount
+        ? createWizardAccountScope({
+            cfg,
+            channelKey: plugin.id,
+            accountId,
+          })
+        : { cfg, restore: (currentCfg: OpenClawConfig) => currentCfg };
       let next = accountScope.cfg;
       let credentialValues = collectCredentialValues({
         wizard,


### PR DESCRIPTION
Closes #111130

AI-assisted maintainer fix.

## What Problem This Solves

Fixes an issue where Nostr users configuring a named account through the setup wizard would receive the selected account id from setup, but the saved configuration silently lost that account label.

## Why This Change Was Made

The generic wizard account scope now remains active for generic account selection and any established accounts map, while wizards that explicitly own account selection and still use top-level storage retain their own routing label. This preserves #110969's multi-account isolation without treating Nostr's persistent `defaultAccount` as temporary scope.

## User Impact

Nostr setup now saves the selected account label consistently, so later routing resolves the same account id that setup returned. Existing multi-account wizard defaults remain unchanged.

## Evidence

- Before: `node scripts/run-vitest.mjs extensions/nostr/src/channel.test.ts` failed `preserves the selected named account label during setup` with expected `work`, received `undefined`.
- After: `node scripts/run-vitest.mjs extensions/nostr/src/channel.test.ts src/channels/plugins/setup-wizard.test.ts` passes 2 files and 43 tests on the final rebased head.
- `node scripts/check-changed.mjs -- src/channels/plugins/setup-wizard.ts` passes core and extension production/test typechecks, formatting, lint, plugin boundaries, dependency guards, database-first guard, and runtime import-cycle checks: https://github.com/openclaw/openclaw/actions/runs/29669985476
- Final structured autoreview against `origin/main`: clean, no accepted/actionable findings.
