### PR TITLE
fix(scripts): startup fixture refresh no longer hangs on stalled benchmarks

### DIFF
--- a/scripts/bench-cli-startup.ts
+++ b/scripts/bench-cli-startup.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { expectDefined } from "../packages/normalization-core/src/expect.js";
 import { parseStrictIntegerOption } from "./lib/dev-tooling-safety.ts";
-import { signalExitCode, terminateManagedChild } from "./lib/managed-child-process.mjs";
+import { terminateManagedChild } from "./lib/managed-child-process.mjs";
 
 type CommandCase = {
   id: string;
@@ -110,61 +110,27 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_TIMEOUT_KILL_GRACE_MS = 1_000;
 const TIMEOUT_KILL_GRACE_MS = resolveTimeoutKillGraceMs(process.env);
 const PROCESS_GROUP_EXIT_POLL_MS = 25;
-const TERMINATION_SIGNALS: NodeJS.Signals[] =
-  process.platform === "win32"
-    ? ["SIGHUP", "SIGINT", "SIGTERM"]
-    : ["SIGHUP", "SIGINT", "SIGQUIT", "SIGTERM"];
+const BENCHMARK_BUDGET_MESSAGE_KIND = "openclaw-cli-startup-bench-budget";
 const ACTIVE_SAMPLE_MESSAGE_KIND = "openclaw-cli-startup-bench-active-sample";
 const CLEARED_SAMPLE_MESSAGE_KIND = "openclaw-cli-startup-bench-cleared-sample";
 const DEFAULT_ENTRY = "openclaw.mjs";
 const MAX_RSS_MARKER = "__OPENCLAW_MAX_RSS_KB__=";
-let activeSampleProcess: ReturnType<typeof spawn> | undefined;
-let requestedTerminationSignal: NodeJS.Signals | undefined;
 
-function notifySampleProcess(kind: string, pid: number | undefined): void {
-  if (!pid || typeof process.send !== "function") {
+function notifyParent(message: object): void {
+  if (typeof process.send !== "function") {
     return;
   }
   try {
-    process.send({ kind, pid }, () => {});
+    process.send(message, () => {});
   } catch {
     // The updater may close its IPC channel while force-terminating this driver.
   }
 }
 
-class BenchmarkTerminationError extends Error {
-  constructor(readonly signal: NodeJS.Signals) {
-    super(`CLI startup benchmark terminated by ${signal}`);
-    this.name = "BenchmarkTerminationError";
+function notifySampleProcess(kind: string, pid: number | undefined): void {
+  if (pid) {
+    notifyParent({ kind, pid });
   }
-}
-
-function throwIfTerminationRequested(): void {
-  if (requestedTerminationSignal) {
-    throw new BenchmarkTerminationError(requestedTerminationSignal);
-  }
-}
-
-function installTerminationHandlers(): () => void {
-  const handlers = new Map<NodeJS.Signals, () => void>();
-  for (const signal of TERMINATION_SIGNALS) {
-    const handler = () => {
-      requestedTerminationSignal ??= signal;
-      process.exitCode = signalExitCode(requestedTerminationSignal);
-      if (activeSampleProcess) {
-        // Samples run in their own process groups. Reap the active group before
-        // the updater's force-kill grace expires, or the CLI can outlive its driver.
-        terminateManagedChild(activeSampleProcess, "SIGKILL");
-      }
-    };
-    handlers.set(signal, handler);
-    process.on(signal, handler);
-  }
-  return () => {
-    for (const [signal, handler] of handlers) {
-      process.off(signal, handler);
-    }
-  };
 }
 
 function resolveTimeoutKillGraceMs(env: NodeJS.ProcessEnv): number {
@@ -820,7 +786,6 @@ async function runSample(params: {
         },
         stdio: ["ignore", "pipe", "pipe"],
       });
-      activeSampleProcess = proc;
       notifySampleProcess(ACTIVE_SAMPLE_MESSAGE_KIND, proc.pid);
 
       const finish = (sample: Omit<Sample, "ms" | "firstOutputMs" | "maxRssMb">) => {
@@ -831,9 +796,6 @@ async function runSample(params: {
         if (forceKillTimer) {
           clearTimeout(forceKillTimer);
           forceKillTimer = null;
-        }
-        if (activeSampleProcess === proc) {
-          activeSampleProcess = undefined;
         }
         notifySampleProcess(CLEARED_SAMPLE_MESSAGE_KIND, proc.pid);
         const ms = Number(process.hrtime.bigint() - started) / 1e6;
@@ -897,10 +859,7 @@ async function runSample(params: {
                   stderrTail: tailLines(stderr, 20),
                 }),
           });
-        if (
-          (timedOut || requestedTerminationSignal) &&
-          isSampleProcessGroupAlive(proc, useProcessGroup)
-        ) {
+        if (timedOut && isSampleProcessGroupAlive(proc, useProcessGroup)) {
           void finishAfterTimeoutCleanup({
             complete,
             forceKillAt,
@@ -986,9 +945,7 @@ async function runCase(params: {
   const samples: Sample[] = [];
   const totalRuns = params.warmup + params.runs;
   for (let i = 0; i < totalRuns; i += 1) {
-    throwIfTerminationRequested();
     const sample = await runSample(params);
-    throwIfTerminationRequested();
     if (i < params.warmup) {
       continue;
     }
@@ -1266,6 +1223,16 @@ async function main(): Promise<void> {
     printDelta(baseline, candidate);
     return;
   }
+  const suiteCount = options.entrySecondary ? 2 : 1;
+  const timeoutMs =
+    options.cases.length *
+    suiteCount *
+    (options.runs + options.warmup) *
+    (options.timeoutMs + 2 * TIMEOUT_KILL_GRACE_MS);
+  if (!Number.isSafeInteger(timeoutMs)) {
+    throw new Error("CLI startup benchmark total timeout exceeds the safe integer range");
+  }
+  notifyParent({ kind: BENCHMARK_BUDGET_MESSAGE_KIND, timeoutMs });
   const tmpDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-bench-"));
   const rssHookPath = buildRssHook(tmpDir);
   try {
@@ -1357,15 +1324,8 @@ export const testing = {
 };
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
-  const removeTerminationHandlers = installTerminationHandlers();
-  try {
-    await main();
-  } catch (error: unknown) {
-    if (!(error instanceof BenchmarkTerminationError)) {
-      console.error(error instanceof Error ? error.message : String(error));
-      process.exitCode = 1;
-    }
-  } finally {
-    removeTerminationHandlers();
-  }
+  await main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
 }

--- a/scripts/bench-cli-startup.ts
+++ b/scripts/bench-cli-startup.ts
@@ -110,7 +110,10 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_TIMEOUT_KILL_GRACE_MS = 1_000;
 const TIMEOUT_KILL_GRACE_MS = resolveTimeoutKillGraceMs(process.env);
 const PROCESS_GROUP_EXIT_POLL_MS = 25;
-const TERMINATION_SIGNALS = ["SIGHUP", "SIGINT", "SIGTERM"] as const;
+const TERMINATION_SIGNALS: NodeJS.Signals[] =
+  process.platform === "win32"
+    ? ["SIGHUP", "SIGINT", "SIGTERM"]
+    : ["SIGHUP", "SIGINT", "SIGQUIT", "SIGTERM"];
 const ACTIVE_SAMPLE_MESSAGE_KIND = "openclaw-cli-startup-bench-active-sample";
 const CLEARED_SAMPLE_MESSAGE_KIND = "openclaw-cli-startup-bench-cleared-sample";
 const DEFAULT_ENTRY = "openclaw.mjs";

--- a/scripts/bench-cli-startup.ts
+++ b/scripts/bench-cli-startup.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { expectDefined } from "../packages/normalization-core/src/expect.js";
 import { parseStrictIntegerOption } from "./lib/dev-tooling-safety.ts";
+import { signalExitCode, terminateManagedChild } from "./lib/managed-child-process.mjs";
 
 type CommandCase = {
   id: string;
@@ -109,8 +110,46 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_TIMEOUT_KILL_GRACE_MS = 1_000;
 const TIMEOUT_KILL_GRACE_MS = resolveTimeoutKillGraceMs(process.env);
 const PROCESS_GROUP_EXIT_POLL_MS = 25;
+const TERMINATION_SIGNALS = ["SIGHUP", "SIGINT", "SIGTERM"] as const;
 const DEFAULT_ENTRY = "openclaw.mjs";
 const MAX_RSS_MARKER = "__OPENCLAW_MAX_RSS_KB__=";
+let activeSampleProcess: ReturnType<typeof spawn> | undefined;
+let requestedTerminationSignal: NodeJS.Signals | undefined;
+
+class BenchmarkTerminationError extends Error {
+  constructor(readonly signal: NodeJS.Signals) {
+    super(`CLI startup benchmark terminated by ${signal}`);
+    this.name = "BenchmarkTerminationError";
+  }
+}
+
+function throwIfTerminationRequested(): void {
+  if (requestedTerminationSignal) {
+    throw new BenchmarkTerminationError(requestedTerminationSignal);
+  }
+}
+
+function installTerminationHandlers(): () => void {
+  const handlers = new Map<NodeJS.Signals, () => void>();
+  for (const signal of TERMINATION_SIGNALS) {
+    const handler = () => {
+      requestedTerminationSignal ??= signal;
+      process.exitCode = signalExitCode(requestedTerminationSignal);
+      if (activeSampleProcess) {
+        // Samples run in their own process groups. Reap the active group before
+        // the updater's force-kill grace expires, or the CLI can outlive its driver.
+        terminateManagedChild(activeSampleProcess, "SIGKILL");
+      }
+    };
+    handlers.set(signal, handler);
+    process.on(signal, handler);
+  }
+  return () => {
+    for (const [signal, handler] of handlers) {
+      process.off(signal, handler);
+    }
+  };
+}
 
 function resolveTimeoutKillGraceMs(env: NodeJS.ProcessEnv): number {
   const raw = env.VITEST ? env.OPENCLAW_TEST_CLI_STARTUP_TIMEOUT_KILL_GRACE_MS : undefined;
@@ -765,6 +804,7 @@ async function runSample(params: {
         },
         stdio: ["ignore", "pipe", "pipe"],
       });
+      activeSampleProcess = proc;
 
       const finish = (sample: Omit<Sample, "ms" | "firstOutputMs" | "maxRssMb">) => {
         if (settled) {
@@ -774,6 +814,9 @@ async function runSample(params: {
         if (forceKillTimer) {
           clearTimeout(forceKillTimer);
           forceKillTimer = null;
+        }
+        if (activeSampleProcess === proc) {
+          activeSampleProcess = undefined;
         }
         const ms = Number(process.hrtime.bigint() - started) / 1e6;
         resolve({
@@ -793,10 +836,10 @@ async function runSample(params: {
 
       const timeout = setTimeout(() => {
         timedOut = true;
-        signalSampleProcess(proc, "SIGTERM", useProcessGroup);
+        signalSampleProcess(proc, "SIGTERM");
         forceKillAt = Date.now() + TIMEOUT_KILL_GRACE_MS;
         forceKillTimer = setTimeout(() => {
-          signalSampleProcess(proc, "SIGKILL", useProcessGroup);
+          signalSampleProcess(proc, "SIGKILL");
         }, TIMEOUT_KILL_GRACE_MS).unref?.();
       }, params.timeoutMs);
       timeout.unref?.();
@@ -836,7 +879,10 @@ async function runSample(params: {
                   stderrTail: tailLines(stderr, 20),
                 }),
           });
-        if (timedOut && isSampleProcessGroupAlive(proc, useProcessGroup)) {
+        if (
+          (timedOut || requestedTerminationSignal) &&
+          isSampleProcessGroupAlive(proc, useProcessGroup)
+        ) {
           void finishAfterTimeoutCleanup({
             complete,
             forceKillAt,
@@ -867,32 +913,14 @@ async function finishAfterTimeoutCleanup(params: {
     await waitForSampleProcessGroupExit(params.proc, params.useProcessGroup, graceRemainingMs);
   }
   if (isSampleProcessGroupAlive(params.proc, params.useProcessGroup)) {
-    signalSampleProcess(params.proc, "SIGKILL", params.useProcessGroup);
+    signalSampleProcess(params.proc, "SIGKILL");
   }
   await waitForSampleProcessGroupExit(params.proc, params.useProcessGroup, TIMEOUT_KILL_GRACE_MS);
   params.complete();
 }
 
-function signalSampleProcess(
-  proc: ReturnType<typeof spawn>,
-  signal: NodeJS.Signals,
-  useProcessGroup: boolean,
-): void {
-  if (!proc.pid) {
-    return;
-  }
-  try {
-    if (useProcessGroup) {
-      process.kill(-proc.pid, signal);
-    } else {
-      proc.kill(signal);
-    }
-  } catch (error) {
-    const code = (error as NodeJS.ErrnoException | undefined)?.code;
-    if (code !== "ESRCH" && code !== "EPERM") {
-      throw error;
-    }
-  }
+function signalSampleProcess(proc: ReturnType<typeof spawn>, signal: NodeJS.Signals): void {
+  terminateManagedChild(proc, signal);
 }
 
 function isSampleProcessGroupAlive(
@@ -940,7 +968,9 @@ async function runCase(params: {
   const samples: Sample[] = [];
   const totalRuns = params.warmup + params.runs;
   for (let i = 0; i < totalRuns; i += 1) {
+    throwIfTerminationRequested();
     const sample = await runSample(params);
+    throwIfTerminationRequested();
     if (i < params.warmup) {
       continue;
     }
@@ -1309,8 +1339,15 @@ export const testing = {
 };
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
-  await main().catch((error: unknown) => {
-    console.error(error instanceof Error ? error.message : String(error));
-    process.exit(1);
-  });
+  const removeTerminationHandlers = installTerminationHandlers();
+  try {
+    await main();
+  } catch (error: unknown) {
+    if (!(error instanceof BenchmarkTerminationError)) {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exitCode = 1;
+    }
+  } finally {
+    removeTerminationHandlers();
+  }
 }

--- a/scripts/bench-cli-startup.ts
+++ b/scripts/bench-cli-startup.ts
@@ -111,10 +111,23 @@ const DEFAULT_TIMEOUT_KILL_GRACE_MS = 1_000;
 const TIMEOUT_KILL_GRACE_MS = resolveTimeoutKillGraceMs(process.env);
 const PROCESS_GROUP_EXIT_POLL_MS = 25;
 const TERMINATION_SIGNALS = ["SIGHUP", "SIGINT", "SIGTERM"] as const;
+const ACTIVE_SAMPLE_MESSAGE_KIND = "openclaw-cli-startup-bench-active-sample";
+const CLEARED_SAMPLE_MESSAGE_KIND = "openclaw-cli-startup-bench-cleared-sample";
 const DEFAULT_ENTRY = "openclaw.mjs";
 const MAX_RSS_MARKER = "__OPENCLAW_MAX_RSS_KB__=";
 let activeSampleProcess: ReturnType<typeof spawn> | undefined;
 let requestedTerminationSignal: NodeJS.Signals | undefined;
+
+function notifySampleProcess(kind: string, pid: number | undefined): void {
+  if (!pid || typeof process.send !== "function") {
+    return;
+  }
+  try {
+    process.send({ kind, pid }, () => {});
+  } catch {
+    // The updater may close its IPC channel while force-terminating this driver.
+  }
+}
 
 class BenchmarkTerminationError extends Error {
   constructor(readonly signal: NodeJS.Signals) {
@@ -805,6 +818,7 @@ async function runSample(params: {
         stdio: ["ignore", "pipe", "pipe"],
       });
       activeSampleProcess = proc;
+      notifySampleProcess(ACTIVE_SAMPLE_MESSAGE_KIND, proc.pid);
 
       const finish = (sample: Omit<Sample, "ms" | "firstOutputMs" | "maxRssMb">) => {
         if (settled) {
@@ -818,6 +832,7 @@ async function runSample(params: {
         if (activeSampleProcess === proc) {
           activeSampleProcess = undefined;
         }
+        notifySampleProcess(CLEARED_SAMPLE_MESSAGE_KIND, proc.pid);
         const ms = Number(process.hrtime.bigint() - started) / 1e6;
         resolve({
           ms,

--- a/scripts/test-update-cli-startup-bench.mjs
+++ b/scripts/test-update-cli-startup-bench.mjs
@@ -18,22 +18,15 @@ import { parseFlagArgs, stringFlag, intFlag } from "./lib/arg-utils.mjs";
 import { signalExitCode, terminateManagedChild } from "./lib/managed-child-process.mjs";
 
 const CLI_STARTUP_BENCH_FIXTURE_PATH = "test/fixtures/cli-startup-bench.json";
-const DEFAULT_BENCHMARK_TIMEOUT_KILL_GRACE_MS = 1_000;
+const DEFAULT_BENCHMARK_STARTUP_TIMEOUT_MS = 30_000;
 const DEFAULT_BENCHMARK_PROCESS_CLEANUP_GRACE_MS = 5_000;
 const FORWARDED_SIGNALS =
   process.platform === "win32"
     ? ["SIGHUP", "SIGINT", "SIGTERM"]
     : ["SIGHUP", "SIGINT", "SIGQUIT", "SIGTERM"];
+const BENCHMARK_BUDGET_MESSAGE_KIND = "openclaw-cli-startup-bench-budget";
 const ACTIVE_SAMPLE_MESSAGE_KIND = "openclaw-cli-startup-bench-active-sample";
 const CLEARED_SAMPLE_MESSAGE_KIND = "openclaw-cli-startup-bench-cleared-sample";
-// A timed-out sample can spend one grace before SIGKILL and another reaping its process group.
-// Keep these preset counts aligned with COMMAND_CASES or a valid fixture run can be cut short.
-const BENCHMARK_TIMEOUT_CLEANUP_WINDOWS = 2;
-const BENCHMARK_CASE_COUNTS = {
-  startup: 6,
-  real: 14,
-  all: 43,
-};
 
 function resolveTestDurationMs(envName, fallback) {
   const raw = process.env.VITEST ? process.env[envName] : undefined;
@@ -42,25 +35,6 @@ function resolveTestDurationMs(envName, fallback) {
   }
   const parsed = Number(raw);
   return Number.isSafeInteger(parsed) ? parsed : fallback;
-}
-
-function resolveBenchmarkProcessTimeoutMs(opts) {
-  const caseCount = BENCHMARK_CASE_COUNTS[opts.preset] ?? BENCHMARK_CASE_COUNTS.all;
-  const timeoutKillGraceMs = resolveTestDurationMs(
-    "OPENCLAW_TEST_CLI_STARTUP_TIMEOUT_KILL_GRACE_MS",
-    DEFAULT_BENCHMARK_TIMEOUT_KILL_GRACE_MS,
-  );
-  const processCleanupGraceMs = resolveTestDurationMs(
-    "OPENCLAW_TEST_CLI_STARTUP_BENCH_PROCESS_CLEANUP_GRACE_MS",
-    DEFAULT_BENCHMARK_PROCESS_CLEANUP_GRACE_MS,
-  );
-  const totalRuns = opts.runs + opts.warmup;
-  const perRunBudgetMs = opts.timeoutMs + BENCHMARK_TIMEOUT_CLEANUP_WINDOWS * timeoutKillGraceMs;
-  const totalTimeoutMs = caseCount * totalRuns * perRunBudgetMs + processCleanupGraceMs;
-  if (!Number.isSafeInteger(totalTimeoutMs)) {
-    throw new Error("CLI startup benchmark total timeout exceeds the safe integer range");
-  }
-  return totalTimeoutMs;
 }
 
 function resolveTemporaryOutputPath(outputPath) {
@@ -142,8 +116,11 @@ function publishBenchmarkOutput(temporaryOutputPath, outputDestination) {
   renameSync(temporaryOutputPath, outputDestination.path);
 }
 
-async function runBenchmarkDriver(args, opts) {
-  const timeoutMs = resolveBenchmarkProcessTimeoutMs(opts);
+async function runBenchmarkDriver(args) {
+  const startupTimeoutMs = resolveTestDurationMs(
+    "OPENCLAW_TEST_CLI_STARTUP_BENCH_STARTUP_TIMEOUT_MS",
+    DEFAULT_BENCHMARK_STARTUP_TIMEOUT_MS,
+  );
   const terminationGraceMs = resolveTestDurationMs(
     "OPENCLAW_TEST_CLI_STARTUP_BENCH_PROCESS_CLEANUP_GRACE_MS",
     DEFAULT_BENCHMARK_PROCESS_CLEANUP_GRACE_MS,
@@ -162,9 +139,21 @@ async function runBenchmarkDriver(args, opts) {
     let forceKillTimer;
     let forceKillSettleTimer;
     let activeSamplePid;
+    let deadlineTimer;
     const signalHandlers = new Map();
     const onMessage = (message) => {
       if (
+        message?.kind === BENCHMARK_BUDGET_MESSAGE_KIND &&
+        Number.isSafeInteger(message.timeoutMs) &&
+        message.timeoutMs > 0 &&
+        !timedOut &&
+        !receivedSignal
+      ) {
+        const totalTimeoutMs = message.timeoutMs + terminationGraceMs;
+        if (Number.isSafeInteger(totalTimeoutMs)) {
+          scheduleDeadline(totalTimeoutMs);
+        }
+      } else if (
         message?.kind === ACTIVE_SAMPLE_MESSAGE_KIND &&
         Number.isSafeInteger(message.pid) &&
         message.pid > 1
@@ -247,6 +236,15 @@ async function runBenchmarkDriver(args, opts) {
         forceKillDriver();
       }, terminationGraceMs);
     };
+    const scheduleDeadline = (timeoutMs) => {
+      clearTimeout(deadlineTimer);
+      deadlineTimer = setTimeout(() => {
+        timedOut = true;
+        // The driver owns detached sample groups, so let it reap them before the
+        // bounded force-kill fallback restores control to this updater.
+        terminateDriver("SIGTERM");
+      }, timeoutMs);
+    };
     for (const signal of FORWARDED_SIGNALS) {
       const handler = () => {
         receivedSignal ??= signal;
@@ -255,12 +253,7 @@ async function runBenchmarkDriver(args, opts) {
       signalHandlers.set(signal, handler);
       process.on(signal, handler);
     }
-    const deadlineTimer = setTimeout(() => {
-      timedOut = true;
-      // The driver owns detached sample groups, so let it reap them before the
-      // bounded force-kill fallback restores control to this updater.
-      terminateDriver("SIGTERM");
-    }, timeoutMs);
+    scheduleDeadline(startupTimeoutMs);
 
     const onError = () => finish(null, null);
     const onClose = (status, signal) => {
@@ -340,7 +333,7 @@ const args = [
 ];
 
 try {
-  const run = await runBenchmarkDriver(args, opts);
+  const run = await runBenchmarkDriver(args);
 
   if (run.status !== 0 || run.timedOut || run.receivedSignal) {
     process.exitCode = run.timedOut

--- a/scripts/test-update-cli-startup-bench.mjs
+++ b/scripts/test-update-cli-startup-bench.mjs
@@ -248,6 +248,7 @@ async function runBenchmarkDriver(args) {
     for (const signal of FORWARDED_SIGNALS) {
       const handler = () => {
         receivedSignal ??= signal;
+        clearTimeout(deadlineTimer);
         terminateDriver(signal);
       };
       signalHandlers.set(signal, handler);

--- a/scripts/test-update-cli-startup-bench.mjs
+++ b/scripts/test-update-cli-startup-bench.mjs
@@ -9,6 +9,8 @@ const CLI_STARTUP_BENCH_FIXTURE_PATH = "test/fixtures/cli-startup-bench.json";
 const DEFAULT_BENCHMARK_TIMEOUT_KILL_GRACE_MS = 1_000;
 const DEFAULT_BENCHMARK_PROCESS_CLEANUP_GRACE_MS = 5_000;
 const FORWARDED_SIGNALS = ["SIGHUP", "SIGINT", "SIGTERM"];
+const ACTIVE_SAMPLE_MESSAGE_KIND = "openclaw-cli-startup-bench-active-sample";
+const CLEARED_SAMPLE_MESSAGE_KIND = "openclaw-cli-startup-bench-cleared-sample";
 // A timed-out sample can spend one grace before SIGKILL and another reaping its process group.
 // Keep these preset counts aligned with COMMAND_CASES or a valid fixture run can be cut short.
 const BENCHMARK_TIMEOUT_CLEANUP_WINDOWS = 2;
@@ -59,7 +61,7 @@ async function runBenchmarkDriver(args, opts) {
   );
   const child = spawn(process.execPath, args, {
     cwd: process.cwd(),
-    stdio: "inherit",
+    stdio: ["inherit", "inherit", "inherit", "ipc"],
     env: process.env,
     detached: process.platform !== "win32",
   });
@@ -69,8 +71,41 @@ async function runBenchmarkDriver(args, opts) {
     let timedOut = false;
     let receivedSignal;
     let forceKillTimer;
+    let forceKillSettleTimer;
+    let activeSamplePid;
     const signalHandlers = new Map();
-    const finish = (status, signal) => {
+    const onMessage = (message) => {
+      if (
+        message?.kind === ACTIVE_SAMPLE_MESSAGE_KIND &&
+        Number.isSafeInteger(message.pid) &&
+        message.pid > 1
+      ) {
+        activeSamplePid = message.pid;
+      } else if (message?.kind === CLEARED_SAMPLE_MESSAGE_KIND && message.pid === activeSamplePid) {
+        activeSamplePid = undefined;
+      }
+    };
+    const terminateActiveSample = () => {
+      if (!activeSamplePid) {
+        return;
+      }
+      const pid = activeSamplePid;
+      activeSamplePid = undefined;
+      terminateManagedChild(
+        {
+          pid,
+          kill: (signal) => {
+            try {
+              return process.kill(pid, signal);
+            } catch {
+              return false;
+            }
+          },
+        },
+        "SIGKILL",
+      );
+    };
+    const finish = (status, signal, abandonChild = false) => {
       if (settled) {
         return;
       }
@@ -79,19 +114,48 @@ async function runBenchmarkDriver(args, opts) {
       if (forceKillTimer) {
         clearTimeout(forceKillTimer);
       }
+      if (forceKillSettleTimer) {
+        clearTimeout(forceKillSettleTimer);
+      }
       for (const [forwardedSignal, handler] of signalHandlers) {
         process.off(forwardedSignal, handler);
       }
+      child.off("error", onError);
+      child.off("close", onClose);
+      child.off("message", onMessage);
+      if (abandonChild) {
+        try {
+          if (child.connected) {
+            child.disconnect();
+          }
+        } catch {
+          // The child may close its IPC channel while the settle deadline fires.
+        }
+        child.unref();
+      }
       resolve({ receivedSignal, signal, status, timedOut });
+    };
+    const forceKillDriver = () => {
+      terminateActiveSample();
+      terminateManagedChild(child, "SIGKILL");
+      forceKillSettleTimer ??= setTimeout(() => {
+        // Signal delivery does not prove process exit. Drop the final parent
+        // references so even an uninterruptible child cannot hang this updater.
+        terminateActiveSample();
+        finish(null, null, true);
+      }, terminationGraceMs);
     };
     const terminateDriver = (signal) => {
       terminateManagedChild(child, signal);
       if (forceKillTimer) {
-        terminateManagedChild(child, "SIGKILL");
+        clearTimeout(forceKillTimer);
+        forceKillTimer = undefined;
+        forceKillDriver();
         return;
       }
       forceKillTimer = setTimeout(() => {
-        terminateManagedChild(child, "SIGKILL");
+        forceKillTimer = undefined;
+        forceKillDriver();
       }, terminationGraceMs);
     };
     for (const signal of FORWARDED_SIGNALS) {
@@ -109,8 +173,16 @@ async function runBenchmarkDriver(args, opts) {
       terminateDriver("SIGTERM");
     }, timeoutMs);
 
-    child.once("error", () => finish(null, null));
-    child.once("close", (status, signal) => finish(status, signal));
+    const onError = () => finish(null, null);
+    const onClose = (status, signal) => {
+      if (timedOut || receivedSignal) {
+        terminateActiveSample();
+      }
+      finish(status, signal);
+    };
+    child.once("error", onError);
+    child.once("close", onClose);
+    child.on("message", onMessage);
   });
 }
 

--- a/scripts/test-update-cli-startup-bench.mjs
+++ b/scripts/test-update-cli-startup-bench.mjs
@@ -2,7 +2,9 @@
 import { spawn } from "node:child_process";
 import {
   closeSync,
+  constants as fsConstants,
   lstatSync,
+  mkdtempSync,
   openSync,
   readFileSync,
   readlinkSync,
@@ -10,6 +12,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { parseFlagArgs, stringFlag, intFlag } from "./lib/arg-utils.mjs";
 import { signalExitCode, terminateManagedChild } from "./lib/managed-child-process.mjs";
@@ -65,6 +68,22 @@ function resolveTemporaryOutputPath(outputPath) {
   return path.join(parsed.dir, `.${parsed.base}.tmp-${process.pid}`);
 }
 
+function prepareTemporaryOutput(outputDestination) {
+  if (outputDestination.exists) {
+    const directory = mkdtempSync(path.join(tmpdir(), "openclaw-cli-startup-bench-"));
+    return {
+      cleanup: () => rmSync(directory, { force: true, recursive: true }),
+      path: path.join(directory, path.basename(outputDestination.path)),
+    };
+  }
+  const temporaryOutputPath = resolveTemporaryOutputPath(outputDestination.path);
+  rmSync(temporaryOutputPath, { force: true });
+  return {
+    cleanup: () => rmSync(temporaryOutputPath, { force: true }),
+    path: temporaryOutputPath,
+  };
+}
+
 // Direct benchmark writes followed output symlinks and retained target metadata.
 // Resolve that same destination for staging, but never rename over a special file.
 function resolveOutputDestination(outputPath) {
@@ -98,7 +117,7 @@ function resolveOutputDestination(outputPath) {
       // Successful publication writes this inode in place, preserving links and metadata.
       let handle;
       try {
-        handle = openSync(destinationPath, "r+");
+        handle = openSync(destinationPath, fsConstants.O_WRONLY);
       } catch (error) {
         throw new Error(`CLI startup benchmark output is not writable: ${destinationPath}`, {
           cause: error,
@@ -245,9 +264,9 @@ async function runBenchmarkDriver(args, opts) {
 
     const onError = () => finish(null, null);
     const onClose = (status, signal) => {
-      if (timedOut || receivedSignal) {
-        terminateActiveSample();
-      }
+      // Any still-reported sample outlived the driver cleanup path, regardless
+      // of whether the driver timed out, was interrupted, or crashed independently.
+      terminateActiveSample();
       finish(status, signal);
     };
     child.once("error", onError);
@@ -300,7 +319,8 @@ const opts = parseFlagArgs(
 );
 
 const outputDestination = resolveOutputDestination(opts.out);
-const temporaryOutputPath = resolveTemporaryOutputPath(outputDestination.path);
+const temporaryOutput = prepareTemporaryOutput(outputDestination);
+const temporaryOutputPath = temporaryOutput.path;
 const args = [
   "--import",
   "tsx",
@@ -319,9 +339,6 @@ const args = [
   temporaryOutputPath,
 ];
 
-// Publish only a completed report; a timed-out driver may have already written
-// its output before stalling in reporting or final cleanup.
-rmSync(temporaryOutputPath, { force: true });
 try {
   const run = await runBenchmarkDriver(args, opts);
 
@@ -336,5 +353,5 @@ try {
     console.log(`[test-update-cli-startup-bench] wrote fixture to ${opts.out}`);
   }
 } finally {
-  rmSync(temporaryOutputPath, { force: true });
+  temporaryOutput.cleanup();
 }

--- a/scripts/test-update-cli-startup-bench.mjs
+++ b/scripts/test-update-cli-startup-bench.mjs
@@ -1,6 +1,6 @@
 // Refreshes the checked-in CLI startup benchmark fixture.
 import { spawn } from "node:child_process";
-import { renameSync, rmSync } from "node:fs";
+import { chmodSync, lstatSync, readlinkSync, renameSync, rmSync } from "node:fs";
 import path from "node:path";
 import { parseFlagArgs, stringFlag, intFlag } from "./lib/arg-utils.mjs";
 import { signalExitCode, terminateManagedChild } from "./lib/managed-child-process.mjs";
@@ -51,6 +51,40 @@ function resolveBenchmarkProcessTimeoutMs(opts) {
 function resolveTemporaryOutputPath(outputPath) {
   const parsed = path.parse(outputPath);
   return path.join(parsed.dir, `.${parsed.base}.tmp-${process.pid}`);
+}
+
+// Direct benchmark writes followed output symlinks and retained target permissions.
+// Resolve that same destination before staging so atomic promotion preserves both.
+function resolveOutputDestination(outputPath) {
+  let destinationPath = outputPath;
+  const visitedPaths = new Set();
+
+  while (true) {
+    const absolutePath = path.resolve(destinationPath);
+    if (visitedPaths.has(absolutePath)) {
+      throw new Error(`CLI startup benchmark output symlink cycle detected at ${destinationPath}`);
+    }
+    visitedPaths.add(absolutePath);
+
+    let stats;
+    try {
+      stats = lstatSync(destinationPath);
+    } catch (error) {
+      if (error?.code === "ENOENT") {
+        return { path: destinationPath };
+      }
+      throw error;
+    }
+
+    if (!stats.isSymbolicLink()) {
+      return { mode: stats.mode & 0o777, path: destinationPath };
+    }
+
+    const targetPath = readlinkSync(destinationPath);
+    destinationPath = path.isAbsolute(targetPath)
+      ? targetPath
+      : path.resolve(path.dirname(destinationPath), targetPath);
+  }
 }
 
 async function runBenchmarkDriver(args, opts) {
@@ -229,6 +263,8 @@ const opts = parseFlagArgs(
   ],
 );
 
+const outputDestination = resolveOutputDestination(opts.out);
+const temporaryOutputPath = resolveTemporaryOutputPath(outputDestination.path);
 const args = [
   "--import",
   "tsx",
@@ -244,10 +280,9 @@ const args = [
   "--timeout-ms",
   String(opts.timeoutMs),
   "--output",
-  resolveTemporaryOutputPath(opts.out),
+  temporaryOutputPath,
 ];
 
-const temporaryOutputPath = args.at(-1);
 // Publish only a completed report; a timed-out driver may have already written
 // its output before stalling in reporting or final cleanup.
 rmSync(temporaryOutputPath, { force: true });
@@ -261,7 +296,10 @@ try {
         ? signalExitCode(run.receivedSignal)
         : (run.status ?? 1);
   } else {
-    renameSync(temporaryOutputPath, opts.out);
+    if (outputDestination.mode !== undefined) {
+      chmodSync(temporaryOutputPath, outputDestination.mode);
+    }
+    renameSync(temporaryOutputPath, outputDestination.path);
     console.log(`[test-update-cli-startup-bench] wrote fixture to ${opts.out}`);
   }
 } finally {

--- a/scripts/test-update-cli-startup-bench.mjs
+++ b/scripts/test-update-cli-startup-bench.mjs
@@ -1,6 +1,15 @@
 // Refreshes the checked-in CLI startup benchmark fixture.
 import { spawn } from "node:child_process";
-import { chmodSync, lstatSync, readlinkSync, renameSync, rmSync } from "node:fs";
+import {
+  closeSync,
+  lstatSync,
+  openSync,
+  readFileSync,
+  readlinkSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 import { parseFlagArgs, stringFlag, intFlag } from "./lib/arg-utils.mjs";
 import { signalExitCode, terminateManagedChild } from "./lib/managed-child-process.mjs";
@@ -8,7 +17,10 @@ import { signalExitCode, terminateManagedChild } from "./lib/managed-child-proce
 const CLI_STARTUP_BENCH_FIXTURE_PATH = "test/fixtures/cli-startup-bench.json";
 const DEFAULT_BENCHMARK_TIMEOUT_KILL_GRACE_MS = 1_000;
 const DEFAULT_BENCHMARK_PROCESS_CLEANUP_GRACE_MS = 5_000;
-const FORWARDED_SIGNALS = ["SIGHUP", "SIGINT", "SIGTERM"];
+const FORWARDED_SIGNALS =
+  process.platform === "win32"
+    ? ["SIGHUP", "SIGINT", "SIGTERM"]
+    : ["SIGHUP", "SIGINT", "SIGQUIT", "SIGTERM"];
 const ACTIVE_SAMPLE_MESSAGE_KIND = "openclaw-cli-startup-bench-active-sample";
 const CLEARED_SAMPLE_MESSAGE_KIND = "openclaw-cli-startup-bench-cleared-sample";
 // A timed-out sample can spend one grace before SIGKILL and another reaping its process group.
@@ -53,8 +65,8 @@ function resolveTemporaryOutputPath(outputPath) {
   return path.join(parsed.dir, `.${parsed.base}.tmp-${process.pid}`);
 }
 
-// Direct benchmark writes followed output symlinks and retained target permissions.
-// Resolve that same destination before staging so atomic promotion preserves both.
+// Direct benchmark writes followed output symlinks and retained target metadata.
+// Resolve that same destination for staging, but never rename over a special file.
 function resolveOutputDestination(outputPath) {
   let destinationPath = outputPath;
   const visitedPaths = new Set();
@@ -77,7 +89,23 @@ function resolveOutputDestination(outputPath) {
     }
 
     if (!stats.isSymbolicLink()) {
-      return { mode: stats.mode & 0o777, path: destinationPath };
+      if (!stats.isFile()) {
+        throw new Error(
+          `CLI startup benchmark output must be a regular file or missing: ${destinationPath}`,
+        );
+      }
+      // Verify the existing inode is writable before spending the benchmark budget.
+      // Successful publication writes this inode in place, preserving links and metadata.
+      let handle;
+      try {
+        handle = openSync(destinationPath, "r+");
+      } catch (error) {
+        throw new Error(`CLI startup benchmark output is not writable: ${destinationPath}`, {
+          cause: error,
+        });
+      }
+      closeSync(handle);
+      return { exists: true, path: destinationPath };
     }
 
     const targetPath = readlinkSync(destinationPath);
@@ -85,6 +113,14 @@ function resolveOutputDestination(outputPath) {
       ? targetPath
       : path.resolve(path.dirname(destinationPath), targetPath);
   }
+}
+
+function publishBenchmarkOutput(temporaryOutputPath, outputDestination) {
+  if (outputDestination.exists) {
+    writeFileSync(outputDestination.path, readFileSync(temporaryOutputPath));
+    return;
+  }
+  renameSync(temporaryOutputPath, outputDestination.path);
 }
 
 async function runBenchmarkDriver(args, opts) {
@@ -296,10 +332,7 @@ try {
         ? signalExitCode(run.receivedSignal)
         : (run.status ?? 1);
   } else {
-    if (outputDestination.mode !== undefined) {
-      chmodSync(temporaryOutputPath, outputDestination.mode);
-    }
-    renameSync(temporaryOutputPath, outputDestination.path);
+    publishBenchmarkOutput(temporaryOutputPath, outputDestination);
     console.log(`[test-update-cli-startup-bench] wrote fixture to ${opts.out}`);
   }
 } finally {

--- a/scripts/test-update-cli-startup-bench.mjs
+++ b/scripts/test-update-cli-startup-bench.mjs
@@ -3,6 +3,44 @@ import { spawnSync } from "node:child_process";
 import { parseFlagArgs, stringFlag, intFlag } from "./lib/arg-utils.mjs";
 
 const CLI_STARTUP_BENCH_FIXTURE_PATH = "test/fixtures/cli-startup-bench.json";
+const DEFAULT_BENCHMARK_TIMEOUT_KILL_GRACE_MS = 1_000;
+const DEFAULT_BENCHMARK_PROCESS_CLEANUP_GRACE_MS = 5_000;
+// A timed-out sample can spend one grace before SIGKILL and another reaping its process group.
+// Keep these preset counts aligned with COMMAND_CASES or a valid fixture run can be cut short.
+const BENCHMARK_TIMEOUT_CLEANUP_WINDOWS = 2;
+const BENCHMARK_CASE_COUNTS = {
+  startup: 6,
+  real: 14,
+  all: 43,
+};
+
+function resolveTestDurationMs(envName, fallback) {
+  const raw = process.env.VITEST ? process.env[envName] : undefined;
+  if (!raw || !/^\d+$/u.test(raw)) {
+    return fallback;
+  }
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) ? parsed : fallback;
+}
+
+function resolveBenchmarkProcessTimeoutMs(opts) {
+  const caseCount = BENCHMARK_CASE_COUNTS[opts.preset] ?? BENCHMARK_CASE_COUNTS.all;
+  const timeoutKillGraceMs = resolveTestDurationMs(
+    "OPENCLAW_TEST_CLI_STARTUP_TIMEOUT_KILL_GRACE_MS",
+    DEFAULT_BENCHMARK_TIMEOUT_KILL_GRACE_MS,
+  );
+  const processCleanupGraceMs = resolveTestDurationMs(
+    "OPENCLAW_TEST_CLI_STARTUP_BENCH_PROCESS_CLEANUP_GRACE_MS",
+    DEFAULT_BENCHMARK_PROCESS_CLEANUP_GRACE_MS,
+  );
+  const totalRuns = opts.runs + opts.warmup;
+  const perRunBudgetMs = opts.timeoutMs + BENCHMARK_TIMEOUT_CLEANUP_WINDOWS * timeoutKillGraceMs;
+  const totalTimeoutMs = caseCount * totalRuns * perRunBudgetMs + processCleanupGraceMs;
+  if (!Number.isSafeInteger(totalTimeoutMs)) {
+    throw new Error("CLI startup benchmark total timeout exceeds the safe integer range");
+  }
+  return totalTimeoutMs;
+}
 
 if (process.argv.slice(2).includes("--help")) {
   console.log(
@@ -69,6 +107,8 @@ const run = spawnSync(process.execPath, args, {
   cwd: process.cwd(),
   stdio: "inherit",
   env: process.env,
+  timeout: resolveBenchmarkProcessTimeoutMs(opts),
+  killSignal: "SIGKILL",
 });
 
 if (run.status !== 0) {

--- a/scripts/test-update-cli-startup-bench.mjs
+++ b/scripts/test-update-cli-startup-bench.mjs
@@ -1,10 +1,14 @@
 // Refreshes the checked-in CLI startup benchmark fixture.
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
+import { renameSync, rmSync } from "node:fs";
+import path from "node:path";
 import { parseFlagArgs, stringFlag, intFlag } from "./lib/arg-utils.mjs";
+import { signalExitCode, terminateManagedChild } from "./lib/managed-child-process.mjs";
 
 const CLI_STARTUP_BENCH_FIXTURE_PATH = "test/fixtures/cli-startup-bench.json";
 const DEFAULT_BENCHMARK_TIMEOUT_KILL_GRACE_MS = 1_000;
 const DEFAULT_BENCHMARK_PROCESS_CLEANUP_GRACE_MS = 5_000;
+const FORWARDED_SIGNALS = ["SIGHUP", "SIGINT", "SIGTERM"];
 // A timed-out sample can spend one grace before SIGKILL and another reaping its process group.
 // Keep these preset counts aligned with COMMAND_CASES or a valid fixture run can be cut short.
 const BENCHMARK_TIMEOUT_CLEANUP_WINDOWS = 2;
@@ -40,6 +44,74 @@ function resolveBenchmarkProcessTimeoutMs(opts) {
     throw new Error("CLI startup benchmark total timeout exceeds the safe integer range");
   }
   return totalTimeoutMs;
+}
+
+function resolveTemporaryOutputPath(outputPath) {
+  const parsed = path.parse(outputPath);
+  return path.join(parsed.dir, `.${parsed.base}.tmp-${process.pid}`);
+}
+
+async function runBenchmarkDriver(args, opts) {
+  const timeoutMs = resolveBenchmarkProcessTimeoutMs(opts);
+  const terminationGraceMs = resolveTestDurationMs(
+    "OPENCLAW_TEST_CLI_STARTUP_BENCH_PROCESS_CLEANUP_GRACE_MS",
+    DEFAULT_BENCHMARK_PROCESS_CLEANUP_GRACE_MS,
+  );
+  const child = spawn(process.execPath, args, {
+    cwd: process.cwd(),
+    stdio: "inherit",
+    env: process.env,
+    detached: process.platform !== "win32",
+  });
+
+  return await new Promise((resolve) => {
+    let settled = false;
+    let timedOut = false;
+    let receivedSignal;
+    let forceKillTimer;
+    const signalHandlers = new Map();
+    const finish = (status, signal) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(deadlineTimer);
+      if (forceKillTimer) {
+        clearTimeout(forceKillTimer);
+      }
+      for (const [forwardedSignal, handler] of signalHandlers) {
+        process.off(forwardedSignal, handler);
+      }
+      resolve({ receivedSignal, signal, status, timedOut });
+    };
+    const terminateDriver = (signal) => {
+      terminateManagedChild(child, signal);
+      if (forceKillTimer) {
+        terminateManagedChild(child, "SIGKILL");
+        return;
+      }
+      forceKillTimer = setTimeout(() => {
+        terminateManagedChild(child, "SIGKILL");
+      }, terminationGraceMs);
+    };
+    for (const signal of FORWARDED_SIGNALS) {
+      const handler = () => {
+        receivedSignal ??= signal;
+        terminateDriver(signal);
+      };
+      signalHandlers.set(signal, handler);
+      process.on(signal, handler);
+    }
+    const deadlineTimer = setTimeout(() => {
+      timedOut = true;
+      // The driver owns detached sample groups, so let it reap them before the
+      // bounded force-kill fallback restores control to this updater.
+      terminateDriver("SIGTERM");
+    }, timeoutMs);
+
+    child.once("error", () => finish(null, null));
+    child.once("close", (status, signal) => finish(status, signal));
+  });
 }
 
 if (process.argv.slice(2).includes("--help")) {
@@ -100,19 +172,26 @@ const args = [
   "--timeout-ms",
   String(opts.timeoutMs),
   "--output",
-  opts.out,
+  resolveTemporaryOutputPath(opts.out),
 ];
 
-const run = spawnSync(process.execPath, args, {
-  cwd: process.cwd(),
-  stdio: "inherit",
-  env: process.env,
-  timeout: resolveBenchmarkProcessTimeoutMs(opts),
-  killSignal: "SIGKILL",
-});
+const temporaryOutputPath = args.at(-1);
+// Publish only a completed report; a timed-out driver may have already written
+// its output before stalling in reporting or final cleanup.
+rmSync(temporaryOutputPath, { force: true });
+try {
+  const run = await runBenchmarkDriver(args, opts);
 
-if (run.status !== 0) {
-  process.exit(run.status ?? 1);
+  if (run.status !== 0 || run.timedOut || run.receivedSignal) {
+    process.exitCode = run.timedOut
+      ? 1
+      : run.receivedSignal
+        ? signalExitCode(run.receivedSignal)
+        : (run.status ?? 1);
+  } else {
+    renameSync(temporaryOutputPath, opts.out);
+    console.log(`[test-update-cli-startup-bench] wrote fixture to ${opts.out}`);
+  }
+} finally {
+  rmSync(temporaryOutputPath, { force: true });
 }
-
-console.log(`[test-update-cli-startup-bench] wrote fixture to ${opts.out}`);

--- a/test/scripts/bench-cli-startup.test.ts
+++ b/test/scripts/bench-cli-startup.test.ts
@@ -1,5 +1,5 @@
 // Bench Cli Startup tests cover bench cli startup script behavior.
-import { spawn, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -19,57 +19,6 @@ function isProcessAlive(pid: number): boolean {
     stdio: ["ignore", "pipe", "ignore"],
   });
   return status.status !== 0 || !/^\s*Z/u.test(status.stdout);
-}
-
-async function waitForFile(filePath: string, timeoutMs: number): Promise<void> {
-  const deadlineAt = Date.now() + timeoutMs;
-  while (!existsSync(filePath)) {
-    if (Date.now() >= deadlineAt) {
-      throw new Error(`Timed out waiting for ${filePath}`);
-    }
-    await new Promise<void>((resolveWait) => {
-      setTimeout(resolveWait, 25);
-    });
-  }
-}
-
-async function waitForChildExit(
-  child: ReturnType<typeof spawn>,
-  timeoutMs: number,
-): Promise<boolean> {
-  if (child.exitCode !== null || child.signalCode !== null) {
-    return true;
-  }
-  return await new Promise<boolean>((resolveWait) => {
-    const onClose = () => {
-      clearTimeout(timeout);
-      resolveWait(true);
-    };
-    const timeout = setTimeout(() => {
-      child.off("close", onClose);
-      resolveWait(false);
-    }, timeoutMs);
-    child.once("close", onClose);
-    if (child.exitCode !== null || child.signalCode !== null) {
-      child.off("close", onClose);
-      clearTimeout(timeout);
-      resolveWait(true);
-    }
-  });
-}
-
-async function stopChild(child: ReturnType<typeof spawn>): Promise<void> {
-  if (child.exitCode !== null || child.signalCode !== null) {
-    return;
-  }
-  child.kill("SIGTERM");
-  if (await waitForChildExit(child, 1_000)) {
-    return;
-  }
-  child.kill("SIGKILL");
-  if (!(await waitForChildExit(child, 1_000))) {
-    child.unref();
-  }
 }
 
 describe("bench-cli-startup", () => {
@@ -222,101 +171,6 @@ describe("bench-cli-startup", () => {
       } finally {
         if (childPid !== undefined && isProcessAlive(childPid)) {
           process.kill(childPid, "SIGKILL");
-        }
-        tempDirs.cleanup();
-      }
-    },
-  );
-
-  it.runIf(process.platform !== "win32")(
-    "cleans the active benchmark process group when the driver receives SIGQUIT",
-    async () => {
-      const tempDirs = createTempDirTracker();
-      const tmpDir = tempDirs.make("openclaw-cli-startup-driver-termination-");
-      const entryPath = join(tmpDir, "entry.mjs");
-      const samplePidPath = join(tmpDir, "sample.pid");
-      const descendantPidPath = join(tmpDir, "descendant.pid");
-      let samplePid: number | undefined;
-      let descendantPid: number | undefined;
-      let driver: ReturnType<typeof spawn> | undefined;
-      try {
-        writeFileSync(
-          entryPath,
-          [
-            "import { spawn } from 'node:child_process';",
-            "import { writeFileSync } from 'node:fs';",
-            `writeFileSync(${JSON.stringify(samplePidPath)}, String(process.pid));`,
-            "const child = spawn(process.execPath, [",
-            "  '-e',",
-            "  \"process.on('SIGTERM',()=>{});setInterval(()=>{},1000);\",",
-            "], { stdio: 'ignore' });",
-            `writeFileSync(${JSON.stringify(descendantPidPath)}, String(child.pid));`,
-            "process.on('SIGTERM', () => {});",
-            "setInterval(() => {}, 1000);",
-            "",
-          ].join("\n"),
-          "utf8",
-        );
-
-        const runningDriver = spawn(
-          process.execPath,
-          [
-            "--import",
-            "tsx",
-            "scripts/bench-cli-startup.ts",
-            "--entry",
-            entryPath,
-            "--case",
-            "version",
-            "--runs",
-            "1",
-            "--warmup",
-            "0",
-            "--timeout-ms",
-            "60000",
-            "--json",
-          ],
-          {
-            cwd: join(__dirname, "../.."),
-            env: {
-              ...process.env,
-              OPENCLAW_TEST_CLI_STARTUP_TIMEOUT_KILL_GRACE_MS: "50",
-              VITEST: "1",
-            },
-            stdio: "ignore",
-          },
-        );
-        driver = runningDriver;
-
-        await waitForFile(descendantPidPath, 5_000);
-        samplePid = Number(readFileSync(samplePidPath, "utf8"));
-        descendantPid = Number(readFileSync(descendantPidPath, "utf8"));
-        runningDriver.kill("SIGQUIT");
-        const result = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
-          (resolveResult, rejectResult) => {
-            runningDriver.once("error", rejectResult);
-            runningDriver.once("close", (code, signal) => resolveResult({ code, signal }));
-          },
-        );
-
-        expect(result.code).toBe(131);
-        expect(result.signal).toBeNull();
-        expect(isProcessAlive(samplePid)).toBe(false);
-        expect(isProcessAlive(descendantPid)).toBe(false);
-      } finally {
-        if (driver) {
-          await stopChild(driver);
-        }
-        if (samplePid === undefined && existsSync(samplePidPath)) {
-          samplePid = Number(readFileSync(samplePidPath, "utf8"));
-        }
-        if (descendantPid === undefined && existsSync(descendantPidPath)) {
-          descendantPid = Number(readFileSync(descendantPidPath, "utf8"));
-        }
-        if (samplePid !== undefined && isProcessAlive(samplePid)) {
-          process.kill(-samplePid, "SIGKILL");
-        } else if (descendantPid !== undefined && isProcessAlive(descendantPid)) {
-          process.kill(descendantPid, "SIGKILL");
         }
         tempDirs.cleanup();
       }

--- a/test/scripts/bench-cli-startup.test.ts
+++ b/test/scripts/bench-cli-startup.test.ts
@@ -1,5 +1,5 @@
 // Bench Cli Startup tests cover bench cli startup script behavior.
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -11,9 +11,25 @@ import { createTempDirTracker } from "../helpers/temp-dir.js";
 function isProcessAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
-    return true;
   } catch {
     return false;
+  }
+  const status = spawnSync("ps", ["-o", "stat=", "-p", String(pid)], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  return status.status !== 0 || !/^\s*Z/u.test(status.stdout);
+}
+
+async function waitForFile(filePath: string, timeoutMs: number): Promise<void> {
+  const deadlineAt = Date.now() + timeoutMs;
+  while (!existsSync(filePath)) {
+    if (Date.now() >= deadlineAt) {
+      throw new Error(`Timed out waiting for ${filePath}`);
+    }
+    await new Promise<void>((resolveWait) => {
+      setTimeout(resolveWait, 25);
+    });
   }
 }
 
@@ -167,6 +183,89 @@ describe("bench-cli-startup", () => {
       } finally {
         if (childPid !== undefined && isProcessAlive(childPid)) {
           process.kill(childPid, "SIGKILL");
+        }
+        tempDirs.cleanup();
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "cleans the active benchmark process group when the driver is terminated",
+    async () => {
+      const tempDirs = createTempDirTracker();
+      const tmpDir = tempDirs.make("openclaw-cli-startup-driver-termination-");
+      const entryPath = join(tmpDir, "entry.mjs");
+      const samplePidPath = join(tmpDir, "sample.pid");
+      const descendantPidPath = join(tmpDir, "descendant.pid");
+      let samplePid: number | undefined;
+      let descendantPid: number | undefined;
+      try {
+        writeFileSync(
+          entryPath,
+          [
+            "import { spawn } from 'node:child_process';",
+            "import { writeFileSync } from 'node:fs';",
+            `writeFileSync(${JSON.stringify(samplePidPath)}, String(process.pid));`,
+            "const child = spawn(process.execPath, [",
+            "  '-e',",
+            "  \"process.on('SIGTERM',()=>{});setInterval(()=>{},1000);\",",
+            "], { stdio: 'ignore' });",
+            `writeFileSync(${JSON.stringify(descendantPidPath)}, String(child.pid));`,
+            "process.on('SIGTERM', () => {});",
+            "setInterval(() => {}, 1000);",
+            "",
+          ].join("\n"),
+          "utf8",
+        );
+
+        const driver = spawn(
+          process.execPath,
+          [
+            "--import",
+            "tsx",
+            "scripts/bench-cli-startup.ts",
+            "--entry",
+            entryPath,
+            "--case",
+            "version",
+            "--runs",
+            "1",
+            "--warmup",
+            "0",
+            "--timeout-ms",
+            "60000",
+            "--json",
+          ],
+          {
+            cwd: join(__dirname, "../.."),
+            env: {
+              ...process.env,
+              OPENCLAW_TEST_CLI_STARTUP_TIMEOUT_KILL_GRACE_MS: "50",
+              VITEST: "1",
+            },
+            stdio: "ignore",
+          },
+        );
+
+        await waitForFile(descendantPidPath, 5_000);
+        samplePid = Number(readFileSync(samplePidPath, "utf8"));
+        descendantPid = Number(readFileSync(descendantPidPath, "utf8"));
+        driver.kill("SIGTERM");
+        const result = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+          (resolveResult, rejectResult) => {
+            driver.once("error", rejectResult);
+            driver.once("close", (code, signal) => resolveResult({ code, signal }));
+          },
+        );
+
+        expect(result.code).not.toBe(0);
+        expect(isProcessAlive(samplePid)).toBe(false);
+        expect(isProcessAlive(descendantPid)).toBe(false);
+      } finally {
+        if (samplePid !== undefined && isProcessAlive(samplePid)) {
+          process.kill(-samplePid, "SIGKILL");
+        } else if (descendantPid !== undefined && isProcessAlive(descendantPid)) {
+          process.kill(descendantPid, "SIGKILL");
         }
         tempDirs.cleanup();
       }

--- a/test/scripts/bench-cli-startup.test.ts
+++ b/test/scripts/bench-cli-startup.test.ts
@@ -199,7 +199,7 @@ describe("bench-cli-startup", () => {
             "--warmup",
             "0",
             "--timeout-ms",
-            "100",
+            "1000",
             "--json",
           ],
           {

--- a/test/scripts/bench-cli-startup.test.ts
+++ b/test/scripts/bench-cli-startup.test.ts
@@ -229,7 +229,7 @@ describe("bench-cli-startup", () => {
   );
 
   it.runIf(process.platform !== "win32")(
-    "cleans the active benchmark process group when the driver is terminated",
+    "cleans the active benchmark process group when the driver receives SIGQUIT",
     async () => {
       const tempDirs = createTempDirTracker();
       const tmpDir = tempDirs.make("openclaw-cli-startup-driver-termination-");
@@ -291,7 +291,7 @@ describe("bench-cli-startup", () => {
         await waitForFile(descendantPidPath, 5_000);
         samplePid = Number(readFileSync(samplePidPath, "utf8"));
         descendantPid = Number(readFileSync(descendantPidPath, "utf8"));
-        runningDriver.kill("SIGTERM");
+        runningDriver.kill("SIGQUIT");
         const result = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
           (resolveResult, rejectResult) => {
             runningDriver.once("error", rejectResult);
@@ -299,7 +299,8 @@ describe("bench-cli-startup", () => {
           },
         );
 
-        expect(result.code).not.toBe(0);
+        expect(result.code).toBe(131);
+        expect(result.signal).toBeNull();
         expect(isProcessAlive(samplePid)).toBe(false);
         expect(isProcessAlive(descendantPid)).toBe(false);
       } finally {

--- a/test/scripts/bench-cli-startup.test.ts
+++ b/test/scripts/bench-cli-startup.test.ts
@@ -33,6 +33,45 @@ async function waitForFile(filePath: string, timeoutMs: number): Promise<void> {
   }
 }
 
+async function waitForChildExit(
+  child: ReturnType<typeof spawn>,
+  timeoutMs: number,
+): Promise<boolean> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return true;
+  }
+  return await new Promise<boolean>((resolveWait) => {
+    const onClose = () => {
+      clearTimeout(timeout);
+      resolveWait(true);
+    };
+    const timeout = setTimeout(() => {
+      child.off("close", onClose);
+      resolveWait(false);
+    }, timeoutMs);
+    child.once("close", onClose);
+    if (child.exitCode !== null || child.signalCode !== null) {
+      child.off("close", onClose);
+      clearTimeout(timeout);
+      resolveWait(true);
+    }
+  });
+}
+
+async function stopChild(child: ReturnType<typeof spawn>): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+  child.kill("SIGTERM");
+  if (await waitForChildExit(child, 1_000)) {
+    return;
+  }
+  child.kill("SIGKILL");
+  if (!(await waitForChildExit(child, 1_000))) {
+    child.unref();
+  }
+}
+
 describe("bench-cli-startup", () => {
   it("rejects unknown CLI options before running benchmarks", () => {
     expect(() => testing.validateCliArgs(["--wat"])).toThrow("Unknown argument: --wat");
@@ -199,6 +238,7 @@ describe("bench-cli-startup", () => {
       const descendantPidPath = join(tmpDir, "descendant.pid");
       let samplePid: number | undefined;
       let descendantPid: number | undefined;
+      let driver: ReturnType<typeof spawn> | undefined;
       try {
         writeFileSync(
           entryPath,
@@ -218,7 +258,7 @@ describe("bench-cli-startup", () => {
           "utf8",
         );
 
-        const driver = spawn(
+        const runningDriver = spawn(
           process.execPath,
           [
             "--import",
@@ -246,15 +286,16 @@ describe("bench-cli-startup", () => {
             stdio: "ignore",
           },
         );
+        driver = runningDriver;
 
         await waitForFile(descendantPidPath, 5_000);
         samplePid = Number(readFileSync(samplePidPath, "utf8"));
         descendantPid = Number(readFileSync(descendantPidPath, "utf8"));
-        driver.kill("SIGTERM");
+        runningDriver.kill("SIGTERM");
         const result = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
           (resolveResult, rejectResult) => {
-            driver.once("error", rejectResult);
-            driver.once("close", (code, signal) => resolveResult({ code, signal }));
+            runningDriver.once("error", rejectResult);
+            runningDriver.once("close", (code, signal) => resolveResult({ code, signal }));
           },
         );
 
@@ -262,6 +303,15 @@ describe("bench-cli-startup", () => {
         expect(isProcessAlive(samplePid)).toBe(false);
         expect(isProcessAlive(descendantPid)).toBe(false);
       } finally {
+        if (driver) {
+          await stopChild(driver);
+        }
+        if (samplePid === undefined && existsSync(samplePidPath)) {
+          samplePid = Number(readFileSync(samplePidPath, "utf8"));
+        }
+        if (descendantPid === undefined && existsSync(descendantPidPath)) {
+          descendantPid = Number(readFileSync(descendantPidPath, "utf8"));
+        }
         if (samplePid !== undefined && isProcessAlive(samplePid)) {
           process.kill(-samplePid, "SIGKILL");
         } else if (descendantPid !== undefined && isProcessAlive(descendantPid)) {

--- a/test/scripts/cli-startup-bench-spawner.test.ts
+++ b/test/scripts/cli-startup-bench-spawner.test.ts
@@ -15,8 +15,8 @@ describe("CLI startup benchmark script spawners", () => {
     for (const scriptPath of SCRIPT_PATHS) {
       const source = fs.readFileSync(path.resolve(process.cwd(), scriptPath), "utf8");
 
-      expect(source).toContain("spawnSync(process.execPath, args");
-      expect(source).not.toContain('spawnSync("node", args');
+      expect(source).toMatch(/spawn(?:Sync)?\(process\.execPath, args/u);
+      expect(source).not.toMatch(/spawn(?:Sync)?\("node", args/u);
     }
   });
 

--- a/test/scripts/test-update-cli-startup-bench.test.ts
+++ b/test/scripts/test-update-cli-startup-bench.test.ts
@@ -41,21 +41,9 @@ const UPDATE_SCRIPT_PATH = path.resolve(process.cwd(), "scripts/test-update-cli-
 const originalArgv = [...process.argv];
 const originalExitCode = process.exitCode;
 const originalVitest = process.env.VITEST;
-const originalTimeoutCleanupGrace = process.env.OPENCLAW_TEST_CLI_STARTUP_TIMEOUT_KILL_GRACE_MS;
+const originalStartupTimeout = process.env.OPENCLAW_TEST_CLI_STARTUP_BENCH_STARTUP_TIMEOUT_MS;
 const originalProcessCleanupGrace =
   process.env.OPENCLAW_TEST_CLI_STARTUP_BENCH_PROCESS_CLEANUP_GRACE_MS;
-
-function countBenchmarkCases(preset: "startup" | "real" | "all"): number {
-  const source = readFileSync(path.resolve(process.cwd(), "scripts/bench-cli-startup.ts"), "utf8");
-  const start = source.indexOf("const COMMAND_CASES");
-  const end = source.indexOf("] as const;", start);
-  expect(start).toBeGreaterThanOrEqual(0);
-  expect(end).toBeGreaterThan(start);
-  const cases = [...source.slice(start, end).matchAll(/presets:\s*\[([^\]]+)\]/gu)].map((match) =>
-    [...(match[1] ?? "").matchAll(/"([^"]+)"/gu)].map((entry) => entry[1]),
-  );
-  return preset === "all" ? cases.length : cases.filter((entry) => entry.includes(preset)).length;
-}
 
 function mockSuccessfulBenchmarkRun(contents = "replacement\n") {
   spawnMock.mockImplementation((_command, args: string[]) => {
@@ -93,10 +81,10 @@ afterEach(() => {
   } else {
     process.env.VITEST = originalVitest;
   }
-  if (originalTimeoutCleanupGrace === undefined) {
-    delete process.env.OPENCLAW_TEST_CLI_STARTUP_TIMEOUT_KILL_GRACE_MS;
+  if (originalStartupTimeout === undefined) {
+    delete process.env.OPENCLAW_TEST_CLI_STARTUP_BENCH_STARTUP_TIMEOUT_MS;
   } else {
-    process.env.OPENCLAW_TEST_CLI_STARTUP_TIMEOUT_KILL_GRACE_MS = originalTimeoutCleanupGrace;
+    process.env.OPENCLAW_TEST_CLI_STARTUP_BENCH_STARTUP_TIMEOUT_MS = originalStartupTimeout;
   }
   if (originalProcessCleanupGrace === undefined) {
     delete process.env.OPENCLAW_TEST_CLI_STARTUP_BENCH_PROCESS_CLEANUP_GRACE_MS;
@@ -111,46 +99,41 @@ afterEach(() => {
 });
 
 describe("test-update-cli-startup-bench", () => {
-  it("gives the benchmark driver a hard total deadline beyond all internal run budgets", async () => {
-    delete process.env.OPENCLAW_TEST_CLI_STARTUP_TIMEOUT_KILL_GRACE_MS;
+  it("uses the benchmark driver's canonical budget after a bounded startup phase", async () => {
+    delete process.env.OPENCLAW_TEST_CLI_STARTUP_BENCH_STARTUP_TIMEOUT_MS;
     delete process.env.OPENCLAW_TEST_CLI_STARTUP_BENCH_PROCESS_CLEANUP_GRACE_MS;
-    mockSuccessfulBenchmarkRun("{}\n");
+    spawnMock.mockImplementation((_command, args: string[]) => {
+      const child = Object.assign(new EventEmitter(), { pid: 123_456, kill: vi.fn() });
+      const outputIndex = args.indexOf("--output");
+      writeFileSync(args[outputIndex + 1] ?? "", "{}\n", "utf8");
+      queueMicrotask(() => {
+        child.emit("message", {
+          kind: "openclaw-cli-startup-bench-budget",
+          timeoutMs: 1_234,
+        });
+        child.emit("close", 0, null);
+      });
+      return child;
+    });
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
     const fixtureRoot = mkdtempSync(path.join(process.cwd(), ".tmp-cli-startup-budget-"));
 
     try {
-      for (const preset of ["startup", "real", "all"] as const) {
-        const outputPath = path.join(fixtureRoot, `${preset}.json`);
-        process.argv = [
-          process.execPath,
-          UPDATE_SCRIPT_PATH,
-          "--out",
-          outputPath,
-          "--preset",
-          preset,
-          "--runs",
-          "2",
-          "--warmup",
-          "1",
-          "--timeout-ms",
-          "100",
-        ];
-        spawnMock.mockClear();
-        setTimeoutSpy.mockClear();
-        await import(pathToFileURL(UPDATE_SCRIPT_PATH).href);
+      const outputPath = path.join(fixtureRoot, "startup.json");
+      setSuccessfulUpdateArgv(outputPath);
+      await import(pathToFileURL(UPDATE_SCRIPT_PATH).href);
 
-        expect(spawnMock).toHaveBeenCalledOnce();
-        const args = spawnMock.mock.calls[0]?.[1] as string[];
-        const options = spawnMock.mock.calls[0]?.[2];
-        const internalBudgetMs = countBenchmarkCases(preset) * (2 + 1) * (100 + 2 * 1_000);
-        expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), internalBudgetMs + 5_000);
-        expect(options?.detached).toBe(process.platform !== "win32");
-        expect(options?.stdio).toEqual(["inherit", "inherit", "inherit", "ipc"]);
-        expect(args.at(-1)).not.toBe(outputPath);
-        expect(path.dirname(args.at(-1) ?? "")).toBe(path.dirname(outputPath));
-        expect(readFileSync(outputPath, "utf8")).toBe("{}\n");
-        vi.resetModules();
-      }
+      expect(spawnMock).toHaveBeenCalledOnce();
+      const args = spawnMock.mock.calls[0]?.[1] as string[];
+      const options = spawnMock.mock.calls[0]?.[2];
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 30_000);
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 6_234);
+      expect(options?.detached).toBe(process.platform !== "win32");
+      expect(options?.stdio).toEqual(["inherit", "inherit", "inherit", "ipc"]);
+      expect(args.at(-1)).not.toBe(outputPath);
+      expect(path.dirname(args.at(-1) ?? "")).toBe(path.dirname(outputPath));
+      expect(readFileSync(outputPath, "utf8")).toBe("{}\n");
     } finally {
       rmSync(fixtureRoot, { recursive: true, force: true });
     }
@@ -158,7 +141,7 @@ describe("test-update-cli-startup-bench", () => {
 
   it("settles after force kill even when the driver never emits close", async () => {
     process.env.VITEST = "true";
-    process.env.OPENCLAW_TEST_CLI_STARTUP_TIMEOUT_KILL_GRACE_MS = "0";
+    process.env.OPENCLAW_TEST_CLI_STARTUP_BENCH_STARTUP_TIMEOUT_MS = "0";
     process.env.OPENCLAW_TEST_CLI_STARTUP_BENCH_PROCESS_CLEANUP_GRACE_MS = "10";
     const fixtureRoot = mkdtempSync(path.join(process.cwd(), ".tmp-cli-startup-no-close-"));
     const outputPath = path.join(fixtureRoot, "cli-startup-bench.json");
@@ -316,7 +299,7 @@ describe("test-update-cli-startup-bench", () => {
           env: {
             ...process.env,
             VITEST: "true",
-            OPENCLAW_TEST_CLI_STARTUP_TIMEOUT_KILL_GRACE_MS: "0",
+            OPENCLAW_TEST_CLI_STARTUP_BENCH_STARTUP_TIMEOUT_MS: "0",
             OPENCLAW_TEST_CLI_STARTUP_BENCH_PROCESS_CLEANUP_GRACE_MS: "100",
           },
           killSignal: "SIGKILL",
@@ -378,7 +361,7 @@ describe("test-update-cli-startup-bench", () => {
           env: {
             ...process.env,
             VITEST: "true",
-            OPENCLAW_TEST_CLI_STARTUP_TIMEOUT_KILL_GRACE_MS: "0",
+            OPENCLAW_TEST_CLI_STARTUP_BENCH_STARTUP_TIMEOUT_MS: "0",
             OPENCLAW_TEST_CLI_STARTUP_BENCH_PROCESS_CLEANUP_GRACE_MS: "1500",
           },
           killSignal: "SIGKILL",

--- a/test/scripts/test-update-cli-startup-bench.test.ts
+++ b/test/scripts/test-update-cli-startup-bench.test.ts
@@ -227,6 +227,38 @@ describe("test-update-cli-startup-bench", () => {
     },
   );
 
+  it("preserves an interrupt that arrives just before the startup deadline", async () => {
+    process.env.VITEST = "true";
+    process.env.OPENCLAW_TEST_CLI_STARTUP_BENCH_STARTUP_TIMEOUT_MS = "200";
+    process.env.OPENCLAW_TEST_CLI_STARTUP_BENCH_PROCESS_CLEANUP_GRACE_MS = "150";
+    const fixtureRoot = mkdtempSync(path.join(process.cwd(), ".tmp-cli-startup-signal-race-"));
+    const outputPath = path.join(fixtureRoot, "cli-startup-bench.json");
+    const child = Object.assign(new EventEmitter(), {
+      connected: false,
+      disconnect: vi.fn(),
+      pid: 123_456,
+      kill: vi.fn(),
+      unref: vi.fn(),
+    });
+    spawnMock.mockReturnValue(child);
+    setSuccessfulUpdateArgv(outputPath);
+
+    try {
+      const updatePromise = import(pathToFileURL(UPDATE_SCRIPT_PATH).href);
+      await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledOnce());
+      process.emit("SIGINT");
+      await updatePromise;
+
+      expect(process.exitCode).toBe(130);
+      expect(terminateManagedChildMock).toHaveBeenCalledWith(child, "SIGINT");
+      expect(terminateManagedChildMock).toHaveBeenCalledWith(child, "SIGKILL");
+      expect(child.unref).toHaveBeenCalledOnce();
+    } finally {
+      child.emit("close", 1, null);
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
   it("cleans the reported active sample when the driver crashes", async () => {
     const fixtureRoot = mkdtempSync(path.join(process.cwd(), ".tmp-cli-startup-driver-crash-"));
     const outputPath = path.join(fixtureRoot, "cli-startup-bench.json");

--- a/test/scripts/test-update-cli-startup-bench.test.ts
+++ b/test/scripts/test-update-cli-startup-bench.test.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from "node:events";
 import {
   chmodSync,
   existsSync,
+  linkSync,
   lstatSync,
   mkdirSync,
   mkdtempSync,
@@ -31,7 +32,8 @@ vi.mock("node:child_process", async () => {
 });
 
 vi.mock("../../scripts/lib/managed-child-process.mjs", () => ({
-  signalExitCode: (signal: NodeJS.Signals) => (signal === "SIGINT" ? 130 : 143),
+  signalExitCode: (signal: NodeJS.Signals) =>
+    signal === "SIGINT" ? 130 : signal === "SIGQUIT" ? 131 : 143,
   terminateManagedChild: terminateManagedChildMock,
 }));
 
@@ -214,6 +216,34 @@ describe("test-update-cli-startup-bench", () => {
     }
   });
 
+  it.skipIf(process.platform === "win32")(
+    "forwards SIGQUIT to the benchmark driver and exits 131",
+    async () => {
+      const fixtureRoot = mkdtempSync(path.join(process.cwd(), ".tmp-cli-startup-sigquit-"));
+      const outputPath = path.join(fixtureRoot, "cli-startup-bench.json");
+      const child = Object.assign(new EventEmitter(), { pid: 123_456, kill: vi.fn() });
+      spawnMock.mockReturnValue(child);
+      setSuccessfulUpdateArgv(outputPath);
+      const updatePromise = import(pathToFileURL(UPDATE_SCRIPT_PATH).href);
+
+      try {
+        await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledOnce());
+
+        process.emit("SIGQUIT");
+        expect(terminateManagedChildMock).toHaveBeenCalledWith(child, "SIGQUIT");
+        child.emit("close", null, "SIGQUIT");
+        await updatePromise;
+
+        expect(process.exitCode).toBe(131);
+        expect(existsSync(outputPath)).toBe(false);
+      } finally {
+        child.emit("close", 1, null);
+        await updatePromise.catch(() => undefined);
+        rmSync(fixtureRoot, { recursive: true, force: true });
+      }
+    },
+  );
+
   it("exits before a hanging benchmark driver can block fixture refresh forever", async () => {
     const actualChildProcess =
       await vi.importActual<typeof import("node:child_process")>("node:child_process");
@@ -342,8 +372,10 @@ describe("test-update-cli-startup-bench", () => {
       const outputPath = path.join(fixtureRoot, "cli-startup-bench.json");
       const intermediateLinkPath = path.join(targetRoot, "fixture-link.json");
       const targetPath = path.join(targetRoot, "fixture.json");
+      const hardLinkPath = path.join(targetRoot, "fixture-hard-link.json");
       mkdirSync(targetRoot, { recursive: true });
       writeFileSync(targetPath, "existing\n", "utf8");
+      linkSync(targetPath, hardLinkPath);
       chmodSync(targetPath, 0o600);
       symlinkSync(path.basename(targetPath), intermediateLinkPath);
       symlinkSync(path.relative(fixtureRoot, intermediateLinkPath), outputPath);
@@ -360,6 +392,8 @@ describe("test-update-cli-startup-bench", () => {
         expect(lstatSync(intermediateLinkPath).isSymbolicLink()).toBe(true);
         expect(readlinkSync(intermediateLinkPath)).toBe(intermediateLinkTarget);
         expect(readFileSync(targetPath, "utf8")).toBe("replacement\n");
+        expect(readFileSync(hardLinkPath, "utf8")).toBe("replacement\n");
+        expect(statSync(targetPath).ino).toBe(statSync(hardLinkPath).ino);
         expect(statSync(targetPath).mode & 0o777).toBe(0o600);
       } finally {
         rmSync(fixtureRoot, { recursive: true, force: true });
@@ -410,4 +444,61 @@ describe("test-update-cli-startup-bench", () => {
       rmSync(fixtureRoot, { recursive: true, force: true });
     }
   });
+
+  it.skipIf(process.platform === "win32")(
+    "rejects a FIFO output without replacing it",
+    async () => {
+      const actualChildProcess =
+        await vi.importActual<typeof import("node:child_process")>("node:child_process");
+      const fixtureRoot = mkdtempSync(path.join(process.cwd(), ".tmp-cli-startup-fifo-"));
+      const outputPath = path.join(fixtureRoot, "cli-startup-bench.fifo");
+      expect(actualChildProcess.spawnSync("mkfifo", [outputPath]).status).toBe(0);
+      process.argv = [process.execPath, UPDATE_SCRIPT_PATH, "--out", outputPath];
+
+      try {
+        await expect(import(pathToFileURL(UPDATE_SCRIPT_PATH).href)).rejects.toThrow(
+          "CLI startup benchmark output must be a regular file or missing",
+        );
+        expect(lstatSync(outputPath).isFIFO()).toBe(true);
+        expect(spawnMock).not.toHaveBeenCalled();
+      } finally {
+        rmSync(fixtureRoot, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "rejects a device output without replacing it",
+    async () => {
+      process.argv = [process.execPath, UPDATE_SCRIPT_PATH, "--out", "/dev/null"];
+
+      await expect(import(pathToFileURL(UPDATE_SCRIPT_PATH).href)).rejects.toThrow(
+        "CLI startup benchmark output must be a regular file or missing: /dev/null",
+      );
+      expect(lstatSync("/dev/null").isCharacterDevice()).toBe(true);
+      expect(spawnMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "rejects a read-only regular output before starting the benchmark",
+    async () => {
+      const fixtureRoot = mkdtempSync(path.join(process.cwd(), ".tmp-cli-startup-read-only-"));
+      const outputPath = path.join(fixtureRoot, "cli-startup-bench.json");
+      writeFileSync(outputPath, "existing\n", "utf8");
+      chmodSync(outputPath, 0o400);
+      process.argv = [process.execPath, UPDATE_SCRIPT_PATH, "--out", outputPath];
+
+      try {
+        await expect(import(pathToFileURL(UPDATE_SCRIPT_PATH).href)).rejects.toThrow(
+          "CLI startup benchmark output is not writable",
+        );
+        expect(readFileSync(outputPath, "utf8")).toBe("existing\n");
+        expect(statSync(outputPath).mode & 0o777).toBe(0o400);
+        expect(spawnMock).not.toHaveBeenCalled();
+      } finally {
+        rmSync(fixtureRoot, { recursive: true, force: true });
+      }
+    },
+  );
 });

--- a/test/scripts/test-update-cli-startup-bench.test.ts
+++ b/test/scripts/test-update-cli-startup-bench.test.ts
@@ -25,6 +25,8 @@ vi.mock("../../scripts/lib/managed-child-process.mjs", () => ({
 
 const UPDATE_SCRIPT_PATH = path.resolve(process.cwd(), "scripts/test-update-cli-startup-bench.mjs");
 const originalArgv = [...process.argv];
+const originalExitCode = process.exitCode;
+const originalVitest = process.env.VITEST;
 const originalTimeoutCleanupGrace = process.env.OPENCLAW_TEST_CLI_STARTUP_TIMEOUT_KILL_GRACE_MS;
 const originalProcessCleanupGrace =
   process.env.OPENCLAW_TEST_CLI_STARTUP_BENCH_PROCESS_CLEANUP_GRACE_MS;
@@ -43,6 +45,12 @@ function countBenchmarkCases(preset: "startup" | "real" | "all"): number {
 
 afterEach(() => {
   process.argv = [...originalArgv];
+  process.exitCode = originalExitCode;
+  if (originalVitest === undefined) {
+    delete process.env.VITEST;
+  } else {
+    process.env.VITEST = originalVitest;
+  }
   if (originalTimeoutCleanupGrace === undefined) {
     delete process.env.OPENCLAW_TEST_CLI_STARTUP_TIMEOUT_KILL_GRACE_MS;
   } else {
@@ -102,11 +110,72 @@ describe("test-update-cli-startup-bench", () => {
         const internalBudgetMs = countBenchmarkCases(preset) * (2 + 1) * (100 + 2 * 1_000);
         expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), internalBudgetMs + 5_000);
         expect(options?.detached).toBe(process.platform !== "win32");
+        expect(options?.stdio).toEqual(["inherit", "inherit", "inherit", "ipc"]);
         expect(args.at(-1)).not.toBe(outputPath);
         expect(path.dirname(args.at(-1) ?? "")).toBe(path.dirname(outputPath));
         expect(readFileSync(outputPath, "utf8")).toBe("{}\n");
         vi.resetModules();
       }
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("settles after force kill even when the driver never emits close", async () => {
+    process.env.VITEST = "true";
+    process.env.OPENCLAW_TEST_CLI_STARTUP_TIMEOUT_KILL_GRACE_MS = "0";
+    process.env.OPENCLAW_TEST_CLI_STARTUP_BENCH_PROCESS_CLEANUP_GRACE_MS = "10";
+    const fixtureRoot = mkdtempSync(path.join(process.cwd(), ".tmp-cli-startup-no-close-"));
+    const outputPath = path.join(fixtureRoot, "cli-startup-bench.json");
+    const child = Object.assign(new EventEmitter(), {
+      connected: true,
+      disconnect: vi.fn(),
+      pid: 123_456,
+      kill: vi.fn(),
+      unref: vi.fn(),
+    });
+    child.disconnect.mockImplementation(() => {
+      child.connected = false;
+    });
+    spawnMock.mockImplementation(() => {
+      queueMicrotask(() => {
+        child.emit("message", {
+          kind: "openclaw-cli-startup-bench-active-sample",
+          pid: 654_321,
+        });
+      });
+      return child;
+    });
+    process.argv = [
+      process.execPath,
+      UPDATE_SCRIPT_PATH,
+      "--out",
+      outputPath,
+      "--preset",
+      "startup",
+      "--runs",
+      "1",
+      "--warmup",
+      "0",
+      "--timeout-ms",
+      "1",
+    ];
+
+    try {
+      const startedAt = Date.now();
+      await import(pathToFileURL(UPDATE_SCRIPT_PATH).href);
+
+      expect(Date.now() - startedAt).toBeLessThan(1_000);
+      expect(process.exitCode).toBe(1);
+      expect(terminateManagedChildMock).toHaveBeenCalledWith(child, "SIGTERM");
+      expect(terminateManagedChildMock).toHaveBeenCalledWith(child, "SIGKILL");
+      expect(terminateManagedChildMock).toHaveBeenCalledWith(
+        expect.objectContaining({ pid: 654_321 }),
+        "SIGKILL",
+      );
+      expect(child.disconnect).toHaveBeenCalledOnce();
+      expect(child.unref).toHaveBeenCalledOnce();
+      expect(existsSync(outputPath)).toBe(false);
     } finally {
       rmSync(fixtureRoot, { recursive: true, force: true });
     }

--- a/test/scripts/test-update-cli-startup-bench.test.ts
+++ b/test/scripts/test-update-cli-startup-bench.test.ts
@@ -1,6 +1,18 @@
 // Test Update Cli Startup Bench tests cover fixture updater subprocess deadlines.
 import { EventEmitter } from "node:events";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -43,6 +55,34 @@ function countBenchmarkCases(preset: "startup" | "real" | "all"): number {
   return preset === "all" ? cases.length : cases.filter((entry) => entry.includes(preset)).length;
 }
 
+function mockSuccessfulBenchmarkRun(contents = "replacement\n") {
+  spawnMock.mockImplementation((_command, args: string[]) => {
+    const child = Object.assign(new EventEmitter(), { pid: 123_456, kill: vi.fn() });
+    const outputIndex = args.indexOf("--output");
+    writeFileSync(args[outputIndex + 1] ?? "", contents, "utf8");
+    queueMicrotask(() => child.emit("close", 0, null));
+    return child;
+  });
+  vi.spyOn(console, "log").mockImplementation(() => undefined);
+}
+
+function setSuccessfulUpdateArgv(outputPath: string) {
+  process.argv = [
+    process.execPath,
+    UPDATE_SCRIPT_PATH,
+    "--out",
+    outputPath,
+    "--preset",
+    "startup",
+    "--runs",
+    "1",
+    "--warmup",
+    "0",
+    "--timeout-ms",
+    "100",
+  ];
+}
+
 afterEach(() => {
   process.argv = [...originalArgv];
   process.exitCode = originalExitCode;
@@ -72,14 +112,7 @@ describe("test-update-cli-startup-bench", () => {
   it("gives the benchmark driver a hard total deadline beyond all internal run budgets", async () => {
     delete process.env.OPENCLAW_TEST_CLI_STARTUP_TIMEOUT_KILL_GRACE_MS;
     delete process.env.OPENCLAW_TEST_CLI_STARTUP_BENCH_PROCESS_CLEANUP_GRACE_MS;
-    spawnMock.mockImplementation((_command, args: string[]) => {
-      const child = Object.assign(new EventEmitter(), { pid: 123_456, kill: vi.fn() });
-      const outputIndex = args.indexOf("--output");
-      writeFileSync(args[outputIndex + 1] ?? "", "{}\n", "utf8");
-      queueMicrotask(() => child.emit("close", 0, null));
-      return child;
-    });
-    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    mockSuccessfulBenchmarkRun("{}\n");
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
     const fixtureRoot = mkdtempSync(path.join(process.cwd(), ".tmp-cli-startup-budget-"));
 
@@ -296,6 +329,83 @@ describe("test-update-cli-startup-bench", () => {
       expect(result.error).toBeUndefined();
       expect(result.status).toBe(1);
       expect(readFileSync(outputPath, "utf8")).toBe(existingFixture);
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "updates a symlink target without replacing the link and preserves its mode",
+    async () => {
+      const fixtureRoot = mkdtempSync(path.join(process.cwd(), ".tmp-cli-startup-symlink-"));
+      const targetRoot = path.join(fixtureRoot, "targets");
+      const outputPath = path.join(fixtureRoot, "cli-startup-bench.json");
+      const intermediateLinkPath = path.join(targetRoot, "fixture-link.json");
+      const targetPath = path.join(targetRoot, "fixture.json");
+      mkdirSync(targetRoot, { recursive: true });
+      writeFileSync(targetPath, "existing\n", "utf8");
+      chmodSync(targetPath, 0o600);
+      symlinkSync(path.basename(targetPath), intermediateLinkPath);
+      symlinkSync(path.relative(fixtureRoot, intermediateLinkPath), outputPath);
+      const outputLinkTarget = readlinkSync(outputPath);
+      const intermediateLinkTarget = readlinkSync(intermediateLinkPath);
+      mockSuccessfulBenchmarkRun();
+      setSuccessfulUpdateArgv(outputPath);
+
+      try {
+        await import(pathToFileURL(UPDATE_SCRIPT_PATH).href);
+
+        expect(lstatSync(outputPath).isSymbolicLink()).toBe(true);
+        expect(readlinkSync(outputPath)).toBe(outputLinkTarget);
+        expect(lstatSync(intermediateLinkPath).isSymbolicLink()).toBe(true);
+        expect(readlinkSync(intermediateLinkPath)).toBe(intermediateLinkTarget);
+        expect(readFileSync(targetPath, "utf8")).toBe("replacement\n");
+        expect(statSync(targetPath).mode & 0o777).toBe(0o600);
+      } finally {
+        rmSync(fixtureRoot, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "creates the final target of a dangling relative symlink chain",
+    async () => {
+      const fixtureRoot = mkdtempSync(path.join(process.cwd(), ".tmp-cli-startup-dangling-"));
+      const targetRoot = path.join(fixtureRoot, "targets");
+      const outputPath = path.join(fixtureRoot, "cli-startup-bench.json");
+      const intermediateLinkPath = path.join(targetRoot, "fixture-link.json");
+      const targetPath = path.join(targetRoot, "fixture.json");
+      mkdirSync(targetRoot, { recursive: true });
+      symlinkSync(path.basename(targetPath), intermediateLinkPath);
+      symlinkSync(path.relative(fixtureRoot, intermediateLinkPath), outputPath);
+      mockSuccessfulBenchmarkRun();
+      setSuccessfulUpdateArgv(outputPath);
+
+      try {
+        await import(pathToFileURL(UPDATE_SCRIPT_PATH).href);
+
+        expect(lstatSync(outputPath).isSymbolicLink()).toBe(true);
+        expect(lstatSync(intermediateLinkPath).isSymbolicLink()).toBe(true);
+        expect(readFileSync(targetPath, "utf8")).toBe("replacement\n");
+      } finally {
+        rmSync(fixtureRoot, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.skipIf(process.platform === "win32")("rejects an output symlink cycle", async () => {
+    const fixtureRoot = mkdtempSync(path.join(process.cwd(), ".tmp-cli-startup-cycle-"));
+    const outputPath = path.join(fixtureRoot, "cli-startup-bench.json");
+    const secondLinkPath = path.join(fixtureRoot, "second-link.json");
+    symlinkSync(path.basename(secondLinkPath), outputPath);
+    symlinkSync(path.basename(outputPath), secondLinkPath);
+    process.argv = [process.execPath, UPDATE_SCRIPT_PATH, "--out", outputPath];
+
+    try {
+      await expect(import(pathToFileURL(UPDATE_SCRIPT_PATH).href)).rejects.toThrow(
+        "CLI startup benchmark output symlink cycle detected",
+      );
+      expect(spawnMock).not.toHaveBeenCalled();
     } finally {
       rmSync(fixtureRoot, { recursive: true, force: true });
     }

--- a/test/scripts/test-update-cli-startup-bench.test.ts
+++ b/test/scripts/test-update-cli-startup-bench.test.ts
@@ -33,7 +33,7 @@ vi.mock("node:child_process", async () => {
 
 vi.mock("../../scripts/lib/managed-child-process.mjs", () => ({
   signalExitCode: (signal: NodeJS.Signals) =>
-    signal === "SIGINT" ? 130 : signal === "SIGQUIT" ? 131 : 143,
+    signal === "SIGINT" ? 130 : signal === "SIGQUIT" ? 131 : signal === "SIGKILL" ? 137 : 143,
   terminateManagedChild: terminateManagedChildMock,
 }));
 
@@ -243,6 +243,36 @@ describe("test-update-cli-startup-bench", () => {
       }
     },
   );
+
+  it("cleans the reported active sample when the driver crashes", async () => {
+    const fixtureRoot = mkdtempSync(path.join(process.cwd(), ".tmp-cli-startup-driver-crash-"));
+    const outputPath = path.join(fixtureRoot, "cli-startup-bench.json");
+    const child = Object.assign(new EventEmitter(), { pid: 123_456, kill: vi.fn() });
+    spawnMock.mockImplementation(() => {
+      queueMicrotask(() => {
+        child.emit("message", {
+          kind: "openclaw-cli-startup-bench-active-sample",
+          pid: 654_321,
+        });
+        child.emit("close", null, "SIGKILL");
+      });
+      return child;
+    });
+    setSuccessfulUpdateArgv(outputPath);
+
+    try {
+      await import(pathToFileURL(UPDATE_SCRIPT_PATH).href);
+
+      expect(process.exitCode).toBe(1);
+      expect(terminateManagedChildMock).toHaveBeenCalledWith(
+        expect.objectContaining({ pid: 654_321 }),
+        "SIGKILL",
+      );
+      expect(existsSync(outputPath)).toBe(false);
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  });
 
   it("exits before a hanging benchmark driver can block fixture refresh forever", async () => {
     const actualChildProcess =
@@ -497,6 +527,62 @@ describe("test-update-cli-startup-bench", () => {
         expect(statSync(outputPath).mode & 0o777).toBe(0o400);
         expect(spawnMock).not.toHaveBeenCalled();
       } finally {
+        rmSync(fixtureRoot, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "updates an existing output inside a non-writable directory",
+    async () => {
+      const fixtureRoot = mkdtempSync(path.join(process.cwd(), ".tmp-cli-startup-restricted-dir-"));
+      const outputRoot = path.join(fixtureRoot, "restricted");
+      const outputPath = path.join(outputRoot, "cli-startup-bench.json");
+      mkdirSync(outputRoot);
+      writeFileSync(outputPath, "existing\n", "utf8");
+      chmodSync(outputPath, 0o600);
+      chmodSync(outputRoot, 0o500);
+      mockSuccessfulBenchmarkRun();
+      setSuccessfulUpdateArgv(outputPath);
+
+      try {
+        await import(pathToFileURL(UPDATE_SCRIPT_PATH).href);
+
+        const args = spawnMock.mock.calls[0]?.[1] as string[];
+        const temporaryOutputPath = args[args.indexOf("--output") + 1] ?? "";
+        expect(path.dirname(temporaryOutputPath)).not.toBe(outputRoot);
+        expect(existsSync(path.dirname(temporaryOutputPath))).toBe(false);
+        expect(readFileSync(outputPath, "utf8")).toBe("replacement\n");
+        expect(statSync(outputPath).mode & 0o777).toBe(0o600);
+      } finally {
+        chmodSync(outputRoot, 0o700);
+        rmSync(fixtureRoot, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "updates an existing write-only output without requiring read access",
+    async () => {
+      const fixtureRoot = mkdtempSync(path.join(process.cwd(), ".tmp-cli-startup-write-only-"));
+      const outputPath = path.join(fixtureRoot, "cli-startup-bench.json");
+      writeFileSync(outputPath, "existing\n", "utf8");
+      chmodSync(outputPath, 0o200);
+      mockSuccessfulBenchmarkRun();
+      setSuccessfulUpdateArgv(outputPath);
+
+      try {
+        await import(pathToFileURL(UPDATE_SCRIPT_PATH).href);
+
+        const args = spawnMock.mock.calls[0]?.[1] as string[];
+        const temporaryOutputPath = args[args.indexOf("--output") + 1] ?? "";
+        expect(path.dirname(temporaryOutputPath)).not.toBe(fixtureRoot);
+        expect(existsSync(path.dirname(temporaryOutputPath))).toBe(false);
+        expect(statSync(outputPath).mode & 0o777).toBe(0o200);
+        chmodSync(outputPath, 0o600);
+        expect(readFileSync(outputPath, "utf8")).toBe("replacement\n");
+      } finally {
+        chmodSync(outputPath, 0o600);
         rmSync(fixtureRoot, { recursive: true, force: true });
       }
     },

--- a/test/scripts/test-update-cli-startup-bench.test.ts
+++ b/test/scripts/test-update-cli-startup-bench.test.ts
@@ -1,20 +1,27 @@
 // Test Update Cli Startup Bench tests cover fixture updater subprocess deadlines.
-import type { SpawnSyncReturns } from "node:child_process";
+import { EventEmitter } from "node:events";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const { spawnSyncMock } = vi.hoisted(() => ({
-  spawnSyncMock: vi.fn(),
+const { spawnMock, terminateManagedChildMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+  terminateManagedChildMock: vi.fn(),
 }));
 
 vi.mock("node:child_process", async () => {
   const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
   return {
     ...actual,
-    spawnSync: spawnSyncMock,
+    spawn: spawnMock,
   };
 });
+
+vi.mock("../../scripts/lib/managed-child-process.mjs", () => ({
+  signalExitCode: (signal: NodeJS.Signals) => (signal === "SIGINT" ? 130 : 143),
+  terminateManagedChild: terminateManagedChildMock,
+}));
 
 const UPDATE_SCRIPT_PATH = path.resolve(process.cwd(), "scripts/test-update-cli-startup-bench.mjs");
 const originalArgv = [...process.argv];
@@ -47,7 +54,8 @@ afterEach(() => {
     process.env.OPENCLAW_TEST_CLI_STARTUP_BENCH_PROCESS_CLEANUP_GRACE_MS =
       originalProcessCleanupGrace;
   }
-  spawnSyncMock.mockReset();
+  spawnMock.mockReset();
+  terminateManagedChildMock.mockReset();
   vi.restoreAllMocks();
   vi.resetModules();
 });
@@ -56,32 +64,51 @@ describe("test-update-cli-startup-bench", () => {
   it("gives the benchmark driver a hard total deadline beyond all internal run budgets", async () => {
     delete process.env.OPENCLAW_TEST_CLI_STARTUP_TIMEOUT_KILL_GRACE_MS;
     delete process.env.OPENCLAW_TEST_CLI_STARTUP_BENCH_PROCESS_CLEANUP_GRACE_MS;
-    spawnSyncMock.mockReturnValue({ status: 0 } as SpawnSyncReturns<Buffer>);
+    spawnMock.mockImplementation((_command, args: string[]) => {
+      const child = Object.assign(new EventEmitter(), { pid: 123_456, kill: vi.fn() });
+      const outputIndex = args.indexOf("--output");
+      writeFileSync(args[outputIndex + 1] ?? "", "{}\n", "utf8");
+      queueMicrotask(() => child.emit("close", 0, null));
+      return child;
+    });
     vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const fixtureRoot = mkdtempSync(path.join(process.cwd(), ".tmp-cli-startup-budget-"));
 
-    for (const preset of ["startup", "real", "all"] as const) {
-      process.argv = [
-        process.execPath,
-        UPDATE_SCRIPT_PATH,
-        "--preset",
-        preset,
-        "--runs",
-        "2",
-        "--warmup",
-        "1",
-        "--timeout-ms",
-        "100",
-      ];
-      spawnSyncMock.mockClear();
-      await import("../../scripts/test-update-cli-startup-bench.mjs");
+    try {
+      for (const preset of ["startup", "real", "all"] as const) {
+        const outputPath = path.join(fixtureRoot, `${preset}.json`);
+        process.argv = [
+          process.execPath,
+          UPDATE_SCRIPT_PATH,
+          "--out",
+          outputPath,
+          "--preset",
+          preset,
+          "--runs",
+          "2",
+          "--warmup",
+          "1",
+          "--timeout-ms",
+          "100",
+        ];
+        spawnMock.mockClear();
+        setTimeoutSpy.mockClear();
+        await import(pathToFileURL(UPDATE_SCRIPT_PATH).href);
 
-      expect(spawnSyncMock).toHaveBeenCalledOnce();
-      const options = spawnSyncMock.mock.calls[0]?.[2];
-      const internalBudgetMs = countBenchmarkCases(preset) * (2 + 1) * (100 + 2 * 1_000);
-      expect(options?.killSignal).toBe("SIGKILL");
-      expect(options?.timeout).toBe(internalBudgetMs + 5_000);
-      expect(options?.timeout).toBeGreaterThan(internalBudgetMs);
-      vi.resetModules();
+        expect(spawnMock).toHaveBeenCalledOnce();
+        const args = spawnMock.mock.calls[0]?.[1] as string[];
+        const options = spawnMock.mock.calls[0]?.[2];
+        const internalBudgetMs = countBenchmarkCases(preset) * (2 + 1) * (100 + 2 * 1_000);
+        expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), internalBudgetMs + 5_000);
+        expect(options?.detached).toBe(process.platform !== "win32");
+        expect(args.at(-1)).not.toBe(outputPath);
+        expect(path.dirname(args.at(-1) ?? "")).toBe(path.dirname(outputPath));
+        expect(readFileSync(outputPath, "utf8")).toBe("{}\n");
+        vi.resetModules();
+      }
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
     }
   });
 
@@ -96,7 +123,12 @@ describe("test-update-cli-startup-bench", () => {
       mkdirSync(path.join(fixtureRoot, "scripts"), { recursive: true });
       writeFileSync(
         path.join(fixtureRoot, "scripts/bench-cli-startup.ts"),
-        ["setInterval(() => {}, 1_000);", "await new Promise(() => {});", ""].join("\n"),
+        [
+          'process.on("SIGTERM", () => {});',
+          "setInterval(() => {}, 1_000);",
+          "await new Promise(() => {});",
+          "",
+        ].join("\n"),
         "utf8",
       );
 
@@ -134,6 +166,67 @@ describe("test-update-cli-startup-bench", () => {
       expect(result.status).toBe(1);
       expect(Date.now() - startedAt).toBeLessThan(4_000);
       expect(existsSync(outputPath)).toBe(false);
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves the existing fixture when the benchmark writes output and then hangs", async () => {
+    const actualChildProcess =
+      await vi.importActual<typeof import("node:child_process")>("node:child_process");
+    const fixtureRoot = mkdtempSync(
+      path.join(process.cwd(), ".tmp-test-update-cli-startup-bench-output-"),
+    );
+    const outputPath = path.join(fixtureRoot, "cli-startup-bench.json");
+    const existingFixture = '{"fixture":"existing"}\n';
+    try {
+      mkdirSync(path.join(fixtureRoot, "scripts"), { recursive: true });
+      writeFileSync(outputPath, existingFixture, "utf8");
+      writeFileSync(
+        path.join(fixtureRoot, "scripts/bench-cli-startup.ts"),
+        [
+          'import { writeFileSync } from "node:fs";',
+          'const outputIndex = process.argv.indexOf("--output");',
+          'writeFileSync(process.argv[outputIndex + 1], "replacement\\n", "utf8");',
+          "setInterval(() => {}, 1_000);",
+          "await new Promise(() => {});",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+
+      const result = actualChildProcess.spawnSync(
+        process.execPath,
+        [
+          UPDATE_SCRIPT_PATH,
+          "--out",
+          outputPath,
+          "--preset",
+          "startup",
+          "--runs",
+          "1",
+          "--warmup",
+          "0",
+          "--timeout-ms",
+          "10",
+        ],
+        {
+          cwd: fixtureRoot,
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            VITEST: "true",
+            OPENCLAW_TEST_CLI_STARTUP_TIMEOUT_KILL_GRACE_MS: "0",
+            OPENCLAW_TEST_CLI_STARTUP_BENCH_PROCESS_CLEANUP_GRACE_MS: "1500",
+          },
+          killSignal: "SIGKILL",
+          timeout: 5_000,
+        },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(1);
+      expect(readFileSync(outputPath, "utf8")).toBe(existingFixture);
     } finally {
       rmSync(fixtureRoot, { recursive: true, force: true });
     }

--- a/test/scripts/test-update-cli-startup-bench.test.ts
+++ b/test/scripts/test-update-cli-startup-bench.test.ts
@@ -1,0 +1,141 @@
+// Test Update Cli Startup Bench tests cover fixture updater subprocess deadlines.
+import type { SpawnSyncReturns } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { spawnSyncMock } = vi.hoisted(() => ({
+  spawnSyncMock: vi.fn(),
+}));
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    spawnSync: spawnSyncMock,
+  };
+});
+
+const UPDATE_SCRIPT_PATH = path.resolve(process.cwd(), "scripts/test-update-cli-startup-bench.mjs");
+const originalArgv = [...process.argv];
+const originalTimeoutCleanupGrace = process.env.OPENCLAW_TEST_CLI_STARTUP_TIMEOUT_KILL_GRACE_MS;
+const originalProcessCleanupGrace =
+  process.env.OPENCLAW_TEST_CLI_STARTUP_BENCH_PROCESS_CLEANUP_GRACE_MS;
+
+function countBenchmarkCases(preset: "startup" | "real" | "all"): number {
+  const source = readFileSync(path.resolve(process.cwd(), "scripts/bench-cli-startup.ts"), "utf8");
+  const start = source.indexOf("const COMMAND_CASES");
+  const end = source.indexOf("] as const;", start);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  const cases = [...source.slice(start, end).matchAll(/presets:\s*\[([^\]]+)\]/gu)].map((match) =>
+    [...(match[1] ?? "").matchAll(/"([^"]+)"/gu)].map((entry) => entry[1]),
+  );
+  return preset === "all" ? cases.length : cases.filter((entry) => entry.includes(preset)).length;
+}
+
+afterEach(() => {
+  process.argv = [...originalArgv];
+  if (originalTimeoutCleanupGrace === undefined) {
+    delete process.env.OPENCLAW_TEST_CLI_STARTUP_TIMEOUT_KILL_GRACE_MS;
+  } else {
+    process.env.OPENCLAW_TEST_CLI_STARTUP_TIMEOUT_KILL_GRACE_MS = originalTimeoutCleanupGrace;
+  }
+  if (originalProcessCleanupGrace === undefined) {
+    delete process.env.OPENCLAW_TEST_CLI_STARTUP_BENCH_PROCESS_CLEANUP_GRACE_MS;
+  } else {
+    process.env.OPENCLAW_TEST_CLI_STARTUP_BENCH_PROCESS_CLEANUP_GRACE_MS =
+      originalProcessCleanupGrace;
+  }
+  spawnSyncMock.mockReset();
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+describe("test-update-cli-startup-bench", () => {
+  it("gives the benchmark driver a hard total deadline beyond all internal run budgets", async () => {
+    delete process.env.OPENCLAW_TEST_CLI_STARTUP_TIMEOUT_KILL_GRACE_MS;
+    delete process.env.OPENCLAW_TEST_CLI_STARTUP_BENCH_PROCESS_CLEANUP_GRACE_MS;
+    spawnSyncMock.mockReturnValue({ status: 0 } as SpawnSyncReturns<Buffer>);
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    for (const preset of ["startup", "real", "all"] as const) {
+      process.argv = [
+        process.execPath,
+        UPDATE_SCRIPT_PATH,
+        "--preset",
+        preset,
+        "--runs",
+        "2",
+        "--warmup",
+        "1",
+        "--timeout-ms",
+        "100",
+      ];
+      spawnSyncMock.mockClear();
+      await import("../../scripts/test-update-cli-startup-bench.mjs");
+
+      expect(spawnSyncMock).toHaveBeenCalledOnce();
+      const options = spawnSyncMock.mock.calls[0]?.[2];
+      const internalBudgetMs = countBenchmarkCases(preset) * (2 + 1) * (100 + 2 * 1_000);
+      expect(options?.killSignal).toBe("SIGKILL");
+      expect(options?.timeout).toBe(internalBudgetMs + 5_000);
+      expect(options?.timeout).toBeGreaterThan(internalBudgetMs);
+      vi.resetModules();
+    }
+  });
+
+  it("exits before a hanging benchmark driver can block fixture refresh forever", async () => {
+    const actualChildProcess =
+      await vi.importActual<typeof import("node:child_process")>("node:child_process");
+    const fixtureRoot = mkdtempSync(
+      path.join(process.cwd(), ".tmp-test-update-cli-startup-bench-"),
+    );
+    const outputPath = path.join(fixtureRoot, "cli-startup-bench.json");
+    try {
+      mkdirSync(path.join(fixtureRoot, "scripts"), { recursive: true });
+      writeFileSync(
+        path.join(fixtureRoot, "scripts/bench-cli-startup.ts"),
+        ["setInterval(() => {}, 1_000);", "await new Promise(() => {});", ""].join("\n"),
+        "utf8",
+      );
+
+      const startedAt = Date.now();
+      const result = actualChildProcess.spawnSync(
+        process.execPath,
+        [
+          UPDATE_SCRIPT_PATH,
+          "--out",
+          outputPath,
+          "--preset",
+          "startup",
+          "--runs",
+          "1",
+          "--warmup",
+          "0",
+          "--timeout-ms",
+          "10",
+        ],
+        {
+          cwd: fixtureRoot,
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            VITEST: "true",
+            OPENCLAW_TEST_CLI_STARTUP_TIMEOUT_KILL_GRACE_MS: "0",
+            OPENCLAW_TEST_CLI_STARTUP_BENCH_PROCESS_CLEANUP_GRACE_MS: "100",
+          },
+          killSignal: "SIGKILL",
+          timeout: 5_000,
+        },
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.status).toBe(1);
+      expect(Date.now() - startedAt).toBeLessThan(4_000);
+      expect(existsSync(outputPath)).toBe(false);
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where contributors refreshing the checked-in CLI startup benchmark fixture could wait forever when the benchmark driver stalled during argument parsing, module loading, report persistence, or final cleanup. The existing `--timeout-ms` option bounded individual measured CLI runs only; the updater's outer wait for the benchmark driver had no deadline.

## Why This Change Was Made

The updater now gives driver startup an independent hard deadline. Once argument parsing and module loading complete, the driver reports its canonical execution budget over IPC from the actual selected case set, runs, warmups, per-run timeout, and cleanup windows; the updater then replaces the startup deadline with that budget plus final cleanup grace. This keeps the case list owned in one place. On expiry the updater asks the driver to terminate, escalates to a force kill, and stops waiting after a final bounded settle phase even if no child `close` event arrives.

The driver writes to a temporary output that is published only after status 0, so a timeout after report persistence cannot replace or truncate the checked-in fixture. A missing destination uses sibling staging and is atomically created; an existing regular destination uses a private system-temporary staging directory and is written through its resolved final inode, preserving symlinks, hardlinks, restricted permissions, ownership, and ACLs without requiring parent-directory write or file read access. Named pipes, devices, and other special outputs are rejected before the benchmark instead of being replaced. The updater forwards the standard POSIX termination set including `SIGQUIT` with conventional exit codes. The benchmark driver only reports its execution budget and active detached sample process-group leader over IPC, allowing the updater to kill that group after timeout, interruption, or an independent driver close without duplicating a second signal state machine in the driver. CLI flags, benchmark defaults, fixture schema, and the separate budget-check command are unchanged; that sibling command's independent deadline fix is tracked in #110923.

## User Impact

Startup fixture refreshes now fail nonzero instead of hanging indefinitely when the benchmark driver stalls. Failed, timed-out, or interrupted refreshes preserve the previous fixture, remove temporary output, and do not leave an active measured CLI process behind. Healthy benchmark runs retain their full modeled execution and cleanup budget, including when a custom regular output is reached through symlinks or hardlinks or has restricted permissions.

## Evidence

- Red regressions before the complete fix reproduced both failure modes: a driver that wrote output and then hung replaced the destination fixture, and terminating a driver with an active detached sample left the sample group running.
- Independent issue-path runtime after the fix used the real updater with a driver that wrote partial output, reported a real detached sample plus descendant, ignored `SIGTERM`, and then stalled. The proof process itself had a separate 10-second supervisor bound. Redacted terminal transcript:

```text
$ node scripts/test-update-cli-startup-bench.mjs --preset startup --runs 1 --warmup 0 --timeout-ms 1
{
  "elapsed_ms": 1195,
  "updater_status": 1,
  "fixture_before": "{\"fixture\":\"existing\"}",
  "fixture_after": "{\"fixture\":\"existing\"}",
  "temporary_outputs": [],
  "sample_running_after_exit": false,
  "descendant_running_after_exit": false
}
```

  This visibly demonstrates bounded nonzero exit, byte-for-byte fixture preservation, temporary-output cleanup, and process-group reaping on Linux with Node 24.16.0.
- Regression suite: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/test-projects.mjs test/scripts/test-update-cli-startup-bench.test.ts test/scripts/bench-cli-startup.test.ts test/scripts/cli-startup-bench-spawner.test.ts` — 41 tests passed, including canonical driver-budget handoff, bounded startup, first-interrupt precedence across a later deadline, no-`close` force-kill settle, independent driver-crash cleanup, signal exit codes, custom-output symlink/hardlink/dangling-target/permission behavior, and FIFO/device rejection.
- Formatting: `./node_modules/.bin/oxfmt --check scripts/test-update-cli-startup-bench.mjs scripts/bench-cli-startup.ts test/scripts/test-update-cli-startup-bench.test.ts test/scripts/bench-cli-startup.test.ts test/scripts/cli-startup-bench-spawner.test.ts`.
- Targeted lint passed for the changed updater, benchmark driver, and regression tests.
- Fresh same-problem recall found no open PR covering this fixture-updater deadline.
