### PR TITLE
fix(ai): reject non-text Codex websocket frames

### DIFF
--- a/packages/ai/src/providers/openai-chatgpt-responses.cache.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.cache.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocket, WebSocketServer } from "ws";
 import { configureAiTransportHost } from "../host.js";
 import { cleanupSessionResources } from "../session-resources.js";
+import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../transports/transport-utils.js";
 import type { Context, Model } from "../types.js";
 import {
   closeOpenAICodexWebSocketSessions,
@@ -385,6 +386,108 @@ describe("ChatGPT Responses cached transport", () => {
         );
       }),
     ).toEqual([]);
+  });
+
+  it.each([
+    {
+      label: "valid UTF-8 JSON",
+      frame: new TextEncoder().encode(JSON.stringify(completion("resp_binary"))).buffer,
+    },
+    {
+      label: "malformed bytes",
+      frame: Uint8Array.from([0xff, 0xfe, 0xfd]).buffer,
+    },
+  ])("rejects $label in a binary frame and invalidates cached state", async ({ frame }) => {
+    const sockets: ProtocolFrameWebSocket[] = [];
+    const sentPayloads: Array<Record<string, unknown>> = [];
+    let connectionCount = 0;
+
+    class ProtocolFrameWebSocket extends EventTarget {
+      readonly connectionId = ++connectionCount;
+      readonly listeners = new Map<string, Set<EventListenerOrEventListenerObject>>();
+      readyState = 1;
+      sendCount = 0;
+
+      constructor() {
+        super();
+        sockets.push(this);
+        queueMicrotask(() => this.dispatchEvent(new Event("open")));
+      }
+
+      override addEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | AddEventListenerOptions,
+      ): void {
+        super.addEventListener(type, listener, options);
+        const listeners = this.listeners.get(type) ?? new Set();
+        listeners.add(listener);
+        this.listeners.set(type, listeners);
+      }
+
+      override removeEventListener(
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | EventListenerOptions,
+      ): void {
+        super.removeEventListener(type, listener, options);
+        this.listeners.get(type)?.delete(listener);
+      }
+
+      send(payload: string): void {
+        this.sendCount += 1;
+        sentPayloads.push(JSON.parse(payload) as Record<string, unknown>);
+        queueMicrotask(() => {
+          const data =
+            this.connectionId === 1 && this.sendCount === 2
+              ? frame
+              : JSON.stringify(completion(`resp_${this.connectionId}_${this.sendCount}`));
+          this.dispatchEvent(Object.assign(new Event("message"), { data }));
+        });
+      }
+
+      close(): void {
+        this.readyState = 3;
+      }
+
+      activeStreamListenerCount(): number {
+        return ["message", "error", "close"].reduce(
+          (count, type) => count + (this.listeners.get(type)?.size ?? 0),
+          0,
+        );
+      }
+    }
+
+    vi.stubGlobal("WebSocket", ProtocolFrameWebSocket);
+    const options = {
+      apiKey: createJwt(),
+      sessionId: `binary-frame-${connectionCount}`,
+      transport: "websocket-cached" as const,
+    };
+    const followUpContext = {
+      messages: [...context.messages, { role: "user", content: "follow-up", timestamp: 2 }],
+    } satisfies Context;
+
+    expect((await streamOpenAICodexResponses(model, context, options).result()).stopReason).toBe(
+      "stop",
+    );
+    expect(sockets[0]?.activeStreamListenerCount()).toBe(0);
+
+    const rejected = await streamOpenAICodexResponses(model, followUpContext, options).result();
+    expect(rejected).toMatchObject({
+      stopReason: "error",
+      errorMessage: MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE,
+    });
+    expect(sockets[0]).toMatchObject({ readyState: 3, sendCount: 2 });
+    expect(sockets[0]?.activeStreamListenerCount()).toBe(0);
+    expect(sentPayloads[1]?.previous_response_id).toBe("resp_1_1");
+
+    expect(
+      (await streamOpenAICodexResponses(model, followUpContext, options).result()).stopReason,
+    ).toBe("stop");
+    expect(sockets).toHaveLength(2);
+    expect(sockets[1]?.activeStreamListenerCount()).toBe(0);
+    expect(sentPayloads[2]?.previous_response_id).toBeUndefined();
   });
 
   it("closes the concurrent acquire loser promptly without leaking its socket", async () => {

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -1254,25 +1254,6 @@ function extractWebSocketCloseError(event: unknown): Error {
   return new Error("WebSocket closed");
 }
 
-async function decodeWebSocketData(data: unknown): Promise<string | null> {
-  if (typeof data === "string") {
-    return data;
-  }
-  if (data instanceof ArrayBuffer) {
-    return new TextDecoder().decode(new Uint8Array(data));
-  }
-  if (ArrayBuffer.isView(data)) {
-    const view = data;
-    return new TextDecoder().decode(new Uint8Array(view.buffer, view.byteOffset, view.byteLength));
-  }
-  if (data && typeof data === "object" && "arrayBuffer" in data) {
-    const blobLike = data as { arrayBuffer: () => Promise<ArrayBuffer> };
-    const arrayBuffer = await blobLike.arrayBuffer();
-    return new TextDecoder().decode(new Uint8Array(arrayBuffer));
-  }
-  return null;
-}
-
 async function* parseWebSocket(
   socket: WebSocketLike,
   signal?: AbortSignal,
@@ -1293,40 +1274,42 @@ async function* parseWebSocket(
   };
 
   const onMessage: WebSocketListener = (event) => {
-    void (async () => {
-      let text: string | null = null;
-      try {
-        if (!event || typeof event !== "object" || !("data" in event)) {
-          return;
-        }
-        text = await decodeWebSocketData((event as { data?: unknown }).data);
-        if (!text) {
-          return;
-        }
-        const parsed = JSON.parse(text) as Record<string, unknown>;
-        const type = typeof parsed.type === "string" ? parsed.type : "";
-        if (
-          type === "response.completed" ||
-          type === "response.done" ||
-          type === "response.incomplete"
-        ) {
-          sawCompletion = true;
-          done = true;
-        }
-        queue.push(parsed);
-        wake();
-      } catch (cause) {
-        failed = new CodexProtocolError(
-          `Invalid Codex WebSocket JSON: ${formatThrownValue(cause)}`,
-          {
-            cause,
-            payload: text,
-          },
-        );
+    const data =
+      event && typeof event === "object" && "data" in event
+        ? (event as { data?: unknown }).data
+        : undefined;
+    if (typeof data !== "string") {
+      // Codex response events are text frames. Keep malformed transport failures
+      // on the shared marker so callers receive the canonical retry guidance.
+      failed = new CodexProtocolError(MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE, {
+        payload: data,
+      });
+      done = true;
+      wake();
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(data) as Record<string, unknown>;
+      const type = typeof parsed.type === "string" ? parsed.type : "";
+      if (
+        type === "response.completed" ||
+        type === "response.done" ||
+        type === "response.incomplete"
+      ) {
+        sawCompletion = true;
         done = true;
-        wake();
       }
-    })();
+      queue.push(parsed);
+      wake();
+    } catch (cause) {
+      failed = new CodexProtocolError(`Invalid Codex WebSocket JSON: ${formatThrownValue(cause)}`, {
+        cause,
+        payload: data,
+      });
+      done = true;
+      wake();
+    }
   };
 
   const onError: WebSocketListener = (event) => {


### PR DESCRIPTION
## What problem this solves

The Codex Responses WebSocket protocol delivers response events as text frames
and treats binary frames as terminal protocol errors. OpenClaw instead accepted
`ArrayBuffer`, typed-array, and Blob-like frames, decoded them as UTF-8, and fed
them into the JSON response stream.

That behavior diverged from Codex's protocol contract and allowed an unexpected
binary frame to participate in a cached continuation before the transport
failed.

## Canonical fix

- Accept only string WebSocket frames.
- Reject every non-text frame with the shared malformed-stream marker so the
  caller receives OpenClaw's canonical retry guidance.
- Remove the asynchronous binary/Blob decoder and its duplicate parsing path.
- Reuse the existing terminal-error cleanup, which clears continuation state,
  evicts the cached socket, closes it, and reconnects cleanly on the next run.

No config, Plugin SDK, protocol schema, persistence, or product feature surface
changes.

## Upstream contract

Direct inspection of sibling `openai/codex` at
`414782450952a196bbb64b1605a458c2531c47b6`:

- `codex-rs/codex-api/src/endpoint/responses_websocket.rs:672-764` processes
  `Message::Text` response events and terminally rejects `Message::Binary`.
- `codex-rs/codex-api/src/endpoint/responses_websocket.rs:778-795` sends
  requests as `Message::Text`.
- `codex-rs/core/tests/common/responses.rs:1392-1399` emits mocked response
  events as text.

Binary parsing at `codex-rs/core/tests/common/responses.rs:1425-1429` is for
inbound client requests, not server response events.

## Evidence

Exact rewritten head: `7b52e5d96c458fc543e57c419de7fd658ee458fb`

- Focused cached-WebSocket suite: 9/9 passed.
- Focused provider and malformed-stream suites: 38/38 passed.
- Prior cache stress: 5 bounded reruns, 45/45 passed.
- Regression coverage proves binary rejection, actionable error projection,
  listener/socket cleanup, cache invalidation, and a clean text-frame reconnect.
- Scoped formatting, targeted type-aware oxlint, and `git diff --check`: clean.
- `check-changed --dry-run`: `core` and `coreTests`.
- P1 autoreview: no actionable findings; correctness confidence 0.98.
- The patch projects byte-for-byte and conflict-free onto current `main`
  `a67c52611e5768ffe89dc2c4eea0cea0e26e34e6`.

### Real behavior proof

On exact head `7b52e5d96c458fc543e57c419de7fd658ee458fb`, a transient
trusted-local harness used an unexpired OpenAI OAuth credential read from
OpenClaw's canonical auth store and the real `openai/gpt-5.5` ChatGPT WebSocket
transport:

- Turn 1 completed against the real ChatGPT service and established a cached
  continuation.
- A local fault-injection WebSocket relay injected one synthetic binary server
  frame into turn 2 at the actual transport boundary.
- Turn 2 failed through the canonical malformed-stream marker.
- Turn 3 completed against the real service on a new connection, with no stale
  continuation id.
- Result: 1/1 passed in 67.10s; 2 downstream connections, 28 upstream text
  frames, exactly 1 injected binary frame.

Redacted behavior evidence:

```json
{"modelRef":"openai/gpt-5.5","firstTurn":"stop","injectedBinaryFrames":1,"malformedMarkerMatched":true,"recoveredTurn":"stop","downstreamConnections":2,"upstreamTextFrames":28,"cachedContinuationBeforeFault":true,"staleContinuationAfterFault":"cleared"}
```

This was not a mock provider or mock channel run: turns 1 and 3 reached the
real ChatGPT service. The upstream service did not naturally emit binary; the
targeted non-text server frame was injected locally between those two real
turns. Trusted-local fallback was used because the disposable Testbox's
hydrated Codex OAuth token was expired, and refreshing the shared rotating
credential from an ephemeral host was intentionally avoided.

The permissive binary decoder entered through PR #85341 (`bb46b79d`) and moved
with the AI package extraction in PR #99059 (`062f88e3`).

## Scope

Production delta: `+34/-51` (net -17) in the Codex Responses WebSocket
transport. Tests add 103 lines.

Changelog not required: this aligns the existing transport with the upstream
protocol contract.
