### PR TITLE
fix(plugins): load active generation after upgrades

### DIFF
--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -523,7 +523,7 @@ The local plugin registry is OpenClaw's persisted cold read model for installed 
 
 Use `plugins registry` to inspect whether the persisted registry is present, current, or stale. Use `--refresh` to rebuild it from the persisted plugin index, config policy, and manifest/package metadata. This is a repair path, not a runtime activation path.
 
-`openclaw doctor --fix` also repairs registry-adjacent managed npm drift: if an orphaned or recovered `@openclaw/*` package under a managed plugin npm project or the legacy flat managed npm root shadows a bundled plugin, doctor removes that stale package and rebuilds the registry so startup validates against the bundled manifest. Doctor also relinks the host `openclaw` package into managed npm plugins that declare `peerDependencies.openclaw`, so package-local runtime imports such as `openclaw/plugin-sdk/*` resolve after updates or npm repairs.
+`openclaw doctor --fix` also repairs registry-adjacent managed npm drift. If an orphaned or recovered `@openclaw/*` package under a managed plugin npm project or the legacy flat managed npm root shadows a bundled plugin, doctor removes that stale package and rebuilds the registry so startup validates against the bundled manifest. When an authoritative install record selects one managed generation but older flat or generation directories remain, doctor retires those stale trees for pruning after the gateway restarts. Doctor also relinks the host `openclaw` package into managed npm plugins that declare `peerDependencies.openclaw`, so package-local runtime imports such as `openclaw/plugin-sdk/*` resolve after updates or npm repairs.
 
 ## Marketplace
 

--- a/src/commands/doctor-plugin-generations.ts
+++ b/src/commands/doctor-plugin-generations.ts
@@ -1,0 +1,158 @@
+import path from "node:path";
+import { note } from "../../packages/terminal-core/src/note.js";
+import { formatCliCommand } from "../cli/command-format.js";
+import type { HealthFinding, HealthRepairEffect } from "../flows/health-checks.js";
+import { normalizeWindowsPathForComparison } from "../infra/path-guards.js";
+import { listRecoveredManagedNpmInstallCandidates } from "../plugins/installed-plugin-index-record-reader.js";
+import {
+  clearLoadInstalledPluginIndexInstallRecordsCache,
+  loadInstalledPluginIndexInstallRecords,
+  type InstalledPluginIndexRecordStoreOptions,
+} from "../plugins/installed-plugin-index-records.js";
+import { markRetainedManagedNpmInstall } from "../plugins/managed-npm-retention.js";
+import { shortenHomePath } from "../utils.js";
+import type { DoctorPrompter } from "./doctor-prompter.js";
+
+export const PLUGIN_REGISTRY_CHECK_ID = "core/doctor/plugin-registry";
+
+export type StaleManagedNpmInstallGenerationIssue = {
+  kind: "stale-managed-npm-install-generation";
+  activePackageDir: string;
+  packageDir: string;
+  pluginId: string;
+  version?: string;
+};
+
+type PluginGenerationDoctorParams = InstalledPluginIndexRecordStoreOptions & {
+  prompter: Pick<DoctorPrompter, "shouldRepair">;
+};
+
+function normalizeManagedInstallPath(filePath: string): string {
+  const resolved = path.resolve(filePath);
+  return process.platform === "win32" ? normalizeWindowsPathForComparison(resolved) : resolved;
+}
+
+export async function listStaleManagedNpmInstallGenerations(
+  params: InstalledPluginIndexRecordStoreOptions,
+): Promise<StaleManagedNpmInstallGenerationIssue[]> {
+  // The reader keeps a persisted active path authoritative and supplies its
+  // deterministic recovery choice when that authority is absent or dangling.
+  const activeRecords = await loadInstalledPluginIndexInstallRecords(params);
+  const candidates = listRecoveredManagedNpmInstallCandidates(params);
+  const candidatesByPluginId = new Map<string, typeof candidates>();
+  for (const candidate of candidates) {
+    const entries = candidatesByPluginId.get(candidate.pluginId) ?? [];
+    entries.push(candidate);
+    candidatesByPluginId.set(candidate.pluginId, entries);
+  }
+
+  const stale: StaleManagedNpmInstallGenerationIssue[] = [];
+  for (const [pluginId, pluginCandidates] of candidatesByPluginId) {
+    const activeRecord = activeRecords[pluginId];
+    if (activeRecord?.source !== "npm" || !activeRecord.installPath) {
+      continue;
+    }
+    const activePath = normalizeManagedInstallPath(activeRecord.installPath);
+    const active = pluginCandidates.find(
+      (candidate) =>
+        candidate.installRecord.installPath &&
+        normalizeManagedInstallPath(candidate.installRecord.installPath) === activePath,
+    );
+    if (!active) {
+      continue;
+    }
+    for (const candidate of pluginCandidates) {
+      const packageDir = candidate.installRecord.installPath;
+      if (!packageDir || normalizeManagedInstallPath(packageDir) === activePath) {
+        continue;
+      }
+      stale.push({
+        kind: "stale-managed-npm-install-generation",
+        pluginId,
+        activePackageDir: activeRecord.installPath,
+        packageDir,
+        ...(candidate.installRecord.resolvedVersion
+          ? { version: candidate.installRecord.resolvedVersion }
+          : {}),
+      });
+    }
+  }
+  return stale.toSorted((left, right) => left.packageDir.localeCompare(right.packageDir));
+}
+
+/** Marks non-authoritative managed npm trees for safe cleanup after gateway shutdown. */
+export async function maybeRepairStaleManagedNpmInstallGenerations(
+  params: PluginGenerationDoctorParams,
+): Promise<boolean> {
+  const stale = await listStaleManagedNpmInstallGenerations(params);
+  if (stale.length === 0) {
+    return false;
+  }
+  if (!params.prompter.shouldRepair) {
+    note(
+      [
+        "Managed npm plugin installs have stale non-authoritative generations:",
+        ...stale.map(
+          (generation) =>
+            `- ${generation.pluginId}: ${shortenHomePath(generation.packageDir)}${generation.version ? ` (${generation.version})` : ""}`,
+        ),
+        `Repair with ${formatCliCommand("openclaw doctor --fix")} to retire stale generations after the gateway restarts.`,
+      ].join("\n"),
+      "Plugin registry",
+    );
+    return false;
+  }
+
+  const retired: StaleManagedNpmInstallGenerationIssue[] = [];
+  for (const generation of stale) {
+    if (
+      await markRetainedManagedNpmInstall({
+        packageDir: generation.packageDir,
+        pluginId: generation.pluginId,
+        reason: "doctor-repaired-stale-managed-npm-generation",
+      })
+    ) {
+      retired.push(generation);
+    }
+  }
+  if (retired.length === 0) {
+    return false;
+  }
+  clearLoadInstalledPluginIndexInstallRecordsCache();
+  note(
+    [
+      "Retired stale managed npm plugin generation(s); they will be pruned after the gateway restarts:",
+      ...retired.map(
+        (generation) =>
+          `- ${generation.pluginId}: ${shortenHomePath(generation.packageDir)}${generation.version ? ` (${generation.version})` : ""}`,
+      ),
+    ].join("\n"),
+    "Plugin registry",
+  );
+  return true;
+}
+
+export function staleManagedNpmInstallGenerationToHealthFinding(
+  issue: StaleManagedNpmInstallGenerationIssue,
+): HealthFinding {
+  return {
+    checkId: PLUGIN_REGISTRY_CHECK_ID,
+    severity: "warning",
+    message: `Managed npm plugin ${issue.pluginId}${issue.version ? `@${issue.version}` : ""} is a stale non-authoritative generation.`,
+    path: issue.packageDir,
+    target: issue.pluginId,
+    fixHint:
+      "Run `openclaw doctor --fix` to retire the stale generation for pruning after the gateway restarts.",
+  };
+}
+
+export function staleManagedNpmInstallGenerationToRepairEffect(
+  issue: StaleManagedNpmInstallGenerationIssue,
+): HealthRepairEffect {
+  return {
+    kind: "package",
+    action: "would-retire-stale-managed-npm-install-generation",
+    target: issue.packageDir,
+    dryRunSafe: false,
+  };
+}

--- a/src/commands/doctor-plugin-registry-generation-repair.test.ts
+++ b/src/commands/doctor-plugin-registry-generation-repair.test.ts
@@ -14,6 +14,7 @@ import {
 import {
   cleanupRetainedManagedNpmInstallGenerations,
   hasRetainedManagedNpmInstallMarker,
+  resolveRetainedManagedNpmInstallPackageInfo,
 } from "../plugins/managed-npm-retention.js";
 import { writeManagedNpmPlugin } from "../plugins/test-helpers/managed-npm-plugin.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
@@ -49,6 +50,17 @@ function writeManagedGeneration(stateDir: string, version: string): string {
   });
   fs.renameSync(flatProjectRoot, generationProjectRoot);
   return path.join(generationProjectRoot, "node_modules", ...PACKAGE_NAME.split("/"));
+}
+
+function setInstallTimestamp(packageDir: string, timestamp: Date): void {
+  const packageInfo = resolveRetainedManagedNpmInstallPackageInfo(packageDir);
+  if (!packageInfo) {
+    throw new Error(`Expected managed npm package dir: ${packageDir}`);
+  }
+  fs.utimesSync(path.join(packageDir, "package.json"), timestamp, timestamp);
+  fs.utimesSync(packageDir, timestamp, timestamp);
+  fs.utimesSync(path.join(packageInfo.projectRoot, "package.json"), timestamp, timestamp);
+  fs.utimesSync(packageInfo.projectRoot, timestamp, timestamp);
 }
 
 afterEach(() => {
@@ -104,8 +116,8 @@ describe("doctor managed npm generation repair", () => {
     const stalePackageDir = writeManagedFlat(stateDir, "9.0.0");
     const activeTimestamp = new Date("2026-01-02T00:00:00.000Z");
     const staleTimestamp = new Date("2026-01-01T00:00:00.000Z");
-    fs.utimesSync(path.join(activePackageDir, "package.json"), activeTimestamp, activeTimestamp);
-    fs.utimesSync(path.join(stalePackageDir, "package.json"), staleTimestamp, staleTimestamp);
+    setInstallTimestamp(activePackageDir, activeTimestamp);
+    setInstallTimestamp(stalePackageDir, staleTimestamp);
     await writePersistedInstalledPluginIndexInstallRecords({}, { stateDir, candidates: [] });
     vi.spyOn(process, "emitWarning").mockImplementation(() => undefined);
 

--- a/src/commands/doctor-plugin-registry-generation-repair.test.ts
+++ b/src/commands/doctor-plugin-registry-generation-repair.test.ts
@@ -1,0 +1,134 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  resolvePluginNpmGenerationProjectDir,
+  resolvePluginNpmProjectDir,
+} from "../plugins/install-paths.js";
+import {
+  clearLoadInstalledPluginIndexInstallRecordsCache,
+  readPersistedInstalledPluginIndexInstallRecords,
+  writePersistedInstalledPluginIndexInstallRecords,
+} from "../plugins/installed-plugin-index-records.js";
+import {
+  cleanupRetainedManagedNpmInstallGenerations,
+  hasRetainedManagedNpmInstallMarker,
+} from "../plugins/managed-npm-retention.js";
+import { writeManagedNpmPlugin } from "../plugins/test-helpers/managed-npm-plugin.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { maybeRepairStaleManagedNpmInstallGenerations } from "./doctor-plugin-generations.js";
+import { maybeRepairPluginRegistryState } from "./doctor-plugin-registry.js";
+
+const PACKAGE_NAME = "@proof/openclaw-generation";
+const PLUGIN_ID = "generation-proof";
+const tempDirs: string[] = [];
+
+function makeStateDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-doctor-plugin-generation-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeManagedFlat(stateDir: string, version: string): string {
+  const npmDir = path.join(stateDir, "npm");
+  writeManagedNpmPlugin({ stateDir, packageName: PACKAGE_NAME, pluginId: PLUGIN_ID, version });
+  return path.join(
+    resolvePluginNpmProjectDir({ npmDir, packageName: PACKAGE_NAME }),
+    "node_modules",
+    ...PACKAGE_NAME.split("/"),
+  );
+}
+
+function writeManagedGeneration(stateDir: string, version: string): string {
+  const npmDir = path.join(stateDir, "npm");
+  writeManagedNpmPlugin({ stateDir, packageName: PACKAGE_NAME, pluginId: PLUGIN_ID, version });
+  const flatProjectRoot = resolvePluginNpmProjectDir({ npmDir, packageName: PACKAGE_NAME });
+  const generationProjectRoot = resolvePluginNpmGenerationProjectDir({
+    npmDir,
+    packageName: PACKAGE_NAME,
+    generationKey: `${PACKAGE_NAME}@${version}`,
+  });
+  fs.renameSync(flatProjectRoot, generationProjectRoot);
+  return path.join(generationProjectRoot, "node_modules", ...PACKAGE_NAME.split("/"));
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  closeOpenClawStateDatabaseForTest();
+  clearLoadInstalledPluginIndexInstallRecordsCache();
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("doctor managed npm generation repair", () => {
+  it("retires the stale flat install and prunes it after gateway shutdown", async () => {
+    const stateDir = makeStateDir();
+    const npmDir = path.join(stateDir, "npm");
+    const activePackageDir = writeManagedGeneration(stateDir, "2026.7.1");
+    const stalePackageDir = writeManagedFlat(stateDir, "2026.6.11");
+    await writePersistedInstalledPluginIndexInstallRecords(
+      {
+        [PLUGIN_ID]: {
+          source: "npm",
+          spec: `${PACKAGE_NAME}@latest`,
+          installPath: activePackageDir,
+          resolvedName: PACKAGE_NAME,
+          resolvedSpec: `${PACKAGE_NAME}@2026.7.1`,
+          resolvedVersion: "2026.7.1",
+          version: "2026.7.1",
+        },
+      },
+      { stateDir, candidates: [] },
+    );
+
+    await expect(
+      maybeRepairStaleManagedNpmInstallGenerations({
+        env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+        prompter: { shouldRepair: true },
+        stateDir,
+      }),
+    ).resolves.toBe(true);
+    expect(hasRetainedManagedNpmInstallMarker(stalePackageDir)).toBe(true);
+    expect(hasRetainedManagedNpmInstallMarker(activePackageDir)).toBe(false);
+
+    await expect(
+      cleanupRetainedManagedNpmInstallGenerations({
+        activeInstallPaths: [activePackageDir],
+        npmDir,
+      }),
+    ).resolves.toBe(1);
+    expect(fs.existsSync(stalePackageDir)).toBe(false);
+    expect(fs.existsSync(activePackageDir)).toBe(true);
+  });
+
+  it("persists the recency fallback when no authoritative record exists", async () => {
+    const stateDir = makeStateDir();
+    const activePackageDir = writeManagedGeneration(stateDir, "1.0.0");
+    const stalePackageDir = writeManagedFlat(stateDir, "9.0.0");
+    const activeTimestamp = new Date("2026-01-02T00:00:00.000Z");
+    const staleTimestamp = new Date("2026-01-01T00:00:00.000Z");
+    fs.utimesSync(path.join(activePackageDir, "package.json"), activeTimestamp, activeTimestamp);
+    fs.utimesSync(path.join(stalePackageDir, "package.json"), staleTimestamp, staleTimestamp);
+    await writePersistedInstalledPluginIndexInstallRecords({}, { stateDir, candidates: [] });
+    vi.spyOn(process, "emitWarning").mockImplementation(() => undefined);
+
+    await maybeRepairPluginRegistryState({
+      config: {
+        plugins: {
+          allow: [PLUGIN_ID],
+          entries: { [PLUGIN_ID]: { enabled: true } },
+        },
+      },
+      env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+      prompter: { shouldRepair: true },
+      stateDir,
+    });
+
+    const persisted = await readPersistedInstalledPluginIndexInstallRecords({ stateDir });
+    expect(persisted?.[PLUGIN_ID]?.installPath).toBe(activePackageDir);
+    expect(hasRetainedManagedNpmInstallMarker(stalePackageDir)).toBe(true);
+    expect(hasRetainedManagedNpmInstallMarker(activePackageDir)).toBe(false);
+  });
+});

--- a/src/commands/doctor-plugin-registry-generation-repair.test.ts
+++ b/src/commands/doctor-plugin-registry-generation-repair.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import {
   resolvePluginNpmGenerationProjectDir,
   resolvePluginNpmProjectDir,
@@ -22,12 +22,10 @@ import { maybeRepairPluginRegistryState } from "./doctor-plugin-registry.js";
 
 const PACKAGE_NAME = "@proof/openclaw-generation";
 const PLUGIN_ID = "generation-proof";
-const tempDirs: string[] = [];
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function makeStateDir(): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-doctor-plugin-generation-"));
-  tempDirs.push(dir);
-  return dir;
+  return tempDirs.make("openclaw-doctor-plugin-generation-");
 }
 
 function writeManagedFlat(stateDir: string, version: string): string {
@@ -57,9 +55,6 @@ afterEach(() => {
   vi.restoreAllMocks();
   closeOpenClawStateDatabaseForTest();
   clearLoadInstalledPluginIndexInstallRecordsCache();
-  for (const dir of tempDirs.splice(0)) {
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
 });
 
 describe("doctor managed npm generation repair", () => {

--- a/src/commands/doctor-plugin-registry.ts
+++ b/src/commands/doctor-plugin-registry.ts
@@ -28,14 +28,20 @@ import {
   type StaleLocalBundledPluginInstallRecord,
 } from "../plugins/stale-local-bundled-plugin-install-records.js";
 import { shortenHomePath } from "../utils.js";
+import {
+  listStaleManagedNpmInstallGenerations,
+  maybeRepairStaleManagedNpmInstallGenerations,
+  PLUGIN_REGISTRY_CHECK_ID,
+  staleManagedNpmInstallGenerationToHealthFinding,
+  staleManagedNpmInstallGenerationToRepairEffect,
+  type StaleManagedNpmInstallGenerationIssue,
+} from "./doctor-plugin-generations.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
 import {
   migratePluginRegistryForInstall,
   preflightPluginRegistryInstallMigration,
   type PluginRegistryInstallMigrationParams,
 } from "./doctor/shared/plugin-registry-migration.js";
-
-const PLUGIN_REGISTRY_CHECK_ID = "core/doctor/plugin-registry";
 
 type PluginRegistryDoctorRepairParams = Omit<PluginRegistryInstallMigrationParams, "config"> &
   InstalledPluginIndexRecordStoreOptions & {
@@ -84,16 +90,16 @@ type PluginRegistryHealthIssue =
       kind: "managed-npm-package-unreadable";
       packageDir: string;
       reason: string;
-    };
+    }
+  | StaleManagedNpmInstallGenerationIssue;
 
 type ManagedNpmPackageReadFailure = {
   packageDir: string;
   reason: string;
 };
 
-function formatPackageReadFailure(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
+const formatPackageReadFailure = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
 
 function readJsonObject(filePath: string): Record<string, unknown> | null {
   const parsed = tryReadJsonSync(filePath);
@@ -513,6 +519,7 @@ export async function detectPluginRegistryHealthIssues(
       stalePath: record.stalePath,
     });
   }
+  issues.push(...(await listStaleManagedNpmInstallGenerations(params)));
   const managedNpmAudit = await listManagedNpmOpenClawPeerLinkIssues(params);
   for (const issue of managedNpmAudit.peerLinkIssues) {
     issues.push({
@@ -583,6 +590,8 @@ export function pluginRegistryIssueToHealthFinding(
         path: issue.packageDir,
         fixHint: "Restore access to the package files, then run `openclaw doctor` again.",
       };
+    case "stale-managed-npm-install-generation":
+      return staleManagedNpmInstallGenerationToHealthFinding(issue);
   }
   return assertNeverPluginRegistryIssue(issue);
 }
@@ -626,6 +635,8 @@ export function pluginRegistryIssueToRepairEffect(
         target: issue.packageDir,
         dryRunSafe: false,
       };
+    case "stale-managed-npm-install-generation":
+      return staleManagedNpmInstallGenerationToRepairEffect(issue);
   }
   return assertNeverPluginRegistryIssue(issue);
 }
@@ -657,6 +668,8 @@ export async function maybeRepairPluginRegistryState(
   const removedStaleManagedNpmBundledPlugins = maybeRepairStaleManagedNpmBundledPlugins(params);
   const removedStaleLocalBundledPluginIds =
     await maybeRepairStaleLocalBundledPluginInstallRecords(params);
+  const retiredStaleManagedNpmInstallGenerations =
+    await maybeRepairStaleManagedNpmInstallGenerations(params);
   const repairedManagedNpmOpenClawPeerLinks = await maybeRepairManagedNpmOpenClawPeerLinks(params);
   const stalePluginIdsToRemove = [
     ...new Set([
@@ -664,6 +677,8 @@ export async function maybeRepairPluginRegistryState(
       ...removedStaleLocalBundledPluginIds,
     ]),
   ];
+  const shouldPersistRepairedInstallRecords =
+    stalePluginIdsToRemove.length > 0 || retiredStaleManagedNpmInstallGenerations;
   if (!params.prompter.shouldRepair) {
     if (preflight.action === "migrate") {
       note(
@@ -680,7 +695,7 @@ export async function maybeRepairPluginRegistryState(
   if (preflight.action === "migrate") {
     const result = await migratePluginRegistryForInstall({
       ...migrationParams,
-      ...(stalePluginIdsToRemove.length > 0
+      ...(shouldPersistRepairedInstallRecords
         ? {
             installRecords: await loadInstallRecordsWithoutPluginIds(
               params,
@@ -704,12 +719,13 @@ export async function maybeRepairPluginRegistryState(
     preflight.action === "skip-existing" ||
     removedStaleManagedNpmBundledPlugins ||
     removedStaleLocalBundledPluginIds.length > 0 ||
+    retiredStaleManagedNpmInstallGenerations ||
     repairedManagedNpmOpenClawPeerLinks
   ) {
     const index = await refreshPluginRegistry({
       ...migrationParams,
       reason: "migration",
-      ...(stalePluginIdsToRemove.length > 0
+      ...(shouldPersistRepairedInstallRecords
         ? {
             installRecords: await loadInstallRecordsWithoutPluginIds(
               params,

--- a/src/plugins/installed-plugin-index-generation-precedence.test.ts
+++ b/src/plugins/installed-plugin-index-generation-precedence.test.ts
@@ -340,6 +340,27 @@ describe("managed npm generation-dir loader precedence", () => {
     });
   });
 
+  it("excludes a doctor-retired legacy-root package when recovering without authority", async () => {
+    const stateDir = makeStateDir();
+    const retiredPackageDir = writeManagedLegacy(stateDir, "3.0.0");
+    const recoveredPackageDir = writeManagedGeneration({
+      stateDir,
+      version: "1.0.0",
+      generationKey: "discord-after-retired-legacy",
+    });
+    await markRetainedManagedNpmInstall({
+      packageDir: retiredPackageDir,
+      pluginId: PLUGIN_ID,
+      reason: "test-retired-legacy-root-package",
+    });
+
+    const loaded = await loadInstalledPluginIndexInstallRecords({ stateDir });
+    expectRecordFields(loaded.discord, {
+      installPath: recoveredPackageDir,
+      resolvedVersion: "1.0.0",
+    });
+  });
+
   it("does not repoint an intentional custom npm install outside the managed root", async () => {
     const stateDir = makeStateDir();
     // A managed generation with a higher version exists on disk...

--- a/src/plugins/installed-plugin-index-generation-precedence.test.ts
+++ b/src/plugins/installed-plugin-index-generation-precedence.test.ts
@@ -179,6 +179,46 @@ describe("managed npm generation-dir loader precedence", () => {
     expect(fs.existsSync(newerPackageDir)).toBe(true);
   });
 
+  it("matches the authoritative generation case-insensitively on Windows", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const stateDir = makeStateDir();
+    const newerPackageDir = writeManagedGeneration({
+      stateDir,
+      version: "3.0.0",
+      generationKey: "discord-newer-on-windows",
+    });
+    const downgradedPackageDir = writeManagedFlat(stateDir, "1.0.0");
+    setInstallTimestamp(downgradedPackageDir, Date.UTC(2026, 0, 1));
+    setInstallTimestamp(newerPackageDir, Date.UTC(2026, 0, 2));
+    const differentlyCasedActivePath = downgradedPackageDir.replace(
+      stateDir,
+      stateDir.toUpperCase(),
+    );
+
+    await writePersistedInstalledPluginIndexInstallRecords(
+      {
+        discord: {
+          source: "npm",
+          spec: `${PACKAGE_NAME}@1.0.0`,
+          installPath: differentlyCasedActivePath,
+          version: "1.0.0",
+          resolvedName: PACKAGE_NAME,
+          resolvedVersion: "1.0.0",
+          resolvedSpec: `${PACKAGE_NAME}@1.0.0`,
+        },
+      },
+      { stateDir, candidates: [] },
+    );
+    const emitWarning = vi.spyOn(process, "emitWarning").mockImplementation(() => undefined);
+
+    const loaded = await loadInstalledPluginIndexInstallRecords({ stateDir });
+    expectRecordFields(loaded.discord, {
+      installPath: differentlyCasedActivePath,
+      resolvedVersion: "1.0.0",
+    });
+    expect(emitWarning).not.toHaveBeenCalled();
+  });
+
   it("uses install recency with a structured warning when no authority exists", async () => {
     const stateDir = makeStateDir();
     const recentPackageDir = writeManagedGeneration({

--- a/src/plugins/installed-plugin-index-generation-precedence.test.ts
+++ b/src/plugins/installed-plugin-index-generation-precedence.test.ts
@@ -3,7 +3,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import {
   resolvePluginNpmGenerationProjectDir,
@@ -15,6 +15,10 @@ import {
   loadInstalledPluginIndexInstallRecordsSync,
   writePersistedInstalledPluginIndexInstallRecords,
 } from "./installed-plugin-index-records.js";
+import {
+  markRetainedManagedNpmInstall,
+  resolveRetainedManagedNpmInstallPackageInfo,
+} from "./managed-npm-retention.js";
 import { writeManagedNpmPlugin } from "./test-helpers/managed-npm-plugin.js";
 
 const PACKAGE_NAME = "@openclaw/discord";
@@ -69,7 +73,27 @@ function writeManagedFlat(stateDir: string, version: string): string {
   return path.join(flatProjectRoot, "node_modules", ...PACKAGE_NAME.split("/"));
 }
 
+function writeManagedLegacy(stateDir: string, version: string): string {
+  return writeManagedNpmPlugin({
+    stateDir,
+    packageName: PACKAGE_NAME,
+    pluginId: PLUGIN_ID,
+    version,
+    layout: "legacy",
+  });
+}
+
+function setInstallTimestamp(packageDir: string, timestampMs: number): void {
+  if (!resolveRetainedManagedNpmInstallPackageInfo(packageDir)) {
+    throw new Error(`Expected managed npm package dir: ${packageDir}`);
+  }
+  const timestamp = new Date(timestampMs);
+  fs.utimesSync(path.join(packageDir, "package.json"), timestamp, timestamp);
+  fs.utimesSync(packageDir, timestamp, timestamp);
+}
+
 afterEach(() => {
+  vi.restoreAllMocks();
   closeOpenClawStateDatabaseForTest();
   clearLoadInstalledPluginIndexInstallRecordsCache();
   for (const dir of tempDirs.splice(0)) {
@@ -78,7 +102,7 @@ afterEach(() => {
 });
 
 describe("managed npm generation-dir loader precedence", () => {
-  it("repoints to a newer managed generation when the persisted install still exists", async () => {
+  it("loads the authoritative generation after an upgrade leaves the old flat install", async () => {
     const stateDir = makeStateDir();
     const staleVersion = "2026.6.11";
     const activeVersion = "2026.7.1";
@@ -97,19 +121,19 @@ describe("managed npm generation-dir loader precedence", () => {
         discord: {
           source: "npm",
           spec: `${PACKAGE_NAME}@latest`,
-          installPath: stalePackageDir,
-          version: staleVersion,
+          installPath: activePackageDir,
+          version: activeVersion,
           resolvedName: PACKAGE_NAME,
-          resolvedVersion: staleVersion,
-          resolvedSpec: `${PACKAGE_NAME}@${staleVersion}`,
-          integrity: "sha512-stale",
+          resolvedVersion: activeVersion,
+          resolvedSpec: `${PACKAGE_NAME}@${activeVersion}`,
+          integrity: "sha512-active",
         },
       },
       { stateDir, candidates: [] },
     );
 
     const loaded = await loadInstalledPluginIndexInstallRecords({ stateDir });
-    const record = expectRecordFields(loaded.discord, {
+    expectRecordFields(loaded.discord, {
       source: "npm",
       spec: `${PACKAGE_NAME}@latest`,
       installPath: activePackageDir,
@@ -117,8 +141,9 @@ describe("managed npm generation-dir loader precedence", () => {
       resolvedName: PACKAGE_NAME,
       resolvedVersion: activeVersion,
       resolvedSpec: `${PACKAGE_NAME}@${activeVersion}`,
+      integrity: "sha512-active",
     });
-    expect(record.integrity).toBeUndefined();
+    expect(fs.existsSync(stalePackageDir)).toBe(true);
 
     clearLoadInstalledPluginIndexInstallRecordsCache();
     expectRecordFields(loadInstalledPluginIndexInstallRecordsSync({ stateDir }).discord, {
@@ -127,24 +152,21 @@ describe("managed npm generation-dir loader precedence", () => {
     });
   });
 
-  it("adopts the highest version when several generations are present", async () => {
+  it("preserves an intentional downgrade when a newer generation lingers", async () => {
     const stateDir = makeStateDir();
-    // On-disk order of generation dirs is hash-based, so this pins that recovery
-    // selects by version rather than by whichever project root sorts last.
-    writeManagedGeneration({ stateDir, version: "2.0.0", generationKey: "discord-two" });
-    const newestPackageDir = writeManagedGeneration({
+    const newerPackageDir = writeManagedGeneration({
       stateDir,
       version: "3.0.0",
       generationKey: "discord-three",
     });
-    const stalePackageDir = writeManagedFlat(stateDir, "1.0.0");
+    const downgradedPackageDir = writeManagedFlat(stateDir, "1.0.0");
 
     await writePersistedInstalledPluginIndexInstallRecords(
       {
         discord: {
           source: "npm",
           spec: `${PACKAGE_NAME}@1.0.0`,
-          installPath: stalePackageDir,
+          installPath: downgradedPackageDir,
           version: "1.0.0",
           resolvedName: PACKAGE_NAME,
           resolvedVersion: "1.0.0",
@@ -156,35 +178,127 @@ describe("managed npm generation-dir loader precedence", () => {
 
     const loaded = await loadInstalledPluginIndexInstallRecords({ stateDir });
     expectRecordFields(loaded.discord, {
-      installPath: newestPackageDir,
-      resolvedVersion: "3.0.0",
+      installPath: downgradedPackageDir,
+      resolvedVersion: "1.0.0",
     });
+    expect(fs.existsSync(newerPackageDir)).toBe(true);
   });
 
-  it("keeps a current managed install when only an older generation lingers", async () => {
+  it("uses install recency with a structured warning when no authority exists", async () => {
     const stateDir = makeStateDir();
-    writeManagedGeneration({ stateDir, version: "2026.6.11", generationKey: "discord-stale" });
-    const activePackageDir = writeManagedFlat(stateDir, "2026.7.1");
+    const recentPackageDir = writeManagedGeneration({
+      stateDir,
+      version: "1.0.0",
+      generationKey: "discord-recent",
+    });
+    const olderPackageDir = writeManagedFlat(stateDir, "9.0.0");
+    setInstallTimestamp(olderPackageDir, Date.UTC(2026, 0, 1));
+    setInstallTimestamp(recentPackageDir, Date.UTC(2026, 0, 2));
+    const emitWarning = vi.spyOn(process, "emitWarning").mockImplementation(() => undefined);
 
+    const loaded = await loadInstalledPluginIndexInstallRecords({ stateDir });
+    expectRecordFields(loaded.discord, {
+      installPath: recentPackageDir,
+      resolvedVersion: "1.0.0",
+    });
+    expect(emitWarning).toHaveBeenCalledWith(
+      expect.stringContaining("without an authoritative active path"),
+      expect.objectContaining({
+        code: "OPENCLAW_PLUGIN_INSTALL_RECOVERY_FALLBACK",
+        type: "OpenClawPluginRecoveryWarning",
+      }),
+    );
+  });
+
+  it("warns when install recency replaces a dangling managed authority", async () => {
+    const stateDir = makeStateDir();
+    const npmDir = path.join(stateDir, "npm");
+    const recentPackageDir = writeManagedGeneration({
+      stateDir,
+      version: "1.0.0",
+      generationKey: "discord-recent-after-dangling",
+    });
+    const olderPackageDir = writeManagedFlat(stateDir, "9.0.0");
+    setInstallTimestamp(olderPackageDir, Date.UTC(2026, 0, 1));
+    setInstallTimestamp(recentPackageDir, Date.UTC(2026, 0, 2));
+    const missingPackageDir = path.join(
+      resolvePluginNpmGenerationProjectDir({
+        npmDir,
+        packageName: PACKAGE_NAME,
+        generationKey: "discord-missing",
+      }),
+      "node_modules",
+      ...PACKAGE_NAME.split("/"),
+    );
     await writePersistedInstalledPluginIndexInstallRecords(
       {
         discord: {
           source: "npm",
-          spec: `${PACKAGE_NAME}@2026.7.1`,
-          installPath: activePackageDir,
-          version: "2026.7.1",
+          spec: `${PACKAGE_NAME}@latest`,
+          installPath: missingPackageDir,
           resolvedName: PACKAGE_NAME,
-          resolvedVersion: "2026.7.1",
-          resolvedSpec: `${PACKAGE_NAME}@2026.7.1`,
+          resolvedVersion: "2.0.0",
         },
       },
       { stateDir, candidates: [] },
     );
+    const emitWarning = vi.spyOn(process, "emitWarning").mockImplementation(() => undefined);
 
     const loaded = await loadInstalledPluginIndexInstallRecords({ stateDir });
     expectRecordFields(loaded.discord, {
-      installPath: activePackageDir,
-      resolvedVersion: "2026.7.1",
+      installPath: recentPackageDir,
+      resolvedVersion: "1.0.0",
+    });
+    expect(emitWarning).toHaveBeenCalledWith(
+      expect.stringContaining("without an authoritative active path"),
+      expect.objectContaining({ code: "OPENCLAW_PLUGIN_INSTALL_RECOVERY_FALLBACK" }),
+    );
+  });
+
+  it("does not treat unrelated legacy-root metadata changes as plugin recency", async () => {
+    const stateDir = makeStateDir();
+    const recentPackageDir = writeManagedGeneration({
+      stateDir,
+      version: "1.0.0",
+      generationKey: "discord-recent-from-legacy",
+    });
+    const olderPackageDir = writeManagedLegacy(stateDir, "9.0.0");
+    setInstallTimestamp(olderPackageDir, Date.UTC(2026, 0, 1));
+    setInstallTimestamp(recentPackageDir, Date.UTC(2026, 0, 2));
+    writeManagedNpmPlugin({
+      stateDir,
+      packageName: "@openclaw/unrelated",
+      pluginId: "unrelated",
+      version: "1.0.0",
+      layout: "legacy",
+    });
+    vi.spyOn(process, "emitWarning").mockImplementation(() => undefined);
+
+    const loaded = await loadInstalledPluginIndexInstallRecords({ stateDir });
+    expectRecordFields(loaded.discord, {
+      installPath: recentPackageDir,
+      resolvedVersion: "1.0.0",
+    });
+  });
+
+  it("excludes doctor-retired generations when recovering without authority", async () => {
+    const stateDir = makeStateDir();
+    const retiredPackageDir = writeManagedGeneration({
+      stateDir,
+      version: "3.0.0",
+      generationKey: "discord-retired",
+    });
+    const recoveredPackageDir = writeManagedFlat(stateDir, "1.0.0");
+    await markRetainedManagedNpmInstall({
+      packageDir: retiredPackageDir,
+      pluginId: PLUGIN_ID,
+      reason: "test-retired-generation",
+    });
+
+    const loaded = await loadInstalledPluginIndexInstallRecords({ stateDir });
+    expectRecordFields(loaded.discord, {
+      installPath: recoveredPackageDir,
+      resolvedVersion: "1.0.0",
     });
   });
 

--- a/src/plugins/installed-plugin-index-generation-precedence.test.ts
+++ b/src/plugins/installed-plugin-index-generation-precedence.test.ts
@@ -1,9 +1,9 @@
 // Covers loader precedence between a plugin's flat project dir and newer
 // `__openclaw-generation__` dirs when reconciling persisted install records.
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import {
   resolvePluginNpmGenerationProjectDir,
@@ -23,12 +23,10 @@ import { writeManagedNpmPlugin } from "./test-helpers/managed-npm-plugin.js";
 
 const PACKAGE_NAME = "@openclaw/discord";
 const PLUGIN_ID = "discord";
-const tempDirs: string[] = [];
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function makeStateDir(): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-generation-precedence-"));
-  tempDirs.push(dir);
-  return dir;
+  return tempDirs.make("openclaw-plugin-generation-precedence-");
 }
 
 function expectRecordFields(record: unknown, expected: Record<string, unknown>) {
@@ -96,9 +94,6 @@ afterEach(() => {
   vi.restoreAllMocks();
   closeOpenClawStateDatabaseForTest();
   clearLoadInstalledPluginIndexInstallRecordsCache();
-  for (const dir of tempDirs.splice(0)) {
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
 });
 
 describe("managed npm generation-dir loader precedence", () => {

--- a/src/plugins/installed-plugin-index-generation-precedence.test.ts
+++ b/src/plugins/installed-plugin-index-generation-precedence.test.ts
@@ -82,12 +82,15 @@ function writeManagedLegacy(stateDir: string, version: string): string {
 }
 
 function setInstallTimestamp(packageDir: string, timestampMs: number): void {
-  if (!resolveRetainedManagedNpmInstallPackageInfo(packageDir)) {
+  const packageInfo = resolveRetainedManagedNpmInstallPackageInfo(packageDir);
+  if (!packageInfo) {
     throw new Error(`Expected managed npm package dir: ${packageDir}`);
   }
   const timestamp = new Date(timestampMs);
   fs.utimesSync(path.join(packageDir, "package.json"), timestamp, timestamp);
   fs.utimesSync(packageDir, timestamp, timestamp);
+  fs.utimesSync(path.join(packageInfo.projectRoot, "package.json"), timestamp, timestamp);
+  fs.utimesSync(packageInfo.projectRoot, timestamp, timestamp);
 }
 
 afterEach(() => {

--- a/src/plugins/installed-plugin-index-generation-precedence.test.ts
+++ b/src/plugins/installed-plugin-index-generation-precedence.test.ts
@@ -1,0 +1,223 @@
+// Covers loader precedence between a plugin's flat project dir and newer
+// `__openclaw-generation__` dirs when reconciling persisted install records.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  resolvePluginNpmGenerationProjectDir,
+  resolvePluginNpmProjectDir,
+} from "./install-paths.js";
+import {
+  clearLoadInstalledPluginIndexInstallRecordsCache,
+  loadInstalledPluginIndexInstallRecords,
+  loadInstalledPluginIndexInstallRecordsSync,
+  writePersistedInstalledPluginIndexInstallRecords,
+} from "./installed-plugin-index-records.js";
+import { writeManagedNpmPlugin } from "./test-helpers/managed-npm-plugin.js";
+
+const PACKAGE_NAME = "@openclaw/discord";
+const PLUGIN_ID = "discord";
+const tempDirs: string[] = [];
+
+function makeStateDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-generation-precedence-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function expectRecordFields(record: unknown, expected: Record<string, unknown>) {
+  if (!record || typeof record !== "object") {
+    throw new Error("Expected record");
+  }
+  const actual = record as Record<string, unknown>;
+  for (const [key, value] of Object.entries(expected)) {
+    expect(actual[key]).toEqual(value);
+  }
+  return actual;
+}
+
+/** Writes a managed plugin version into an `__openclaw-generation__` dir. */
+function writeManagedGeneration(params: {
+  stateDir: string;
+  version: string;
+  generationKey: string;
+}): string {
+  const npmDir = path.join(params.stateDir, "npm");
+  writeManagedNpmPlugin({
+    stateDir: params.stateDir,
+    packageName: PACKAGE_NAME,
+    pluginId: PLUGIN_ID,
+    version: params.version,
+  });
+  const flatProjectRoot = resolvePluginNpmProjectDir({ npmDir, packageName: PACKAGE_NAME });
+  const generationProjectRoot = resolvePluginNpmGenerationProjectDir({
+    npmDir,
+    packageName: PACKAGE_NAME,
+    generationKey: params.generationKey,
+  });
+  fs.renameSync(flatProjectRoot, generationProjectRoot);
+  return path.join(generationProjectRoot, "node_modules", ...PACKAGE_NAME.split("/"));
+}
+
+/** Writes a managed plugin version into the flat project dir and leaves it there. */
+function writeManagedFlat(stateDir: string, version: string): string {
+  const npmDir = path.join(stateDir, "npm");
+  writeManagedNpmPlugin({ stateDir, packageName: PACKAGE_NAME, pluginId: PLUGIN_ID, version });
+  const flatProjectRoot = resolvePluginNpmProjectDir({ npmDir, packageName: PACKAGE_NAME });
+  return path.join(flatProjectRoot, "node_modules", ...PACKAGE_NAME.split("/"));
+}
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  clearLoadInstalledPluginIndexInstallRecordsCache();
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("managed npm generation-dir loader precedence", () => {
+  it("repoints to a newer managed generation when the persisted install still exists", async () => {
+    const stateDir = makeStateDir();
+    const staleVersion = "2026.6.11";
+    const activeVersion = "2026.7.1";
+
+    const activePackageDir = writeManagedGeneration({
+      stateDir,
+      version: activeVersion,
+      generationKey: `discord-${activeVersion}`,
+    });
+    // Recreate the prior version at the flat project dir so it is still present
+    // on disk (the case `isUnavailableManagedNpmInstallRecord` does not cover).
+    const stalePackageDir = writeManagedFlat(stateDir, staleVersion);
+
+    await writePersistedInstalledPluginIndexInstallRecords(
+      {
+        discord: {
+          source: "npm",
+          spec: `${PACKAGE_NAME}@latest`,
+          installPath: stalePackageDir,
+          version: staleVersion,
+          resolvedName: PACKAGE_NAME,
+          resolvedVersion: staleVersion,
+          resolvedSpec: `${PACKAGE_NAME}@${staleVersion}`,
+          integrity: "sha512-stale",
+        },
+      },
+      { stateDir, candidates: [] },
+    );
+
+    const loaded = await loadInstalledPluginIndexInstallRecords({ stateDir });
+    const record = expectRecordFields(loaded.discord, {
+      source: "npm",
+      spec: `${PACKAGE_NAME}@latest`,
+      installPath: activePackageDir,
+      version: activeVersion,
+      resolvedName: PACKAGE_NAME,
+      resolvedVersion: activeVersion,
+      resolvedSpec: `${PACKAGE_NAME}@${activeVersion}`,
+    });
+    expect(record.integrity).toBeUndefined();
+
+    clearLoadInstalledPluginIndexInstallRecordsCache();
+    expectRecordFields(loadInstalledPluginIndexInstallRecordsSync({ stateDir }).discord, {
+      installPath: activePackageDir,
+      resolvedVersion: activeVersion,
+    });
+  });
+
+  it("adopts the highest version when several generations are present", async () => {
+    const stateDir = makeStateDir();
+    // On-disk order of generation dirs is hash-based, so this pins that recovery
+    // selects by version rather than by whichever project root sorts last.
+    writeManagedGeneration({ stateDir, version: "2.0.0", generationKey: "discord-two" });
+    const newestPackageDir = writeManagedGeneration({
+      stateDir,
+      version: "3.0.0",
+      generationKey: "discord-three",
+    });
+    const stalePackageDir = writeManagedFlat(stateDir, "1.0.0");
+
+    await writePersistedInstalledPluginIndexInstallRecords(
+      {
+        discord: {
+          source: "npm",
+          spec: `${PACKAGE_NAME}@1.0.0`,
+          installPath: stalePackageDir,
+          version: "1.0.0",
+          resolvedName: PACKAGE_NAME,
+          resolvedVersion: "1.0.0",
+          resolvedSpec: `${PACKAGE_NAME}@1.0.0`,
+        },
+      },
+      { stateDir, candidates: [] },
+    );
+
+    const loaded = await loadInstalledPluginIndexInstallRecords({ stateDir });
+    expectRecordFields(loaded.discord, {
+      installPath: newestPackageDir,
+      resolvedVersion: "3.0.0",
+    });
+  });
+
+  it("keeps a current managed install when only an older generation lingers", async () => {
+    const stateDir = makeStateDir();
+    writeManagedGeneration({ stateDir, version: "2026.6.11", generationKey: "discord-stale" });
+    const activePackageDir = writeManagedFlat(stateDir, "2026.7.1");
+
+    await writePersistedInstalledPluginIndexInstallRecords(
+      {
+        discord: {
+          source: "npm",
+          spec: `${PACKAGE_NAME}@2026.7.1`,
+          installPath: activePackageDir,
+          version: "2026.7.1",
+          resolvedName: PACKAGE_NAME,
+          resolvedVersion: "2026.7.1",
+          resolvedSpec: `${PACKAGE_NAME}@2026.7.1`,
+        },
+      },
+      { stateDir, candidates: [] },
+    );
+
+    const loaded = await loadInstalledPluginIndexInstallRecords({ stateDir });
+    expectRecordFields(loaded.discord, {
+      installPath: activePackageDir,
+      resolvedVersion: "2026.7.1",
+    });
+  });
+
+  it("does not repoint an intentional custom npm install outside the managed root", async () => {
+    const stateDir = makeStateDir();
+    // A managed generation with a higher version exists on disk...
+    writeManagedGeneration({ stateDir, version: "2.0.0", generationKey: "discord-managed" });
+    // ...but the persisted record points at a custom install outside the npm root.
+    const customInstallPath = path.join(stateDir, "custom", "node_modules", "@openclaw", "discord");
+
+    await writePersistedInstalledPluginIndexInstallRecords(
+      {
+        discord: {
+          source: "npm",
+          spec: `${PACKAGE_NAME}@beta`,
+          installPath: customInstallPath,
+          version: "1.0.0",
+          resolvedName: PACKAGE_NAME,
+          resolvedVersion: "1.0.0",
+          resolvedSpec: `${PACKAGE_NAME}@1.0.0`,
+          integrity: "sha512-custom",
+        },
+      },
+      { stateDir, candidates: [] },
+    );
+
+    const loaded = await loadInstalledPluginIndexInstallRecords({ stateDir });
+    expectRecordFields(loaded.discord, {
+      source: "npm",
+      spec: `${PACKAGE_NAME}@beta`,
+      installPath: customInstallPath,
+      resolvedVersion: "1.0.0",
+      integrity: "sha512-custom",
+    });
+  });
+});

--- a/src/plugins/installed-plugin-index-record-reader.ts
+++ b/src/plugins/installed-plugin-index-record-reader.ts
@@ -121,12 +121,30 @@ function resolveRecoveredManagedNpmPluginId(params: {
   return validatePluginId(pluginId) ? undefined : pluginId;
 }
 
-function buildRecoveredManagedNpmInstallRecordsForRoot(
+export type RecoveredManagedNpmInstallCandidate = {
+  installRecord: PluginInstallRecord;
+  installTimestampMs: number;
+  pluginId: string;
+};
+
+function readManagedNpmInstallTimestampMs(packageDir: string): number {
+  for (const filePath of [path.join(packageDir, "package.json"), packageDir]) {
+    try {
+      return fs.statSync(filePath).mtimeMs;
+    } catch {
+      // Recovery already verified the package directory. Missing package metadata
+      // simply leaves the package directory mtime as the final recency signal.
+    }
+  }
+  return 0;
+}
+
+function buildRecoveredManagedNpmInstallCandidatesForRoot(
   npmRoot: string,
-): Record<string, PluginInstallRecord> {
+): RecoveredManagedNpmInstallCandidate[] {
   const rootManifest = readJsonObjectFileSync(path.join(npmRoot, "package.json"));
   const dependencies = readStringRecord(rootManifest?.dependencies);
-  const records: Record<string, PluginInstallRecord> = {};
+  const candidates: RecoveredManagedNpmInstallCandidate[] = [];
   for (const [packageName, dependencySpec] of Object.entries(dependencies)) {
     const packageDir = path.join(npmRoot, "node_modules", ...packageName.split("/"));
     let stat: fs.Stats;
@@ -150,52 +168,29 @@ function buildRecoveredManagedNpmInstallRecordsForRoot(
       typeof packageManifest?.version === "string" && packageManifest.version.trim()
         ? packageManifest.version.trim()
         : undefined;
-    records[pluginId] = {
-      source: "npm",
-      spec: `${packageName}@${dependencySpec}`,
-      installPath: packageDir,
-      ...(version ? { version, resolvedName: packageName, resolvedVersion: version } : {}),
-      ...(version ? { resolvedSpec: `${packageName}@${version}` } : {}),
-    };
+    candidates.push({
+      pluginId,
+      installTimestampMs: readManagedNpmInstallTimestampMs(packageDir),
+      installRecord: {
+        source: "npm",
+        spec: `${packageName}@${dependencySpec}`,
+        installPath: packageDir,
+        ...(version ? { version, resolvedName: packageName, resolvedVersion: version } : {}),
+        ...(version ? { resolvedSpec: `${packageName}@${version}` } : {}),
+      },
+    });
   }
-  return records;
+  return candidates;
 }
 
-function pickNewerRecoveredManagedNpmRecord(
-  existing: PluginInstallRecord | undefined,
-  candidate: PluginInstallRecord,
-): PluginInstallRecord {
-  if (!existing) {
-    return candidate;
-  }
-  const existingVersion = readInstallRecordVersion(existing);
-  const candidateVersion = readInstallRecordVersion(candidate);
-  // A legacy flat dir and one or more `__openclaw-generation__` dirs can hold
-  // the same plugin at once, and their on-disk order is unrelated to version.
-  // Keep the highest version so recovery reflects the newest install rather than
-  // whichever directory sorts last. On ties prefer the later candidate so a
-  // generation dir still supersedes the legacy flat dir.
-  if (existingVersion !== undefined && candidateVersion !== undefined) {
-    return compareValidSemver(existingVersion, candidateVersion) === 1 ? existing : candidate;
-  }
-  return candidate;
-}
-
-function buildRecoveredManagedNpmInstallRecords(
+/** Lists recoverable managed npm installs without assigning active precedence. */
+export function listRecoveredManagedNpmInstallCandidates(
   options: InstalledPluginIndexStoreOptions = {},
-): Record<string, PluginInstallRecord> {
+): RecoveredManagedNpmInstallCandidate[] {
   const npmRoot = resolveRecoveredManagedNpmRoot(options);
-  const records: Record<string, PluginInstallRecord> = {};
-  const absorb = (source: Record<string, PluginInstallRecord>): void => {
-    for (const [pluginId, record] of Object.entries(source)) {
-      records[pluginId] = pickNewerRecoveredManagedNpmRecord(records[pluginId], record);
-    }
-  };
-  absorb(buildRecoveredManagedNpmInstallRecordsForRoot(npmRoot));
-  for (const projectRoot of listManagedPluginNpmProjectRootsSync(npmRoot)) {
-    absorb(buildRecoveredManagedNpmInstallRecordsForRoot(projectRoot));
-  }
-  return records;
+  return [npmRoot, ...listManagedPluginNpmProjectRootsSync(npmRoot)].flatMap((projectRoot) =>
+    buildRecoveredManagedNpmInstallCandidatesForRoot(projectRoot),
+  );
 }
 
 function recordsShareInstallPath(
@@ -206,6 +201,79 @@ function recordsShareInstallPath(
     return false;
   }
   return path.resolve(left.installPath) === path.resolve(right.installPath);
+}
+
+function pickMostRecentRecoveredManagedNpmCandidate(
+  candidates: readonly RecoveredManagedNpmInstallCandidate[],
+): RecoveredManagedNpmInstallCandidate {
+  return candidates.toSorted((left, right) => {
+    const byTimestamp = right.installTimestampMs - left.installTimestampMs;
+    if (byTimestamp !== 0) {
+      return byTimestamp;
+    }
+    return (right.installRecord.installPath ?? "").localeCompare(
+      left.installRecord.installPath ?? "",
+    );
+  })[0]!;
+}
+
+function emitManagedNpmRecoveryFallbackWarning(params: {
+  pluginId: string;
+  selected: RecoveredManagedNpmInstallCandidate;
+  candidates: readonly RecoveredManagedNpmInstallCandidate[];
+}): void {
+  process.emitWarning(
+    `Managed npm recovery found ${params.candidates.length} installs for plugin "${params.pluginId}" without an authoritative active path; selected the most recently installed candidate. Run \`openclaw doctor --fix\` to persist and retire stale generations.`,
+    {
+      code: "OPENCLAW_PLUGIN_INSTALL_RECOVERY_FALLBACK",
+      type: "OpenClawPluginRecoveryWarning",
+      detail: JSON.stringify({
+        pluginId: params.pluginId,
+        selectedInstallPath: params.selected.installRecord.installPath,
+        candidates: params.candidates.map((candidate) => ({
+          installPath: candidate.installRecord.installPath,
+          installTimestampMs: candidate.installTimestampMs,
+        })),
+      }),
+    },
+  );
+}
+
+function buildRecoveredManagedNpmInstallRecords(
+  persisted: Record<string, PluginInstallRecord> | null,
+  options: InstalledPluginIndexStoreOptions = {},
+): Record<string, PluginInstallRecord> {
+  const npmRoot = resolveRecoveredManagedNpmRoot(options);
+  const records: Record<string, PluginInstallRecord> = {};
+  const candidatesByPluginId = new Map<string, RecoveredManagedNpmInstallCandidate[]>();
+  for (const candidate of listRecoveredManagedNpmInstallCandidates(options)) {
+    const candidates = candidatesByPluginId.get(candidate.pluginId) ?? [];
+    candidates.push(candidate);
+    candidatesByPluginId.set(candidate.pluginId, candidates);
+  }
+  for (const [pluginId, candidates] of candidatesByPluginId) {
+    // The install ledger is the active-generation authority. Directory order,
+    // version, and recency may only break ties when that authority is absent.
+    const persistedRecord = persisted?.[pluginId];
+    const authoritative = candidates.find((candidate) =>
+      recordsShareInstallPath(persistedRecord, candidate.installRecord),
+    );
+    const selected = authoritative ?? pickMostRecentRecoveredManagedNpmCandidate(candidates);
+    records[pluginId] = selected.installRecord;
+    const recoversUnavailableManagedPath = isUnavailableManagedNpmInstallRecord({
+      npmRoot,
+      persisted: persistedRecord,
+      recovered: selected.installRecord,
+    });
+    if (
+      !authoritative &&
+      candidates.length > 1 &&
+      (!persistedRecord || recoversUnavailableManagedPath)
+    ) {
+      emitManagedNpmRecoveryFallbackWarning({ pluginId, selected, candidates });
+    }
+  }
+  return records;
 }
 
 function readInstallRecordVersion(record: PluginInstallRecord | undefined): string | undefined {
@@ -282,26 +350,6 @@ function mergeRecoveredManagedNpmMetadata(
   return next;
 }
 
-function isManagedNpmInstallPath(installPath: string | undefined, npmRoot: string): boolean {
-  if (!installPath) {
-    return false;
-  }
-  const packageInfo = resolveRetainedManagedNpmInstallPackageInfo(installPath);
-  if (!packageInfo) {
-    return false;
-  }
-  const normalize = (value: string): string => {
-    const resolved = path.resolve(value);
-    return process.platform === "win32" ? normalizeWindowsPathForComparison(resolved) : resolved;
-  };
-  const projectRoot = normalize(packageInfo.projectRoot);
-  return (
-    projectRoot === normalize(npmRoot) ||
-    normalize(path.dirname(packageInfo.projectRoot)) ===
-      normalize(resolvePluginNpmProjectsDir(npmRoot))
-  );
-}
-
 function mergeRecoveredManagedNpmRecord(params: {
   npmRoot: string;
   persisted: PluginInstallRecord | undefined;
@@ -322,26 +370,8 @@ function mergeRecoveredManagedNpmRecord(params: {
   ) {
     return mergeRecoveredManagedNpmMetadata(params.persisted, params.recovered);
   }
-  // A managed install/update writes the new version into a distinct managed
-  // project directory (for example an `__openclaw-generation__` dir) without
-  // removing the prior one, so the persisted record can keep pointing at an
-  // older, still-present install and the runtime loads the stale version. When
-  // the freshly-discovered managed install is a strictly newer version at a
-  // different path, repoint to it. The strict-newer comparison keeps a lingering
-  // older generation directory from superseding a current install, and the
-  // managed-path guard leaves intentional custom/outside npm installs untouched.
-  if (
-    params.persisted?.source === "npm" &&
-    isManagedNpmInstallPath(params.persisted.installPath, params.npmRoot) &&
-    !recordsShareInstallPath(params.persisted, params.recovered) &&
-    persistedVersion !== undefined &&
-    recoveredVersion !== undefined &&
-    compareValidSemver(persistedVersion, recoveredVersion) === -1
-  ) {
-    return mergeRecoveredManagedNpmMetadata(params.persisted, params.recovered, {
-      preservePersistedSpec: true,
-    });
-  }
+  // Missing managed paths were recovered above. Any remaining persisted path is
+  // the active ledger choice, including an intentional downgrade or custom install.
   return params.persisted ?? params.recovered;
 }
 
@@ -350,7 +380,7 @@ function mergeRecoveredManagedNpmInstallRecords(
   options: InstalledPluginIndexStoreOptions,
 ): Record<string, PluginInstallRecord> {
   const npmRoot = resolveRecoveredManagedNpmRoot(options);
-  const recovered = buildRecoveredManagedNpmInstallRecords(options);
+  const recovered = buildRecoveredManagedNpmInstallRecords(persisted, options);
   const merged: Record<string, PluginInstallRecord> = { ...persisted };
   for (const [pluginId, record] of Object.entries(recovered)) {
     merged[pluginId] = mergeRecoveredManagedNpmRecord({

--- a/src/plugins/installed-plugin-index-record-reader.ts
+++ b/src/plugins/installed-plugin-index-record-reader.ts
@@ -200,7 +200,15 @@ function recordsShareInstallPath(
   if (!left?.installPath || !right.installPath) {
     return false;
   }
-  return path.resolve(left.installPath) === path.resolve(right.installPath);
+  return (
+    normalizeInstallPathForComparison(left.installPath) ===
+    normalizeInstallPathForComparison(right.installPath)
+  );
+}
+
+function normalizeInstallPathForComparison(filePath: string): string {
+  const resolved = path.resolve(filePath);
+  return process.platform === "win32" ? normalizeWindowsPathForComparison(resolved) : resolved;
 }
 
 function pickMostRecentRecoveredManagedNpmCandidate(
@@ -303,18 +311,14 @@ function isUnavailableManagedNpmInstallRecord(params: {
   if (!packageInfo || packageInfo.packageName !== params.recovered.resolvedName) {
     return false;
   }
-  const normalizeForComparison = (value: string): string => {
-    const resolved = path.resolve(value);
-    return process.platform === "win32" ? normalizeWindowsPathForComparison(resolved) : resolved;
-  };
   // Persisted Windows paths can differ only by casing. Use filesystem comparison
   // semantics so a managed generation is not mistaken for a custom install.
-  const npmRoot = normalizeForComparison(params.npmRoot);
-  const projectRoot = normalizeForComparison(packageInfo.projectRoot);
+  const npmRoot = normalizeInstallPathForComparison(params.npmRoot);
+  const projectRoot = normalizeInstallPathForComparison(packageInfo.projectRoot);
   return (
     projectRoot === npmRoot ||
-    normalizeForComparison(path.dirname(packageInfo.projectRoot)) ===
-      normalizeForComparison(resolvePluginNpmProjectsDir(params.npmRoot))
+    normalizeInstallPathForComparison(path.dirname(packageInfo.projectRoot)) ===
+      normalizeInstallPathForComparison(resolvePluginNpmProjectsDir(params.npmRoot))
   );
 }
 

--- a/src/plugins/installed-plugin-index-record-reader.ts
+++ b/src/plugins/installed-plugin-index-record-reader.ts
@@ -127,26 +127,37 @@ export type RecoveredManagedNpmInstallCandidate = {
   pluginId: string;
 };
 
-function readManagedNpmInstallTimestampMs(packageDir: string): number {
-  for (const filePath of [path.join(packageDir, "package.json"), packageDir]) {
+function readManagedNpmInstallTimestampMs(params: {
+  packageDir: string;
+  projectRoot: string;
+  sharedLegacyRoot: boolean;
+}): number {
+  // Isolated flat/generation roots have an OpenClaw-owned project manifest that
+  // is rewritten during install. The legacy root is shared, so only its
+  // package-local directory mtime can represent this plugin's install.
+  const timestampPaths = params.sharedLegacyRoot
+    ? [params.packageDir]
+    : [path.join(params.projectRoot, "package.json"), params.projectRoot];
+  for (const filePath of timestampPaths) {
     try {
       return fs.statSync(filePath).mtimeMs;
     } catch {
-      // Recovery already verified the package directory. Missing package metadata
-      // simply leaves the package directory mtime as the final recency signal.
+      // Recovery already verified the package directory. Missing project
+      // metadata simply leaves the containing directory as the final signal.
     }
   }
   return 0;
 }
 
-function buildRecoveredManagedNpmInstallCandidatesForRoot(
-  npmRoot: string,
-): RecoveredManagedNpmInstallCandidate[] {
-  const rootManifest = readJsonObjectFileSync(path.join(npmRoot, "package.json"));
+function buildRecoveredManagedNpmInstallCandidatesForRoot(params: {
+  projectRoot: string;
+  sharedLegacyRoot: boolean;
+}): RecoveredManagedNpmInstallCandidate[] {
+  const rootManifest = readJsonObjectFileSync(path.join(params.projectRoot, "package.json"));
   const dependencies = readStringRecord(rootManifest?.dependencies);
   const candidates: RecoveredManagedNpmInstallCandidate[] = [];
   for (const [packageName, dependencySpec] of Object.entries(dependencies)) {
-    const packageDir = path.join(npmRoot, "node_modules", ...packageName.split("/"));
+    const packageDir = path.join(params.projectRoot, "node_modules", ...packageName.split("/"));
     let stat: fs.Stats;
     try {
       stat = fs.statSync(packageDir);
@@ -170,7 +181,11 @@ function buildRecoveredManagedNpmInstallCandidatesForRoot(
         : undefined;
     candidates.push({
       pluginId,
-      installTimestampMs: readManagedNpmInstallTimestampMs(packageDir),
+      installTimestampMs: readManagedNpmInstallTimestampMs({
+        packageDir,
+        projectRoot: params.projectRoot,
+        sharedLegacyRoot: params.sharedLegacyRoot,
+      }),
       installRecord: {
         source: "npm",
         spec: `${packageName}@${dependencySpec}`,
@@ -188,9 +203,18 @@ export function listRecoveredManagedNpmInstallCandidates(
   options: InstalledPluginIndexStoreOptions = {},
 ): RecoveredManagedNpmInstallCandidate[] {
   const npmRoot = resolveRecoveredManagedNpmRoot(options);
-  return [npmRoot, ...listManagedPluginNpmProjectRootsSync(npmRoot)].flatMap((projectRoot) =>
-    buildRecoveredManagedNpmInstallCandidatesForRoot(projectRoot),
-  );
+  return [
+    ...buildRecoveredManagedNpmInstallCandidatesForRoot({
+      projectRoot: npmRoot,
+      sharedLegacyRoot: true,
+    }),
+    ...listManagedPluginNpmProjectRootsSync(npmRoot).flatMap((projectRoot) =>
+      buildRecoveredManagedNpmInstallCandidatesForRoot({
+        projectRoot,
+        sharedLegacyRoot: false,
+      }),
+    ),
+  ];
 }
 
 function recordsShareInstallPath(

--- a/src/plugins/installed-plugin-index-record-reader.ts
+++ b/src/plugins/installed-plugin-index-record-reader.ts
@@ -121,7 +121,7 @@ function resolveRecoveredManagedNpmPluginId(params: {
   return validatePluginId(pluginId) ? undefined : pluginId;
 }
 
-export type RecoveredManagedNpmInstallCandidate = {
+type RecoveredManagedNpmInstallCandidate = {
   installRecord: PluginInstallRecord;
   installTimestampMs: number;
   pluginId: string;

--- a/src/plugins/installed-plugin-index-record-reader.ts
+++ b/src/plugins/installed-plugin-index-record-reader.ts
@@ -161,16 +161,41 @@ function buildRecoveredManagedNpmInstallRecordsForRoot(
   return records;
 }
 
+function pickNewerRecoveredManagedNpmRecord(
+  existing: PluginInstallRecord | undefined,
+  candidate: PluginInstallRecord,
+): PluginInstallRecord {
+  if (!existing) {
+    return candidate;
+  }
+  const existingVersion = readInstallRecordVersion(existing);
+  const candidateVersion = readInstallRecordVersion(candidate);
+  // A legacy flat dir and one or more `__openclaw-generation__` dirs can hold
+  // the same plugin at once, and their on-disk order is unrelated to version.
+  // Keep the highest version so recovery reflects the newest install rather than
+  // whichever directory sorts last. On ties prefer the later candidate so a
+  // generation dir still supersedes the legacy flat dir.
+  if (existingVersion !== undefined && candidateVersion !== undefined) {
+    return compareValidSemver(existingVersion, candidateVersion) === 1 ? existing : candidate;
+  }
+  return candidate;
+}
+
 function buildRecoveredManagedNpmInstallRecords(
   options: InstalledPluginIndexStoreOptions = {},
 ): Record<string, PluginInstallRecord> {
   const npmRoot = resolveRecoveredManagedNpmRoot(options);
-  const legacyRecords = buildRecoveredManagedNpmInstallRecordsForRoot(npmRoot);
-  const projectRecords: Record<string, PluginInstallRecord> = {};
+  const records: Record<string, PluginInstallRecord> = {};
+  const absorb = (source: Record<string, PluginInstallRecord>): void => {
+    for (const [pluginId, record] of Object.entries(source)) {
+      records[pluginId] = pickNewerRecoveredManagedNpmRecord(records[pluginId], record);
+    }
+  };
+  absorb(buildRecoveredManagedNpmInstallRecordsForRoot(npmRoot));
   for (const projectRoot of listManagedPluginNpmProjectRootsSync(npmRoot)) {
-    Object.assign(projectRecords, buildRecoveredManagedNpmInstallRecordsForRoot(projectRoot));
+    absorb(buildRecoveredManagedNpmInstallRecordsForRoot(projectRoot));
   }
-  return { ...legacyRecords, ...projectRecords };
+  return records;
 }
 
 function recordsShareInstallPath(
@@ -257,6 +282,26 @@ function mergeRecoveredManagedNpmMetadata(
   return next;
 }
 
+function isManagedNpmInstallPath(installPath: string | undefined, npmRoot: string): boolean {
+  if (!installPath) {
+    return false;
+  }
+  const packageInfo = resolveRetainedManagedNpmInstallPackageInfo(installPath);
+  if (!packageInfo) {
+    return false;
+  }
+  const normalize = (value: string): string => {
+    const resolved = path.resolve(value);
+    return process.platform === "win32" ? normalizeWindowsPathForComparison(resolved) : resolved;
+  };
+  const projectRoot = normalize(packageInfo.projectRoot);
+  return (
+    projectRoot === normalize(npmRoot) ||
+    normalize(path.dirname(packageInfo.projectRoot)) ===
+      normalize(resolvePluginNpmProjectsDir(npmRoot))
+  );
+}
+
 function mergeRecoveredManagedNpmRecord(params: {
   npmRoot: string;
   persisted: PluginInstallRecord | undefined;
@@ -276,6 +321,26 @@ function mergeRecoveredManagedNpmRecord(params: {
     persistedVersion !== recoveredVersion
   ) {
     return mergeRecoveredManagedNpmMetadata(params.persisted, params.recovered);
+  }
+  // A managed install/update writes the new version into a distinct managed
+  // project directory (for example an `__openclaw-generation__` dir) without
+  // removing the prior one, so the persisted record can keep pointing at an
+  // older, still-present install and the runtime loads the stale version. When
+  // the freshly-discovered managed install is a strictly newer version at a
+  // different path, repoint to it. The strict-newer comparison keeps a lingering
+  // older generation directory from superseding a current install, and the
+  // managed-path guard leaves intentional custom/outside npm installs untouched.
+  if (
+    params.persisted?.source === "npm" &&
+    isManagedNpmInstallPath(params.persisted.installPath, params.npmRoot) &&
+    !recordsShareInstallPath(params.persisted, params.recovered) &&
+    persistedVersion !== undefined &&
+    recoveredVersion !== undefined &&
+    compareValidSemver(persistedVersion, recoveredVersion) === -1
+  ) {
+    return mergeRecoveredManagedNpmMetadata(params.persisted, params.recovered, {
+      preservePersistedSpec: true,
+    });
   }
   return params.persisted ?? params.recovered;
 }


### PR DESCRIPTION
Closes #107228

## What Problem This Solves

Fixes an issue where users upgrading a managed plugin could keep loading the old version when the previous flat install directory remained beside the newly installed generation directory. The failure was visible in `openclaw plugins inspect <id> --runtime`: install and update completed, but runtime inspection still reported the pre-upgrade path and version.

## Why This Change Was Made

The durable install record is now the sole authority for the active managed generation, including intentional downgrades. Recovery never substitutes a higher semantic version for that choice. When the record is absent or points at an unavailable managed path, recovery uses a deterministic per-install timestamp from OpenClaw-owned managed project metadata, falls back to path order only on a timestamp tie, and emits a structured `OPENCLAW_PLUGIN_INSTALL_RECOVERY_FALLBACK` warning.

`openclaw doctor --fix` owns convergence: it records the recovered active path, marks every other managed generation as retained, and lets the existing post-gateway-shutdown cleanup remove those stale trees safely. Runtime loading remains side-effect free. Valid custom npm paths outside the managed root remain authoritative.

This reworks the original diagnosis from @Marvinthebored and @Peetiegonzalez; the highest-version proposal was replaced because it could undo an intentional downgrade.

## User Impact

Upgrades load the generation committed by the install flow even while an older flat directory still exists. Explicit downgrades stay downgraded when a newer generation lingers. Damaged or missing install records recover deterministically with an operator-visible warning, and doctor can then persist the choice and retire stale trees.

## Evidence

- `node scripts/run-vitest.mjs src/commands/doctor-plugin-registry-generation-repair.test.ts src/plugins/installed-plugin-index-generation-precedence.test.ts src/plugins/installed-plugin-index-records.test.ts` — 41 tests passed across command and plugin-index shards on final head.
- Regression coverage includes upgrade with stale flat install, intentional downgrade with newer generation present, missing and dangling authority fallback, Windows path casing, custom installs, retained generation and shared-legacy exclusion, doctor persistence, and post-shutdown pruning.
- Full changed-file Testbox gate (typecheck, test types, lint, formatting, size ratchet, plugin boundaries, import cycles, database-first and safety guards): https://github.com/openclaw/openclaw/actions/runs/29700366819 (`exit=0`). The final rebase was conflict-free and the focused suite remained green.
- Black-box `plugins inspect --runtime` / doctor lifecycle proof: https://github.com/openclaw/openclaw/actions/runs/29698399820. It proved upgrade selects 2026.7.1 over a stale 2026.6.11 flat install, intentional downgrade keeps 1.0.0 despite a lingering 3.0.0 generation, missing authority emits the structured fallback warning, and doctor plus post-shutdown cleanup removes only the stale tree.
- Final branch autoreview: clean, with no accepted or actionable findings.
