### PR TITLE
fix(state): reject non-UTF-8 legacy session-watch sentinel markers

### DIFF
--- a/src/state/openclaw-state-db-session-watch-migration.test.ts
+++ b/src/state/openclaw-state-db-session-watch-migration.test.ts
@@ -1,0 +1,72 @@
+// Session-watch provenance migration: legacy sentinel marker decoding.
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it } from "vitest";
+import { migrateSessionWatchCursorProvenance } from "./openclaw-state-db-session-watch-migration.js";
+
+function createLegacySessionWatchTable(db: DatabaseSync): void {
+  db.exec(`
+    CREATE TABLE session_watch_cursors (
+      watcher_session_key TEXT NOT NULL,
+      target_session_key TEXT NOT NULL,
+      last_seen_sequence INTEGER NOT NULL DEFAULT 0,
+      notified_sequence INTEGER NOT NULL DEFAULT 0,
+      material_sequence INTEGER NOT NULL DEFAULT 0,
+      updated_at INTEGER NOT NULL,
+      PRIMARY KEY (watcher_session_key, target_session_key)
+    ) STRICT;
+  `);
+}
+
+function seedCursor(db: DatabaseSync, watcherSessionKey: string, updatedAt: number): void {
+  db.prepare(`
+    INSERT INTO session_watch_cursors (watcher_session_key, target_session_key, updated_at)
+    VALUES (?, 't-1', ?);
+  `).run(watcherSessionKey, updatedAt);
+}
+
+function readProvenance(db: DatabaseSync, watcherSessionKey: string): string | undefined {
+  const row = db
+    .prepare(
+      "SELECT provenance FROM session_watch_cursors WHERE watcher_session_key = ? AND target_session_key = 't-1'",
+    )
+    .get(watcherSessionKey) as { provenance: string } | undefined;
+  return row?.provenance;
+}
+
+describe("migrateSessionWatchCursorProvenance", () => {
+  it("promotes the cursor row for a valid legacy sentinel marker", () => {
+    const db = new DatabaseSync(":memory:");
+    createLegacySessionWatchTable(db);
+    seedCursor(db, "watcher-1", 5);
+    const marker = `ambient-group-watch:${Buffer.from("watcher-1", "utf8").toString("hex")}`;
+    seedCursor(db, marker, 9);
+
+    const result = migrateSessionWatchCursorProvenance(db);
+
+    expect(result).toEqual({
+      addedColumn: true,
+      migratedAmbientWatches: 1,
+      removedLegacySentinels: 1,
+    });
+    expect(readProvenance(db, "watcher-1")).toBe("ambient-group");
+    expect(readProvenance(db, marker)).toBeUndefined();
+    db.close();
+  });
+
+  it("does not promote a row when the legacy sentinel marker is not valid UTF-8", () => {
+    const db = new DatabaseSync(":memory:");
+    createLegacySessionWatchTable(db);
+    seedCursor(db, "�", 5);
+    // 0xFF is not valid UTF-8; a forgiving decode would collide with the
+    // literal U+FFFD key above and promote a row the marker never owned.
+    seedCursor(db, "ambient-group-watch:ff", 9);
+
+    const result = migrateSessionWatchCursorProvenance(db);
+
+    expect(result.migratedAmbientWatches).toBe(0);
+    expect(result.removedLegacySentinels).toBe(1);
+    expect(readProvenance(db, "�")).toBe("explicit");
+    expect(readProvenance(db, "ambient-group-watch:ff")).toBeUndefined();
+    db.close();
+  });
+});

--- a/src/state/openclaw-state-db-session-watch-migration.ts
+++ b/src/state/openclaw-state-db-session-watch-migration.ts
@@ -65,7 +65,14 @@ function decodeLegacyAmbientWatchMarkerKey(markerKey: string): string | undefine
   if (!encoded || encoded.length % 2 !== 0 || !/^[0-9a-f]+$/.test(encoded)) {
     return undefined;
   }
-  return Buffer.from(encoded, "hex").toString("utf8");
+  // Legacy markers were written as the hex of a valid UTF-8 session key, so a
+  // payload that fails strict UTF-8 decoding is corrupt: fail closed instead of
+  // letting U+FFFD collisions promote an unrelated cursor row.
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(Buffer.from(encoded, "hex"));
+  } catch {
+    return undefined;
+  }
 }
 
 export function migrateSessionWatchCursorProvenance(


### PR DESCRIPTION
## Summary

Reject legacy ambient session-watch sentinel markers whose hex payload is not valid UTF-8, so a corrupt sentinel can no longer collide via U+FFFD and promote an unrelated `session_watch_cursors` row to ambient provenance during the schema-v4 migration.

## What Problem This Solves

The schema-v4 migration (`migrateSessionWatchCursorProvenance` in `src/state/openclaw-state-db-session-watch-migration.ts`) rewrites legacy ambient-watch sentinel rows. A sentinel's `watcher_session_key` is `ambient-group-watch:<hex>`, where the hex encodes the original watcher session key.

- `decodeLegacyAmbientWatchMarkerKey` validated only the hex shape, then decoded with a forgiving UTF-8 conversion (`Buffer.from(encoded, "hex").toString("utf8")`).
- Legacy markers were always written as the hex of a valid UTF-8 session key, so a payload that is not valid UTF-8 is by definition corrupt — but the forgiving decode silently turned it into a string containing U+FFFD.
- That decoded key is then used in a `WHERE watcher_session_key = ?` lookup. A corrupt marker whose bytes collapse to U+FFFD can match a real, unrelated cursor row whose key legitimately contains U+FFFD, and the migration promotes that row to `ambient-group` provenance — a provenance it never owned.

**Code evidence**: at [openclaw-state-db-session-watch-migration.ts:68](src/state/openclaw-state-db-session-watch-migration.ts#L68), the hex payload is decoded without UTF-8 validation.

## Root Cause

- Node's `Buffer.toString("utf8")` (like `TextDecoder` with `fatal: false`) substitutes U+FFFD for malformed byte sequences instead of throwing.
- Two different byte payloads — a valid encoding of U+FFFD (`efbfbd`) and a corrupt byte (`ff`) — decode to the same string, so the corrupt sentinel collides with a row it was never written for.
- Invariant violated: "a legacy sentinel's hex payload always encodes a valid UTF-8 session key" — guaranteed by the legacy writer, but never verified at migration time.

## Why This Fix

Decode with `TextDecoder("utf-8", { fatal: true })` inside the existing validator and return `undefined` on failure:

- A marker that fails strict UTF-8 decoding is treated exactly like the other malformed markers the function already rejects (odd length, non-hex characters): no promotion happens and the sentinel row is cleaned up as before.
- Fail-closed matches the migration's data-integrity role: a marker that cannot be a product of the legacy writer must not influence durable rows.
- This is the same strict-decode pattern already used for provider JSON bodies in `readProviderJsonResponse` ([provider-http-errors.ts:344](src/agents/provider-http-errors.ts#L344)).
- Alternative considered: byte-comparing the re-encoded key against the original hex — equivalent outcome, but more code than the standard strict decoder.

## User Impact

- **Before**: a corrupt sentinel row can promote an unrelated user's watch cursor to `ambient-group` provenance, changing how that watch is attributed and displayed after migration.
- **After**: corrupt sentinels are skipped and removed; only rows whose markers round-trip as valid UTF-8 are migrated.

## Evidence

- **Before** (upstream/main): `migratedAmbientWatches=1, U+FFFD row provenance=ambient-group` — **FAIL**: corrupt sentinel marker collided via U+FFFD and promoted an unrelated row
- **After** (with fix): `migratedAmbientWatches=0, U+FFFD row provenance=explicit` — **PASS**: corrupt sentinel marker rejected, unrelated row left untouched

## Real Behavior Proof

Proof seeds a real in-memory SQLite database with a cursor row whose key is a literal U+FFFD plus a corrupt sentinel (`ambient-group-watch:ff`), then runs the real `migrateSessionWatchCursorProvenance`.

### Before (on main)

```bash
$ node --import tsx proof.mjs
migratedAmbientWatches=1, U+FFFD row provenance=ambient-group
FAIL: corrupt sentinel marker collided via U+FFFD and promoted an unrelated row
```

### After (with fix)

```bash
$ node --import tsx proof.mjs
migratedAmbientWatches=0, U+FFFD row provenance=explicit
PASS: corrupt sentinel marker rejected, unrelated row left untouched
```

## Tests and Validation

- `npx vitest run src/state/openclaw-state-db-session-watch-migration.test.ts` — 2 passed (new test file; the module had no tests before)
- New regression tests: `promotes the cursor row for a valid legacy sentinel marker` (control) and `does not promote a row when the legacy sentinel marker is not valid UTF-8`
- `tsgo:core` typecheck passed; `oxlint` and `oxfmt --check` clean on the changed files
