### PR TITLE
fix(ui): ignore malformed tool stream entries

### DIFF
--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -1870,6 +1870,26 @@ describe("buildCachedChatItems", () => {
     expect(messageRecord(groupAt(groups, 0)).content).toBe("still visible");
   });
 
+  it("does not expose malformed tool stream entries to message rendering", () => {
+    const items = buildCachedChatItems(
+      createProps({
+        toolMessages: [
+          null,
+          undefined,
+          {
+            role: "assistant",
+            content: [{ type: "toolcall", name: "heartbeat_respond", arguments: {} }],
+            timestamp: 1,
+          },
+        ],
+      }),
+    );
+
+    const groups = items.filter((item) => item.kind === "group");
+    expect(groups).toHaveLength(1);
+    expect(messageRecord(groupAt(groups, 0)).role).toBe("assistant");
+  });
+
   it("does not collapse duplicate text messages separated by another message", () => {
     const groups = messageGroups({
       messages: [

--- a/ui/src/pages/chat/chat-thread.ts
+++ b/ui/src/pages/chat/chat-thread.ts
@@ -1187,7 +1187,9 @@ function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | MessageGro
   const history = (Array.isArray(props.messages) ? props.messages : []).filter(
     (message) => !isAssistantHeartbeatAckForDisplay(message),
   );
-  const tools = Array.isArray(props.toolMessages) ? props.toolMessages : [];
+  const tools = Array.isArray(props.toolMessages)
+    ? props.toolMessages.filter((message) => asRecord(message) !== null)
+    : [];
   const historyKeys = buildMessageKeys(history);
   const toolKeys = buildMessageKeys(tools, history.length);
   const liftedCanvasSources = tools.flatMap((message, index) => {


### PR DESCRIPTION
## Summary

- discard non-record tool-stream entries before chat-item keying, grouping, and rendering
- prevent malformed transient entries from aborting incoming gateway event handling and leaving Control UI chat visually stale
- cover `null` and `undefined` tool entries while preserving valid tool-message rendering

## Verification

- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-thread.test.ts ui/src/pages/chat/components/chat-message.test.ts` (219 passed)
- `OPENCLAW_UI_E2E_ARTIFACT_DIR="$PWD/.artifacts/control-ui-e2e/chat-follow" node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-flow.e2e.test.ts -t "keeps live assistant stream text before the matching tool card"` (1 passed)
- Blacksmith Testbox `tbx_01kxw3z9ckjc14hmy5pdsv7cym`: `check:changed` passed ([run](https://github.com/openclaw/openclaw/actions/runs/29670572929))
- autoreview: clean on the final branch diff against `upstream/main`

## Real behavior proof

Behavior addressed: Control UI continues processing incoming chat updates when the tool stream temporarily contains a malformed entry.

Real environment tested: Authenticated team Control UI for failure evidence; mocked Chromium Control UI for patched stream/tool rendering.

Exact steps or command run after this patch: Ran the focused unit suite and the existing Chromium gateway-flow scenario that streams assistant text before its matching tool card.

Evidence after fix: The regression test accepts `null` and `undefined` tool entries without throwing and still renders the valid assistant tool message; Chromium renders the assistant stream before the tool card with the composer anchored at the bottom.

Observed result after fix: Incoming chat derivation remains valid and the visual chat flow completes instead of aborting while reading `message.role`.

What was not tested: The patched branch was not deployed to the authenticated team environment before merge.

## Release note

Fixes Control UI chat appearing to stop following new messages when a malformed transient tool-stream entry aborts incoming event rendering.
