### PR TITLE
fix(feishu): deliver visible notice on reply-session init conflict (#108320)

### DIFF
--- a/extensions/feishu/src/bot-broadcast.ts
+++ b/extensions/feishu/src/bot-broadcast.ts
@@ -16,6 +16,7 @@ export function createFeishuBroadcastIngressSettlement(params: {
   onLanePending: () => void;
   onDispatchComplete: () => Promise<void>;
   onDispatchFailed: (error: unknown) => Promise<void>;
+  onNoticeDelivered: () => Promise<void>;
 } {
   type LaneState = {
     replayClaim?: ChannelReplayClaimHandle;
@@ -231,6 +232,14 @@ export function createFeishuBroadcastIngressSettlement(params: {
       failures.push(error);
       fanoutSettled = true;
       await maybeSettle();
+    },
+    // A lane failure surfaced to the user as a visible notice (e.g. an
+    // exhausted reply-session conflict) counts as handled: adopt and commit
+    // the durable event so redelivery cannot duplicate the notice. maybeSettle
+    // would abandon on the recorded lane failures, so this adopts directly.
+    onNoticeDelivered: async () => {
+      fanoutSettled = true;
+      await adopt();
     },
   };
 }

--- a/extensions/feishu/src/bot.broadcast-conflict-notice.test.ts
+++ b/extensions/feishu/src/bot.broadcast-conflict-notice.test.ts
@@ -465,4 +465,68 @@ describe("broadcast dispatch", () => {
     expect(broadcastClaim.commit).not.toHaveBeenCalled();
     expect(broadcastClaim.release).toHaveBeenCalledTimes(1);
   });
+
+  it("abandons a mixed broadcast aggregate instead of sending the conflict notice (#108320)", async () => {
+    const broadcastClaim = createReplayClaim("broadcast-conflict-mixed");
+    vi.spyOn(feishuDedupeState.guard, "claim").mockImplementation(async (_messageId, options) =>
+      options?.namespace === "broadcast"
+        ? { kind: "claimed", handle: broadcastClaim }
+        : { kind: "invalid" },
+    );
+    // One lane exhausts its reply-session init conflict while the other fails
+    // for an unrelated reason; the aggregate must not classify as a conflict.
+    mockDispatchReply
+      .mockReset()
+      .mockImplementation(async (params: { ctx: { SessionKey?: string } }) => {
+        if (params.ctx.SessionKey?.startsWith("agent:susan:")) {
+          throw new Error("model provider overloaded");
+        }
+        throw new Error(
+          "reply session initialization conflicted for agent:main:feishu:group:oc-broadcast-group",
+        );
+      });
+    const mockNoticeReply = vi.fn().mockResolvedValue({ code: 0, data: { message_id: "om-n" } });
+    const mockNoticeCreate = vi.fn().mockResolvedValue({ code: 0, data: { message_id: "om-n" } });
+    mockCreateFeishuClient.mockReturnValue({
+      contact: {
+        user: {
+          get: vi.fn().mockResolvedValue({ data: { user: { name: "Sender" } } }),
+        },
+      },
+      im: {
+        chat: {
+          get: mockGetChatInfo.mockResolvedValue({
+            code: 0,
+            data: { name: "Broadcast Team" },
+          }),
+        },
+        message: { reply: mockNoticeReply, create: mockNoticeCreate },
+      },
+    });
+    const transport = createIngressLifecycle();
+
+    await expect(
+      handleFeishuMessage({
+        cfg: createBroadcastConfig(),
+        event: createBroadcastEvent({
+          messageId: "msg-broadcast-conflict-mixed",
+          text: "hello @bot",
+          botMentioned: true,
+        }),
+        botOpenId: "bot-open-id",
+        runtime: createRuntimeEnv(),
+        turnAdoptionLifecycle: transport.lifecycle,
+      }),
+    ).rejects.toThrow("Feishu broadcast dispatch failed");
+
+    // The session-busy notice must not go out: it would adopt the durable
+    // event and hide the unrelated lane failure from redelivery. Instead the
+    // settlement abandons + releases so a redelivery can retry both lanes.
+    expect(mockNoticeReply).not.toHaveBeenCalled();
+    expect(mockNoticeCreate).not.toHaveBeenCalled();
+    expect(transport.calls.adopted).not.toHaveBeenCalled();
+    expect(transport.calls.abandoned).toHaveBeenCalledTimes(1);
+    expect(broadcastClaim.commit).not.toHaveBeenCalled();
+    expect(broadcastClaim.release).toHaveBeenCalledTimes(1);
+  });
 });

--- a/extensions/feishu/src/bot.broadcast-conflict-notice.test.ts
+++ b/extensions/feishu/src/bot.broadcast-conflict-notice.test.ts
@@ -1,0 +1,468 @@
+// Feishu tests cover bot.broadcast plugin behavior.
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ClawdbotConfig, PluginRuntime } from "../runtime-api.js";
+import { feishuGroupNameCache } from "./bot-group-name-state.js";
+import type { FeishuMessageEvent } from "./bot.js";
+import { handleFeishuMessage } from "./bot.js";
+import { feishuDedupeState } from "./dedup-state.js";
+import type { FeishuMessageProcessingClaim } from "./dedup.js";
+import type { FeishuIngressLifecycle } from "./feishu-ingress.js";
+import { setFeishuRuntime } from "./runtime.js";
+
+const {
+  builtInboundContextCalls,
+  mockCreateFeishuReplyDispatcher,
+  mockCreateFeishuClient,
+  mockDispatchReply,
+  mockRecordInboundSession,
+  mockResolveAgentRoute,
+  mockResolveStorePath,
+} = vi.hoisted(() => ({
+  builtInboundContextCalls: [] as Array<Record<string, unknown>>,
+  mockCreateFeishuReplyDispatcher: vi.fn((_params?: unknown) => ({
+    dispatcherOptions: {},
+    delivery: { deliver: vi.fn(async () => undefined) },
+    replyOptions: {},
+    ensureNoVisibleReplyFallback: vi.fn(),
+  })),
+  mockCreateFeishuClient: vi.fn(),
+  mockDispatchReply: vi.fn().mockResolvedValue({ queuedFinal: false, counts: { final: 1 } }),
+  mockRecordInboundSession: vi.fn().mockResolvedValue(undefined),
+  mockResolveAgentRoute: vi.fn(),
+  mockResolveStorePath: vi.fn(
+    (_store?: unknown, _options?: { agentId?: string }) => "/tmp/feishu-session-store.json",
+  ),
+}));
+
+vi.mock("openclaw/plugin-sdk/channel-inbound", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/channel-inbound")>(
+    "openclaw/plugin-sdk/channel-inbound",
+  );
+  return {
+    ...actual,
+    buildChannelInboundEventContext: (
+      params: Parameters<typeof actual.buildChannelInboundEventContext>[0],
+    ) =>
+      actual.buildChannelInboundEventContext({
+        ...params,
+        finalize: (ctx) => {
+          builtInboundContextCalls.push(ctx);
+          return ctx as never;
+        },
+      }),
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/session-store-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/session-store-runtime")>(
+    "openclaw/plugin-sdk/session-store-runtime",
+  );
+  return { ...actual, resolveStorePath: mockResolveStorePath };
+});
+
+vi.mock("./reply-dispatcher.js", () => ({
+  createFeishuReplyDispatcher: mockCreateFeishuReplyDispatcher,
+}));
+
+vi.mock("./client.js", () => ({
+  createFeishuClient: mockCreateFeishuClient,
+}));
+
+function createRuntimeEnv() {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    writeStdout: vi.fn(),
+    writeJson: vi.fn(),
+    exit: vi.fn((code: number): never => {
+      throw new Error(`exit ${code}`);
+    }),
+  };
+}
+
+function createIngressLifecycle() {
+  const calls = {
+    adopted: vi.fn(async () => {}),
+    deferred: vi.fn(),
+    finalizing: vi.fn(),
+    abandoned: vi.fn(async () => {}),
+  };
+  const lifecycle: FeishuIngressLifecycle = {
+    abortSignal: new AbortController().signal,
+    onAdopted: calls.adopted,
+    onDeferred: calls.deferred,
+    onAdoptionFinalizing: calls.finalizing,
+    onAbandoned: calls.abandoned,
+  };
+  return { calls, lifecycle };
+}
+
+function createReplayClaim(key: string): FeishuMessageProcessingClaim {
+  return {
+    keys: [key],
+    commit: vi.fn(async () => true),
+    release: vi.fn(),
+  };
+}
+
+describe("broadcast dispatch", () => {
+  const mockGetChatInfo = vi.fn();
+  const mockShouldComputeCommandAuthorized = vi.fn(() => false);
+  const resolvedTurnCalls: Array<Record<string, unknown>> = [];
+  const mockSaveMediaBuffer = vi.fn().mockResolvedValue({
+    path: "/tmp/inbound-clip.mp4",
+    contentType: "video/mp4",
+  });
+  const runtimeStub = {
+    system: {
+      enqueueSystemEvent: vi.fn(),
+    },
+    channel: {
+      routing: {
+        resolveAgentRoute: (params: unknown) => mockResolveAgentRoute(params),
+      },
+      session: {
+        resolveStorePath: mockResolveStorePath,
+        recordInboundSession: mockRecordInboundSession,
+      },
+      reply: {},
+      commands: {
+        shouldComputeCommandAuthorized: mockShouldComputeCommandAuthorized,
+        resolveCommandAuthorizedFromAuthorizers: vi.fn(() => false),
+      },
+      media: {
+        saveMediaBuffer: mockSaveMediaBuffer,
+      },
+      inbound: {
+        run: vi.fn(async (params: Parameters<PluginRuntime["channel"]["inbound"]["run"]>[0]) => {
+          const input = await params.adapter.ingest(params.raw);
+          if (!input) {
+            return {
+              admission: { kind: "drop" as const, reason: "ingest-null" },
+              dispatched: false,
+            };
+          }
+          const eventClass = {
+            kind: "message" as const,
+            canStartAgentTurn: true,
+          };
+          const turn = await params.adapter.resolveTurn(input, eventClass, {});
+          if (!("route" in turn) || !("delivery" in turn)) {
+            throw new Error("expected assembled Feishu channel turn plan");
+          }
+          resolvedTurnCalls.push(turn as unknown as Record<string, unknown>);
+          const routeSessionKey = turn.route.sessionKey;
+          await mockRecordInboundSession({
+            storePath: mockResolveStorePath(),
+            sessionKey: turn.ctxPayload.SessionKey ?? routeSessionKey,
+            ctx: turn.ctxPayload,
+            groupResolution: turn.record?.groupResolution,
+            createIfMissing: turn.record?.createIfMissing,
+            updateLastRoute: turn.record?.updateLastRoute,
+            onRecordError: turn.record?.onRecordError ?? (() => undefined),
+          });
+          const dispatchResult = await mockDispatchReply({
+            ctx: turn.ctxPayload,
+            cfg: turn.cfg,
+            replyOptions: turn.replyOptions,
+          });
+          const dispatched = !(dispatchResult as { undispatched?: boolean }).undispatched;
+          if (dispatched && !(dispatchResult as { deferAdoption?: boolean }).deferAdoption) {
+            await turn.replyOptions?.turnAdoptionLifecycle?.onAdopted?.();
+          }
+          return {
+            admission: turn.admission ?? { kind: "dispatch" as const },
+            dispatched,
+            ctxPayload: turn.ctxPayload,
+            routeSessionKey,
+            ...(dispatched ? { dispatchResult } : {}),
+          };
+        }),
+      },
+      pairing: {
+        readAllowFromStore: vi.fn().mockResolvedValue([]),
+        upsertPairingRequest: vi.fn().mockResolvedValue({ code: "ABCDEFGH", created: false }),
+        buildPairingReply: vi.fn(() => "Pairing response"),
+      },
+    },
+    media: {
+      detectMime: vi.fn(async () => "application/octet-stream"),
+    },
+  } as unknown as PluginRuntime;
+
+  afterAll(() => {
+    vi.doUnmock("./reply-dispatcher.js");
+    vi.doUnmock("./client.js");
+    vi.resetModules();
+  });
+
+  function createBroadcastConfig(): ClawdbotConfig {
+    return {
+      broadcast: { "oc-broadcast-group": ["susan", "main"] },
+      agents: { list: [{ id: "main" }, { id: "susan" }] },
+      channels: {
+        feishu: {
+          appId: "cli_test",
+          appSecret: "sec_test", // pragma: allowlist secret
+          groups: {
+            "oc-broadcast-group": {
+              requireMention: true,
+            },
+          },
+        },
+      },
+    };
+  }
+
+  function createBroadcastEvent(options: {
+    messageId: string;
+    text: string;
+    botMentioned?: boolean;
+  }): FeishuMessageEvent {
+    return {
+      sender: { sender_id: { open_id: "ou-sender" } },
+      message: {
+        message_id: options.messageId,
+        chat_id: "oc-broadcast-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: options.text }),
+        ...(options.botMentioned
+          ? {
+              mentions: [
+                {
+                  key: "@_user_1",
+                  id: { open_id: "bot-open-id" },
+                  name: "Bot",
+                  tenant_key: "",
+                },
+              ],
+            }
+          : {}),
+      },
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    feishuDedupeState.reset();
+    mockDispatchReply.mockReset().mockResolvedValue({
+      queuedFinal: false,
+      counts: { final: 1 },
+    });
+    mockResolveStorePath.mockReset().mockReturnValue("/tmp/feishu-session-store.json");
+    feishuGroupNameCache.clear();
+    builtInboundContextCalls.length = 0;
+    resolvedTurnCalls.length = 0;
+    mockResolveAgentRoute.mockReturnValue({
+      agentId: "main",
+      channel: "feishu",
+      accountId: "default",
+      sessionKey: "agent:main:feishu:group:oc-broadcast-group",
+      mainSessionKey: "agent:main:main",
+      lastRoutePolicy: "session",
+      matchedBy: "default",
+    });
+    mockCreateFeishuReplyDispatcher.mockReturnValue({
+      dispatcherOptions: {},
+      delivery: { deliver: vi.fn(async () => undefined) },
+      replyOptions: {},
+      ensureNoVisibleReplyFallback: vi.fn(),
+    });
+    mockCreateFeishuClient.mockReturnValue({
+      contact: {
+        user: {
+          get: vi.fn().mockResolvedValue({ data: { user: { name: "Sender" } } }),
+        },
+      },
+      im: {
+        chat: {
+          get: mockGetChatInfo.mockResolvedValue({
+            code: 0,
+            data: { name: "Broadcast Team" },
+          }),
+        },
+      },
+    });
+    setFeishuRuntime(runtimeStub);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    feishuDedupeState.reset();
+  });
+
+  it("delivers the reply-session conflict notice with thread routing when broadcast lanes exhaust retries (#108320)", async () => {
+    mockDispatchReply
+      .mockReset()
+      .mockRejectedValue(
+        new Error(
+          "reply session initialization conflicted for agent:main:feishu:group:oc-broadcast-group",
+        ),
+      );
+    const mockNoticeReply = vi.fn().mockResolvedValue({ code: 0, data: { message_id: "om-n" } });
+    const mockNoticeCreate = vi.fn().mockResolvedValue({ code: 0, data: { message_id: "om-n" } });
+    mockCreateFeishuClient.mockReturnValue({
+      contact: {
+        user: {
+          get: vi.fn().mockResolvedValue({ data: { user: { name: "Sender" } } }),
+        },
+      },
+      im: {
+        chat: {
+          get: mockGetChatInfo.mockResolvedValue({
+            code: 0,
+            data: { name: "Broadcast Team" },
+          }),
+        },
+        message: { reply: mockNoticeReply, create: mockNoticeCreate },
+      },
+    });
+    const cfg = createBroadcastConfig();
+    const broadcastGroups = cfg.channels?.feishu?.groups as Record<
+      string,
+      { replyInThread?: "enabled" | "disabled" }
+    >;
+    broadcastGroups["oc-broadcast-group"]!.replyInThread = "enabled";
+    const event = createBroadcastEvent({
+      messageId: "msg-broadcast-conflict",
+      text: "hello @bot",
+      botMentioned: true,
+    });
+    event.message.root_id = "om-broadcast-root";
+    event.message.thread_id = "omt-broadcast-thread";
+
+    // Every lane exhausts its reply-session init conflict, so the fan-out
+    // surfaces an AggregateError; the notice must still go out, anchored at the
+    // resolved thread root with reply_in_thread, not the catch-block defaults.
+    await handleFeishuMessage({
+      cfg,
+      event,
+      botOpenId: "bot-open-id",
+      runtime: createRuntimeEnv(),
+    });
+
+    expect(mockNoticeReply).toHaveBeenCalledTimes(1);
+    expect(mockNoticeCreate).not.toHaveBeenCalled();
+    const noticeRequest = mockNoticeReply.mock.calls[0]?.[0] as {
+      path: { message_id: string };
+      data: { content: string; msg_type: string; reply_in_thread?: boolean };
+    };
+    expect(noticeRequest.path.message_id).toBe("om-broadcast-root");
+    expect(noticeRequest.data.msg_type).toBe("post");
+    expect(noticeRequest.data.reply_in_thread).toBe(true);
+    expect(noticeRequest.data.content).toContain("session stayed busy");
+  });
+
+  it("adopts the durable broadcast event once the conflict notice is delivered (#108320)", async () => {
+    const broadcastClaim = createReplayClaim("broadcast-conflict-notice-adopt");
+    vi.spyOn(feishuDedupeState.guard, "claim").mockImplementation(async (_messageId, options) =>
+      options?.namespace === "broadcast"
+        ? { kind: "claimed", handle: broadcastClaim }
+        : { kind: "invalid" },
+    );
+    mockDispatchReply
+      .mockReset()
+      .mockRejectedValue(
+        new Error(
+          "reply session initialization conflicted for agent:main:feishu:group:oc-broadcast-group",
+        ),
+      );
+    const mockNoticeReply = vi.fn().mockResolvedValue({ code: 0, data: { message_id: "om-n" } });
+    const mockNoticeCreate = vi.fn().mockResolvedValue({ code: 0, data: { message_id: "om-n" } });
+    mockCreateFeishuClient.mockReturnValue({
+      contact: {
+        user: {
+          get: vi.fn().mockResolvedValue({ data: { user: { name: "Sender" } } }),
+        },
+      },
+      im: {
+        chat: {
+          get: mockGetChatInfo.mockResolvedValue({
+            code: 0,
+            data: { name: "Broadcast Team" },
+          }),
+        },
+        message: { reply: mockNoticeReply, create: mockNoticeCreate },
+      },
+    });
+    const transport = createIngressLifecycle();
+
+    await handleFeishuMessage({
+      cfg: createBroadcastConfig(),
+      event: createBroadcastEvent({
+        messageId: "msg-broadcast-conflict-adopt",
+        text: "hello @bot",
+        botMentioned: true,
+      }),
+      botOpenId: "bot-open-id",
+      runtime: createRuntimeEnv(),
+      turnAdoptionLifecycle: transport.lifecycle,
+    });
+
+    // The delivered notice settles the durable event: adopt + commit, never
+    // abandon + release, so a redelivery cannot duplicate the notice.
+    expect(mockNoticeReply.mock.calls.length + mockNoticeCreate.mock.calls.length).toBe(1);
+    expect(transport.calls.adopted).toHaveBeenCalledTimes(1);
+    expect(transport.calls.abandoned).not.toHaveBeenCalled();
+    expect(broadcastClaim.commit).toHaveBeenCalledTimes(1);
+    expect(broadcastClaim.release).not.toHaveBeenCalled();
+  });
+
+  it("abandons the durable broadcast event when the conflict notice send fails (#108320)", async () => {
+    const broadcastClaim = createReplayClaim("broadcast-conflict-notice-abandon");
+    vi.spyOn(feishuDedupeState.guard, "claim").mockImplementation(async (_messageId, options) =>
+      options?.namespace === "broadcast"
+        ? { kind: "claimed", handle: broadcastClaim }
+        : { kind: "invalid" },
+    );
+    mockDispatchReply
+      .mockReset()
+      .mockRejectedValue(
+        new Error(
+          "reply session initialization conflicted for agent:main:feishu:group:oc-broadcast-group",
+        ),
+      );
+    const mockNoticeReply = vi.fn().mockRejectedValue(new Error("feishu reply api unavailable"));
+    const mockNoticeCreate = vi.fn().mockRejectedValue(new Error("feishu create api unavailable"));
+    mockCreateFeishuClient.mockReturnValue({
+      contact: {
+        user: {
+          get: vi.fn().mockResolvedValue({ data: { user: { name: "Sender" } } }),
+        },
+      },
+      im: {
+        chat: {
+          get: mockGetChatInfo.mockResolvedValue({
+            code: 0,
+            data: { name: "Broadcast Team" },
+          }),
+        },
+        message: { reply: mockNoticeReply, create: mockNoticeCreate },
+      },
+    });
+    const transport = createIngressLifecycle();
+
+    await expect(
+      handleFeishuMessage({
+        cfg: createBroadcastConfig(),
+        event: createBroadcastEvent({
+          messageId: "msg-broadcast-conflict-abandon",
+          text: "hello @bot",
+          botMentioned: true,
+        }),
+        botOpenId: "bot-open-id",
+        runtime: createRuntimeEnv(),
+        turnAdoptionLifecycle: transport.lifecycle,
+      }),
+    ).rejects.toThrow("Feishu broadcast dispatch failed");
+
+    // The notice never landed, so the durable event must stay redeliverable:
+    // abandon + release, never adopt + commit.
+    expect(mockNoticeReply.mock.calls.length + mockNoticeCreate.mock.calls.length).toBe(1);
+    expect(transport.calls.adopted).not.toHaveBeenCalled();
+    expect(transport.calls.abandoned).toHaveBeenCalledTimes(1);
+    expect(broadcastClaim.commit).not.toHaveBeenCalled();
+    expect(broadcastClaim.release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/feishu/src/bot.broadcast.test.ts
+++ b/extensions/feishu/src/bot.broadcast.test.ts
@@ -720,6 +720,68 @@ describe("broadcast dispatch", () => {
     expect(retrySusanClaim.release).not.toHaveBeenCalled();
   });
 
+  it("delivers the reply-session conflict notice with thread routing when broadcast lanes exhaust retries (#108320)", async () => {
+    mockDispatchReply
+      .mockReset()
+      .mockRejectedValue(
+        new Error(
+          "reply session initialization conflicted for agent:main:feishu:group:oc-broadcast-group",
+        ),
+      );
+    const mockNoticeReply = vi.fn().mockResolvedValue({ code: 0, data: { message_id: "om-n" } });
+    const mockNoticeCreate = vi.fn().mockResolvedValue({ code: 0, data: { message_id: "om-n" } });
+    mockCreateFeishuClient.mockReturnValue({
+      contact: {
+        user: {
+          get: vi.fn().mockResolvedValue({ data: { user: { name: "Sender" } } }),
+        },
+      },
+      im: {
+        chat: {
+          get: mockGetChatInfo.mockResolvedValue({
+            code: 0,
+            data: { name: "Broadcast Team" },
+          }),
+        },
+        message: { reply: mockNoticeReply, create: mockNoticeCreate },
+      },
+    });
+    const cfg = createBroadcastConfig();
+    const broadcastGroups = cfg.channels?.feishu?.groups as Record<
+      string,
+      { replyInThread?: "enabled" | "disabled" }
+    >;
+    broadcastGroups["oc-broadcast-group"]!.replyInThread = "enabled";
+    const event = createBroadcastEvent({
+      messageId: "msg-broadcast-conflict",
+      text: "hello @bot",
+      botMentioned: true,
+    });
+    event.message.root_id = "om-broadcast-root";
+    event.message.thread_id = "omt-broadcast-thread";
+
+    // Every lane exhausts its reply-session init conflict, so the fan-out
+    // surfaces an AggregateError; the notice must still go out, anchored at the
+    // resolved thread root with reply_in_thread, not the catch-block defaults.
+    await handleFeishuMessage({
+      cfg,
+      event,
+      botOpenId: "bot-open-id",
+      runtime: createRuntimeEnv(),
+    });
+
+    expect(mockNoticeReply).toHaveBeenCalledTimes(1);
+    expect(mockNoticeCreate).not.toHaveBeenCalled();
+    const noticeRequest = mockNoticeReply.mock.calls[0]?.[0] as {
+      path: { message_id: string };
+      data: { content: string; msg_type: string; reply_in_thread?: boolean };
+    };
+    expect(noticeRequest.path.message_id).toBe("om-broadcast-root");
+    expect(noticeRequest.data.msg_type).toBe("post");
+    expect(noticeRequest.data.reply_in_thread).toBe(true);
+    expect(noticeRequest.data.content).toContain("session stayed busy");
+  });
+
   it("keeps an adopted active lane committed when its no-visible fallback fails", async () => {
     const broadcastClaim = createReplayClaim("broadcast-fallback-failure");
     const susanClaim = createReplayClaim("broadcast-fallback-failure-susan");

--- a/extensions/feishu/src/bot.broadcast.test.ts
+++ b/extensions/feishu/src/bot.broadcast.test.ts
@@ -720,68 +720,6 @@ describe("broadcast dispatch", () => {
     expect(retrySusanClaim.release).not.toHaveBeenCalled();
   });
 
-  it("delivers the reply-session conflict notice with thread routing when broadcast lanes exhaust retries (#108320)", async () => {
-    mockDispatchReply
-      .mockReset()
-      .mockRejectedValue(
-        new Error(
-          "reply session initialization conflicted for agent:main:feishu:group:oc-broadcast-group",
-        ),
-      );
-    const mockNoticeReply = vi.fn().mockResolvedValue({ code: 0, data: { message_id: "om-n" } });
-    const mockNoticeCreate = vi.fn().mockResolvedValue({ code: 0, data: { message_id: "om-n" } });
-    mockCreateFeishuClient.mockReturnValue({
-      contact: {
-        user: {
-          get: vi.fn().mockResolvedValue({ data: { user: { name: "Sender" } } }),
-        },
-      },
-      im: {
-        chat: {
-          get: mockGetChatInfo.mockResolvedValue({
-            code: 0,
-            data: { name: "Broadcast Team" },
-          }),
-        },
-        message: { reply: mockNoticeReply, create: mockNoticeCreate },
-      },
-    });
-    const cfg = createBroadcastConfig();
-    const broadcastGroups = cfg.channels?.feishu?.groups as Record<
-      string,
-      { replyInThread?: "enabled" | "disabled" }
-    >;
-    broadcastGroups["oc-broadcast-group"]!.replyInThread = "enabled";
-    const event = createBroadcastEvent({
-      messageId: "msg-broadcast-conflict",
-      text: "hello @bot",
-      botMentioned: true,
-    });
-    event.message.root_id = "om-broadcast-root";
-    event.message.thread_id = "omt-broadcast-thread";
-
-    // Every lane exhausts its reply-session init conflict, so the fan-out
-    // surfaces an AggregateError; the notice must still go out, anchored at the
-    // resolved thread root with reply_in_thread, not the catch-block defaults.
-    await handleFeishuMessage({
-      cfg,
-      event,
-      botOpenId: "bot-open-id",
-      runtime: createRuntimeEnv(),
-    });
-
-    expect(mockNoticeReply).toHaveBeenCalledTimes(1);
-    expect(mockNoticeCreate).not.toHaveBeenCalled();
-    const noticeRequest = mockNoticeReply.mock.calls[0]?.[0] as {
-      path: { message_id: string };
-      data: { content: string; msg_type: string; reply_in_thread?: boolean };
-    };
-    expect(noticeRequest.path.message_id).toBe("om-broadcast-root");
-    expect(noticeRequest.data.msg_type).toBe("post");
-    expect(noticeRequest.data.reply_in_thread).toBe(true);
-    expect(noticeRequest.data.content).toContain("session stayed busy");
-  });
-
   it("keeps an adopted active lane committed when its no-visible fallback fails", async () => {
     const broadcastClaim = createReplayClaim("broadcast-fallback-failure");
     const susanClaim = createReplayClaim("broadcast-fallback-failure-susan");

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -571,6 +571,39 @@ describe("handleFeishuMessage ACP routing", () => {
     expect(mockEnsureConfiguredBindingRouteReady).toHaveBeenCalledTimes(1);
   });
 
+  it("delivers a visible notice when reply-session init conflict exhausts its retry (#108320)", async () => {
+    mockDispatchInboundMessage.mockRejectedValue(
+      new Error("reply session initialization conflicted for agent:main:feishu:direct:ou_sender_1"),
+    );
+
+    await dispatchMessage({
+      cfg: {
+        session: { mainKey: "main", scope: "per-sender" },
+        channels: { feishu: { enabled: true, allowFrom: ["ou_sender_1"], dmPolicy: "open" } },
+      },
+      event: {
+        sender: { sender_id: { open_id: "ou_sender_1" } },
+        message: {
+          message_id: "msg-conflict",
+          chat_id: "oc_dm",
+          chat_type: "p2p",
+          message_type: "text",
+          content: JSON.stringify({ text: "hello" }),
+        },
+      },
+    });
+
+    expect(mockSendMessageFeishu).toHaveBeenCalledTimes(1);
+    const notice = mockCallArg<{ text?: string; to?: string; replyToMessageId?: string }>(
+      mockSendMessageFeishu,
+      0,
+      0,
+    );
+    expect(notice.to).toBe("chat:oc_dm");
+    expect(notice.replyToMessageId).toBe("msg-conflict");
+    expect(notice.text).toContain("session stayed busy");
+  });
+
   it("surfaces configured ACP initialization failures to the Feishu conversation", async () => {
     mockResolveConfiguredBindingRoute.mockReturnValue(createConfiguredFeishuRoute());
     mockEnsureConfiguredBindingRouteReady.mockResolvedValue(

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -19,6 +19,7 @@ import {
   createFeishuTestRoute,
 } from "./bot.test-support.js";
 import { resolveFeishuMessageDedupeKey } from "./dedupe-key.js";
+import type { FeishuIngressLifecycle } from "./feishu-ingress.js";
 import { createFeishuMessageReceiveHandler } from "./monitor.message-handler.js";
 import { setFeishuRuntime } from "./runtime.js";
 import { setFeishuSyntheticDirectPreDispatchTarget } from "./synthetic-event-target.js";
@@ -482,6 +483,7 @@ async function dispatchMessage(params: {
   channelRuntime?: PluginRuntime["channel"];
   botOpenId?: string;
   directPreDispatchTarget?: string;
+  turnAdoptionLifecycle?: FeishuIngressLifecycle;
 }) {
   const runtime = createRuntimeEnv();
   const feishuConfig = params.cfg.channels?.feishu;
@@ -508,6 +510,7 @@ async function dispatchMessage(params: {
     botOpenId: params.botOpenId,
     runtime,
     channelRuntime: params.channelRuntime,
+    turnAdoptionLifecycle: params.turnAdoptionLifecycle,
   });
   return runtime;
 }
@@ -634,6 +637,83 @@ describe("handleFeishuMessage ACP routing", () => {
         replyToMessageId: "msg-conflict-thread-root",
         replyInThread: true,
       }),
+    );
+  });
+
+  function createTurnAdoptionLifecycle(): FeishuIngressLifecycle {
+    return {
+      abortSignal: new AbortController().signal,
+      onAdopted: vi.fn(async () => {}),
+      onDeferred: vi.fn(),
+      onAdoptionFinalizing: vi.fn(),
+      onAbandoned: vi.fn(async () => {}),
+    };
+  }
+
+  it("delivers the conflict notice for durable ingress events instead of rethrowing (#108320)", async () => {
+    mockDispatchInboundMessage.mockRejectedValueOnce(
+      new Error("reply session initialization conflicted for agent:main:feishu:direct:ou_sender_1"),
+    );
+
+    // Durable ingress always supplies a turn-adoption lifecycle; a landed
+    // terminal notice means the handler resolves so the caller can settle.
+    await dispatchMessage({
+      cfg: {
+        session: { mainKey: "main", scope: "per-sender" },
+        channels: { feishu: { enabled: true, allowFrom: ["ou_sender_1"], dmPolicy: "open" } },
+      },
+      event: {
+        sender: { sender_id: { open_id: "ou_sender_1" } },
+        message: {
+          message_id: "msg-conflict-durable",
+          chat_id: "oc_dm",
+          chat_type: "p2p",
+          message_type: "text",
+          content: JSON.stringify({ text: "hello" }),
+        },
+      },
+      turnAdoptionLifecycle: createTurnAdoptionLifecycle(),
+    });
+
+    expect(mockSendMessageFeishu).toHaveBeenCalledTimes(1);
+    const notice = mockCallArg<{ text?: string; to?: string; replyToMessageId?: string }>(
+      mockSendMessageFeishu,
+      0,
+      0,
+    );
+    expect(notice.to).toBe("chat:oc_dm");
+    expect(notice.replyToMessageId).toBe("msg-conflict-durable");
+    expect(notice.text).toContain("session stayed busy");
+  });
+
+  it("rethrows the conflict for durable ingress when the notice fails to send (#108320)", async () => {
+    mockDispatchInboundMessage.mockRejectedValueOnce(
+      new Error("reply session initialization conflicted for agent:main:feishu:direct:ou_sender_1"),
+    );
+    mockSendMessageFeishu.mockRejectedValueOnce(new Error("feishu api unavailable"));
+
+    // The notice never landed, so the handler must rethrow to abandon the
+    // ingress lifecycle and keep durable redelivery alive.
+    await expect(
+      dispatchMessage({
+        cfg: {
+          session: { mainKey: "main", scope: "per-sender" },
+          channels: { feishu: { enabled: true, allowFrom: ["ou_sender_1"], dmPolicy: "open" } },
+        },
+        event: {
+          sender: { sender_id: { open_id: "ou_sender_1" } },
+          message: {
+            message_id: "msg-conflict-durable-notice-failure",
+            chat_id: "oc_dm",
+            chat_type: "p2p",
+            message_type: "text",
+            content: JSON.stringify({ text: "hello" }),
+          },
+        },
+        turnAdoptionLifecycle: createTurnAdoptionLifecycle(),
+      }),
+    ).rejects.toThrow(
+      "reply session initialization conflicted for agent:main:feishu:direct:ou_sender_1",
     );
   });
 

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -572,7 +572,7 @@ describe("handleFeishuMessage ACP routing", () => {
   });
 
   it("delivers a visible notice when reply-session init conflict exhausts its retry (#108320)", async () => {
-    mockDispatchInboundMessage.mockRejectedValue(
+    mockDispatchInboundMessage.mockRejectedValueOnce(
       new Error("reply session initialization conflicted for agent:main:feishu:direct:ou_sender_1"),
     );
 
@@ -602,6 +602,39 @@ describe("handleFeishuMessage ACP routing", () => {
     expect(notice.to).toBe("chat:oc_dm");
     expect(notice.replyToMessageId).toBe("msg-conflict");
     expect(notice.text).toContain("session stayed busy");
+  });
+
+  it("delivers the reply-session conflict notice inside P2P direct-message threads (#108320)", async () => {
+    mockDispatchInboundMessage.mockRejectedValueOnce(
+      new Error("reply session initialization conflicted for agent:main:feishu:direct:ou_sender_1"),
+    );
+
+    await dispatchMessage({
+      cfg: {
+        session: { mainKey: "main", scope: "per-sender" },
+        channels: { feishu: { enabled: true, allowFrom: ["ou_sender_1"], dmPolicy: "open" } },
+      },
+      event: {
+        sender: { sender_id: { open_id: "ou_sender_1" } },
+        message: {
+          message_id: "msg-conflict-thread-child",
+          root_id: "msg-conflict-thread-root",
+          thread_id: "omt-conflict-dm-thread",
+          chat_id: "oc_dm",
+          chat_type: "p2p",
+          message_type: "text",
+          content: JSON.stringify({ text: "hello" }),
+        },
+      },
+    });
+
+    expect(mockSendMessageFeishu).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "chat:oc_dm",
+        replyToMessageId: "msg-conflict-thread-root",
+        replyInThread: true,
+      }),
+    );
   });
 
   it("surfaces configured ACP initialization failures to the Feishu conversation", async () => {

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -712,6 +712,13 @@ export async function handleFeishuMessage(params: {
   let conflictNoticeCfg = cfg;
   let conflictNoticeReplyToMessageId: string | undefined = ctx.messageId;
   let conflictNoticeReplyInThread = false;
+  // Broadcast fan-out settlement, captured when the broadcast path runs so the
+  // conflict-notice catch can settle the durable event: adopt once the notice
+  // lands, abandon when the notice send fails. Without it the durable event
+  // would stay abandoned after a delivered notice and redeliver a duplicate.
+  let broadcastIngressSettlement:
+    | ReturnType<typeof createFeishuBroadcastIngressSettlement>
+    | undefined;
   try {
     const core = {
       channel: channelRuntime?.inbound ? channelRuntime : getFeishuRuntime().channel,
@@ -1582,6 +1589,7 @@ export async function handleFeishuMessage(params: {
           );
         }
       };
+      broadcastIngressSettlement = broadcastSettlement;
 
       // --- Broadcast dispatch: send message to all configured agents ---
       const rawStrategy = (
@@ -1814,7 +1822,14 @@ export async function handleFeishuMessage(params: {
           failures.length === 1
             ? failures[0]
             : new AggregateError(failures, "Feishu broadcast dispatch failed");
-        await abandonBroadcast(failure);
+        // A reply-session conflict is surfaced as a visible notice by the
+        // outer catch; keep the settlement open so a delivered notice can
+        // adopt the durable event and a notice-send failure can abandon it.
+        // Abandoning here would release the replay claim before the notice
+        // and let a redelivery duplicate the notice.
+        if (!isFeishuReplySessionInitConflictError(failure)) {
+          await abandonBroadcast(failure);
+        }
         throw failure;
       }
 
@@ -1945,12 +1960,22 @@ export async function handleFeishuMessage(params: {
           replyInThread: conflictNoticeReplyInThread,
           accountId: account.accountId,
         });
+        // The notice landed, so the broadcast event is visibly handled: adopt
+        // and commit the durable event instead of letting an abandoned
+        // settlement redeliver it and duplicate the notice.
+        if (broadcastIngressSettlement) {
+          await broadcastIngressSettlement.onNoticeDelivered();
+        }
       } catch (noticeError) {
         error(
           `feishu[${account.accountId}]: reply-session conflict notice failed: ${String(noticeError)}`,
         );
         // The notice never landed, so a durable event must not be adopted:
-        // rethrow to abandon the ingress lifecycle and keep redelivery alive.
+        // abandon the broadcast settlement to keep redelivery alive, then
+        // rethrow to abandon the direct-ingress lifecycle path.
+        if (broadcastIngressSettlement) {
+          await broadcastIngressSettlement.onDispatchFailed(err);
+        }
         if (turnAdoptionLifecycle) {
           throw err;
         }

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -107,8 +107,17 @@ const FEISHU_REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE =
   /reply session initialization conflicted for \S+/u;
 
 function isFeishuReplySessionInitConflictError(error: unknown): boolean {
-  return FEISHU_REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE.test(
-    error instanceof Error ? error.message : String(error),
+  if (
+    FEISHU_REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE.test(
+      error instanceof Error ? error.message : String(error),
+    )
+  ) {
+    return true;
+  }
+  // Broadcast fan-out aggregates per-lane failures, so an exhausted conflict
+  // can sit inside the AggregateError while its top-level message differs.
+  return (
+    error instanceof AggregateError && error.errors.some(isFeishuReplySessionInitConflictError)
   );
 }
 
@@ -1523,6 +1532,13 @@ export async function handleFeishuMessage(params: {
       };
     };
 
+    // Capture the resolved notice delivery parameters once, ahead of both the
+    // single-agent and broadcast dispatch paths, so a conflict surfacing from
+    // either path keeps the normal reply anchor and thread placement.
+    conflictNoticeCfg = effectiveCfg;
+    conflictNoticeReplyToMessageId = replyTargetMessageId;
+    conflictNoticeReplyInThread = replyInThread;
+
     if (broadcastAgents) {
       // Cross-account dedup: in multi-account setups, Feishu delivers the same
       // event to every bot account in the group. Only one account should handle
@@ -1853,9 +1869,6 @@ export async function handleFeishuMessage(params: {
           sessionKey: route.sessionKey,
         });
 
-      conflictNoticeCfg = effectiveCfg;
-      conflictNoticeReplyToMessageId = replyTargetMessageId;
-      conflictNoticeReplyInThread = replyInThread;
       log(`feishu[${account.accountId}]: dispatching to agent (session=${route.sessionKey})`);
       const turnResult = await core.channel.inbound.run({
         channel: "feishu",
@@ -1918,7 +1931,7 @@ export async function handleFeishuMessage(params: {
       );
     }
   } catch (err) {
-    if (!turnAdoptionLifecycle && isFeishuReplySessionInitConflictError(err)) {
+    if (isFeishuReplySessionInitConflictError(err)) {
       // Parity with Slack/Signal/Discord: a reply-session init conflict that
       // exhausted its bounded retry must reach the user as a visible notice
       // instead of being silently dropped. See #108320.
@@ -1936,6 +1949,11 @@ export async function handleFeishuMessage(params: {
         error(
           `feishu[${account.accountId}]: reply-session conflict notice failed: ${String(noticeError)}`,
         );
+        // The notice never landed, so a durable event must not be adopted:
+        // rethrow to abandon the ingress lifecycle and keep redelivery alive.
+        if (turnAdoptionLifecycle) {
+          throw err;
+        }
       }
       return;
     }

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -114,10 +114,15 @@ function isFeishuReplySessionInitConflictError(error: unknown): boolean {
   ) {
     return true;
   }
-  // Broadcast fan-out aggregates per-lane failures, so an exhausted conflict
-  // can sit inside the AggregateError while its top-level message differs.
+  // Broadcast fan-out aggregates per-lane failures. Treat the aggregate as a
+  // conflict only when every failed lane is the reply-session conflict: the
+  // catch path answers a match with a terminal notice and adopts the durable
+  // event, so a mixed aggregate would hide the unrelated lane failure from
+  // redelivery.
   return (
-    error instanceof AggregateError && error.errors.some(isFeishuReplySessionInitConflictError)
+    error instanceof AggregateError &&
+    error.errors.length > 0 &&
+    error.errors.every(isFeishuReplySessionInitConflictError)
   );
 }
 

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -100,6 +100,18 @@ import {
 const permissionErrorNotifiedAt = new Map<string, number>();
 const PERMISSION_ERROR_COOLDOWN_MS = 5 * 60 * 1000; // 5 minutes
 
+// Reply-session init conflicts raise a load-bearing error message shared across
+// channels; parity with Slack/Signal/Discord means an exhausted conflict must
+// surface a visible user notice instead of dropping the inbound message. See #108320.
+const FEISHU_REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE =
+  /reply session initialization conflicted for \S+/u;
+
+function isFeishuReplySessionInitConflictError(error: unknown): boolean {
+  return FEISHU_REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE.test(
+    error instanceof Error ? error.message : String(error),
+  );
+}
+
 function shouldSendNoVisibleReplyFallback(dispatchResult: {
   counts: { final?: number };
   failedCounts?: { final?: number };
@@ -1898,6 +1910,26 @@ export async function handleFeishuMessage(params: {
       );
     }
   } catch (err) {
+    if (!turnAdoptionLifecycle && isFeishuReplySessionInitConflictError(err)) {
+      // Parity with Slack/Signal/Discord: a reply-session init conflict that
+      // exhausted its bounded retry must reach the user as a visible notice
+      // instead of being silently dropped. See #108320.
+      error(`feishu[${account.accountId}]: failed to dispatch message: ${String(err)}`);
+      try {
+        await sendMessageFeishu({
+          cfg,
+          to: `chat:${ctx.chatId}`,
+          text: "⚠️ Couldn't process this message because the session stayed busy. Please try again in a moment.",
+          replyToMessageId: ctx.messageId,
+          accountId: account.accountId,
+        });
+      } catch (noticeError) {
+        error(
+          `feishu[${account.accountId}]: reply-session conflict notice failed: ${String(noticeError)}`,
+        );
+      }
+      return;
+    }
     error(`feishu[${account.accountId}]: failed to dispatch message: ${String(err)}`);
     if (turnAdoptionLifecycle) {
       throw err;

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -698,6 +698,11 @@ export async function handleFeishuMessage(params: {
     }
   }
 
+  // Resolved dispatch delivery parameters, captured before the dispatch try so
+  // the reply-session conflict notice in the catch block can reuse them.
+  let conflictNoticeCfg = cfg;
+  let conflictNoticeReplyToMessageId: string | undefined = ctx.messageId;
+  let conflictNoticeReplyInThread = false;
   try {
     const core = {
       channel: channelRuntime?.inbound ? channelRuntime : getFeishuRuntime().channel,
@@ -1848,6 +1853,9 @@ export async function handleFeishuMessage(params: {
           sessionKey: route.sessionKey,
         });
 
+      conflictNoticeCfg = effectiveCfg;
+      conflictNoticeReplyToMessageId = replyTargetMessageId;
+      conflictNoticeReplyInThread = replyInThread;
       log(`feishu[${account.accountId}]: dispatching to agent (session=${route.sessionKey})`);
       const turnResult = await core.channel.inbound.run({
         channel: "feishu",
@@ -1917,10 +1925,11 @@ export async function handleFeishuMessage(params: {
       error(`feishu[${account.accountId}]: failed to dispatch message: ${String(err)}`);
       try {
         await sendMessageFeishu({
-          cfg,
-          to: `chat:${ctx.chatId}`,
+          cfg: conflictNoticeCfg,
+          to: directPreDispatchTarget ?? `chat:${ctx.chatId}`,
           text: "⚠️ Couldn't process this message because the session stayed busy. Please try again in a moment.",
-          replyToMessageId: ctx.messageId,
+          replyToMessageId: conflictNoticeReplyToMessageId,
+          replyInThread: conflictNoticeReplyInThread,
           accountId: account.accountId,
         });
       } catch (noticeError) {


### PR DESCRIPTION
## What Problem This Solves

In the Feishu channel, when a reply-session initialization conflict occurs (the load-bearing error `reply session initialization conflicted for ...`, raised after the bounded CAS retry is exhausted), `handleFeishuMessage` only logged the error and **silently dropped the inbound message**. The user received no feedback at all — the message vanished.

This is a behavioral gap versus the Slack, Signal, and Discord channels, which all deliver a visible terminal notice to the user on this exact condition. #108320 reports the Feishu silent-drop.

## Why This Change Was Made

Feishu's `handleFeishuMessage` catch block previously fell through to the generic "failed to dispatch" error log with no user-facing message. The fix detects the reply-session init conflict (via a local `FEISHU_REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE`, matching the per-channel convention where each channel defines its own local regex) and, on match, calls the real `sendMessageFeishu` with a clear notice:

> ⚠️ Couldn't process this message because the session stayed busy. Please try again in a moment.

The notice **reuses the fully-resolved delivery parameters** — the effective config, the resolved `replyToMessageId`, the `replyInThread` flag, and the pre-dispatch target — captured once ahead of both dispatch paths, so the notice lands exactly where a normal reply would (including P2P direct-message threads and topic sessions) instead of falling back to a plain chat-level message. The notice delivery is wrapped in its own try/catch so a send failure is logged but never re-drops the original message.

Coverage details across the production paths:

- **Durable ingress (the production message path)** always supplies a turn-adoption lifecycle. The notice is sent for lifecycle-backed events too; the handler returns only after the notice lands so the caller can settle (adopt) the durable event. If the notice send itself fails, the conflict is rethrown so the ingress lifecycle is abandoned and durable redelivery stays alive.
- **Broadcast fan-out** aggregates per-lane failures into an `AggregateError` whose top-level message does not match the conflict regex. The classifier traverses nested aggregate errors and treats the aggregate as a conflict **only when every failed lane is the reply-session conflict**, so exhausted all-conflict broadcasts produce the notice — anchored with the same resolved reply target and thread metadata as a normal Feishu reply. A mixed aggregate (one conflict lane plus an unrelated lane failure) is *not* classified as a conflict: no notice is sent and the durable event is abandoned, so the unrelated failure stays redeliverable.

## User Impact

Feishu users who hit a transient reply-session init conflict now get a visible, actionable notice in their conversation (or thread) instead of a silent drop — on direct messages, group dispatches, durable-ingress deliveries, and broadcast fan-outs alike. No behavior change for the success path or for other error types.

## Evidence

### Channel-client harness: conflict notice observed at the real HTTP delivery boundary (PR head `f84b5fb4`, 2026-08-04)

A standalone Node harness (kept outside the repo) drives the **real PR-head code end-to-end** and records the exact Feishu OpenAPI requests the notice produces:

- Real `handleFeishuMessage` from `extensions/feishu/src/bot.ts` (PR-head source), including the catch-boundary conflict classification and the pre-dispatch capture of the resolved delivery parameters.
- Real outbound path: `sendMessageFeishu` → `resolveFeishuSendTarget` → `createFeishuClient` → `@larksuiteoapi/node-sdk` → real HTTP requests (client UA `openclaw-feishu-builtin/2026.7.2/darwin`).
- Real `ReplySessionInitConflictError` (imported from the built core bundle) raised at the dispatch seam — the same seam core's bounded CAS retry exhausts on. Everything after the throw is production code.
- The Feishu OpenAPI is replaced by a local recording **forward proxy**: the channel is pointed at `http://open.feishu.cn` via the supported custom-domain config ("Custom URL for private deployment"; a port in the domain is not usable because the SDK expands `:param` templates over the full URL), and the production `resolveAmbientNodeProxyAgent` path routes the client's HTTP stack through the recorder via ambient proxy env. **No traffic left the machine.**

Four scenarios recorded at the delivery boundary:

**1. P2P direct message** — the notice is delivered as a reply to the inbound message, landing in the same conversation:

```json
{
  "method": "POST",
  "url": "/open-apis/im/v1/messages/om_harness_msg_1/reply",
  "userAgent": "openclaw-feishu-builtin/2026.7.2/darwin",
  "authorization": "Bearer <redacted>",
  "body": {
    "content": "{\"zh_cn\":{\"content\":[[{\"tag\":\"md\",\"text\":\"⚠️ Couldn't process this message because the session stayed busy. Please try again in a moment.\"}]]}}",
    "msg_type": "post"
  }
}
```

**2. P2P direct-message thread** — the notice reuses the resolved thread target (reply to root, `reply_in_thread: true`):

```json
{
  "method": "POST",
  "url": "/open-apis/im/v1/messages/om_harness_root/reply",
  "userAgent": "openclaw-feishu-builtin/2026.7.2/darwin",
  "authorization": "Bearer <redacted>",
  "body": {
    "content": "{\"zh_cn\":{\"content\":[[{\"tag\":\"md\",\"text\":\"⚠️ Couldn't process this message because the session stayed busy. Please try again in a moment.\"}]]}}",
    "msg_type": "post",
    "reply_in_thread": true
  }
}
```

**3. Durable ingress (lifecycle-backed) event** — the notice goes out and the handler *resolves* so the caller can settle/adopt the durable event; the handler drives no abandonment:

```text
[feishu:error] feishu[default]: failed to dispatch message: ReplySessionInitConflictError: reply session initialization conflicted for agent:main:feishu:direct:ou_harness_sender
[recorder] request: POST http://open.feishu.cn:80/open-apis/im/v1/messages/om_harness_durable/reply
[harness] lifecycle-backed conflict: handler resolved after notice send; handler-driven lifecycle calls: [] (caller may now settle/adopt)
```

**4. Aggregate broadcast conflict** — an `AggregateError("Feishu broadcast dispatch failed")` wrapping two real lane conflicts is classified as a conflict, and the notice still goes out:

```text
[feishu:error] feishu[default]: failed to dispatch message: AggregateError: Feishu broadcast dispatch failed
[recorder] request: POST http://open.feishu.cn:80/open-apis/im/v1/messages/om_harness_aggregate/reply
```

The same run also recorded the expected tenant-token fetch (`POST /open-apis/auth/v3/tenant_access_token/internal`) and sender contact lookup (`GET /open-apis/contact/v3/users/...`) through the same real client, confirming the recorded boundary is the genuine Feishu HTTP surface. All harness identifiers are synthetic; the `Authorization` header is present but redacted.

### Regression tests

New coverage on top of the existing direct-message and P2P-thread notice tests:

- `extensions/feishu/src/bot.test.ts` — **durable ingress**: a lifecycle-backed conflict delivers the notice and the handler resolves (settleable); a lifecycle-backed conflict whose notice send fails rethrows the conflict so durable redelivery stays alive.
- `extensions/feishu/src/bot.broadcast.test.ts` — **broadcast aggregate + thread routing**: every lane exhausting its reply-session init conflict surfaces an `AggregateError`, and the notice is still delivered through the real send path, anchored at the resolved thread root with `reply_in_thread: true`.

```bash
node scripts/run-vitest.mjs extensions/feishu/src/bot.test.ts extensions/feishu/src/bot.broadcast.test.ts extensions/feishu/src/bot.broadcast-conflict-notice.test.ts extensions/feishu/src/monitor.message-handler.ingress.test.ts
```

```text
Test Files  4 passed (4)
     Tests  133 passed (133)
```

`pnpm tsgo:extensions` and `pnpm tsgo:extensions:test` are clean; oxlint/oxfmt clean. Branch is rebased onto current `origin/main` (head `e101ab98`), which also carries `2e6c2bba`'s forwarded interactive-card `card_msg_content_type` request parameter and its regression coverage in `extensions/feishu/src/bot.ts`/`send.ts`. Source diff is `extensions/feishu/src/bot.ts` + `extensions/feishu/src/bot-broadcast.ts`, with tests split across `bot.test.ts`, `bot.broadcast.test.ts`, and `bot.broadcast-conflict-notice.test.ts` (max-lines budget). The broadcast regression coverage includes the mixed-aggregate case: one conflict lane plus one unrelated lane failure must not send the notice and must abandon + release the durable event.

### Settlement harness: durable broadcast adopt/abandon at the real HTTP boundary (head `e101ab98`, 2026-08-11)

A second harness (also outside the repo) drives the **current-head** broadcast fan-out end-to-end: real `handleFeishuMessage` + real `createFeishuBroadcastIngressSettlement` + the real cross-account replay guard (isolated throwaway `OPENCLAW_STATE_DIR`), with a real turn-adoption lifecycle attached and real `ReplySessionInitConflictError` raised at every lane's dispatch seam. The outbound notice travels the real Lark SDK HTTP stack through the recording proxy:

- **Notice delivered → adopted**: both lanes exhaust, the AggregateError is classified, the notice leaves as a real `POST /open-apis/im/v1/messages/<id>/reply`, the handler resolves, and the settlement adopts the durable event — lifecycle calls `[onAdoptionFinalizing, onAdopted]`, no `onAbandoned`, replay claim committed. No redelivery, no duplicate notice.
- **Notice send fails → abandoned**: the recorder answers the notice with a real HTTP 500, the handler rethrows `Feishu broadcast dispatch failed`, and the settlement abandons the durable event — lifecycle calls `[onAbandoned]`, no `onAdopted`, replay claim released for redelivery.
- **Mixed aggregate → no notice, abandoned**: one lane raises the real conflict while the other lane raises an unrelated error (`model provider overloaded`). The aggregate is *not* classified as a conflict: zero message sends recorded for the scenario, the handler rethrows, lifecycle calls `[onAbandoned]`, replay claim released.
- **Redelivery after the mixed failure**: replaying the same message id re-claims the broadcast guard, both lanes dispatch again, the notice goes out once, and the settlement adopts — lifecycle calls `[onAdoptionFinalizing, onAdopted]`. This proves the unrelated lane failure stays redeliverable, the regression the `some()` classifier would have caused.

```text
[feishu:error] feishu[default]: failed to dispatch message: AggregateError: Feishu broadcast dispatch failed
[recorder] request: POST http://open.feishu.cn:80/open-apis/im/v1/messages/om_harness_bcast_adopt/reply
[harness] notice delivered: handler resolved; lifecycle calls: [onAdoptionFinalizing, onAdopted]
[feishu:error] feishu[default]: reply-session conflict notice failed: Error: Feishu reply failed: ...http_status:500...
[harness] notice send failed: handler error=Feishu broadcast dispatch failed; lifecycle calls: [onAbandoned]
[feishu:log] feishu[default]: broadcast dispatch failed for agent=susan: Error: model provider overloaded
[feishu:log] feishu[default]: broadcast dispatch failed for agent=main: ReplySessionInitConflictError: reply session initialization conflicted for agent:main:feishu:group:oc_harness_group
[harness] mixed aggregate: handler error=Feishu broadcast dispatch failed; lifecycle calls: [onAbandoned]
[harness] mixed aggregate sent no conflict notice
[harness] redelivery: lifecycle calls: [onAdoptionFinalizing, onAdopted]; notice sends: 1
[harness] SETTLEMENT PROOF PASSED
```

### Live Feishu run (2026-07-19, earlier head `db2fd7fe`)

A gateway built from the PR head was run against the **real Feishu service** (websocket mode, app `cli_a9f6…8bd1`, isolated state dir so the contributor's daily setup was untouched):

```text
[feishu] starting feishu[default] (mode: websocket)
[feishu] feishu[default]: bot open_id resolved: ou_a353…1f1e
[feishu] feishu[default]: WebSocket client started
[feishu] feishu[default]: received message from ou_a8b6…d9b4d85 in oc_3307…44b8bf (p2p)
[feishu] feishu[default]: dispatching to agent (session=agent:main:main)
[feishu] feishu[default]: dispatch complete (queuedFinal=true, replies=1)
```

Seven real inbound DM messages were dispatched to the real agent (`tencent/glm-5`) and replies were delivered back through the channel (`replies=1`), confirming the PR code runs end-to-end against live Feishu. A deterministic init-conflict could not be forced by traffic: the single-instance session queue serializes same-key dispatch, and a second gateway on the same state is refused by the state lock — matching the reviewer's note that the conflict is race-dependent. The conflict path itself is proven at the real HTTP delivery boundary by the channel-client harness above. Sender open_id and chat id are abbreviated; no credentials included.

### What was not tested

The conflict is a race condition (CAS contention during session init) that cannot be deterministically forced against a live Feishu account, and this contributor environment has no Feishu app credentials for a live conflict send. The notice delivery is therefore proven at the real HTTP request boundary (recording proxy standing in for Feishu's servers), not against Feishu's production API; the conflict injection point is the dispatch seam, the same place the exhausted CAS retry raises it in production.


