### PR TITLE
feat(codex): fork upstream-linked sessions at a message via thread/fork

### DIFF
--- a/extensions/codex/harness.ts
+++ b/extensions/codex/harness.ts
@@ -8,6 +8,7 @@ import type {
   ContextEngineHostCapability,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import type { CodexAppServerBindingStore } from "./src/app-server/session-binding.js";
 import type { CodexSessionCatalogControl } from "./src/session-catalog-types.js";
 
@@ -51,6 +52,7 @@ export function createCodexAppServerAgentHarness(options: {
   pluginConfig?: unknown;
   resolvePluginConfig?: () => unknown;
   resolveConfig?: () => OpenClawConfig | undefined;
+  runtime?: PluginRuntime;
   bindingStore: CodexAppServerBindingStore;
   sessionCatalogControl?: CodexSessionCatalogControl;
 }): AgentHarness {
@@ -62,6 +64,7 @@ export function createCodexAppServerAgentHarness(options: {
     ),
   );
   const sessionCatalogControl = options.sessionCatalogControl;
+  const sessionRuntime = options.runtime;
   const harness: CodexAppServerAgentHarness = {
     id: harnessRuntimeId,
     label: options?.label ?? "Codex agent harness",
@@ -72,7 +75,7 @@ export function createCodexAppServerAgentHarness(options: {
       visibleReplies: "message_tool",
     },
     authBootstrap: "harness",
-    ...(sessionCatalogControl
+    ...(sessionCatalogControl && sessionRuntime
       ? {
           sessionFork: {
             upstreamKinds: ["codex-app-server"] as const,
@@ -82,7 +85,9 @@ export function createCodexAppServerAgentHarness(options: {
               return await forkCodexUpstreamSession(params, {
                 bindingStore: options.bindingStore,
                 control: sessionCatalogControl,
+                harnessRuntimeId,
                 resolveConfig: options.resolveConfig,
+                runtime: sessionRuntime,
               });
             },
           },

--- a/extensions/codex/harness.ts
+++ b/extensions/codex/harness.ts
@@ -9,6 +9,7 @@ import type {
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { CodexAppServerBindingStore } from "./src/app-server/session-binding.js";
+import type { CodexSessionCatalogControl } from "./src/session-catalog-types.js";
 
 // `codex` is legacy input only until Part 2 doctor migration rewrites stored refs.
 // New runtime identity uses the `openai` provider.
@@ -51,6 +52,7 @@ export function createCodexAppServerAgentHarness(options: {
   resolvePluginConfig?: () => unknown;
   resolveConfig?: () => OpenClawConfig | undefined;
   bindingStore: CodexAppServerBindingStore;
+  sessionCatalogControl?: CodexSessionCatalogControl;
 }): AgentHarness {
   const harnessRuntimeId = options?.id ?? "codex";
   const normalizedHarnessRuntimeId = harnessRuntimeId.trim().toLowerCase();
@@ -59,6 +61,7 @@ export function createCodexAppServerAgentHarness(options: {
       id.trim().toLowerCase(),
     ),
   );
+  const sessionCatalogControl = options.sessionCatalogControl;
   const harness: CodexAppServerAgentHarness = {
     id: harnessRuntimeId,
     label: options?.label ?? "Codex agent harness",
@@ -69,6 +72,22 @@ export function createCodexAppServerAgentHarness(options: {
       visibleReplies: "message_tool",
     },
     authBootstrap: "harness",
+    ...(sessionCatalogControl
+      ? {
+          sessionFork: {
+            upstreamKinds: ["codex-app-server"] as const,
+            fork: async (params) => {
+              const { forkCodexUpstreamSession } =
+                await import("./src/app-server/upstream-session-fork.js");
+              return await forkCodexUpstreamSession(params, {
+                bindingStore: options.bindingStore,
+                control: sessionCatalogControl,
+                resolveConfig: options.resolveConfig,
+              });
+            },
+          },
+        }
+      : {}),
     authBinding: {
       fingerprint: async (params) => {
         const { fingerprintCodexAppServerAuthBinding } =

--- a/extensions/codex/index.ts
+++ b/extensions/codex/index.ts
@@ -153,6 +153,7 @@ export default definePluginEntry({
         sessionCatalogControl,
         resolveConfig: resolveCurrentConfig,
         resolvePluginConfig: resolveCurrentPluginConfig,
+        runtime: api.runtime,
       }),
     );
     api.registerMediaUnderstandingProvider(

--- a/extensions/codex/index.ts
+++ b/extensions/codex/index.ts
@@ -150,6 +150,7 @@ export default definePluginEntry({
     api.registerAgentHarness(
       createCodexAppServerAgentHarness({
         bindingStore,
+        sessionCatalogControl,
         resolveConfig: resolveCurrentConfig,
         resolvePluginConfig: resolveCurrentPluginConfig,
       }),

--- a/extensions/codex/src/app-server/protocol-validators.test.ts
+++ b/extensions/codex/src/app-server/protocol-validators.test.ts
@@ -1,6 +1,7 @@
 // Codex tests cover protocol validators plugin behavior.
 import { describe, expect, it } from "vitest";
 import {
+  assertCodexThreadForkParams,
   readCodexModelListResponse,
   readCodexTurn,
   assertCodexThreadStartResponse,
@@ -49,6 +50,24 @@ describe("Codex thread response validators", () => {
       delete (response.thread as Record<string, unknown>).sessionId;
       expect(() => assertResponse(response)).toThrow("Invalid Codex app-server");
     }
+  });
+});
+
+describe("assertCodexThreadForkParams", () => {
+  it("accepts the experimental beforeTurnId boundary", () => {
+    expect(
+      assertCodexThreadForkParams({
+        threadId: "thread-1",
+        beforeTurnId: "turn-2",
+        excludeTurns: true,
+      }),
+    ).toMatchObject({ beforeTurnId: "turn-2" });
+  });
+
+  it("rejects a non-string beforeTurnId", () => {
+    expect(() => assertCodexThreadForkParams({ threadId: "thread-1", beforeTurnId: 2 })).toThrow(
+      "Invalid Codex app-server thread/fork params",
+    );
   });
 });
 

--- a/extensions/codex/src/app-server/protocol-validators.ts
+++ b/extensions/codex/src/app-server/protocol-validators.ts
@@ -16,6 +16,7 @@ import type {
   CodexErrorNotification,
   CodexModelListResponse,
   CodexThreadForkResponse,
+  CodexThreadForkParams,
   CodexThreadResumeResponse,
   CodexThreadStartResponse,
   CodexTurn,
@@ -234,6 +235,21 @@ export function assertCodexThreadStartResponse(value: unknown): CodexThreadStart
 export function assertCodexThreadForkResponse(value: unknown): CodexThreadForkResponse {
   const normalized = normalizeWithDefaults(threadStartResponseSchema, value);
   return assertCodexShape(validateThreadStartResponse, normalized, "thread/fork response");
+}
+
+/** Asserts the experimental beforeTurnId request field before it crosses the app-server boundary. */
+export function assertCodexThreadForkParams(value: unknown): CodexThreadForkParams {
+  if (
+    !isRecord(value) ||
+    typeof value.threadId !== "string" ||
+    !value.threadId.trim() ||
+    (value.beforeTurnId !== undefined &&
+      value.beforeTurnId !== null &&
+      typeof value.beforeTurnId !== "string")
+  ) {
+    throw new Error("Invalid Codex app-server thread/fork params");
+  }
+  return value as CodexThreadForkParams;
 }
 
 /** Asserts and normalizes a Codex thread/resume response. */

--- a/extensions/codex/src/app-server/protocol.ts
+++ b/extensions/codex/src/app-server/protocol.ts
@@ -165,6 +165,7 @@ export type CodexThreadStartResponse = {
 export type CodexThreadForkParams = JsonObject & {
   threadId: string;
   lastTurnId?: string | null;
+  beforeTurnId?: string | null;
   path?: string | null;
   model?: string | null;
   modelProvider?: string | null;

--- a/extensions/codex/src/app-server/session-history-import.ts
+++ b/extensions/codex/src/app-server/session-history-import.ts
@@ -1,0 +1,64 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
+import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
+import type { CodexThread } from "./protocol.js";
+import { importCodexThreadHistoryToTranscript } from "./transcript-mirror.js";
+
+type CreatedCodexImportedSession = Awaited<
+  ReturnType<PluginRuntime["agent"]["session"]["createSessionEntry"]>
+>;
+
+/** Creates a session whose transcript is derived from one verified Codex thread snapshot. */
+export async function createImportedCodexSession(params: {
+  runtime: PluginRuntime;
+  config: OpenClawConfig;
+  key: string;
+  agentId: string;
+  thread: CodexThread;
+  throughTurnId: string | null;
+  recoverMatchingInitialEntry?: true;
+  initialEntry: {
+    agentHarnessId: string;
+    modelSelectionLocked?: true;
+    pluginExtensions?: CreatedCodexImportedSession["entry"]["pluginExtensions"];
+  };
+  afterImport: (
+    created: CreatedCodexImportedSession,
+  ) => Promise<{ pluginExtensions: CreatedCodexImportedSession["entry"]["pluginExtensions"] }>;
+}): Promise<CreatedCodexImportedSession> {
+  const label = params.thread.name?.trim() || undefined;
+  const spawnedCwd = params.thread.cwd?.trim() || undefined;
+  const createParams = {
+    cfg: params.config,
+    key: params.key,
+    agentId: params.agentId,
+    ...(label ? { label } : {}),
+    ...(spawnedCwd ? { spawnedCwd } : {}),
+    initialEntry: params.initialEntry,
+    afterCreate: async (entry: CreatedCodexImportedSession) => {
+      // Post-flip the mirror targets SQLite rows; resolve the agent's store
+      // path instead of trusting the legacy sessionFile locator marker.
+      const storePath = resolveStorePath(params.config.session?.store, {
+        agentId: entry.agentId,
+      });
+      await importCodexThreadHistoryToTranscript({
+        thread: params.thread,
+        throughTurnId: params.throughTurnId,
+        storePath,
+        sessionId: entry.sessionId,
+        sessionKey: entry.key,
+        agentId: entry.agentId,
+        ...(spawnedCwd ? { cwd: spawnedCwd } : {}),
+        modelProvider: params.thread.modelProvider,
+        config: params.config,
+      });
+      return await params.afterImport(entry);
+    },
+  };
+  return params.recoverMatchingInitialEntry
+    ? await params.runtime.agent.session.createSessionEntry({
+        ...createParams,
+        recoverMatchingInitialEntry: true,
+      })
+    : await params.runtime.agent.session.createSessionEntry(createParams);
+}

--- a/extensions/codex/src/app-server/upstream-fork-boundary.test.ts
+++ b/extensions/codex/src/app-server/upstream-fork-boundary.test.ts
@@ -1,9 +1,15 @@
+import type { SessionTranscriptMessageEntry } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { describe, expect, it, vi } from "vitest";
 import type { CodexThreadItem, CodexTurn } from "./protocol.js";
-import {
-  resolveCodexUpstreamForkBoundary,
-  resolveCodexUpstreamForkBoundaryFromTurns,
-} from "./upstream-fork-boundary.js";
+import { resolveCodexUpstreamForkBoundary } from "./upstream-fork-boundary.js";
+
+const transcriptMocks = vi.hoisted(() => ({
+  readVisibleEntries: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/session-transcript-runtime", () => ({
+  readVisibleSessionTranscriptMessageEntries: transcriptMocks.readVisibleEntries,
+}));
 
 function item(type: string, overrides: Record<string, unknown> = {}): CodexThreadItem {
   return { id: `${type}-item`, type, ...overrides } as CodexThreadItem;
@@ -17,9 +23,41 @@ function turn(id: string, items: CodexThreadItem[], overrides: Partial<CodexTurn
   return { id, status: "completed", items, ...overrides };
 }
 
+async function resolveFromTurns(params: {
+  turns: readonly CodexTurn[];
+  userMessageOrdinal: number;
+  localPrefixTexts: readonly (string | undefined)[];
+}) {
+  const entries: SessionTranscriptMessageEntry[] = params.localPrefixTexts.map((text, index) => ({
+    entryId: `entry-${index}`,
+    parentId: index > 0 ? `entry-${index - 1}` : null,
+    seq: index,
+    role: "user",
+    message: {
+      role: "user",
+      content: text ?? [{ type: "image", data: "", mimeType: "image/png" }],
+      timestamp: index,
+    },
+  }));
+  transcriptMocks.readVisibleEntries.mockResolvedValue(entries);
+  const result = await resolveCodexUpstreamForkBoundary({
+    agentId: "main",
+    sessionId: "session-1",
+    sessionKey: "agent:main:upstream",
+    storePath: "/tmp/does-not-matter",
+    entryId: `entry-${params.userMessageOrdinal}`,
+    threadId: "thread-1",
+    control: {
+      readThread: vi.fn(async () => ({ id: "thread-1" })),
+      listTurnPage: vi.fn(async () => ({ data: [...params.turns] })),
+    } as unknown as Parameters<typeof resolveCodexUpstreamForkBoundary>[0]["control"],
+  });
+  return result.ok ? { ok: true as const, boundary: result.boundary } : result;
+}
+
 describe("resolveCodexUpstreamForkBoundaryFromTurns", () => {
-  it("maps the local user ordinal to the upstream turn", () => {
-    const result = resolveCodexUpstreamForkBoundaryFromTurns({
+  it("maps the local user ordinal to the upstream turn", async () => {
+    const result = await resolveFromTurns({
       turns: [turn("turn-1", [user("one")]), turn("turn-2", [user("two")])],
       userMessageOrdinal: 1,
       localPrefixTexts: ["one", "two"],
@@ -35,8 +73,8 @@ describe("resolveCodexUpstreamForkBoundaryFromTurns", () => {
     });
   });
 
-  it("cuts before the first turn with an empty retained baseline", () => {
-    const result = resolveCodexUpstreamForkBoundaryFromTurns({
+  it("cuts before the first turn with an empty retained baseline", async () => {
+    const result = await resolveFromTurns({
       turns: [turn("turn-1", [user("one")])],
       userMessageOrdinal: 0,
       localPrefixTexts: ["one"],
@@ -51,8 +89,8 @@ describe("resolveCodexUpstreamForkBoundaryFromTurns", () => {
     });
   });
 
-  it("rejects a selected steer message", () => {
-    const result = resolveCodexUpstreamForkBoundaryFromTurns({
+  it("rejects a selected steer message", async () => {
+    const result = await resolveFromTurns({
       turns: [turn("turn-1", [user("one"), user("steer")])],
       userMessageOrdinal: 1,
       localPrefixTexts: ["one", "steer"],
@@ -61,8 +99,8 @@ describe("resolveCodexUpstreamForkBoundaryFromTurns", () => {
     expect(result).toMatchObject({ ok: false, code: "steer-message" });
   });
 
-  it("skips prompts inside review spans", () => {
-    const result = resolveCodexUpstreamForkBoundaryFromTurns({
+  it("skips prompts inside review spans", async () => {
+    const result = await resolveFromTurns({
       turns: [
         turn("turn-review", [
           item("enteredReviewMode"),
@@ -85,8 +123,8 @@ describe("resolveCodexUpstreamForkBoundaryFromTurns", () => {
     });
   });
 
-  it("rejects an in-progress target turn", () => {
-    const result = resolveCodexUpstreamForkBoundaryFromTurns({
+  it("rejects an in-progress target turn", async () => {
+    const result = await resolveFromTurns({
       turns: [turn("turn-1", [user("one")], { status: "inProgress" })],
       userMessageOrdinal: 0,
       localPrefixTexts: ["one"],
@@ -95,8 +133,8 @@ describe("resolveCodexUpstreamForkBoundaryFromTurns", () => {
     expect(result).toMatchObject({ ok: false, code: "in-progress-turn" });
   });
 
-  it("rejects local and upstream text drift", () => {
-    const result = resolveCodexUpstreamForkBoundaryFromTurns({
+  it("rejects local and upstream text drift", async () => {
+    const result = await resolveFromTurns({
       turns: [turn("turn-1", [user("persisted")])],
       userMessageOrdinal: 0,
       localPrefixTexts: ["local mirror"],
@@ -105,8 +143,8 @@ describe("resolveCodexUpstreamForkBoundaryFromTurns", () => {
     expect(result).toMatchObject({ ok: false, code: "drift-mismatch" });
   });
 
-  it("rejects equal targets over divergent prefixes", () => {
-    const result = resolveCodexUpstreamForkBoundaryFromTurns({
+  it("rejects equal targets over divergent prefixes", async () => {
+    const result = await resolveFromTurns({
       turns: [turn("turn-1", [user("upstream-old")]), turn("turn-2", [user("target")])],
       userMessageOrdinal: 1,
       localPrefixTexts: ["local-old", "target"],
@@ -115,8 +153,8 @@ describe("resolveCodexUpstreamForkBoundaryFromTurns", () => {
     expect(result).toMatchObject({ ok: false, code: "drift-mismatch" });
   });
 
-  it("rejects upstream messages carrying semantic non-text inputs", () => {
-    const result = resolveCodexUpstreamForkBoundaryFromTurns({
+  it("rejects upstream messages carrying semantic non-text inputs", async () => {
+    const result = await resolveFromTurns({
       turns: [
         turn("turn-1", [
           item("userMessage", {
@@ -135,8 +173,8 @@ describe("resolveCodexUpstreamForkBoundaryFromTurns", () => {
     expect(result).toMatchObject({ ok: false, code: "drift-mismatch" });
   });
 
-  it("rejects prefixes whose content identity cannot be verified", () => {
-    const result = resolveCodexUpstreamForkBoundaryFromTurns({
+  it("rejects prefixes whose content identity cannot be verified", async () => {
+    const result = await resolveFromTurns({
       turns: [turn("turn-1", [user("one")]), turn("turn-2", [user("target")])],
       userMessageOrdinal: 1,
       localPrefixTexts: [undefined, "target"],

--- a/extensions/codex/src/app-server/upstream-fork-boundary.test.ts
+++ b/extensions/codex/src/app-server/upstream-fork-boundary.test.ts
@@ -22,7 +22,7 @@ describe("resolveCodexUpstreamForkBoundaryFromTurns", () => {
     const result = resolveCodexUpstreamForkBoundaryFromTurns({
       turns: [turn("turn-1", [user("one")]), turn("turn-2", [user("two")])],
       userMessageOrdinal: 1,
-      localText: "two",
+      localPrefixTexts: ["one", "two"],
     });
 
     expect(result).toEqual({
@@ -39,7 +39,7 @@ describe("resolveCodexUpstreamForkBoundaryFromTurns", () => {
     const result = resolveCodexUpstreamForkBoundaryFromTurns({
       turns: [turn("turn-1", [user("one")])],
       userMessageOrdinal: 0,
-      localText: "one",
+      localPrefixTexts: ["one"],
     });
     expect(result.ok).toBe(false);
     if (!result.ok) {
@@ -51,7 +51,7 @@ describe("resolveCodexUpstreamForkBoundaryFromTurns", () => {
     const result = resolveCodexUpstreamForkBoundaryFromTurns({
       turns: [turn("turn-1", [user("one"), user("steer")])],
       userMessageOrdinal: 1,
-      localText: "steer",
+      localPrefixTexts: ["one", "steer"],
     });
 
     expect(result).toMatchObject({ ok: false, code: "steer-message" });
@@ -68,7 +68,7 @@ describe("resolveCodexUpstreamForkBoundaryFromTurns", () => {
         turn("turn-2", [user("visible")]),
       ],
       userMessageOrdinal: 0,
-      localText: "visible",
+      localPrefixTexts: ["visible"],
     });
 
     expect(result).toEqual({
@@ -85,7 +85,7 @@ describe("resolveCodexUpstreamForkBoundaryFromTurns", () => {
     const result = resolveCodexUpstreamForkBoundaryFromTurns({
       turns: [turn("turn-1", [user("one")], { status: "inProgress" })],
       userMessageOrdinal: 0,
-      localText: "one",
+      localPrefixTexts: ["one"],
     });
 
     expect(result).toMatchObject({ ok: false, code: "in-progress-turn" });
@@ -95,7 +95,27 @@ describe("resolveCodexUpstreamForkBoundaryFromTurns", () => {
     const result = resolveCodexUpstreamForkBoundaryFromTurns({
       turns: [turn("turn-1", [user("persisted")])],
       userMessageOrdinal: 0,
-      localText: "local mirror",
+      localPrefixTexts: ["local mirror"],
+    });
+
+    expect(result).toMatchObject({ ok: false, code: "drift-mismatch" });
+  });
+
+  it("rejects equal targets over divergent prefixes", () => {
+    const result = resolveCodexUpstreamForkBoundaryFromTurns({
+      turns: [turn("turn-1", [user("upstream-old")]), turn("turn-2", [user("target")])],
+      userMessageOrdinal: 1,
+      localPrefixTexts: ["local-old", "target"],
+    });
+
+    expect(result).toMatchObject({ ok: false, code: "drift-mismatch" });
+  });
+
+  it("rejects prefixes whose content identity cannot be verified", () => {
+    const result = resolveCodexUpstreamForkBoundaryFromTurns({
+      turns: [turn("turn-1", [user("one")]), turn("turn-2", [user("target")])],
+      userMessageOrdinal: 1,
+      localPrefixTexts: [undefined, "target"],
     });
 
     expect(result).toMatchObject({ ok: false, code: "drift-mismatch" });

--- a/extensions/codex/src/app-server/upstream-fork-boundary.test.ts
+++ b/extensions/codex/src/app-server/upstream-fork-boundary.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import type { CodexThreadItem, CodexTurn } from "./protocol.js";
+import { resolveCodexUpstreamForkBoundaryFromTurns } from "./upstream-fork-boundary.js";
+
+function item(type: string, overrides: Record<string, unknown> = {}): CodexThreadItem {
+  return { id: `${type}-item`, type, ...overrides } as CodexThreadItem;
+}
+
+function user(text: string): CodexThreadItem {
+  return item("userMessage", { content: [{ type: "text", text, textElements: [] }] });
+}
+
+function turn(id: string, items: CodexThreadItem[], overrides: Partial<CodexTurn> = {}): CodexTurn {
+  return { id, status: "completed", items, ...overrides };
+}
+
+describe("resolveCodexUpstreamForkBoundaryFromTurns", () => {
+  it("maps the local user ordinal to the upstream turn", () => {
+    const result = resolveCodexUpstreamForkBoundaryFromTurns({
+      turns: [turn("turn-1", [user("one")]), turn("turn-2", [user("two")])],
+      userMessageOrdinal: 1,
+      localText: "two",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      boundary: { beforeTurnId: "turn-2", targetTurnId: "turn-2" },
+    });
+  });
+
+  it("returns a whole-thread boundary for the first turn", () => {
+    expect(
+      resolveCodexUpstreamForkBoundaryFromTurns({
+        turns: [turn("turn-1", [user("one")])],
+        userMessageOrdinal: 0,
+        localText: "one",
+      }),
+    ).toEqual({
+      ok: true,
+      boundary: { wholeThread: true, targetTurnId: "turn-1" },
+    });
+  });
+
+  it("rejects a selected steer message", () => {
+    const result = resolveCodexUpstreamForkBoundaryFromTurns({
+      turns: [turn("turn-1", [user("one"), user("steer")])],
+      userMessageOrdinal: 1,
+      localText: "steer",
+    });
+
+    expect(result).toMatchObject({ ok: false, code: "steer-message" });
+  });
+
+  it("skips prompts inside review spans", () => {
+    const result = resolveCodexUpstreamForkBoundaryFromTurns({
+      turns: [
+        turn("turn-review", [
+          item("enteredReviewMode"),
+          user("hidden review prompt"),
+          item("exitedReviewMode"),
+        ]),
+        turn("turn-2", [user("visible")]),
+      ],
+      userMessageOrdinal: 0,
+      localText: "visible",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      boundary: { beforeTurnId: "turn-2", targetTurnId: "turn-2" },
+    });
+  });
+
+  it("rejects an in-progress target turn", () => {
+    const result = resolveCodexUpstreamForkBoundaryFromTurns({
+      turns: [turn("turn-1", [user("one")], { status: "inProgress" })],
+      userMessageOrdinal: 0,
+      localText: "one",
+    });
+
+    expect(result).toMatchObject({ ok: false, code: "in-progress-turn" });
+  });
+
+  it("rejects local and upstream text drift", () => {
+    const result = resolveCodexUpstreamForkBoundaryFromTurns({
+      turns: [turn("turn-1", [user("persisted")])],
+      userMessageOrdinal: 0,
+      localText: "local mirror",
+    });
+
+    expect(result).toMatchObject({ ok: false, code: "drift-mismatch" });
+  });
+});

--- a/extensions/codex/src/app-server/upstream-fork-boundary.test.ts
+++ b/extensions/codex/src/app-server/upstream-fork-boundary.test.ts
@@ -111,6 +111,26 @@ describe("resolveCodexUpstreamForkBoundaryFromTurns", () => {
     expect(result).toMatchObject({ ok: false, code: "drift-mismatch" });
   });
 
+  it("rejects upstream messages carrying semantic non-text inputs", () => {
+    const result = resolveCodexUpstreamForkBoundaryFromTurns({
+      turns: [
+        turn("turn-1", [
+          item("userMessage", {
+            content: [
+              { type: "text", text: "one", textElements: [] },
+              { type: "skill", name: "reviewer" },
+            ],
+          }),
+        ]),
+        turn("turn-2", [user("target")]),
+      ],
+      userMessageOrdinal: 1,
+      localPrefixTexts: ["one", "target"],
+    });
+
+    expect(result).toMatchObject({ ok: false, code: "drift-mismatch" });
+  });
+
   it("rejects prefixes whose content identity cannot be verified", () => {
     const result = resolveCodexUpstreamForkBoundaryFromTurns({
       turns: [turn("turn-1", [user("one")]), turn("turn-2", [user("target")])],

--- a/extensions/codex/src/app-server/upstream-fork-boundary.test.ts
+++ b/extensions/codex/src/app-server/upstream-fork-boundary.test.ts
@@ -28,17 +28,16 @@ describe("resolveCodexUpstreamForkBoundaryFromTurns", () => {
     });
   });
 
-  it("returns a whole-thread boundary for the first turn", () => {
-    expect(
-      resolveCodexUpstreamForkBoundaryFromTurns({
-        turns: [turn("turn-1", [user("one")])],
-        userMessageOrdinal: 0,
-        localText: "one",
-      }),
-    ).toEqual({
-      ok: true,
-      boundary: { wholeThread: true, targetTurnId: "turn-1" },
+  it("rejects a cut at the first turn instead of copying the whole thread", () => {
+    const result = resolveCodexUpstreamForkBoundaryFromTurns({
+      turns: [turn("turn-1", [user("one")])],
+      userMessageOrdinal: 0,
+      localText: "one",
     });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("first-message");
+    }
   });
 
   it("rejects a selected steer message", () => {

--- a/extensions/codex/src/app-server/upstream-fork-boundary.test.ts
+++ b/extensions/codex/src/app-server/upstream-fork-boundary.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { CodexThreadItem, CodexTurn } from "./protocol.js";
-import { resolveCodexUpstreamForkBoundaryFromTurns } from "./upstream-fork-boundary.js";
+import {
+  resolveCodexUpstreamForkBoundary,
+  resolveCodexUpstreamForkBoundaryFromTurns,
+} from "./upstream-fork-boundary.js";
 
 function item(type: string, overrides: Record<string, unknown> = {}): CodexThreadItem {
   return { id: `${type}-item`, type, ...overrides } as CodexThreadItem;
@@ -24,7 +27,11 @@ describe("resolveCodexUpstreamForkBoundaryFromTurns", () => {
 
     expect(result).toEqual({
       ok: true,
-      boundary: { beforeTurnId: "turn-2", targetTurnId: "turn-2" },
+      boundary: {
+        beforeTurnId: "turn-2",
+        targetTurnId: "turn-2",
+        retainedMarker: { turnId: "turn-1", userMessageCount: 1 },
+      },
     });
   });
 
@@ -66,7 +73,11 @@ describe("resolveCodexUpstreamForkBoundaryFromTurns", () => {
 
     expect(result).toEqual({
       ok: true,
-      boundary: { beforeTurnId: "turn-2", targetTurnId: "turn-2" },
+      boundary: {
+        beforeTurnId: "turn-2",
+        targetTurnId: "turn-2",
+        retainedMarker: { turnId: "turn-review", userMessageCount: 1 },
+      },
     });
   });
 
@@ -88,5 +99,25 @@ describe("resolveCodexUpstreamForkBoundaryFromTurns", () => {
     });
 
     expect(result).toMatchObject({ ok: false, code: "drift-mismatch" });
+  });
+});
+
+describe("resolveCodexUpstreamForkBoundary", () => {
+  it("rejects paginated-history threads before reading turns", async () => {
+    const readThread = vi.fn(async () => ({ id: "thread-1", historyMode: "paginated" }));
+    const result = await resolveCodexUpstreamForkBoundary({
+      agentId: "main",
+      sessionId: "session-1",
+      sessionKey: "agent:main:upstream",
+      storePath: "/tmp/does-not-matter",
+      entryId: "entry-1",
+      threadId: "thread-1",
+      control: { readThread } as unknown as Parameters<
+        typeof resolveCodexUpstreamForkBoundary
+      >[0]["control"],
+    });
+
+    expect(result).toMatchObject({ ok: false, code: "upstream-unavailable" });
+    expect(readThread).toHaveBeenCalledWith("thread-1", false);
   });
 });

--- a/extensions/codex/src/app-server/upstream-fork-boundary.test.ts
+++ b/extensions/codex/src/app-server/upstream-fork-boundary.test.ts
@@ -35,16 +35,20 @@ describe("resolveCodexUpstreamForkBoundaryFromTurns", () => {
     });
   });
 
-  it("rejects a cut at the first turn instead of copying the whole thread", () => {
+  it("cuts before the first turn with an empty retained baseline", () => {
     const result = resolveCodexUpstreamForkBoundaryFromTurns({
       turns: [turn("turn-1", [user("one")])],
       userMessageOrdinal: 0,
       localPrefixTexts: ["one"],
     });
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.code).toBe("first-message");
-    }
+    expect(result).toEqual({
+      ok: true,
+      boundary: {
+        beforeTurnId: "turn-1",
+        targetTurnId: "turn-1",
+        retainedMarker: { turnId: null, userMessageCount: 0 },
+      },
+    });
   });
 
   it("rejects a selected steer message", () => {

--- a/extensions/codex/src/app-server/upstream-fork-boundary.ts
+++ b/extensions/codex/src/app-server/upstream-fork-boundary.ts
@@ -5,16 +5,16 @@ import type { CodexThreadItem, CodexTurn } from "./protocol.js";
 export type CodexUpstreamForkBoundaryFailureCode =
   | "steer-message"
   | "in-progress-turn"
-  | "first-message"
   | "drift-mismatch"
   | "upstream-unavailable";
 
 export type CodexUpstreamForkBoundary = {
   beforeTurnId: string;
   targetTurnId: string;
-  /** Baseline for the forked thread: the last retained turn, so the upstream
-   * monitor does not replay retained history as fresh external activity. */
-  retainedMarker: { turnId: string; userMessageCount: number };
+  /** Baseline for the forked thread: the last retained turn (null when the cut is
+   * before the first turn), so the upstream monitor does not replay retained
+   * history as fresh external activity. */
+  retainedMarker: { turnId: string | null; userMessageCount: number };
 };
 
 export type CodexUpstreamForkBoundaryResult =
@@ -179,31 +179,22 @@ export function resolveCodexUpstreamForkBoundaryFromTurns(params: {
           "This Codex turn is still in progress. Wait for it to finish, then try forking again.",
         );
       }
-      if (turnIndex === 0) {
-        // A cut before the first turn would need a whole-thread upstream copy while the
-        // local mirror keeps an empty prefix — divergent histories. Fail closed; a fresh
-        // session covers the "start over" intent.
-        return failure(
-          "first-message",
-          "Forking before the first message of a Codex session is not supported. Start a new session instead.",
-        );
-      }
-      const retained = params.turns[turnIndex - 1];
-      if (!retained) {
-        return failure(
-          "drift-mismatch",
-          "The message could not be matched to the Codex thread. Refresh the session and try again.",
-        );
-      }
+      // beforeTurnId at the first turn yields a valid empty-history fork upstream
+      // (codex-rs thread_fork_inner has no minimum-turn guard), matching the empty
+      // local mirror prefix.
+      const retained = turnIndex > 0 ? params.turns[turnIndex - 1] : undefined;
       return {
         ok: true,
         boundary: {
           beforeTurnId: turn.id,
           targetTurnId: turn.id,
-          retainedMarker: {
-            turnId: retained.id,
-            userMessageCount: retained.items.filter((item) => item.type === "userMessage").length,
-          },
+          retainedMarker: retained
+            ? {
+                turnId: retained.id,
+                userMessageCount: retained.items.filter((item) => item.type === "userMessage")
+                  .length,
+              }
+            : { turnId: null, userMessageCount: 0 },
         },
       };
     }

--- a/extensions/codex/src/app-server/upstream-fork-boundary.ts
+++ b/extensions/codex/src/app-server/upstream-fork-boundary.ts
@@ -45,22 +45,30 @@ function asInputs(item: CodexThreadItem): UserInput[] {
 function userMessageDisplay(item: CodexThreadItem): {
   text: string;
   visible: boolean;
-  hasImage: boolean;
+  hasUnverifiableInput: boolean;
 } {
   let text = "";
   let hasTextElement = false;
   let hasImage = false;
+  // Any non-text input (images, skills, mentions, future variants) has no canonical
+  // cross-system identity; its presence makes the message unverifiable for drift checks.
+  let hasUnverifiableInput = false;
   for (const input of asInputs(item)) {
     if (input.type === "text") {
       if (typeof input.text === "string") {
         text += input.text;
       }
       hasTextElement ||= Array.isArray(input.textElements) && input.textElements.length > 0;
-    } else if (input.type === "image" || input.type === "localImage") {
-      hasImage = true;
+    } else {
+      hasUnverifiableInput = true;
+      hasImage ||= input.type === "image" || input.type === "localImage";
     }
   }
-  return { text, visible: Boolean(text.trim()) || hasTextElement || hasImage, hasImage };
+  return {
+    text,
+    visible: Boolean(text.trim()) || hasTextElement || hasImage,
+    hasUnverifiableInput,
+  };
 }
 
 function isHiddenNestedReviewTurn(previous: CodexTurn | undefined, turn: CodexTurn): boolean {
@@ -143,7 +151,7 @@ export function resolveCodexUpstreamForkBoundaryFromTurns(params: {
       // The local transcript is only a mirror; every prefix message must match, not just
       // the target — equal tails over different prefixes would bind divergent histories.
       const localText = params.localPrefixTexts[ordinal];
-      if (localText === undefined || display.hasImage) {
+      if (localText === undefined || display.hasUnverifiableInput) {
         return failure(
           "drift-mismatch",
           "A message before the fork point contains images or attachments that cannot be verified across OpenClaw and Codex. Fork from a text-only span instead.",

--- a/extensions/codex/src/app-server/upstream-fork-boundary.ts
+++ b/extensions/codex/src/app-server/upstream-fork-boundary.ts
@@ -9,7 +9,13 @@ export type CodexUpstreamForkBoundaryFailureCode =
   | "drift-mismatch"
   | "upstream-unavailable";
 
-export type CodexUpstreamForkBoundary = { beforeTurnId: string; targetTurnId: string };
+export type CodexUpstreamForkBoundary = {
+  beforeTurnId: string;
+  targetTurnId: string;
+  /** Baseline for the forked thread: the last retained turn, so the upstream
+   * monitor does not replay retained history as fresh external activity. */
+  retainedMarker: { turnId: string; userMessageCount: number };
+};
 
 export type CodexUpstreamForkBoundaryResult =
   | { ok: true; boundary: CodexUpstreamForkBoundary }
@@ -156,7 +162,24 @@ export function resolveCodexUpstreamForkBoundaryFromTurns(params: {
           "Forking before the first message of a Codex session is not supported. Start a new session instead.",
         );
       }
-      return { ok: true, boundary: { beforeTurnId: turn.id, targetTurnId: turn.id } };
+      const retained = params.turns[turnIndex - 1];
+      if (!retained) {
+        return failure(
+          "drift-mismatch",
+          "The message could not be matched to the Codex thread. Refresh the session and try again.",
+        );
+      }
+      return {
+        ok: true,
+        boundary: {
+          beforeTurnId: turn.id,
+          targetTurnId: turn.id,
+          retainedMarker: {
+            turnId: retained.id,
+            userMessageCount: retained.items.filter((item) => item.type === "userMessage").length,
+          },
+        },
+      };
     }
   }
   return failure(
@@ -203,6 +226,15 @@ export async function resolveCodexUpstreamForkBoundary(params: {
   control: CodexSessionCatalogControl;
 }): Promise<CodexUpstreamForkBoundaryResult> {
   try {
+    // Paginated-history threads reject itemsView "full" turn reads (thread/items/list
+    // is required); fork support for them is future work — fail closed with intent.
+    const thread = await params.control.readThread(params.threadId, false);
+    if (thread.historyMode === "paginated") {
+      return failure(
+        "upstream-unavailable",
+        "This Codex thread uses paginated history, which cannot be forked from OpenClaw yet.",
+      );
+    }
     const entries = await readVisibleSessionTranscriptMessageEntries({
       agentId: params.agentId,
       sessionId: params.sessionId,

--- a/extensions/codex/src/app-server/upstream-fork-boundary.ts
+++ b/extensions/codex/src/app-server/upstream-fork-boundary.ts
@@ -18,7 +18,7 @@ export type CodexUpstreamForkBoundary = {
 };
 
 export type CodexUpstreamForkBoundaryResult =
-  | { ok: true; boundary: CodexUpstreamForkBoundary }
+  | { ok: true; boundary: CodexUpstreamForkBoundary; editorText?: string }
   | { ok: false; code: CodexUpstreamForkBoundaryFailureCode; message: string };
 
 const TURN_PAGE_LIMIT = 100;
@@ -199,8 +199,9 @@ export function resolveCodexUpstreamForkBoundaryFromTurns(params: {
           retainedMarker: retained
             ? {
                 turnId: retained.id,
-                userMessageCount: retained.items.filter((item) => item.type === "userMessage")
-                  .length,
+                userMessageCount: retained.items.filter(
+                  (retainedItem) => retainedItem.type === "userMessage",
+                ).length,
               }
             : { turnId: null, userMessageCount: 0 },
         },
@@ -280,11 +281,14 @@ export async function resolveCodexUpstreamForkBoundary(params: {
       .slice(0, userMessageOrdinal + 1)
       .map((entry) => localMessageText(entry.message.content));
     const turns = await listCodexUpstreamTurns(params.control, params.threadId);
-    return resolveCodexUpstreamForkBoundaryFromTurns({
+    const resolved = resolveCodexUpstreamForkBoundaryFromTurns({
       turns,
       userMessageOrdinal,
       localPrefixTexts,
     });
+    return resolved.ok
+      ? { ...resolved, editorText: localPrefixTexts[userMessageOrdinal] }
+      : resolved;
   } catch {
     return failure(
       "upstream-unavailable",

--- a/extensions/codex/src/app-server/upstream-fork-boundary.ts
+++ b/extensions/codex/src/app-server/upstream-fork-boundary.ts
@@ -5,12 +5,11 @@ import type { CodexThreadItem, CodexTurn } from "./protocol.js";
 export type CodexUpstreamForkBoundaryFailureCode =
   | "steer-message"
   | "in-progress-turn"
+  | "first-message"
   | "drift-mismatch"
   | "upstream-unavailable";
 
-export type CodexUpstreamForkBoundary =
-  | { wholeThread: true; targetTurnId: string }
-  | { beforeTurnId: string; targetTurnId: string };
+export type CodexUpstreamForkBoundary = { beforeTurnId: string; targetTurnId: string };
 
 export type CodexUpstreamForkBoundaryResult =
   | { ok: true; boundary: CodexUpstreamForkBoundary }
@@ -81,7 +80,9 @@ function localMessageText(content: unknown): string | undefined {
   if (!Array.isArray(content)) {
     return undefined;
   }
-  const text = content
+  // Image-only prompts canonicalize to "" on both sides; the text-equality drift
+  // guard then degrades to ordinal matching for them instead of hard-failing.
+  return content
     .flatMap((block) => {
       if (!block || typeof block !== "object" || Array.isArray(block)) {
         return [];
@@ -90,7 +91,6 @@ function localMessageText(content: unknown): string | undefined {
       return typed.type === "text" && typeof typed.text === "string" ? [typed.text] : [];
     })
     .join("");
-  return text || undefined;
 }
 
 export function resolveCodexUpstreamForkBoundaryFromTurns(params: {
@@ -147,13 +147,16 @@ export function resolveCodexUpstreamForkBoundaryFromTurns(params: {
           "The local message no longer matches the Codex thread. Refresh the session and try again.",
         );
       }
-      return {
-        ok: true,
-        boundary:
-          turnIndex === 0
-            ? { wholeThread: true, targetTurnId: turn.id }
-            : { beforeTurnId: turn.id, targetTurnId: turn.id },
-      };
+      if (turnIndex === 0) {
+        // A cut before the first turn would need a whole-thread upstream copy while the
+        // local mirror keeps an empty prefix — divergent histories. Fail closed; a fresh
+        // session covers the "start over" intent.
+        return failure(
+          "first-message",
+          "Forking before the first message of a Codex session is not supported. Start a new session instead.",
+        );
+      }
+      return { ok: true, boundary: { beforeTurnId: turn.id, targetTurnId: turn.id } };
     }
   }
   return failure(

--- a/extensions/codex/src/app-server/upstream-fork-boundary.ts
+++ b/extensions/codex/src/app-server/upstream-fork-boundary.ts
@@ -1,0 +1,252 @@
+import { readVisibleSessionTranscriptMessageEntries } from "openclaw/plugin-sdk/session-transcript-runtime";
+import type { CodexSessionCatalogControl } from "../session-catalog-types.js";
+import type { CodexThreadItem, CodexTurn } from "./protocol.js";
+
+export type CodexUpstreamForkBoundaryFailureCode =
+  | "steer-message"
+  | "in-progress-turn"
+  | "drift-mismatch"
+  | "upstream-unavailable";
+
+export type CodexUpstreamForkBoundary =
+  | { wholeThread: true; targetTurnId: string }
+  | { beforeTurnId: string; targetTurnId: string };
+
+export type CodexUpstreamForkBoundaryResult =
+  | { ok: true; boundary: CodexUpstreamForkBoundary }
+  | { ok: false; code: CodexUpstreamForkBoundaryFailureCode; message: string };
+
+const TURN_PAGE_LIMIT = 100;
+
+type UserInput = {
+  type?: unknown;
+  text?: unknown;
+  textElements?: unknown;
+  url?: unknown;
+  path?: unknown;
+};
+
+function failure(
+  code: CodexUpstreamForkBoundaryFailureCode,
+  message: string,
+): CodexUpstreamForkBoundaryResult {
+  return { ok: false, code, message };
+}
+
+function asInputs(item: CodexThreadItem): UserInput[] {
+  return Array.isArray(item.content) ? (item.content as UserInput[]) : [];
+}
+
+function userMessageDisplay(item: CodexThreadItem): {
+  text: string;
+  visible: boolean;
+} {
+  let text = "";
+  let hasTextElement = false;
+  let hasImage = false;
+  for (const input of asInputs(item)) {
+    if (input.type === "text") {
+      if (typeof input.text === "string") {
+        text += input.text;
+      }
+      hasTextElement ||= Array.isArray(input.textElements) && input.textElements.length > 0;
+    } else if (input.type === "image" || input.type === "localImage") {
+      hasImage = true;
+    }
+  }
+  return { text, visible: Boolean(text.trim()) || hasTextElement || hasImage };
+}
+
+function isHiddenNestedReviewTurn(previous: CodexTurn | undefined, turn: CodexTurn): boolean {
+  if (
+    previous?.status !== "completed" ||
+    turn.status !== "interrupted" ||
+    turn.completedAt != null ||
+    !previous.items.some((item) => item.type === "enteredReviewMode") ||
+    !previous.items.some((item) => item.type === "exitedReviewMode")
+  ) {
+    return false;
+  }
+  const userMessages = turn.items.filter((item) => item.type === "userMessage");
+  return (
+    userMessages.length === 2 &&
+    JSON.stringify(asInputs(userMessages[0])) === JSON.stringify(asInputs(userMessages[1]))
+  );
+}
+
+function localMessageText(content: unknown): string | undefined {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+  const text = content
+    .flatMap((block) => {
+      if (!block || typeof block !== "object" || Array.isArray(block)) {
+        return [];
+      }
+      const typed = block as { type?: unknown; text?: unknown };
+      return typed.type === "text" && typeof typed.text === "string" ? [typed.text] : [];
+    })
+    .join("");
+  return text || undefined;
+}
+
+export function resolveCodexUpstreamForkBoundaryFromTurns(params: {
+  turns: readonly CodexTurn[];
+  userMessageOrdinal: number;
+  localText: string;
+}): CodexUpstreamForkBoundaryResult {
+  let visibleUserMessagesSeen = 0;
+  let reviewMode = false;
+  for (const [turnIndex, turn] of params.turns.entries()) {
+    const hiddenNestedReviewTurn = isHiddenNestedReviewTurn(params.turns[turnIndex - 1], turn);
+    let userMessagesInTurn = 0;
+    for (const item of turn.items) {
+      if (item.type === "enteredReviewMode") {
+        reviewMode = true;
+        continue;
+      }
+      if (item.type === "exitedReviewMode") {
+        reviewMode = false;
+        continue;
+      }
+      if (item.type !== "userMessage") {
+        continue;
+      }
+      const isSteer = userMessagesInTurn > 0;
+      userMessagesInTurn += 1;
+      if (reviewMode || hiddenNestedReviewTurn) {
+        continue;
+      }
+      const display = userMessageDisplay(item);
+      if (!display.visible) {
+        continue;
+      }
+      if (visibleUserMessagesSeen !== params.userMessageOrdinal) {
+        visibleUserMessagesSeen += 1;
+        continue;
+      }
+      if (isSteer) {
+        return failure(
+          "steer-message",
+          "This message steered an existing Codex turn and cannot be forked independently. Fork from the turn's first message instead.",
+        );
+      }
+      if (turn.status === "inProgress") {
+        return failure(
+          "in-progress-turn",
+          "This Codex turn is still in progress. Wait for it to finish, then try forking again.",
+        );
+      }
+      // The local transcript is only a mirror; never cut the authoritative rollout on ordinal alone.
+      if (display.text !== params.localText) {
+        return failure(
+          "drift-mismatch",
+          "The local message no longer matches the Codex thread. Refresh the session and try again.",
+        );
+      }
+      return {
+        ok: true,
+        boundary:
+          turnIndex === 0
+            ? { wholeThread: true, targetTurnId: turn.id }
+            : { beforeTurnId: turn.id, targetTurnId: turn.id },
+      };
+    }
+  }
+  return failure(
+    "drift-mismatch",
+    "The message could not be matched to the Codex thread. Refresh the session and try again.",
+  );
+}
+
+export async function listCodexUpstreamTurns(
+  control: CodexSessionCatalogControl,
+  threadId: string,
+): Promise<CodexTurn[]> {
+  const turns: CodexTurn[] = [];
+  const seenCursors = new Set<string>();
+  let cursor: string | undefined;
+  for (;;) {
+    const page = await control.listTurnPage({
+      threadId,
+      limit: TURN_PAGE_LIMIT,
+      sortDirection: "asc",
+      itemsView: "full",
+      ...(cursor ? { cursor } : {}),
+    });
+    turns.push(...page.data);
+    const nextCursor = page.nextCursor?.trim() || undefined;
+    if (!nextCursor) {
+      return turns;
+    }
+    if (seenCursors.has(nextCursor)) {
+      throw new Error("Codex returned a repeated thread/turns/list cursor");
+    }
+    seenCursors.add(nextCursor);
+    cursor = nextCursor;
+  }
+}
+
+export async function resolveCodexUpstreamForkBoundary(params: {
+  agentId: string;
+  sessionId: string;
+  sessionKey: string;
+  storePath: string;
+  entryId: string;
+  threadId: string;
+  control: CodexSessionCatalogControl;
+}): Promise<CodexUpstreamForkBoundaryResult> {
+  try {
+    const entries = await readVisibleSessionTranscriptMessageEntries({
+      agentId: params.agentId,
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      storePath: params.storePath,
+    });
+    const visibleUserEntries = entries.filter((entry) => entry.role === "user");
+    const userMessageOrdinal = visibleUserEntries.findIndex(
+      (entry) => entry.entryId === params.entryId,
+    );
+    const localText = localMessageText(visibleUserEntries[userMessageOrdinal]?.message.content);
+    if (userMessageOrdinal < 0 || localText === undefined) {
+      return failure(
+        "drift-mismatch",
+        "The local message could not be mapped to the Codex thread. Refresh the session and try again.",
+      );
+    }
+    const turns = await listCodexUpstreamTurns(params.control, params.threadId);
+    return resolveCodexUpstreamForkBoundaryFromTurns({
+      turns,
+      userMessageOrdinal,
+      localText,
+    });
+  } catch {
+    return failure(
+      "upstream-unavailable",
+      "The Codex thread could not be read. Check that Codex is available, then try again.",
+    );
+  }
+}
+
+export function precheckCodexUpstreamForkBoundary(params: {
+  boundary: CodexUpstreamForkBoundary;
+  turns: readonly CodexTurn[];
+}): CodexUpstreamForkBoundaryResult {
+  const target = params.turns.find((turn) => turn.id === params.boundary.targetTurnId);
+  if (!target) {
+    return failure(
+      "upstream-unavailable",
+      "The Codex thread changed before it could be forked. Refresh the session and try again.",
+    );
+  }
+  if (target.status === "inProgress") {
+    return failure(
+      "in-progress-turn",
+      "This Codex turn is still in progress. Wait for it to finish, then try forking again.",
+    );
+  }
+  return { ok: true, boundary: params.boundary };
+}

--- a/extensions/codex/src/app-server/upstream-fork-boundary.ts
+++ b/extensions/codex/src/app-server/upstream-fork-boundary.ts
@@ -141,6 +141,14 @@ export function resolveCodexUpstreamForkBoundaryFromTurns(params: {
         continue;
       }
       const display = userMessageDisplay(item);
+      // Unverifiable inputs fail closed even when display-invisible: a skipped
+      // skill/mention-only message would silently desync ordinals against the mirror.
+      if (display.hasUnverifiableInput) {
+        return failure(
+          "drift-mismatch",
+          "A message before the fork point contains images or attachments that cannot be verified across OpenClaw and Codex. Fork from a text-only span instead.",
+        );
+      }
       if (!display.visible) {
         continue;
       }
@@ -151,7 +159,7 @@ export function resolveCodexUpstreamForkBoundaryFromTurns(params: {
       // The local transcript is only a mirror; every prefix message must match, not just
       // the target — equal tails over different prefixes would bind divergent histories.
       const localText = params.localPrefixTexts[ordinal];
-      if (localText === undefined || display.hasUnverifiableInput) {
+      if (localText === undefined) {
         return failure(
           "drift-mismatch",
           "A message before the fork point contains images or attachments that cannot be verified across OpenClaw and Codex. Fork from a text-only span instead.",

--- a/extensions/codex/src/app-server/upstream-fork-boundary.ts
+++ b/extensions/codex/src/app-server/upstream-fork-boundary.ts
@@ -2,13 +2,13 @@ import { readVisibleSessionTranscriptMessageEntries } from "openclaw/plugin-sdk/
 import type { CodexSessionCatalogControl } from "../session-catalog-types.js";
 import type { CodexThreadItem, CodexTurn } from "./protocol.js";
 
-export type CodexUpstreamForkBoundaryFailureCode =
+type CodexUpstreamForkBoundaryFailureCode =
   | "steer-message"
   | "in-progress-turn"
   | "drift-mismatch"
   | "upstream-unavailable";
 
-export type CodexUpstreamForkBoundary = {
+type CodexUpstreamForkBoundary = {
   beforeTurnId: string;
   targetTurnId: string;
   /** Baseline for the forked thread: the last retained turn (null when the cut is
@@ -17,7 +17,7 @@ export type CodexUpstreamForkBoundary = {
   retainedMarker: { turnId: string | null; userMessageCount: number };
 };
 
-export type CodexUpstreamForkBoundaryResult =
+type CodexUpstreamForkBoundaryResult =
   | { ok: true; boundary: CodexUpstreamForkBoundary; editorText?: string }
   | { ok: false; code: CodexUpstreamForkBoundaryFailureCode; message: string };
 
@@ -82,10 +82,11 @@ function isHiddenNestedReviewTurn(previous: CodexTurn | undefined, turn: CodexTu
     return false;
   }
   const userMessages = turn.items.filter((item) => item.type === "userMessage");
-  return (
-    userMessages.length === 2 &&
-    JSON.stringify(asInputs(userMessages[0])) === JSON.stringify(asInputs(userMessages[1]))
-  );
+  const [firstUserMessage, secondUserMessage] = userMessages;
+  if (!firstUserMessage || !secondUserMessage || userMessages.length !== 2) {
+    return false;
+  }
+  return JSON.stringify(asInputs(firstUserMessage)) === JSON.stringify(asInputs(secondUserMessage));
 }
 
 function localMessageText(content: unknown): string | undefined {
@@ -111,7 +112,7 @@ function localMessageText(content: unknown): string | undefined {
   return texts.join("");
 }
 
-export function resolveCodexUpstreamForkBoundaryFromTurns(params: {
+function resolveCodexUpstreamForkBoundaryFromTurns(params: {
   turns: readonly CodexTurn[];
   userMessageOrdinal: number;
   /** Canonical text for every visible local user message through the target ordinal;
@@ -279,7 +280,9 @@ export async function resolveCodexUpstreamForkBoundary(params: {
     }
     const localPrefixTexts = visibleUserEntries
       .slice(0, userMessageOrdinal + 1)
-      .map((entry) => localMessageText(entry.message.content));
+      .map((entry) =>
+        localMessageText("content" in entry.message ? entry.message.content : undefined),
+      );
     const turns = await listCodexUpstreamTurns(params.control, params.threadId);
     const resolved = resolveCodexUpstreamForkBoundaryFromTurns({
       turns,

--- a/extensions/codex/src/app-server/upstream-fork-boundary.ts
+++ b/extensions/codex/src/app-server/upstream-fork-boundary.ts
@@ -45,6 +45,7 @@ function asInputs(item: CodexThreadItem): UserInput[] {
 function userMessageDisplay(item: CodexThreadItem): {
   text: string;
   visible: boolean;
+  hasImage: boolean;
 } {
   let text = "";
   let hasTextElement = false;
@@ -59,7 +60,7 @@ function userMessageDisplay(item: CodexThreadItem): {
       hasImage = true;
     }
   }
-  return { text, visible: Boolean(text.trim()) || hasTextElement || hasImage };
+  return { text, visible: Boolean(text.trim()) || hasTextElement || hasImage, hasImage };
 }
 
 function isHiddenNestedReviewTurn(previous: CodexTurn | undefined, turn: CodexTurn): boolean {
@@ -86,23 +87,28 @@ function localMessageText(content: unknown): string | undefined {
   if (!Array.isArray(content)) {
     return undefined;
   }
-  // Image-only prompts canonicalize to "" on both sides; the text-equality drift
-  // guard then degrades to ordinal matching for them instead of hard-failing.
-  return content
-    .flatMap((block) => {
-      if (!block || typeof block !== "object" || Array.isArray(block)) {
-        return [];
-      }
-      const typed = block as { type?: unknown; text?: unknown };
-      return typed.type === "text" && typeof typed.text === "string" ? [typed.text] : [];
-    })
-    .join("");
+  // Non-text blocks (images/attachments) have no canonical cross-system identity;
+  // undefined marks the message unverifiable so boundary resolution fails closed.
+  const texts: string[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== "object" || Array.isArray(block)) {
+      return undefined;
+    }
+    const typed = block as { type?: unknown; text?: unknown };
+    if (typed.type !== "text" || typeof typed.text !== "string") {
+      return undefined;
+    }
+    texts.push(typed.text);
+  }
+  return texts.join("");
 }
 
 export function resolveCodexUpstreamForkBoundaryFromTurns(params: {
   turns: readonly CodexTurn[];
   userMessageOrdinal: number;
-  localText: string;
+  /** Canonical text for every visible local user message through the target ordinal;
+   * undefined marks content (images/attachments) whose identity cannot be verified. */
+  localPrefixTexts: readonly (string | undefined)[];
 }): CodexUpstreamForkBoundaryResult {
   let visibleUserMessagesSeen = 0;
   let reviewMode = false;
@@ -130,7 +136,26 @@ export function resolveCodexUpstreamForkBoundaryFromTurns(params: {
       if (!display.visible) {
         continue;
       }
-      if (visibleUserMessagesSeen !== params.userMessageOrdinal) {
+      const ordinal = visibleUserMessagesSeen;
+      if (ordinal > params.userMessageOrdinal) {
+        break;
+      }
+      // The local transcript is only a mirror; every prefix message must match, not just
+      // the target — equal tails over different prefixes would bind divergent histories.
+      const localText = params.localPrefixTexts[ordinal];
+      if (localText === undefined || display.hasImage) {
+        return failure(
+          "drift-mismatch",
+          "A message before the fork point contains images or attachments that cannot be verified across OpenClaw and Codex. Fork from a text-only span instead.",
+        );
+      }
+      if (display.text !== localText) {
+        return failure(
+          "drift-mismatch",
+          "The local conversation no longer matches the Codex thread. Refresh the session and try again.",
+        );
+      }
+      if (ordinal !== params.userMessageOrdinal) {
         visibleUserMessagesSeen += 1;
         continue;
       }
@@ -144,13 +169,6 @@ export function resolveCodexUpstreamForkBoundaryFromTurns(params: {
         return failure(
           "in-progress-turn",
           "This Codex turn is still in progress. Wait for it to finish, then try forking again.",
-        );
-      }
-      // The local transcript is only a mirror; never cut the authoritative rollout on ordinal alone.
-      if (display.text !== params.localText) {
-        return failure(
-          "drift-mismatch",
-          "The local message no longer matches the Codex thread. Refresh the session and try again.",
         );
       }
       if (turnIndex === 0) {
@@ -245,18 +263,20 @@ export async function resolveCodexUpstreamForkBoundary(params: {
     const userMessageOrdinal = visibleUserEntries.findIndex(
       (entry) => entry.entryId === params.entryId,
     );
-    const localText = localMessageText(visibleUserEntries[userMessageOrdinal]?.message.content);
-    if (userMessageOrdinal < 0 || localText === undefined) {
+    if (userMessageOrdinal < 0) {
       return failure(
         "drift-mismatch",
         "The local message could not be mapped to the Codex thread. Refresh the session and try again.",
       );
     }
+    const localPrefixTexts = visibleUserEntries
+      .slice(0, userMessageOrdinal + 1)
+      .map((entry) => localMessageText(entry.message.content));
     const turns = await listCodexUpstreamTurns(params.control, params.threadId);
     return resolveCodexUpstreamForkBoundaryFromTurns({
       turns,
       userMessageOrdinal,
-      localText,
+      localPrefixTexts,
     });
   } catch {
     return failure(

--- a/extensions/codex/src/app-server/upstream-session-fork.test.ts
+++ b/extensions/codex/src/app-server/upstream-session-fork.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it, vi } from "vitest";
 import type { CodexSessionCatalogControl } from "../session-catalog-types.js";
 import type { CodexAppServerBindingStore } from "./session-binding.js";
 
-const boundary = { beforeTurnId: "turn-2", targetTurnId: "turn-2" } as const;
+const boundary = {
+  beforeTurnId: "turn-2",
+  targetTurnId: "turn-2",
+  retainedMarker: { turnId: "turn-1", userMessageCount: 1 },
+} as const;
 
 vi.mock("./upstream-fork-boundary.js", () => ({
   resolveCodexUpstreamForkBoundary: vi.fn(async () => ({ ok: true, boundary })),
@@ -74,7 +78,7 @@ describe("forkCodexUpstreamSession", () => {
     expect(result).toMatchObject({
       status: "forked",
       upstream: {
-        marker: { turnId: null, userMessageCount: 0 },
+        marker: { turnId: "turn-1", userMessageCount: 1 },
         threadId: "thread-forked",
       },
     });

--- a/extensions/codex/src/app-server/upstream-session-fork.test.ts
+++ b/extensions/codex/src/app-server/upstream-session-fork.test.ts
@@ -1,7 +1,7 @@
 import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CodexSessionCatalogControl } from "../session-catalog-types.js";
-import type { CodexTurn } from "./protocol.js";
+import type { CodexThreadForkParams, CodexTurn } from "./protocol.js";
 import type { CodexAppServerBindingStore } from "./session-binding.js";
 
 const boundaryMocks = vi.hoisted(() => ({
@@ -49,12 +49,23 @@ function turn(id: string, text: string): CodexTurn {
     status: "completed",
     items: [
       {
+        aggregatedOutput: null,
+        changes: [],
+        command: null,
+        cwd: null,
         id: `${id}-user`,
-        type: "userMessage",
+        name: null,
+        query: null,
+        server: null,
+        status: null,
+        text: "",
+        title: null,
+        tool: null,
         content: [{ type: "text", text, textElements: [] }],
+        type: "userMessage",
       },
     ],
-  } as CodexTurn;
+  };
 }
 
 function forkResponse(threadId = "thread-forked") {
@@ -102,7 +113,9 @@ function forkParams() {
   };
 }
 
-function forkControl(forkThread = vi.fn(async () => forkResponse())) {
+type ForkThreadStub = (params: CodexThreadForkParams) => Promise<unknown>;
+
+function forkControl(forkThread: ForkThreadStub = vi.fn(async () => forkResponse())) {
   const archiveThread = vi.fn(async () => undefined);
   const control = {
     archiveThread,
@@ -140,6 +153,7 @@ describe("forkCodexUpstreamSession", () => {
       return true;
     });
     const runtime = createPluginRuntimeMock();
+    const createSessionEntry = vi.mocked(runtime.agent.session.createSessionEntry);
 
     const result = await forkCodexUpstreamSession(forkParams(), {
       bindingStore: { mutate } as unknown as CodexAppServerBindingStore,
@@ -174,9 +188,7 @@ describe("forkCodexUpstreamSession", () => {
         initialEntry: expect.objectContaining({ agentHarnessId: "codex-custom" }),
       }),
     );
-    expect(runtime.agent.session.createSessionEntry.mock.calls[0]?.[0]).not.toHaveProperty(
-      "recoverMatchingInitialEntry",
-    );
+    expect(createSessionEntry.mock.calls[0]?.[0]).not.toHaveProperty("recoverMatchingInitialEntry");
     expect(events).toEqual(["link", "bind"]);
     expect(result).toEqual({
       status: "created",

--- a/extensions/codex/src/app-server/upstream-session-fork.test.ts
+++ b/extensions/codex/src/app-server/upstream-session-fork.test.ts
@@ -138,4 +138,45 @@ describe("forkCodexUpstreamSession", () => {
     expect(result).toMatchObject({ status: "failed", code: "upstream-unavailable" });
     expect(archiveThread).toHaveBeenCalledWith("thread-orphan");
   });
+
+  it("rejects a fork response that reuses the source thread id", async () => {
+    const { forkCodexUpstreamSession } = await import("./upstream-session-fork.js");
+    const forkThread = vi.fn(async () => ({
+      thread: { id: "thread-source" },
+      model: "gpt-5",
+    }));
+    const archiveThread = vi.fn();
+    const control = {
+      connectionFingerprint: "fingerprint",
+      forkThread,
+      archiveThread,
+      listTurnPage: vi.fn(),
+      readThread: vi.fn(),
+      withPinnedConnection: async (run: (c: unknown) => Promise<unknown>) => await run(control),
+    } as never;
+
+    const result = await forkCodexUpstreamSession(
+      {
+        source: {
+          agentId: "main",
+          sessionId: "session-1",
+          sessionKey: "agent:main:upstream",
+          storePath: "/tmp/does-not-matter",
+          entryId: "entry-1",
+        },
+        upstream: {
+          kind: "codex-app-server",
+          threadId: "thread-source",
+          ref: { connectionFingerprint: "fingerprint", threadId: "thread-source" },
+        },
+      },
+      {
+        bindingStore: { mutate: vi.fn() } as never,
+        control,
+      },
+    );
+
+    expect(result).toMatchObject({ status: "failed", code: "upstream-unavailable" });
+    expect(archiveThread).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/codex/src/app-server/upstream-session-fork.test.ts
+++ b/extensions/codex/src/app-server/upstream-session-fork.test.ts
@@ -1,6 +1,19 @@
-import { describe, expect, it, vi } from "vitest";
+import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CodexSessionCatalogControl } from "../session-catalog-types.js";
+import type { CodexTurn } from "./protocol.js";
 import type { CodexAppServerBindingStore } from "./session-binding.js";
+
+const boundaryMocks = vi.hoisted(() => ({
+  listTurns: vi.fn(),
+}));
+const linkMocks = vi.hoisted(() => ({
+  delete: vi.fn(),
+  upsert: vi.fn(),
+}));
+const transcriptMocks = vi.hoisted(() => ({
+  importHistory: vi.fn(),
+}));
 
 const boundary = {
   beforeTurnId: "turn-2",
@@ -8,173 +21,247 @@ const boundary = {
   retainedMarker: { turnId: "turn-1", userMessageCount: 1 },
 } as const;
 
+vi.mock("openclaw/plugin-sdk/session-catalog", async (importOriginal) => ({
+  ...(await importOriginal()),
+  deleteSessionUpstreamLink: linkMocks.delete,
+  upsertSessionUpstreamLink: linkMocks.upsert,
+}));
+
+vi.mock("./transcript-mirror.js", () => ({
+  importCodexThreadHistoryToTranscript: transcriptMocks.importHistory,
+}));
+
 vi.mock("./upstream-fork-boundary.js", () => ({
-  resolveCodexUpstreamForkBoundary: vi.fn(async () => ({ ok: true, boundary })),
-  listCodexUpstreamTurns: vi.fn(async () => [{ id: "turn-2", status: "completed", items: [] }]),
+  resolveCodexUpstreamForkBoundary: vi.fn(async () => ({
+    ok: true,
+    boundary,
+    editorText: "edit me",
+  })),
+  listCodexUpstreamTurns: boundaryMocks.listTurns,
   precheckCodexUpstreamForkBoundary: vi.fn(() => ({ ok: true, boundary })),
 }));
 
 import { forkCodexUpstreamSession } from "./upstream-session-fork.js";
 
-describe("forkCodexUpstreamSession", () => {
-  it("forks before the mapped turn and attaches the returned thread", async () => {
-    const forkThread = vi.fn(async () => ({
-      approvalPolicy: "never",
-      approvalsReviewer: "user",
-      cwd: "/tmp",
-      model: "gpt-5.4",
-      modelProvider: "openai",
-      sandbox: { type: "dangerFullAccess" },
-      thread: {
-        id: "thread-forked",
-        sessionId: "session-forked",
-        cliVersion: "0.143.0",
-        createdAt: 1715299200,
-        updatedAt: 1715299200,
-        cwd: "/tmp",
-        ephemeral: false,
-        modelProvider: "openai",
-        preview: "forked thread",
-        source: "appServer",
-        status: { type: "notLoaded" },
-        turns: [],
+function turn(id: string, text: string): CodexTurn {
+  return {
+    id,
+    status: "completed",
+    items: [
+      {
+        id: `${id}-user`,
+        type: "userMessage",
+        content: [{ type: "text", text, textElements: [] }],
       },
-    }));
-    const archiveThread = vi.fn(async () => undefined);
-    const control = {
-      archiveThread,
-      connectionFingerprint: "fingerprint",
-      forkThread,
-    } as unknown as CodexSessionCatalogControl;
-    control.withPinnedConnection = async (run) => await run(control);
-    const mutate = vi.fn(async () => true);
+    ],
+  } as CodexTurn;
+}
 
-    const result = await forkCodexUpstreamSession(
-      {
-        source: {
-          agentId: "main",
-          sessionId: "session-source",
-          sessionKey: "agent:main:source",
-          storePath: "/tmp/sessions.db",
-          entryId: "entry-2",
-        },
-        upstream: {
-          kind: "codex-app-server",
-          threadId: "thread-source",
-          ref: { connectionFingerprint: "fingerprint", threadId: "thread-source" },
-        },
-      },
-      {
-        bindingStore: { mutate } as unknown as CodexAppServerBindingStore,
-        control,
-      },
-    );
+function forkResponse(threadId = "thread-forked") {
+  return {
+    approvalPolicy: "never",
+    approvalsReviewer: "user",
+    cwd: "/tmp",
+    model: "gpt-5.4",
+    modelProvider: "openai",
+    sandbox: { type: "dangerFullAccess" },
+    thread: {
+      id: threadId,
+      sessionId: "session-forked",
+      cliVersion: "0.143.0",
+      createdAt: 1715299200,
+      updatedAt: 1715299200,
+      cwd: "/tmp",
+      ephemeral: false,
+      modelProvider: "openai",
+      preview: "forked thread",
+      source: "appServer",
+      status: { type: "notLoaded" },
+      turns: [],
+    },
+  };
+}
+
+function forkParams() {
+  return {
+    targetKey: "agent:main:dashboard:forked",
+    source: {
+      agentId: "main",
+      sessionId: "session-source",
+      sessionKey: "agent:main:source",
+      storePath: "/tmp/sessions.db",
+      entryId: "entry-2",
+    },
+    upstream: {
+      catalogId: "codex",
+      hostId: "gateway:local",
+      kind: "codex-app-server" as const,
+      threadId: "thread-source",
+      ref: { connectionFingerprint: "fingerprint", threadId: "thread-source" },
+    },
+  };
+}
+
+function forkControl(forkThread = vi.fn(async () => forkResponse())) {
+  const archiveThread = vi.fn(async () => undefined);
+  const control = {
+    archiveThread,
+    connectionFingerprint: "fingerprint",
+    forkThread,
+  } as unknown as CodexSessionCatalogControl;
+  control.withPinnedConnection = async (run) => await run(control);
+  return { archiveThread, control, forkThread };
+}
+
+beforeEach(() => {
+  boundaryMocks.listTurns.mockReset();
+  linkMocks.delete.mockReset();
+  linkMocks.upsert.mockReset().mockReturnValue(true);
+  transcriptMocks.importHistory.mockReset().mockResolvedValue({
+    importedMessages: 1,
+    omittedMessages: 0,
+  });
+});
+
+describe("forkCodexUpstreamSession", () => {
+  it("verifies the cut, imports the fork history, then links before binding", async () => {
+    const retainedTurn = turn("turn-1", "one");
+    boundaryMocks.listTurns
+      .mockResolvedValueOnce([turn("turn-2", "edit me")])
+      .mockResolvedValueOnce([retainedTurn]);
+    const { archiveThread, control, forkThread } = forkControl();
+    const events: string[] = [];
+    linkMocks.upsert.mockImplementation(() => {
+      events.push("link");
+      return true;
+    });
+    const mutate = vi.fn(async () => {
+      events.push("bind");
+      return true;
+    });
+    const runtime = createPluginRuntimeMock();
+
+    const result = await forkCodexUpstreamSession(forkParams(), {
+      bindingStore: { mutate } as unknown as CodexAppServerBindingStore,
+      control,
+      harnessRuntimeId: "codex-custom",
+      resolveConfig: () => ({}),
+      runtime,
+    });
 
     expect(forkThread).toHaveBeenCalledWith({
       threadId: "thread-source",
       beforeTurnId: "turn-2",
       excludeTurns: true,
     });
-    expect(result).toMatchObject({
-      status: "forked",
-      upstream: {
-        marker: { turnId: "turn-1", userMessageCount: 1 },
-        threadId: "thread-forked",
-      },
-    });
-    if (result.status !== "forked") {
-      throw new Error("expected the Codex fork to succeed");
-    }
-    await result.attach({
-      agentId: "main",
-      sessionId: "session-local-fork",
-      sessionKey: "agent:main:fork",
-    });
-    expect(mutate).toHaveBeenCalledWith(
-      expect.objectContaining({ sessionId: "session-local-fork" }),
+    expect(boundaryMocks.listTurns).toHaveBeenLastCalledWith(control, "thread-forked");
+    expect(transcriptMocks.importHistory).toHaveBeenCalledWith(
       expect.objectContaining({
-        kind: "set",
-        binding: expect.objectContaining({ threadId: "thread-forked" }),
+        sessionKey: "agent:main:dashboard:forked",
+        thread: expect.objectContaining({ id: "thread-forked", turns: [retainedTurn] }),
+        throughTurnId: "turn-1",
       }),
     );
-    await result.archive();
-    expect(mutate).toHaveBeenLastCalledWith(
-      expect.objectContaining({ sessionId: "session-local-fork" }),
-      { kind: "clear", threadId: "thread-forked" },
+    expect(linkMocks.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        marker: { turnId: "turn-1", userMessageCount: 1 },
+        sessionKey: "agent:main:dashboard:forked",
+        threadId: "thread-forked",
+      }),
     );
+    expect(runtime.agent.session.createSessionEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialEntry: expect.objectContaining({ agentHarnessId: "codex-custom" }),
+      }),
+    );
+    expect(runtime.agent.session.createSessionEntry.mock.calls[0]?.[0]).not.toHaveProperty(
+      "recoverMatchingInitialEntry",
+    );
+    expect(events).toEqual(["link", "bind"]);
+    expect(result).toEqual({
+      status: "created",
+      key: "agent:main:dashboard:forked",
+      editorText: "edit me",
+    });
+    expect(archiveThread).not.toHaveBeenCalled();
+  });
+
+  it("archives a fork whose read-back history proves beforeTurnId was ignored", async () => {
+    boundaryMocks.listTurns
+      .mockResolvedValueOnce([turn("turn-2", "edit me")])
+      .mockResolvedValueOnce([turn("turn-1", "one"), turn("turn-2", "edit me")]);
+    const { archiveThread, control } = forkControl();
+    const runtime = createPluginRuntimeMock();
+
+    const result = await forkCodexUpstreamSession(forkParams(), {
+      bindingStore: { mutate: vi.fn() } as unknown as CodexAppServerBindingStore,
+      control,
+      harnessRuntimeId: "codex",
+      runtime,
+    });
+
+    expect(result).toMatchObject({
+      status: "failed",
+      code: "upstream-unavailable",
+      message: expect.stringContaining("Codex version"),
+    });
+    expect(archiveThread).toHaveBeenCalledWith("thread-forked");
+    expect(runtime.agent.session.createSessionEntry).not.toHaveBeenCalled();
+    expect(linkMocks.upsert).not.toHaveBeenCalled();
+  });
+
+  it("cleans the link and archives the fork when binding materialization fails", async () => {
+    boundaryMocks.listTurns
+      .mockResolvedValueOnce([turn("turn-2", "edit me")])
+      .mockResolvedValueOnce([turn("turn-1", "one")]);
+    const { archiveThread, control } = forkControl();
+    const mutate = vi.fn(async () => false);
+
+    const result = await forkCodexUpstreamSession(forkParams(), {
+      bindingStore: { mutate } as unknown as CodexAppServerBindingStore,
+      control,
+      harnessRuntimeId: "codex",
+      runtime: createPluginRuntimeMock(),
+    });
+
+    expect(result).toMatchObject({ status: "failed", code: "upstream-unavailable" });
+    expect(linkMocks.delete).toHaveBeenCalledWith("agent:main:dashboard:forked", "main");
+    expect(mutate).toHaveBeenLastCalledWith(expect.anything(), {
+      kind: "clear",
+      threadId: "thread-forked",
+    });
     expect(archiveThread).toHaveBeenCalledWith("thread-forked");
   });
 
   it("archives a recoverable orphan id when the fork response is invalid", async () => {
-    const archiveThread = vi.fn(async () => undefined);
-    const control = {
-      archiveThread,
-      connectionFingerprint: "fingerprint",
-      forkThread: vi.fn(async () => ({ thread: { id: "thread-orphan" } })),
-    } as unknown as CodexSessionCatalogControl;
-    control.withPinnedConnection = async (run) => await run(control);
-
-    const result = await forkCodexUpstreamSession(
-      {
-        source: {
-          agentId: "main",
-          sessionId: "session-source",
-          sessionKey: "agent:main:source",
-          storePath: "/tmp/sessions.db",
-          entryId: "entry-2",
-        },
-        upstream: {
-          kind: "codex-app-server",
-          threadId: "thread-source",
-          ref: { connectionFingerprint: "fingerprint", threadId: "thread-source" },
-        },
-      },
-      {
-        bindingStore: {} as CodexAppServerBindingStore,
-        control,
-      },
+    boundaryMocks.listTurns.mockResolvedValueOnce([turn("turn-2", "edit me")]);
+    const { archiveThread, control } = forkControl(
+      vi.fn(async () => ({ thread: { id: "thread-orphan" } })),
     );
+
+    const result = await forkCodexUpstreamSession(forkParams(), {
+      bindingStore: {} as CodexAppServerBindingStore,
+      control,
+      harnessRuntimeId: "codex",
+      runtime: createPluginRuntimeMock(),
+    });
 
     expect(result).toMatchObject({ status: "failed", code: "upstream-unavailable" });
     expect(archiveThread).toHaveBeenCalledWith("thread-orphan");
   });
 
   it("rejects a fork response that reuses the source thread id", async () => {
-    const { forkCodexUpstreamSession } = await import("./upstream-session-fork.js");
-    const forkThread = vi.fn(async () => ({
-      thread: { id: "thread-source" },
-      model: "gpt-5",
-    }));
-    const archiveThread = vi.fn();
-    const control = {
-      connectionFingerprint: "fingerprint",
-      forkThread,
-      archiveThread,
-      listTurnPage: vi.fn(),
-      readThread: vi.fn(),
-      withPinnedConnection: async (run: (c: unknown) => Promise<unknown>) => await run(control),
-    } as never;
-
-    const result = await forkCodexUpstreamSession(
-      {
-        source: {
-          agentId: "main",
-          sessionId: "session-1",
-          sessionKey: "agent:main:upstream",
-          storePath: "/tmp/does-not-matter",
-          entryId: "entry-1",
-        },
-        upstream: {
-          kind: "codex-app-server",
-          threadId: "thread-source",
-          ref: { connectionFingerprint: "fingerprint", threadId: "thread-source" },
-        },
-      },
-      {
-        bindingStore: { mutate: vi.fn() } as never,
-        control,
-      },
+    boundaryMocks.listTurns.mockResolvedValueOnce([turn("turn-2", "edit me")]);
+    const { archiveThread, control } = forkControl(
+      vi.fn(async () => forkResponse("thread-source")),
     );
+
+    const result = await forkCodexUpstreamSession(forkParams(), {
+      bindingStore: { mutate: vi.fn() } as unknown as CodexAppServerBindingStore,
+      control,
+      harnessRuntimeId: "codex",
+      runtime: createPluginRuntimeMock(),
+    });
 
     expect(result).toMatchObject({ status: "failed", code: "upstream-unavailable" });
     expect(archiveThread).not.toHaveBeenCalled();

--- a/extensions/codex/src/app-server/upstream-session-fork.test.ts
+++ b/extensions/codex/src/app-server/upstream-session-fork.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CodexSessionCatalogControl } from "../session-catalog-types.js";
+import type { CodexAppServerBindingStore } from "./session-binding.js";
+
+const boundary = { beforeTurnId: "turn-2", targetTurnId: "turn-2" } as const;
+
+vi.mock("./upstream-fork-boundary.js", () => ({
+  resolveCodexUpstreamForkBoundary: vi.fn(async () => ({ ok: true, boundary })),
+  listCodexUpstreamTurns: vi.fn(async () => [{ id: "turn-2", status: "completed", items: [] }]),
+  precheckCodexUpstreamForkBoundary: vi.fn(() => ({ ok: true, boundary })),
+}));
+
+import { forkCodexUpstreamSession } from "./upstream-session-fork.js";
+
+describe("forkCodexUpstreamSession", () => {
+  it("forks before the mapped turn and attaches the returned thread", async () => {
+    const forkThread = vi.fn(async () => ({
+      approvalPolicy: "never",
+      approvalsReviewer: "user",
+      cwd: "/tmp",
+      model: "gpt-5.4",
+      modelProvider: "openai",
+      sandbox: { type: "dangerFullAccess" },
+      thread: {
+        id: "thread-forked",
+        sessionId: "session-forked",
+        cliVersion: "0.143.0",
+        createdAt: 1715299200,
+        updatedAt: 1715299200,
+        cwd: "/tmp",
+        ephemeral: false,
+        modelProvider: "openai",
+        preview: "forked thread",
+        source: "appServer",
+        status: { type: "notLoaded" },
+        turns: [],
+      },
+    }));
+    const archiveThread = vi.fn(async () => undefined);
+    const control = {
+      archiveThread,
+      connectionFingerprint: "fingerprint",
+      forkThread,
+    } as unknown as CodexSessionCatalogControl;
+    control.withPinnedConnection = async (run) => await run(control);
+    const mutate = vi.fn(async () => true);
+
+    const result = await forkCodexUpstreamSession(
+      {
+        source: {
+          agentId: "main",
+          sessionId: "session-source",
+          sessionKey: "agent:main:source",
+          storePath: "/tmp/sessions.db",
+          entryId: "entry-2",
+        },
+        upstream: {
+          kind: "codex-app-server",
+          threadId: "thread-source",
+          ref: { connectionFingerprint: "fingerprint", threadId: "thread-source" },
+        },
+      },
+      {
+        bindingStore: { mutate } as unknown as CodexAppServerBindingStore,
+        control,
+      },
+    );
+
+    expect(forkThread).toHaveBeenCalledWith({
+      threadId: "thread-source",
+      beforeTurnId: "turn-2",
+      excludeTurns: true,
+    });
+    expect(result).toMatchObject({
+      status: "forked",
+      upstream: {
+        marker: { turnId: null, userMessageCount: 0 },
+        threadId: "thread-forked",
+      },
+    });
+    if (result.status !== "forked") {
+      throw new Error("expected the Codex fork to succeed");
+    }
+    await result.attach({
+      agentId: "main",
+      sessionId: "session-local-fork",
+      sessionKey: "agent:main:fork",
+    });
+    expect(mutate).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: "session-local-fork" }),
+      expect.objectContaining({
+        kind: "set",
+        binding: expect.objectContaining({ threadId: "thread-forked" }),
+      }),
+    );
+    await result.archive();
+    expect(mutate).toHaveBeenLastCalledWith(
+      expect.objectContaining({ sessionId: "session-local-fork" }),
+      { kind: "clear", threadId: "thread-forked" },
+    );
+    expect(archiveThread).toHaveBeenCalledWith("thread-forked");
+  });
+
+  it("archives a recoverable orphan id when the fork response is invalid", async () => {
+    const archiveThread = vi.fn(async () => undefined);
+    const control = {
+      archiveThread,
+      connectionFingerprint: "fingerprint",
+      forkThread: vi.fn(async () => ({ thread: { id: "thread-orphan" } })),
+    } as unknown as CodexSessionCatalogControl;
+    control.withPinnedConnection = async (run) => await run(control);
+
+    const result = await forkCodexUpstreamSession(
+      {
+        source: {
+          agentId: "main",
+          sessionId: "session-source",
+          sessionKey: "agent:main:source",
+          storePath: "/tmp/sessions.db",
+          entryId: "entry-2",
+        },
+        upstream: {
+          kind: "codex-app-server",
+          threadId: "thread-source",
+          ref: { connectionFingerprint: "fingerprint", threadId: "thread-source" },
+        },
+      },
+      {
+        bindingStore: {} as CodexAppServerBindingStore,
+        control,
+      },
+    );
+
+    expect(result).toMatchObject({ status: "failed", code: "upstream-unavailable" });
+    expect(archiveThread).toHaveBeenCalledWith("thread-orphan");
+  });
+});

--- a/extensions/codex/src/app-server/upstream-session-fork.ts
+++ b/extensions/codex/src/app-server/upstream-session-fork.ts
@@ -65,9 +65,7 @@ export async function forkCodexUpstreamSession(
       // beforeTurnId is experimental; the initialized shared client explicitly negotiates it.
       const rawResponse = await control.forkThread({
         threadId: params.upstream.threadId,
-        ...("wholeThread" in resolved.boundary
-          ? {}
-          : { beforeTurnId: resolved.boundary.beforeTurnId }),
+        beforeTurnId: resolved.boundary.beforeTurnId,
         excludeTurns: true,
       });
       let response: CodexThreadForkResponse;
@@ -78,7 +76,9 @@ export async function forkCodexUpstreamSession(
           isRecord(rawResponse.thread) && typeof rawResponse.thread.id === "string"
             ? rawResponse.thread.id.trim()
             : "";
-        if (orphanThreadId) {
+        // A malformed response cannot be trusted to name a NEW thread; never archive an
+        // id that matches the source conversation.
+        if (orphanThreadId && orphanThreadId !== params.upstream.threadId) {
           await control.archiveThread(orphanThreadId).catch(() => undefined);
         }
         throw error;

--- a/extensions/codex/src/app-server/upstream-session-fork.ts
+++ b/extensions/codex/src/app-server/upstream-session-fork.ts
@@ -97,7 +97,9 @@ export async function forkCodexUpstreamSession(
         upstream: {
           threadId,
           ref: { connectionFingerprint, threadId },
-          marker: { turnId: null, userMessageCount: 0 },
+          // Baseline at the last retained turn: a null marker would replay the fork's
+          // retained history as fresh external activity on the first monitor tick.
+          marker: resolved.boundary.retainedMarker,
         },
         attach: async (target) => {
           attachedIdentity = sessionBindingIdentity({

--- a/extensions/codex/src/app-server/upstream-session-fork.ts
+++ b/extensions/codex/src/app-server/upstream-session-fork.ts
@@ -87,6 +87,11 @@ export async function forkCodexUpstreamSession(
       if (!threadId) {
         throw new Error("Codex thread/fork response did not include a thread id");
       }
+      // A contract-violating response reusing the source id would bind (and later
+      // archive) the original conversation; reject identity reuse outright.
+      if (threadId === params.upstream.threadId) {
+        throw new Error("Codex thread/fork response reused the source thread id");
+      }
       const connectionFingerprint = control.connectionFingerprint;
       if (!connectionFingerprint) {
         throw new Error("Codex fork connection did not include a fingerprint");

--- a/extensions/codex/src/app-server/upstream-session-fork.ts
+++ b/extensions/codex/src/app-server/upstream-session-fork.ts
@@ -1,0 +1,144 @@
+import type {
+  AgentHarnessSessionForkParams,
+  AgentHarnessSessionForkResult,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { CodexSessionCatalogControl } from "../session-catalog-types.js";
+import { assertCodexThreadForkResponse } from "./protocol-validators.js";
+import type { CodexThreadForkResponse } from "./protocol.js";
+import { sessionBindingIdentity, type CodexAppServerBindingStore } from "./session-binding.js";
+import {
+  listCodexUpstreamTurns,
+  precheckCodexUpstreamForkBoundary,
+  resolveCodexUpstreamForkBoundary,
+} from "./upstream-fork-boundary.js";
+
+function readConnectionFingerprint(ref: unknown): string | undefined {
+  if (!isRecord(ref)) {
+    return undefined;
+  }
+  return typeof ref.connectionFingerprint === "string" && ref.connectionFingerprint.trim()
+    ? ref.connectionFingerprint
+    : undefined;
+}
+
+export async function forkCodexUpstreamSession(
+  params: AgentHarnessSessionForkParams,
+  options: {
+    bindingStore: CodexAppServerBindingStore;
+    control: CodexSessionCatalogControl;
+    resolveConfig?: () => OpenClawConfig | undefined;
+  },
+): Promise<AgentHarnessSessionForkResult> {
+  try {
+    return await options.control.withPinnedConnection(async (control) => {
+      const sourceFingerprint = readConnectionFingerprint(params.upstream.ref);
+      if (
+        params.upstream.kind !== "codex-app-server" ||
+        !sourceFingerprint ||
+        sourceFingerprint !== control.connectionFingerprint
+      ) {
+        return {
+          status: "failed",
+          code: "upstream-unavailable",
+          message:
+            "This Codex thread is not available on the current connection. Reconnect to its host and try again.",
+        };
+      }
+      const resolved = await resolveCodexUpstreamForkBoundary({
+        ...params.source,
+        threadId: params.upstream.threadId,
+        control,
+      });
+      if (!resolved.ok) {
+        return { status: "failed", code: resolved.code, message: resolved.message };
+      }
+      const liveTurns = await listCodexUpstreamTurns(control, params.upstream.threadId);
+      const precheck = precheckCodexUpstreamForkBoundary({
+        boundary: resolved.boundary,
+        turns: liveTurns,
+      });
+      if (!precheck.ok) {
+        return { status: "failed", code: precheck.code, message: precheck.message };
+      }
+      // beforeTurnId is experimental; the initialized shared client explicitly negotiates it.
+      const rawResponse = await control.forkThread({
+        threadId: params.upstream.threadId,
+        ...("wholeThread" in resolved.boundary
+          ? {}
+          : { beforeTurnId: resolved.boundary.beforeTurnId }),
+        excludeTurns: true,
+      });
+      let response: CodexThreadForkResponse;
+      try {
+        response = assertCodexThreadForkResponse(rawResponse);
+      } catch (error) {
+        const orphanThreadId =
+          isRecord(rawResponse.thread) && typeof rawResponse.thread.id === "string"
+            ? rawResponse.thread.id.trim()
+            : "";
+        if (orphanThreadId) {
+          await control.archiveThread(orphanThreadId).catch(() => undefined);
+        }
+        throw error;
+      }
+      const threadId = response.thread.id.trim();
+      if (!threadId) {
+        throw new Error("Codex thread/fork response did not include a thread id");
+      }
+      const connectionFingerprint = control.connectionFingerprint;
+      if (!connectionFingerprint) {
+        throw new Error("Codex fork connection did not include a fingerprint");
+      }
+      let attachedIdentity: ReturnType<typeof sessionBindingIdentity> | undefined;
+      return {
+        status: "forked",
+        upstream: {
+          threadId,
+          ref: { connectionFingerprint, threadId },
+          marker: { turnId: null, userMessageCount: 0 },
+        },
+        attach: async (target) => {
+          attachedIdentity = sessionBindingIdentity({
+            ...target,
+            config: options.resolveConfig?.(),
+          });
+          const attached = await options.bindingStore.mutate(attachedIdentity, {
+            kind: "set",
+            binding: {
+              threadId,
+              cwd: response.thread.cwd ?? "",
+              model: response.model,
+              modelProvider: response.modelProvider ?? undefined,
+              historyCoveredThrough: new Date().toISOString(),
+            },
+          });
+          if (!attached) {
+            throw new Error("Codex session binding changed before the fork could be attached");
+          }
+        },
+        archive: async () => {
+          if (attachedIdentity) {
+            await options.bindingStore
+              .mutate(attachedIdentity, { kind: "clear", threadId })
+              .catch(() => undefined);
+          }
+          await options.control.withPinnedConnection(async (archiveControl) => {
+            if (archiveControl.connectionFingerprint !== connectionFingerprint) {
+              throw new Error("Codex connection changed before orphan cleanup");
+            }
+            await archiveControl.archiveThread(threadId);
+          });
+        },
+      };
+    });
+  } catch {
+    return {
+      status: "failed",
+      code: "upstream-unavailable",
+      message:
+        "The Codex thread could not be forked. Check that Codex is available, then try again.",
+    };
+  }
+}

--- a/extensions/codex/src/app-server/upstream-session-fork.ts
+++ b/extensions/codex/src/app-server/upstream-session-fork.ts
@@ -3,11 +3,18 @@ import type {
   AgentHarnessSessionForkResult,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
+import {
+  deleteSessionUpstreamLink,
+  upsertSessionUpstreamLink,
+} from "openclaw/plugin-sdk/session-catalog";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { CodexSessionCatalogControl } from "../session-catalog-types.js";
+import { codexLastTerminalTurnId, codexUpstreamBaseline } from "../session-upstream-marker.js";
 import { assertCodexThreadForkResponse } from "./protocol-validators.js";
-import type { CodexThreadForkResponse } from "./protocol.js";
+import type { CodexThread, CodexThreadForkResponse } from "./protocol.js";
 import { sessionBindingIdentity, type CodexAppServerBindingStore } from "./session-binding.js";
+import { createImportedCodexSession } from "./session-history-import.js";
 import {
   listCodexUpstreamTurns,
   precheckCodexUpstreamForkBoundary,
@@ -23,16 +30,35 @@ function readConnectionFingerprint(ref: unknown): string | undefined {
     : undefined;
 }
 
+function normalizeTurnId(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
 export async function forkCodexUpstreamSession(
   params: AgentHarnessSessionForkParams,
   options: {
     bindingStore: CodexAppServerBindingStore;
     control: CodexSessionCatalogControl;
+    harnessRuntimeId: string;
     resolveConfig?: () => OpenClawConfig | undefined;
+    runtime: PluginRuntime;
   },
 ): Promise<AgentHarnessSessionForkResult> {
   try {
     return await options.control.withPinnedConnection(async (control) => {
+      let linked = false;
+      let bindingIdentity: ReturnType<typeof sessionBindingIdentity> | undefined;
+      const compensateFork = async (forkedThreadId: string) => {
+        if (bindingIdentity) {
+          await options.bindingStore
+            .mutate(bindingIdentity, { kind: "clear", threadId: forkedThreadId })
+            .catch(() => undefined);
+        }
+        if (linked) {
+          deleteSessionUpstreamLink(params.targetKey, params.source.agentId);
+        }
+        await control.archiveThread(forkedThreadId).catch(() => undefined);
+      };
       const sourceFingerprint = readConnectionFingerprint(params.upstream.ref);
       if (
         params.upstream.kind !== "codex-app-server" ||
@@ -92,53 +118,95 @@ export async function forkCodexUpstreamSession(
       if (threadId === params.upstream.threadId) {
         throw new Error("Codex thread/fork response reused the source thread id");
       }
-      const connectionFingerprint = control.connectionFingerprint;
-      if (!connectionFingerprint) {
-        throw new Error("Codex fork connection did not include a fingerprint");
-      }
-      let attachedIdentity: ReturnType<typeof sessionBindingIdentity> | undefined;
-      return {
-        status: "forked",
-        upstream: {
-          threadId,
-          ref: { connectionFingerprint, threadId },
-          // Baseline at the last retained turn: a null marker would replay the fork's
-          // retained history as fresh external activity on the first monitor tick.
-          marker: resolved.boundary.retainedMarker,
-        },
-        attach: async (target) => {
-          attachedIdentity = sessionBindingIdentity({
-            ...target,
-            config: options.resolveConfig?.(),
-          });
-          const attached = await options.bindingStore.mutate(attachedIdentity, {
-            kind: "set",
-            binding: {
+      const forkedThreadId = threadId;
+      try {
+        const connectionFingerprint = control.connectionFingerprint;
+        if (!connectionFingerprint) {
+          throw new Error("Codex fork connection did not include a fingerprint");
+        }
+        const forkedTurns = await listCodexUpstreamTurns(control, threadId);
+        const expectedLastTurnId = resolved.boundary.retainedMarker.turnId;
+        const actualLastTurnId = forkedTurns.at(-1)?.id ?? null;
+        // Boundary resolution already verified the source prefix; this read-back tail identity
+        // detects app-server versions that ignored the exclusive beforeTurnId cut.
+        if (actualLastTurnId !== expectedLastTurnId) {
+          await compensateFork(forkedThreadId);
+          return {
+            status: "failed",
+            code: "upstream-unavailable",
+            message:
+              "This Codex version does not support message-level forks. Update Codex, reconnect, and try again.",
+          };
+        }
+        const forkedThread: CodexThread = { ...response.thread, turns: forkedTurns };
+        const throughTurnId = codexLastTerminalTurnId(forkedThread, normalizeTurnId) ?? null;
+        const marker = codexUpstreamBaseline(forkedThread, normalizeTurnId);
+        const config = options.resolveConfig?.() ?? {};
+        const created = await createImportedCodexSession({
+          runtime: options.runtime,
+          config,
+          key: params.targetKey,
+          agentId: params.source.agentId,
+          thread: forkedThread,
+          throughTurnId,
+          initialEntry: {
+            agentHarnessId: options.harnessRuntimeId,
+            modelSelectionLocked: true,
+          },
+          afterImport: async (entry) => {
+            bindingIdentity = sessionBindingIdentity({
+              agentId: entry.agentId,
+              sessionId: entry.sessionId,
+              sessionKey: entry.key,
+              config,
+            });
+            // Link BEFORE bind: a crash cannot expose a bound session to local-only
+            // rewind/switch while its canonical upstream ownership is missing.
+            linked = upsertSessionUpstreamLink({
+              sessionKey: entry.key,
+              agentId: entry.agentId,
+              catalogId: params.upstream.catalogId,
+              hostId: params.upstream.hostId,
               threadId,
-              cwd: response.thread.cwd ?? "",
-              model: response.model,
-              modelProvider: response.modelProvider ?? undefined,
-              historyCoveredThrough: new Date().toISOString(),
-            },
-          });
-          if (!attached) {
-            throw new Error("Codex session binding changed before the fork could be attached");
-          }
-        },
-        archive: async () => {
-          if (attachedIdentity) {
-            await options.bindingStore
-              .mutate(attachedIdentity, { kind: "clear", threadId })
-              .catch(() => undefined);
-          }
-          await options.control.withPinnedConnection(async (archiveControl) => {
-            if (archiveControl.connectionFingerprint !== connectionFingerprint) {
-              throw new Error("Codex connection changed before orphan cleanup");
+              upstreamKind: params.upstream.kind,
+              upstreamRef: { connectionFingerprint, threadId },
+              marker,
+            });
+            if (!linked) {
+              throw new Error("Codex fork link could not be persisted");
             }
-            await archiveControl.archiveThread(threadId);
-          });
-        },
-      };
+            const attached = await options.bindingStore.mutate(bindingIdentity, {
+              kind: "set",
+              binding: {
+                threadId,
+                cwd: forkedThread.cwd ?? "",
+                model: response.model,
+                modelProvider: response.modelProvider ?? undefined,
+                historyCoveredThrough: new Date().toISOString(),
+              },
+            });
+            if (!attached) {
+              throw new Error("Codex session binding changed before the fork could be attached");
+            }
+            return { pluginExtensions: entry.entry.pluginExtensions };
+          },
+        });
+        return {
+          status: "created",
+          key: created.key,
+          ...(resolved.editorText !== undefined ? { editorText: resolved.editorText } : {}),
+        };
+      } catch {
+        // thread/fork commits before local materialization. The guarded session initializer
+        // rolls back its row/transcript; this capability clears link/binding and archives the orphan.
+        await compensateFork(forkedThreadId);
+        return {
+          status: "failed",
+          code: "upstream-unavailable",
+          message:
+            "The Codex fork could not be verified or imported into a new session. Refresh sessions and try again.",
+        };
+      }
     });
   } catch {
     return {

--- a/extensions/codex/src/session-catalog-types.ts
+++ b/extensions/codex/src/session-catalog-types.ts
@@ -1,5 +1,7 @@
 import type {
   CodexThread,
+  CodexThreadForkParams,
+  CodexThreadForkResponse,
   CodexThreadListParams,
   CodexThreadListResponse,
   CodexThreadTurnsListParams,
@@ -45,6 +47,7 @@ export type CodexSessionCatalogControl = {
   listPage(params: CodexSessionCatalogPageParams): Promise<CodexSessionCatalogPage>;
   listDescendantPage(params: CodexThreadListParams): Promise<CodexThreadListResponse>;
   listTurnPage(params: CodexThreadTurnsListParams): Promise<CodexThreadTurnsListResponse>;
+  forkThread(params: CodexThreadForkParams): Promise<CodexThreadForkResponse>;
   readThread(threadId: string, includeTurns?: boolean): Promise<CodexThread>;
   archiveThread(threadId: string): Promise<void>;
 };

--- a/extensions/codex/src/session-catalog.ts
+++ b/extensions/codex/src/session-catalog.ts
@@ -16,8 +16,11 @@ import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { CODEX_CONTROL_METHODS } from "./app-server/capabilities.js";
 import { resolveCodexSupervisionAppServerRuntimeOptions } from "./app-server/config.js";
 import { buildCodexAppServerConnectionFingerprint } from "./app-server/plugin-app-cache-key.js";
+import { assertCodexThreadForkParams } from "./app-server/protocol-validators.js";
 import type {
   CodexThread,
+  CodexThreadForkParams,
+  CodexThreadForkResponse,
   CodexThreadListParams,
   CodexThreadListResponse,
   CodexThreadTurnsListParams,
@@ -123,6 +126,7 @@ type CodexSessionCatalogRequestSnapshot = {
   requestTimeoutMs: number;
   listThreads(params: CodexThreadListParams, timeoutMs: number): Promise<CodexThreadListResponse>;
   listThreadTurns(params: CodexThreadTurnsListParams): Promise<CodexThreadTurnsListResponse>;
+  forkThread(params: CodexThreadForkParams): Promise<CodexThreadForkResponse>;
   readThread(threadId: string, includeTurns: boolean): Promise<CodexThread>;
   archiveThread(threadId: string): Promise<void>;
 };
@@ -213,6 +217,9 @@ function createCodexSessionCatalogControlFromRequests(params: {
       const response = await params.createRequestSnapshot().listThreadTurns(listParams);
       return response;
     },
+    async forkThread(forkParams) {
+      return await params.createRequestSnapshot().forkThread(forkParams);
+    },
     async archiveThread(threadId) {
       await params.createRequestSnapshot().archiveThread(threadId);
     },
@@ -255,6 +262,13 @@ export function createCodexSessionCatalogControl(params: {
           pluginConfig,
           CODEX_CONTROL_METHODS.listThreadTurns,
           listParams,
+          requestOptions,
+        ),
+      forkThread: async (forkParams) =>
+        await codexControlRequest(
+          pluginConfig,
+          CODEX_CONTROL_METHODS.forkThread,
+          assertCodexThreadForkParams(forkParams),
           requestOptions,
         ),
       archiveThread: async (threadId) => {
@@ -304,6 +318,14 @@ export function createCodexSessionCatalogControl(params: {
             client,
             method: CODEX_CONTROL_METHODS.listThreadTurns,
             requestParams: listParams,
+            config: runtimeConfig,
+            timeoutMs: runtime.requestTimeoutMs,
+          }),
+        forkThread: async (forkParams) =>
+          await requestCodexAppServerClientJson<CodexThreadForkResponse>({
+            client,
+            method: CODEX_CONTROL_METHODS.forkThread,
+            requestParams: assertCodexThreadForkParams(forkParams),
             config: runtimeConfig,
             timeoutMs: runtime.requestTimeoutMs,
           }),

--- a/extensions/codex/src/session-catalog.ts
+++ b/extensions/codex/src/session-catalog.ts
@@ -11,7 +11,6 @@ import type {
   SessionCatalogHost,
   SessionCatalogProvider,
 } from "openclaw/plugin-sdk/session-catalog";
-import { resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { CODEX_CONTROL_METHODS } from "./app-server/capabilities.js";
 import { resolveCodexSupervisionAppServerRuntimeOptions } from "./app-server/config.js";
@@ -34,12 +33,12 @@ import {
   type CodexAppServerPendingSupervisionBranch,
   type CodexAppServerThreadBinding,
 } from "./app-server/session-binding.js";
+import { createImportedCodexSession } from "./app-server/session-history-import.js";
 import {
   getLeasedSharedCodexAppServerClient,
   releaseLeasedSharedCodexAppServerClient,
 } from "./app-server/shared-client.js";
 import { assertCodexArchiveDescendantsUnowned } from "./app-server/thread-archive-guard.js";
-import { importCodexThreadHistoryToTranscript } from "./app-server/transcript-mirror.js";
 import { codexControlRequest } from "./command-rpc.js";
 import {
   adoptedSourceKey,
@@ -888,17 +887,17 @@ async function createOrReuseAdoptedSession(params: {
   let createdBindingIdentity: ReturnType<typeof sessionBindingIdentity> | undefined;
   let createdPendingBinding: CodexAppServerPendingSupervisionBranch | undefined;
   try {
-    const label = params.sourceThread.name?.trim() || undefined;
     const spawnedCwd = params.sourceThread.cwd?.trim() || undefined;
     const pendingLastTurnId = codexLastTerminalTurnId(params.sourceThread, boundCatalogSessionId);
     const marker: CodexSupervisionMarker = { sourceThreadId: params.sourceThread.id };
-    const created = await params.api.runtime.agent.session.createSessionEntry({
-      cfg: params.config,
+    const created = await createImportedCodexSession({
+      runtime: params.api.runtime,
+      config: params.config,
       key: adoptionSessionKey(params.sourceThread.id),
       agentId: resolveDefaultAgentId(params.config),
+      thread: params.sourceThread,
+      throughTurnId: pendingLastTurnId ?? null,
       recoverMatchingInitialEntry: true,
-      ...(label ? { label } : {}),
-      ...(spawnedCwd ? { spawnedCwd } : {}),
       initialEntry: {
         agentHarnessId: "codex",
         modelSelectionLocked: true,
@@ -912,26 +911,10 @@ async function createOrReuseAdoptedSession(params: {
           },
         },
       },
-      afterCreate: async (entry) => {
+      afterImport: async (entry) => {
         createdBindingIdentity = sessionBindingIdentity({
           sessionId: entry.sessionId,
           sessionKey: entry.key,
-          config: params.config,
-        });
-        // Post-flip the mirror targets SQLite rows; resolve the agent's store
-        // path instead of trusting the legacy sessionFile locator marker.
-        const storePath = resolveStorePath(params.config.session?.store, {
-          agentId: entry.agentId,
-        });
-        await importCodexThreadHistoryToTranscript({
-          thread: params.sourceThread,
-          throughTurnId: pendingLastTurnId ?? null,
-          storePath,
-          sessionId: entry.sessionId,
-          sessionKey: entry.key,
-          agentId: entry.agentId,
-          ...(spawnedCwd ? { cwd: spawnedCwd } : {}),
-          modelProvider: params.sourceThread.modelProvider,
           config: params.config,
         });
         createdPendingBinding = {

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -282,7 +282,9 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
       // +9: shared ingress monitor factory and lifecycle/result contracts across
       // channel-outbound and its two deprecated compatibility barrels.
       // +1: SwarmConfig exposes the tools.swarm contract through config-types.
-      8178,
+      // +3: harness sessionFork capability params, result, and failure-code contracts.
+      // +2: upstream-link registry write/delete for harness-owned session forks.
+      8183,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -327,7 +329,8 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
       // +1: bounded raw transcript cursor reader.
       // +1: bounded visible transcript cursor reader.
       // +3: shared ingress monitor factory across channel-outbound and compat mirrors.
-      4546,
+      // +2: upstream-link registry write/delete for harness-owned session forks.
+      4548,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/agents/harness/types.ts
+++ b/src/agents/harness/types.ts
@@ -128,6 +128,44 @@ export type AgentHarnessResetParams = {
   reason?: "new" | "reset" | "idle" | "daily" | "compaction" | "deleted" | "unknown";
 };
 
+export type AgentHarnessSessionForkFailureCode =
+  | "steer-message"
+  | "in-progress-turn"
+  | "drift-mismatch"
+  | "upstream-unavailable";
+
+export type AgentHarnessSessionForkParams = {
+  source: {
+    agentId: string;
+    sessionId: string;
+    sessionKey: string;
+    storePath: string;
+    entryId: string;
+  };
+  upstream: {
+    kind: import("../../plugins/session-catalog.js").SessionUpstreamKind;
+    threadId: string;
+    ref: import("../../plugins/session-catalog.js").SessionUpstreamJsonValue;
+  };
+};
+
+export type AgentHarnessSessionForkResult =
+  | {
+      status: "forked";
+      upstream: {
+        threadId: string;
+        ref: import("../../plugins/session-catalog.js").SessionUpstreamJsonValue;
+        marker: import("../../plugins/session-catalog.js").SessionUpstreamJsonValue;
+      };
+      attach(params: { agentId: string; sessionId: string; sessionKey: string }): Promise<void>;
+      archive(): Promise<void>;
+    }
+  | {
+      status: "failed";
+      code: AgentHarnessSessionForkFailureCode;
+      message: string;
+    };
+
 export type AgentHarnessResultClassification =
   | "ok"
   | NonNullable<AgentHarnessAttemptResult["agentHarnessResultClassification"]>;
@@ -188,6 +226,13 @@ type AgentHarnessSessionLifecycleCapability = {
   dispose?(): Promise<void> | void;
 };
 
+type AgentHarnessSessionForkCapability = {
+  sessionFork?: {
+    upstreamKinds: readonly import("../../plugins/session-catalog.js").SessionUpstreamKind[];
+    fork(params: AgentHarnessSessionForkParams): Promise<AgentHarnessSessionForkResult>;
+  };
+};
+
 type AgentHarnessRuntimeArtifactCapability = {
   /** Revalidate an artifact only at setup and persistent-operation boundaries. */
   runtimeArtifact?: {
@@ -225,6 +270,7 @@ export type AgentHarness = AgentHarnessRunCapability &
   AgentHarnessRuntimeArtifactCapability &
   AgentHarnessAuthBindingCapability &
   AgentHarnessProviderUsageCapability &
+  AgentHarnessSessionForkCapability &
   AgentHarnessSessionLifecycleCapability;
 
 export type RegisteredAgentHarness = {

--- a/src/agents/harness/types.ts
+++ b/src/agents/harness/types.ts
@@ -135,6 +135,7 @@ export type AgentHarnessSessionForkFailureCode =
   | "upstream-unavailable";
 
 export type AgentHarnessSessionForkParams = {
+  targetKey: string;
   source: {
     agentId: string;
     sessionId: string;
@@ -143,6 +144,8 @@ export type AgentHarnessSessionForkParams = {
     entryId: string;
   };
   upstream: {
+    catalogId: string;
+    hostId: string;
     kind: import("../../plugins/session-catalog.js").SessionUpstreamKind;
     threadId: string;
     ref: import("../../plugins/session-catalog.js").SessionUpstreamJsonValue;
@@ -151,14 +154,9 @@ export type AgentHarnessSessionForkParams = {
 
 export type AgentHarnessSessionForkResult =
   | {
-      status: "forked";
-      upstream: {
-        threadId: string;
-        ref: import("../../plugins/session-catalog.js").SessionUpstreamJsonValue;
-        marker: import("../../plugins/session-catalog.js").SessionUpstreamJsonValue;
-      };
-      attach(params: { agentId: string; sessionId: string; sessionKey: string }): Promise<void>;
-      archive(): Promise<void>;
+      status: "created";
+      key: string;
+      editorText?: string;
     }
   | {
       status: "failed";

--- a/src/agents/harness/types.ts
+++ b/src/agents/harness/types.ts
@@ -131,7 +131,6 @@ export type AgentHarnessResetParams = {
 export type AgentHarnessSessionForkFailureCode =
   | "steer-message"
   | "in-progress-turn"
-  | "first-message"
   | "drift-mismatch"
   | "upstream-unavailable";
 

--- a/src/agents/harness/types.ts
+++ b/src/agents/harness/types.ts
@@ -131,6 +131,7 @@ export type AgentHarnessResetParams = {
 export type AgentHarnessSessionForkFailureCode =
   | "steer-message"
   | "in-progress-turn"
+  | "first-message"
   | "drift-mismatch"
   | "upstream-unavailable";
 

--- a/src/gateway/server-methods/sessions-rewind.test.ts
+++ b/src/gateway/server-methods/sessions-rewind.test.ts
@@ -8,8 +8,29 @@ import type { GatewayRequestContext, RespondFn } from "./types.js";
 
 const mocks = vi.hoisted(() => ({
   active: false,
+  capability: false,
   external: false,
+  archive: vi.fn(),
+  attach: vi.fn(),
+  upstreamFork: vi.fn(),
+  upstreamUpsert: vi.fn(),
   queueClear: vi.fn(),
+}));
+
+vi.mock("../../agents/harness/registry.js", () => ({
+  listRegisteredAgentHarnesses: () =>
+    mocks.capability
+      ? [
+          {
+            harness: {
+              sessionFork: {
+                upstreamKinds: ["codex-app-server"],
+                fork: mocks.upstreamFork,
+              },
+            },
+          },
+        ]
+      : [],
 }));
 
 vi.mock("../../auto-reply/reply/queue/cleanup.js", () => ({
@@ -17,7 +38,20 @@ vi.mock("../../auto-reply/reply/queue/cleanup.js", () => ({
 }));
 
 vi.mock("../../sessions/session-upstream-links.js", () => ({
-  readSessionUpstreamLink: () => (mocks.external ? { upstreamKind: "external" } : undefined),
+  readSessionUpstreamLink: () =>
+    mocks.external
+      ? {
+          agentId: "main",
+          catalogId: "codex",
+          hostId: "gateway:local",
+          marker: { turnId: "turn-2", userMessageCount: 1 },
+          sessionKey,
+          threadId: "thread-source",
+          upstreamKind: "codex-app-server",
+          upstreamRef: { connectionFingerprint: "fingerprint", threadId: "thread-source" },
+        }
+      : undefined,
+  upsertSessionUpstreamLink: mocks.upstreamUpsert,
 }));
 
 vi.mock("./session-active-runs.js", () => {
@@ -27,8 +61,11 @@ vi.mock("./session-active-runs.js", () => {
 import {
   appendTranscriptEvent,
   appendTranscriptMessage,
+  listSessionEntries,
+  loadSessionEntry,
   upsertSessionEntry,
 } from "../../config/sessions/session-accessor.js";
+import { readVisibleSessionTranscriptMessageEntries } from "../../plugin-sdk/session-transcript-runtime.js";
 import { sessionsHandlers } from "./sessions.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -36,7 +73,12 @@ const sessionKey = "agent:main:rewind-handler";
 
 beforeEach(async () => {
   mocks.active = false;
+  mocks.capability = false;
   mocks.external = false;
+  mocks.archive.mockReset().mockResolvedValue(undefined);
+  mocks.attach.mockReset();
+  mocks.upstreamFork.mockReset();
+  mocks.upstreamUpsert.mockReset().mockReturnValue(true);
   mocks.queueClear.mockReset();
   vi.stubEnv("OPENCLAW_STATE_DIR", tempDirs.make("openclaw-rewind-handler-"));
   await upsertSessionEntry(
@@ -221,6 +263,198 @@ describe("session message-cut methods", () => {
       );
     }
   });
+
+  it("forks an upstream-linked session and binds the local mirror", async () => {
+    mocks.external = true;
+    mocks.capability = true;
+    mocks.upstreamFork.mockResolvedValue({
+      status: "forked",
+      upstream: {
+        threadId: "thread-forked",
+        ref: { connectionFingerprint: "fingerprint", threadId: "thread-forked" },
+        marker: { turnId: null, userMessageCount: 0 },
+      },
+      archive: mocks.archive,
+      attach: mocks.attach,
+    });
+
+    const respond = await invoke("sessions.fork", "user-entry");
+    const result = respond.mock.calls[0]?.[1] as { sessionKey?: string } | undefined;
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ editorText: "edit me", sessionKey: expect.any(String) }),
+      undefined,
+    );
+    expect(mocks.upstreamFork).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: expect.objectContaining({ entryId: "user-entry", sessionKey }),
+        upstream: expect.objectContaining({
+          kind: "codex-app-server",
+          threadId: "thread-source",
+        }),
+      }),
+    );
+    const forkedEntry = loadSessionEntry({ agentId: "main", sessionKey: result?.sessionKey ?? "" });
+    expect(forkedEntry?.sessionId).toBeTruthy();
+    expect(
+      await readVisibleSessionTranscriptMessageEntries({
+        agentId: "main",
+        sessionId: forkedEntry?.sessionId ?? "",
+        sessionKey: result?.sessionKey ?? "",
+      }),
+    ).toEqual([]);
+    expect(mocks.upstreamUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        marker: { turnId: null, userMessageCount: 0 },
+        sessionKey: result?.sessionKey,
+        threadId: "thread-forked",
+      }),
+    );
+    expect(mocks.attach).toHaveBeenCalledWith({
+      agentId: "main",
+      sessionId: forkedEntry?.sessionId,
+      sessionKey: result?.sessionKey,
+    });
+  });
+
+  it("does not mutate the local session when the upstream fork fails", async () => {
+    mocks.external = true;
+    mocks.capability = true;
+    mocks.upstreamFork.mockResolvedValue({
+      status: "failed",
+      code: "upstream-unavailable",
+      message: "Codex is offline. Try again.",
+    });
+
+    const entryCount = listSessionEntries({ agentId: "main" }).length;
+    const respond = await invoke("sessions.fork", "user-entry");
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: ErrorCodes.UNAVAILABLE,
+        details: { reason: "upstream-unavailable" },
+      }),
+    );
+    expect(mocks.upstreamUpsert).not.toHaveBeenCalled();
+    expect(mocks.attach).not.toHaveBeenCalled();
+    expect(listSessionEntries({ agentId: "main" })).toHaveLength(entryCount);
+  });
+
+  it("archives an upstream fork when the local mirror fork fails", async () => {
+    mocks.external = true;
+    mocks.capability = true;
+    mocks.upstreamFork.mockResolvedValue({
+      status: "forked",
+      upstream: {
+        threadId: "thread-orphan",
+        ref: { connectionFingerprint: "fingerprint", threadId: "thread-orphan" },
+        marker: { turnId: null, userMessageCount: 0 },
+      },
+      archive: mocks.archive,
+      attach: mocks.attach,
+    });
+
+    const respond = await invoke("sessions.fork", "missing");
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "message entry not found: missing" }),
+    );
+    expect(mocks.archive).toHaveBeenCalledOnce();
+    expect(mocks.upstreamUpsert).not.toHaveBeenCalled();
+    expect(mocks.attach).not.toHaveBeenCalled();
+  });
+
+  it("rolls back the local mirror when binding attachment fails", async () => {
+    mocks.external = true;
+    mocks.capability = true;
+    mocks.attach.mockRejectedValue(new Error("binding conflict"));
+    mocks.upstreamFork.mockResolvedValue({
+      status: "forked",
+      upstream: {
+        threadId: "thread-orphan",
+        ref: { connectionFingerprint: "fingerprint", threadId: "thread-orphan" },
+        marker: { turnId: null, userMessageCount: 0 },
+      },
+      archive: mocks.archive,
+      attach: mocks.attach,
+    });
+    const entryCount = listSessionEntries({ agentId: "main" }).length;
+
+    const respond = await invoke("sessions.fork", "user-entry");
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: ErrorCodes.UNAVAILABLE,
+        message: expect.stringContaining("could not be attached"),
+      }),
+    );
+    expect(mocks.archive).toHaveBeenCalledOnce();
+    expect(mocks.upstreamUpsert).not.toHaveBeenCalled();
+    expect(listSessionEntries({ agentId: "main" })).toHaveLength(entryCount);
+  });
+
+  it("rolls back both forks when the upstream link cannot be persisted", async () => {
+    mocks.external = true;
+    mocks.capability = true;
+    mocks.upstreamUpsert.mockReturnValue(false);
+    mocks.upstreamFork.mockResolvedValue({
+      status: "forked",
+      upstream: {
+        threadId: "thread-orphan",
+        ref: { connectionFingerprint: "fingerprint", threadId: "thread-orphan" },
+        marker: { turnId: null, userMessageCount: 0 },
+      },
+      archive: mocks.archive,
+      attach: mocks.attach,
+    });
+    const entryCount = listSessionEntries({ agentId: "main" }).length;
+
+    const respond = await invoke("sessions.fork", "user-entry");
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: ErrorCodes.UNAVAILABLE,
+        message: expect.stringContaining("could not be linked"),
+      }),
+    );
+    expect(mocks.archive).toHaveBeenCalledOnce();
+    expect(mocks.attach).toHaveBeenCalledOnce();
+    expect(listSessionEntries({ agentId: "main" })).toHaveLength(entryCount);
+  });
+
+  it.each(["steer-message", "in-progress-turn", "drift-mismatch"] as const)(
+    "passes through the %s boundary failure",
+    async (reason) => {
+      mocks.external = true;
+      mocks.capability = true;
+      mocks.upstreamFork.mockResolvedValue({
+        status: "failed",
+        code: reason,
+        message: `boundary failed: ${reason}`,
+      });
+
+      const respond = await invoke("sessions.fork", "user-entry");
+
+      expect(respond).toHaveBeenCalledWith(
+        false,
+        undefined,
+        expect.objectContaining({
+          code: ErrorCodes.INVALID_REQUEST,
+          details: { reason },
+          message: `boundary failed: ${reason}`,
+        }),
+      );
+      expect(mocks.upstreamUpsert).not.toHaveBeenCalled();
+    },
+  );
 
   it("returns a typed error for unsupported transcript storage", async () => {
     await upsertSessionEntry(

--- a/src/gateway/server-methods/sessions-rewind.test.ts
+++ b/src/gateway/server-methods/sessions-rewind.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   attach: vi.fn(),
   upstreamFork: vi.fn(),
   upstreamUpsert: vi.fn(),
+  upstreamDelete: vi.fn(),
   queueClear: vi.fn(),
 }));
 
@@ -52,6 +53,7 @@ vi.mock("../../sessions/session-upstream-links.js", () => ({
         }
       : undefined,
   upsertSessionUpstreamLink: mocks.upstreamUpsert,
+  deleteSessionUpstreamLink: mocks.upstreamDelete,
 }));
 
 vi.mock("./session-active-runs.js", () => {
@@ -79,6 +81,7 @@ beforeEach(async () => {
   mocks.attach.mockReset();
   mocks.upstreamFork.mockReset();
   mocks.upstreamUpsert.mockReset().mockReturnValue(true);
+  mocks.upstreamDelete.mockReset();
   mocks.queueClear.mockReset();
   vi.stubEnv("OPENCLAW_STATE_DIR", tempDirs.make("openclaw-rewind-handler-"));
   await upsertSessionEntry(
@@ -414,7 +417,8 @@ describe("session message-cut methods", () => {
       }),
     );
     expect(mocks.archive).toHaveBeenCalledOnce();
-    expect(mocks.upstreamUpsert).not.toHaveBeenCalled();
+    expect(mocks.upstreamUpsert).toHaveBeenCalledOnce();
+    expect(mocks.upstreamDelete).toHaveBeenCalledOnce();
     expect(listSessionEntries({ agentId: "main" })).toHaveLength(entryCount);
   });
 
@@ -445,7 +449,7 @@ describe("session message-cut methods", () => {
       }),
     );
     expect(mocks.archive).toHaveBeenCalledOnce();
-    expect(mocks.attach).toHaveBeenCalledOnce();
+    expect(mocks.attach).not.toHaveBeenCalled();
     expect(listSessionEntries({ agentId: "main" })).toHaveLength(entryCount);
   });
 

--- a/src/gateway/server-methods/sessions-rewind.test.ts
+++ b/src/gateway/server-methods/sessions-rewind.test.ts
@@ -264,6 +264,25 @@ describe("session message-cut methods", () => {
     }
   });
 
+  it.each(["sessions.rewind", "sessions.branches.switch"] as const)(
+    "rejects %s for upstream-linked sessions even with a fork-capable harness",
+    async (method) => {
+      mocks.external = true;
+      mocks.capability = true;
+      const respond = await invoke(method, "user-entry");
+
+      expect(respond).toHaveBeenCalledWith(
+        false,
+        undefined,
+        expect.objectContaining({
+          code: ErrorCodes.INVALID_REQUEST,
+          message: expect.stringContaining("external agent harness"),
+        }),
+      );
+      expect(mocks.upstreamFork).not.toHaveBeenCalled();
+    },
+  );
+
   it("forks an upstream-linked session and binds the local mirror", async () => {
     mocks.external = true;
     mocks.capability = true;

--- a/src/gateway/server-methods/sessions-rewind.test.ts
+++ b/src/gateway/server-methods/sessions-rewind.test.ts
@@ -10,11 +10,7 @@ const mocks = vi.hoisted(() => ({
   active: false,
   capability: false,
   external: false,
-  archive: vi.fn(),
-  attach: vi.fn(),
   upstreamFork: vi.fn(),
-  upstreamUpsert: vi.fn(),
-  upstreamDelete: vi.fn(),
   queueClear: vi.fn(),
 }));
 
@@ -52,8 +48,6 @@ vi.mock("../../sessions/session-upstream-links.js", () => ({
           upstreamRef: { connectionFingerprint: "fingerprint", threadId: "thread-source" },
         }
       : undefined,
-  upsertSessionUpstreamLink: mocks.upstreamUpsert,
-  deleteSessionUpstreamLink: mocks.upstreamDelete,
 }));
 
 vi.mock("./session-active-runs.js", () => {
@@ -64,10 +58,8 @@ import {
   appendTranscriptEvent,
   appendTranscriptMessage,
   listSessionEntries,
-  loadSessionEntry,
   upsertSessionEntry,
 } from "../../config/sessions/session-accessor.js";
-import { readVisibleSessionTranscriptMessageEntries } from "../../plugin-sdk/session-transcript-runtime.js";
 import { sessionsHandlers } from "./sessions.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -77,11 +69,7 @@ beforeEach(async () => {
   mocks.active = false;
   mocks.capability = false;
   mocks.external = false;
-  mocks.archive.mockReset().mockResolvedValue(undefined);
-  mocks.attach.mockReset();
   mocks.upstreamFork.mockReset();
-  mocks.upstreamUpsert.mockReset().mockReturnValue(true);
-  mocks.upstreamDelete.mockReset();
   mocks.queueClear.mockReset();
   vi.stubEnv("OPENCLAW_STATE_DIR", tempDirs.make("openclaw-rewind-handler-"));
   await upsertSessionEntry(
@@ -286,57 +274,33 @@ describe("session message-cut methods", () => {
     },
   );
 
-  it("forks an upstream-linked session and binds the local mirror", async () => {
+  it("delegates complete upstream fork materialization to the harness", async () => {
     mocks.external = true;
     mocks.capability = true;
     mocks.upstreamFork.mockResolvedValue({
-      status: "forked",
-      upstream: {
-        threadId: "thread-forked",
-        ref: { connectionFingerprint: "fingerprint", threadId: "thread-forked" },
-        marker: { turnId: null, userMessageCount: 0 },
-      },
-      archive: mocks.archive,
-      attach: mocks.attach,
+      status: "created",
+      key: "agent:main:dashboard:forked",
+      editorText: "edit me",
     });
 
     const respond = await invoke("sessions.fork", "user-entry");
-    const result = respond.mock.calls[0]?.[1] as { sessionKey?: string } | undefined;
     expect(respond).toHaveBeenCalledWith(
       true,
-      expect.objectContaining({ editorText: "edit me", sessionKey: expect.any(String) }),
+      { editorText: "edit me", sessionKey: "agent:main:dashboard:forked" },
       undefined,
     );
     expect(mocks.upstreamFork).toHaveBeenCalledWith(
       expect.objectContaining({
         source: expect.objectContaining({ entryId: "user-entry", sessionKey }),
+        targetKey: expect.stringMatching(/^agent:main:dashboard:/),
         upstream: expect.objectContaining({
+          catalogId: "codex",
+          hostId: "gateway:local",
           kind: "codex-app-server",
           threadId: "thread-source",
         }),
       }),
     );
-    const forkedEntry = loadSessionEntry({ agentId: "main", sessionKey: result?.sessionKey ?? "" });
-    expect(forkedEntry?.sessionId).toBeTruthy();
-    expect(
-      await readVisibleSessionTranscriptMessageEntries({
-        agentId: "main",
-        sessionId: forkedEntry?.sessionId ?? "",
-        sessionKey: result?.sessionKey ?? "",
-      }),
-    ).toEqual([]);
-    expect(mocks.upstreamUpsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        marker: { turnId: null, userMessageCount: 0 },
-        sessionKey: result?.sessionKey,
-        threadId: "thread-forked",
-      }),
-    );
-    expect(mocks.attach).toHaveBeenCalledWith({
-      agentId: "main",
-      sessionId: forkedEntry?.sessionId,
-      sessionKey: result?.sessionKey,
-    });
   });
 
   it("does not mutate the local session when the upstream fork fails", async () => {
@@ -359,97 +323,6 @@ describe("session message-cut methods", () => {
         details: { reason: "upstream-unavailable" },
       }),
     );
-    expect(mocks.upstreamUpsert).not.toHaveBeenCalled();
-    expect(mocks.attach).not.toHaveBeenCalled();
-    expect(listSessionEntries({ agentId: "main" })).toHaveLength(entryCount);
-  });
-
-  it("archives an upstream fork when the local mirror fork fails", async () => {
-    mocks.external = true;
-    mocks.capability = true;
-    mocks.upstreamFork.mockResolvedValue({
-      status: "forked",
-      upstream: {
-        threadId: "thread-orphan",
-        ref: { connectionFingerprint: "fingerprint", threadId: "thread-orphan" },
-        marker: { turnId: null, userMessageCount: 0 },
-      },
-      archive: mocks.archive,
-      attach: mocks.attach,
-    });
-
-    const respond = await invoke("sessions.fork", "missing");
-
-    expect(respond).toHaveBeenCalledWith(
-      false,
-      undefined,
-      expect.objectContaining({ message: "message entry not found: missing" }),
-    );
-    expect(mocks.archive).toHaveBeenCalledOnce();
-    expect(mocks.upstreamUpsert).not.toHaveBeenCalled();
-    expect(mocks.attach).not.toHaveBeenCalled();
-  });
-
-  it("rolls back the local mirror when binding attachment fails", async () => {
-    mocks.external = true;
-    mocks.capability = true;
-    mocks.attach.mockRejectedValue(new Error("binding conflict"));
-    mocks.upstreamFork.mockResolvedValue({
-      status: "forked",
-      upstream: {
-        threadId: "thread-orphan",
-        ref: { connectionFingerprint: "fingerprint", threadId: "thread-orphan" },
-        marker: { turnId: null, userMessageCount: 0 },
-      },
-      archive: mocks.archive,
-      attach: mocks.attach,
-    });
-    const entryCount = listSessionEntries({ agentId: "main" }).length;
-
-    const respond = await invoke("sessions.fork", "user-entry");
-
-    expect(respond).toHaveBeenCalledWith(
-      false,
-      undefined,
-      expect.objectContaining({
-        code: ErrorCodes.UNAVAILABLE,
-        message: expect.stringContaining("could not be attached"),
-      }),
-    );
-    expect(mocks.archive).toHaveBeenCalledOnce();
-    expect(mocks.upstreamUpsert).toHaveBeenCalledOnce();
-    expect(mocks.upstreamDelete).toHaveBeenCalledOnce();
-    expect(listSessionEntries({ agentId: "main" })).toHaveLength(entryCount);
-  });
-
-  it("rolls back both forks when the upstream link cannot be persisted", async () => {
-    mocks.external = true;
-    mocks.capability = true;
-    mocks.upstreamUpsert.mockReturnValue(false);
-    mocks.upstreamFork.mockResolvedValue({
-      status: "forked",
-      upstream: {
-        threadId: "thread-orphan",
-        ref: { connectionFingerprint: "fingerprint", threadId: "thread-orphan" },
-        marker: { turnId: null, userMessageCount: 0 },
-      },
-      archive: mocks.archive,
-      attach: mocks.attach,
-    });
-    const entryCount = listSessionEntries({ agentId: "main" }).length;
-
-    const respond = await invoke("sessions.fork", "user-entry");
-
-    expect(respond).toHaveBeenCalledWith(
-      false,
-      undefined,
-      expect.objectContaining({
-        code: ErrorCodes.UNAVAILABLE,
-        message: expect.stringContaining("could not be linked"),
-      }),
-    );
-    expect(mocks.archive).toHaveBeenCalledOnce();
-    expect(mocks.attach).not.toHaveBeenCalled();
     expect(listSessionEntries({ agentId: "main" })).toHaveLength(entryCount);
   });
 
@@ -475,7 +348,6 @@ describe("session message-cut methods", () => {
           message: `boundary failed: ${reason}`,
         }),
       );
-      expect(mocks.upstreamUpsert).not.toHaveBeenCalled();
     },
   );
 

--- a/src/gateway/server-methods/sessions-rewind.ts
+++ b/src/gateway/server-methods/sessions-rewind.ts
@@ -24,6 +24,7 @@ import {
   runExclusiveSessionLifecycleMutation,
 } from "../../sessions/session-lifecycle-admission.js";
 import {
+  deleteSessionUpstreamLink,
   readSessionUpstreamLink,
   upsertSessionUpstreamLink,
   type SessionUpstreamLink,
@@ -399,34 +400,9 @@ async function mutateSessionAtMessage(
         return;
       }
       if (upstreamLink && upstreamFork?.status === "forked") {
-        try {
-          await upstreamFork.attach({
-            agentId: current.target.agentId,
-            sessionId: result.entry.sessionId,
-            sessionKey: result.key,
-          });
-        } catch {
-          await upstreamFork.archive().catch(() => undefined);
-          await deleteSessionEntryLifecycle({
-            agentId: current.target.agentId,
-            archiveTranscript: true,
-            expectedEntry: result.entry,
-            expectedSessionId: result.entry.sessionId,
-            expectedUpdatedAt: result.entry.updatedAt,
-            storePath: current.storePath,
-            target: { canonicalKey: result.key, storeKeys: [result.key] },
-          }).catch(() => undefined);
-          respond(
-            false,
-            undefined,
-            errorShape(
-              ErrorCodes.UNAVAILABLE,
-              "The Codex fork was created but could not be attached. Refresh sessions and try again.",
-              { details: { reason: "upstream-unavailable" } },
-            ),
-          );
-          return;
-        }
+        // Link BEFORE attach: a crash between the two leaves the session marked
+        // upstream-owned with no binding (rewind/switch stay rejected), never a
+        // bound session the local mutation path could silently diverge.
         const linked = upsertSessionUpstreamLink({
           sessionKey: result.key,
           agentId: current.target.agentId,
@@ -438,7 +414,31 @@ async function mutateSessionAtMessage(
           marker: upstreamFork.upstream.marker,
         });
         if (!linked) {
+          await abandonForkedSession(
+            "The Codex fork could not be linked to the new session. Refresh sessions and try again.",
+          );
+          return;
+        }
+        try {
+          await upstreamFork.attach({
+            agentId: current.target.agentId,
+            sessionId: result.entry.sessionId,
+            sessionKey: result.key,
+          });
+        } catch {
+          deleteSessionUpstreamLink(result.key, current.target.agentId);
+          await abandonForkedSession(
+            "The Codex fork was created but could not be attached. Refresh sessions and try again.",
+          );
+          return;
+        }
+      }
+
+      async function abandonForkedSession(message: string): Promise<void> {
+        if (upstreamFork?.status === "forked") {
           await upstreamFork.archive().catch(() => undefined);
+        }
+        if (result.status === "created") {
           await deleteSessionEntryLifecycle({
             agentId: current.target.agentId,
             archiveTranscript: true,
@@ -448,17 +448,14 @@ async function mutateSessionAtMessage(
             storePath: current.storePath,
             target: { canonicalKey: result.key, storeKeys: [result.key] },
           }).catch(() => undefined);
-          respond(
-            false,
-            undefined,
-            errorShape(
-              ErrorCodes.UNAVAILABLE,
-              "The Codex fork could not be linked to the new session. Refresh sessions and try again.",
-              { details: { reason: "upstream-unavailable" } },
-            ),
-          );
-          return;
         }
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.UNAVAILABLE, message, {
+            details: { reason: "upstream-unavailable" },
+          }),
+        );
       }
       if (action !== "fork") {
         clearSessionQueues(lifecycleIdentities);

--- a/src/gateway/server-methods/sessions-rewind.ts
+++ b/src/gateway/server-methods/sessions-rewind.ts
@@ -193,7 +193,9 @@ async function mutateSessionAtMessage(
   const initialSessionId = initial.entry.sessionId;
   const initialLifecycleRevision = initial.entry.lifecycleRevision;
   const initialUpstreamLink = readSessionUpstreamLink(initial.canonicalKey, initial.target.agentId);
-  if (initialUpstreamLink && action === "rewind") {
+  // Only fork may cross to an upstream-owned conversation (it creates a new thread).
+  // Rewind and switch would mutate the shared upstream history in place; fail closed.
+  if (initialUpstreamLink && action !== "fork") {
     respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, EXTERNAL_CONVERSATION_ERROR));
     return;
   }
@@ -288,7 +290,7 @@ async function mutateSessionAtMessage(
         return;
       }
       const upstreamLink = readSessionUpstreamLink(current.canonicalKey, current.target.agentId);
-      if (upstreamLink && action === "rewind") {
+      if (upstreamLink && action !== "fork") {
         respond(
           false,
           undefined,

--- a/src/gateway/server-methods/sessions-rewind.ts
+++ b/src/gateway/server-methods/sessions-rewind.ts
@@ -7,8 +7,10 @@ import {
   validateSessionsRewindParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { listRegisteredAgentHarnesses } from "../../agents/harness/registry.js";
 import { clearSessionQueues } from "../../auto-reply/reply/queue/cleanup.js";
 import {
+  deleteSessionEntryLifecycle,
   forkSessionAtMessage,
   listSessionBranches,
   rewindSessionToMessage,
@@ -21,7 +23,11 @@ import {
   isCompetingSessionWorkAdmissionActive,
   runExclusiveSessionLifecycleMutation,
 } from "../../sessions/session-lifecycle-admission.js";
-import { readSessionUpstreamLink } from "../../sessions/session-upstream-links.js";
+import {
+  readSessionUpstreamLink,
+  upsertSessionUpstreamLink,
+  type SessionUpstreamLink,
+} from "../../sessions/session-upstream-links.js";
 import {
   buildDashboardSessionKey,
   resolveRequestedSessionAgentId as resolveRequestedGlobalAgentId,
@@ -41,6 +47,13 @@ type MessageCutAction = "fork" | "rewind" | "switch";
 
 const EXTERNAL_CONVERSATION_ERROR =
   "Session history changes are unavailable because this session is owned by an external agent harness.";
+
+function resolveUpstreamForkHarness(link: SessionUpstreamLink) {
+  const matches = listRegisteredAgentHarnesses().filter((entry) =>
+    entry.harness.sessionFork?.upstreamKinds.includes(link.upstreamKind),
+  );
+  return matches.length === 1 ? matches[0]?.harness.sessionFork : undefined;
+}
 
 export const sessionRewindHandlers: GatewayRequestHandlers = {
   "sessions.branches.list": async (options) => {
@@ -179,7 +192,8 @@ async function mutateSessionAtMessage(
   }
   const initialSessionId = initial.entry.sessionId;
   const initialLifecycleRevision = initial.entry.lifecycleRevision;
-  if (readSessionUpstreamLink(initial.canonicalKey, initial.target.agentId)) {
+  const initialUpstreamLink = readSessionUpstreamLink(initial.canonicalKey, initial.target.agentId);
+  if (initialUpstreamLink && action === "rewind") {
     respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, EXTERNAL_CONVERSATION_ERROR));
     return;
   }
@@ -273,7 +287,8 @@ async function mutateSessionAtMessage(
         );
         return;
       }
-      if (readSessionUpstreamLink(current.canonicalKey, current.target.agentId)) {
+      const upstreamLink = readSessionUpstreamLink(current.canonicalKey, current.target.agentId);
+      if (upstreamLink && action === "rewind") {
         respond(
           false,
           undefined,
@@ -293,33 +308,155 @@ async function mutateSessionAtMessage(
       }
       const targetKey =
         action === "fork" ? buildDashboardSessionKey(current.target.agentId) : current.canonicalKey;
-      const result = await (action === "fork"
-        ? forkSessionAtMessage({
-            agentId: current.target.agentId,
-            entryId,
-            sessionKey: current.canonicalKey,
-            sessionStoreKey: current.sessionStoreKey,
-            storePath: current.storePath,
-            targetKey,
-          })
-        : action === "rewind"
-          ? rewindSessionToMessage({
+      const upstreamForkHarness = upstreamLink
+        ? resolveUpstreamForkHarness(upstreamLink)
+        : undefined;
+      if (upstreamLink && !upstreamForkHarness) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, EXTERNAL_CONVERSATION_ERROR),
+        );
+        return;
+      }
+      const upstreamFork =
+        upstreamLink && upstreamForkHarness
+          ? await upstreamForkHarness.fork({
+              source: {
+                agentId: current.target.agentId,
+                sessionId: current.entry.sessionId,
+                sessionKey: current.canonicalKey,
+                storePath: current.storePath,
+                entryId,
+              },
+              upstream: {
+                kind: upstreamLink.upstreamKind,
+                threadId: upstreamLink.threadId,
+                ref: upstreamLink.upstreamRef,
+              },
+            })
+          : undefined;
+      if (upstreamFork?.status === "failed") {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            upstreamFork.code === "upstream-unavailable"
+              ? ErrorCodes.UNAVAILABLE
+              : ErrorCodes.INVALID_REQUEST,
+            upstreamFork.message,
+            { details: { reason: upstreamFork.code } },
+          ),
+        );
+        return;
+      }
+      let result: SessionMessageCutMutationResult | SessionBranchSwitchMutationResult;
+      try {
+        result = await (action === "fork"
+          ? forkSessionAtMessage({
               agentId: current.target.agentId,
               entryId,
               sessionKey: current.canonicalKey,
               sessionStoreKey: current.sessionStoreKey,
               storePath: current.storePath,
+              targetKey,
             })
-          : switchSessionBranch({
-              agentId: current.target.agentId,
-              leafEntryId: entryId,
-              sessionKey: current.canonicalKey,
-              sessionStoreKey: current.sessionStoreKey,
-              storePath: current.storePath,
-            }));
+          : action === "rewind"
+            ? rewindSessionToMessage({
+                agentId: current.target.agentId,
+                entryId,
+                sessionKey: current.canonicalKey,
+                sessionStoreKey: current.sessionStoreKey,
+                storePath: current.storePath,
+              })
+            : switchSessionBranch({
+                agentId: current.target.agentId,
+                leafEntryId: entryId,
+                sessionKey: current.canonicalKey,
+                sessionStoreKey: current.sessionStoreKey,
+                storePath: current.storePath,
+              }));
+      } catch {
+        if (upstreamFork?.status === "forked") {
+          await upstreamFork.archive().catch(() => undefined);
+        }
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.UNAVAILABLE, `Failed to ${action} the local session. Try again.`),
+        );
+        return;
+      }
       if (result.status !== "created") {
+        if (upstreamFork?.status === "forked") {
+          // The upstream fork commits before SQLite by contract; archive it if the local mirror
+          // cannot commit so a failed OpenClaw action does not leave an unmanaged Codex thread.
+          await upstreamFork.archive().catch(() => undefined);
+        }
         respondMessageCutError(result, action, entryId, respond);
         return;
+      }
+      if (upstreamLink && upstreamFork?.status === "forked") {
+        try {
+          await upstreamFork.attach({
+            agentId: current.target.agentId,
+            sessionId: result.entry.sessionId,
+            sessionKey: result.key,
+          });
+        } catch {
+          await upstreamFork.archive().catch(() => undefined);
+          await deleteSessionEntryLifecycle({
+            agentId: current.target.agentId,
+            archiveTranscript: true,
+            expectedEntry: result.entry,
+            expectedSessionId: result.entry.sessionId,
+            expectedUpdatedAt: result.entry.updatedAt,
+            storePath: current.storePath,
+            target: { canonicalKey: result.key, storeKeys: [result.key] },
+          }).catch(() => undefined);
+          respond(
+            false,
+            undefined,
+            errorShape(
+              ErrorCodes.UNAVAILABLE,
+              "The Codex fork was created but could not be attached. Refresh sessions and try again.",
+              { details: { reason: "upstream-unavailable" } },
+            ),
+          );
+          return;
+        }
+        const linked = upsertSessionUpstreamLink({
+          sessionKey: result.key,
+          agentId: current.target.agentId,
+          catalogId: upstreamLink.catalogId,
+          hostId: upstreamLink.hostId,
+          threadId: upstreamFork.upstream.threadId,
+          upstreamKind: upstreamLink.upstreamKind,
+          upstreamRef: upstreamFork.upstream.ref,
+          marker: upstreamFork.upstream.marker,
+        });
+        if (!linked) {
+          await upstreamFork.archive().catch(() => undefined);
+          await deleteSessionEntryLifecycle({
+            agentId: current.target.agentId,
+            archiveTranscript: true,
+            expectedEntry: result.entry,
+            expectedSessionId: result.entry.sessionId,
+            expectedUpdatedAt: result.entry.updatedAt,
+            storePath: current.storePath,
+            target: { canonicalKey: result.key, storeKeys: [result.key] },
+          }).catch(() => undefined);
+          respond(
+            false,
+            undefined,
+            errorShape(
+              ErrorCodes.UNAVAILABLE,
+              "The Codex fork could not be linked to the new session. Refresh sessions and try again.",
+              { details: { reason: "upstream-unavailable" } },
+            ),
+          );
+          return;
+        }
       }
       if (action !== "fork") {
         clearSessionQueues(lifecycleIdentities);

--- a/src/gateway/server-methods/sessions-rewind.ts
+++ b/src/gateway/server-methods/sessions-rewind.ts
@@ -10,7 +10,6 @@ import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { listRegisteredAgentHarnesses } from "../../agents/harness/registry.js";
 import { clearSessionQueues } from "../../auto-reply/reply/queue/cleanup.js";
 import {
-  deleteSessionEntryLifecycle,
   forkSessionAtMessage,
   listSessionBranches,
   rewindSessionToMessage,
@@ -24,9 +23,7 @@ import {
   runExclusiveSessionLifecycleMutation,
 } from "../../sessions/session-lifecycle-admission.js";
 import {
-  deleteSessionUpstreamLink,
   readSessionUpstreamLink,
-  upsertSessionUpstreamLink,
   type SessionUpstreamLink,
 } from "../../sessions/session-upstream-links.js";
 import {
@@ -325,6 +322,7 @@ async function mutateSessionAtMessage(
       const upstreamFork =
         upstreamLink && upstreamForkHarness
           ? await upstreamForkHarness.fork({
+              targetKey,
               source: {
                 agentId: current.target.agentId,
                 sessionId: current.entry.sessionId,
@@ -333,6 +331,8 @@ async function mutateSessionAtMessage(
                 entryId,
               },
               upstream: {
+                catalogId: upstreamLink.catalogId,
+                hostId: upstreamLink.hostId,
                 kind: upstreamLink.upstreamKind,
                 threadId: upstreamLink.threadId,
                 ref: upstreamLink.upstreamRef,
@@ -351,6 +351,28 @@ async function mutateSessionAtMessage(
             { details: { reason: upstreamFork.code } },
           ),
         );
+        return;
+      }
+      if (upstreamFork?.status === "created") {
+        // Canonical fork lineage stays upstream. Linked sessions intentionally do not enter
+        // the local branch graph; branch listing/switching remains rejected for them above.
+        respond(
+          true,
+          {
+            sessionKey: upstreamFork.key,
+            ...(upstreamFork.editorText !== undefined
+              ? { editorText: upstreamFork.editorText }
+              : {}),
+          },
+          undefined,
+        );
+        emitSessionsChanged(context, {
+          sessionKey: upstreamFork.key,
+          ...(upstreamFork.key === "global" && requestedAgent.agentId
+            ? { agentId: requestedAgent.agentId }
+            : {}),
+          reason: "fork",
+        });
         return;
       }
       let result: SessionMessageCutMutationResult | SessionBranchSwitchMutationResult;
@@ -380,9 +402,6 @@ async function mutateSessionAtMessage(
                 storePath: current.storePath,
               }));
       } catch {
-        if (upstreamFork?.status === "forked") {
-          await upstreamFork.archive().catch(() => undefined);
-        }
         respond(
           false,
           undefined,
@@ -391,71 +410,8 @@ async function mutateSessionAtMessage(
         return;
       }
       if (result.status !== "created") {
-        if (upstreamFork?.status === "forked") {
-          // The upstream fork commits before SQLite by contract; archive it if the local mirror
-          // cannot commit so a failed OpenClaw action does not leave an unmanaged Codex thread.
-          await upstreamFork.archive().catch(() => undefined);
-        }
         respondMessageCutError(result, action, entryId, respond);
         return;
-      }
-      if (upstreamLink && upstreamFork?.status === "forked") {
-        // Link BEFORE attach: a crash between the two leaves the session marked
-        // upstream-owned with no binding (rewind/switch stay rejected), never a
-        // bound session the local mutation path could silently diverge.
-        const linked = upsertSessionUpstreamLink({
-          sessionKey: result.key,
-          agentId: current.target.agentId,
-          catalogId: upstreamLink.catalogId,
-          hostId: upstreamLink.hostId,
-          threadId: upstreamFork.upstream.threadId,
-          upstreamKind: upstreamLink.upstreamKind,
-          upstreamRef: upstreamFork.upstream.ref,
-          marker: upstreamFork.upstream.marker,
-        });
-        if (!linked) {
-          await abandonForkedSession(
-            "The Codex fork could not be linked to the new session. Refresh sessions and try again.",
-          );
-          return;
-        }
-        try {
-          await upstreamFork.attach({
-            agentId: current.target.agentId,
-            sessionId: result.entry.sessionId,
-            sessionKey: result.key,
-          });
-        } catch {
-          deleteSessionUpstreamLink(result.key, current.target.agentId);
-          await abandonForkedSession(
-            "The Codex fork was created but could not be attached. Refresh sessions and try again.",
-          );
-          return;
-        }
-      }
-
-      async function abandonForkedSession(message: string): Promise<void> {
-        if (upstreamFork?.status === "forked") {
-          await upstreamFork.archive().catch(() => undefined);
-        }
-        if (result.status === "created") {
-          await deleteSessionEntryLifecycle({
-            agentId: current.target.agentId,
-            archiveTranscript: true,
-            expectedEntry: result.entry,
-            expectedSessionId: result.entry.sessionId,
-            expectedUpdatedAt: result.entry.updatedAt,
-            storePath: current.storePath,
-            target: { canonicalKey: result.key, storeKeys: [result.key] },
-          }).catch(() => undefined);
-        }
-        respond(
-          false,
-          undefined,
-          errorShape(ErrorCodes.UNAVAILABLE, message, {
-            details: { reason: "upstream-unavailable" },
-          }),
-        );
       }
       if (action !== "fork") {
         clearSessionQueues(lifecycleIdentities);

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -51,6 +51,9 @@ export type {
   AgentHarnessSideQuestionParams,
   AgentHarnessSideQuestionResult,
   AgentHarnessResetParams,
+  AgentHarnessSessionForkFailureCode,
+  AgentHarnessSessionForkParams,
+  AgentHarnessSessionForkResult,
   AgentHarnessSupport,
   AgentHarnessSupportContext,
 } from "../agents/harness/types.js";

--- a/src/plugin-sdk/session-catalog.ts
+++ b/src/plugin-sdk/session-catalog.ts
@@ -28,6 +28,10 @@ export type {
   SessionsCatalogReadResult,
 } from "../../packages/gateway-protocol/src/schema/sessions-catalog.js";
 export {
+  deleteSessionUpstreamLink,
+  upsertSessionUpstreamLink,
+} from "../sessions/session-upstream-links.js";
+export {
   classifyClaudeCliHistoryMessage,
   classifyClaudeCliHistoryLine,
   type ClaudeCliHistoryLineClassification,

--- a/src/sessions/session-upstream-links.ts
+++ b/src/sessions/session-upstream-links.ts
@@ -18,7 +18,7 @@ type SessionUpstreamDatabase = Pick<
 >;
 type SessionUpstreamLinkRow = Selectable<OpenClawStateKyselyDatabase["session_upstream_links"]>;
 
-type SessionUpstreamLink = {
+export type SessionUpstreamLink = {
   sessionKey: string;
   agentId: string;
   catalogId: string;
@@ -79,7 +79,7 @@ export function upsertSessionUpstreamLink(
     marker: SessionUpstreamJsonValue;
   },
   options: OpenClawStateDatabaseOptions & { now?: number } = {},
-): void {
+): boolean {
   const now = options.now ?? Date.now();
   try {
     runOpenClawStateWriteTransaction(({ db }) => {
@@ -141,8 +141,10 @@ export function upsertSessionUpstreamLink(
           ),
       );
     }, options);
+    return true;
   } catch (error) {
     log.warn(`failed to upsert session upstream link: ${String(error)}`);
+    return false;
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

`sessions.fork` (#110660) rejects sessions whose conversation is owned by an external agent harness — for Codex-app-server-backed sessions the canonical history lives in Codex rollout files addressed by threadId, so a local-mirror fork would diverge from the authoritative context. Fork from a message bubble therefore did not work for adopted/Continue Codex sessions. Final follow-up agreed in #110660.

## Why This Change Was Made

- New generic `AgentHarness.sessionFork` capability: core resolves it from the harness registry by upstream kind (single-match, fail-closed) and delegates the entire fork; core imports no plugin code. The Codex plugin registers the implementation.
- Cut-point resolution ports Codex TUI's own backtrack algorithm (`codex-rs/tui/src/app_backtrack.rs:473-544`): ordinal walk over visible turn-initial user messages with steer/review-span skips, full-prefix text verification against the local transcript, and fail-closed handling of anything unverifiable (images, skills, mentions, hidden semantic inputs), in-progress turns, and drifted text. First-message cuts fork with `beforeTurnId` of the first turn — a valid empty-history fork (verified: `thread_fork_inner` has no minimum-turn guard). Paginated-history threads are rejected with a clear message (upstream forbids forking them: `method_not_found("paginated_threads is not supported yet")`).
- Upstream fork uses `thread/fork` + experimental `beforeTurnId` (the shared client already negotiates `experimentalApi`), pinned to the connection fingerprint that owns the thread. Because an older app-server could silently drop the experimental field and copy full history, the forked thread is **read back and its tail verified** against the expected retained boundary; mismatches archive the fork and fail with a version message. A response reusing the source thread id is rejected outright and never archived.
- The local session is **materialized by importing the verified forked thread's history** (the same machinery session adoption uses), so local history derives from upstream canon instead of the best-effort mirror — no equality proof between mirror and upstream is needed beyond the cut mapping. Marker/covered-through derive from the standard adoption helpers; the upstream link is written before the binding so any crash window leaves a fail-closed (upstream-owned, unbound) session, never a locally mutable one. All compensation (archive fork, clear binding, delete link) lives in the capability.
- Rewind, branch switch, and branch listing stay rejected for upstream-linked sessions (in-place mutation of shared upstream history; upstream `thread/rollback` is deprecated). Covered by tests including the previously masked capability-registered case.
- Plugin SDK surface intentionally grows by the harness fork contracts and the upstream-link registry write/delete (ledger updated in `scripts/plugin-sdk-surface-report.mjs` with rationale). Protocol unchanged.

## User Impact

"Fork from here" now works on Codex-backed (adopted/Continue) sessions in every surface that calls `sessions.fork`: it forks the real Codex thread at the chosen message, creates a new OpenClaw session whose history is imported from that fork, and binds it for the next turn. Unsupported cases fail with precise, actionable errors (steered messages, in-progress turns, image-bearing spans, paginated threads, old Codex versions) instead of generic failures.

## Evidence

- Upstream contracts verified directly in the sibling `codex-rs` checkout: `app-server-protocol/src/protocol/v2/thread.rs:495-626` (fork params/response, experimental gating), `common.rs:494-499`, `app-server/src/request_processors/thread_processor.rs:3702+` (fork mechanics, paginated rejection, no empty-fork guard), `core/src/thread_rollout_truncation.rs:162-235` (before/after truncation asymmetry), `tui/src/app_backtrack.rs:473-544` (reference cut algorithm).
- `node scripts/run-vitest.mjs src/gateway/server-methods/sessions-rewind.test.ts` — 20 tests: capability delegation, typed failure pass-through, rewind/switch rejection for upstream links (with and without a registered capability), non-upstream paths unchanged.
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/upstream-fork-boundary.test.ts extensions/codex/src/app-server/upstream-session-fork.test.ts` — 15 tests: ordinal/prefix/steer/review/in-progress/drift/unverifiable-input/first-turn/paginated boundaries; verified import, version-skew read-back mismatch → archive + typed failure, source-id reuse rejection, compensation, fresh-target materialization.
- `pnpm tsgo:core` + `pnpm tsgo:extensions` green locally; oxlint/oxfmt clean; `pnpm plugin-sdk:surface:check` green after the ledger update.
- Seven autoreview cycles (codex `gpt-5.6-sol`) drove the design here — findings on cut semantics, marker baselines, crash ordering, drift-guard completeness, and version skew were each verified against `codex-rs` and fixed (or, for first-message forks, corrected back per upstream evidence); the final cycle on the import-based design reported no actionable findings.
