### PR TITLE
fix(ui): composer small-width polish (placeholder, scrollbar pill, talk split-button)

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1617,6 +1617,16 @@ openclaw-chat-page {
   color: var(--muted);
 }
 
+/* One ellipsized line while empty: long agent names otherwise wrap the
+   placeholder, grow the box, and surface the overlay scrollbar as a stray
+   gray pill. On the control (not ::placeholder) so Firefox honors it too;
+   typing unsets :placeholder-shown, restoring normal wrapping. */
+.agent-chat__composer-combobox > :is(textarea, input):placeholder-shown {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 @media (hover: none) and (pointer: coarse) {
   .agent-chat__composer-combobox > :is(textarea, input) {
     font-size: var(--control-ui-input-text-size);
@@ -2304,8 +2314,11 @@ openclaw-chat-page {
   border-radius: var(--radius-full) 0 0 var(--radius-full);
 }
 
+/* Stretch instead of a fixed height so the picker always matches the voice
+   button, including the 44px mobile bump in layout.mobile.css. */
 .chat-talk-input-picker {
   display: inline-flex;
+  align-self: stretch;
 }
 
 .chat-talk-input-picker__trigger {
@@ -2314,7 +2327,7 @@ openclaw-chat-page {
   justify-content: center;
   width: 20px;
   min-width: 20px;
-  height: 36px;
+  height: 100%;
   padding: 0;
   border: 0;
   border-left: 1px solid color-mix(in srgb, var(--accent) 24%, transparent);


### PR DESCRIPTION
## What Problem This Solves

At small widths the chat composer degraded three ways (screenshot report from the macOS app at narrow size): a long agent-name placeholder ("Message C-3PO (Clawd's Third Protocol Observer)") wrapped to a second, clipped line; the wrapped placeholder made the empty textarea scrollable, surfacing the overlay scrollbar as a stray gray pill next to the mic button; and the voice split-button was mismatched — the mic bumps to 44px on mobile (layout.mobile.css) while the input-picker chevron stayed at its fixed 36px height.

## Why This Change Was Made

Maintainer-reported visual bug; pure CSS fix at the owning stylesheet (ui/src/styles/chat/layout.css).

## User Impact

- Empty composer shows a single ellipsized placeholder line at any width; typing restores normal wrapping (`:placeholder-shown` gates the nowrap, applied to the control — not `::placeholder` — so Firefox honors it too).
- No more phantom scrollbar pill (the empty textarea is no longer scrollable).
- The mic + picker read as one control at every breakpoint: the picker stretches (`align-self: stretch`, `height: 100%`) instead of hardcoding 36px, so it follows the 44px mobile bump automatically.

| Before (420px) | After (420px) |
| --- | --- |
| ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/composer-small/before-narrow.png) | ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/composer-small/after-narrow.png) |

## Evidence

- Playwright measurements in the mock harness — before: mic 44×44 vs trigger 20×36, empty textarea scrollable; after: trigger 20×44 (mobile) / 20×36 (desktop), textarea not scrollable, placeholder computed `white-space: nowrap` while empty and `pre-wrap` with 110px multi-line growth once text is typed.
- Codex autoreview (gpt-5.6-sol), two rounds: round 1 correctly flagged that `text-overflow` on `::placeholder` is not reliable cross-browser — fix moved to `:placeholder-shown` on the control; round 2 clean.
