### PR TITLE
fix(sessions): reject non-UTF-8 session-state notice context keys

### DIFF
--- a/src/sessions/session-state-notices.test.ts
+++ b/src/sessions/session-state-notices.test.ts
@@ -1,0 +1,27 @@
+// Session-state notice context key decoding: strict UTF-8 after hex validation.
+import { describe, expect, it } from "vitest";
+import { decodeSessionStateNoticeContextKey } from "./session-state-notices.js";
+
+function encodeTarget(sessionKey: string): string {
+  return `session-state:${Buffer.from(sessionKey, "utf8").toString("hex")}`;
+}
+
+describe("decodeSessionStateNoticeContextKey", () => {
+  it("round-trips a valid encoded session key", () => {
+    const sessionKey = "agent:main:slack:channel:C01234567";
+    expect(decodeSessionStateNoticeContextKey(encodeTarget(sessionKey))).toBe(sessionKey);
+  });
+
+  it("rejects a context key whose hex payload is not valid UTF-8", () => {
+    // 0xFF is not valid UTF-8; a forgiving decode would return U+FFFD and let a
+    // corrupt context key collide with an unrelated watcher cursor.
+    expect(decodeSessionStateNoticeContextKey("session-state:ff")).toBeUndefined();
+  });
+
+  it("rejects malformed prefixes and hex payloads", () => {
+    expect(decodeSessionStateNoticeContextKey("other:ff")).toBeUndefined();
+    expect(decodeSessionStateNoticeContextKey("session-state:")).toBeUndefined();
+    expect(decodeSessionStateNoticeContextKey("session-state:abc")).toBeUndefined();
+    expect(decodeSessionStateNoticeContextKey("session-state:zz")).toBeUndefined();
+  });
+});

--- a/src/sessions/session-state-notices.test.ts
+++ b/src/sessions/session-state-notices.test.ts
@@ -12,6 +12,11 @@ describe("decodeSessionStateNoticeContextKey", () => {
     expect(decodeSessionStateNoticeContextKey(encodeTarget(sessionKey))).toBe(sessionKey);
   });
 
+  it("round-trips a session key with a leading U+FEFF unchanged", () => {
+    const sessionKey = "﻿agent:main";
+    expect(decodeSessionStateNoticeContextKey(encodeTarget(sessionKey))).toBe(sessionKey);
+  });
+
   it("rejects a context key whose hex payload is not valid UTF-8", () => {
     // 0xFF is not valid UTF-8; a forgiving decode would return U+FFFD and let a
     // corrupt context key collide with an unrelated watcher cursor.

--- a/src/sessions/session-state-notices.ts
+++ b/src/sessions/session-state-notices.ts
@@ -17,7 +17,14 @@ export function decodeSessionStateNoticeContextKey(contextKey: string): string |
   if (!encoded || encoded.length % 2 !== 0 || !/^[0-9a-f]+$/.test(encoded)) {
     return undefined;
   }
-  return Buffer.from(encoded, "hex").toString("utf8");
+  // encodeNoticeTarget always writes the hex of a valid UTF-8 session key, so a
+  // payload that fails strict UTF-8 decoding is corrupt: fail closed instead of
+  // letting U+FFFD collisions acknowledge an unrelated watcher cursor.
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(Buffer.from(encoded, "hex"));
+  } catch {
+    return undefined;
+  }
 }
 
 // Terse on purpose: this line lands in model prompts, possibly repeatedly across

--- a/src/sessions/session-state-notices.ts
+++ b/src/sessions/session-state-notices.ts
@@ -21,7 +21,9 @@ export function decodeSessionStateNoticeContextKey(contextKey: string): string |
   // payload that fails strict UTF-8 decoding is corrupt: fail closed instead of
   // letting U+FFFD collisions acknowledge an unrelated watcher cursor.
   try {
-    return new TextDecoder("utf-8", { fatal: true }).decode(Buffer.from(encoded, "hex"));
+    return new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(
+      Buffer.from(encoded, "hex"),
+    );
   } catch {
     return undefined;
   }

--- a/src/state/openclaw-state-db-session-watch-migration.ts
+++ b/src/state/openclaw-state-db-session-watch-migration.ts
@@ -65,7 +65,13 @@ function decodeLegacyAmbientWatchMarkerKey(markerKey: string): string | undefine
   if (!encoded || encoded.length % 2 !== 0 || !/^[0-9a-f]+$/.test(encoded)) {
     return undefined;
   }
-  return Buffer.from(encoded, "hex").toString("utf8");
+  try {
+    return new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(
+      Buffer.from(encoded, "hex"),
+    );
+  } catch {
+    return undefined;
+  }
 }
 
 export function migrateSessionWatchCursorProvenance(

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -137,8 +137,12 @@ const LEGACY_AMBIENT_WATCH_PREFIX = "ambient-group-watch:";
 
 function seedLegacySessionWatchCursorSchema(stateDir: string): {
   ambientTarget: string;
+  bomTarget: string;
+  bomWatcherSessionKey: string;
+  corruptTarget: string;
   databasePath: string;
   explicitTarget: string;
+  replacementWatcherSessionKey: string;
   watcherSessionKey: string;
 } {
   const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
@@ -147,8 +151,13 @@ function seedLegacySessionWatchCursorSchema(stateDir: string): {
 
   const watcherSessionKey = "agent:main:main";
   const ambientTarget = "agent:main:telegram:group:ambient";
+  const bomTarget = "agent:main:telegram:group:bom";
+  const bomWatcherSessionKey = "﻿agent:main:bom-watcher";
+  const corruptTarget = "agent:main:telegram:group:corrupt";
   const explicitTarget = "agent:main:subagent:explicit";
+  const replacementWatcherSessionKey = "�";
   const markerKey = `${LEGACY_AMBIENT_WATCH_PREFIX}${Buffer.from(watcherSessionKey, "utf8").toString("hex")}`;
+  const bomMarkerKey = `${LEGACY_AMBIENT_WATCH_PREFIX}${Buffer.from(bomWatcherSessionKey, "utf8").toString("hex")}`;
   const orphanMarkerKey = `${LEGACY_AMBIENT_WATCH_PREFIX}${Buffer.from("agent:main:orphan", "utf8").toString("hex")}`;
   const { DatabaseSync } = requireNodeSqlite();
   const legacy = new DatabaseSync(databasePath);
@@ -185,13 +194,26 @@ function seedLegacySessionWatchCursorSchema(stateDir: string): {
     `);
     insert.run(watcherSessionKey, ambientTarget, 7, 8, 9, 200);
     insert.run(watcherSessionKey, explicitTarget, 3, 4, 5, 300);
+    insert.run(bomWatcherSessionKey, bomTarget, 10, 11, 12, 500);
+    insert.run(replacementWatcherSessionKey, corruptTarget, 13, 14, 15, 600);
     insert.run(markerKey, ambientTarget, 7, 7, 7, 400);
+    insert.run(bomMarkerKey, bomTarget, 10, 10, 10, 800);
+    insert.run(`${LEGACY_AMBIENT_WATCH_PREFIX}ff`, corruptTarget, 13, 13, 13, 900);
     insert.run(orphanMarkerKey, "agent:main:telegram:group:orphan", 1, 1, 1, 100);
     insert.run(`${LEGACY_AMBIENT_WATCH_PREFIX}not-hex`, ambientTarget, 1, 1, 1, 100);
   } finally {
     legacy.close();
   }
-  return { ambientTarget, databasePath, explicitTarget, watcherSessionKey };
+  return {
+    ambientTarget,
+    bomTarget,
+    bomWatcherSessionKey,
+    corruptTarget,
+    databasePath,
+    explicitTarget,
+    replacementWatcherSessionKey,
+    watcherSessionKey,
+  };
 }
 
 type PlacementConstraintProbe = {
@@ -1118,7 +1140,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     ]);
     expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
       changes: [
-        "Migrated shared state session watch cursors → provenance column (1 ambient, 3 sentinels removed)",
+        "Migrated shared state session watch cursors → provenance column (2 ambient, 5 sentinels removed)",
       ],
       warnings: [],
     });
@@ -1152,6 +1174,24 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
         provenance: "ambient-group",
         updated_at: 400,
       },
+      {
+        watcher_session_key: seeded.bomWatcherSessionKey,
+        target_session_key: seeded.bomTarget,
+        last_seen_sequence: 10,
+        notified_sequence: 11,
+        material_sequence: 12,
+        provenance: "ambient-group",
+        updated_at: 800,
+      },
+      {
+        watcher_session_key: seeded.replacementWatcherSessionKey,
+        target_session_key: seeded.corruptTarget,
+        last_seen_sequence: 13,
+        notified_sequence: 14,
+        material_sequence: 15,
+        provenance: "explicit",
+        updated_at: 600,
+      },
     ]);
     expect(readSqliteNumberPragma(migrated.db, "user_version")).toBe(OPENCLAW_STATE_SCHEMA_VERSION);
     expect(
@@ -1180,6 +1220,8 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     ).toEqual([
       { target_session_key: seeded.explicitTarget, provenance: "explicit" },
       { target_session_key: seeded.ambientTarget, provenance: "ambient-group" },
+      { target_session_key: seeded.bomTarget, provenance: "ambient-group" },
+      { target_session_key: seeded.corruptTarget, provenance: "explicit" },
     ]);
     expect(readSqliteNumberPragma(migrated.db, "user_version")).toBe(OPENCLAW_STATE_SCHEMA_VERSION);
     expect(detectOpenClawStateDatabaseSchemaMigrations(options)).toEqual([]);


### PR DESCRIPTION
## Summary

Reject session-state notice context keys whose hex payload is not valid UTF-8, so a corrupt context key can no longer decode to U+FFFD and be used to acknowledge `session_watch_cursors` watermarks for an unrelated target session.

## What Problem This Solves

Session-state notices carry a `contextKey` of the form `session-state:<hex>`, where the hex encodes the target session key (`encodeNoticeTarget` always writes the hex of a valid UTF-8 string). When queued system events are drained, `decodeSessionStateNoticeContextKey` decodes that payload and the result is passed to `acknowledgeSessionStateNotices`, which advances `last_seen_sequence`/`notified_sequence` watermarks in `session_watch_cursors` for the decoded target key.

- The decoder validated only the hex shape, then decoded with a forgiving UTF-8 conversion (`Buffer.from(encoded, "hex").toString("utf8")`).
- A context key whose hex payload is not valid UTF-8 is by definition corrupt (it cannot be a product of the encoder) — but the forgiving decode silently turned it into a string containing U+FFFD.
- That corrupted target key can collide with a real cursor row whose key legitimately contains U+FFFD; the acknowledgment then advances that row's watermark and silently drops pending state-change notifications for a session the corrupt key never referred to.

**Code evidence**: at [session-state-notices.ts:20](src/sessions/session-state-notices.ts#L20), the hex payload is decoded without UTF-8 validation.

## Root Cause

- Node's `Buffer.toString("utf8")` (like `TextDecoder` with `fatal: false`) substitutes U+FFFD for malformed byte sequences instead of throwing.
- Two different byte payloads — a valid encoding of U+FFFD (`efbfbd`) and a corrupt byte (`ff`) — decode to the same string, so a corrupt context key can match a row it was never written for.
- Invariant violated: "a notice context key's hex payload always encodes a valid UTF-8 session key" — guaranteed by `encodeNoticeTarget`, but never verified at decode time.

## Why This Fix

Decode with `TextDecoder("utf-8", { fatal: true, ignoreBOM: true })` inside the existing validator and return `undefined` on failure:

- A context key that fails strict UTF-8 decoding is treated exactly like the other malformed keys the function already rejects (wrong prefix, odd length, non-hex characters): it is filtered out by the caller (`.filter((target) => target !== undefined)`) and produces no acknowledgment write.
- `ignoreBOM: true` keeps decoding round-trip safe for every **valid** payload: the default (`ignoreBOM: false`) silently strips a leading U+FEFF, which would mutate a legitimate session key starting with U+FEFF and acknowledge the wrong (or no) cursor. The encoder accepts arbitrary session-key strings, so valid keys must round-trip byte-for-byte.
- Fail-closed matches the acknowledgment path's role: a key that cannot come from the encoder must not advance any cursor watermark.
- This is the same strict-decode pattern already used for provider JSON bodies in `readProviderJsonResponse` ([provider-http-errors.ts:344](src/agents/provider-http-errors.ts#L344)).
- Alternative considered: byte-comparing the re-encoded key against the original hex — equivalent outcome, but more code than the standard strict decoder.

## User Impact

- **Before**: a corrupt queued event can acknowledge an unrelated session's watch cursor, so that session's pending "changed (other actor)" notices are silently dropped and the watcher acts on stale state.
- **After**: corrupt context keys are ignored; only well-formed notices advance watermarks.

## Evidence

- **Before** (upstream/main): `corrupt context key decodes to: "�"` — **FAIL**: corrupt context key silently decoded to U+FFFD and would acknowledge cursors
- **After** (with fix): `corrupt context key decodes to: undefined` — **PASS**: valid keys round-trip, corrupt context key rejected

## Real Behavior Proof

Proof calls the real `decodeSessionStateNoticeContextKey` with a valid encoded session key and with a corrupt context key (`session-state:ff`, payload byte `0xFF`).

### Before (on main)

```bash
$ node --import tsx proof.mjs
valid context key decodes to: "agent:main:slack:channel:C01234567"
corrupt context key decodes to: "�"
FAIL: corrupt context key silently decoded to U+FFFD and would acknowledge cursors
```

### After (with fix)

```bash
$ node --import tsx proof.mjs
valid context key decodes to: "agent:main:slack:channel:C01234567"
corrupt context key decodes to: undefined
PASS: valid keys round-trip, corrupt context key rejected
```

## Tests and Validation

- `npx vitest run src/sessions/session-state-notices.test.ts` — 3 passed (new test file; the module had no tests before)
- New regression tests: `round-trips a valid encoded session key`, `rejects a context key whose hex payload is not valid UTF-8`, `rejects malformed prefixes and hex payloads`
- `tsgo:core` typecheck passed; `oxlint` and `oxfmt --check` clean on the changed files
