### PR TITLE
fix(gateway): add structured scope error details to two remaining paths

### DIFF
--- a/src/gateway/server-methods/agent-reset-phase.ts
+++ b/src/gateway/server-methods/agent-reset-phase.ts
@@ -77,7 +77,7 @@ export async function runAgentResetPhase(params: {
     params.respond(
       false,
       undefined,
-      errorShape(ErrorCodes.INVALID_REQUEST, `missing scope: ${ADMIN_SCOPE}`),
+      missingScopeErrorShape({ missingScope: ADMIN_SCOPE, requiredScopes: [ADMIN_SCOPE] }),
     );
     return { ...base, stop: true, accepted: false };
   }

--- a/src/gateway/server-methods/talk.ts
+++ b/src/gateway/server-methods/talk.ts
@@ -727,7 +727,10 @@ export const talkHandlers: GatewayRequestHandlers = {
       respond(
         false,
         undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, `missing scope: ${TALK_SECRETS_SCOPE}`),
+        missingScopeErrorShape({
+          missingScope: TALK_SECRETS_SCOPE,
+          requiredScopes: [TALK_SECRETS_SCOPE],
+        }),
       );
       return;
     }


### PR DESCRIPTION
## What Problem This Solves

PR #111013 added `MissingScopeErrorDetails` and `missingScopeErrorShape` for machine-readable scope error responses across clients, but two scope-error code paths were missed: the admin-scope check in `agent-reset-phase.ts` and the talk.secrets-scope check in `talk.ts`.

## Why This Change Was Made

These two paths still emit the legacy `errorShape` without structured `details`. Clients and tools that only read the structured `MISSING_SCOPE` code, `missingScope`, and `requiredScopes` fields from `error.details` silently fail to identify these as scope errors.

## User Impact

API clients consuming structured error details now get proper `MISSING_SCOPE` details from agent-reset-phase and talk secrets-scope failures instead of falling through to the legacy message-pattern fallback.

## Evidence

Both files already imported `missingScopeErrorShape` from PR #111013 (#62c5a8b) but did not use it in these two code paths.

```
src/gateway/server-methods/agent-reset-phase.ts:77-84
src/gateway/server-methods/talk.ts:727-733
```