### PR TITLE
fix: background image generation keeps session OAuth

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -20,7 +20,11 @@ import type { SkillWorkshopRunOptions } from "../skills/workshop/types.js";
 import { resolveTranscriptsConfig } from "../transcripts/config.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import type { GatewayMessageChannel } from "../utils/message-channel.js";
-import { resolveAgentWorkspaceDir, resolveSessionAgentIds } from "./agent-scope.js";
+import {
+  resolveAgentDir,
+  resolveAgentWorkspaceDir,
+  resolveSessionAgentIds,
+} from "./agent-scope.js";
 import {
   type HookContext,
   isToolWrappedWithBeforeToolCallHook,
@@ -291,7 +295,9 @@ export function createOpenClawTools(
   );
   const requesterSessionKey = options?.agentSessionKey;
   const requesterTurnRunId = options?.runId;
-  const imageToolAgentDir = options?.agentDir;
+  const imageToolAgentDir =
+    options?.agentDir ??
+    (resolvedConfig ? resolveAgentDir(resolvedConfig, sessionAgentId) : undefined);
   const imageTool = resolveImageToolFactoryAvailable({
     config: availabilityConfig ?? resolvedConfig,
     agentDir: imageToolAgentDir,
@@ -317,7 +323,7 @@ export function createOpenClawTools(
   const imageGenerateTool = optionalMediaTools.imageGenerate
     ? createImageGenerateTool({
         config: options?.config,
-        agentDir: options?.agentDir,
+        agentDir: imageToolAgentDir,
         authProfileStore: options?.authProfileStore,
         agentSessionKey: mediaGenerationAgentSessionKey,
         requesterOrigin: deliveryContext ?? undefined,

--- a/src/agents/openclaw-tools.tts-config.test.ts
+++ b/src/agents/openclaw-tools.tts-config.test.ts
@@ -1,6 +1,7 @@
 // Verifies createOpenClawTools wires shared config and context into the TTS tool.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveAgentDir } from "./agent-scope.js";
 import { createOpenClawTools } from "./openclaw-tools.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
@@ -333,6 +334,53 @@ describe("createOpenClawTools media generation session wiring", () => {
     expect(mocks.createImageGenerateToolOptions).toHaveBeenCalledWith(
       expect.objectContaining({
         agentSessionKey: "agent:main:slack:channel:C123",
+      }),
+    );
+  });
+
+  it("infers the image generation agent directory from the session agent", () => {
+    const config = {
+      agents: {
+        defaults: {
+          imageGenerationModel: { primary: "image-owner/model" },
+        },
+        list: [{ id: "reader" }],
+      },
+    } satisfies OpenClawConfig;
+
+    createOpenClawTools({
+      config,
+      agentSessionKey: "agent:reader:telegram:direct:123",
+      disableMessageTool: true,
+      disablePluginTools: true,
+    });
+
+    expect(mocks.createImageGenerateToolOptions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentDir: resolveAgentDir(config, "reader"),
+      }),
+    );
+  });
+
+  it("preserves an explicit image generation agent directory", () => {
+    const config = {
+      agents: {
+        defaults: {
+          imageGenerationModel: { primary: "image-owner/model" },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    createOpenClawTools({
+      config,
+      agentDir: "/tmp/openclaw-explicit-agent",
+      disableMessageTool: true,
+      disablePluginTools: true,
+    });
+
+    expect(mocks.createImageGenerateToolOptions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentDir: "/tmp/openclaw-explicit-agent",
       }),
     );
   });


### PR DESCRIPTION
Related: #87051
Related: #90074

## What Problem This Solves

Fixes an issue where users running image generation from background or session-created agent turns could receive an `OpenAI API key missing` error even though the session agent had a valid ChatGPT/Codex OAuth profile.

The image-generation tool could be constructed without an agent directory when callers supplied the session key and config but omitted the redundant `agentDir` option. Provider auth then could not find the session agent's auth store and fell back to API-key resolution.

## Why This Change Was Made

When `createOpenClawTools` has a resolved config but no explicit agent directory, it now resolves the directory from the current session agent and passes it to both image understanding and image generation. Explicit caller-provided directories remain authoritative.

The change stays within existing agent-directory and auth-profile ownership; it adds no config, migration, or provider-specific fallback.

## User Impact

Background and channel agent turns can use the same per-agent OAuth credentials for image generation as foreground turns. Users no longer need an unrelated API key solely because a tool-construction caller omitted `agentDir`.

## Evidence

- Added regression coverage for inferring the image-generation agent directory from a non-default session agent.
- Added coverage proving an explicit agent directory is preserved.
- `PATH=/tmp/node-v25.9.0-darwin-arm64/bin:$PATH node scripts/run-vitest.mjs src/agents/openclaw-tools.tts-config.test.ts` -> 12/12 tests passed.
- `PATH=/tmp/node-v25.9.0-darwin-arm64/bin:$PATH node scripts/run-oxlint.mjs src/agents/openclaw-tools.ts src/agents/openclaw-tools.tts-config.test.ts` -> passed.
- `git diff --check` -> passed.
- Production observation on OpenClaw 2026.6.1: the missing-directory path failed with `OpenAI API key missing`; applying the equivalent installed-package fix selected `provider=openai mode=oauth transport=codex-responses` and produced a valid `gpt-image-2` PNG.

AI-assisted by Codex. I reviewed the source path, tests, and resulting behavior and understand the change.
