### PR TITLE
fix(network): guarded redirects survive cleanup rejection

### DIFF
--- a/src/agents/tools/web-fetch.ssrf.test.ts
+++ b/src/agents/tools/web-fetch.ssrf.test.ts
@@ -16,7 +16,7 @@ function redirectResponse(location: string): Response {
     ok: false,
     status: 302,
     headers: makeFetchHeaders({ location }),
-    body: { cancel: vi.fn() },
+    body: { cancel: vi.fn(async () => undefined) },
   } as unknown as Response;
 }
 

--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -976,7 +976,18 @@ describe("fetchWithSsrFGuard hardening", () => {
         lookupFn: createPublicLookup(),
       });
 
-      await expect(result.response.text()).resolves.toBe("redirected");
+      const reader = result.response.body?.getReader();
+      if (!reader) {
+        throw new Error("expected redirected response body");
+      }
+      try {
+        const firstChunk = await reader.read();
+        expect(firstChunk.done).toBe(false);
+        expect(new TextDecoder().decode(firstChunk.value)).toBe("redirected");
+        await expect(reader.read()).resolves.toEqual({ done: true, value: undefined });
+      } finally {
+        reader.releaseLock();
+      }
       expect(cancel).toHaveBeenCalledOnce();
       await new Promise<void>((resolve) => {
         setImmediate(resolve);

--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -949,6 +949,46 @@ describe("fetchWithSsrFGuard hardening", () => {
     await result.release();
   });
 
+  it("preserves redirects when response body cancellation rejects", async () => {
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledRejections.push(reason);
+    };
+    const cancel = vi.fn(() => {
+      throw new Error("redirect cancellation failed");
+    });
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(new ReadableStream<Uint8Array>({ cancel }), {
+          status: 302,
+          headers: { location: "https://cdn.example.com/asset" },
+        }),
+      )
+      .mockResolvedValueOnce(okResponse("redirected"));
+    process.on("unhandledRejection", onUnhandledRejection);
+    let result: Awaited<ReturnType<typeof fetchWithSsrFGuard>> | undefined;
+
+    try {
+      result = await fetchWithSsrFGuard({
+        url: "https://api.example.com/start",
+        fetchImpl,
+        lookupFn: createPublicLookup(),
+      });
+
+      await expect(result.response.text()).resolves.toBe("redirected");
+      expect(cancel).toHaveBeenCalledOnce();
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(unhandledRejections).toStrictEqual([]);
+    } finally {
+      await result?.release();
+      process.off("unhandledRejection", onUnhandledRejection);
+      expect(process.listeners("unhandledRejection")).not.toContain(onUnhandledRejection);
+    }
+  });
+
   it("strips sensitive headers when redirect crosses origins", async () => {
     const lookupFn = createPublicLookup();
     const fetchImpl = vi

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -698,7 +698,7 @@ async function fetchWithSsrFGuardInternal(
           throw new Error("Redirect loop detected");
         }
         visited.add(nextVisitKey);
-        void response.body?.cancel();
+        void response.body?.cancel().catch(() => undefined);
         await closeDispatcher(dispatcher);
         currentUrl = nextUrl;
         continue;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where guarded fetch redirects could fail after receiving a valid redirect response when best-effort response-body cleanup rejected.

## Why This Change Was Made

Redirect processing now observes and ignores only the asynchronous rejection from cancelling the superseded response body. Redirect validation, redirect limits, and all fetch failures retain their existing behavior. A native `ReadableStream` regression covers the two-hop redirect and verifies the process-level rejection listener is always removed. The adjacent web_fetch SSRF fixture now honors the promise-returning stream cancellation contract.

## User Impact

Users can complete SSRF-guarded redirects even when the discarded redirect response cannot be cleanly cancelled.

## Evidence

- `node scripts/run-vitest.mjs src/infra/net/fetch-guard.ssrf.test.ts` — 99 tests passed.
- `node scripts/run-vitest.mjs src/agents/tools/web-fetch.ssrf.test.ts` — 11 tests passed.
- `node scripts/check-changed.mjs -- src/infra/net/fetch-guard.ts src/infra/net/fetch-guard.ssrf.test.ts src/agents/tools/web-fetch.ssrf.test.ts` — passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29672117608
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/29672075099
- Autoreview: clean, confidence 0.98.
- OpenGrep's initial test-only finding on unbounded `Response.text()` was resolved by reading the controlled fixture through its native reader and releasing the lock.

AI-assisted maintainer follow-up from the cancellation-rejection audit for #111105, #111106, and #111056.
