### PR TITLE
fix(scripts): bound Droid CLI install curl with connect/max timeouts

### DIFF
--- a/scripts/test-live-acp-bind-docker.sh
+++ b/scripts/test-live-acp-bind-docker.sh
@@ -242,7 +242,7 @@ WRAP
     ;;
   droid)
     if ! command -v droid >/dev/null 2>&1; then
-      run_setup_command bash -lc 'curl -fsSL https://app.factory.ai/cli | sh'
+      run_setup_command bash -lc 'curl -fsSL --connect-timeout 10 --max-time 120 https://app.factory.ai/cli | sh'
       export PATH="$HOME/.local/bin:$PATH"
     fi
     droid --version

--- a/scripts/test-live-acp-bind-docker.sh
+++ b/scripts/test-live-acp-bind-docker.sh
@@ -242,7 +242,13 @@ WRAP
     ;;
   droid)
     if ! command -v droid >/dev/null 2>&1; then
-      run_setup_command bash -lc 'curl -fsSL --connect-timeout 10 --max-time 120 https://app.factory.ai/cli | sh'
+      # Use -S (show error) on top of -s (silent) so that curl surfaces the
+      # reason when --connect-timeout / --max-time fire. Without -S, the
+      # silent mode would swallow the timeout error and the only signal
+      # would be the non-zero exit code from the `| sh` pipeline.
+      # `set -euo pipefail` (top of this script) ensures the curl failure
+      # propagates instead of being masked by `sh` exiting 0.
+      run_setup_command bash -lc 'curl -fsSL --show-error --connect-timeout 10 --max-time 120 https://app.factory.ai/cli | sh'
       export PATH="$HOME/.local/bin:$PATH"
     fi
     droid --version

--- a/scripts/test-live-acp-bind-docker.sh
+++ b/scripts/test-live-acp-bind-docker.sh
@@ -242,13 +242,15 @@ WRAP
     ;;
   droid)
     if ! command -v droid >/dev/null 2>&1; then
-      # Use -S (show error) on top of -s (silent) so that curl surfaces the
-      # reason when --connect-timeout / --max-time fire. Without -S, the
-      # silent mode would swallow the timeout error and the only signal
-      # would be the non-zero exit code from the `| sh` pipeline.
-      # `set -euo pipefail` (top of this script) ensures the curl failure
-      # propagates instead of being masked by `sh` exiting 0.
-      run_setup_command bash -lc 'curl -fsSL --show-error --connect-timeout 10 --max-time 120 https://app.factory.ai/cli | sh'
+      # Use `-o pipefail` on the nested bash so a curl timeout/failure
+      # propagates through the `| sh` pipeline instead of being masked by
+      # `sh` exiting 0 on empty input. The script-level `pipefail` does
+      # NOT govern this nested `bash -lc` process — without `-o pipefail`
+      # here, a stalled download would let the harness continue until
+      # `droid --version` produces a misleading secondary error.
+      # `--show-error` (curl `-S`) surfaces the timeout reason even though
+      # `-s` (silent) is part of `-fsSL`.
+      run_setup_command bash -o pipefail -lc 'curl -fsSL --show-error --connect-timeout 10 --max-time 120 https://app.factory.ai/cli | sh'
       export PATH="$HOME/.local/bin:$PATH"
     fi
     droid --version

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2194,7 +2194,7 @@ describe("package artifact reuse", () => {
     expect(workflow.match(/OPENCLAW_LIVE_ACP_BIND_CLAUDE_AUTH=subscription/g)).toHaveLength(2);
     expect(workflow.match(/OPENCLAW_LIVE_ACP_BIND_CLAUDE_AUTH=api-key/g)).toHaveLength(2);
     expect(readFileSync("scripts/test-live-acp-bind-docker.sh", "utf8")).toContain(
-      "run_setup_command bash -lc 'curl -fsSL https://app.factory.ai/cli | sh'",
+      "run_setup_command bash -lc 'curl -fsSL --connect-timeout 10 --max-time 120 https://app.factory.ai/cli | sh'",
     );
     expect(readFileSync("scripts/test-live-codex-harness-docker.sh", "utf8")).toContain(
       "OPENCLAW_LIVE_CODEX_HARNESS_DOCKER_RUN_TIMEOUT:-$((2100 * CODEX_HARNESS_TARGET_COUNT))s",

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2194,7 +2194,7 @@ describe("package artifact reuse", () => {
     expect(workflow.match(/OPENCLAW_LIVE_ACP_BIND_CLAUDE_AUTH=subscription/g)).toHaveLength(2);
     expect(workflow.match(/OPENCLAW_LIVE_ACP_BIND_CLAUDE_AUTH=api-key/g)).toHaveLength(2);
     expect(readFileSync("scripts/test-live-acp-bind-docker.sh", "utf8")).toContain(
-      "run_setup_command bash -lc 'curl -fsSL --show-error --connect-timeout 10 --max-time 120 https://app.factory.ai/cli | sh'",
+      "run_setup_command bash -o pipefail -lc 'curl -fsSL --show-error --connect-timeout 10 --max-time 120 https://app.factory.ai/cli | sh'",
     );
     expect(readFileSync("scripts/test-live-codex-harness-docker.sh", "utf8")).toContain(
       "OPENCLAW_LIVE_CODEX_HARNESS_DOCKER_RUN_TIMEOUT:-$((2100 * CODEX_HARNESS_TARGET_COUNT))s",
@@ -2230,6 +2230,49 @@ describe("package artifact reuse", () => {
       'local scripts_dir="${OPENCLAW_LIVE_DOCKER_SCRIPTS_DIR:-/src/scripts}"',
     );
     expect(stage).toContain('node --import tsx "$scripts_dir/live-docker-normalize-config.ts"');
+  });
+
+  it("propagates curl failures through the Droid CLI install pipeline (pipefail proof)", () => {
+    // ClawSweeper flagged that the script-level `set -euo pipefail` does
+    // NOT govern the nested `bash -lc 'curl ... | sh'` child process, so a
+    // stalled or failed curl could let `sh` exit 0 on empty input and
+    // defer the failure to `droid --version`. PR #111157 added
+    // `bash -o pipefail -lc` to close that gap. This test exercises the
+    // fix with a controlled failing `curl` replacement (a stub that
+    // exits 22 mimicking curl's HTTP-error exit code) and verifies the
+    // nested pipeline returns non-zero instead of letting `sh` exit 0.
+    const fs = require("node:fs") as typeof import("node:fs");
+    const path = require("node:path") as typeof import("node:path");
+    const os = require("node:os") as typeof import("node:os");
+    const { spawnSync } = require("node:child_process") as typeof import("node:child_process");
+
+    const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-pipefail-proof-"));
+    const fakeCurl = path.join(stubDir, "curl");
+    // Stub curl that exits 22 (curl's HTTP-error exit) without writing
+    // anything to stdout, simulating a --connect-timeout / --max-time
+    // failure where curl surfaces an error and exits non-zero.
+    fs.writeFileSync(fakeCurl, "#!/bin/sh\nexit 22\n");
+    fs.chmodSync(fakeCurl, 0o755);
+
+    try {
+      // Without -o pipefail: sh exits 0 because it received EOF on stdin
+      // (no input), masking the curl failure. With -o pipefail: the
+      // pipeline inherits curl's non-zero status and the bash exits 22.
+      const withoutPipefail = spawnSync("bash", ["-lc", `'${fakeCurl}' | sh`], {
+        encoding: "utf8",
+        shell: false,
+      });
+      const withPipefail = spawnSync("bash", ["-o", "pipefail", "-lc", `'${fakeCurl}' | sh`], {
+        encoding: "utf8",
+        shell: false,
+      });
+      // Sanity: without pipefail, sh exits 0 (bug)
+      expect(withoutPipefail.status).toBe(0);
+      // Fix: with pipefail, the bash inherits curl's exit 22
+      expect(withPipefail.status).toBe(22);
+    } finally {
+      fs.rmSync(stubDir, { recursive: true, force: true });
+    }
   });
 
   it("fails Droid ACP Docker live proof when Factory auth is missing", () => {

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2194,7 +2194,7 @@ describe("package artifact reuse", () => {
     expect(workflow.match(/OPENCLAW_LIVE_ACP_BIND_CLAUDE_AUTH=subscription/g)).toHaveLength(2);
     expect(workflow.match(/OPENCLAW_LIVE_ACP_BIND_CLAUDE_AUTH=api-key/g)).toHaveLength(2);
     expect(readFileSync("scripts/test-live-acp-bind-docker.sh", "utf8")).toContain(
-      "run_setup_command bash -lc 'curl -fsSL --connect-timeout 10 --max-time 120 https://app.factory.ai/cli | sh'",
+      "run_setup_command bash -lc 'curl -fsSL --show-error --connect-timeout 10 --max-time 120 https://app.factory.ai/cli | sh'",
     );
     expect(readFileSync("scripts/test-live-codex-harness-docker.sh", "utf8")).toContain(
       "OPENCLAW_LIVE_CODEX_HARNESS_DOCKER_RUN_TIMEOUT:-$((2100 * CODEX_HARNESS_TARGET_COUNT))s",


### PR DESCRIPTION
## What Problem This Solves
The live ACP bind Docker harness installs the Droid CLI via an unbounded network pipe:

```sh
run_setup_command bash -lc 'curl -fsSL https://app.factory.ai/cli | sh'
```

If `app.factory.ai` accepts the TCP connection but then stalls mid-stream, `curl` blocks forever inside the bounded setup window. The outer docker run eventually times out, but the actionable error (connection stalled, DNS unreachable, etc.) is never surfaced in the ACP bind logs.

This matches the unbounded-network-operation pattern that previous timeout/limit PRs (Dockerfile curl install, performance workflow curl install) addressed.

## Fix

Add `--connect-timeout 10 --max-time 120` to the Factory Droid CLI install curl invocation so a stalled connection fails fast and the live ACP bind logs surface the real network error:

```sh
run_setup_command bash -lc 'curl -fsSL --connect-timeout 10 --max-time 120 https://app.factory.ai/cli | sh'
```

The bounded connect/max timeouts mirror the pattern used in:
- `Dockerfile` curl installs (PR #108894)
- `.github/workflows/openclaw-performance.yml` OCM download (`--max-time 180`)

## Evidence
Update the `package-acceptance-workflow` contract test that asserts the exact ACP bind Docker setup script shape to assert the new bounded invocation. Verified the test passes locally.

## Verification

- [x] Latest `main` checked; this curl invocation is still unbounded at `scripts/test-live-acp-bind-docker.sh:245`.
- [x] Contract test in `test/scripts/package-acceptance-workflow.test.ts:2196` updated and passing locally.