### PR TITLE
fix(proxy): observe response cleanup failures during validation

### DIFF
--- a/src/infra/net/proxy/proxy-validation.test.ts
+++ b/src/infra/net/proxy/proxy-validation.test.ts
@@ -1,15 +1,19 @@
 // Covers proxy validation config precedence, TLS overrides, denied-destination
 // canaries, and APNs reachability result interpretation.
+import { EventEmitter } from "node:events";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { runProxyValidation } from "./proxy-validation.js";
 
+const TEST_UNDICI_RUNTIME_DEPS_KEY = "__OPENCLAW_TEST_UNDICI_RUNTIME_DEPS__";
+
 describe("proxy validation", () => {
   const tempDirs: string[] = [];
 
   afterEach(() => {
+    Reflect.deleteProperty(globalThis as object, TEST_UNDICI_RUNTIME_DEPS_KEY);
     for (const dir of tempDirs.splice(0)) {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -22,6 +26,40 @@ describe("proxy validation", () => {
     writeFileSync(caFile, contents, "utf8");
     return caFile;
   }
+
+  it("observes response cleanup failures in the default fetch check", async () => {
+    const cleanupError = new Error("cancel failed");
+    const cleanupRejection = Promise.reject(cleanupError);
+    const observeCleanupFailure = vi.spyOn(cleanupRejection, "catch");
+    cleanupRejection.catch(() => undefined);
+    observeCleanupFailure.mockClear();
+    const response = new Response("ok");
+    const cancel = vi.spyOn(response.body!, "cancel").mockReturnValue(cleanupRejection);
+    const close = vi.fn().mockResolvedValue(undefined);
+    const runtimeFetch = vi.fn().mockResolvedValue(response);
+
+    class MockProxyAgent extends EventEmitter {
+      close = close;
+    }
+
+    (globalThis as Record<string, unknown>)[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+      Agent: MockProxyAgent,
+      EnvHttpProxyAgent: MockProxyAgent,
+      ProxyAgent: MockProxyAgent,
+      fetch: runtimeFetch,
+    };
+
+    const result = await runProxyValidation({
+      proxyUrlOverride: "http://127.0.0.1:3128",
+      allowedUrls: ["http://127.0.0.1:8080/"],
+      deniedUrls: [],
+    });
+
+    expect(result.ok).toBe(true);
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(close).toHaveBeenCalledOnce();
+    expect(observeCleanupFailure).toHaveBeenCalledOnce();
+  });
 
   it("reports disabled proxy config when a config URL is present but proxy routing is disabled", async () => {
     const fetchCheck = vi.fn();

--- a/src/infra/net/proxy/proxy-validation.ts
+++ b/src/infra/net/proxy/proxy-validation.ts
@@ -230,7 +230,7 @@ async function defaultProxyValidationFetchCheck({
       dispatcher,
       redirect: "manual",
     });
-    void response.body?.cancel();
+    void response.body?.cancel().catch(() => undefined);
     return {
       ok: response.ok,
       status: response.status,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators validating a forward proxy could receive a process-level unhandled rejection when discarding a probe response body failed after the HTTP result had already been determined.

## Why This Change Was Made

The detached response-body cancellation now observes and swallows cleanup-only rejection while preserving the existing probe result and dispatcher-close lifecycle. This is limited to best-effort response cleanup; proxy routing, status interpretation, timeouts, and TLS behavior are unchanged.

## User Impact

Proxy validation keeps reporting the established probe result without leaking a response cleanup failure as an unhandled rejection.

## Evidence

Manual behavior proof on Node `v24.18.0` used `runProxyValidation()` with a real localhost HTTP target and CONNECT forward proxy, then the repository's Undici runtime seam with a real `ReadableStream` whose underlying `cancel()` throws. The same script was run against the then-current `upstream/main` (`c2a9579c591`) and the original patch head (`9cac5dea963`):

```text
before (upstream/main)
{"node":"v24.18.0","live":{"ok":true,"status":200,"proxyConnects":1,"targetRequests":1},"cleanup":{"ok":true,"status":200,"cancelCount":1,"closeCount":1,"unhandled":["cancel failed"]}}

after (this branch)
{"node":"v24.18.0","live":{"ok":true,"status":200,"proxyConnects":1,"targetRequests":1},"cleanup":{"ok":true,"status":200,"cancelCount":1,"closeCount":1,"unhandled":[]}}
```

The baseline also serves as the negative control: removing the rejection observer restores the same `cancel failed` process-level rejection while the validation result and dispatcher close remain successful.

After rebasing the unchanged production fix onto current `upstream/main` (`cc57514e680`) at head `eba2b733e3c`, the focused regression and exact CI type lane passed. The two unrelated files that failed in the prior broad CI run also pass independently on this head.

Focused regression test:

```text
$ node scripts/run-vitest.mjs src/infra/net/proxy/proxy-validation.test.ts
Test Files  1 passed (1)
Tests  26 passed (26)

$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/pr111159-core-test.tsbuildinfo
(exit 0)

$ node scripts/run-vitest.mjs src/system-agent/setup-inference-detection.test.ts
Tests  2 passed (2)

$ node scripts/run-vitest.mjs src/cli/acp-cli-exit.process.test.ts
Tests  5 passed (5)
```

Formatting check:

```text
$ ./node_modules/.bin/oxfmt --check src/infra/net/proxy/proxy-validation.ts src/infra/net/proxy/proxy-validation.test.ts
All matched files use the correct format.
```

Full build, type, lint, and test suites were not run locally; GitHub Actions will provide the broad checks.

AI-assisted: Codex helped inspect the code path and prepare the patch; the behavior proof and focused test were run manually.
