### PR TITLE
fix(skills): coding-agent completion works with SecretRef auth

### DIFF
--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -41,10 +41,12 @@ Use for background feature builds, PR reviews, large refactors, and issue-to-PR 
 - Always launch with `background:true`.
 - Codex and OpenCode: use `pty:true`.
 - Claude Code: no PTY; use `claude --permission-mode bypassPermissions --print`.
-- Capture a real notification route before spawning.
-- Worker must send completion/failure via `openclaw message send`.
-- Do not rely on heartbeat, system events, or notify-on-exit.
+- Capture a real notification route before spawning and keep it in the parent context.
+- Parent must send exactly one completion/failure notification with the `message` tool after the worker reaches a terminal state.
+- Never put the notification route or Gateway credentials in the worker prompt or environment.
+- Do not rely on worker-originated messages, heartbeat, system events, or notify-on-exit.
 - Monitor with `process`; do not kill slow workers without cause.
+- Keep the parent turn active until the worker finishes and the notification attempt completes.
 - If user asked for a specific agent, use that agent.
 - If worker fails/hangs, respawn or ask; do not silently hand-code instead.
 - Never checkout branches or run background coding agents in `~/Projects/openclaw`; use an isolated checkout.
@@ -84,25 +86,35 @@ Immediately before the final push or PR for newly authored work, run `git fetch 
 
 For trusted refs, the launcher must create and verify the worktree before starting the editing worker; do not delegate worktree creation to that worker. The approved untrusted-PR workflow must instead own checkout and worktree materialization inside its sandbox. Never start a worker in `~/Projects/openclaw`. Read-only tasks and non-project scratch work do not require the Git preparation block.
 
-## Notification block
+## Completion handoff
 
-Append this shape to every worker prompt with real values:
+Keep this route only in the parent context:
 
 ```text
-Notification route:
+Parent route:
 - channel: <notifyChannel>
 - target: <notifyTarget>
-- account: <notifyAccount or omit>
-- reply_to: <notifyReplyTo or omit>
-- thread_id: <notifyThreadId or omit>
-
-When finished, send exactly one completion or failure message using:
-openclaw message send --channel <channel> --target '<target>' --message '<brief result>'
-Add --account, --reply-to, or --thread-id only when present above.
-Do not use openclaw system event or heartbeat.
+- accountId: <notifyAccount or omit>
+- replyTo: <notifyReplyTo or omit>
+- threadId: <notifyThreadId or omit>
 ```
 
-If no trustworthy route exists, say completion auto-notify is unavailable.
+Append this block to every worker prompt:
+
+```text
+Completion handoff:
+When finished, end your final response with a concise completion or failure summary for the parent.
+Do not send messages, run `openclaw message send`, emit system events, or use heartbeat.
+```
+
+After launch:
+
+1. Monitor the worker with `process` until it reaches a terminal state. Do not return from the parent turn while it is running.
+2. Read the result file. If the worker failed without a usable result, construct a concise failure summary from its status and final log output.
+3. Use the parent `message` tool with `action: "send"`, the captured `channel`, `target`, and summary as `message`. Add `accountId`, `replyTo`, or `threadId` only when present in the captured route.
+4. Send once for the overall task after the final attempt, not once per retry. If delivery fails, report that failure without exposing credentials or asking the worker to retry delivery.
+
+If no trustworthy route exists or the parent `message` tool cannot send to it, say completion auto-notify is unavailable before spawning.
 
 ## Launch forms
 
@@ -110,41 +122,43 @@ Write the worker prompt to a temp file first. This avoids shell quoting bugs whe
 
 ```bash
 PROMPT=$(mktemp -t openclaw-worker-prompt.XXXXXX)
+RESULT=$(mktemp -t openclaw-worker-result.XXXXXX)
 cat >"$PROMPT" <<'EOF'
 Task.
 <mandatory Git preparation block>
-<notification block>
+<completion handoff block>
 EOF
 printf 'prompt file: %s\n' "$PROMPT"
+printf 'result file: %s\n' "$RESULT"
 ```
 
-Use `$PROMPT` when launching from the same shell/session. If using a separate tool call, substitute the printed path. The launch forms below are for trusted checkouts only; untrusted contributor refs require the repository's approved sandbox/review workflow.
+Use `$PROMPT` and `$RESULT` when launching from the same shell/session. If using a separate tool call, substitute the printed paths. The launch forms below are for trusted checkouts only; untrusted contributor refs require the repository's approved sandbox/review workflow.
 
 Codex:
 
 ```bash
-bash pty:true background:true workdir:/path/isolated-worktree command:"codex exec - < \"$PROMPT\""
+bash pty:true background:true workdir:/path/isolated-worktree command:"codex exec --output-last-message \"$RESULT\" - < \"$PROMPT\""
 ```
 
 Claude Code:
 
 ```bash
-bash background:true workdir:/path/isolated-worktree command:"claude --permission-mode bypassPermissions --print < \"$PROMPT\""
+bash background:true workdir:/path/isolated-worktree command:"set -o pipefail; claude --permission-mode bypassPermissions --print < \"$PROMPT\" | tee \"$RESULT\""
 ```
 
 OpenCode:
 
 ```bash
-bash pty:true background:true workdir:/path/isolated-worktree command:"opencode run < \"$PROMPT\""
+bash pty:true background:true workdir:/path/isolated-worktree command:"set -o pipefail; opencode run < \"$PROMPT\" | tee \"$RESULT\""
 ```
 
 ## Long issue-to-PR work
 
 1. Create/reuse a GitHub issue as durable spec.
-2. Include issue URL, repo, canonical remote/default branch, target base branch/SHA, isolated worktree, working branch, expected PR, proof, and notification route.
-3. Include the mandatory Git preparation block, then tell the worker to implement, test, run review until no accepted actionable findings, and open the PR.
-4. Return issue URL and `sessionId` immediately.
-5. Monitor with `process`; cancel through Task Registry if mirrored there.
+2. Include issue URL, repo, canonical remote/default branch, target base branch/SHA, isolated worktree, working branch, expected PR, and proof. Keep the notification route in the parent context.
+3. Include the mandatory Git preparation and completion handoff blocks, then tell the worker to implement, test, run review until no accepted actionable findings, and open the PR.
+4. Send a start status with the issue URL and `sessionId`, then keep the parent turn active.
+5. Monitor with `process`, send the parent-owned terminal notification, and cancel through Task Registry if mirrored there.
 
 ## Scratch Codex
 
@@ -154,12 +168,14 @@ Codex needs a trusted git repo. This throwaway scaffold is not project work and 
 SCRATCH=$(mktemp -d)
 git -C "$SCRATCH" init
 PROMPT=$(mktemp -t openclaw-worker-prompt.XXXXXX)
+RESULT=$(mktemp -t openclaw-worker-result.XXXXXX)
 cat >"$PROMPT" <<'EOF'
 Build X.
-<notification block>
+<completion handoff block>
 EOF
 printf 'prompt file: %s\n' "$PROMPT"
-bash pty:true background:true workdir:$SCRATCH command:"codex exec - < \"$PROMPT\""
+printf 'result file: %s\n' "$RESULT"
+bash pty:true background:true workdir:$SCRATCH command:"codex exec --output-last-message \"$RESULT\" - < \"$PROMPT\""
 ```
 
 ## Process actions
@@ -175,5 +191,6 @@ bash pty:true background:true workdir:$SCRATCH command:"codex exec - < \"$PROMPT
 ## Status to user
 
 - Say what started, where, and `sessionId`.
+- Keep monitoring after the start status; do not treat it as the terminal reply.
 - Update only on milestone, worker question, error, user action needed, or finish.
 - If killed, say why.

--- a/src/skills/loading/coding-agent-notification.test.ts
+++ b/src/skills/loading/coding-agent-notification.test.ts
@@ -1,0 +1,26 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const skillPath =
+  process.env.TEST_CODING_AGENT_SKILL_PATH ??
+  path.resolve(import.meta.dirname, "..", "..", "..", "skills", "coding-agent", "SKILL.md");
+
+describe("coding-agent completion notification", () => {
+  it("keeps delivery in the authenticated parent runtime", () => {
+    const skill = fs.readFileSync(skillPath, "utf8");
+
+    expect(skill).toContain(
+      "Parent must send exactly one completion/failure notification with the `message` tool",
+    );
+    expect(skill).toContain(
+      "Never put the notification route or Gateway credentials in the worker prompt or environment.",
+    );
+    expect(skill).toContain("Keep this route only in the parent context:");
+    expect(skill).toContain("Parent route:");
+    expect(skill).not.toContain("Worker must send completion/failure via `openclaw message send`.");
+    expect(skill).not.toContain(
+      "When finished, send exactly one completion or failure message using:",
+    );
+  });
+});


### PR DESCRIPTION
Closes #109738

## What Problem This Solves

Fixes an issue where users running the bundled coding-agent skill with SecretRef-backed Gateway authentication would lose the required completion or failure notification after an external coding worker finished.

## Why This Change Was Made

The worker can edit its isolated workspace but should not receive the parent's Gateway credential or own channel delivery. The bundled skill now keeps the notification route in the authenticated parent, captures each worker's terminal result, requires the parent to remain active while monitoring, and sends one terminal notification through the parent `message` tool.

Codex uses its supported `--output-last-message` handoff. Claude Code and OpenCode stream their terminal output through `tee` with `pipefail`, so worker failures remain visible while the parent receives a result file. The worker prompt contains only a completion-summary contract, not the route or credentials.

## User Impact

External coding workers can complete under restricted sandbox policies without needing access to the parent OpenClaw state directory, Gateway SecretRef provider, or long-lived Gateway credential. Completion and failure delivery remains available through the already authenticated parent runtime.

## Root Cause

`skills/coding-agent/SKILL.md` assigned channel delivery to the least privileged process:

```before
Worker must send completion/failure via `openclaw message send`.
```

That worker command starts a new Gateway-authenticated CLI path inside the external sandbox. Exec-backed SecretRefs may be unavailable there even though the parent Gateway and channel are healthy.

## Fix

```after
Parent must send exactly one completion/failure notification with the `message` tool after the worker reaches a terminal state.
```

The route stays in parent context, the worker supplies only its final summary, and the parent sends after the final attempt. This preserves fail-closed SecretRef behavior and avoids credential injection.

## Why This Is the Right Boundary

The parent already owns the trusted notification route, the process session, and the authenticated channel tool. The external worker owns only coding work and its terminal result. The same invariant now covers Codex, Claude Code, OpenCode, long issue-to-PR work, and scratch Codex without adding a second Gateway authentication path or a new credential surface.

PR #91921 is adjacent but distinct: it changes automatic background-exec wake prompts and does not modify the coding-agent worker notification contract. PRs #81562 and #92290 preserve managed Codex HOME behavior and strict SecretRef diagnostics respectively, but neither provides external coding workers with a safe completion delivery owner.

## Evidence

The production skill-loading path reports that pristine main assigns delivery to the worker and includes the route in the worker prompt. The patched head assigns delivery to the parent and omits that route from the worker prompt.

AI-assisted: Codex. I reviewed the resulting skill contract, worker launch commands, security boundary, regression coverage, and upstream Codex implementation.

## Verification

- `node scripts/run-vitest.mjs src/skills/loading/coding-agent-notification.test.ts src/skills/loading/env-path-guidance.test.ts`: 2 files passed, 7 checks passed.
- The new regression assertion fails against pristine main `c2a9579c5919bbb609c489a35b19a225d9eb9aed` and passes at `18246c803320d2823e34bcfbb8b3c8e52b8725c3`.
- `node_modules/.bin/oxlint src/skills/loading/coding-agent-notification.test.ts`: passed.
- `node_modules/.bin/oxfmt --check skills/coding-agent/SKILL.md src/skills/loading/coding-agent-notification.test.ts`: passed.
- `git diff --check origin/main...HEAD`: passed.
- `codex exec --help`: confirms `--output-last-message <FILE>` on the locally installed Codex CLI. Current upstream Codex source also defines the option in `codex-rs/exec/src/cli.rs` and clears/rebuilds shell-command environments in `codex-rs/core/src/spawn.rs`.
- The repository lint wrapper was blocked before reaching the changed file while preparing package-boundary declarations with reused dependencies from an older checkout. The reported `packages/net-policy/src/ip.ts` surface has no branch diff; direct scoped lint is clean and hosted CI will run with a fresh dependency graph.
- Full build not run because the change updates a bundled Markdown skill contract and its content regression only.

## Real behavior proof

Behavior addressed: Coding-agent completion delivery no longer depends on a worker-side Gateway authentication path that cannot resolve the parent's SecretRef.
Real environment tested: OpenClaw's production `scanNodeHostedSkills` loader read the bundled coding-agent skill from pristine main and the patched tree with no external boundary substituted.
Exact steps or command run after this patch: Loaded each tree through `scanNodeHostedSkills`, selected `coding-agent`, and reported the delivery owner and whether the route block would enter the worker prompt.
Evidence after fix:
```
# BEFORE (pristine main d0f37bd8433782147629bdd2fc1b076c1def61d3)
notification_owner=worker-cli
route_in_worker_prompt=true
# AFTER (patched head 18246c803320d2823e34bcfbb8b3c8e52b8725c3)
notification_owner=parent-message-tool
route_in_worker_prompt=false
```
Observed result after fix: The loaded contract now keeps both route ownership and terminal delivery in the authenticated parent.
What was not tested: No live Telegram delivery or live model-backed worker run was performed. In the completion lifecycle evidence below, only the external coding CLI is replaced by a restricted stand-in; the shipped launch pipeline, sandbox restriction, result capture, and exit propagation are real shell. Hosted checks will validate the fresh Linux dependency graph.

### Restricted external worker completion lifecycle

Driver: the shipped launch pipeline from `skills/coding-agent/SKILL.md` run against a restricted worker (`env -i`, coreutils-only PATH, no `openclaw` binary reachable, none of the parent route or Gateway credential vars exported) for a succeeding and a failing worker, under the pristine and patched contracts. The worker stands in for the external coding CLI and the live channel is a recording stand-in; the sandbox restriction, the patched Claude Code launch form (`set -o pipefail; ... | tee "$RESULT"`), result capture, and exit propagation are real shell. Route, target, and credential values redacted.

Command per run: `bash launch.sh <success|fail> <before|after>`. The parent holds the route and SecretRef-backed Gateway credential; it reads `$RESULT` after the worker reaches a terminal state and sends once through the `message` tool.

```
## contract=before mode=success     # pristine main: worker owns delivery
route_in_worker_prompt=true
worker_exit_status=0
worker_self_delivery=FAILED (rc=127, openclaw unavailable in sandbox)
result_file_captured_bytes=0
parent_notifications_sent=0
## contract=before mode=fail
route_in_worker_prompt=true
worker_exit_status=3
worker_self_delivery=FAILED (rc=127, openclaw unavailable in sandbox)
result_file_captured_bytes=0
parent_notifications_sent=0
## contract=after mode=success      # patched head: parent owns delivery
route_in_worker_prompt=false
worker_exit_status=0
result_file_captured_bytes=122
worker_env_had_route_or_cred=no (env -i sandbox; parent vars never exported)
[1] terminal result captured -> then [2] one authenticated parent message call
parent_notifications_sent=1
delivery=parent message(send) channel=<redacted> target=<redacted> auth=SecretRef(parent) msg='implemented feature; all checks passed'
## contract=after mode=fail
route_in_worker_prompt=false
worker_exit_status=3
result_file_captured_bytes=83
worker_env_had_route_or_cred=no (env -i sandbox; parent vars never exported)
[1] terminal result captured -> then [2] one authenticated parent message call
parent_notifications_sent=1
delivery=parent message(send) channel=<redacted> target=<redacted> auth=SecretRef(parent) msg='worker failed (rc=3): [worker] running project checks'
```

Success path: under the patched contract the worker's terminal summary is captured to `$RESULT` first, and only then does the authenticated parent make exactly one `message(send)` call carrying that summary. The worker prompt no longer holds the route (`route_in_worker_prompt=false`).

Failure path: the failing worker's nonzero exit survives the pipe because the shipped form sets `set -o pipefail` (dropping it lets `tee`'s exit 0 mask the failure: exit=3 becomes exit=0). The parent captures the terminal log, constructs one failure summary, and sends exactly one failure notification. The send happens entirely in the parent, which is the only holder of the route and SecretRef credential; the worker ran under `env -i` with no route or credential in its environment (`worker_env_had_route_or_cred=no`), so no worker-side credential is involved.

Under the pristine contract the restricted worker owns delivery and cannot self-deliver (`openclaw` is unreachable, rc=127), so both the succeeding and failing run send zero notifications and the result was never captured. The patched contract captures the result and delivers exactly one parent-owned notification in both cases.


