### PR TITLE
fix(msteams): catch body cancel rejections in attachment fetch

### DIFF
--- a/extensions/msteams/src/attachments/bot-framework.test.ts
+++ b/extensions/msteams/src/attachments/bot-framework.test.ts
@@ -6,6 +6,7 @@ import {
   downloadMSTeamsBotFrameworkAttachments,
   isBotFrameworkPersonalChatId,
 } from "./bot-framework.js";
+import { createResponseWithRejectingCancel, watchUnhandledRejections } from "./test-helpers.js";
 import type { MSTeamsAccessTokenProvider } from "./types.js";
 
 type SavedCall = {
@@ -588,6 +589,152 @@ describe("downloadMSTeamsBotFrameworkAttachment", () => {
       } finally {
         jsonSpy.mockRestore();
       }
+    });
+  });
+
+  describe("rejecting body.cancel() regression coverage", () => {
+    it("handles attachmentInfo non-ok response with rejecting cancel", async () => {
+      const watcher = watchUnhandledRejections();
+      try {
+        const fetchFn: typeof fetch = vi.fn(async () =>
+          createResponseWithRejectingCancel("server error", { status: 500 }),
+        );
+
+        const media = await downloadMSTeamsBotFrameworkAttachment({
+          serviceUrl: "https://smba.trafficmanager.net/amer",
+          attachmentId: "att-1",
+          tokenProvider: buildTokenProvider(),
+          maxBytes: 10_000_000,
+          fetchFn,
+          fetchFnSupportsDispatcher: true,
+          resolveFn: resolvePublicHost,
+        });
+
+        expect(media).toBeUndefined();
+      } finally {
+        watcher.detach();
+      }
+      expect(watcher.unhandled).toEqual([]);
+    });
+
+    it("handles attachmentView non-ok response with rejecting cancel", async () => {
+      const watcher = watchUnhandledRejections();
+      try {
+        const info = {
+          name: "report.pdf",
+          type: "application/pdf",
+          views: [{ viewId: "original", size: 10 }],
+        };
+        const fetchFn: typeof fetch = vi.fn(async (input: RequestInfo | URL) => {
+          const url =
+            typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+          if (url.endsWith("/v3/attachments/att-1")) {
+            return new Response(JSON.stringify(info), {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            });
+          }
+          return createResponseWithRejectingCancel("forbidden", { status: 403 });
+        });
+
+        const media = await downloadMSTeamsBotFrameworkAttachment({
+          serviceUrl: "https://smba.trafficmanager.net/amer",
+          attachmentId: "att-1",
+          tokenProvider: buildTokenProvider(),
+          maxBytes: 10_000_000,
+          fetchFn,
+          fetchFnSupportsDispatcher: true,
+          resolveFn: resolvePublicHost,
+        });
+
+        expect(media).toBeUndefined();
+      } finally {
+        watcher.detach();
+      }
+      expect(watcher.unhandled).toEqual([]);
+    });
+
+    it("handles attachmentView invalid content-length with rejecting cancel", async () => {
+      const watcher = watchUnhandledRejections();
+      try {
+        const info = {
+          name: "report.pdf",
+          type: "application/pdf",
+          views: [{ viewId: "original", size: 3 }],
+        };
+        const warn = vi.fn();
+        const fetchFn: typeof fetch = vi.fn(async (input: RequestInfo | URL) => {
+          const url =
+            typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+          if (url.endsWith("/v3/attachments/att-1")) {
+            return new Response(JSON.stringify(info), {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            });
+          }
+          return createResponseWithRejectingCancel("PDFBYTES", {
+            status: 200,
+            headers: { "content-length": "0x3" },
+          });
+        });
+
+        const media = await downloadMSTeamsBotFrameworkAttachment({
+          serviceUrl: "https://smba.trafficmanager.net/amer",
+          attachmentId: "att-1",
+          tokenProvider: buildTokenProvider(),
+          maxBytes: 10_000_000,
+          fetchFn,
+          fetchFnSupportsDispatcher: true,
+          resolveFn: resolvePublicHost,
+          logger: { warn },
+        });
+
+        expect(media).toBeUndefined();
+        expect(warn).toHaveBeenCalledWith(
+          "msteams botFramework attachmentView invalid content-length",
+          { error: "invalid content-length header: 0x3" },
+        );
+      } finally {
+        watcher.detach();
+      }
+      expect(watcher.unhandled).toEqual([]);
+    });
+
+    it("handles attachmentView content-length exceeding maxBytes with rejecting cancel", async () => {
+      const watcher = watchUnhandledRejections();
+      try {
+        const info = {
+          name: "huge.bin",
+          type: "application/octet-stream",
+          views: [{ viewId: "original", size: 50_000_000 }],
+        };
+        const fetchFn: typeof fetch = vi.fn(async (input: RequestInfo | URL) => {
+          const url =
+            typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+          if (url.endsWith("/v3/attachments/att-1")) {
+            return new Response(JSON.stringify(info), { status: 200 });
+          }
+          return createResponseWithRejectingCancel("BYTES", {
+            status: 200,
+            headers: { "content-length": "99999999" },
+          });
+        });
+
+        const media = await downloadMSTeamsBotFrameworkAttachment({
+          serviceUrl: "https://smba.trafficmanager.net/amer",
+          attachmentId: "att-1",
+          tokenProvider: buildTokenProvider(),
+          maxBytes: 10_000_000,
+          fetchFn,
+          fetchFnSupportsDispatcher: true,
+          resolveFn: resolvePublicHost,
+        });
+
+        expect(media).toBeUndefined();
+      } finally {
+        watcher.detach();
+      }
+      expect(watcher.unhandled).toEqual([]);
     });
   });
 });

--- a/extensions/msteams/src/attachments/bot-framework.ts
+++ b/extensions/msteams/src/attachments/bot-framework.ts
@@ -113,7 +113,7 @@ async function fetchBotFrameworkAttachmentInfo(params: {
     return undefined;
   }
   if (!response.ok) {
-    await response.body?.cancel();
+    await response.body?.cancel().catch(() => undefined);
     params.logger?.warn?.("msteams botFramework attachmentInfo non-ok", {
       status: response.status,
     });
@@ -173,7 +173,7 @@ async function saveBotFrameworkAttachmentView(params: {
     return undefined;
   }
   if (!response.ok) {
-    await response.body?.cancel();
+    await response.body?.cancel().catch(() => undefined);
     params.logger?.warn?.("msteams botFramework attachmentView non-ok", {
       status: response.status,
     });
@@ -183,14 +183,14 @@ async function saveBotFrameworkAttachmentView(params: {
   try {
     contentLength = parseMediaContentLength(response.headers.get("content-length"));
   } catch (err) {
-    await response.body?.cancel();
+    await response.body?.cancel().catch(() => undefined);
     params.logger?.warn?.("msteams botFramework attachmentView invalid content-length", {
       error: err instanceof Error ? err.message : String(err),
     });
     return undefined;
   }
   if (contentLength !== null && contentLength > params.maxBytes) {
-    await response.body?.cancel();
+    await response.body?.cancel().catch(() => undefined);
     return undefined;
   }
   try {

--- a/extensions/msteams/src/attachments/download.test.ts
+++ b/extensions/msteams/src/attachments/download.test.ts
@@ -1,0 +1,190 @@
+// Msteams tests cover attachment download auth-fallback cancel behavior.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createResponseWithRejectingCancel, watchUnhandledRejections } from "./test-helpers.js";
+import type { MSTeamsAccessTokenProvider } from "./types.js";
+
+const saveResponseMediaMock = vi.hoisted(() =>
+  vi.fn(
+    async (
+      response: Response,
+      options?: { maxBytes?: number },
+    ): Promise<{
+      id: string;
+      path: string;
+      size: number;
+      contentType?: string;
+      fileName?: string;
+    }> => {
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const contentLength = Number(response.headers.get("content-length"));
+      if (Number.isFinite(contentLength) && options?.maxBytes && contentLength > options.maxBytes) {
+        throw new Error(`content length ${contentLength} exceeds maxBytes ${options.maxBytes}`);
+      }
+      return {
+        id: "saved",
+        path: "/tmp/saved.png",
+        size: 42,
+        contentType: response.headers.get("content-type") ?? "image/png",
+      };
+    },
+  ),
+);
+
+vi.mock("openclaw/plugin-sdk/media-runtime", async () => ({
+  saveResponseMedia: saveResponseMediaMock,
+}));
+
+vi.mock("../runtime.js", () => ({
+  getMSTeamsRuntime: () => ({
+    media: {
+      detectMime: vi.fn(async () => "image/png"),
+    },
+    channel: {
+      media: {
+        saveMediaBuffer: vi.fn(async (buffer: Buffer, contentType?: string) => ({
+          id: "saved",
+          path: "/tmp/saved.png",
+          size: buffer.length,
+          contentType: contentType ?? "image/png",
+        })),
+        saveRemoteMedia: vi.fn(),
+      },
+    },
+  }),
+}));
+
+import { downloadMSTeamsAttachments } from "./download.js";
+
+function buildTokenProvider(): MSTeamsAccessTokenProvider {
+  return {
+    getAccessToken: vi.fn(async (scope: string) => {
+      if (scope.includes("botframework.com")) {
+        return "bf-token";
+      }
+      return "graph-token";
+    }),
+  };
+}
+
+async function resolvePublicHost(): Promise<{ address: string }> {
+  return { address: "93.184.216.34" };
+}
+
+function makeAttachment(): {
+  contentType: string;
+  contentUrl: string;
+  name: string;
+} {
+  return {
+    contentType: "application/pdf",
+    contentUrl: "https://graph.microsoft.com/v1.0/foo",
+    name: "doc.pdf",
+  };
+}
+
+describe("downloadMSTeamsAttachments rejecting body.cancel() regression coverage", () => {
+  beforeEach(() => {
+    saveResponseMediaMock.mockClear();
+  });
+
+  it("cancels the firstAttempt 401 body before auth fallback", async () => {
+    const watcher = watchUnhandledRejections();
+    try {
+      const fetchFn = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        const auth = new Headers(init?.headers).get("authorization");
+        if (!auth) {
+          return createResponseWithRejectingCancel("unauthorized", { status: 401 });
+        }
+        return new Response(Buffer.from("OK"), {
+          status: 200,
+          headers: { "content-type": "application/pdf" },
+        });
+      });
+
+      const result = await downloadMSTeamsAttachments({
+        attachments: [makeAttachment()],
+        maxBytes: 10_000_000,
+        tokenProvider: buildTokenProvider(),
+        fetchFn: fetchFn as unknown as typeof fetch,
+        fetchFnSupportsDispatcher: true,
+        resolveFn: resolvePublicHost,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(fetchFn).toHaveBeenCalledTimes(2);
+    } finally {
+      watcher.detach();
+    }
+    expect(watcher.unhandled).toEqual([]);
+  });
+
+  it("cancels a non-auth-failure authAttempt body and continues to the next scope", async () => {
+    const watcher = watchUnhandledRejections();
+    try {
+      const fetchFn = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        const auth = new Headers(init?.headers).get("authorization");
+        if (!auth) {
+          return createResponseWithRejectingCancel("unauthorized", { status: 401 });
+        }
+        if (auth.includes("graph-token")) {
+          return createResponseWithRejectingCancel("server error", { status: 500 });
+        }
+        return new Response(Buffer.from("OK"), {
+          status: 200,
+          headers: { "content-type": "application/pdf" },
+        });
+      });
+
+      const result = await downloadMSTeamsAttachments({
+        attachments: [makeAttachment()],
+        maxBytes: 10_000_000,
+        tokenProvider: buildTokenProvider(),
+        fetchFn: fetchFn as unknown as typeof fetch,
+        fetchFnSupportsDispatcher: true,
+        resolveFn: resolvePublicHost,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(fetchFn).toHaveBeenCalledTimes(3);
+    } finally {
+      watcher.detach();
+    }
+    expect(watcher.unhandled).toEqual([]);
+  });
+
+  it("cancels a 401 authAttempt body before trying the next scope", async () => {
+    const watcher = watchUnhandledRejections();
+    try {
+      const fetchFn = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        const auth = new Headers(init?.headers).get("authorization");
+        if (!auth) {
+          return createResponseWithRejectingCancel("unauthorized", { status: 401 });
+        }
+        if (auth.includes("graph-token")) {
+          return createResponseWithRejectingCancel("forbidden", { status: 403 });
+        }
+        return new Response(Buffer.from("OK"), {
+          status: 200,
+          headers: { "content-type": "application/pdf" },
+        });
+      });
+
+      const result = await downloadMSTeamsAttachments({
+        attachments: [makeAttachment()],
+        maxBytes: 10_000_000,
+        tokenProvider: buildTokenProvider(),
+        fetchFn: fetchFn as unknown as typeof fetch,
+        fetchFnSupportsDispatcher: true,
+        resolveFn: resolvePublicHost,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(fetchFn).toHaveBeenCalledTimes(3);
+    } finally {
+      watcher.detach();
+    }
+    expect(watcher.unhandled).toEqual([]);
+  });
+});

--- a/extensions/msteams/src/attachments/download.ts
+++ b/extensions/msteams/src/attachments/download.ts
@@ -158,7 +158,7 @@ async function fetchWithAuthFallback(params: {
   if (!isUrlAllowed(params.url, params.policy.authAllowHosts)) {
     return firstAttempt;
   }
-  await firstAttempt.body?.cancel();
+  await firstAttempt.body?.cancel().catch(() => undefined);
 
   const scopes = scopeCandidatesForUrl(params.url);
   const fetchFn = params.fetchFn ?? fetch;
@@ -192,10 +192,10 @@ async function fetchWithAuthFallback(params: {
       }
       if (authAttempt.status !== 401 && authAttempt.status !== 403) {
         // Preserve scope fallback semantics for non-auth failures.
-        await authAttempt.body?.cancel();
+        await authAttempt.body?.cancel().catch(() => undefined);
         continue;
       }
-      await authAttempt.body?.cancel();
+      await authAttempt.body?.cancel().catch(() => undefined);
     } catch {
       // Try the next scope.
     }

--- a/extensions/msteams/src/attachments/test-helpers.ts
+++ b/extensions/msteams/src/attachments/test-helpers.ts
@@ -1,0 +1,57 @@
+// Shared MSTeams attachment test utilities.
+
+/**
+ * Build a `Response` whose body stream `cancel()` rejects. Useful for proving
+ * that cleanup sites using `response.body?.cancel().catch(() => undefined)` do
+ * not emit unhandled rejections.
+ */
+export function createResponseWithRejectingCancel(
+  bodyInit: BodyInit | null = null,
+  init?: ResponseInit,
+): Response {
+  const chunks: Uint8Array[] = [];
+  if (bodyInit !== null) {
+    if (typeof bodyInit === "string") {
+      chunks.push(new TextEncoder().encode(bodyInit));
+    } else if (bodyInit instanceof Uint8Array) {
+      chunks.push(bodyInit);
+    } else if (bodyInit instanceof ArrayBuffer) {
+      chunks.push(new Uint8Array(bodyInit));
+    }
+  }
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+    cancel() {
+      return Promise.reject(new Error("body cancel rejected"));
+    },
+  });
+
+  return new Response(stream, init);
+}
+
+/**
+ * Attach a process-level unhandled rejection listener for the duration of a
+ * test. Returns the collected reasons and a detach function.
+ */
+export function watchUnhandledRejections(): {
+  unhandled: unknown[];
+  detach: () => void;
+} {
+  const unhandled: unknown[] = [];
+  const handler = (reason: unknown) => {
+    unhandled.push(reason);
+  };
+  process.on("unhandledRejection", handler);
+  return {
+    unhandled,
+    detach: () => {
+      process.off("unhandledRejection", handler);
+    },
+  };
+}

--- a/extensions/msteams/src/attachments/test-helpers.ts
+++ b/extensions/msteams/src/attachments/test-helpers.ts
@@ -25,7 +25,9 @@ export function createResponseWithRejectingCancel(
       for (const chunk of chunks) {
         controller.enqueue(chunk);
       }
-      controller.close();
+      // Do not close — keep the stream open so the production cancel() path
+      // triggers the rejecting cancel hook below instead of short-circuiting
+      // on an already-closed stream.
     },
     cancel() {
       return Promise.reject(new Error("body cancel rejected"));


### PR DESCRIPTION
## What Problem This Solves

The same pattern fixed in today's PRs #111106 (tlon), #111105 (matrix), and #111081 (tlon): `response.body?.cancel()` can reject when the ReadableStream underlying source cancel method throws, which produces an unhandled promise rejection. The MS Teams attachment fetch code had 7 unprotected cancel() calls across two files, while bot-framework.ts already had the .catch() fix at one call site (line 211) — suggesting the others were simply overlooked.

## Why This Change Was Made

Add `.catch(() => undefined)` to all remaining `response.body?.cancel()` calls in the MS Teams attachment fetch path so body cancellation failures cannot produce unhandled rejections.

## User Impact

No user-visible behavior change — the body cancel is always a best-effort cleanup. This prevents potential Node.js process warnings or crash paths from unhandled rejections during attachment download retries.

## Evidence

- Added shared helper `extensions/msteams/src/attachments/test-helpers.ts` that builds a `Response` whose `ReadableStream.cancel()` rejects.
- Added focused regression coverage in `extensions/msteams/src/attachments/bot-framework.test.ts` for the four changed cancel sites:
  - `attachmentInfo` non-OK response
  - `attachmentView` non-OK response
  - `attachmentView` invalid `content-length`
  - `attachmentView` `content-length` > `maxBytes`
- Added `extensions/msteams/src/attachments/download.test.ts` covering the three changed cancel sites in `fetchWithAuthFallback`:
  - first attempt 401 → cancel before auth fallback
  - auth attempt non-401/403 → cancel and continue to next scope
  - auth attempt 401/403 → cancel before next scope
- All new tests assert the function returns the expected result and `unhandledRejection` is empty.

Test run (worktree uses a temporary node_modules symlink to the parent checkout):

```bash
node scripts/run-vitest.mjs extensions/msteams/src/attachments/bot-framework.test.ts extensions/msteams/src/attachments/download.test.ts
```

```
[test] starting test/vitest/vitest.extension-msteams.config.ts

 RUN  v4.1.10 /home/0668000387/openclawCxbAsDev/.worktrees/pr111161

 ✓ |extension-msteams| extensions/msteams/src/attachments/download.test.ts (3 tests) 467ms
     ✓ cancels the firstAttempt 401 body before auth fallback  450ms
 ✓ |extension-msteams| extensions/msteams/src/attachments/bot-framework.test.ts (25 tests) 213ms

 Test Files  2 passed (2)
      Tests  28 passed (28)
   Start at  14:46:51
   Duration  14.66s (transform 14.96s, setup 2.44s, import 16.33s, tests 680ms, environment 0ms)

[test] passed 1 Vitest shard in 21.46s
```

@clawsweeper re-review