### PR TITLE
fix: background replies recover legacy channel targets

### DIFF
--- a/src/utils/delivery-context.shared.ts
+++ b/src/utils/delivery-context.shared.ts
@@ -218,7 +218,7 @@ export function deliveryContextFromSession(
     route: entry.route,
     channel: entry.channel ?? entry.origin?.provider,
     lastChannel: entry.lastChannel,
-    lastTo: entry.lastTo,
+    lastTo: entry.lastTo ?? entry.origin?.to,
     lastAccountId: entry.lastAccountId ?? entry.origin?.accountId,
     lastThreadId: entry.lastThreadId ?? entry.deliveryContext?.threadId ?? entry.origin?.threadId,
     origin: entry.origin,

--- a/src/utils/delivery-context.test.ts
+++ b/src/utils/delivery-context.test.ts
@@ -180,6 +180,22 @@ describe("delivery context helpers", () => {
       accountId: undefined,
       threadId: "777",
     });
+
+    expect(
+      deliveryContextFromSession({
+        origin: {
+          provider: "telegram",
+          to: " 5295861568 ",
+          accountId: " default ",
+          threadId: 42,
+        },
+      }),
+    ).toEqual({
+      channel: "telegram",
+      to: "5295861568",
+      accountId: "default",
+      threadId: 42,
+    });
   });
 
   it("prefers explicit external delivery context over stale webchat legacy fields", () => {

--- a/src/utils/delivery-context.types.ts
+++ b/src/utils/delivery-context.types.ts
@@ -45,6 +45,7 @@ export type DeliveryContextSessionSource = {
   /** Older origin fields emitted before delivery context became canonical. */
   origin?: {
     provider?: string;
+    to?: string;
     accountId?: string;
     threadId?: string | number;
   };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where background or recovered replies could be written into a requester transcript without being delivered to the originating channel when the session record stored its destination only in the older `origin.to` field.

The shared session-delivery reconstruction already recovered the legacy origin provider, account, and thread, but omitted the destination. That produced an incomplete delivery context with no routable `to` value.

## Why This Change Was Made

The canonical delivery-context helper now includes `origin.to` in the legacy origin type and uses it only when the newer `lastTo` field is absent. Existing route, delivery-context, and `lastTo` precedence remains unchanged.

The fix lives at the shared normalization boundary so restart, subagent, and other best-effort delivery callers receive the same complete context without channel-specific fallback code.

## User Impact

Users with older or partially migrated session rows can receive background and recovery replies in the original Telegram or other channel instead of finding an invisible assistant message only in transcript history.

## Evidence

- Added regression coverage for a session whose complete Telegram target exists only in `origin.provider`, `origin.to`, `origin.accountId`, and `origin.threadId`.
- `PATH=/tmp/node-v25.9.0-darwin-arm64/bin:$PATH node scripts/run-vitest.mjs src/utils/delivery-context.test.ts` -> 11/11 tests passed.
- `PATH=/tmp/node-v25.9.0-darwin-arm64/bin:$PATH node_modules/.bin/oxlint src/utils/delivery-context.shared.ts src/utils/delivery-context.types.ts src/utils/delivery-context.test.ts` -> passed.
- `git diff --check` -> passed.
- Production observation on OpenClaw 2026.6.1: a Telegram background completion with a legacy origin was committed to the requester transcript but not sent externally. Applying the equivalent installed-package fix restored `telegram outbound send ok` delivery for the pending completion and restart recovery.

AI-assisted by Codex. I reviewed the persisted session shape, shared normalization precedence, callers, tests, and resulting behavior and understand the change.
