### PR TITLE
fix: catch body cancel rejections in redirect and proxy-validation paths

### DIFF
--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -69,6 +69,53 @@ function okResponse(body = "ok"): Response {
   return new Response(body, { status: 200 });
 }
 
+function createResponseWithRejectingCancel(
+  bodyInit: BodyInit | null = null,
+  init?: ResponseInit,
+): Response {
+  const chunks: Uint8Array[] = [];
+  if (bodyInit !== null) {
+    if (typeof bodyInit === "string") {
+      chunks.push(new TextEncoder().encode(bodyInit));
+    } else if (bodyInit instanceof Uint8Array) {
+      chunks.push(bodyInit);
+    } else if (bodyInit instanceof ArrayBuffer) {
+      chunks.push(new Uint8Array(bodyInit));
+    }
+  }
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+    cancel() {
+      return Promise.reject(new Error("body cancel rejected"));
+    },
+  });
+
+  return new Response(stream, init);
+}
+
+function watchUnhandledRejections(): {
+  unhandled: unknown[];
+  detach: () => void;
+} {
+  const unhandled: unknown[] = [];
+  const handler = (reason: unknown) => {
+    unhandled.push(reason);
+  };
+  process.on("unhandledRejection", handler);
+  return {
+    unhandled,
+    detach: () => {
+      process.off("unhandledRejection", handler);
+    },
+  };
+}
+
 async function raceWithTimeoutResult<T>(
   promise: Promise<T>,
   timeoutMs: number,
@@ -2300,6 +2347,35 @@ describe("fetchWithSsrFGuard hardening", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1);
     expect(lookupFn).toHaveBeenCalledOnce();
     await result.release();
+  });
+
+  it("follows a redirect when the redirect body cancel() rejects and preserves no unhandled rejection", async () => {
+    const watcher = watchUnhandledRejections();
+    try {
+      const fetchImpl = vi
+        .fn()
+        .mockResolvedValueOnce(
+          createResponseWithRejectingCancel("redirect body", {
+            status: 302,
+            headers: { location: "https://public.example/final" },
+          }),
+        )
+        .mockResolvedValueOnce(okResponse("final"));
+
+      const result = await fetchWithSsrFGuard({
+        url: "https://public.example/start",
+        fetchImpl,
+      });
+
+      expect(result.response.status).toBe(200);
+      expect(await result.response.text()).toBe("final");
+      expect(result.finalUrl).toBe("https://public.example/final");
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+      await result.release();
+    } finally {
+      watcher.detach();
+    }
+    expect(watcher.unhandled).toEqual([]);
   });
 });
 

--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -89,7 +89,9 @@ function createResponseWithRejectingCancel(
       for (const chunk of chunks) {
         controller.enqueue(chunk);
       }
-      controller.close();
+      // Do not close — keep the stream open so the production cancel() path
+      // triggers the rejecting cancel hook below instead of short-circuiting
+      // on an already-closed stream.
     },
     cancel() {
       return Promise.reject(new Error("body cancel rejected"));

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -698,7 +698,7 @@ async function fetchWithSsrFGuardInternal(
           throw new Error("Redirect loop detected");
         }
         visited.add(nextVisitKey);
-        void response.body?.cancel();
+        void response.body?.cancel().catch(() => undefined);
         await closeDispatcher(dispatcher);
         currentUrl = nextUrl;
         continue;

--- a/src/infra/net/proxy/proxy-validation.test.ts
+++ b/src/infra/net/proxy/proxy-validation.test.ts
@@ -4,7 +4,71 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+
+const fetchWithRuntimeDispatcherMock = vi.hoisted(() => vi.fn());
+const createHttp1ProxyAgentMock = vi.hoisted(() =>
+  vi.fn(() => ({
+    close: vi.fn(async () => {}),
+  })),
+);
+
+vi.mock("../runtime-fetch.js", () => ({
+  fetchWithRuntimeDispatcher: fetchWithRuntimeDispatcherMock,
+  isMockedFetch: () => false,
+}));
+
+vi.mock("../undici-runtime.js", () => ({
+  createHttp1ProxyAgent: createHttp1ProxyAgentMock,
+}));
+
 import { runProxyValidation } from "./proxy-validation.js";
+
+function createResponseWithRejectingCancel(
+  bodyInit: BodyInit | null = null,
+  init?: ResponseInit,
+): Response {
+  const chunks: Uint8Array[] = [];
+  if (bodyInit !== null) {
+    if (typeof bodyInit === "string") {
+      chunks.push(new TextEncoder().encode(bodyInit));
+    } else if (bodyInit instanceof Uint8Array) {
+      chunks.push(bodyInit);
+    } else if (bodyInit instanceof ArrayBuffer) {
+      chunks.push(new Uint8Array(bodyInit));
+    }
+  }
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+    cancel() {
+      return Promise.reject(new Error("body cancel rejected"));
+    },
+  });
+
+  return new Response(stream, init);
+}
+
+function watchUnhandledRejections(): {
+  unhandled: unknown[];
+  detach: () => void;
+} {
+  const unhandled: unknown[] = [];
+  const handler = (reason: unknown) => {
+    unhandled.push(reason);
+  };
+  process.on("unhandledRejection", handler);
+  return {
+    unhandled,
+    detach: () => {
+      process.off("unhandledRejection", handler);
+    },
+  };
+}
 
 describe("proxy validation", () => {
   const tempDirs: string[] = [];
@@ -630,5 +694,47 @@ describe("proxy validation", () => {
         error: "HTTP/1.1 403 Forbidden",
       },
     ]);
+  });
+
+  it("preserves the fetch probe result when the proxy response body cancel() rejects", async () => {
+    const watcher = watchUnhandledRejections();
+    try {
+      fetchWithRuntimeDispatcherMock.mockResolvedValueOnce(
+        createResponseWithRejectingCancel("allowed body", {
+          status: 200,
+          headers: { "content-type": "text/plain" },
+        }),
+      );
+
+      const result = await runProxyValidation({
+        proxyUrlOverride: "http://proxy.example:3128",
+        allowedUrls: ["https://example.com/"],
+        deniedUrls: [],
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.checks).toEqual([
+        {
+          kind: "allowed",
+          url: "https://example.com/",
+          ok: true,
+          status: 200,
+        },
+      ]);
+      expect(createHttp1ProxyAgentMock).toHaveBeenCalledWith(
+        { uri: "http://proxy.example:3128" },
+        5000,
+      );
+      expect(fetchWithRuntimeDispatcherMock).toHaveBeenCalledWith(
+        "https://example.com/",
+        expect.objectContaining({
+          redirect: "manual",
+          dispatcher: expect.any(Object),
+        }),
+      );
+    } finally {
+      watcher.detach();
+    }
+    expect(watcher.unhandled).toEqual([]);
   });
 });

--- a/src/infra/net/proxy/proxy-validation.test.ts
+++ b/src/infra/net/proxy/proxy-validation.test.ts
@@ -43,7 +43,9 @@ function createResponseWithRejectingCancel(
       for (const chunk of chunks) {
         controller.enqueue(chunk);
       }
-      controller.close();
+      // Do not close — keep the stream open so the production cancel() path
+      // triggers the rejecting cancel hook below instead of short-circuiting
+      // on an already-closed stream.
     },
     cancel() {
       return Promise.reject(new Error("body cancel rejected"));

--- a/src/infra/net/proxy/proxy-validation.ts
+++ b/src/infra/net/proxy/proxy-validation.ts
@@ -230,7 +230,7 @@ async function defaultProxyValidationFetchCheck({
       dispatcher,
       redirect: "manual",
     });
-    void response.body?.cancel();
+    void response.body?.cancel().catch(() => undefined);
     return {
       ok: response.ok,
       status: response.status,


### PR DESCRIPTION
## What Problem This Solves

Same pattern as today's PRs #111106 (tlon), #111105 (matrix), and #111081 (tlon): `void response.body?.cancel()` can produce an unhandled promise rejection when the ReadableStream underlying source cancel throws. Two sites in core infra code had this pattern.

## Why This Change Was Made

Add `.catch(() => undefined)` so body cancellation failures in redirect processing (fetch-guard.ts) and proxy validation probes (proxy-validation.ts) cannot produce unhandled rejections.

## User Impact

No user-visible behavior change — body cancel is always best-effort cleanup. Prevents potential Node.js process warnings from unhandled rejections during HTTP redirect following and proxy validation.

## Evidence

- Added a focused test in `src/infra/net/fetch-guard.ssrf.test.ts` that drives `fetchWithSsrFGuard` through a 302 → 200 redirect where the redirect response body has a rejecting `cancel()`. Asserts the final 200 response is returned and no `unhandledRejection` occurs.
- Added a focused test in `src/infra/net/proxy/proxy-validation.test.ts` that mocks the proxy agent/dispatcher and drives the default fetch probe with a response whose body `cancel()` rejects. Asserts the validation result is preserved and no `unhandledRejection` occurs.

Filtered test runs (proxy env vars cleared; worktree uses a temporary node_modules symlink to the parent checkout):

```bash
env -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY -u all_proxy -u ALL_PROXY -u no_proxy -u NO_PROXY -u ftp_proxy -u FTP_PROXY node scripts/run-vitest.mjs src/infra/net/fetch-guard.ssrf.test.ts --testNamePattern='follows a redirect when the redirect body cancel\(\) rejects'
```

```
[test] starting test/vitest/vitest.infra.config.ts

 RUN  v4.1.10 /home/0668000387/openclawCxbAsDev/.worktrees/pr111163

 ✓ |infra| src/infra/net/fetch-guard.ssrf.test.ts (99 tests | 98 skipped) 134ms

 Test Files  1 passed (1)
      Tests  1 passed | 98 skipped (99)
   Start at  14:52:00
   Duration  1.00s (transform 438ms, setup 516ms, import 165ms, tests 134ms, environment 0ms)

[test] passed 1 Vitest shard in 7.20s
```

```bash
env -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY -u all_proxy -u ALL_PROXY -u no_proxy -u NO_PROXY -u ftp_proxy -u FTP_PROXY node scripts/run-vitest.mjs src/infra/net/proxy/proxy-validation.test.ts --testNamePattern='preserves the fetch probe result when the proxy response body cancel\(\) rejects'
```

```
[test] starting test/vitest/vitest.infra.config.ts

 RUN  v4.1.10 /home/0668000387/openclawCxbAsDev/.worktrees/pr111163

 ✓ |infra| src/infra/net/proxy/proxy-validation.test.ts (26 tests | 25 skipped) 161ms

 Test Files  1 passed (1)
      Tests  1 passed | 25 skipped (26)
   Start at  14:52:12
   Duration  1.05s (transform 423ms, setup 549ms, import 150ms, tests 161ms, environment 0ms)

[test] passed 1 Vitest shard in 7.50s
```

Note: Running the full `fetch-guard.ssrf.test.ts` file in this environment surfaces one pre-existing unrelated failure (`blocks exact-origin private DNS when it resolves to NAT64-embedded IPv4 unspecified`) that does not involve the changed cancel-handling code. The new focused tests pass.

@clawsweeper re-review