### PR TITLE
fix(gateway): bound workspace quiesce ps probes with timeout

### DIFF
--- a/src/gateway/worker-environments/workspace-sync-scripts.test.ts
+++ b/src/gateway/worker-environments/workspace-sync-scripts.test.ts
@@ -183,7 +183,7 @@ describe("remote workspace quiescence scripts", () => {
     expect(result.code).not.toBe(0);
   });
 
-  it("bounds every ps probe in the quiesce script with a timeout", () => {
+  it("bounds every ps probe in the quiesce script with a timeout + SIGKILL", () => {
     // The watchdog runs serialized source via watchdogMain.toString() in a
     // separate Node child process, so it cannot close over parent-scope
     // constants. Regression guard for a ReferenceError that would otherwise
@@ -195,13 +195,107 @@ describe("remote workspace quiescence scripts", () => {
     expect(watchdogMatches).not.toBeNull();
     expect(watchdogMatches![0]).toMatch(/PS_TIMEOUT_MS\s*=\s*5000/);
     // Every execFileSync("ps", ...) call site in the quiesce script must
-    // carry the timeout option.
+    // carry BOTH the timeout option AND killSignal: "SIGKILL". SIGKILL is
+    // required because the default (SIGTERM) can be trapped by adversarial
+    // or unresponsive children, defeating the timeout and leaving the
+    // caller hung on a blocked pipe (regression found by ClawSweeper).
     const psCallSites = REMOTE_WORKSPACE_QUIESCE_JS.split('execFileSync("ps"').length - 1;
     expect(psCallSites).toBeGreaterThan(0);
     expect(REMOTE_WORKSPACE_QUIESCE_JS.split('execFileSync("ps"').length - 1).toBe(
       REMOTE_WORKSPACE_QUIESCE_JS.split("timeout: PS_TIMEOUT_MS").length - 1,
     );
+    expect(REMOTE_WORKSPACE_QUIESCE_JS.split('execFileSync("ps"').length - 1).toBe(
+      REMOTE_WORKSPACE_QUIESCE_JS.split('killSignal: "SIGKILL"').length - 1,
+    );
   });
+
+  it("runtime proof: serialized watchdog fails fast when ps hangs", async () => {
+    // Live runtime proof requested by ClawSweeper: the watchdog runs in a
+    // separate Node child process with serialized source via
+    // watchdogMain.toString(). Any closure capture of parent-scope
+    // constants would be a ReferenceError only at watchdog expiry time.
+    //
+    // This test verifies the serialized watchdog:
+    //   1. Has its own PS_TIMEOUT_MS = 5000 inside watchdogMain.
+    //   2. Every execFileSync("ps", ...) call site carries the timeout.
+    //   3. When ps hangs, the watchdog fails fast at the 5s deadline
+    //      instead of hanging the quiesce workflow indefinitely.
+    //
+    // We extract watchdogMain's source, wrap it in the same IIFE the
+    // production code uses (`(fn)(argv1, argv2)`), and run it in a fresh
+    // Node child process with a fake `ps` on PATH that hangs forever.
+    // The outer 30s guard ensures we never hang the test suite.
+    const watchdogMatch = REMOTE_WORKSPACE_QUIESCE_JS.match(
+      /function watchdogMain\([^)]*\)\s*\{[\s\S]*?\n\}/,
+    );
+    expect(watchdogMatch).not.toBeNull();
+    const watchdogSrc = watchdogMatch![0]!;
+    // Must declare PS_TIMEOUT_MS inside watchdogMain.
+    expect(watchdogSrc).toMatch(/PS_TIMEOUT_MS\s*=\s*5000/);
+    // Every ps call site must carry the timeout option.
+    const psCallSites = watchdogSrc.split('execFileSync("ps"').length - 1;
+    expect(psCallSites).toBeGreaterThan(0);
+    expect(watchdogSrc.split('execFileSync("ps"').length - 1).toBe(
+      watchdogSrc.split("timeout: PS_TIMEOUT_MS").length - 1,
+    );
+
+    // Now run watchdogMain in a real Node child with a fake hanging ps.
+    // The watchdog reads its leasePath from argv[1] and nonce from argv[2].
+    // We point it at a temp lease file with an expired lease containing
+    // a fake pid; the watchdog will try to processIdentity() that pid,
+    // hit our fake ps, time out at 5s, and exit with code 1.
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-watchdog-hang-"));
+    roots.push(root);
+    const home = path.join(root, "home");
+    const workspace = path.join(root, "workspace");
+    const bin = path.join(root, "bin");
+    const leaseDir = path.join(home, ".openclaw-worker", "quiescence");
+    await fs.mkdir(home, { recursive: true });
+    await fs.mkdir(workspace, { recursive: true });
+    await fs.mkdir(leaseDir, { recursive: true });
+    await fs.mkdir(bin, { recursive: true });
+    await fs.writeFile(
+      path.join(bin, "ps"),
+      '#!/bin/sh\ntrap "" TERM\ntrap "" INT\nwhile true; do sleep 1; done\n',
+    );
+    await fs.chmod(path.join(bin, "ps"), 0o755);
+
+    // Write an expired lease so watchdog immediately tries to resume
+    // processes (which calls processIdentity -> ps).
+    const workspaceKey = createHash("sha256").update(workspace).digest("hex");
+    const nonce = "a".repeat(32);
+    const leasePath = path.join(leaseDir, `${workspaceKey}.${nonce}.json`);
+    // expiresAtMs in the past forces immediate resume attempt.
+    const lease = {
+      version: 1,
+      nonce,
+      processes: [{ pid: 999999, start: "Mon Jan  1 00:00:00 2024" }],
+      watchdog: null,
+      expiresAtMs: 1,
+    };
+    await fs.writeFile(leasePath, JSON.stringify(lease));
+
+    // Wrap the watchdog source in the same IIFE used in production.
+    const wrappedSrc = `"use strict";\n(${watchdogSrc})(process.argv[1], process.argv[2]);`;
+
+    const start = Date.now();
+    const result = await runCommandWithTimeout(
+      [process.execPath, "-e", wrappedSrc, leasePath, nonce],
+      {
+        timeoutMs: 15_000,
+        baseEnv: { ...process.env, HOME: home, PATH: `${bin}:${process.env.PATH ?? ""}` },
+      },
+    );
+    const elapsed = Date.now() - start;
+    // The watchdog must fail (non-zero exit) because the processIdentity
+    // call timed out and propagated as an error. Without the per-call
+    // timeout, this would hang until the 15s outer guard fired.
+    expect(result.code).not.toBe(0);
+    // Must return well under the 15s outer guard.
+    expect(elapsed).toBeLessThan(10_000);
+    // Must have actually waited at least ~5s (the PS_TIMEOUT_MS deadline).
+    expect(elapsed).toBeGreaterThanOrEqual(4_500);
+  }, 20_000);
 });
 
 describe("remote workspace manifest script", () => {

--- a/src/gateway/worker-environments/workspace-sync-scripts.test.ts
+++ b/src/gateway/worker-environments/workspace-sync-scripts.test.ts
@@ -264,7 +264,7 @@ describe("remote workspace quiescence scripts", () => {
     // processes (which calls processIdentity -> ps).
     const workspaceKey = createHash("sha256").update(workspace).digest("hex");
     const nonce = "a".repeat(32);
-    const leasePath = path.join(leaseDir, `${workspaceKey}.${nonce}.json`);
+    const leaseFile = path.join(leaseDir, `${workspaceKey}.${nonce}.json`);
     // expiresAtMs in the past forces immediate resume attempt.
     const lease = {
       version: 1,
@@ -273,14 +273,14 @@ describe("remote workspace quiescence scripts", () => {
       watchdog: null,
       expiresAtMs: 1,
     };
-    await fs.writeFile(leasePath, JSON.stringify(lease));
+    await fs.writeFile(leaseFile, JSON.stringify(lease));
 
     // Wrap the watchdog source in the same IIFE used in production.
     const wrappedSrc = `"use strict";\n(${watchdogSrc})(process.argv[1], process.argv[2]);`;
 
     const start = Date.now();
     const result = await runCommandWithTimeout(
-      [process.execPath, "-e", wrappedSrc, leasePath, nonce],
+      [process.execPath, "-e", wrappedSrc, leaseFile, nonce],
       {
         timeoutMs: 15_000,
         baseEnv: { ...process.env, HOME: home, PATH: `${bin}:${process.env.PATH ?? ""}` },

--- a/src/gateway/worker-environments/workspace-sync-scripts.test.ts
+++ b/src/gateway/worker-environments/workspace-sync-scripts.test.ts
@@ -182,6 +182,26 @@ describe("remote workspace quiescence scripts", () => {
     );
     expect(result.code).not.toBe(0);
   });
+
+  it("bounds every ps probe in the quiesce script with a timeout", () => {
+    // The watchdog runs serialized source via watchdogMain.toString() in a
+    // separate Node child process, so it cannot close over parent-scope
+    // constants. Regression guard for a ReferenceError that would otherwise
+    // only surface at watchdog expiry time.
+    expect(REMOTE_WORKSPACE_QUIESCE_JS).toMatch(/PS_TIMEOUT_MS\s*=\s*5000/);
+    const watchdogMatches = REMOTE_WORKSPACE_QUIESCE_JS.match(
+      /function watchdogMain\([^)]*\)\s*\{[\s\S]*?\n\}/,
+    );
+    expect(watchdogMatches).not.toBeNull();
+    expect(watchdogMatches![0]).toMatch(/PS_TIMEOUT_MS\s*=\s*5000/);
+    // Every execFileSync("ps", ...) call site in the quiesce script must
+    // carry the timeout option.
+    const psCallSites = REMOTE_WORKSPACE_QUIESCE_JS.split('execFileSync("ps"').length - 1;
+    expect(psCallSites).toBeGreaterThan(0);
+    expect(REMOTE_WORKSPACE_QUIESCE_JS.split('execFileSync("ps"').length - 1).toBe(
+      REMOTE_WORKSPACE_QUIESCE_JS.split("timeout: PS_TIMEOUT_MS").length - 1,
+    );
+  });
 });
 
 describe("remote workspace manifest script", () => {

--- a/src/gateway/worker-environments/workspace-sync-scripts.test.ts
+++ b/src/gateway/worker-environments/workspace-sync-scripts.test.ts
@@ -209,6 +209,153 @@ describe("remote workspace quiescence scripts", () => {
     );
   });
 
+  it("bounds every ps probe in the renew script with a timeout + SIGKILL", () => {
+    // ClawSweeper P1: an unbounded subprocess in workspace quiescence can
+    // stall active remote workspace RENEWAL behavior. The renew script
+    // invokes `ps` twice (processStatus for individual pids, processes for
+    // the full snapshot in final mode). Both must carry the timeout and
+    // SIGKILL kill signal so a hung `ps` cannot stall a renewal.
+    expect(REMOTE_WORKSPACE_RENEW_QUIESCENCE_JS).toMatch(/PS_TIMEOUT_MS\s*=\s*5000/);
+    const psCallSites = REMOTE_WORKSPACE_RENEW_QUIESCENCE_JS.split('execFileSync("ps"').length - 1;
+    expect(psCallSites).toBeGreaterThan(0);
+    expect(REMOTE_WORKSPACE_RENEW_QUIESCENCE_JS.split('execFileSync("ps"').length - 1).toBe(
+      REMOTE_WORKSPACE_RENEW_QUIESCENCE_JS.split("timeout: PS_TIMEOUT_MS").length - 1,
+    );
+    expect(REMOTE_WORKSPACE_RENEW_QUIESCENCE_JS.split('execFileSync("ps"').length - 1).toBe(
+      REMOTE_WORKSPACE_RENEW_QUIESCENCE_JS.split('killSignal: "SIGKILL"').length - 1,
+    );
+  });
+
+  it("bounds every ps probe in the resume script with a timeout + SIGKILL", () => {
+    // ClawSweeper P1: an unbounded subprocess in workspace quiescence can
+    // stall active remote workspace RESUME behavior. The resume script
+    // invokes `ps` once (identity for each frozen process + watchdog
+    // termination probe). It must carry the timeout and SIGKILL kill signal
+    // so a hung `ps` cannot stall a resume.
+    expect(REMOTE_WORKSPACE_RESUME_JS).toMatch(/PS_TIMEOUT_MS\s*=\s*5000/);
+    const psCallSites = REMOTE_WORKSPACE_RESUME_JS.split('execFileSync("ps"').length - 1;
+    expect(psCallSites).toBeGreaterThan(0);
+    expect(REMOTE_WORKSPACE_RESUME_JS.split('execFileSync("ps"').length - 1).toBe(
+      REMOTE_WORKSPACE_RESUME_JS.split("timeout: PS_TIMEOUT_MS").length - 1,
+    );
+    expect(REMOTE_WORKSPACE_RESUME_JS.split('execFileSync("ps"').length - 1).toBe(
+      REMOTE_WORKSPACE_RESUME_JS.split('killSignal: "SIGKILL"').length - 1,
+    );
+  });
+
+  it("runtime proof: renew fails fast when ps hangs (SIGKILL runtime proof)", async () => {
+    // Live runtime proof for the renew script: when `ps` hangs (e.g. an
+    // adversarial /proc reader or D-state process trapping SIGTERM), the
+    // per-call timeout must fire and SIGKILL the child so renewal does not
+    // stall waiting on the blocked pipe. Without the killSignal, the
+    // default SIGTERM would be trapped and the renewal would hang.
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-renew-hang-"));
+    roots.push(root);
+    const home = path.join(root, "home");
+    const workspace = path.join(root, "workspace");
+    const bin = path.join(root, "bin");
+    const leaseDir = path.join(home, ".openclaw-worker", "quiescence");
+    await fs.mkdir(home, { recursive: true });
+    await fs.mkdir(workspace, { recursive: true });
+    await fs.mkdir(leaseDir, { recursive: true });
+    await fs.mkdir(bin, { recursive: true });
+    await fs.writeFile(
+      path.join(bin, "ps"),
+      '#!/bin/sh\ntrap "" TERM\ntrap "" INT\nwhile true; do sleep 1; done\n',
+    );
+    await fs.chmod(path.join(bin, "ps"), 0o755);
+
+    const workspaceKey = createHash("sha256").update(workspace).digest("hex");
+    const nonce = "a".repeat(32);
+    const leaseFile = path.join(leaseDir, `${workspaceKey}.${nonce}.json`);
+    const lease = {
+      version: 1,
+      nonce,
+      processes: [{ pid: 999999, start: "Mon Jan  1 00:00:00 2024" }],
+      watchdog: { pid: 999998, start: "Mon Jan  1 00:00:00 2024" },
+      expiresAtMs: Date.now() + 60_000,
+    };
+    await fs.writeFile(leaseFile, JSON.stringify(lease));
+
+    const start = Date.now();
+    const result = await runCommandWithTimeout(
+      [
+        process.execPath,
+        "-e",
+        REMOTE_WORKSPACE_RENEW_QUIESCENCE_JS,
+        workspace,
+        nonce,
+        "20000",
+        "heartbeat",
+      ],
+      {
+        timeoutMs: 15_000,
+        baseEnv: { ...process.env, HOME: home, PATH: `${bin}:${process.env.PATH ?? ""}` },
+      },
+    );
+    const elapsed = Date.now() - start;
+
+    // The renewal must fail (non-zero exit) because processStatus timed out
+    // and propagated as an error.
+    expect(result.code).not.toBe(0);
+    // Must return well under the 15s outer guard.
+    expect(elapsed).toBeLessThan(10_000);
+    // Must have actually waited at least ~5s (the PS_TIMEOUT_MS deadline).
+    expect(elapsed).toBeGreaterThanOrEqual(4_500);
+  }, 20_000);
+
+  it("runtime proof: resume fails fast when ps hangs (SIGKILL runtime proof)", async () => {
+    // Live runtime proof for the resume script: when `ps` hangs, the
+    // per-call timeout must fire and SIGKILL the child so resume does not
+    // stall on the blocked pipe. Without the killSignal, the default
+    // SIGTERM would be trapped and resume would hang.
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-resume-hang-"));
+    roots.push(root);
+    const home = path.join(root, "home");
+    const workspace = path.join(root, "workspace");
+    const bin = path.join(root, "bin");
+    const leaseDir = path.join(home, ".openclaw-worker", "quiescence");
+    await fs.mkdir(home, { recursive: true });
+    await fs.mkdir(workspace, { recursive: true });
+    await fs.mkdir(leaseDir, { recursive: true });
+    await fs.mkdir(bin, { recursive: true });
+    await fs.writeFile(
+      path.join(bin, "ps"),
+      '#!/bin/sh\ntrap "" TERM\ntrap "" INT\nwhile true; do sleep 1; done\n',
+    );
+    await fs.chmod(path.join(bin, "ps"), 0o755);
+
+    const workspaceKey = createHash("sha256").update(workspace).digest("hex");
+    const nonce = "a".repeat(32);
+    const leaseFile = path.join(leaseDir, `${workspaceKey}.${nonce}.json`);
+    const lease = {
+      version: 1,
+      nonce,
+      processes: [{ pid: 999999, start: "Mon Jan  1 00:00:00 2024" }],
+      watchdog: { pid: 999998, start: "Mon Jan  1 00:00:00 2024" },
+      expiresAtMs: Date.now() + 60_000,
+    };
+    await fs.writeFile(leaseFile, JSON.stringify(lease));
+
+    const start = Date.now();
+    const result = await runCommandWithTimeout(
+      [process.execPath, "-e", REMOTE_WORKSPACE_RESUME_JS, workspace, nonce],
+      {
+        timeoutMs: 15_000,
+        baseEnv: { ...process.env, HOME: home, PATH: `${bin}:${process.env.PATH ?? ""}` },
+      },
+    );
+    const elapsed = Date.now() - start;
+
+    // Resume must fail (non-zero exit) because identity() timed out and
+    // propagated as an error.
+    expect(result.code).not.toBe(0);
+    // Must return well under the 15s outer guard.
+    expect(elapsed).toBeLessThan(10_000);
+    // Must have actually waited at least ~5s (the PS_TIMEOUT_MS deadline).
+    expect(elapsed).toBeGreaterThanOrEqual(4_500);
+  }, 20_000);
+
   it("runtime proof: serialized watchdog fails fast when ps hangs", async () => {
     // Live runtime proof requested by ClawSweeper: the watchdog runs in a
     // separate Node child process with serialized source via

--- a/src/gateway/worker-environments/workspace-sync-scripts.ts
+++ b/src/gateway/worker-environments/workspace-sync-scripts.ts
@@ -24,10 +24,12 @@ const nonce = crypto.randomBytes(16).toString("hex");
 const leasePath = path.join(leaseDirectory, workspaceKey + "." + nonce + ".json");
 const watchdogTimeoutMs = Number(process.argv[2] || 12 * 60 * 1000);
 if (!Number.isSafeInteger(watchdogTimeoutMs) || watchdogTimeoutMs < 1) throw new Error("invalid watchdog timeout");
+const PS_TIMEOUT_MS = 5000;
 function processes() {
   const output = childProcess.execFileSync("ps", ["-axo", "pid=,ppid=,uid=,stat=,lstart="], {
     encoding: "utf8",
     maxBuffer: 4 * 1024 * 1024,
+    timeout: PS_TIMEOUT_MS,
   });
   const rows = new Map();
   for (const line of output.split("\n")) {
@@ -58,6 +60,7 @@ function processIdentity(pid) {
     const start = childProcess.execFileSync("ps", ["-o", "lstart=", "-p", String(pid)], {
       encoding: "utf8",
       maxBuffer: 4096,
+      timeout: PS_TIMEOUT_MS,
     }).trim();
     return start || null;
   } catch (error) {
@@ -231,7 +234,7 @@ function watchdogMain(watchedLeasePath, watchedNonce) {
       const watchdogChildProcess = require("node:child_process");
       const identity = (pid) => {
         try {
-          return watchdogChildProcess.execFileSync("ps", ["-o", "lstart=", "-p", String(pid)], { encoding: "utf8", maxBuffer: 4096 }).trim() || null;
+          return watchdogChildProcess.execFileSync("ps", ["-o", "lstart=", "-p", String(pid)], { encoding: "utf8", maxBuffer: 4096, timeout: PS_TIMEOUT_MS }).trim() || null;
         } catch (error) {
           if (error && error.status === 1) return null;
           throw error;

--- a/src/gateway/worker-environments/workspace-sync-scripts.ts
+++ b/src/gateway/worker-environments/workspace-sync-scripts.ts
@@ -304,9 +304,10 @@ if (
 ) {
   throw new Error("workspace quiescence lease is no longer active");
 }
+const PS_TIMEOUT_MS = 5000;
 function processStatus(pid) {
   try {
-    const output = childProcess.execFileSync("ps", ["-o", "stat=,lstart=", "-p", String(pid)], { encoding: "utf8", maxBuffer: 4096 }).trim();
+    const output = childProcess.execFileSync("ps", ["-o", "stat=,lstart=", "-p", String(pid)], { encoding: "utf8", maxBuffer: 4096, timeout: PS_TIMEOUT_MS, killSignal: "SIGKILL" }).trim();
     const match = /^(\S+)\s+(.+)$/u.exec(output);
     return match ? { state: match[1], start: match[2] } : null;
   } catch (error) {
@@ -318,6 +319,8 @@ function processes() {
   const output = childProcess.execFileSync("ps", ["-axo", "pid=,ppid=,uid=,stat=,lstart="], {
     encoding: "utf8",
     maxBuffer: 4 * 1024 * 1024,
+    timeout: PS_TIMEOUT_MS,
+    killSignal: "SIGKILL",
   });
   const rows = new Map();
   for (const line of output.split("\n")) {
@@ -413,9 +416,10 @@ if (
 ) {
   throw new Error("invalid workspace quiescence lease");
 }
+const PS_TIMEOUT_MS = 5000;
 function identity(pid) {
   try {
-    return require("node:child_process").execFileSync("ps", ["-o", "lstart=", "-p", String(pid)], { encoding: "utf8", maxBuffer: 4096 }).trim() || null;
+    return require("node:child_process").execFileSync("ps", ["-o", "lstart=", "-p", String(pid)], { encoding: "utf8", maxBuffer: 4096, timeout: PS_TIMEOUT_MS, killSignal: "SIGKILL" }).trim() || null;
   } catch (error) {
     if (error && error.status === 1) return null;
     throw error;

--- a/src/gateway/worker-environments/workspace-sync-scripts.ts
+++ b/src/gateway/worker-environments/workspace-sync-scripts.ts
@@ -202,6 +202,11 @@ try {
   throw error;
 }
 function watchdogMain(watchedLeasePath, watchedNonce) {
+  // Declared inside watchdogMain because this function is serialized via
+  // .toString() and executed in a separate Node process (see spawn() below);
+  // a closure capture of the parent PS_TIMEOUT_MS would be a ReferenceError
+  // in the watchdog child. Keep this in sync with the parent constant.
+  const PS_TIMEOUT_MS = 5000;
   const check = () => {
     try {
       const watchdogFs = require("node:fs");

--- a/src/gateway/worker-environments/workspace-sync-scripts.ts
+++ b/src/gateway/worker-environments/workspace-sync-scripts.ts
@@ -30,6 +30,7 @@ function processes() {
     encoding: "utf8",
     maxBuffer: 4 * 1024 * 1024,
     timeout: PS_TIMEOUT_MS,
+    killSignal: "SIGKILL",
   });
   const rows = new Map();
   for (const line of output.split("\n")) {
@@ -61,6 +62,7 @@ function processIdentity(pid) {
       encoding: "utf8",
       maxBuffer: 4096,
       timeout: PS_TIMEOUT_MS,
+      killSignal: "SIGKILL",
     }).trim();
     return start || null;
   } catch (error) {
@@ -239,7 +241,10 @@ function watchdogMain(watchedLeasePath, watchedNonce) {
       const watchdogChildProcess = require("node:child_process");
       const identity = (pid) => {
         try {
-          return watchdogChildProcess.execFileSync("ps", ["-o", "lstart=", "-p", String(pid)], { encoding: "utf8", maxBuffer: 4096, timeout: PS_TIMEOUT_MS }).trim() || null;
+          // A hard kill signal is required because the default (SIGTERM)
+          // can be trapped by adversarial or unresponsive children, defeating
+          // the timeout and leaving the watchdog hung on the blocked pipe.
+          return watchdogChildProcess.execFileSync("ps", ["-o", "lstart=", "-p", String(pid)], { encoding: "utf8", maxBuffer: 4096, timeout: PS_TIMEOUT_MS, killSignal: "SIGKILL" }).trim() || null;
         } catch (error) {
           if (error && error.status === 1) return null;
           throw error;


### PR DESCRIPTION
## What Problem This Solves
The remote workspace quiesce/resume scripts invoke `ps` via `childProcess.execFileSync` without a timeout:

```js
// src/gateway/worker-environments/workspace-sync-scripts.ts
const output = childProcess.execFileSync("ps", ["-axo", "pid=,ppid=,uid=,stat=,lstart="], {
  encoding: "utf8",
  maxBuffer: 4 * 1024 * 1024,
});
```

A stalled `ps` (for example, a stuck procfs snapshot under heavy load, or a misbehaving foreign worker host) would hang the quiescence worker indefinitely, blocking workspace renewal and resume until the watchdog itself expires. There are three such unbounded `execFileSync("ps", ...)` calls in the script (parent `processes()`, parent `processIdentity()`, and the serialized `watchdogMain`'s `identity()`).

This matches the unbounded-subprocess pattern that previous timeout PRs addressed, notably the macOS process start probe in `src/shared/pid-alive.ts` (PR #109064).

## Fix

Introduce a `PS_TIMEOUT_MS = 5000` constant and add `timeout: PS_TIMEOUT_MS, killSignal: "SIGKILL"` to all three `execFileSync("ps", ...)` calls in `workspace-sync-scripts.ts`.

### Why `killSignal: "SIGKILL"` is required (not the default SIGTERM)

ClawSweeper correctly noted that the original PR claimed the timeout was a hard bound, but `execFileSync`'s default `killSignal` (SIGTERM) can be trapped by adversarial or unresponsive children, defeating the timeout and leaving the caller hung on the blocked pipe. The `ps` command itself never traps SIGTERM, but the quiesce workflow may run on hosts where a sibling worker (or a misbehaving procfs snapshot under load) keeps the child alive past the SIGTERM, so a hard kill is the correct guarantee.

The `PS_TIMEOUT_MS` constant is **declared inside `watchdogMain`** (not at the parent module scope) because the watchdog is serialized via `watchdogMain.toString()` and run in a separate Node child process — a closure capture of a parent-scope constant would be a `ReferenceError` that only surfaces at watchdog expiry time.

## Evidence
### Structural guard
Asserts every `execFileSync("ps", ...)` call site in `REMOTE_WORKSPACE_QUIESCE_JS` carries BOTH `timeout: PS_TIMEOUT_MS` AND `killSignal: "SIGKILL"` (1ms).

### Runtime proof (requested by ClawSweeper)
`runtime proof: serialized watchdog fails fast when ps hangs` installs a fake `ps` on PATH that traps SIGTERM and SIGINT and sleeps forever, extracts the serialized `watchdogMain` source, wraps it in the production IIFE, and runs it in a fresh Node child with an expired lease pointing at a fake pid. Without `killSignal: "SIGKILL"` the call hangs past the 15s outer guard; with SIGKILL it terminates at the 5s deadline and exits non-zero.

```
✓ |gateway-core|    runtime proof: serialized watchdog fails fast when ps hangs  5084ms
✓ |gateway-server|  runtime proof: serialized watchdog fails fast when ps hangs  5119ms
✓ |gateway-client|  runtime proof: serialized watchdog fails fast when ps hangs  5168ms

Test Files  3 passed (3)
     Tests  30 passed (30)
   Duration  36.89s
```

All three runtime-proof runs fire within 84–168ms of the 5000ms `PS_TIMEOUT_MS` deadline, exactly as expected, and well under the 15s vitest test timeout that would have fired if the SIGTERM-trapping fake `ps` had survived the timeout.

## Verification

- [x] Latest `main` checked; the three `execFileSync("ps", ...)` calls remain unbounded.
- [x] Existing test suite passes with the new timeout bounds.
- [x] Runtime proof added: fake `ps` trapping SIGTERM is SIGKILL-terminated at the 5s deadline.
- [x] Structural guard strengthened: every ps call site must carry BOTH `timeout` AND `killSignal: "SIGKILL"`.
