### PR TITLE
fix(doctor): treat invalid legacy session stubs as warnings during session SQLite import

### DIFF
--- a/src/commands/doctor-session-sqlite-types.ts
+++ b/src/commands/doctor-session-sqlite-types.ts
@@ -7,6 +7,18 @@ export type DoctorSessionSqliteIssue = {
   sessionKey?: string;
 };
 
+const SESSION_SQLITE_WARNING_ISSUE_CODES = new Set([
+  "entry_invalid",
+  "transcript_archive_failed",
+  "transcript_malformed",
+  "transcript_missing",
+  "unreferenced_jsonl_archive_failed",
+]);
+
+export function isSessionSqliteMigrationWarning(issue: DoctorSessionSqliteIssue): boolean {
+  return SESSION_SQLITE_WARNING_ISSUE_CODES.has(issue.code);
+}
+
 export type DoctorSessionSqliteRestoreConflict = {
   archivePath: string;
   reason: string;

--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -229,7 +229,7 @@ describe("runDoctorSessionSqlite", () => {
 
   it("keeps mismatched older agent schema versions blocking during all-agent import", async () => {
     const tempDir = autoCleanupTempDirs.make("openclaw-doctor-session-sqlite-");
-    const stateDir = path.join(tempDir, "state");
+    const stateDir = path.join(tempDir, "token=supersecret", "state");
     const sessionsDir = path.join(stateDir, "agents", "drifted", "sessions");
     const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
     fs.mkdirSync(sessionsDir, { recursive: true });
@@ -261,6 +261,17 @@ describe("runDoctorSessionSqlite", () => {
         message: expect.stringMatching(/uses schema version 1/iu),
       }),
     ]);
+    const manifest = readMigrationManifest(report.migrationRun?.manifestPath);
+    expect(manifest.failedAt).toBeTruthy();
+    expect(manifest.failureReports).toBeDefined();
+    const failureReportPath = expectDefined(
+      report.migrationRun?.failureReportMarkdownPath,
+      "blocking migration failure report path",
+    );
+    const failureReport = fs.readFileSync(failureReportPath, "utf-8");
+    expect(failureReport).toContain("sqlite_compact_failed");
+    expect(failureReport).toContain("openclaw doctor --session-sqlite recover --github-issue");
+    expect(failureReport).not.toContain("supersecret");
     const after = new sqlite.DatabaseSync(sqlitePath);
     try {
       expect(after.prepare("PRAGMA user_version").get()).toEqual({ user_version: 1 });
@@ -481,6 +492,57 @@ describe("runDoctorSessionSqlite", () => {
         storePath: store.storePath,
       }),
     ).toHaveLength(2);
+  });
+
+  it("archives legacy stores with valid sessions and invalid cron stubs without failing", async () => {
+    const store = createLegacyStore();
+    const legacyStore = JSON.parse(fs.readFileSync(store.storePath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    const cronStubKey = "agent:main:cron:legacy-stub";
+    legacyStore[cronStubKey] = { updatedAt: 1500 };
+    fs.writeFileSync(store.storePath, `${JSON.stringify(legacyStore, null, 2)}\n`, { mode: 0o600 });
+
+    const report = await runDoctorSessionSqlite({
+      env: store.env,
+      mode: "import",
+      store: store.storePath,
+    });
+
+    expect(report.totals).toMatchObject({
+      archivedLegacyStoreFiles: 1,
+      importedEntries: 1,
+      importedTranscriptEvents: 2,
+      issues: 1,
+      sqliteEntries: 1,
+    });
+    expect(report.targets[0]?.issues).toEqual([
+      {
+        code: "entry_invalid",
+        message: "Session entry is missing a valid sessionId.",
+        sessionKey: cronStubKey,
+      },
+    ]);
+    const archivedStorePath = expectDefined(
+      report.targets[0]?.archivedLegacyStoreFiles?.[0],
+      "archived legacy store path",
+    );
+    expect(fs.existsSync(store.storePath)).toBe(false);
+    expect(fs.existsSync(archivedStorePath)).toBe(true);
+    expect(JSON.parse(fs.readFileSync(archivedStorePath, "utf-8"))).toMatchObject({
+      [cronStubKey]: { updatedAt: 1500 },
+    });
+
+    const manifest = readMigrationManifest(report.migrationRun?.manifestPath);
+    expect(manifest.failedAt).toBeUndefined();
+    expect(manifest.failureReports).toBeUndefined();
+    expect(manifest.targets[0]).toMatchObject({
+      issues: [expect.objectContaining({ code: "entry_invalid", sessionKey: cronStubKey })],
+      validationBeforeArchive: "passed",
+    });
+    expect(report.migrationRun?.failureReportJsonPath).toBeUndefined();
+    expect(report.migrationRun?.failureReportMarkdownPath).toBeUndefined();
   });
 
   it("compacts migrated agent SQLite databases and reports reclaimed pages", async () => {
@@ -2461,14 +2523,9 @@ describe("runDoctorSessionSqlite", () => {
     expect(
       manifest.targets[0]?.completedMoves.some((move) => move.kind === "unreferenced-jsonl"),
     ).toBe(true);
-    expect(report.migrationRun?.failureReportMarkdownPath).toBeTruthy();
-    const failureReport = fs.readFileSync(
-      report.migrationRun?.failureReportMarkdownPath ?? "",
-      "utf-8",
-    );
-    expect(failureReport).toContain("transcript_malformed");
-    expect(failureReport).toContain("openclaw doctor --session-sqlite recover --github-issue");
-    expect(failureReport).not.toContain("supersecret");
+    expect(manifest.failedAt).toBeUndefined();
+    expect(manifest.failureReports).toBeUndefined();
+    expect(report.migrationRun?.failureReportMarkdownPath).toBeUndefined();
   });
 
   it("reports malformed selected legacy transcripts during validation", async () => {

--- a/src/commands/doctor-session-sqlite.ts
+++ b/src/commands/doctor-session-sqlite.ts
@@ -55,12 +55,13 @@ import {
 } from "./doctor-session-sqlite-readers.js";
 import { recoverDoctorSessionSqliteTargets } from "./doctor-session-sqlite-recover-report.js";
 import { restoreDoctorSessionSqliteTargets } from "./doctor-session-sqlite-restore-report.js";
-import type {
-  DoctorSessionSqliteIssue,
-  DoctorSessionSqliteMode,
-  DoctorSessionSqliteOptions,
-  DoctorSessionSqliteReport,
-  DoctorSessionSqliteTargetReport,
+import {
+  isSessionSqliteMigrationWarning,
+  type DoctorSessionSqliteIssue,
+  type DoctorSessionSqliteMode,
+  type DoctorSessionSqliteOptions,
+  type DoctorSessionSqliteReport,
+  type DoctorSessionSqliteTargetReport,
 } from "./doctor-session-sqlite-types.js";
 export {
   restoreSessionSqliteMigrationRun,
@@ -81,13 +82,6 @@ type LegacySessionRecord = {
   sessionKey: string;
   transcriptPath?: string;
 };
-
-const WARNING_ISSUE_CODES = new Set([
-  "transcript_missing",
-  "transcript_archive_failed",
-  "transcript_malformed",
-  "unreferenced_jsonl_archive_failed",
-]);
 
 /** Runs the targeted doctor SQLite session migration/inspection submode. */
 export async function runDoctorSessionSqlite(
@@ -140,9 +134,9 @@ export async function runDoctorSessionSqlite(
   }
   if (activeRun) {
     archiveImportedLegacySessionStores(targets, reports, activeRun, fullyCoveredStorePaths);
-    const hasIssues = reports.some((report) => report.issues.length > 0);
+    const hasBlockingIssues = reports.some((report) => blockingIssueCount(report) > 0);
     activeRun.manifest.completedAt = new Date().toISOString();
-    if (hasIssues) {
+    if (hasBlockingIssues) {
       activeRun.manifest.failedAt = activeRun.manifest.completedAt;
       const failureReports = writeSessionSqliteMigrationFailureReports(activeRun.manifestPath, {
         reason: "doctor import reported session SQLite migration issues",
@@ -341,7 +335,7 @@ function resolveFullyCoveredLegacyStorePaths(
           isLegacySessionRecordOwnedByTarget(cfg, target, record.sessionKey),
       ),
     );
-    if (issues.length === 0 && coversEveryRecord) {
+    if (issues.every(isSessionSqliteMigrationWarning) && coversEveryRecord) {
       covered.add(storePath);
     }
   }
@@ -459,7 +453,7 @@ function countLegacyTranscript(
 }
 
 function blockingIssueCount(report: DoctorSessionSqliteTargetReport): number {
-  return report.issues.filter((issue) => !WARNING_ISSUE_CODES.has(issue.code)).length;
+  return report.issues.filter((issue) => !isSessionSqliteMigrationWarning(issue)).length;
 }
 
 async function importLegacySessionRecord(

--- a/src/gateway/server-startup-session-migration.test.ts
+++ b/src/gateway/server-startup-session-migration.test.ts
@@ -244,6 +244,11 @@ describe("runStartupSessionMigration", () => {
           importedTranscriptEvents: 0,
           issues: [
             {
+              code: "entry_invalid",
+              message: "Session entry is missing a valid sessionId.",
+              sessionKey: "agent:main:cron:legacy-stub",
+            },
+            {
               code: "transcript_malformed",
               message: "/tmp/bad.jsonl: SyntaxError",
               sessionKey: "agent:main:main",
@@ -264,7 +269,7 @@ describe("runStartupSessionMigration", () => {
         archivedUnreferencedJsonlFiles: 0,
         importedEntries: 0,
         importedTranscriptEvents: 0,
-        issues: 1,
+        issues: 2,
         legacyEntries: 1,
         sqliteEntries: 0,
         targets: 1,
@@ -280,9 +285,9 @@ describe("runStartupSessionMigration", () => {
       deps: makeDeps(migrate, 0, runDoctorSessionSqlite),
     });
 
-    expect(firstLogMessage(log.warn, "malformed transcript warning")).toContain(
-      "session SQLite migration warnings",
-    );
+    const warning = firstLogMessage(log.warn, "legacy file warnings");
+    expect(warning).toContain("session SQLite migration warnings");
+    expect(warning).toContain("[entry_invalid] agent:main:cron:legacy-stub");
   });
 
   it("classifies corrupt SQLite startup failures with recovery guidance", async () => {

--- a/src/gateway/server-startup-session-migration.ts
+++ b/src/gateway/server-startup-session-migration.ts
@@ -1,9 +1,10 @@
 import { listAgentIds } from "../agents/agent-scope.js";
-import type {
-  DoctorSessionSqliteIssue,
-  DoctorSessionSqliteReport,
-  DoctorSessionSqliteRestoreReport,
-} from "../commands/doctor-session-sqlite.js";
+import {
+  isSessionSqliteMigrationWarning,
+  type DoctorSessionSqliteIssue,
+  type DoctorSessionSqliteReport,
+  type DoctorSessionSqliteRestoreReport,
+} from "../commands/doctor-session-sqlite-types.js";
 import {
   runSessionStartupMigration,
   type SessionStartupMigrationLogger,
@@ -33,14 +34,6 @@ type SessionMigrationDeps = Parameters<typeof runSessionStartupMigration>[0]["de
   runDoctorSessionSqlite?: SessionSqliteStartupImportRunner;
   writeSessionSqliteMigrationFailureReports?: SessionSqliteStartupFailureReportWriter;
 };
-
-const STARTUP_WARNING_ISSUE_CODES = new Set([
-  "entry_invalid",
-  "transcript_archive_failed",
-  "transcript_malformed",
-  "transcript_missing",
-  "unreferenced_jsonl_archive_failed",
-]);
 
 /**
  * Run session migrations at gateway startup before runtime session access.
@@ -194,16 +187,14 @@ function collectStartupBlockingIssues(
   report: DoctorSessionSqliteReport,
 ): DoctorSessionSqliteIssue[] {
   return report.targets.flatMap((target) =>
-    target.issues.filter((issue) => !STARTUP_WARNING_ISSUE_CODES.has(issue.code)),
+    target.issues.filter((issue) => !isSessionSqliteMigrationWarning(issue)),
   );
 }
 
 function collectStartupWarningIssues(
   report: DoctorSessionSqliteReport,
 ): DoctorSessionSqliteIssue[] {
-  return report.targets.flatMap((target) =>
-    target.issues.filter((issue) => STARTUP_WARNING_ISSUE_CODES.has(issue.code)),
-  );
+  return report.targets.flatMap((target) => target.issues.filter(isSessionSqliteMigrationWarning));
 }
 
 function formatStartupIssueLines(issues: readonly DoctorSessionSqliteIssue[]): readonly string[] {


### PR DESCRIPTION
## Summary

Older builds' cron runs wrote session stub entries into `sessions.json` that lack a `sessionId`. During the session→SQLite migration these stubs are correctly skipped at read time with an `entry_invalid` issue, but the doctor import machinery classified that code as blocking: post-import validation and archival were skipped, the migration-run manifest was marked failed with failure reports, and the legacy store was never archived — so every gateway startup re-ran the import against the same store. A field report from a 2026.7.2-beta.1 → beta.2 upgrade on Linux hit exactly this ("entry_invalid, 0 entries migrated") and required hand-deleting four stub entries plus `openclaw doctor --session-sqlite recover`. Long-time installs with cron jobs are broadly exposed.

The startup wrapper already classified `entry_invalid` as a warning (`STARTUP_WARNING_ISSUE_CODES`); the doctor-side gates disagreed. Git history shows both sets were introduced together in https://github.com/openclaw/openclaw/pull/98236 with no documented reason for the divergence — an oversight, not a deliberate distinction.

## Fix

- Single canonical classifier `isSessionSqliteMigrationWarning` in `doctor-session-sqlite-types.ts`, shared by the doctor gates (`blockingIssueCount`, fully-covered-store archival, manifest failure marking) and the startup collectors, replacing the two divergent inline sets.
- `entry_invalid` is a warning everywhere: valid entries import, validation and archival proceed, the legacy store archives (invalid stubs remain preserved inside the archived store file), and the run manifest is not marked failed. Genuinely blocking codes (`store_unreadable`, `store_not_object`, `sqlite_read_failed`, `sqlite_compact_failed`, …) are unchanged.
- Regression test: a store with valid sessions plus a `sessionId`-less cron stub imports the valid entries, surfaces `entry_invalid` as a warning, archives the store, and leaves the manifest un-failed. Blocking-path coverage now also asserts failure-report content: issue codes, recovery guidance, and secret redaction.

## Release-note context

Legacy cron session stubs without a `sessionId` no longer fail the session→SQLite migration; they are skipped as warnings and preserved in the archived legacy store.

## Verification

- `node scripts/run-vitest.mjs run src/commands/doctor-session-sqlite.test.ts src/gateway/server-startup-session-migration.test.ts` — 82 passed (re-run after rebase onto current `main`).
- `pnpm check:changed` — passed (delegated Testbox run `tbx_01kxw2m8r3qa5k15v83s12kfdz`).
- No config or secret implications.

Implementation by a delegated Codex (`gpt-5.6-sol`) thread; reviewed, verified, and integrated by Claude.
