### PR TITLE
fix(plugins): report newer registry releases for exact-pinned npm installs

### DIFF
--- a/src/plugins/update-attempt.ts
+++ b/src/plugins/update-attempt.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ClawHubTrustErrorCode } from "../infra/clawhub-install-trust.js";
+import type { UpdateChannel } from "../infra/update-channels.js";
 import { CLAWHUB_INSTALL_ERROR_CODE } from "./clawhub-error-codes.js";
 import { installPluginFromClawHub, type ClawHubRiskAcknowledgementRequest } from "./clawhub.js";
 import { installPluginFromGitSpec } from "./git-install.js";
@@ -20,6 +21,19 @@ import {
   type PluginUpdateOutcome,
   type UpdatablePluginInstallRecord,
 } from "./update-source.js";
+
+export function formatNewerExactPinnedNpmDefaultLineMessage(params: {
+  pluginId: string;
+  effectiveSpec: string;
+  currentVersion: string;
+  newer: { packageName: string; registryLine: "beta" | "latest"; version: string };
+}): string {
+  return (
+    `${params.pluginId} is pinned to ${params.effectiveSpec} (installed ${params.currentVersion}); ` +
+    `registry ${params.newer.registryLine} resolves to ${params.newer.version}. ` +
+    `Pass \`openclaw plugins update ${params.newer.packageName}@${params.newer.registryLine}\` to follow that registry line.`
+  );
+}
 
 export function formatNpmInstallFailure(params: {
   pluginId: string;
@@ -230,6 +244,7 @@ export async function buildDryRunPluginUpdateOutcome(params: {
   usedOfficialNpmFallback: boolean;
   hasSpecOverride: boolean;
   hasOfficialNpmSpec: boolean;
+  updateChannel?: UpdateChannel;
   timeoutMs?: number;
   channelFallbackSuffix: string;
   npmChannelFallback?: PluginUpdateChannelFallback;
@@ -268,6 +283,7 @@ export async function buildDryRunPluginUpdateOutcome(params: {
           currentVersion: params.currentVersion,
           effectiveSpec: params.effectiveSpec,
           probeNpmVersion: npmProbeVersion,
+          updateChannel: params.updateChannel,
           timeoutMs: params.timeoutMs,
         })
       : undefined;
@@ -275,16 +291,18 @@ export async function buildDryRunPluginUpdateOutcome(params: {
   if (unchanged) {
     const message =
       newerExactPinnedDefaultLine && params.effectiveSpec
-        ? `${params.pluginId} is pinned to ${params.effectiveSpec} (installed ${currentLabel}); ` +
-          `registry default resolves to ${newerExactPinnedDefaultLine.version}. ` +
-          `Pass \`openclaw plugins update ${newerExactPinnedDefaultLine.packageName}@latest\` to follow the registry default line.` +
-          params.channelFallbackSuffix
+        ? formatNewerExactPinnedNpmDefaultLineMessage({
+            pluginId: params.pluginId,
+            effectiveSpec: params.effectiveSpec,
+            currentVersion: currentLabel,
+            newer: newerExactPinnedDefaultLine,
+          }) + params.channelFallbackSuffix
         : `${params.pluginId} is up to date (${currentLabel}).${params.channelFallbackSuffix}`;
     return {
       pluginId: params.pluginId,
       status: "unchanged",
       currentVersion: params.currentVersion,
-      nextVersion: resolvedProbeVersion,
+      nextVersion: newerExactPinnedDefaultLine?.version ?? resolvedProbeVersion,
       message,
       ...(params.npmChannelFallback ? { channelFallback: params.npmChannelFallback } : {}),
     };

--- a/src/plugins/update-installed.ts
+++ b/src/plugins/update-installed.ts
@@ -30,6 +30,7 @@ import {
   formatClawHubInstallFailure,
   formatGitInstallFailure,
   formatMarketplaceInstallFailure,
+  formatNewerExactPinnedNpmDefaultLineMessage,
   formatNpmInstallFailure,
   readClawHubTrustErrorCode,
   runPluginUpdateAttempt,
@@ -58,6 +59,7 @@ import {
   resolveClawHubUpdateSpecs,
   resolveNpmSpecPackageName,
   resolveNpmUpdateSpecs,
+  resolveNewerExactPinnedNpmDefaultLine,
   resolveTrustedOfficialPrereleaseFallbackMetadataForUpdate,
   resolveTrustedSourceLinkedOfficialNpmFallbackForClawHubUpdate,
   shouldBypassTrustedOfficialUnchangedNpmCheck,
@@ -427,6 +429,16 @@ export async function updateNpmInstalledPlugins(params: {
             metadata: metadataResult.metadata,
           })
         ) {
+          const newerExactPinnedDefaultLine =
+            !params.specOverrides?.[pluginId] && !officialNpmSpec
+              ? await resolveNewerExactPinnedNpmDefaultLine({
+                  currentVersion,
+                  effectiveSpec,
+                  probeNpmVersion: metadataResult.metadata.version,
+                  updateChannel: params.updateChannel,
+                  timeoutMs: params.timeoutMs,
+                })
+              : undefined;
           if (params.syncOfficialPluginInstalls && trustedSourceLinkedOfficialInstall) {
             const nextRecordSpec = resolveNpmInstallRecordSpec({
               requestedSpec: recordSpec,
@@ -461,8 +473,16 @@ export async function updateNpmInstalledPlugins(params: {
             pluginId,
             status: "unchanged",
             currentVersion,
-            nextVersion: metadataResult.metadata.version,
-            message: `${pluginId} is up to date (${currentVersion}).`,
+            nextVersion: newerExactPinnedDefaultLine?.version ?? metadataResult.metadata.version,
+            message:
+              newerExactPinnedDefaultLine && effectiveSpec
+                ? formatNewerExactPinnedNpmDefaultLineMessage({
+                    pluginId,
+                    effectiveSpec,
+                    currentVersion,
+                    newer: newerExactPinnedDefaultLine,
+                  })
+                : `${pluginId} is up to date (${currentVersion}).`,
           });
           continue;
         }
@@ -600,6 +620,7 @@ export async function updateNpmInstalledPlugins(params: {
           usedOfficialNpmFallback,
           hasSpecOverride: Boolean(params.specOverrides?.[pluginId]),
           hasOfficialNpmSpec: Boolean(officialNpmSpec),
+          updateChannel: officialNpmSpec ? officialSyncUpdateChannel : params.updateChannel,
           timeoutMs: params.timeoutMs,
           channelFallbackSuffix,
           npmChannelFallback,

--- a/src/plugins/update-source.ts
+++ b/src/plugins/update-source.ts
@@ -237,8 +237,9 @@ export async function resolveNewerExactPinnedNpmDefaultLine(params: {
   currentVersion: string | undefined;
   effectiveSpec: string | undefined;
   probeNpmVersion: string | undefined;
+  updateChannel?: UpdateChannel;
   timeoutMs?: number;
-}): Promise<{ packageName: string; version: string } | undefined> {
+}): Promise<{ packageName: string; registryLine: "beta" | "latest"; version: string } | undefined> {
   if (!params.currentVersion || !params.probeNpmVersion || !params.effectiveSpec) {
     return undefined;
   }
@@ -249,10 +250,16 @@ export async function resolveNewerExactPinnedNpmDefaultLine(params: {
     return undefined;
   }
 
-  const metadataResult = await resolveNpmSpecMetadata({
-    spec: packageName,
-    timeoutMs: params.timeoutMs,
-  }).catch(() => undefined);
+  const resolveMetadata = async (spec: string) =>
+    await resolveNpmSpecMetadata({ spec, timeoutMs: params.timeoutMs }).catch(() => undefined);
+  let registryLine: "beta" | "latest" = params.updateChannel === "beta" ? "beta" : "latest";
+  let metadataResult = await resolveMetadata(
+    registryLine === "beta" ? `${packageName}@beta` : packageName,
+  );
+  if (registryLine === "beta" && !metadataResult?.ok) {
+    registryLine = "latest";
+    metadataResult = await resolveMetadata(packageName);
+  }
   if (
     !metadataResult?.ok ||
     metadataResult.metadata.name !== packageName ||
@@ -261,7 +268,7 @@ export async function resolveNewerExactPinnedNpmDefaultLine(params: {
     return undefined;
   }
   return compareNpmSemverForUpdate(metadataResult.metadata.version, params.currentVersion) > 0
-    ? { packageName, version: metadataResult.metadata.version }
+    ? { packageName, registryLine, version: metadataResult.metadata.version }
     : undefined;
 }
 
@@ -684,14 +691,6 @@ export function resolveNpmUpdateSpecs(params: {
       : (params.officialSpecOverride ?? params.record.spec));
   if (!recordSpec) {
     return {};
-  }
-  if (params.specOverride) {
-    return resolveNpmInstallSpecsForUpdateChannel({
-      spec: recordSpec,
-      updateChannel: params.updateChannel,
-      officialPackageName: params.officialPackageName,
-      coreVersion: params.coreVersion,
-    });
   }
   return resolveNpmInstallSpecsForUpdateChannel({
     spec: recordSpec,

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -1397,6 +1397,151 @@ describe("updateNpmInstalledPlugins", () => {
     ]);
   });
 
+  it.each([
+    {
+      name: "latest",
+      updateChannel: undefined,
+      registrySpec: "@acme/demo",
+      registryVersion: "1.2.4",
+      overrideSpec: "@acme/demo@latest",
+    },
+    {
+      name: "beta",
+      updateChannel: "beta" as const,
+      registrySpec: "@acme/demo@beta",
+      registryVersion: "1.3.0-beta.1",
+      overrideSpec: "@acme/demo@beta",
+    },
+  ])(
+    "reports newer $name releases for exact-pinned installed records instead of claiming up to date",
+    async ({ updateChannel, registrySpec, registryVersion, overrideSpec }) => {
+      const installPath = createInstalledPackageDir({
+        name: "@acme/demo",
+        version: "1.2.3",
+      });
+      mockNpmViewMetadata({
+        name: "@acme/demo",
+        version: "1.2.3",
+        integrity: "sha512-same",
+        shasum: "same",
+      });
+      mockNpmViewMetadata({
+        name: "@acme/demo",
+        version: registryVersion,
+      });
+      installPluginFromNpmSpecMock.mockRejectedValue(new Error("installer should not run"));
+      const config = createNpmInstallConfig({
+        pluginId: "demo",
+        spec: "@acme/demo@1.2.3",
+        installPath,
+        resolvedName: "@acme/demo",
+        resolvedSpec: "@acme/demo@1.2.3",
+        resolvedVersion: "1.2.3",
+        integrity: "sha512-same",
+        shasum: "same",
+        installedAt: "2026-07-01T00:00:00.000Z",
+        resolvedAt: "2026-07-01T00:00:01.000Z",
+      });
+
+      const result = await updateNpmInstalledPlugins({
+        config,
+        pluginIds: ["demo"],
+        ...(updateChannel ? { updateChannel } : {}),
+      });
+
+      expect(installPluginFromNpmSpecMock).not.toHaveBeenCalled();
+      expect(runCommandWithTimeoutMock.mock.calls).toHaveLength(2);
+      expect(runCommandWithTimeoutMock.mock.calls[1]?.[0]).toEqual([
+        "npm",
+        "view",
+        registrySpec,
+        "name",
+        "version",
+        "dist.integrity",
+        "dist.shasum",
+        "openclaw",
+        "--json",
+      ]);
+      expect(result.changed).toBe(false);
+      expect(result.config).toBe(config);
+      expect(result.outcomes).toEqual([
+        {
+          pluginId: "demo",
+          status: "unchanged",
+          currentVersion: "1.2.3",
+          nextVersion: registryVersion,
+          message:
+            `demo is pinned to @acme/demo@1.2.3 (installed 1.2.3); ` +
+            `registry ${updateChannel === "beta" ? "beta" : "latest"} resolves to ${registryVersion}. ` +
+            `Pass \`openclaw plugins update ${overrideSpec}\` to follow that registry line.`,
+        },
+      ]);
+    },
+  );
+
+  it("reports a newer latest release when the beta line for an exact pin is unavailable", async () => {
+    const installPath = createInstalledPackageDir({
+      name: "@acme/demo",
+      version: "1.2.3",
+    });
+    mockNpmViewMetadata({
+      name: "@acme/demo",
+      version: "1.2.3",
+      integrity: "sha512-same",
+      shasum: "same",
+    });
+    runCommandWithTimeoutMock.mockResolvedValueOnce({
+      code: 1,
+      stdout: "",
+      stderr: "npm error code E404",
+    });
+    mockNpmViewMetadata({
+      name: "@acme/demo",
+      version: "1.2.4",
+    });
+    installPluginFromNpmSpecMock.mockRejectedValue(new Error("installer should not run"));
+
+    const result = await updateNpmInstalledPlugins({
+      config: createNpmInstallConfig({
+        pluginId: "demo",
+        spec: "@acme/demo@1.2.3",
+        installPath,
+        resolvedName: "@acme/demo",
+        resolvedSpec: "@acme/demo@1.2.3",
+        resolvedVersion: "1.2.3",
+        integrity: "sha512-same",
+        shasum: "same",
+      }),
+      pluginIds: ["demo"],
+      updateChannel: "beta",
+    });
+
+    expect(installPluginFromNpmSpecMock).not.toHaveBeenCalled();
+    expect(runCommandWithTimeoutMock.mock.calls).toHaveLength(3);
+    expect(runCommandWithTimeoutMock.mock.calls[2]?.[0]).toEqual([
+      "npm",
+      "view",
+      "@acme/demo",
+      "name",
+      "version",
+      "dist.integrity",
+      "dist.shasum",
+      "openclaw",
+      "--json",
+    ]);
+    expect(result.outcomes).toEqual([
+      {
+        pluginId: "demo",
+        status: "unchanged",
+        currentVersion: "1.2.3",
+        nextVersion: "1.2.4",
+        message:
+          "demo is pinned to @acme/demo@1.2.3 (installed 1.2.3); registry latest resolves to 1.2.4. " +
+          "Pass `openclaw plugins update @acme/demo@latest` to follow that registry line.",
+      },
+    ]);
+  });
+
   it("does not skip unchanged npm plugins when package metadata requires a newer plugin API", async () => {
     vi.stubEnv("OPENCLAW_COMPATIBILITY_HOST_VERSION", "2026.5.28-beta.3");
     const installPath = createInstalledPackageDir({
@@ -2760,8 +2905,8 @@ describe("updateNpmInstalledPlugins", () => {
         pluginId: "demo",
         status: "unchanged",
         currentVersion: "1.2.3",
-        nextVersion: "1.2.3",
-        message: `demo is pinned to ${spec} (installed 1.2.3); registry default resolves to 1.2.4. Pass \`openclaw plugins update @acme/demo@latest\` to follow the registry default line.`,
+        nextVersion: "1.2.4",
+        message: `demo is pinned to ${spec} (installed 1.2.3); registry latest resolves to 1.2.4. Pass \`openclaw plugins update @acme/demo@latest\` to follow that registry line.`,
       });
     },
   );


### PR DESCRIPTION
## Summary

`openclaw plugins update <id>` reported "up to date" even when a newer version existed on npm (field report: newer versions under both `beta` and `latest` dist-tags; explicit `plugins install pkg@version` worked). Root cause: install records store exact-pinned resolved specs, so the update path re-resolves the pin, metadata always matches the installed version, and the early unchanged short-circuit in `updateNpmInstalledPlugins` returns "up to date" before the existing exact-pin mitigation (`resolveNewerExactPinnedNpmDefaultLine`) — which was wired only into the dry-run attempt path — could run.

History check: pin protection is intentional (manual pins must not be silently unpinned), and persisted records cannot distinguish user pins from installer-managed pins, so auto-updating pinned records is not safe. The narrowest fix consistent with that contract is to stop the false claim and make the outcome actionable.

## Fix

- The early unchanged short-circuit now probes the registry line — `beta` when the update channel is beta (falling back to `latest` when the beta dist-tag is unavailable), `latest` otherwise — and, when a newer version exists, replaces "up to date" with: pinned spec, installed version, what the registry line resolves to, and the exact `openclaw plugins update pkg@<line>` command to follow that line. `nextVersion` on the outcome carries the newer version.
- The dry-run path shares the same message formatting and now respects the beta channel instead of always probing `latest`.
- Explicit spec overrides and official-sync installs bypass the probe (their specs are channel-managed).
- Removed a duplicate branch in `resolveNpmUpdateSpecs` (both arms were identical).

## Release-note context

`openclaw plugins update` no longer claims an exact-pinned plugin is "up to date" when its registry line has a newer version; it now reports the newer version and the exact command to follow that line. Pinned installs are still never updated implicitly.

## Verification

- Repro test asserted red on unmodified code (missing second registry probe), green with the fix; covers `latest`, `beta`, and beta-tag-unavailable fallback.
- `node scripts/run-vitest.mjs run src/plugins/update.test.ts` — 124 passed (re-run after rebase onto current `main`).
- `pnpm check:changed` — passed (delegated Testbox run); live isolated CLI proof on Testbox `tbx_01kxw3b8nkdprdtykdp6m1wenh`.
- No config or secret implications.

Implementation by a delegated Codex (`gpt-5.6-sol`) thread; reviewed, verified, and integrated by Claude.
