### PR TITLE
fix(agents): reject non-UTF-8 JWT payloads in auth binding fingerprints

### DIFF
--- a/src/agents/execution-auth-binding.test.ts
+++ b/src/agents/execution-auth-binding.test.ts
@@ -150,6 +150,35 @@ describe("execution auth binding fingerprints", () => {
     expect(fingerprint("access-a", "subject-1")).not.toBe(fingerprint("access-a", "subject-2"));
   });
 
+  it("ignores an id-token whose payload is not valid UTF-8", () => {
+    const corruptIdToken = `header.${Buffer.concat([
+      Buffer.from('{"sub":"subject-1'),
+      Buffer.from([0xff]),
+      Buffer.from('","email":"user@example.test"}'),
+    ]).toString("base64url")}.signature`;
+    const fingerprint = (access: string, idToken?: string) =>
+      fingerprintAuthProfileCredential({
+        profileId: "google:oauth",
+        credential: {
+          type: "oauth",
+          provider: "google",
+          access,
+          refresh: "refresh-a",
+          expires: 1,
+          ...(idToken ? { idToken } : {}),
+        },
+      });
+
+    // A corrupt id-token yields no verified identity, so the credential must
+    // bind the opaque grant (rotates with access) — not a U+FFFD-stable subject.
+    expect(fingerprint("access-a", corruptIdToken)).not.toBe(
+      fingerprint("access-b", corruptIdToken),
+    );
+    // Control: a valid id-token identity stays stable across token rotation.
+    const validIdToken = jwt({ sub: "subject-1", email: "user@example.test" });
+    expect(fingerprint("access-a", validIdToken)).toBe(fingerprint("access-b", validIdToken));
+  });
+
   it("keeps resolved credential fingerprints opaque and stable within one process", () => {
     const fingerprint = (apiKey: string) =>
       fingerprintResolvedProviderAuth({

--- a/src/agents/execution-auth-binding.ts
+++ b/src/agents/execution-auth-binding.ts
@@ -178,7 +178,9 @@ function decodeJwtIdentity(token: string | undefined): { subject?: string; email
     return {};
   }
   try {
-    const claims = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as {
+    const claims = JSON.parse(
+      new TextDecoder("utf-8", { fatal: true }).decode(Buffer.from(payload, "base64url")),
+    ) as {
       sub?: unknown;
       email?: unknown;
     };


### PR DESCRIPTION
## Summary

Reject OAuth id-token JWT payloads that are not valid UTF-8 when deriving execution auth-binding fingerprints, so a U+FFFD-corrupted `sub`/`email` claim can no longer be accepted as a stable principal identity.

## What Problem This Solves

`fingerprintAuthProfileCredential` binds OAuth executions to a stable owner identity. For `oauth` credentials it calls `decodeJwtIdentity`, which base64url-decodes the id-token payload and parses the claims (`sub`, `email`).

- The payload was decoded with a forgiving UTF-8 conversion (`Buffer.from(payload, "base64url").toString("utf8")`), so invalid byte sequences silently became U+FFFD.
- When the corruption lands inside the `sub` or `email` string value, `JSON.parse` still succeeds, and the corrupted claim is returned as a real identity.
- In the `oauth` fingerprint branch, any non-empty decoded identity becomes the `stableIdentity`, so the owner fingerprint pins to the U+FFFD-corrupted subject and stays stable across access-token rotation — the execution is attributed to a principal that never existed, indistinguishable from a real identity binding.

**Code evidence**: at [execution-auth-binding.ts:181](src/agents/execution-auth-binding.ts#L181), the JWT payload is decoded without UTF-8 validation.

## Root Cause

- Node's `Buffer.toString("utf8")` (like `TextDecoder` with `fatal: false`) substitutes U+FFFD for malformed byte sequences instead of throwing.
- `decodeJwtIdentity` already fails closed for malformed JSON (its `try/catch` returns `{}`, i.e. "no verified identity"), but the lenient decode let a whole class of corruption reach `JSON.parse` as if it were genuine claims.
- Invariant violated: "a JWT payload carrying identity claims is always valid UTF-8 JSON" — not guaranteed for tokens read from storage or passed through proxies.

## Why This Fix

Decode with `TextDecoder("utf-8", { fatal: true })`:

- Invalid bytes now throw a `TypeError` inside the existing `try/catch`, so `decodeJwtIdentity` returns `{}` — exactly the same fail-closed outcome as malformed JSON.
- With no verified identity, the `oauth` branch falls back to its designed semantics for identity-less credentials: it binds the opaque grant (raw token material), which rotates with the access token instead of pinning to a fabricated principal. This matches the established behavior asserted by the existing `invalidates identity-less OAuth when its opaque grant changes` test.
- This is the same strict-decode pattern already used for provider JSON bodies in `readProviderJsonResponse` ([provider-http-errors.ts:344](src/agents/provider-http-errors.ts#L344)).
- Alternative considered: rejecting claims containing U+FFFD after parsing — rejected, because U+FFFD can be legitimate content and post-hoc scanning cannot distinguish corruption from real data.

## User Impact

- **Before**: a corrupted id-token produces a stable owner fingerprint for a non-existent principal, so execution ownership/audit attribution silently binds to the wrong identity (and stays stuck there across token refreshes).
- **After**: corrupted id-tokens contribute no identity; the credential binds its opaque grant and rotates normally, so ownership attribution never fabricates a principal.

## Evidence

- **Before** (upstream/main): `corrupt id-token fingerprint stable across access rotation: true` — **FAIL**: U+FFFD-corrupted subject accepted as a stable identity
- **After** (with fix): `corrupt id-token fingerprint stable across access rotation: false`, `valid id-token ... : true` — **PASS**: corrupt id-token binds the opaque grant, valid id-token keeps stable identity

## Real Behavior Proof

Proof calls the real `fingerprintAuthProfileCredential` with an OAuth credential whose id-token payload contains a raw `0xFF` byte inside the `sub` claim, and compares fingerprint stability across access-token rotation against a valid id-token control.

### Before (on main)

```bash
$ node --import tsx proof.mjs
corrupt id-token fingerprint stable across access rotation: true
valid id-token fingerprint stable across access rotation:   true
FAIL: U+FFFD-corrupted subject accepted as a stable identity
```

### After (with fix)

```bash
$ node --import tsx proof.mjs
corrupt id-token fingerprint stable across access rotation: false
valid id-token fingerprint stable across access rotation:   true
PASS: corrupt id-token binds the opaque grant, valid id-token keeps stable identity
```

## Tests and Validation

- `npx vitest run src/agents/execution-auth-binding.test.ts` — 16 passed (15 existing + 1 new)
- New regression test: `ignores an id-token whose payload is not valid UTF-8`
- `tsgo:core` typecheck passed; `oxlint` and `oxfmt --check` clean on the changed files
