### PR TITLE
fix(gateway): reject unknown session agents instead of provisioning them

### DIFF
--- a/scripts/lib/session-accessor-debt-baseline.json
+++ b/scripts/lib/session-accessor-debt-baseline.json
@@ -9,6 +9,7 @@
     "src/commands/doctor-heartbeat-session-target.ts": 2,
     "src/commands/doctor-state-integrity.ts": 2,
     "src/commands/doctor/shared/codex-route-session-repair.ts": 3,
+    "src/config/sessions/legacy-store-readonly.ts": 2,
     "src/config/sessions/session-accessor.entry.ts": 2,
     "src/config/sessions/store-load.ts": 3,
     "src/config/sessions/store.ts": 10,

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.test-harness.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.test-harness.ts
@@ -373,6 +373,11 @@ vi.mock("../config/config.js", () => ({
 }));
 
 vi.mock("../config/sessions.js", () => ({
+  isConfiguredSessionStoreAgentId: (
+    cfg: { agents?: { list?: Array<{ id?: string }> } },
+    agentId: string,
+  ) => agentId === "main" || cfg.agents?.list?.some((agent) => agent.id === agentId) === true,
+  isLegacyOnlySessionStoreTarget: () => false,
   loadSessionStore: () => hoisted.sessionStore,
   mergeSessionEntry: (existing: object | undefined, patch: object) => ({
     ...existing,
@@ -384,6 +389,8 @@ vi.mock("../config/sessions.js", () => ({
     cfg?: { session?: { mainKey?: string } };
     agentId: string;
   }) => `agent:${params.agentId}:${params.cfg?.session?.mainKey ?? "main"}`,
+  readLegacySessionStoreTarget: () => undefined,
+  resolveExistingAgentSessionStoreTargetsSync: () => [],
   resolveStorePath: () => "/tmp/openclaw-sessions-spawn-test-store.json",
   updateSessionStore: async (
     _storePath: string,

--- a/src/config/sessions.ts
+++ b/src/config/sessions.ts
@@ -9,6 +9,7 @@ export * from "./sessions/main-session.js";
 export type { MainRestartRecoveryState } from "./sessions/main-session-recovery.types.js";
 export * from "./sessions/main-session.runtime.js";
 export * from "./sessions/lifecycle.js";
+export * from "./sessions/legacy-store-readonly.js";
 export * from "./sessions/paths.js";
 export * from "./sessions/reset.js";
 export {

--- a/src/config/sessions/legacy-store-readonly.ts
+++ b/src/config/sessions/legacy-store-readonly.ts
@@ -1,0 +1,28 @@
+// Read-only compatibility for discovered legacy stores that predate the SQLite session store.
+// Callers must establish that the target already exists; this seam never provisions or writes it.
+import fs from "node:fs";
+import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
+import { loadSessionStore } from "./store-load.js";
+import type { SessionEntry } from "./types.js";
+
+export function isLegacyOnlySessionStoreTarget(storePath: string, agentId?: string): boolean {
+  if (!fs.existsSync(storePath)) {
+    return false;
+  }
+  const sqlitePath = resolveSqliteTargetFromSessionStorePath(storePath, { agentId }).path;
+  return !sqlitePath || !fs.existsSync(sqlitePath);
+}
+
+export function readLegacySessionStoreTarget(
+  storePath: string,
+  agentId?: string,
+): Record<string, SessionEntry> | undefined {
+  if (!isLegacyOnlySessionStoreTarget(storePath, agentId)) {
+    return undefined;
+  }
+  return loadSessionStore(storePath, {
+    clone: true,
+    hydrateSkillPromptRefs: false,
+    skipCache: true,
+  });
+}

--- a/src/config/sessions/session-accessor.sqlite-entry-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-store.ts
@@ -229,6 +229,15 @@ export function readSqliteSessionEntryCount(database: OpenClawAgentDatabase): nu
   return count === undefined || count === null ? 0 : normalizeSqliteNumber(count);
 }
 
+/** Lists persisted session keys without materializing their entry payloads. */
+export function readSqliteSessionEntryKeys(database: OpenClawAgentDatabaseReader): string[] {
+  const db = getSessionKysely(database.db);
+  return executeSqliteQuerySync(
+    database.db,
+    db.selectFrom("session_entries").select("session_key").orderBy("session_key", "asc"),
+  ).rows.map((row) => row.session_key);
+}
+
 export function resolveSqliteLifecyclePrimaryEntry(
   database: OpenClawAgentDatabase,
   target: { canonicalKey: string; storeKeys: string[] },

--- a/src/config/sessions/session-transcript-search.ts
+++ b/src/config/sessions/session-transcript-search.ts
@@ -4,6 +4,7 @@
 // when doctor imports or out-of-band writes leave derived rows behind.
 import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import { truncateUtf16Safe } from "../../utils.js";
+import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
 import { listSessionsNeedingTranscriptIndexReconcile } from "./session-transcript-index.js";
 import {
   isSessionTranscriptIndexReconcileRunning,
@@ -45,6 +46,7 @@ export function searchSessionTranscripts(params: {
   limit?: number;
   query: string;
   sessionKeys?: string[];
+  storePath?: string;
 }): SessionTranscriptSearchResult {
   const query = params.query.trim();
   if (!query) {
@@ -53,14 +55,20 @@ export function searchSessionTranscripts(params: {
   if (query.length > SEARCH_QUERY_MAX_CHARS) {
     throw new Error(`query must not exceed ${SEARCH_QUERY_MAX_CHARS} characters`);
   }
+  const databasePath = params.storePath
+    ? resolveSqliteTargetFromSessionStorePath(params.storePath, {
+        agentId: params.agentId,
+      }).path
+    : undefined;
   const databaseOptions = {
     agentId: params.agentId,
     ...(params.env ? { env: params.env } : {}),
+    ...(databasePath ? { path: databasePath } : {}),
   };
   const database = openOpenClawAgentDatabase(databaseOptions);
   const dirtySessions = listSessionsNeedingTranscriptIndexReconcile(database.db);
   if (dirtySessions.length > 0) {
-    startSessionTranscriptIndexReconcile(params);
+    startSessionTranscriptIndexReconcile(databaseOptions);
   }
   const indexing =
     dirtySessions.length > 0 || isSessionTranscriptIndexReconcileRunning(databaseOptions);

--- a/src/config/sessions/targets.test.ts
+++ b/src/config/sessions/targets.test.ts
@@ -10,6 +10,7 @@ import {
   resolveAgentSessionStoreTargetsSync,
   resolveAllAgentSessionStoreCandidateTargetsSync,
   resolveAllAgentSessionStoreTargetsSync,
+  resolveExistingAgentSessionStoreTargetsSync,
   resolveSessionStoreTargets,
 } from "./targets.js";
 
@@ -243,6 +244,128 @@ describe("resolveAgentSessionStoreTargetsSync", () => {
           storePath: storePaths["Retired Agent"],
         },
       ]);
+    });
+  });
+});
+
+describe("resolveExistingAgentSessionStoreTargetsSync", () => {
+  it("requires agent-specific rows instead of fixed-store file existence", async () => {
+    await withTempHome(async (home) => {
+      const storePath = path.join(home, "shared", "sessions.json");
+      await fs.mkdir(path.dirname(storePath), { recursive: true });
+      await fs.writeFile(storePath, "{}\n", "utf8");
+      const cfg: OpenClawConfig = {
+        agents: { list: [{ id: "main", default: true }] },
+        session: { store: storePath },
+      };
+
+      expect(resolveExistingAgentSessionStoreTargetsSync(cfg, "ghost")).toEqual([]);
+
+      await replaceSessionEntry(
+        { agentId: "ghost", sessionKey: "agent:ghost:existing", storePath },
+        { sessionId: "session-ghost", updatedAt: 42 },
+      );
+
+      expect(resolveExistingAgentSessionStoreTargetsSync(cfg, "ghost")).toEqual([
+        { agentId: "ghost", storePath },
+      ]);
+    });
+  });
+
+  it("recognizes matching rows in a fixed legacy store without creating SQLite", async () => {
+    await withTempHome(async (home) => {
+      const storePath = path.join(home, "shared", "sessions.json");
+      await fs.mkdir(path.dirname(storePath), { recursive: true });
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          "agent:retired:existing": { sessionId: "legacy-retired", updatedAt: 42 },
+          "agent:other:existing": { sessionId: "legacy-other", updatedAt: 41 },
+        }),
+        "utf8",
+      );
+      const cfg: OpenClawConfig = {
+        agents: { list: [{ id: "main", default: true }] },
+        session: { store: storePath },
+      };
+
+      expect(resolveExistingAgentSessionStoreTargetsSync(cfg, "retired")).toEqual([
+        { agentId: "retired", storePath },
+      ]);
+      expect(resolveExistingAgentSessionStoreTargetsSync(cfg, "ghost")).toEqual([]);
+      expect(await fs.readdir(path.dirname(storePath))).toEqual(["sessions.json"]);
+    });
+  });
+
+  it("includes existing deterministic template targets outside discoverable agent roots", async () => {
+    await withTempHome(async (home) => {
+      const storeTemplate = path.join(home, "external-stores", "sessions-{agentId}.json");
+      const cfg: OpenClawConfig = {
+        agents: { list: [{ id: "main", default: true }] },
+        session: { store: storeTemplate },
+      };
+      const legacyStorePath = resolveStorePath(storeTemplate, { agentId: "retired-legacy" });
+      const sqliteStorePath = resolveStorePath(storeTemplate, { agentId: "retired-sqlite" });
+      await fs.mkdir(path.dirname(legacyStorePath), { recursive: true });
+      await fs.writeFile(
+        legacyStorePath,
+        JSON.stringify({
+          "agent:retired-legacy:existing": { sessionId: "legacy-retired", updatedAt: 42 },
+        }),
+        "utf8",
+      );
+      await replaceSessionEntry(
+        {
+          agentId: "retired-sqlite",
+          sessionKey: "agent:retired-sqlite:existing",
+          storePath: sqliteStorePath,
+        },
+        { sessionId: "sqlite-retired", updatedAt: 42 },
+      );
+
+      expect(resolveAllAgentSessionStoreTargetsSync(cfg)).not.toContainEqual({
+        agentId: "retired-legacy",
+        storePath: legacyStorePath,
+      });
+      expect(resolveAllAgentSessionStoreTargetsSync(cfg)).not.toContainEqual({
+        agentId: "retired-sqlite",
+        storePath: sqliteStorePath,
+      });
+      expect(resolveExistingAgentSessionStoreTargetsSync(cfg, "retired-legacy")).toEqual([
+        { agentId: "retired-legacy", storePath: legacyStorePath },
+      ]);
+      expect(resolveExistingAgentSessionStoreTargetsSync(cfg, "retired-sqlite")).toEqual([
+        { agentId: "retired-sqlite", storePath: sqliteStorePath },
+      ]);
+      expect(resolveExistingAgentSessionStoreTargetsSync(cfg, "ghost")).toEqual([]);
+    });
+  });
+
+  it("rejects a deterministic target whose store symlink escapes the agents root", async () => {
+    await withTempHome(async (home) => {
+      if (process.platform === "win32") {
+        return;
+      }
+      const customRoot = path.join(home, "custom-state");
+      const escapedSessionsDir = path.join(customRoot, "agents", "escaped", "sessions");
+      const outsideStorePath = path.join(home, "outside-sessions.json");
+      const escapedStorePath = path.join(escapedSessionsDir, "sessions.json");
+      await fs.mkdir(escapedSessionsDir, { recursive: true });
+      await fs.writeFile(
+        outsideStorePath,
+        JSON.stringify({
+          "agent:escaped:secret": { sessionId: "outside-session", updatedAt: 42 },
+        }),
+        "utf8",
+      );
+      await fs.symlink(outsideStorePath, escapedStorePath);
+
+      const cfg = createCustomRootCfg(customRoot, "main");
+      expect(resolveAllAgentSessionStoreTargetsSync(cfg)).not.toContainEqual({
+        agentId: "escaped",
+        storePath: escapedStorePath,
+      });
+      expect(resolveExistingAgentSessionStoreTargetsSync(cfg, "escaped")).toEqual([]);
     });
   });
 });

--- a/src/config/sessions/targets.ts
+++ b/src/config/sessions/targets.ts
@@ -4,10 +4,16 @@ import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { listAgentIds, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { resolveAgentSessionDirsFromAgentsDirSync } from "../../agents/session-dirs.js";
-import { DEFAULT_AGENT_ID, normalizeAgentId } from "../../routing/session-key.js";
+import {
+  DEFAULT_AGENT_ID,
+  normalizeAgentId,
+  parseAgentSessionKey,
+} from "../../routing/session-key.js";
+import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
 import { resolveStateDir } from "../paths.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 import { resolveAgentsDirFromSessionStorePath, resolveStorePath } from "./paths.js";
+import { readSqliteSessionEntryKeys } from "./session-accessor.sqlite-entry-store.js";
 import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
 
 /** CLI/session-store target selection options. */
@@ -58,6 +64,21 @@ function dedupeTargetsBySqliteTarget(targets: SessionStoreTarget[]): SessionStor
 function shouldSkipDiscoveryError(err: unknown): boolean {
   const code = (err as NodeJS.ErrnoException | undefined)?.code;
   return typeof code === "string" && NON_FATAL_DISCOVERY_ERROR_CODES.has(code);
+}
+
+function legacySessionStoreHasAgentKey(storePath: string, agentId: string): boolean {
+  try {
+    const parsed: unknown = JSON.parse(fsSync.readFileSync(storePath, "utf8"));
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return false;
+    }
+    return Object.keys(parsed).some((sessionKey) => {
+      const owner = parseAgentSessionKey(sessionKey)?.agentId;
+      return owner !== undefined && normalizeAgentId(owner) === agentId;
+    });
+  } catch {
+    return false;
+  }
 }
 
 function isWithinRoot(realPath: string, realRoot: string): boolean {
@@ -120,6 +141,18 @@ export function listConfiguredSessionStoreAgentIds(cfg: OpenClawConfig): string[
   return [...ids];
 }
 
+/** Checks whether an agent is configured to own a session store. */
+export function isConfiguredSessionStoreAgentId(cfg: OpenClawConfig, agentId: string): boolean {
+  const normalizedAgentId = normalizeAgentId(agentId);
+  return listConfiguredSessionStoreAgentIds(cfg).includes(normalizedAgentId);
+}
+
+/** Whether session.store resolves to a distinct store for each agent. */
+export function isPerAgentSessionStoreConfig(storeConfig: string | undefined): boolean {
+  const normalized = storeConfig?.trim();
+  return !normalized || normalized.includes("{agentId}");
+}
+
 function resolveValidatedDiscoveredStorePathSync(params: {
   sessionsDir: string;
   agentsRoot: string;
@@ -145,6 +178,26 @@ function resolveValidatedDiscoveredStorePathSync(params: {
   })
     ? storePath
     : undefined;
+}
+
+function resolveValidatedExistingSessionStoreTargetSync(
+  target: SessionStoreTarget,
+): SessionStoreTarget | undefined {
+  const agentsRoot = resolveAgentsDirFromSessionStorePath(target.storePath);
+  if (!agentsRoot) {
+    const sqlitePath = resolveSqliteTargetFromSessionStorePath(target.storePath, {
+      agentId: target.agentId,
+    }).path;
+    return fsSync.existsSync(target.storePath) ||
+      Boolean(sqlitePath && fsSync.existsSync(sqlitePath))
+      ? target
+      : undefined;
+  }
+  const validatedStorePath = resolveValidatedDiscoveredStorePathSync({
+    sessionsDir: path.dirname(target.storePath),
+    agentsRoot,
+  });
+  return validatedStorePath ? { ...target, storePath: validatedStorePath } : undefined;
 }
 
 function isValidatedRecoveryCandidateSessionsDir(params: {
@@ -305,6 +358,60 @@ export function resolveAllAgentSessionStoreTargetsSync(
     }
   });
   return dedupeTargetsBySqliteTarget([...validatedConfiguredTargets, ...discoveredTargets]);
+}
+
+/** Resolves only already-existing stores for one configured, retired, or manual agent. */
+export function resolveExistingAgentSessionStoreTargetsSync(
+  cfg: OpenClawConfig,
+  agentId: string,
+  params: { env?: NodeJS.ProcessEnv } = {},
+): SessionStoreTarget[] {
+  const env = params.env ?? process.env;
+  const requested = normalizeAgentId(agentId);
+  const storeConfig = cfg.session?.store;
+  if (!isPerAgentSessionStoreConfig(storeConfig)) {
+    const fixedTarget = {
+      agentId: requested,
+      storePath: resolveStorePath(storeConfig, { agentId: requested, env }),
+    };
+    const sqlitePath = resolveSqliteTargetFromSessionStorePath(fixedTarget.storePath, {
+      agentId: requested,
+    }).path;
+    if (sqlitePath && fsSync.existsSync(sqlitePath)) {
+      try {
+        const result = withOpenClawAgentDatabaseReadOnly(
+          (database) =>
+            readSqliteSessionEntryKeys(database).some((sessionKey) => {
+              const parsed = parseAgentSessionKey(sessionKey);
+              // Unscoped keys belong to the validated database owner. Explicit agent keys must
+              // match so a fixed store containing only another agent's rows proves nothing.
+              return !parsed || normalizeAgentId(parsed.agentId) === requested;
+            }),
+          { agentId: requested, env, path: sqlitePath },
+        );
+        return result.found && result.value ? [fixedTarget] : [];
+      } catch {
+        return [];
+      }
+    }
+    // The legacy file is authoritative only before its derived SQLite store exists. Once SQLite
+    // exists, even an empty store can represent intentional deletion of the final session row.
+    return legacySessionStoreHasAgentKey(fixedTarget.storePath, requested) ? [fixedTarget] : [];
+  }
+  const requestedTarget = {
+    agentId: requested,
+    storePath: resolveStorePath(storeConfig, { agentId: requested, env }),
+  };
+  // Directory discovery cannot enumerate arbitrary templates. Keep an existing retired store
+  // visible by checking the requested agent's deterministic target alongside discovered stores.
+  const discoveredTargets = resolveAllAgentSessionStoreTargetsSync(cfg, { env }).filter(
+    (target) => normalizeAgentId(target.agentId) === requested,
+  );
+  const validatedRequestedTarget = resolveValidatedExistingSessionStoreTargetSync(requestedTarget);
+  return dedupeTargetsBySqliteTarget([
+    ...(validatedRequestedTarget ? [validatedRequestedTarget] : []),
+    ...discoveredTargets,
+  ]);
 }
 
 /**

--- a/src/gateway/server-methods/sessions-abort.test.ts
+++ b/src/gateway/server-methods/sessions-abort.test.ts
@@ -1,0 +1,245 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, expect, test } from "vitest";
+import { replaceSessionEntry } from "../../config/sessions/session-accessor.js";
+import { resolveSqliteTargetFromSessionStorePath } from "../../config/sessions/session-sqlite-target.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  listOpenClawRegisteredAgentDatabases,
+  resolveOpenClawAgentSqlitePath,
+} from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { testState } from "../test-helpers.js";
+import {
+  directSessionReq,
+  getGatewayConfigModule,
+  setupGatewaySessionsTestHarness,
+} from "../test/server-sessions.test-helpers.js";
+import { createActiveRun, createChatAbortContext } from "./chat.abort.test-helpers.js";
+
+setupGatewaySessionsTestHarness();
+
+function requireStateDir(): string {
+  const stateDir = process.env.OPENCLAW_STATE_DIR;
+  if (!stateDir) {
+    throw new Error("OPENCLAW_STATE_DIR is required");
+  }
+  return stateDir;
+}
+
+beforeEach(async () => {
+  testState.sessionStorePath = undefined;
+  testState.sessionConfig = undefined;
+  testState.agentsConfig = { list: [{ id: "main", default: true }, { id: "work" }] };
+  const { clearConfigCache, clearRuntimeConfigSnapshot } = await getGatewayConfigModule();
+  clearRuntimeConfigSnapshot();
+  clearConfigCache();
+});
+
+afterEach(() => {
+  testState.sessionStorePath = undefined;
+  testState.sessionConfig = undefined;
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+});
+
+async function configureFixedSessionStore(label = "default"): Promise<string> {
+  const storePath = path.join(requireStateDir(), `shared-abort-sessions-${label}`, "sessions.json");
+  fs.mkdirSync(path.dirname(storePath), { recursive: true });
+  fs.writeFileSync(storePath, "{}\n", "utf8");
+  testState.sessionStorePath = storePath;
+  testState.agentsConfig = { list: [{ id: "main", default: true }] };
+  const { clearConfigCache, clearRuntimeConfigSnapshot } = await getGatewayConfigModule();
+  clearRuntimeConfigSnapshot();
+  clearConfigCache();
+  const { getRuntimeConfig } = await getGatewayConfigModule();
+  expect(getRuntimeConfig().session?.store).toBe(storePath);
+  return storePath;
+}
+
+test("sessions.abort rejects an unknown agent without provisioning its store", async () => {
+  const result = await directSessionReq("sessions.abort", { key: "agent:ghost:zzz" });
+
+  expect(result).toMatchObject({
+    ok: false,
+    error: { code: "INVALID_REQUEST", message: 'agent "ghost" not found' },
+  });
+  const env = { OPENCLAW_STATE_DIR: requireStateDir() };
+  expect(fs.existsSync(path.join(env.OPENCLAW_STATE_DIR, "agents", "ghost"))).toBe(false);
+  expect(fs.existsSync(resolveOpenClawAgentSqlitePath({ agentId: "ghost", env }))).toBe(false);
+  expect(listOpenClawRegisteredAgentDatabases({ env }).map((entry) => entry.agentId)).not.toContain(
+    "ghost",
+  );
+});
+
+test("sessions.abort aborts a pre-existing session after its agent is removed from config", async () => {
+  const agentId = "retired";
+  const sessionKey = `agent:${agentId}:existing`;
+  const sessionId = "session-retired";
+  const runId = "run-retired";
+  const storePath = path.join(requireStateDir(), "agents", agentId, "sessions", "sessions.json");
+  await replaceSessionEntry({ agentId, sessionKey, storePath }, { sessionId, updatedAt: 42 });
+  const activeRun = createActiveRun(sessionKey, { agentId, sessionId });
+  const { getRuntimeConfig: _getRuntimeConfig, ...abortContext } = createChatAbortContext({
+    chatAbortControllers: new Map([[runId, activeRun]]),
+  });
+
+  const result = await directSessionReq(
+    "sessions.abort",
+    { key: sessionKey },
+    {
+      context: abortContext,
+    },
+  );
+
+  expect(result).toMatchObject({
+    ok: true,
+    payload: { ok: true, abortedRunId: runId, status: "aborted" },
+  });
+  expect(activeRun.controller.signal.aborted).toBe(true);
+});
+
+test("sessions.abort aborts an exact active run for an unconfigured agent without a store", async () => {
+  const agentId = "active-only";
+  const sessionKey = `agent:${agentId}:running`;
+  const runId = "run-active-only";
+  const activeRun = createActiveRun(sessionKey, { agentId });
+  const { getRuntimeConfig: _getRuntimeConfig, ...abortContext } = createChatAbortContext({
+    chatAbortControllers: new Map([[runId, activeRun]]),
+  });
+
+  const result = await directSessionReq(
+    "sessions.abort",
+    { key: sessionKey },
+    { context: abortContext },
+  );
+
+  expect(result).toMatchObject({
+    ok: true,
+    payload: { ok: true, abortedRunId: runId, status: "aborted" },
+  });
+  expect(activeRun.controller.signal.aborted).toBe(true);
+  const env = { OPENCLAW_STATE_DIR: requireStateDir() };
+  expect(fs.existsSync(path.join(env.OPENCLAW_STATE_DIR, "agents", agentId))).toBe(false);
+  expect(fs.existsSync(resolveOpenClawAgentSqlitePath({ agentId, env }))).toBe(false);
+  expect(listOpenClawRegisteredAgentDatabases({ env }).map((entry) => entry.agentId)).not.toContain(
+    agentId,
+  );
+});
+
+test("sessions.abort rejects an unknown agent when only the fixed store file exists", async () => {
+  const storePath = await configureFixedSessionStore();
+
+  const result = await directSessionReq("sessions.abort", { key: "agent:ghost:missing" });
+
+  expect(result).toMatchObject({
+    ok: false,
+    error: { code: "INVALID_REQUEST", message: 'agent "ghost" not found' },
+  });
+  const sqlitePath = resolveSqliteTargetFromSessionStorePath(storePath, {
+    agentId: "ghost",
+  }).path;
+  expect(sqlitePath).toBeDefined();
+  expect(fs.existsSync(sqlitePath!)).toBe(false);
+});
+
+test("sessions.abort aborts an unconfigured agent with rows in a fixed store", async () => {
+  const storePath = await configureFixedSessionStore();
+  const agentId = "retired";
+  const sessionKey = `agent:${agentId}:existing`;
+  const sessionId = "session-retired-fixed";
+  const runId = "run-retired-fixed";
+  await replaceSessionEntry({ agentId, sessionKey, storePath }, { sessionId, updatedAt: 42 });
+  const activeRun = createActiveRun(sessionKey, { agentId, sessionId });
+  const { getRuntimeConfig: _getRuntimeConfig, ...abortContext } = createChatAbortContext({
+    chatAbortControllers: new Map([[runId, activeRun]]),
+  });
+
+  const result = await directSessionReq(
+    "sessions.abort",
+    { key: sessionKey },
+    { context: abortContext },
+  );
+
+  expect(result).toMatchObject({
+    ok: true,
+    payload: { ok: true, abortedRunId: runId, status: "aborted" },
+  });
+  expect(activeRun.controller.signal.aborted).toBe(true);
+});
+
+test("sessions.abort recognizes an unconfigured agent in a fixed legacy store", async () => {
+  const storePath = await configureFixedSessionStore("legacy");
+  const sessionKey = "agent:retired:legacy";
+  fs.writeFileSync(
+    storePath,
+    JSON.stringify({ [sessionKey]: { sessionId: "session-retired-legacy", updatedAt: 42 } }),
+    "utf8",
+  );
+
+  const result = await directSessionReq("sessions.abort", { key: sessionKey });
+
+  expect(result).toMatchObject({
+    ok: true,
+    payload: { ok: true, abortedRunId: null, status: "no-active-run" },
+  });
+  const sqlitePath = resolveSqliteTargetFromSessionStorePath(storePath, {
+    agentId: "retired",
+  }).path;
+  expect(sqlitePath).toBeDefined();
+  expect(fs.existsSync(sqlitePath!)).toBe(false);
+});
+
+test("sessions.abort finds a retired store only reachable through its deterministic template", async () => {
+  const agentId = "template-retired";
+  const sessionKey = `agent:${agentId}:existing`;
+  const sessionId = "session-template-retired";
+  const runId = "run-template-retired";
+  const storeTemplate = path.join(
+    requireStateDir(),
+    "external-abort-stores",
+    "sessions-{agentId}.json",
+  );
+  const storePath = storeTemplate.replace("{agentId}", agentId);
+  testState.sessionStorePath = storeTemplate;
+  testState.agentsConfig = { list: [{ id: "main", default: true }] };
+  const { clearConfigCache, clearRuntimeConfigSnapshot } = await getGatewayConfigModule();
+  clearRuntimeConfigSnapshot();
+  clearConfigCache();
+  await replaceSessionEntry({ agentId, sessionKey, storePath }, { sessionId, updatedAt: 42 });
+  const activeRun = createActiveRun(sessionKey, { agentId, sessionId });
+  const { getRuntimeConfig: _getRuntimeConfig, ...abortContext } = createChatAbortContext({
+    chatAbortControllers: new Map([[runId, activeRun]]),
+  });
+
+  const result = await directSessionReq(
+    "sessions.abort",
+    { key: sessionKey },
+    { context: abortContext },
+  );
+
+  expect(result).toMatchObject({
+    ok: true,
+    payload: { ok: true, abortedRunId: runId, status: "aborted" },
+  });
+  expect(activeRun.controller.signal.aborted).toBe(true);
+});
+
+test.each(["main", "work"])("sessions.abort still resolves the %s agent store", async (agentId) => {
+  const result = await directSessionReq("sessions.abort", {
+    key: `agent:${agentId}:missing`,
+  });
+
+  expect(result).toMatchObject({
+    ok: true,
+    payload: { ok: true, abortedRunId: null, status: "no-active-run" },
+  });
+  expect(
+    fs.existsSync(
+      resolveOpenClawAgentSqlitePath({
+        agentId,
+        env: { OPENCLAW_STATE_DIR: requireStateDir() },
+      }),
+    ),
+  ).toBe(true);
+});

--- a/src/gateway/server-methods/sessions-abort.ts
+++ b/src/gateway/server-methods/sessions-abort.ts
@@ -10,6 +10,10 @@ import {
   validateSessionsAbortParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import {
+  isConfiguredSessionStoreAgentId,
+  resolveExistingAgentSessionStoreTargetsSync,
+} from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
 import { resolveSessionKeyForRun } from "../server-session-key.js";
@@ -195,7 +199,36 @@ export const sessionAbortHandlers: GatewayRequestHandlers = {
       return;
     }
     const requestedGlobalAgentId = requestedGlobalAgent.agentId;
-    const { canonicalKey } = loadSessionEntry(key, { agentId: requestedGlobalAgentId });
+    const targetAgentId =
+      requestedGlobalAgentId ??
+      resolveSessionStoreAgentId(cfg, resolveSessionStoreKey({ cfg, sessionKey: key }));
+    const configuredTarget = isConfiguredSessionStoreAgentId(cfg, targetAgentId);
+    const existingTargets = configuredTarget
+      ? []
+      : resolveExistingAgentSessionStoreTargetsSync(cfg, targetAgentId);
+    const hasExactActiveRun = requestedRunId
+      ? scopedActiveRunSessionKey === key
+      : [...context.chatAbortControllers.values()].some(
+          (entry) => entry.controlUiVisible !== false && entry.sessionKey === key,
+        );
+    if (!configuredTarget && existingTargets.length === 0 && !hasExactActiveRun) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, `agent "${targetAgentId}" not found`),
+      );
+      return;
+    }
+    // An exact live controller is already authoritative. Avoid opening the fallback store when
+    // neither config nor persistence owns it; that edge is the only one that could create state.
+    const canonicalKey =
+      configuredTarget || existingTargets.length > 0
+        ? loadSessionEntry(key, { agentId: requestedGlobalAgentId }).canonicalKey
+        : resolveSessionStoreKey({
+            cfg,
+            sessionKey: key,
+            ...(requestedGlobalAgentId ? { storeAgentId: requestedGlobalAgentId } : {}),
+          });
     const requestedKeyAliases =
       requestedKey &&
       requestedKey !== key &&

--- a/src/gateway/server-methods/sessions-read.test.ts
+++ b/src/gateway/server-methods/sessions-read.test.ts
@@ -1,0 +1,338 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, expect, test } from "vitest";
+import { replaceSessionEntry } from "../../config/sessions/session-accessor.js";
+import { resolveSqliteTargetFromSessionStorePath } from "../../config/sessions/session-sqlite-target.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  listOpenClawRegisteredAgentDatabases,
+  resolveOpenClawAgentSqlitePath,
+} from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { testState } from "../test-helpers.js";
+import {
+  getGatewayConfigModule,
+  directSessionReq,
+  seedLinearSessionTranscript,
+  setupGatewaySessionsTestHarness,
+} from "../test/server-sessions.test-helpers.js";
+import { agentsHandlers } from "./agents.js";
+import type { GatewayRequestContext } from "./types.js";
+
+setupGatewaySessionsTestHarness();
+
+const UNKNOWN_AGENT_ID = "ghost";
+const UNKNOWN_SESSION_KEY = `agent:${UNKNOWN_AGENT_ID}:zzz`;
+
+function requireStateDir(): string {
+  const stateDir = process.env.OPENCLAW_STATE_DIR;
+  if (!stateDir) {
+    throw new Error("OPENCLAW_STATE_DIR is required");
+  }
+  return stateDir;
+}
+
+function expectAgentStoreAbsent(agentId: string): void {
+  const env = { OPENCLAW_STATE_DIR: requireStateDir() };
+  expect(fs.existsSync(path.join(env.OPENCLAW_STATE_DIR, "agents", agentId))).toBe(false);
+  expect(fs.existsSync(resolveOpenClawAgentSqlitePath({ agentId, env }))).toBe(false);
+  expect(listOpenClawRegisteredAgentDatabases({ env }).map((entry) => entry.agentId)).not.toContain(
+    agentId,
+  );
+}
+
+async function listAgentIdsViaRpc(): Promise<string[]> {
+  const { getRuntimeConfig } = await getGatewayConfigModule();
+  let ids: string[] | undefined;
+  await agentsHandlers["agents.list"]?.({
+    req: {} as never,
+    params: {},
+    respond: (ok, payload) => {
+      if (ok) {
+        ids = (payload as { agents: Array<{ id: string }> }).agents.map((agent) => agent.id);
+      }
+    },
+    context: {
+      getRuntimeConfig,
+      loadGatewayModelCatalog: async () => [],
+    } as unknown as GatewayRequestContext,
+    client: null,
+    isWebchatConnect: () => false,
+  });
+  return ids ?? [];
+}
+
+async function setAgentsConfig(agentsConfig: Record<string, unknown> | undefined): Promise<void> {
+  testState.agentsConfig = agentsConfig;
+  const { clearConfigCache, clearRuntimeConfigSnapshot } = await getGatewayConfigModule();
+  clearRuntimeConfigSnapshot();
+  clearConfigCache();
+}
+
+beforeEach(async () => {
+  testState.sessionStorePath = undefined;
+  testState.sessionConfig = undefined;
+  await setAgentsConfig(undefined);
+});
+
+afterEach(() => {
+  testState.sessionStorePath = undefined;
+  testState.sessionConfig = undefined;
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+});
+
+async function configureFixedSessionStore(label = "default"): Promise<string> {
+  const storePath = path.join(requireStateDir(), `shared-sessions-${label}`, "sessions.json");
+  fs.mkdirSync(path.dirname(storePath), { recursive: true });
+  fs.writeFileSync(storePath, "{}\n", "utf8");
+  testState.sessionStorePath = storePath;
+  await setAgentsConfig({ list: [{ id: "main", default: true }] });
+  const { getRuntimeConfig } = await getGatewayConfigModule();
+  expect(getRuntimeConfig().session?.store).toBe(storePath);
+  return storePath;
+}
+
+test("unknown-agent session reads return missing results without provisioning an agent", async () => {
+  const described = await directSessionReq<{ session: unknown }>("sessions.describe", {
+    key: UNKNOWN_SESSION_KEY,
+  });
+  expect(described).toMatchObject({ ok: true, payload: { session: null } });
+
+  const messages = await directSessionReq<{ messages: unknown[] }>("sessions.get", {
+    key: UNKNOWN_SESSION_KEY,
+  });
+  expect(messages).toMatchObject({ ok: true, payload: { messages: [] } });
+
+  const preview = await directSessionReq<{
+    previews: Array<{ key: string; status: string; items: unknown[] }>;
+  }>("sessions.preview", { keys: [UNKNOWN_SESSION_KEY] });
+  expect(preview.payload?.previews).toEqual([
+    { key: UNKNOWN_SESSION_KEY, status: "missing", items: [] },
+  ]);
+
+  const searched = await directSessionReq<{ results: unknown[] }>("sessions.search", {
+    query: "ghost",
+    sessionKeys: [UNKNOWN_SESSION_KEY],
+  });
+  expect(searched).toMatchObject({ ok: true, payload: { results: [] } });
+
+  expectAgentStoreAbsent(UNKNOWN_AGENT_ID);
+  expect(await listAgentIdsViaRpc()).toEqual(["main"]);
+});
+
+test("sessions.describe reads a pre-existing store after its agent is removed from config", async () => {
+  const storePath = path.join(
+    requireStateDir(),
+    "agents",
+    UNKNOWN_AGENT_ID,
+    "sessions",
+    "sessions.json",
+  );
+  await replaceSessionEntry(
+    {
+      agentId: UNKNOWN_AGENT_ID,
+      sessionKey: UNKNOWN_SESSION_KEY,
+      storePath,
+    },
+    { sessionId: "session-ghost", updatedAt: 42 },
+  );
+  await setAgentsConfig({ list: [{ id: "main", default: true }] });
+  const registeredBefore = listOpenClawRegisteredAgentDatabases({
+    env: { OPENCLAW_STATE_DIR: requireStateDir() },
+  });
+
+  const described = await directSessionReq<{ session: { key: string; sessionId: string } | null }>(
+    "sessions.describe",
+    { key: UNKNOWN_SESSION_KEY },
+  );
+
+  expect(described).toMatchObject({
+    ok: true,
+    payload: { session: { key: UNKNOWN_SESSION_KEY, sessionId: "session-ghost" } },
+  });
+  expect(await listAgentIdsViaRpc()).toEqual(["main"]);
+  expect(
+    listOpenClawRegisteredAgentDatabases({
+      env: { OPENCLAW_STATE_DIR: requireStateDir() },
+    }),
+  ).toEqual(registeredBefore);
+});
+
+test("sessions.describe does not treat a fixed store file as proof an unknown agent exists", async () => {
+  const storePath = await configureFixedSessionStore();
+  const described = await directSessionReq<{ session: unknown }>("sessions.describe", {
+    key: UNKNOWN_SESSION_KEY,
+  });
+
+  expect(described).toMatchObject({ ok: true, payload: { session: null } });
+  const sqlitePath = resolveSqliteTargetFromSessionStorePath(storePath, {
+    agentId: UNKNOWN_AGENT_ID,
+  }).path;
+  expect(sqlitePath).toBeDefined();
+  expect(fs.existsSync(sqlitePath!)).toBe(false);
+});
+
+test("sessions.describe reads an unconfigured agent with rows in a fixed store", async () => {
+  const storePath = await configureFixedSessionStore();
+  await replaceSessionEntry(
+    { agentId: UNKNOWN_AGENT_ID, sessionKey: UNKNOWN_SESSION_KEY, storePath },
+    { sessionId: "session-ghost-fixed", updatedAt: 42 },
+  );
+
+  const described = await directSessionReq<{ session: { sessionId: string } | null }>(
+    "sessions.describe",
+    { key: UNKNOWN_SESSION_KEY },
+  );
+
+  expect(described).toMatchObject({
+    ok: true,
+    payload: { session: { sessionId: "session-ghost-fixed" } },
+  });
+});
+
+test.each([
+  { name: "unknown first", keys: [UNKNOWN_SESSION_KEY, "agent:main:preview-valid"] },
+  { name: "valid first", keys: ["agent:main:preview-valid", UNKNOWN_SESSION_KEY] },
+])(
+  "sessions.preview keeps fixed-store cache entries agent-distinct with $name",
+  async ({ keys }) => {
+    const storePath = await configureFixedSessionStore("preview-order");
+    const validSessionKey = "agent:main:preview-valid";
+    const validSessionId = "session-main-preview-valid";
+    await replaceSessionEntry(
+      { agentId: "main", sessionKey: validSessionKey, storePath },
+      { sessionId: validSessionId, updatedAt: 42 },
+    );
+    await seedLinearSessionTranscript({
+      agentId: "main",
+      contents: ["fixed store preview"],
+      sessionId: validSessionId,
+      sessionKey: validSessionKey,
+      storePath,
+    });
+
+    const preview = await directSessionReq<{
+      previews: Array<{ key: string; status: string; items: unknown[] }>;
+    }>("sessions.preview", { keys });
+
+    expect(preview.payload?.previews).toEqual(
+      keys.map((key) =>
+        key === UNKNOWN_SESSION_KEY
+          ? { key, status: "missing", items: [] }
+          : { key, status: "ok", items: expect.any(Array) },
+      ),
+    );
+    expect(
+      preview.payload?.previews.find((entry) => entry.key === validSessionKey)?.items,
+    ).not.toEqual([]);
+  },
+);
+
+test("sessions.describe reads an unconfigured agent from a fixed legacy store", async () => {
+  const storePath = await configureFixedSessionStore("legacy");
+  fs.writeFileSync(
+    storePath,
+    JSON.stringify({
+      [UNKNOWN_SESSION_KEY]: { sessionId: "session-ghost-legacy", updatedAt: 42 },
+    }),
+    "utf8",
+  );
+
+  const described = await directSessionReq<{ session: { sessionId: string } | null }>(
+    "sessions.describe",
+    { key: UNKNOWN_SESSION_KEY },
+  );
+
+  expect(described).toMatchObject({
+    ok: true,
+    payload: { session: { sessionId: "session-ghost-legacy" } },
+  });
+});
+
+test("sessions.search searches a retired per-agent store without explicit session keys", async () => {
+  const agentId = "retired";
+  const sessionKey = `agent:${agentId}:existing`;
+  const sessionId = "session-retired-search";
+  const storePath = path.join(requireStateDir(), "agents", agentId, "sessions", "sessions.json");
+  await replaceSessionEntry({ agentId, sessionKey, storePath }, { sessionId, updatedAt: 42 });
+  await seedLinearSessionTranscript({
+    agentId,
+    contents: ["retired search needle"],
+    sessionId,
+    sessionKey,
+    storePath,
+  });
+  await setAgentsConfig({ list: [{ id: "main", default: true }] });
+
+  const searched = await directSessionReq<{ results: Array<{ sessionKey: string }> }>(
+    "sessions.search",
+    { agentId, query: "retired search needle" },
+  );
+
+  expect(searched.payload?.results).toEqual([expect.objectContaining({ sessionKey })]);
+});
+
+test("session reads find a retired store only reachable through its deterministic template", async () => {
+  const agentId = "template-retired";
+  const sessionKey = `agent:${agentId}:existing`;
+  const sessionId = "session-template-retired";
+  const storeTemplate = path.join(
+    requireStateDir(),
+    "external-session-stores",
+    "sessions-{agentId}.json",
+  );
+  const storePath = storeTemplate.replace("{agentId}", agentId);
+  testState.sessionStorePath = storeTemplate;
+  await setAgentsConfig({ list: [{ id: "main", default: true }] });
+  const { getRuntimeConfig } = await getGatewayConfigModule();
+  expect(getRuntimeConfig().session?.store).toBe(storeTemplate);
+  await replaceSessionEntry({ agentId, sessionKey, storePath }, { sessionId, updatedAt: 42 });
+  await seedLinearSessionTranscript({
+    agentId,
+    contents: ["deterministic template search needle"],
+    sessionId,
+    sessionKey,
+    storePath,
+  });
+
+  const described = await directSessionReq<{ session: { sessionId: string } | null }>(
+    "sessions.describe",
+    { key: sessionKey },
+  );
+  const searched = await directSessionReq<{ results: Array<{ sessionKey: string }> }>(
+    "sessions.search",
+    { agentId, query: "deterministic template search needle" },
+  );
+
+  expect(described).toMatchObject({
+    ok: true,
+    payload: { session: { sessionId } },
+  });
+  expect(searched.payload?.results).toEqual([expect.objectContaining({ sessionKey })]);
+  expect(await listAgentIdsViaRpc()).toEqual(["main"]);
+});
+
+test("session reads still open stores for the default and configured agents", async () => {
+  await setAgentsConfig({ list: [{ id: "main", default: true }, { id: "work" }] });
+  for (const agentId of ["main", "work"]) {
+    const result = await directSessionReq<{ session: unknown }>("sessions.describe", {
+      key: `agent:${agentId}:missing`,
+    });
+    expect(result).toMatchObject({ ok: true, payload: { session: null } });
+    expect(
+      fs.existsSync(
+        resolveOpenClawAgentSqlitePath({
+          agentId,
+          env: { OPENCLAW_STATE_DIR: requireStateDir() },
+        }),
+      ),
+    ).toBe(true);
+  }
+
+  expect(
+    listOpenClawRegisteredAgentDatabases({
+      env: { OPENCLAW_STATE_DIR: requireStateDir() },
+    }).map((entry) => entry.agentId),
+  ).toEqual(expect.arrayContaining(["main", "work"]));
+});

--- a/src/gateway/server-methods/sessions-read.ts
+++ b/src/gateway/server-methods/sessions-read.ts
@@ -12,17 +12,21 @@ import {
 } from "../../../packages/gateway-protocol/src/index.js";
 import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import {
+  isConfiguredSessionStoreAgentId,
+  isPerAgentSessionStoreConfig,
+  resolveExistingAgentSessionStoreTargetsSync,
   runSessionsCleanup,
   serializeSessionCleanupResult,
   type SessionEntry,
 } from "../../config/sessions.js";
+import { listSessionEntries } from "../../config/sessions/session-accessor.js";
 import { searchSessionTranscripts } from "../../config/sessions/session-transcript-search.js";
 import {
   measureDiagnosticsTimelineSpan,
   measureDiagnosticsTimelineSpanSync,
 } from "../../infra/diagnostics-timeline.js";
 import { formatErrorMessage } from "../../infra/errors.js";
-import { normalizeAgentId } from "../../routing/session-key.js";
+import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
 import { resolveRequestedSessionAgentId as resolveRequestedGlobalAgentId } from "../session-create-service.js";
 import {
   resolveSessionStoreAgentId,
@@ -67,14 +71,6 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
       return;
     }
     const cfg = context.getRuntimeConfig();
-    if (params.agentId && !params.sessionKeys) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, "agentId requires sessionKeys"),
-      );
-      return;
-    }
     const requestedAgentId = params.agentId ? normalizeAgentId(params.agentId) : undefined;
     const sessionKeys = params.sessionKeys?.map((sessionKey) =>
       requestedAgentId
@@ -101,17 +97,87 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
     }
     const agentId =
       requestedAgentId ?? agentIds.values().next().value ?? resolveDefaultAgentId(cfg);
+    const configured = isConfiguredSessionStoreAgentId(cfg, agentId);
+    if (requestedAgentId && !params.sessionKeys && configured) {
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, "agentId requires sessionKeys"),
+      );
+      return;
+    }
+    const scopedSessionKeys = configured
+      ? sessionKeys
+      : sessionKeys?.filter((sessionKey) => {
+          const sessionAgentId =
+            requestedAgentId && (sessionKey === "global" || sessionKey === "unknown")
+              ? requestedAgentId
+              : resolveSessionStoreAgentId(cfg, sessionKey);
+          return sessionAgentId === agentId;
+        });
+    if (!configured && scopedSessionKeys?.length === 0) {
+      respond(true, { results: [] }, undefined);
+      return;
+    }
+    const existingTargets = configured
+      ? []
+      : resolveExistingAgentSessionStoreTargetsSync(cfg, agentId);
+    if (!configured && existingTargets.length === 0) {
+      respond(true, { results: [] }, undefined);
+      return;
+    }
     try {
-      const result = searchSessionTranscripts({
-        agentId,
-        query,
-        limit: params.limit,
-        ...(sessionKeys ? { sessionKeys } : {}),
+      const searchTargets = configured ? [undefined] : existingTargets;
+      const targetResults = searchTargets.flatMap((target) => {
+        const targetSessionKeys =
+          scopedSessionKeys ??
+          (target && !isPerAgentSessionStoreConfig(cfg.session?.store)
+            ? listSessionEntries({ agentId: target.agentId, storePath: target.storePath })
+                .map((entry) => entry.sessionKey)
+                .filter((sessionKey) => {
+                  const parsed = parseAgentSessionKey(sessionKey);
+                  return !parsed || normalizeAgentId(parsed.agentId) === agentId;
+                })
+            : undefined);
+        if (targetSessionKeys?.length === 0) {
+          return [];
+        }
+        return [
+          searchSessionTranscripts({
+            agentId: target?.agentId ?? agentId,
+            query,
+            // Over-fetch retired multi-store searches so deduplication can still fill the caller's
+            // requested page when the same transcript was copied during a store migration.
+            limit: configured ? params.limit : 25,
+            ...(targetSessionKeys ? { sessionKeys: targetSessionKeys } : {}),
+            ...(target ? { storePath: target.storePath } : {}),
+          }),
+        ];
+      });
+      const limit = params.limit ?? 10;
+      const sortedHits = targetResults
+        .flatMap((result) => result.hits)
+        .toSorted(
+          (left, right) =>
+            right.score - left.score ||
+            right.timestamp - left.timestamp ||
+            left.messageId.localeCompare(right.messageId),
+        );
+      const seenHits = new Set<string>();
+      const hits = sortedHits.filter((hit) => {
+        const identity = `${hit.sessionKey}\u0000${hit.sessionId}\u0000${hit.messageId}`;
+        if (seenHits.has(identity)) {
+          return false;
+        }
+        seenHits.add(identity);
+        return true;
       });
       respond(true, {
-        results: result.hits,
-        ...(result.indexing ? { indexing: true } : {}),
-        ...(result.truncated ? { truncated: true } : {}),
+        results: hits.slice(0, limit),
+        ...(targetResults.some((result) => result.indexing) ? { indexing: true } : {}),
+        ...(targetResults.some((result) => result.truncated) || hits.length > limit
+          ? { truncated: true }
+          : {}),
       });
     } catch (error) {
       respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatErrorMessage(error)));
@@ -294,8 +360,11 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
           cfg,
           key,
         });
-        const store = storeCache.get(cachedStoreTarget.storePath) ?? cachedStoreTarget.store;
-        storeCache.set(cachedStoreTarget.storePath, store);
+        // Fixed stores share a legacy path but resolve to owner-specific SQLite databases. Keep
+        // synthetic misses from poisoning another agent's real store entry in this batch.
+        const storeCacheKey = `${cachedStoreTarget.agentId}\u0000${cachedStoreTarget.storePath}`;
+        const store = storeCache.get(storeCacheKey) ?? cachedStoreTarget.store;
+        storeCache.set(storeCacheKey, store);
         const target = resolveGatewaySessionStoreTarget({
           cfg,
           key,

--- a/src/gateway/server-methods/sessions-search.test.ts
+++ b/src/gateway/server-methods/sessions-search.test.ts
@@ -5,14 +5,25 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayRequestContext, RespondFn } from "./types.js";
 
 const searchSessionTranscriptsMock = vi.fn();
+const listSessionEntriesMock = vi.fn();
+const resolveExistingAgentSessionStoreTargetsSyncMock = vi.fn();
 
 vi.mock("../../config/sessions/session-transcript-search.js", () => ({
   searchSessionTranscripts: (...args: unknown[]) => searchSessionTranscriptsMock(...args),
 }));
+vi.mock("../../config/sessions/session-accessor.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../config/sessions/session-accessor.js")>()),
+  listSessionEntries: (...args: unknown[]) => listSessionEntriesMock(...args),
+}));
+vi.mock("../../config/sessions.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../config/sessions.js")>()),
+  resolveExistingAgentSessionStoreTargetsSync: (...args: unknown[]) =>
+    resolveExistingAgentSessionStoreTargetsSyncMock(...args),
+}));
 
 import { sessionsHandlers } from "./sessions.js";
 
-const cfg = {
+let cfg: Record<string, unknown> = {
   agents: { list: [{ id: "main", default: true }, { id: "work" }] },
 };
 
@@ -34,8 +45,13 @@ async function callSearch(params: Record<string, unknown>): Promise<ReturnType<t
 
 describe("sessions.search gateway method", () => {
   beforeEach(() => {
+    cfg = { agents: { list: [{ id: "main", default: true }, { id: "work" }] } };
     searchSessionTranscriptsMock.mockReset();
     searchSessionTranscriptsMock.mockReturnValue({ hits: [], indexing: false });
+    listSessionEntriesMock.mockReset();
+    listSessionEntriesMock.mockReturnValue([]);
+    resolveExistingAgentSessionStoreTargetsSyncMock.mockReset();
+    resolveExistingAgentSessionStoreTargetsSyncMock.mockReturnValue([]);
   });
 
   it("validates params and rejects whitespace-only queries", async () => {
@@ -140,5 +156,80 @@ describe("sessions.search gateway method", () => {
       expect.objectContaining({ code: "INVALID_REQUEST", message: "agentId requires sessionKeys" }),
     );
     expect(searchSessionTranscriptsMock).not.toHaveBeenCalled();
+  });
+
+  it("searches only scoped keys in existing retired stores and deduplicates migrated hits", async () => {
+    resolveExistingAgentSessionStoreTargetsSyncMock.mockReturnValue([
+      { agentId: "retired", storePath: "/stores/retired-a/sessions.json" },
+      { agentId: "retired", storePath: "/stores/retired-b/sessions.json" },
+    ]);
+    const duplicate = {
+      sessionKey: "agent:retired:main",
+      sessionId: "session-retired",
+      messageId: "message-1",
+      role: "user",
+      timestamp: 20,
+      snippet: "needle",
+      score: 3,
+    };
+    searchSessionTranscriptsMock
+      .mockReturnValueOnce({
+        hits: [duplicate, { ...duplicate, messageId: "message-2", score: 1 }],
+        indexing: false,
+      })
+      .mockReturnValueOnce({
+        hits: [{ ...duplicate }, { ...duplicate, messageId: "message-3", score: 2 }],
+        indexing: false,
+      });
+
+    const respond = await callSearch({
+      agentId: "retired",
+      query: "needle",
+      sessionKeys: ["main"],
+      limit: 3,
+    });
+
+    expect(searchSessionTranscriptsMock).toHaveBeenCalledTimes(2);
+    expect(searchSessionTranscriptsMock).toHaveBeenNthCalledWith(1, {
+      agentId: "retired",
+      query: "needle",
+      limit: 25,
+      sessionKeys: ["agent:retired:main"],
+      storePath: "/stores/retired-a/sessions.json",
+    });
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        results: [
+          expect.objectContaining({ messageId: "message-1" }),
+          expect.objectContaining({ messageId: "message-3" }),
+          expect.objectContaining({ messageId: "message-2" }),
+        ],
+      }),
+    );
+  });
+
+  it("scopes omitted filters to the requested agent in a fixed store", async () => {
+    cfg = {
+      agents: { list: [{ id: "main", default: true }] },
+      session: { store: "/stores/shared/sessions.json" },
+    };
+    resolveExistingAgentSessionStoreTargetsSyncMock.mockReturnValue([
+      { agentId: "retired", storePath: "/stores/shared/sessions.json" },
+    ]);
+    listSessionEntriesMock.mockReturnValue([
+      { sessionKey: "agent:retired:mine", entry: {} },
+      { sessionKey: "agent:other:secret", entry: {} },
+    ]);
+
+    await callSearch({ agentId: "retired", query: "needle" });
+
+    expect(searchSessionTranscriptsMock).toHaveBeenCalledWith({
+      agentId: "retired",
+      query: "needle",
+      limit: 25,
+      sessionKeys: ["agent:retired:mine"],
+      storePath: "/stores/shared/sessions.json",
+    });
   });
 });

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1580,6 +1580,31 @@ describe("gateway session utils", () => {
     expect(target.storeKeys).toContain("agent:ops:main");
   });
 
+  test("resolveGatewaySessionStoreTarget keeps a fixed configured store authoritative", async () => {
+    await withStateDirEnv("session-utils-fixed-store-", async ({ stateDir }) => {
+      const fixedStorePath = path.join(stateDir, "configured", "sessions.json");
+      const staleStorePath = path.join(stateDir, "agents", "ops", "sessions", "sessions.json");
+      await seedSessionEntries(fixedStorePath, {
+        "agent:ops:main": { sessionId: "sess-fixed", updatedAt: 1 },
+      });
+      await seedSessionEntries(staleStorePath, {
+        "agent:ops:main": { sessionId: "sess-stale", updatedAt: 99 },
+      });
+      const cfg = {
+        session: { mainKey: "main", store: fixedStorePath },
+        agents: { list: [{ id: "ops", default: true }] },
+      } as OpenClawConfig;
+
+      const target = resolveGatewaySessionStoreTargetWithStore({
+        cfg,
+        key: "agent:ops:main",
+      });
+
+      expect(target.storePath).toBe(path.resolve(fixedStorePath));
+      expect(target.store["agent:ops:main"]?.sessionId).toBe("sess-fixed");
+    });
+  });
+
   test("resolveGatewaySessionStoreTarget preserves discovered store paths for non-round-tripping agent dirs", async () => {
     await withStateDirEnv("session-utils-discovered-store-", async ({ stateDir }) => {
       const retiredSessionsDir = path.join(stateDir, "agents", "Retired Agent", "sessions");
@@ -1600,6 +1625,68 @@ describe("gateway session utils", () => {
       const target = resolveGatewaySessionStoreTarget({ cfg, key: "agent:retired-agent:main" });
 
       expect(target.storePath).toBe(path.resolve(retiredStorePath));
+    });
+  });
+
+  test("resolveGatewaySessionStoreTarget keeps discovered contents paired with their path", async () => {
+    await withStateDirEnv("session-utils-discovered-contents-", async ({ stateDir }) => {
+      const retiredSessionsDir = path.join(stateDir, "agents", "Retired Agent", "sessions");
+      fs.mkdirSync(retiredSessionsDir, { recursive: true });
+      const retiredStorePath = path.join(retiredSessionsDir, "sessions.json");
+      await seedSessionEntries(retiredStorePath, {
+        "agent:retired-agent:other": { sessionId: "sess-discovered-other", updatedAt: 1 },
+      });
+      const cfg = {
+        session: {
+          mainKey: "main",
+          store: path.join(stateDir, "agents", "{agentId}", "sessions", "sessions.json"),
+        },
+        agents: { list: [{ id: "main", default: true }] },
+      } as OpenClawConfig;
+      const fallbackStore = {
+        "agent:retired-agent:main": { sessionId: "sess-fallback", updatedAt: 99 },
+      };
+
+      const target = resolveGatewaySessionStoreTargetWithStore({
+        cfg,
+        key: "agent:retired-agent:main",
+        store: fallbackStore,
+      });
+
+      expect(target.storePath).toBe(path.resolve(retiredStorePath));
+      expect(target.store).toHaveProperty("agent:retired-agent:other");
+      expect(target.store).not.toHaveProperty("agent:retired-agent:main");
+    });
+  });
+
+  test("resolveGatewaySessionStoreTarget reads a retired legacy store without provisioning SQLite", async () => {
+    await withStateDirEnv("session-utils-retired-legacy-", async ({ stateDir }) => {
+      const retiredSessionsDir = path.join(stateDir, "agents", "retired", "sessions");
+      const retiredStorePath = path.join(retiredSessionsDir, "sessions.json");
+      fs.mkdirSync(retiredSessionsDir, { recursive: true });
+      fs.writeFileSync(
+        retiredStorePath,
+        JSON.stringify({
+          "agent:retired:main": { sessionId: "sess-retired-legacy", updatedAt: 1 },
+        }),
+        "utf8",
+      );
+      const cfg = {
+        session: {
+          mainKey: "main",
+          store: path.join(stateDir, "agents", "{agentId}", "sessions", "sessions.json"),
+        },
+        agents: { list: [{ id: "main", default: true }] },
+      } as OpenClawConfig;
+
+      const target = resolveGatewaySessionStoreTargetWithStore({
+        cfg,
+        key: "agent:retired:main",
+      });
+
+      expect(target.storePath).toBe(retiredStorePath);
+      expect(target.store["agent:retired:main"]?.sessionId).toBe("sess-retired-legacy");
+      expect(fs.readdirSync(retiredSessionsDir)).toEqual(["sessions.json"]);
     });
   });
 

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -77,9 +77,13 @@ import {
   buildGroupDisplayName,
   buildGroupDisplayTitle,
   getSessionStoreCacheVersion,
+  isConfiguredSessionStoreAgentId,
+  isLegacyOnlySessionStoreTarget,
   isTerminalSessionStatus,
+  readLegacySessionStoreTarget,
   resolveAllAgentSessionStoreTargetsSync,
   resolveAgentMainSessionKey,
+  resolveExistingAgentSessionStoreTargetsSync,
   resolveFreshSessionTotalTokens,
   resolveSessionGoalDisplayState,
   resolveStorePath,
@@ -1320,31 +1324,31 @@ function buildGatewaySessionStoreScanTargets(params: {
 function resolveGatewaySessionStoreCandidates(
   cfg: OpenClawConfig,
   agentId: string,
-): SessionStoreTarget[] {
+): { existing: SessionStoreTarget[]; fallback: SessionStoreTarget } {
   const storeConfig = cfg.session?.store;
-  const defaultTarget = {
+  const fallback = {
     agentId,
     storePath: resolveStorePath(storeConfig, { agentId }),
   };
-  if (!isStorePathTemplate(storeConfig)) {
-    return [defaultTarget];
-  }
-  const targets = new Map<string, SessionStoreTarget>();
-  targets.set(defaultTarget.storePath, defaultTarget);
-  for (const target of resolveAllAgentSessionStoreTargetsSync(cfg)) {
-    if (target.agentId === agentId) {
-      targets.set(target.storePath, target);
-    }
-  }
-  return [...targets.values()];
+  return {
+    existing: resolveExistingAgentSessionStoreTargetsSync(cfg, agentId),
+    fallback,
+  };
 }
 
 function loadGatewaySessionLookupStore(
   storePath: string,
   clone: boolean | undefined,
   agentId?: string,
+  options: { allowLegacyFallback?: boolean } = {},
 ): Record<string, SessionEntry> {
   try {
+    if (options.allowLegacyFallback) {
+      const legacyStore = readLegacySessionStoreTarget(storePath, agentId);
+      if (legacyStore) {
+        return legacyStore;
+      }
+    }
     return Object.fromEntries(
       listAccessorSessionEntries({
         ...(agentId ? { agentId } : {}),
@@ -1370,15 +1374,30 @@ function resolveGatewaySessionStoreLookup(params: {
   match: { entry: SessionEntry; key: string } | undefined;
 } {
   const scanTargets = buildGatewaySessionStoreScanTargets(params);
-  const candidates = resolveGatewaySessionStoreCandidates(params.cfg, params.agentId);
-  const fallback = candidates[0] ?? {
-    agentId: params.agentId,
-    storePath: resolveStorePath(params.cfg.session?.store, { agentId: params.agentId }),
-  };
+  const { existing, fallback } = resolveGatewaySessionStoreCandidates(params.cfg, params.agentId);
+  const configured = isConfiguredSessionStoreAgentId(params.cfg, params.agentId);
+  const candidates = configured
+    ? [fallback, ...existing.filter((target) => target.storePath !== fallback.storePath)]
+    : existing;
+  if (candidates.length === 0) {
+    // Discovery is read-only. Only configured agents may cross the fallback edge that creates a
+    // missing SQLite store; retired/manual agents must already have a discovered store.
+    return {
+      storePath: fallback.storePath,
+      store: {},
+      match: undefined,
+    };
+  }
   const loadStore = (target: SessionStoreTarget) =>
-    loadGatewaySessionLookupStore(target.storePath, params.clone, target.agentId);
-  let selectedStorePath = fallback.storePath;
-  let selectedStore = params.initialStore ?? loadStore(fallback);
+    loadGatewaySessionLookupStore(target.storePath, params.clone, target.agentId, {
+      allowLegacyFallback: !configured,
+    });
+  const firstCandidate = candidates[0] ?? fallback;
+  let selectedStorePath = firstCandidate.storePath;
+  let selectedStore =
+    params.initialStore && firstCandidate.storePath === fallback.storePath
+      ? params.initialStore
+      : loadStore(firstCandidate);
   let selectedMatch = findFreshestStoreMatch(selectedStore, ...scanTargets);
   let selectedUpdatedAt = selectedMatch?.entry.updatedAt ?? Number.NEGATIVE_INFINITY;
 
@@ -1906,7 +1925,6 @@ export function buildGatewaySessionRow(params: {
 }): GatewaySessionRow {
   const { cfg, storePath, store, key, entry } = params;
   const lightweight = params.lightweightListRow === true;
-  const skipTranscriptUsage = params.skipTranscriptUsageFallback === true;
   const now = params.now ?? Date.now();
   const updatedAt = entry?.updatedAt ?? null;
   const parsed = parseGroupKey(key);
@@ -1942,6 +1960,10 @@ export function buildGatewaySessionRow(params: {
   const sessionAgentId = normalizeAgentId(
     parsedAgent?.agentId ?? params.agentId ?? resolveDefaultAgentId(cfg),
   );
+  const skipTranscriptUsage =
+    params.skipTranscriptUsageFallback === true ||
+    (!isConfiguredSessionStoreAgentId(cfg, sessionAgentId) &&
+      isLegacyOnlySessionStoreTarget(storePath, sessionAgentId));
   const rowContext = params.rowContext;
   const subagentRun = rowContext
     ? rowContext.subagentRuns.getDisplaySubagentRun(key)


### PR DESCRIPTION
## What Problem This Solves

Calling `sessions.describe` or `sessions.abort` with a session key for an agent id that doesn't exist (`agent:ghost:zzz`) silently PROVISIONED that agent — creating `agents/ghost/agent/openclaw-agent.sqlite`, an `agent_databases` row, and an `agents.list` entry that survives restart. A caller with operator scopes and arbitrary session keys could create unbounded agents/databases through a read/abort path. It was also inconsistent: `agents.delete` on an unknown id correctly returns not-found. Found by the R7 QA campaign; the fix approach was chosen by the maintainer (reject unknown).

## Why This Change Was Made

Provisioning is a side effect of opening an agent's store while resolving a session key. The gate should block CREATION of a store that doesn't exist — without losing access to any store that DOES exist.

## User Impact

`sessions.describe`/`get`/`search` and `sessions.abort` now resolve read-only: if no store exists for the agent, describe/search return not-found/empty and abort returns `agent "<id>" not found`, and **nothing is created** (no directory, SQLite, registry row, or `agents.list` entry). Every legitimate way to reach an EXISTING store is preserved — a configured agent, a retired/removed-from-config agent whose store still exists (per-agent, deterministic-template, discovered, or legacy `sessions.json`), an agent that has rows in a shared store, or an in-memory active run. `main` and `agents.create` are unchanged.

## Evidence

- Reuses the existing configured-agent existence check and the discovery path's `lstat`/`realpath`/root-containment validation (deterministic targets are validated the same way — a symlink escaping the agents root is rejected, not followed).
- Fixed-store negative results get a cache-distinct identity so a batch/preview ordered `[unknownKey, validKey]` no longer mis-reports the valid session as missing.
- Tests (167 across four files): unknown id creates nothing (dir/sqlite/registry/list all absent); retired agent with a validated persisted store readable/searchable/abortable; exact in-memory active run abortable; deterministic-template symlink-escape rejected; batch cache order-independence; legacy fixed store recognized; configured/main/agents.create unchanged.
- Autoreview (codex gpt-5.6-sol, xhigh): **clean** after a deep multi-round review that surfaced and closed real edges (shared-store-vs-agent existence, retired-store search, active-run abort, deterministic-template validation, symlink containment, cache collision). Prod change is small; the bulk of the diff is regression tests.
