### PR TITLE
fix(venice): reject invalid UTF-8 usage responses

### DIFF
--- a/extensions/venice/usage.test.ts
+++ b/extensions/venice/usage.test.ts
@@ -2,6 +2,20 @@ import { describe, expect, it, vi } from "vitest";
 import { fetchVeniceUsage } from "./usage.js";
 
 describe("Venice usage", () => {
+  it("rejects usage JSON containing invalid UTF-8", async () => {
+    const prefix = new TextEncoder().encode('{"balances":{"usd":8.5},"consumptionCurrency":"DI');
+    const suffix = new TextEncoder().encode('EM"}');
+    const body = new Uint8Array([...prefix, 0xff, ...suffix]);
+    const snapshot = await fetchVeniceUsage({
+      token: "test-token",
+      timeoutMs: 5000,
+      fetchFn: vi.fn(async () => new Response(body)) as unknown as typeof fetch,
+    });
+
+    expect(snapshot.error).toBe("Malformed usage response");
+    expect(snapshot.windows).toEqual([]);
+  });
+
   it("maps balances and DIEM epoch allocation", async () => {
     const fetchFn = vi.fn(async () =>
       Response.json({

--- a/extensions/venice/usage.ts
+++ b/extensions/venice/usage.ts
@@ -38,7 +38,7 @@ async function readPayload(response: Response, timeoutMs: number): Promise<Venic
     onIdleTimeout: ({ chunkTimeoutMs }) =>
       new Error(`Venice usage response stalled for ${chunkTimeoutMs}ms`),
   });
-  const data = objectRecord(JSON.parse(new TextDecoder().decode(buffer)));
+  const data = objectRecord(JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(buffer)));
   if (!data) {
     throw new Error("Venice usage response is not an object");
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users checking Venice usage could receive a corrupted billing plan when an otherwise valid JSON response contained invalid UTF-8 bytes. The default decoder silently replaced those bytes with `U+FFFD`, so the response was accepted instead of reported as malformed.

## Why This Change Was Made

The bounded Venice usage response is now decoded as fatal UTF-8 before JSON parsing, using the existing malformed-response boundary for decoding failures. The change is limited to invalidly encoded responses; valid UTF-8 payloads, response limits, timeouts, and field mapping are unchanged.

AI-assisted: yes.

## User Impact

Venice usage checks now report a stable malformed-response error instead of showing text derived from corrupted response bytes.

## Evidence

### Real behavior proof

Environment: Linux 6.8.0-136-generic x86_64, Node v24.18.0, base `b57660d02491728e8738a51d81fed551c6ba5d6d`.

I ran a temporary TypeScript harness with:

```text
node --import tsx .proof-invalid-utf8.ts
```

The harness started a real `node:http` server on `127.0.0.1`, sent `0xff` inside the JSON string `consumptionCurrency`, and called the production `fetchVeniceUsage` function through its `fetchFn` transport seam.

Before / negative control, with the decoder restored to the `upstream/main` implementation:

```json
{"invalidResult":{"provider":"venice","displayName":"Venice","windows":[],"billing":[{"type":"balance","label":"USD balance","amount":8.5,"unit":"USD"}],"plan":"DI�EM billing"},"validPlan":"DIEM billing"}
```

After this change, using the same server and bytes:

```json
{"invalidResult":{"provider":"venice","displayName":"Venice","windows":[],"error":"Malformed usage response"},"validPlan":"DIEM billing"}
```

The valid control remained `DIEM billing`, showing that valid UTF-8 behavior is unchanged. The live Venice service was not asked to emit malformed bytes; the loopback server exercises the same bounded network-response and production parsing path deterministically.

### Runtime premise

Node documents that `TextDecoder` defaults `fatal` to `false` and throws `TypeError` on decoding errors when `fatal` is enabled: https://nodejs.org/api/util.html#new-textdecoderencoding-options

```text
$ node -e 'const b=Uint8Array.of(0xff); console.log("soft="+new TextDecoder().decode(b)); try { new TextDecoder("utf-8", { fatal: true }).decode(b) } catch (error) { console.log("fatal="+error.name) }'
soft=�
fatal=TypeError
```

### Focused validation

```text
$ node scripts/run-vitest.mjs extensions/venice/usage.test.ts
Test Files  1 passed (1)
Tests       6 passed (6)

$ node_modules/.bin/oxlint extensions/venice/usage.ts extensions/venice/usage.test.ts
# exit 0

$ git diff --check upstream/main...HEAD
# exit 0
```

Autoreview command:

```text
.agents/skills/autoreview/scripts/autoreview --mode uncommitted --prompt 'Scope baseline: Venice usage decoder only; changed files extensions/venice/usage.ts and usage.test.ts; no API/config changes.'
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.99)
```
