### PR TITLE
fix(canvas): bound A2UI JSONL file reads

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline/gateway-runtime.json
+++ b/docs/.generated/plugin-sdk-api-baseline/gateway-runtime.json
@@ -1,1 +1,1 @@
-{"contentHash":"38dbab19f1c23c82c20443339807822f5dfc626d42171dbb71f3322992d01097","entrypoint":"gateway-runtime","importSpecifier":"openclaw/plugin-sdk/gateway-runtime"}
+{"contentHash":"a78c6ecd0e9a32fa4e8feb562bea0513e8a8244bde63f87fbc8d8e5fd6f6a3dd","entrypoint":"gateway-runtime","importSpecifier":"openclaw/plugin-sdk/gateway-runtime"}

--- a/extensions/canvas/src/a2ui-jsonl-file.test.ts
+++ b/extensions/canvas/src/a2ui-jsonl-file.test.ts
@@ -1,0 +1,47 @@
+import { truncate, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { withTempDir } from "openclaw/plugin-sdk/test-env";
+import { describe, expect, it } from "vitest";
+import { readA2UIJsonlFile } from "./a2ui-jsonl-file.js";
+
+const FILE_BYTE_LIMIT = 16 * 1024 * 1024;
+
+describe("readA2UIJsonlFile", () => {
+  it("reads a valid A2UI payload above the former 8 MiB limit", async () => {
+    await withTempDir("openclaw-canvas-jsonl-", async (tempRoot) => {
+      const filePath = path.join(tempRoot, "large.jsonl");
+      const jsonl = JSON.stringify({
+        surfaceUpdate: {
+          surfaceId: "main",
+          components: [
+            {
+              id: "text",
+              component: {
+                Text: {
+                  text: { literalString: "x".repeat(9 * 1024 * 1024) },
+                },
+              },
+            },
+          ],
+        },
+      });
+      expect(Buffer.byteLength(jsonl)).toBeGreaterThan(8 * 1024 * 1024);
+      expect(Buffer.byteLength(jsonl)).toBeLessThan(FILE_BYTE_LIMIT);
+      await writeFile(filePath, jsonl);
+
+      await expect(readA2UIJsonlFile(filePath)).resolves.toBe(jsonl);
+    });
+  });
+
+  it("rejects an oversized file before reading it into memory", async () => {
+    await withTempDir("openclaw-canvas-jsonl-", async (tempRoot) => {
+      const filePath = path.join(tempRoot, "oversized.jsonl");
+      await writeFile(filePath, "");
+      await truncate(filePath, FILE_BYTE_LIMIT + 1);
+
+      await expect(readA2UIJsonlFile(filePath)).rejects.toThrow(
+        `File exceeds ${FILE_BYTE_LIMIT} bytes`,
+      );
+    });
+  });
+});

--- a/extensions/canvas/src/a2ui-jsonl-file.ts
+++ b/extensions/canvas/src/a2ui-jsonl-file.ts
@@ -1,0 +1,14 @@
+import { readRegularFile } from "openclaw/plugin-sdk/security-runtime";
+
+// Keep both Canvas file entry points on the same allocation ceiling. GatewayClient
+// separately enforces the exact encoded frame against the negotiated maxPayload.
+const MAX_A2UI_JSONL_FILE_BYTES = 16 * 1024 * 1024;
+
+/** Reads an A2UI JSONL file without unbounded buffering. */
+export async function readA2UIJsonlFile(filePath: string): Promise<string> {
+  const { buffer } = await readRegularFile({
+    filePath,
+    maxBytes: MAX_A2UI_JSONL_FILE_BYTES,
+  });
+  return buffer.toString("utf8");
+}

--- a/extensions/canvas/src/cli.test.ts
+++ b/extensions/canvas/src/cli.test.ts
@@ -1,11 +1,33 @@
 // Canvas tests cover cli plugin behavior.
+import { symlink, truncate, writeFile } from "node:fs/promises";
+import path from "node:path";
 import { Command } from "commander";
+import { withTempDir } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it, vi } from "vitest";
 import {
   createDefaultCanvasCliDependencies,
   registerNodesCanvasCommands,
   type CanvasCliDependencies,
 } from "./cli.js";
+
+const FILE_BYTE_LIMIT = 16 * 1024 * 1024;
+
+const VALID_A2UI_V08_JSONL = [
+  JSON.stringify({
+    surfaceUpdate: {
+      surfaceId: "main",
+      components: [
+        {
+          id: "root",
+          component: {
+            Text: { text: { literalString: "Canvas symlink proof" }, usageHint: "body" },
+          },
+        },
+      ],
+    },
+  }),
+  JSON.stringify({ beginRendering: { surfaceId: "main", root: "root" } }),
+].join("\n");
 
 function createCanvasCliDeps() {
   const writtenFiles: Array<{ filePath: string; base64: string }> = [];
@@ -533,4 +555,57 @@ describe("canvas CLI", () => {
     ).rejects.toThrow(`${flag} must be a number.`);
     expect(deps.callGatewayCli).not.toHaveBeenCalled();
   });
+
+  it("rejects oversized A2UI JSONL files before invoking the node", async () => {
+    await withTempDir("openclaw-canvas-cli-", async (tempRoot) => {
+      const filePath = path.join(tempRoot, "oversized.jsonl");
+      await writeFile(filePath, "");
+      await truncate(filePath, FILE_BYTE_LIMIT + 1);
+      const program = new Command();
+      program.exitOverride();
+      const nodes = program.command("nodes");
+      const { deps } = createCanvasCliDeps();
+      registerNodesCanvasCommands(nodes, deps);
+
+      await expect(
+        program.parseAsync(
+          ["nodes", "canvas", "a2ui", "push", "--node", "ios-node", "--jsonl", filePath],
+          { from: "user" },
+        ),
+      ).rejects.toThrow(`File exceeds ${FILE_BYTE_LIMIT} bytes`);
+      expect(deps.callGatewayCli).not.toHaveBeenCalled();
+    });
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "follows a final symlink for --jsonl payload paths",
+    async () => {
+      await withTempDir("openclaw-canvas-cli-", async (tempRoot) => {
+        const targetPath = path.join(tempRoot, "events.jsonl");
+        const linkPath = path.join(tempRoot, "events-link.jsonl");
+        await writeFile(targetPath, VALID_A2UI_V08_JSONL);
+        await symlink(targetPath, linkPath);
+        const program = new Command();
+        program.exitOverride();
+        const nodes = program.command("nodes");
+        const { deps } = createCanvasCliDeps();
+        registerNodesCanvasCommands(nodes, deps);
+
+        await program.parseAsync(
+          ["nodes", "canvas", "a2ui", "push", "--node", "ios-node", "--jsonl", linkPath],
+          { from: "user" },
+        );
+
+        expect(deps.callGatewayCli).toHaveBeenCalledWith(
+          "node.invoke",
+          expect.any(Object),
+          expect.objectContaining({
+            command: "canvas.a2ui.pushJSONL",
+            params: { jsonl: VALID_A2UI_V08_JSONL },
+          }),
+          expect.any(Object),
+        );
+      });
+    },
+  );
 });

--- a/extensions/canvas/src/cli.ts
+++ b/extensions/canvas/src/cli.ts
@@ -23,6 +23,7 @@ import {
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { shortenHomePath } from "openclaw/plugin-sdk/text-utility-runtime";
+import { readA2UIJsonlFile } from "./a2ui-jsonl-file.js";
 import { buildA2UITextJsonl, validateSupportedA2UIJsonl } from "./a2ui-jsonl.js";
 import { canvasSnapshotTempPath, parseCanvasSnapshotPayload } from "./cli-helpers.js";
 
@@ -460,7 +461,7 @@ export function registerNodesCanvasCommands(nodes: Command, deps: CanvasCliDepen
 
           const jsonl = hasText
             ? buildA2UITextJsonl(opts.text ?? "")
-            : await fs.readFile(String(opts.jsonl), "utf8");
+            : await readA2UIJsonlFile(await fs.realpath(String(opts.jsonl)));
           const { messageCount } = validateSupportedA2UIJsonl(jsonl);
           const result = await invokeCanvas(deps, opts, "canvas.a2ui.pushJSONL", { jsonl });
           writeCanvasInvokeResult(

--- a/extensions/canvas/src/tool.test.ts
+++ b/extensions/canvas/src/tool.test.ts
@@ -1,9 +1,11 @@
 // Canvas tests cover tool plugin behavior.
-import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, rm, symlink, truncate, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { CANVAS_JSONL_MAX_BYTES, createCanvasTool } from "./tool.js";
+import { createCanvasTool } from "./tool.js";
+
+const FILE_BYTE_LIMIT = 16 * 1024 * 1024;
 
 const VALID_A2UI_V08_JSONL = [
   JSON.stringify({
@@ -147,22 +149,22 @@ describe("Canvas tool", () => {
     },
   );
 
-  it("rejects jsonlPath files above the shared bounded-read limit", async () => {
+  it("rejects oversized jsonlPath files before resolving a node", async () => {
     tempRoot = await mkdtemp(path.join(os.tmpdir(), "openclaw-canvas-tool-"));
     const workspaceDir = path.join(tempRoot, "workspace");
     await mkdir(workspaceDir);
-    await writeFile(
-      path.join(workspaceDir, "events.jsonl"),
-      Buffer.alloc(CANVAS_JSONL_MAX_BYTES + 1),
-    );
+    const filePath = path.join(workspaceDir, "oversized.jsonl");
+    await writeFile(filePath, "");
+    await truncate(filePath, FILE_BYTE_LIMIT + 1);
     const tool = createCanvasTool({ workspaceDir });
 
     await expect(
       tool.execute("tool-call-1", {
         action: "a2ui_push",
-        jsonlPath: "events.jsonl",
+        jsonlPath: "oversized.jsonl",
       }),
-    ).rejects.toThrow(`exceeds ${CANVAS_JSONL_MAX_BYTES} bytes`);
+    ).rejects.toThrow(`File exceeds ${FILE_BYTE_LIMIT} bytes`);
+    expect(mocks.listNodes).not.toHaveBeenCalled();
     expect(mocks.callGatewayTool).not.toHaveBeenCalled();
   });
 

--- a/extensions/canvas/src/tool.ts
+++ b/extensions/canvas/src/tool.ts
@@ -21,8 +21,9 @@ import {
 } from "openclaw/plugin-sdk/number-runtime";
 import { readFiniteNumberParam, readPositiveIntegerParam } from "openclaw/plugin-sdk/param-readers";
 import type { AnyAgentTool, OpenClawConfig } from "openclaw/plugin-sdk/plugin-entry";
-import { readRegularFile, wrapExternalContent } from "openclaw/plugin-sdk/security-runtime";
+import { wrapExternalContent } from "openclaw/plugin-sdk/security-runtime";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
+import { readA2UIJsonlFile } from "./a2ui-jsonl-file.js";
 import { validateSupportedA2UIJsonl } from "./a2ui-jsonl.js";
 import { normalizeCanvasSnapshotFileExtension, parseCanvasSnapshotPayload } from "./cli-helpers.js";
 import { CanvasToolSchema } from "./tool-schema.js";
@@ -37,10 +38,8 @@ type CanvasImageSanitizationLimits = {
   maxDimensionPx?: number;
 };
 
-export const CANVAS_JSONL_MAX_BYTES = 16 * 1024 * 1024;
 const DEFAULT_CANVAS_NODE_INVOKE_TIMEOUT_MS = 30_000;
 const CANVAS_NODE_INVOKE_TRANSPORT_GRACE_MS = 10_000;
-
 function readGatewayCallOptions(params: Record<string, unknown>) {
   return {
     gatewayUrl: readStringParam(params, "gatewayUrl", { trim: false }),
@@ -87,9 +86,7 @@ async function readJsonlFromPath(jsonlPath: string, workspaceDir?: string): Prom
   if (!isPathInsideRoot(workspaceReal, resolvedReal)) {
     throw new Error("jsonlPath outside workspace");
   }
-  return (
-    await readRegularFile({ filePath: resolvedReal, maxBytes: CANVAS_JSONL_MAX_BYTES })
-  ).buffer.toString("utf8");
+  return await readA2UIJsonlFile(resolvedReal);
 }
 
 function resolveCanvasImageSanitizationLimits(

--- a/packages/gateway-client/src/client.ts
+++ b/packages/gateway-client/src/client.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import { randomUUID } from "node:crypto";
 import type { ClientRequest, IncomingMessage } from "node:http";
 import {
@@ -396,6 +397,10 @@ function formatGatewayClientErrorForLog(err: unknown): string {
 const FORCE_STOP_TERMINATE_GRACE_MS = 250;
 const STOP_AND_WAIT_TIMEOUT_MS = 1_000;
 const MAX_SUPPRESSED_TRANSIENT_PRE_HELLO_CLEAN_CLOSES = 1;
+const DEFAULT_GATEWAY_MAX_PAYLOAD_BYTES = 25 * 1024 * 1024;
+// The Gateway receiver accepts only 64 KiB before authentication; mirror the
+// server-side MAX_PREAUTH_PAYLOAD_BYTES contract for pre-auth connect frames.
+const DEFAULT_GATEWAY_PREAUTH_MAX_PAYLOAD_BYTES = 64 * 1024;
 
 function resolveLegacyNodePlatform(platform: string): string | undefined {
   switch (platform) {
@@ -436,6 +441,7 @@ export class GatewayClient {
   private pendingStop: PendingStop | null = null;
   private transportValidated = false;
   private suppressedTransientPreHelloCleanCloses = 0;
+  private maxPayloadBytes = DEFAULT_GATEWAY_MAX_PAYLOAD_BYTES;
 
   constructor(opts: GatewayClientOptions) {
     // Defaults keep the package inert until device identity support is used.
@@ -465,6 +471,17 @@ export class GatewayClient {
       createRequestTimeoutError: (method, timeoutMs, requestSent) =>
         new GatewayClientRequestTimeoutError({ method, timeoutMs, requestSent }),
       createRequestAbortError: createGatewayRequestAbortError,
+      validateRequestFrame: (frame, method) => {
+        const frameBytes = Buffer.byteLength(frame, "utf8");
+        const isConnect = method === "connect";
+        const limit = isConnect ? DEFAULT_GATEWAY_PREAUTH_MAX_PAYLOAD_BYTES : this.maxPayloadBytes;
+        if (frameBytes > limit) {
+          throw new RangeError(
+            `gateway request ${method} exceeds ${isConnect ? "pre-auth" : "negotiated"} max payload ` +
+              `(${frameBytes} > ${limit} bytes)`,
+          );
+        }
+      },
       buildConnectPlan: ({ nonce, challengeTs }) => {
         if (!nonce) {
           throw new Error("gateway connect challenge missing nonce");
@@ -609,7 +626,7 @@ export class GatewayClient {
       configuredTimeoutMs: this.opts.preauthHandshakeTimeoutMs,
     });
     const wsOptions: FingerprintCheckingClientOptions = {
-      maxPayload: 25 * 1024 * 1024,
+      maxPayload: DEFAULT_GATEWAY_MAX_PAYLOAD_BYTES,
       handshakeTimeout: handshakeTimeoutMs,
       ...(this.opts.origin ? { origin: this.opts.origin } : {}),
     };
@@ -1013,6 +1030,7 @@ export class GatewayClient {
   }
 
   private handleConnectHello(helloOk: HelloOk, assembled: AssembledConnect): void {
+    this.maxPayloadBytes = DEFAULT_GATEWAY_MAX_PAYLOAD_BYTES;
     const reconnectWithCurrentNodeProtocol =
       this.useLegacyNodeProtocolEnvelope &&
       this.shouldNegotiateLegacyNodeProtocol() &&
@@ -1056,6 +1074,16 @@ export class GatewayClient {
       this.protocol.resetReconnectBackoff(250);
       this.protocol.closeSocket(1012, "gateway protocol upgraded");
       return;
+    }
+    // The Gateway installs this advertised limit on its WebSocket receiver after auth,
+    // so it bounds serialized client-to-Gateway request frames.
+    const advertisedMaxPayload = helloOk.policy?.maxPayload;
+    if (
+      typeof advertisedMaxPayload === "number" &&
+      Number.isFinite(advertisedMaxPayload) &&
+      advertisedMaxPayload > 0
+    ) {
+      this.maxPayloadBytes = advertisedMaxPayload;
     }
     this.lastTick = Date.now();
     this.startTickWatch();

--- a/packages/gateway-client/src/client.watchdog.payload.test.ts
+++ b/packages/gateway-client/src/client.watchdog.payload.test.ts
@@ -1,0 +1,201 @@
+// Gateway Client tests cover negotiated request-frame payload enforcement.
+import type { HelloOk } from "@openclaw/gateway-protocol";
+import { describe, expect, test, vi } from "vitest";
+import { WebSocket } from "ws";
+import { GatewayClient } from "./client.js";
+import type { GatewayProtocolSocket } from "./protocol-client.js";
+
+type ProtocolHarness = {
+  socket: GatewayProtocolSocket | null;
+  stopped: boolean;
+  generation: number;
+  reconnectSupervisor: { reset(initialMs?: number): void };
+  handleMessage: (socket: GatewayProtocolSocket, generation: number, raw: string) => void;
+};
+
+type PayloadHarness = {
+  handleConnectHello: (
+    hello: { auth?: HelloOk["auth"]; policy?: Partial<HelloOk["policy"]> },
+    assembled: unknown,
+  ) => void;
+  maxPayloadBytes: number;
+};
+
+function protocolHarness(client: GatewayClient): ProtocolHarness {
+  return (client as unknown as { protocol: ProtocolHarness }).protocol;
+}
+
+function payloadHarness(client: GatewayClient): PayloadHarness {
+  return client as unknown as PayloadHarness;
+}
+
+function installSyntheticSocket(
+  client: GatewayClient,
+  send: (data: string) => unknown,
+  close: (code?: number, reason?: string) => unknown,
+): void {
+  const socket: GatewayProtocolSocket = {
+    isOpen: () => true,
+    send: (data) => send(data),
+    close: (code, reason) => close(code, reason),
+  };
+  Object.assign(protocolHarness(client), { socket, stopped: false, generation: 1 });
+  (client as unknown as { ws: unknown }).ws = {
+    readyState: WebSocket.OPEN,
+    send,
+    close,
+    terminate: vi.fn(),
+  };
+}
+
+function createOpenGatewayClient(requestTimeoutMs: number): {
+  client: GatewayClient;
+  send: ReturnType<typeof vi.fn>;
+} {
+  const client = new GatewayClient({
+    requestTimeoutMs,
+  });
+  const send = vi.fn();
+  installSyntheticSocket(client, send, vi.fn());
+  return { client, send };
+}
+
+function getPendingCount(client: GatewayClient): number {
+  return client.hasPendingRequests ? 1 : 0;
+}
+
+function handleGatewayMessage(client: GatewayClient, payload: Record<string, unknown>): void {
+  const protocol = protocolHarness(client);
+  if (!protocol.socket) {
+    throw new Error("synthetic protocol socket missing");
+  }
+  protocol.handleMessage(protocol.socket, protocol.generation, JSON.stringify(payload));
+}
+
+describe("GatewayClient", () => {
+  test("rejects oversized pre-auth connect frames before sending", async () => {
+    const { client, send } = createOpenGatewayClient(25);
+    await expect(client.request("connect", { pathEnv: "x".repeat(70 * 1024) })).rejects.toThrow(
+      "gateway request connect exceeds pre-auth max payload",
+    );
+    expect(send).not.toHaveBeenCalled();
+    expect(getPendingCount(client)).toBe(0);
+
+    const request = client.request("connect", { pathEnv: "x".repeat(1024) });
+    const frame = JSON.parse(String(send.mock.calls[0]?.[0])) as {
+      id: string;
+      method: string;
+    };
+    expect(frame.method).toBe("connect");
+    handleGatewayMessage(client, {
+      type: "res",
+      id: frame.id,
+      ok: true,
+      payload: { type: "hello-ok", protocol: 4, auth: { role: "operator", scopes: [] } },
+    });
+    await expect(request).resolves.toMatchObject({ type: "hello-ok" });
+    client.stop();
+  });
+
+  test("keeps the default request payload limit when hello omits policy", async () => {
+    const { client, send } = createOpenGatewayClient(25);
+    const harness = payloadHarness(client);
+    harness.handleConnectHello({ auth: { role: "operator", scopes: [] } }, {});
+    harness.handleConnectHello(
+      {
+        auth: { role: "operator", scopes: [] },
+        policy: { maxPayload: 0, maxBufferedBytes: 256, tickIntervalMs: 30_000 },
+      },
+      {},
+    );
+
+    const request = client.request<{ status: string }>("node.invoke", {
+      jsonl: "x".repeat(128),
+    });
+    const frame = JSON.parse(String(send.mock.calls[0]?.[0])) as { id: string };
+    handleGatewayMessage(client, {
+      type: "res",
+      id: frame.id,
+      ok: true,
+      payload: { status: "ok" },
+    });
+
+    await expect(request).resolves.toEqual({ status: "ok" });
+    expect(harness.maxPayloadBytes).toBe(25 * 1024 * 1024);
+    expect(send).toHaveBeenCalledTimes(1);
+    client.stop();
+  });
+
+  test("resets the request payload limit when reconnecting to a policyless Gateway", async () => {
+    const { client, send } = createOpenGatewayClient(25);
+    const harness = payloadHarness(client);
+    harness.handleConnectHello(
+      {
+        auth: { role: "operator", scopes: [] },
+        policy: { maxPayload: 128, maxBufferedBytes: 256, tickIntervalMs: 30_000 },
+      },
+      {},
+    );
+    expect(harness.maxPayloadBytes).toBe(128);
+
+    harness.handleConnectHello({ auth: { role: "operator", scopes: [] } }, {});
+
+    const request = client.request<{ status: string }>("node.invoke", {
+      jsonl: "x".repeat(128),
+    });
+    const frame = JSON.parse(String(send.mock.calls[0]?.[0])) as { id: string };
+    handleGatewayMessage(client, {
+      type: "res",
+      id: frame.id,
+      ok: true,
+      payload: { status: "ok" },
+    });
+
+    await expect(request).resolves.toEqual({ status: "ok" });
+    expect(harness.maxPayloadBytes).toBe(25 * 1024 * 1024);
+    expect(send).toHaveBeenCalledTimes(1);
+    client.stop();
+  });
+
+  test("enforces the latest negotiated request payload before sending", async () => {
+    const { client, send } = createOpenGatewayClient(25);
+    const harness = payloadHarness(client);
+    harness.handleConnectHello(
+      {
+        auth: { role: "operator", scopes: [] },
+        policy: { maxPayload: 128, maxBufferedBytes: 256, tickIntervalMs: 30_000 },
+      },
+      {},
+    );
+
+    await expect(client.request("node.invoke", { jsonl: "x".repeat(128) })).rejects.toThrow(
+      "gateway request node.invoke exceeds negotiated max payload",
+    );
+    expect(harness.maxPayloadBytes).toBe(128);
+    expect(send).not.toHaveBeenCalled();
+    expect(getPendingCount(client)).toBe(0);
+
+    harness.handleConnectHello(
+      {
+        auth: { role: "operator", scopes: [] },
+        policy: { maxPayload: 512, maxBufferedBytes: 1_024, tickIntervalMs: 30_000 },
+      },
+      {},
+    );
+    const request = client.request<{ status: string }>("node.invoke", {
+      jsonl: "x".repeat(128),
+    });
+    const frame = JSON.parse(String(send.mock.calls[0]?.[0])) as { id: string };
+    handleGatewayMessage(client, {
+      type: "res",
+      id: frame.id,
+      ok: true,
+      payload: { status: "ok" },
+    });
+
+    await expect(request).resolves.toEqual({ status: "ok" });
+    expect(harness.maxPayloadBytes).toBe(512);
+    expect(send).toHaveBeenCalledTimes(1);
+    client.stop();
+  });
+});

--- a/packages/gateway-client/src/protocol-client-contract.ts
+++ b/packages/gateway-client/src/protocol-client-contract.ts
@@ -66,6 +66,7 @@ export type GatewayProtocolClientOptions<TPlan> = {
   createRequestError?: (error: Partial<ErrorShape>) => GatewayProtocolRequestError;
   createRequestTimeoutError?: (method: string, timeoutMs: number, requestSent: boolean) => Error;
   createRequestAbortError?: (method: string) => Error;
+  validateRequestFrame?: (frame: string, method: string) => void;
   buildConnectPlan: (params: {
     nonce: string | null;
     challengeTs: number | null | undefined;

--- a/packages/gateway-client/src/protocol-client.ts
+++ b/packages/gateway-client/src/protocol-client.ts
@@ -134,7 +134,17 @@ export class GatewayProtocolClient<TPlan> {
     if (typeof method !== "string" || method.length === 0) {
       return Promise.reject(new Error("invalid request frame: method must be a non-empty string"));
     }
-    return this.requests.request<T>(socket, method, params, options);
+    return this.requests.request<T>(
+      {
+        send: (frame) => {
+          this.opts.validateRequestFrame?.(frame, method);
+          socket.send(frame);
+        },
+      },
+      method,
+      params,
+      options,
+    );
   }
 
   addEventListener(listener: (event: EventFrame) => void): () => void {

--- a/proof-browser-payload.mts
+++ b/proof-browser-payload.mts
@@ -1,0 +1,169 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer as createHttpServer } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+// Real-browser proof for the negotiated request-frame payload guard in the
+// Control UI Gateway browser client. Starts a real local Gateway, bundles the
+// actual GatewayBrowserClient module for Chromium, then records that an
+// oversized chat.send frame is rejected locally before socket.send while the
+// connection stays usable.
+import { build } from "esbuild";
+import { chromium } from "playwright";
+import { createOpenClawTestInstance } from "./test/helpers/openclaw-test-instance.js";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const entrySource = `
+import { GatewayBrowserClient } from ${JSON.stringify(path.join(scriptDir, "ui/src/api/gateway.ts"))};
+
+(globalThis as unknown as { runProof: (wsUrl: string, token: string) => Promise<Record<string, unknown>> }).runProof =
+  async (wsUrl, token) => {
+    const results: Record<string, unknown> = {};
+    let helloPolicy: unknown;
+    let resolveHello: (hello: unknown) => void = () => undefined;
+    const helloReady = new Promise<unknown>((resolve) => {
+      resolveHello = resolve;
+    });
+    const client = new GatewayBrowserClient({
+      url: wsUrl,
+      token,
+      onHello: (hello) => {
+        helloPolicy = hello.policy;
+        resolveHello(hello);
+      },
+    });
+    const deadline = Date.now() + 20_000;
+    client.start();
+    while (!client.connected && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    if (!client.connected) {
+      throw new Error("browser gateway client did not connect");
+    }
+    await Promise.race([
+      helloReady,
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("gateway hello did not arrive")), 20_000),
+      ),
+    ]);
+
+    const normal = await client.request<{ pending?: unknown[] }>("node.pair.list", {});
+    results.normalRequest = { ok: true, pendingCount: normal?.pending?.length ?? 0 };
+
+    // 21 MiB of zeros base64-encodes to about 28 MiB, exceeding the 25 MiB
+    // receiver cap the Gateway advertises in hello-ok.policy.maxPayload.
+    const bigBase64 = "A".repeat(Math.ceil((21 * 1024 * 1024) / 3) * 4);
+    let oversizedError = "";
+    let sentWhileOversized = false;
+    const socket = (client as unknown as { client: { socket?: { isOpen?: () => boolean } } }).client.socket;
+    try {
+      await client.request("chat.send", {
+        messages: [{ attachments: [{ data: bigBase64 }] }],
+      });
+    } catch (error) {
+      oversizedError = error instanceof Error ? error.message : String(error);
+    }
+    sentWhileOversized = Boolean(socket?.isOpen?.());
+    results.oversizedRequest = { error: oversizedError, socketStillOpen: sentWhileOversized };
+
+    const after = await client.request<{ pending?: unknown[] }>("node.pair.list", {});
+    results.afterRejection = { ok: true, pendingCount: after?.pending?.length ?? 0 };
+    results.helloPolicy = helloPolicy;
+    client.stop();
+    return results;
+  };
+`;
+
+async function main() {
+  const inst = await createOpenClawTestInstance({
+    name: "canvas-a2ui-browser-payload-proof",
+  });
+  let tempDir = "";
+  let server: ReturnType<typeof createHttpServer> | undefined;
+  try {
+    await inst.startGateway();
+    const gatewayUrl = inst.url;
+    const token = inst.gatewayToken;
+
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-browser-payload-proof-"));
+    const entryPath = path.join(tempDir, "proof-entry.ts");
+    await writeFile(entryPath, entrySource);
+    await build({
+      entryPoints: [entryPath],
+      bundle: true,
+      platform: "browser",
+      format: "esm",
+      outfile: path.join(tempDir, "proof.js"),
+      logLevel: "silent",
+    });
+    await writeFile(
+      path.join(tempDir, "index.html"),
+      '<!doctype html><meta charset="utf-8"><title>gateway payload proof</title><script type="module" src="./proof.js"></script>',
+    );
+
+    const port = await new Promise<number>((resolve, reject) => {
+      const httpServer = createHttpServer(async (request, response) => {
+        try {
+          const urlPath = request.url === "/" ? "/index.html" : (request.url ?? "/index.html");
+          const filePath = path.join(tempDir, path.basename(urlPath));
+          const body = await readFile(filePath);
+          response.writeHead(200, {
+            "content-type": urlPath.endsWith(".js")
+              ? "text/javascript"
+              : "text/html; charset=utf-8",
+          });
+          response.end(body);
+        } catch {
+          response.writeHead(404);
+          response.end("not found");
+        }
+      });
+      httpServer.listen(0, "127.0.0.1", () => {
+        const address = httpServer.address();
+        if (address && typeof address === "object") {
+          resolve(address.port);
+        } else {
+          reject(new Error("failed to bind proof http server"));
+        }
+      });
+      server = httpServer;
+    });
+
+    const browser = await chromium.launch({ headless: true });
+    try {
+      const page = await browser.newPage();
+      const pageErrors: string[] = [];
+      page.on("pageerror", (error) => pageErrors.push(error.message));
+      await page.goto(`http://127.0.0.1:${port}/`, { waitUntil: "load" });
+      const results = (await page.evaluate(
+        ([wsUrl, authToken]) =>
+          (
+            globalThis as unknown as {
+              runProof: (u: string, t: string) => Promise<Record<string, unknown>>;
+            }
+          ).runProof(wsUrl, authToken),
+        [gatewayUrl, token],
+      )) as Record<string, unknown>;
+      console.log(`gateway=${gatewayUrl}`);
+      console.log(`token=<redacted>`);
+      console.log(JSON.stringify({ ...results, pageErrors }, null, 2));
+    } finally {
+      await browser.close();
+    }
+  } finally {
+    if (server) {
+      await new Promise((resolve) => {
+        server?.close(resolve);
+      });
+    }
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+    await inst.cleanup();
+  }
+}
+
+void main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -30,6 +30,12 @@ type MockLoggingConfig = {
   redactSensitive?: "off" | "tools";
 };
 
+const TEST_GATEWAY_POLICY = {
+  maxPayload: 1_000_000,
+  maxBufferedBytes: 1_000_000,
+  tickIntervalMs: 60_000,
+} as const;
+
 const wsInstances = vi.hoisted((): MockWebSocket[] => []);
 const wsConstructorObservers = vi.hoisted((): Array<(url: string, options: unknown) => void> => []);
 const clearDeviceAuthTokenMock = vi.hoisted(() => vi.fn());
@@ -612,6 +618,7 @@ describe("GatewayClient request errors", () => {
         payload: {
           type: "hello-ok",
           auth: { role: "operator", scopes: ["operator.admin"] },
+          policy: TEST_GATEWAY_POLICY,
         },
       }),
     );
@@ -927,6 +934,7 @@ describe("GatewayClient close handling", () => {
           payload: {
             type: "hello-ok",
             auth: { role: "operator", scopes: ["operator.admin"] },
+            policy: TEST_GATEWAY_POLICY,
           },
         }),
       );
@@ -1863,6 +1871,7 @@ describe("GatewayClient connect auth payload", () => {
           type: "hello-ok",
           protocol,
           auth: { role: "operator", scopes: ["operator.admin"] },
+          policy: TEST_GATEWAY_POLICY,
         },
       }),
     );

--- a/src/gateway/gateway-cli-backend.connect.test.ts
+++ b/src/gateway/gateway-cli-backend.connect.test.ts
@@ -55,11 +55,6 @@ async function startMinimalGatewayServer(params: { token: string }) {
               stateVersion: { presence: 0, health: 0 },
               uptimeMs: 0,
             },
-            policy: {
-              maxPayload: 1,
-              maxBufferedBytes: 1,
-              tickIntervalMs: 60_000,
-            },
           }),
         );
         return;

--- a/src/tui/gateway-chat.scopes.test.ts
+++ b/src/tui/gateway-chat.scopes.test.ts
@@ -226,6 +226,11 @@ describe("GatewayChatClient operator scopes", () => {
             scopes: requestedScopes,
             deviceToken: "approved-tui-device-token",
           },
+          policy: {
+            maxPayload: 512,
+            maxBufferedBytes: 1_024,
+            tickIntervalMs: 30_000,
+          },
         },
       });
       await approved.client.waitForReady();
@@ -269,6 +274,16 @@ describe("GatewayChatClient operator scopes", () => {
         runId: "tui-scope-upgrade-run",
         status: "started",
       });
+
+      const sentCount = approved.socket.sent.length;
+      await expect(
+        approved.client.sendChat({
+          sessionKey: "main",
+          message: "x".repeat(512),
+          runId: "tui-oversized-chat-run",
+        }),
+      ).rejects.toThrow("gateway request chat.send exceeds negotiated max payload");
+      expect(approved.socket.sent).toHaveLength(sentCount);
     } finally {
       await Promise.all(clients.map((client) => client.stop()));
       vi.doUnmock("ws");

--- a/ui/src/api/gateway.node.test.ts
+++ b/ui/src/api/gateway.node.test.ts
@@ -751,6 +751,129 @@ describe("GatewayBrowserClient", () => {
     });
   });
 
+  it("rejects oversized frames against the negotiated payload before sending", async () => {
+    const client = new GatewayBrowserClient({
+      url: "ws://127.0.0.1:18789",
+      token: "shared-auth-token",
+    });
+    const { ws, connectFrame } = await startConnect(client);
+    ws.emitMessage({
+      type: "res",
+      id: connectFrame.id,
+      ok: true,
+      payload: {
+        type: "hello-ok",
+        protocol: 4,
+        auth: { role: "operator", scopes: [] },
+        policy: { maxPayload: 128 },
+      },
+    });
+    await vi.waitFor(() => expect(client.connected).toBe(true));
+    ws.sent.length = 0;
+
+    await expect(client.request("chat.send", { text: "x".repeat(256) })).rejects.toThrow(
+      "gateway request chat.send exceeds negotiated max payload",
+    );
+    expect(ws.sent).toHaveLength(0);
+
+    const request = client.request("sessions.list", { includeGlobal: true });
+    const frame = JSON.parse(ws.sent.at(-1) ?? "{}") as { id?: string; method?: string };
+    expect(frame.method).toBe("sessions.list");
+    ws.emitMessage({
+      type: "res",
+      id: frame.id,
+      ok: true,
+      payload: { sessions: [] },
+    });
+    await expect(request).resolves.toEqual({ sessions: [] });
+  });
+
+  it("resets the negotiated payload limit when reconnecting to a policyless Gateway", async () => {
+    useNodeFakeTimers();
+    const client = new GatewayBrowserClient({
+      url: "ws://127.0.0.1:18789",
+      token: "shared-auth-token",
+    });
+    const { ws: firstWs, connectFrame: firstConnect } = await startConnect(client);
+    firstWs.emitMessage({
+      type: "res",
+      id: firstConnect.id,
+      ok: true,
+      payload: {
+        type: "hello-ok",
+        protocol: 4,
+        auth: { role: "operator", scopes: [] },
+        policy: { maxPayload: 128 },
+      },
+    });
+    await vi.waitFor(() => expect(client.connected).toBe(true));
+
+    firstWs.emitClose(1006, "socket lost");
+    await vi.advanceTimersByTimeAsync(800);
+    const secondWs = getLatestWebSocket();
+    expect(secondWs).not.toBe(firstWs);
+    const { connectFrame: secondConnect } = await continueConnect(secondWs, "nonce-policyless");
+    secondWs.emitMessage({
+      type: "res",
+      id: secondConnect.id,
+      ok: true,
+      payload: {
+        type: "hello-ok",
+        protocol: 4,
+        auth: { role: "operator", scopes: [] },
+      },
+    });
+    await vi.waitFor(() => expect(client.connected).toBe(true));
+    secondWs.sent.length = 0;
+
+    const request = client.request("chat.send", { text: "x".repeat(256) });
+    const frame = JSON.parse(secondWs.sent.at(-1) ?? "{}") as { id?: string; method?: string };
+    expect(frame.method).toBe("chat.send");
+    secondWs.emitMessage({
+      type: "res",
+      id: frame.id,
+      ok: true,
+      payload: { ok: true },
+    });
+    await expect(request).resolves.toEqual({ ok: true });
+  });
+
+  it("rejects oversized pre-auth connect frames before sending", async () => {
+    const client = new GatewayBrowserClient({
+      url: "ws://127.0.0.1:18789",
+      token: "shared-auth-token",
+    });
+    const { ws, connectFrame } = await startConnect(client);
+    ws.emitMessage({
+      type: "res",
+      id: connectFrame.id,
+      ok: true,
+      payload: {
+        type: "hello-ok",
+        protocol: 4,
+        auth: { role: "operator", scopes: [] },
+      },
+    });
+    await vi.waitFor(() => expect(client.connected).toBe(true));
+    ws.sent.length = 0;
+
+    await expect(client.request("connect", { pathEnv: "x".repeat(70 * 1024) })).rejects.toThrow(
+      "gateway request connect exceeds pre-auth max payload",
+    );
+    expect(ws.sent).toHaveLength(0);
+
+    const request = client.request("sessions.list", { includeGlobal: true });
+    const frame = JSON.parse(ws.sent.at(-1) ?? "{}") as { id?: string; method?: string };
+    expect(frame.method).toBe("sessions.list");
+    ws.emitMessage({
+      type: "res",
+      id: frame.id,
+      ok: true,
+      payload: { sessions: [] },
+    });
+    await expect(request).resolves.toEqual({ sessions: [] });
+  });
+
   it("tracks inbound activity and delegates forced reconnect to the shared socket", async () => {
     const client = new GatewayBrowserClient({
       url: "ws://127.0.0.1:18789",

--- a/ui/src/api/gateway.ts
+++ b/ui/src/api/gateway.ts
@@ -203,6 +203,10 @@ const BROWSER_WEBSOCKET_CONSTRUCTOR_ERROR_CODE = "BROWSER_WEBSOCKET_CONSTRUCTOR_
 const BROWSER_WEBSOCKET_SECURITY_ERROR_CODE = "BROWSER_WEBSOCKET_SECURITY_ERROR";
 const DEFAULT_GATEWAY_TICK_INTERVAL_MS = 30_000;
 const MIN_GATEWAY_TICK_WATCH_INTERVAL_MS = 1_000;
+const DEFAULT_GATEWAY_MAX_PAYLOAD_BYTES = 25 * 1024 * 1024;
+// The Gateway receiver accepts only 64 KiB before authentication; mirror the
+// server-side MAX_PREAUTH_PAYLOAD_BYTES contract for pre-auth connect frames.
+const DEFAULT_GATEWAY_PREAUTH_MAX_PAYLOAD_BYTES = 64 * 1024;
 function toGatewayErrorInfo(error: GatewayRequestError): GatewayErrorInfo {
   const { gatewayCode: code, message, details, retryable, retryAfterMs } = error;
   return { code, message, details, retryable, retryAfterMs };
@@ -317,11 +321,23 @@ export class GatewayBrowserClient {
   private recoveryScopeValue = "";
   private recoveryScopeResolved = false;
   private recoveryScopeGeneration = 0;
+  private maxPayloadBytes = DEFAULT_GATEWAY_MAX_PAYLOAD_BYTES;
 
   constructor(private opts: GatewayBrowserClientOptions) {
     this.client = new GatewayProtocolClient<ConnectPlan>({
       createSocket: (handlers) => createBrowserGatewaySocket(this.opts.url, handlers),
       createRequestId: generateUUID,
+      validateRequestFrame: (frame, method) => {
+        const frameBytes = new TextEncoder().encode(frame).byteLength;
+        const isConnect = method === "connect";
+        const limit = isConnect ? DEFAULT_GATEWAY_PREAUTH_MAX_PAYLOAD_BYTES : this.maxPayloadBytes;
+        if (frameBytes > limit) {
+          throw new RangeError(
+            `gateway request ${method} exceeds ${isConnect ? "pre-auth" : "negotiated"} max payload ` +
+              `(${frameBytes} > ${limit} bytes)`,
+          );
+        }
+      },
       createRequestError: (error) =>
         new GatewayRequestError({
           code: error.code ?? "UNAVAILABLE",
@@ -516,7 +532,18 @@ export class GatewayBrowserClient {
   }
 
   private handleConnectHello(hello: GatewayHelloOk, plan: ConnectPlan) {
+    this.maxPayloadBytes = DEFAULT_GATEWAY_MAX_PAYLOAD_BYTES;
     this.startTickWatch(hello);
+    // The Gateway installs this advertised limit on its WebSocket receiver after auth,
+    // so it bounds serialized client-to-Gateway request frames.
+    const advertisedMaxPayload = hello.policy?.maxPayload;
+    if (
+      typeof advertisedMaxPayload === "number" &&
+      Number.isFinite(advertisedMaxPayload) &&
+      advertisedMaxPayload > 0
+    ) {
+      this.maxPayloadBytes = advertisedMaxPayload;
+    }
     this.pendingDeviceTokenRetry = false;
     this.deviceTokenRetryBudgetUsed = false;
     this.opts.bootstrapToken = undefined;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Canvas A2UI users could make the CLI or agent tool buffer an arbitrarily large JSONL file before validation.

## Why This Change Was Made

Canvas uses one bounded reader for both `--jsonl` and `jsonlPath`. The reader reuses the shared regular-file primitive with the existing 16 MiB Canvas ceiling.

`GatewayClient` deliberately applies the authenticated Gateway's required `hello-ok.policy.maxPayload` contract to every serialized request frame before transport. Each new connection resets to the 25 MiB compatibility default before applying that connection's finite policy, so reconnects to legacy policyless Gateways do not inherit stale lower limits.

## User Impact

Large valid A2UI payloads above the former 8 MiB limit can complete a real node invocation, while payloads that expand beyond the Gateway wire budget fail locally without disconnecting the Gateway or reaching the node.

## Evidence

- Real Gateway/node success: a 9,437,302-byte valid JSONL file completed `nodes canvas a2ui push`; the connected node received all 9,437,302 bytes and returned success.
- Encoded-frame negative control: a 14,680,182-byte valid file expanded to a 29,360,548-byte request and was rejected against the negotiated 26,214,400-byte limit before node delivery.
- Real-browser proof (Control UI): `pnpm exec tsx proof-browser-payload.mts` loaded the real `GatewayBrowserClient` module in Chromium against a real local Gateway; a normal request succeeded, an encoded 29,360,261-byte `chat.send` frame was rejected locally with `exceeds negotiated max payload (29360261 > 26214400 bytes)` before `socket.send`, the socket stayed open, and a follow-up request still succeeded.
- Pre-auth boundary: `connect` frames are capped at the Gateway's 64 KiB pre-auth receiver limit, so an oversized connect frame fails locally instead of a remote 1009 disconnect (no-send coverage in `client.watchdog.payload.test.ts` and `gateway.node.test.ts`).
- Legacy hello compatibility: current head `44a1e594041ef6412c4615a5392ac25a694c534a` keeps the default 25 MiB cap when `hello-ok.policy` is absent or invalid, accepts a later finite positive advertised cap, and resets back to the default when reconnecting from a low advertised policy to a policyless hello.
- `node scripts/run-vitest.mjs packages/gateway-client/src/client.watchdog.payload.test.ts ui/src/api/gateway.node.test.ts`: 66 tests passed across the Node and Control UI Gateway payload regressions.
- `node --max-old-space-size=8192 --import tsx scripts/generate-plugin-sdk-api-baseline.ts --check`: passed for the refreshed `openclaw/plugin-sdk/gateway-runtime` API baseline.
- Rebase status: rebased locally onto `29fd6aaf6bb3978fa34fcb2e766c176501a242e6` with no conflict stop; current head is `44a1e594041ef6412c4615a5392ac25a694c534a`.

```text
$ pnpm exec tsx proof-live-transport.mts
gateway=ws://127.0.0.1:<port>

$ pnpm openclaw nodes canvas a2ui push --node <proof-node> --jsonl <valid-large.jsonl>
validBytes=9437302
nodeReceivedBytes=9437302
invokeCountAfterValid=1
validExit=0
canvas a2ui push ok (v0.8, 1 message)

$ pnpm openclaw nodes canvas a2ui push --node <proof-node> --jsonl <escape-heavy.jsonl>
escapeHeavyRawBytes=14680182
invokeCountAfterRejected=1
rejectedExit=1
nodes canvas a2ui push failed: gateway request node.invoke exceeds negotiated max payload (29360548 > 26214400 bytes)
```

```text
$ pnpm exec tsx proof-browser-payload.mts
gateway=ws://127.0.0.1:<port>
token=<redacted>
normalRequest: ok (pendingCount=0)
oversizedRequest: gateway request chat.send exceeds negotiated max payload (29360261 > 26214400 bytes); socketStillOpen=true
afterRejection: ok (pendingCount=0)
pageErrors: none
```

<details>
<summary>proof-live-transport.mts</summary>

```ts
import { mkdir, writeFile } from "node:fs/promises";
import path from "node:path";
import { connectGatewayClient } from "./src/gateway/test-helpers.e2e.ts";
import { loadOrCreateDeviceIdentity } from "./src/infra/device-identity.ts";
import {
  GATEWAY_CLIENT_MODES,
  GATEWAY_CLIENT_NAMES,
} from "./src/utils/message-channel.ts";
import { waitForNodeStatus } from "./test/helpers/gateway-e2e-harness.ts";
import { createOpenClawTestInstance } from "./test/helpers/openclaw-test-instance.ts";

async function main() {
  const inst = await createOpenClawTestInstance({
    name: "canvas-a2ui-large-payload-proof",
    config: {
      gateway: { nodes: { commands: { allow: ["canvas.a2ui.pushJSONL"] } } },
      plugins: { entries: { canvas: { enabled: true } } },
    },
  });
  const previousStateDir = process.env.OPENCLAW_STATE_DIR;
  const previousConfigPath = process.env.OPENCLAW_CONFIG_PATH;
  process.env.OPENCLAW_STATE_DIR = inst.stateDir;
  process.env.OPENCLAW_CONFIG_PATH = inst.configPath;
  let nodeClient: Awaited<ReturnType<typeof connectGatewayClient>> | undefined;
  let operatorClient: Awaited<ReturnType<typeof connectGatewayClient>> | undefined;
  let receivedBytes = 0;
  let invokeCount = 0;

  try {
    await inst.startGateway();
    const identity = loadOrCreateDeviceIdentity({
      path: path.join(inst.homeDir, "canvas-proof-node.sqlite"),
    });
    nodeClient = await connectGatewayClient({
      url: inst.url,
      token: inst.gatewayToken,
      clientName: GATEWAY_CLIENT_NAMES.NODE_HOST,
      clientDisplayName: "canvas-proof-node",
      clientVersion: "1.0.0",
      platform: "ios",
      mode: GATEWAY_CLIENT_MODES.NODE,
      role: "node",
      scopes: [],
      caps: ["canvas"],
      commands: ["canvas.a2ui.pushJSONL"],
      deviceIdentity: identity,
      onEvent: (event) => {
        if (event.event !== "node.invoke.request") return;
        const payload = event.payload as {
          id?: string;
          nodeId?: string;
          paramsJSON?: string | null;
        };
        const params = JSON.parse(payload.paramsJSON ?? "{}") as { jsonl?: string };
        receivedBytes = Buffer.byteLength(params.jsonl ?? "");
        invokeCount += 1;
        void nodeClient?.request("node.invoke.result", {
          id: payload.id,
          nodeId: payload.nodeId,
          ok: true,
          payloadJSON: JSON.stringify({ acceptedBytes: receivedBytes }),
        });
      },
    });
    operatorClient = await connectGatewayClient({
      url: inst.url,
      token: inst.gatewayToken,
      clientName: GATEWAY_CLIENT_NAMES.CLI,
      clientDisplayName: "canvas-proof-operator",
      clientVersion: "1.0.0",
      platform: "test",
      mode: GATEWAY_CLIENT_MODES.CLI,
      role: "operator",
      scopes: ["operator.admin"],
    });
    const pairings = await operatorClient.request<{
      pending?: Array<{ nodeId?: string; requestId?: string }>;
    }>("node.pair.list", {});
    const pending = pairings.pending?.find((entry) => entry.nodeId === identity.deviceId);
    if (!pending?.requestId) throw new Error("expected pending Canvas node command approval");
    await operatorClient.request("node.pair.approve", { requestId: pending.requestId });
    await waitForNodeStatus(inst, identity.deviceId);

    const fixtureRoot = path.join(inst.homeDir, "fixtures");
    await mkdir(fixtureRoot, { recursive: true });
    const makePayload = (literalString: string) =>
      JSON.stringify({
        surfaceUpdate: {
          surfaceId: "main",
          components: [
            {
              id: "text",
              component: { Text: { text: { literalString } } },
            },
          ],
        },
      });

    const valid = makePayload("x".repeat(9 * 1024 * 1024));
    const validPath = path.join(fixtureRoot, "valid-large.jsonl");
    await writeFile(validPath, valid);
    const validResult = await inst.cli([
      "nodes", "canvas", "a2ui", "push",
      "--node", identity.deviceId, "--jsonl", validPath,
    ]);
    console.log(`gateway=${inst.url}`);
    console.log(`validBytes=${Buffer.byteLength(valid)}`);
    console.log(`nodeReceivedBytes=${receivedBytes}`);
    console.log(`invokeCountAfterValid=${invokeCount}`);
    console.log(`validExit=${validResult.code}`);
    console.log(validResult.stdout.trim().split("\n").at(-1) ?? "");

    const escapeHeavy = makePayload("\\".repeat(7 * 1024 * 1024));
    const escapeHeavyPath = path.join(fixtureRoot, "escape-heavy.jsonl");
    await writeFile(escapeHeavyPath, escapeHeavy);
    const rejectedResult = await inst.cli([
      "nodes", "canvas", "a2ui", "push",
      "--node", identity.deviceId, "--jsonl", escapeHeavyPath,
    ]);
    console.log(`escapeHeavyRawBytes=${Buffer.byteLength(escapeHeavy)}`);
    console.log(`invokeCountAfterRejected=${invokeCount}`);
    console.log(`rejectedExit=${rejectedResult.code}`);
    console.log(
      rejectedResult.stderr
        .split("\n")
        .find((line) => /exceeds negotiated|max payload|nodes canvas/i.test(line)) ?? "",
    );
  } finally {
    await operatorClient?.stopAndWait().catch(() => operatorClient?.stop());
    await nodeClient?.stopAndWait().catch(() => nodeClient?.stop());
    await inst.cleanup();
    previousStateDir === undefined
      ? delete process.env.OPENCLAW_STATE_DIR
      : (process.env.OPENCLAW_STATE_DIR = previousStateDir);
    previousConfigPath === undefined
      ? delete process.env.OPENCLAW_CONFIG_PATH
      : (process.env.OPENCLAW_CONFIG_PATH = previousConfigPath);
  }
}

void main().catch((error: unknown) => {
  console.error(error);
  process.exitCode = 1;
});
```

</details>

AI-assisted: built with Codex
