### PR TITLE
fix(openrouter): reject invalid UTF-8 usage responses

### DIFF
--- a/extensions/openrouter/usage.test.ts
+++ b/extensions/openrouter/usage.test.ts
@@ -6,6 +6,27 @@ function requestUrl(input: string | URL | Request): string {
 }
 
 describe("OpenRouter usage", () => {
+  it("rejects invalid UTF-8 in an endpoint response", async () => {
+    const prefix = new TextEncoder().encode('{"data":{"label":"Prod');
+    const suffix = new TextEncoder().encode('ction","usage":2.5}}');
+    const invalidKeyPayload = new Uint8Array([...prefix, 0xff, ...suffix]);
+    const snapshot = await fetchOpenRouterUsage({
+      token: "test-token",
+      timeoutMs: 5000,
+      fetchFn: vi.fn(async (input: string | URL | Request) =>
+        requestUrl(input).endsWith("/credits")
+          ? Response.json({ data: { total_credits: 10, total_usage: 2 } })
+          : new Response(invalidKeyPayload),
+      ) as unknown as typeof fetch,
+    });
+
+    expect(snapshot.plan).toBeUndefined();
+    expect(snapshot.billing).toEqual([
+      { type: "balance", label: "Account balance", amount: 8, unit: "USD" },
+      { type: "spend", label: "Account usage", amount: 2, unit: "USD" },
+    ]);
+  });
+
   it("combines account credits with key quota and period spend", async () => {
     const fetchFn = vi.fn(async (input: string | URL | Request) => {
       const url = requestUrl(input);

--- a/extensions/openrouter/usage.ts
+++ b/extensions/openrouter/usage.ts
@@ -81,7 +81,7 @@ async function readJson(response: Response, timeoutMs: number): Promise<unknown>
     onIdleTimeout: ({ chunkTimeoutMs }) =>
       new Error(`OpenRouter usage response stalled for ${chunkTimeoutMs}ms`),
   });
-  return JSON.parse(new TextDecoder().decode(buffer));
+  return JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(buffer));
 }
 
 async function fetchEndpoint(params: {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users checking OpenRouter usage could see a corrupted API-key label when an otherwise valid JSON response contained invalid UTF-8 bytes. The default decoder silently replaced those bytes with `U+FFFD`, allowing the damaged endpoint payload to be accepted.

## Why This Change Was Made

Each bounded OpenRouter usage response is now decoded as fatal UTF-8 before JSON parsing, using the existing per-endpoint malformed-response handling for decoding failures. The change is limited to invalidly encoded responses; valid UTF-8 payloads, partial endpoint availability, limits, and field mapping are unchanged.

AI-assisted: yes.

## User Impact

OpenRouter usage checks no longer display labels derived from corrupted response bytes, while valid data from the other usage endpoint remains available.

## Evidence

### Real behavior proof

Environment: Linux 6.8.0-136-generic x86_64, Node v24.18.0, base `86bd524a75d68beb491a0ca0b862999cbefaf98e`.

I ran a temporary TypeScript harness with:

```text
node --import tsx .proof-invalid-utf8.ts
```

The harness started a real `node:http` server on `127.0.0.1`, routed both production `fetchOpenRouterUsage` endpoint requests through the existing `fetchFn` transport seam, returned valid credits JSON, and sent `0xff` inside the key endpoint's `label` string.

Before / negative control, with the decoder restored to the `upstream/main` implementation:

```json
{"invalidHasPlan":true,"invalidPlan":"Prod�ction","validPlan":"Production"}
```

After this change, using the same server and bytes:

```json
{"invalidHasPlan":false,"validPlan":"Production"}
```

The malformed key endpoint is discarded while valid account billing remains available; the valid control remains `Production`. The live OpenRouter service was not asked to emit malformed bytes, so the loopback server provides deterministic proof of the bounded network-response and production parsing path.

### Runtime premise

Node documents that `TextDecoder` defaults `fatal` to `false` and throws `TypeError` on decoding errors when `fatal` is enabled: https://nodejs.org/api/util.html#new-textdecoderencoding-options

```text
$ node -e 'const b=Uint8Array.of(0xff); console.log("soft="+new TextDecoder().decode(b)); try { new TextDecoder("utf-8", { fatal: true }).decode(b) } catch (error) { console.log("fatal="+error.name) }'
soft=�
fatal=TypeError
```

### Focused validation

```text
$ node scripts/run-vitest.mjs extensions/openrouter/usage.test.ts
Test Files  1 passed (1)
Tests       10 passed (10)

$ node_modules/.bin/oxlint extensions/openrouter/usage.ts extensions/openrouter/usage.test.ts
# exit 0

$ git diff --check upstream/main...HEAD
# exit 0
```

Autoreview command:

```text
.agents/skills/autoreview/scripts/autoreview --mode uncommitted --prompt 'Scope baseline: OpenRouter usage decoder only; changed files extensions/openrouter/usage.ts and usage.test.ts; no API/config changes.'
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.98)
```
