### PR TITLE
fix(clawrouter): reject invalid UTF-8 usage responses

### DIFF
--- a/extensions/clawrouter/usage.test.ts
+++ b/extensions/clawrouter/usage.test.ts
@@ -205,6 +205,22 @@ describe("ClawRouter usage", () => {
     expect(snapshot.billing).toEqual([{ type: "spend", amount: 0, unit: "USD" }]);
   });
 
+  it("rejects usage JSON containing invalid UTF-8", async () => {
+    const prefix = new TextEncoder().encode(
+      '{"budget":{"configured":true,"windowKey":"default/test-policy/2026-',
+    );
+    const suffix = new TextEncoder().encode('","limitMicros":1000000,"spentMicros":500000}}');
+    const body = new Uint8Array([...prefix, 0xff, ...suffix]);
+
+    await expect(
+      fetchClawRouterUsage({
+        token: "test-token",
+        timeoutMs: 5000,
+        fetchGuard: mockFetchGuard(new Response(body)),
+      }),
+    ).rejects.toThrow(TypeError);
+  });
+
   it("cancels non-OK usage response body before throwing", async () => {
     let cancelled = false;
     const response = new Response(

--- a/extensions/clawrouter/usage.ts
+++ b/extensions/clawrouter/usage.ts
@@ -82,7 +82,9 @@ async function readClawRouterUsagePayload(
     onIdleTimeout: ({ chunkTimeoutMs }) =>
       new Error(`ClawRouter usage response stalled: no data received for ${chunkTimeoutMs}ms`),
   });
-  return JSON.parse(new TextDecoder().decode(buffer)) as ClawRouterUsagePayload;
+  return JSON.parse(
+    new TextDecoder("utf-8", { fatal: true }).decode(buffer),
+  ) as ClawRouterUsagePayload;
 }
 
 export async function fetchClawRouterUsage(params: {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where ClawRouter usage checks could accept a monthly budget payload whose window identifier contained corrupted text from invalid UTF-8 bytes. The default decoder replaced the bytes with `U+FFFD`, so the damaged JSON was treated as valid usage data.

## Why This Change Was Made

The bounded ClawRouter usage response is now decoded as fatal UTF-8 before JSON parsing. The change is limited to invalidly encoded responses and keeps the existing SSRF-guarded transport, response limits, timeouts, and valid payload mapping unchanged.

AI-assisted: yes.

## User Impact

ClawRouter usage checks now reject corrupted response bytes instead of accepting a damaged budget window identifier.

## Evidence

### Real behavior proof

Environment: Linux 6.8.0-136-generic x86_64, Node v24.18.0, base `86bd524a75d68beb491a0ca0b862999cbefaf98e`.

I ran a temporary TypeScript harness with:

```text
node --import tsx .proof-invalid-utf8.ts
```

The harness started a real `node:http` server on `127.0.0.1`, called `fetchClawRouterUsage` through its production SSRF-guarded transport, and sent `0xff` inside `budget.windowKey`. `NO_PROXY=127.0.0.1` kept the loopback request direct.

Before / negative control, with the decoder restored to the `upstream/main` implementation:

```json
{"invalidOutcome":{"provider":"clawrouter","displayName":"ClawRouter","windows":[{"label":"Monthly budget","usedPercent":50}],"billing":[{"type":"budget","used":0.5,"limit":1,"unit":"USD","period":"month"}],"plan":"Managed monthly budget"},"validResetAt":1785542400000}
```

After this change, using the same server and bytes:

```json
{"invalidOutcome":{"error":"TypeError"},"validResetAt":1785542400000}
```

The valid control still resolves the July 2026 reset timestamp (`1785542400000`). The live ClawRouter service was not asked to emit malformed bytes; the loopback proof exercises the real guarded network path and production parser deterministically.

### Runtime premise

Node documents that `TextDecoder` defaults `fatal` to `false` and throws `TypeError` on decoding errors when `fatal` is enabled: https://nodejs.org/api/util.html#new-textdecoderencoding-options

```text
$ node -e 'const b=Uint8Array.of(0xff); console.log("soft="+new TextDecoder().decode(b)); try { new TextDecoder("utf-8", { fatal: true }).decode(b) } catch (error) { console.log("fatal="+error.name) }'
soft=�
fatal=TypeError
```

### Focused validation

```text
$ node scripts/run-vitest.mjs extensions/clawrouter/usage.test.ts
Test Files  1 passed (1)
Tests       9 passed (9)

$ node_modules/.bin/oxlint extensions/clawrouter/usage.ts extensions/clawrouter/usage.test.ts
# exit 0

$ git diff --check upstream/main...HEAD
# exit 0
```

Autoreview command:

```text
.agents/skills/autoreview/scripts/autoreview --mode uncommitted --prompt 'Scope baseline: ClawRouter usage decoder only; changed files extensions/clawrouter/usage.ts and usage.test.ts; no API/config changes.'
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.99)
```
