### PR TITLE
refactor(channels): share durable ingress monitor

### DIFF
--- a/extensions/discord/src/monitor/ingress.ts
+++ b/extensions/discord/src/monitor/ingress.ts
@@ -1,10 +1,10 @@
 // Discord plugin module owns raw gateway-message durable ingress and replay draining.
 import { GatewayDispatchEvents, type APIMessage } from "discord-api-types/v10";
 import {
-  createChannelIngressDrain,
-  DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
-  DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
+  createChannelIngressMonitor,
   type ChannelIngressQueue,
+  type ChannelIngressMonitorDeliveryResult,
+  type ChannelIngressMonitorLifecycle,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { danger, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import type { Client } from "../internal/discord.js";
@@ -25,18 +25,11 @@ type DiscordIngressPayload = {
   rawMessage: APIMessage;
 };
 
-export type DiscordIngressLifecycle = {
-  abortSignal: AbortSignal;
-  onAdopted: () => void | Promise<void>;
-  onDeferred: () => void;
-  onAdoptionFinalizing: () => void;
-  onAbandoned: () => void | Promise<void>;
-};
+type DiscordIngressBody = Omit<DiscordIngressPayload, "version">;
 
-export type DiscordIngressDispatchResult =
-  | { kind: "completed" }
-  | { kind: "deferred" }
-  | { kind: "failed-retryable"; error: unknown };
+export type DiscordIngressLifecycle = Omit<ChannelIngressMonitorLifecycle, "admission">;
+
+export type DiscordIngressDispatchResult = ChannelIngressMonitorDeliveryResult;
 
 type DiscordIngressDispatch = (
   event: DiscordMessageEvent,
@@ -50,8 +43,8 @@ type DiscordIngressMonitor = {
 };
 
 class DiscordIngressPayloadError extends Error {
-  constructor(message: string) {
-    super(message);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = "DiscordIngressPayloadError";
   }
 }
@@ -76,19 +69,28 @@ function inspectDiscordMessage(rawMessage: unknown): { eventId: string; laneKey:
   return { eventId, laneKey: `channel:${channelId}` };
 }
 
-function parseClaimedMessage(payload: unknown, claimedId: string): APIMessage {
+function decodeDiscordIngressPayload(
+  payload: DiscordIngressPayload,
+  claimedId: string,
+): { version: unknown; body: DiscordIngressBody } {
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
     throw new DiscordIngressPayloadError("Discord ingress payload must be an object");
   }
   const candidate = payload as Partial<DiscordIngressPayload>;
-  if (candidate.version !== DISCORD_INGRESS_PAYLOAD_VERSION) {
-    throw new DiscordIngressPayloadError("Discord ingress payload version is unsupported");
+  try {
+    inspectDiscordMessage(candidate.rawMessage);
+  } catch (error) {
+    throw new DiscordIngressPayloadError(`Discord ingress payload ${claimedId} is invalid`, {
+      cause: error,
+    });
   }
-  const facts = inspectDiscordMessage(candidate.rawMessage);
-  if (facts.eventId !== claimedId) {
-    throw new DiscordIngressPayloadError("Discord message id changed after durable admission");
-  }
-  return candidate.rawMessage as APIMessage;
+  return {
+    version: candidate.version,
+    body: {
+      receivedAt: candidate.receivedAt as number,
+      rawMessage: candidate.rawMessage as APIMessage,
+    },
+  };
 }
 
 function errorText(error: unknown): string {
@@ -121,27 +123,28 @@ export function createDiscordIngressMonitor(params: {
     getDiscordRuntime().state.openChannelIngressQueue<DiscordIngressPayload>({
       accountId: params.accountId,
     });
-  const shutdown = new AbortController();
-  const drain = createChannelIngressDrain<DiscordIngressPayload>({
+  const monitor = createChannelIngressMonitor<
+    APIMessage,
+    DiscordIngressBody,
+    DiscordIngressPayload
+  >({
     queue,
-    abortSignal: shutdown.signal,
-    retryPolicy: {
-      maxAttempts: DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
-      deadLetterMinAgeMs: DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
+    inspect: inspectDiscordMessage,
+    payload: {
+      version: DISCORD_INGRESS_PAYLOAD_VERSION,
+      serialize: (rawMessage, { receivedAt }) => ({ receivedAt, rawMessage }),
+      deserialize: (body) => body.rawMessage,
+      encode: ({ body }) => ({ version: DISCORD_INGRESS_PAYLOAD_VERSION, ...body }),
+      decode: (payload, { claim }) => decodeDiscordIngressPayload(payload, claim.id),
+      createClaimError: (kind) =>
+        new DiscordIngressPayloadError(
+          kind === "invalid-version"
+            ? "Discord ingress payload version is unsupported"
+            : "Discord message identity changed after durable admission",
+        ),
     },
-    resolveNonRetryableFailure: (error) => {
-      if (error instanceof DiscordIngressPayloadError) {
-        return { reason: "invalid-event", message: error.message };
-      }
-      if (isDiscordAuthenticationFailure(error)) {
-        return { reason: "authentication-failed", message: errorText(error) };
-      }
-      return null;
-    },
-    onLog: (message) => params.runtime.error?.(danger(`discord ingress: ${message}`)),
-    dispatchClaimedEvent: async (claimed, lifecycle) => {
-      const rawMessage = parseClaimedMessage(claimed.payload, claimed.id);
-      // Gateway mapping is intentionally delayed until after the durable claim.
+    // Gateway mapping is intentionally delayed until after the durable claim.
+    deliver: async (rawMessage, lifecycle) => {
       const event = mapGatewayDispatchData(
         params.client,
         GatewayDispatchEvents.MessageCreate,
@@ -149,83 +152,37 @@ export function createDiscordIngressMonitor(params: {
       ) as DiscordMessageEvent;
       return await params.dispatch(event, lifecycle);
     },
+    pollIntervalMs: DISCORD_INGRESS_DRAIN_INTERVAL_MS,
+    retention: {
+      // Discord previously pruned before every enqueue rather than on a timed cadence.
+      pruneIntervalMs: 0,
+      completedTtlMs: DISCORD_INGRESS_COMPLETED_TTL_MS,
+      completedMaxEntries: DISCORD_INGRESS_COMPLETED_MAX_ENTRIES,
+      failedTtlMs: DISCORD_INGRESS_FAILED_TTL_MS,
+      failedMaxEntries: DISCORD_INGRESS_FAILED_MAX_ENTRIES,
+    },
+    appendRetryDelaysMs: [0],
+    drain: {
+      resolveNonRetryableFailure: (error) => {
+        if (error instanceof DiscordIngressPayloadError) {
+          return { reason: "invalid-event", message: error.message };
+        }
+        if (isDiscordAuthenticationFailure(error)) {
+          return { reason: "authentication-failed", message: errorText(error) };
+        }
+        return null;
+      },
+      onLog: (message) => params.runtime.error?.(danger(`discord ingress: ${message}`)),
+    },
+    onError: (error) =>
+      params.runtime.error?.(danger(`discord ingress drain failed: ${errorText(error)}`)),
   });
-  let running = false;
-  let drainRequested = false;
-  let drainTask: Promise<void> | undefined;
-  let drainTimer: ReturnType<typeof setInterval> | undefined;
-
-  const requestDrain = (): void => {
-    if (!running || shutdown.signal.aborted) {
-      return;
-    }
-    drainRequested = true;
-    if (drainTask) {
-      return;
-    }
-    drainTask = (async () => {
-      while (drainRequested && !shutdown.signal.aborted) {
-        if (!running) {
-          break;
-        }
-        drainRequested = false;
-        await drain.drainOnce();
-      }
-    })()
-      .catch((error: unknown) => {
-        params.runtime.error?.(danger(`discord ingress drain failed: ${errorText(error)}`));
-      })
-      .finally(() => {
-        drainTask = undefined;
-        if (running && drainRequested && !shutdown.signal.aborted) {
-          requestDrain();
-        }
-      });
-  };
 
   return {
     accept: async (rawMessage) => {
-      const facts = inspectDiscordMessage(rawMessage);
-      await queue.prune({
-        completedTtlMs: DISCORD_INGRESS_COMPLETED_TTL_MS,
-        completedMaxEntries: DISCORD_INGRESS_COMPLETED_MAX_ENTRIES,
-        failedTtlMs: DISCORD_INGRESS_FAILED_TTL_MS,
-        failedMaxEntries: DISCORD_INGRESS_FAILED_MAX_ENTRIES,
-      });
-      const receivedAt = Date.now();
-      await queue.enqueue(
-        facts.eventId,
-        {
-          version: DISCORD_INGRESS_PAYLOAD_VERSION,
-          receivedAt,
-          rawMessage,
-        },
-        { receivedAt, laneKey: facts.laneKey },
-      );
-      requestDrain();
+      await monitor.admit(rawMessage);
     },
-    start: () => {
-      if (running) {
-        return;
-      }
-      running = true;
-      requestDrain();
-      drainTimer = setInterval(requestDrain, DISCORD_INGRESS_DRAIN_INTERVAL_MS);
-      drainTimer.unref?.();
-    },
-    stop: async () => {
-      if (!running && shutdown.signal.aborted) {
-        return;
-      }
-      running = false;
-      if (drainTimer) {
-        clearInterval(drainTimer);
-        drainTimer = undefined;
-      }
-      shutdown.abort();
-      await drainTask;
-      await drain.waitForIdle();
-      drain.dispose();
-    },
+    start: monitor.start,
+    stop: monitor.stop,
   };
 }

--- a/extensions/imessage/src/monitor/ingress.test.ts
+++ b/extensions/imessage/src/monitor/ingress.test.ts
@@ -68,6 +68,14 @@ function lifecycle() {
   } satisfies IMessageIngressLifecycle;
 }
 
+function deferred() {
+  let resolve = () => {};
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
 afterEach(() => {
   closeOpenClawStateDatabaseForTest();
   vi.restoreAllMocks();
@@ -99,6 +107,71 @@ describe("iMessage durable ingress", () => {
         expect(onDurableEnqueueFailure).toHaveBeenCalledWith(101, appendError);
         expect(dispatch).not.toHaveBeenCalled();
       } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("notifies the source when inspection fails before durable append", async () => {
+    await withQueue(async (queue) => {
+      const onDurableEnqueueFailure = vi.fn();
+      const ingress = createIMessageDurableIngress({
+        accountId: "default",
+        queue,
+        dispatch: vi.fn(),
+        runtime: runtime(),
+        onDurableEnqueueFailure,
+      });
+
+      try {
+        await expect(ingress.receive(rawRow({ guid: undefined }))).rejects.toThrow(
+          "missing its stable GUID",
+        );
+        expect(onDurableEnqueueFailure).toHaveBeenCalledWith(101, expect.any(Error));
+        expect(await queue.listPending({ limit: "all" })).toHaveLength(0);
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("serializes durable cursor advancement before admitting the next row", async () => {
+    await withQueue(async (queue) => {
+      const cursorGate = deferred();
+      const cursorStarted = deferred();
+      let currentTime = 1_000;
+      const onDurableEnqueue = vi.fn(async () => {
+        cursorStarted.resolve();
+        await cursorGate.promise;
+      });
+      const ingress = createIMessageDurableIngress({
+        accountId: "default",
+        queue,
+        dispatch: vi.fn(),
+        runtime: runtime(),
+        onDurableEnqueue,
+        now: () => currentTime,
+      });
+
+      try {
+        const first = ingress.receive(rawRow());
+        await cursorStarted.promise;
+        currentTime = 2_000;
+        const second = ingress.receive(rawRow({ id: 102, guid: "GUID-102" }));
+        await Promise.resolve();
+
+        expect((await queue.listPending({ limit: "all" })).map((record) => record.id)).toEqual([
+          "GUID-101",
+        ]);
+        currentTime = 9_000;
+        cursorGate.resolve();
+        await Promise.all([first, second]);
+        expect(onDurableEnqueue).toHaveBeenCalledTimes(2);
+        expect(
+          (await queue.listPending({ limit: "all" })).map((record) => record.payload.receivedAt),
+        ).toEqual([1_000, 2_000]);
+      } finally {
+        cursorGate.resolve();
         await ingress.stop();
       }
     });
@@ -267,6 +340,35 @@ describe("iMessage durable ingress", () => {
         await ingress.waitForIdle();
         expect((await queue.enqueue("GUID-bad", {} as IMessageIngressPayload)).kind).toBe("failed");
         expect(dispatch).not.toHaveBeenCalled();
+      } finally {
+        await ingress.stop();
+      }
+    });
+  });
+
+  it("dead-letters a persisted row whose inspected identity is malformed", async () => {
+    await withQueue(async (queue) => {
+      await queue.enqueue(
+        "GUID-missing",
+        {
+          version: 1,
+          receivedAt: Date.now(),
+          raw: rawRow({ guid: undefined }),
+        },
+        { laneKey: "chat:42" },
+      );
+      const ingress = createIMessageDurableIngress({
+        accountId: "default",
+        queue,
+        dispatch: vi.fn(),
+        runtime: runtime(),
+      });
+      ingress.start();
+      try {
+        await ingress.waitForIdle();
+        expect((await queue.enqueue("GUID-missing", {} as IMessageIngressPayload)).kind).toBe(
+          "failed",
+        );
       } finally {
         await ingress.stop();
       }

--- a/extensions/imessage/src/monitor/ingress.ts
+++ b/extensions/imessage/src/monitor/ingress.ts
@@ -1,10 +1,9 @@
 // iMessage plugin module owns raw-row durable admission and replay.
 import {
-  createChannelIngressDrain,
-  DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
-  DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
-  type ChannelIngressDrain,
+  createChannelIngressMonitor,
   type ChannelIngressQueue,
+  type ChannelIngressMonitorDeliveryResult,
+  type ChannelIngressMonitorLifecycle,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { collectErrorGraphCandidates, formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
@@ -30,18 +29,18 @@ type IMessageIngressPayload = {
   catchup?: boolean;
 };
 
-export type IMessageIngressLifecycle = {
-  abortSignal: AbortSignal;
-  onAdopted: () => void | Promise<void>;
-  onDeferred: () => void;
-  onAdoptionFinalizing: () => void;
-  onAbandoned: () => void | Promise<void>;
+type IMessageIngressBody = Omit<IMessageIngressPayload, "version">;
+
+type IMessageIngressRaw = {
+  raw: unknown;
+  catchup?: boolean;
+  receivedAt?: number;
+  message?: IMessagePayload;
 };
 
-type IMessageIngressDispatchResult =
-  | { kind: "completed" }
-  | { kind: "deferred" }
-  | { kind: "failed-retryable"; error: unknown };
+export type IMessageIngressLifecycle = Omit<ChannelIngressMonitorLifecycle, "admission">;
+
+type IMessageIngressDispatchResult = ChannelIngressMonitorDeliveryResult;
 
 type IMessageIngressFacts = {
   eventId: string;
@@ -104,27 +103,37 @@ function inspectIMessageIngress(raw: unknown): IMessageIngressFacts {
   };
 }
 
-function parseClaimedIMessageIngress(payload: IMessageIngressPayload, eventId: string) {
-  if (
-    payload.version !== IMESSAGE_INGRESS_PAYLOAD_VERSION ||
-    typeof payload.receivedAt !== "number" ||
-    !Number.isFinite(payload.receivedAt)
-  ) {
+function decodeIMessageIngressPayload(
+  payload: IMessageIngressPayload,
+  eventId: string,
+): { version: unknown; body: IMessageIngressBody } {
+  if (typeof payload.receivedAt !== "number" || !Number.isFinite(payload.receivedAt)) {
     throw new IMessageIngressPayloadError(`iMessage ingress payload ${eventId} is invalid.`);
   }
-  let facts: IMessageIngressFacts;
-  try {
-    facts = inspectIMessageIngress(payload.raw);
-  } catch (error) {
-    throw new IMessageIngressPayloadError(`iMessage ingress payload ${eventId} is invalid.`, {
-      cause: error,
-    });
-  }
-  const message = parseIMessageNotification(payload.raw);
-  if (!message || facts.eventId !== eventId) {
+  return {
+    version: payload.version,
+    body: {
+      receivedAt: payload.receivedAt,
+      raw: payload.raw,
+      ...(payload.catchup ? { catchup: true } : {}),
+    },
+  };
+}
+
+function deserializeIMessageIngress(
+  body: IMessageIngressBody,
+  eventId: string,
+): IMessageIngressRaw {
+  const message = parseIMessageNotification(body.raw);
+  if (!message) {
     throw new IMessageIngressPayloadError(`iMessage ingress payload ${eventId} is invalid.`);
   }
-  return message;
+  return {
+    raw: body.raw,
+    receivedAt: body.receivedAt,
+    message,
+    ...(body.catchup ? { catchup: true } : {}),
+  };
 }
 
 function isIMessageAuthenticationFailure(error: unknown): boolean {
@@ -238,14 +247,71 @@ export function createIMessageDurableIngress(options: {
     });
   const now = options.now ?? Date.now;
   const dispatchAdmissionQueue = new KeyedAsyncQueue();
-  let drain: ChannelIngressDrain | undefined;
-  const getDrain = () => {
-    drain ??= createChannelIngressDrain<IMessageIngressPayload>({
-      queue,
-      retryPolicy: {
-        maxAttempts: DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
-        deadLetterMinAgeMs: DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
-      },
+  const monitor = createChannelIngressMonitor<
+    IMessageIngressRaw,
+    IMessageIngressBody,
+    IMessageIngressPayload
+  >({
+    queue,
+    inspect: (event, context) => {
+      try {
+        return inspectIMessageIngress(event.raw);
+      } catch (error) {
+        if (context.phase === "claim") {
+          throw new IMessageIngressPayloadError(
+            `iMessage ingress payload ${context.claimedId} is invalid.`,
+            { cause: error },
+          );
+        }
+        throw error;
+      }
+    },
+    payload: {
+      version: IMESSAGE_INGRESS_PAYLOAD_VERSION,
+      serialize: (event, { receivedAt }) => ({
+        receivedAt,
+        raw: event.raw,
+        ...(event.catchup ? { catchup: true } : {}),
+      }),
+      deserialize: (body, { claim }) => deserializeIMessageIngress(body, claim.id),
+      encode: ({ body }) => ({ version: IMESSAGE_INGRESS_PAYLOAD_VERSION, ...body }),
+      decode: (payload, { claim }) => decodeIMessageIngressPayload(payload, claim.id),
+      createClaimError: (_kind, claim) =>
+        new IMessageIngressPayloadError(`iMessage ingress payload ${claim.id} is invalid.`),
+    },
+    deliver: async (event, lifecycle, record) =>
+      await dispatchAdmissionQueue.enqueue(record.laneKey ?? record.id, async () => {
+        if (!event.message || event.receivedAt === undefined) {
+          throw new IMessageIngressPayloadError(
+            `iMessage ingress payload ${record.id} is invalid.`,
+          );
+        }
+        if (lifecycle.abortSignal.aborted) {
+          throw lifecycle.abortSignal.reason;
+        }
+        return await options.dispatch(
+          event.message,
+          lifecycle,
+          event.receivedAt,
+          event.catchup ? { catchup: true } : {},
+        );
+      }),
+    pollIntervalMs: IMESSAGE_INGRESS_DRAIN_INTERVAL_MS,
+    retention: {
+      pruneIntervalMs: IMESSAGE_INGRESS_PRUNE_INTERVAL_MS,
+      completedTtlMs: IMESSAGE_INGRESS_COMPLETED_TTL_MS,
+      completedMaxEntries: IMESSAGE_INGRESS_COMPLETED_MAX_ENTRIES,
+      failedTtlMs: IMESSAGE_INGRESS_FAILED_TTL_MS,
+      failedMaxEntries: IMESSAGE_INGRESS_FAILED_MAX_ENTRIES,
+    },
+    appendRetryDelaysMs: [0],
+    onDurableAdmission: async (event) => {
+      await options.onDurableEnqueue?.(inspectIMessageIngress(event.raw));
+    },
+    onAdmissionFailure: async (event, error) => {
+      await options.onDurableEnqueueFailure?.(rawRowid(event.raw), error);
+    },
+    drain: {
       // Rows retain their per-chat lane in durable state. Claims use a unique
       // core lane so a deferred debounce entry cannot block the later rows it
       // must merge with; this short queue preserves chat order until debounce
@@ -253,133 +319,27 @@ export function createIMessageDurableIngress(options: {
       deriveLaneKey: (record) => `${record.laneKey ?? "event"}:${record.id}`,
       resolveNonRetryableFailure: resolveIMessageIngressNonRetryableFailure,
       onLog: (message) => options.runtime.log?.(`imessage ${message}`),
-      dispatchClaimedEvent: async (record, lifecycle) =>
-        await dispatchAdmissionQueue.enqueue(record.laneKey ?? record.id, async () => {
-          const message = parseClaimedIMessageIngress(record.payload, record.id);
-          if (lifecycle.abortSignal.aborted) {
-            throw lifecycle.abortSignal.reason;
-          }
-          return await options.dispatch(
-            message,
-            lifecycle,
-            record.payload.receivedAt,
-            record.payload.catchup ? { catchup: true } : {},
-          );
-        }),
-    });
-    return drain;
-  };
-  let running = false;
-  let requested = false;
-  let pumping: Promise<void> | undefined;
-  let pollTimer: ReturnType<typeof setInterval> | undefined;
-  let lastPrunedAt = Number.NEGATIVE_INFINITY;
-  let admissionTail = Promise.resolve();
-
-  const pruneIfDue = async () => {
-    const currentTime = now();
-    if (currentTime - lastPrunedAt < IMESSAGE_INGRESS_PRUNE_INTERVAL_MS) {
-      return;
-    }
-    await queue.prune({
-      completedTtlMs: IMESSAGE_INGRESS_COMPLETED_TTL_MS,
-      completedMaxEntries: IMESSAGE_INGRESS_COMPLETED_MAX_ENTRIES,
-      failedTtlMs: IMESSAGE_INGRESS_FAILED_TTL_MS,
-      failedMaxEntries: IMESSAGE_INGRESS_FAILED_MAX_ENTRIES,
-      now: currentTime,
-    });
-    lastPrunedAt = currentTime;
-  };
-
-  const runPump = async () => {
-    try {
-      for (;;) {
-        requested = false;
-        await pruneIfDue();
-        const activeDrain = getDrain();
-        const { started } = await activeDrain.drainOnce();
-        await activeDrain.waitForIdle();
-        if (!running || (!requested && started === 0)) {
-          break;
-        }
-      }
-    } catch (error) {
-      options.runtime.error?.(`imessage: ingress drain failed: ${formatErrorMessage(error)}`);
-    } finally {
-      pumping = undefined;
-      if (running && requested) {
-        requestDrain();
-      }
-    }
-  };
-
-  const requestDrain = () => {
-    requested = true;
-    if (!running || pumping) {
-      return;
-    }
-    pumping = runPump();
-  };
-
-  const receive = async (raw: unknown, receiveOpts?: { catchup?: boolean }) => {
-    const admission = admissionTail.then(async () => {
-      const rowid = rawRowid(raw);
-      try {
-        const facts = inspectIMessageIngress(raw);
-        await pruneIfDue();
-        const receivedAt = now();
-        await queue.enqueue(
-          facts.eventId,
-          {
-            version: IMESSAGE_INGRESS_PAYLOAD_VERSION,
-            receivedAt,
-            raw,
-            ...(receiveOpts?.catchup ? { catchup: true } : {}),
-          },
-          { receivedAt, laneKey: facts.laneKey },
-        );
-        await options.onDurableEnqueue?.(facts);
-        requestDrain();
-      } catch (error) {
-        await options.onDurableEnqueueFailure?.(rowid, error);
-        throw error;
-      }
-    });
-    admissionTail = admission.catch(() => undefined);
-    return await admission;
-  };
+    },
+    now,
+    onError: (error) =>
+      options.runtime.error?.(`imessage: ingress drain failed: ${formatErrorMessage(error)}`),
+  });
+  let stopTask: Promise<void> | undefined;
 
   return {
-    receive,
-    start: () => {
-      if (running) {
-        return;
-      }
-      running = true;
-      requestDrain();
-      pollTimer = setInterval(requestDrain, IMESSAGE_INGRESS_DRAIN_INTERVAL_MS);
-      pollTimer.unref?.();
+    receive: async (raw, receiveOpts) => {
+      await monitor.admit({ raw, ...(receiveOpts?.catchup ? { catchup: true } : {}) });
     },
-    stop: async () => {
-      if (pollTimer) {
-        clearInterval(pollTimer);
-        pollTimer = undefined;
-      }
-      await admissionTail;
-      // Source shutdown happens first. Drain every durably accepted row into
-      // its deferred owner before disposing claim lifecycles; later restart is
-      // then only for genuinely unadopted work.
-      requestDrain();
-      await pumping;
-      running = false;
-      await drain?.waitForIdle();
-      drain?.dispose();
-      drain = undefined;
+    start: monitor.start,
+    stop: () => {
+      stopTask ??= (async () => {
+        // iMessage debounce must own every accepted claim before disposal so a
+        // restart replays only rows that were never handed to a flush.
+        await monitor.waitForIdle();
+        await monitor.stop();
+      })();
+      return stopTask;
     },
-    waitForIdle: async () => {
-      await admissionTail;
-      await pumping;
-      await drain?.waitForIdle();
-    },
+    waitForIdle: monitor.waitForIdle,
   };
 }

--- a/extensions/signal/src/monitor.ts
+++ b/extensions/signal/src/monitor.ts
@@ -689,9 +689,6 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
       accountId: accountInfo.accountId,
       dispatch: handleEvent,
       runtime,
-      runTrackedTask: (task) => {
-        void monitorTaskRunner.runTask(task);
-      },
     });
 
     await runSignalSseLoop({

--- a/extensions/signal/src/signal-ingress.test.ts
+++ b/extensions/signal/src/signal-ingress.test.ts
@@ -14,42 +14,14 @@ type SignalIngressQueue = NonNullable<Parameters<typeof startSignalIngressMonito
 type SignalIngressPayload = Parameters<SignalIngressQueue["enqueue"]>[1];
 type SignalIngressDispatch = Parameters<typeof startSignalIngressMonitor>[0]["dispatch"];
 
-function createTrackedTaskRunner() {
-  const pending = new Set<Promise<void>>();
-  const failures: unknown[] = [];
-
-  const runTrackedTask = (task: () => Promise<void>) => {
-    const promise = task()
-      .catch((error: unknown) => {
-        failures.push(error);
-      })
-      .finally(() => {
-        pending.delete(promise);
-      });
-    pending.add(promise);
-  };
-  const waitForIdle = async () => {
-    while (pending.size > 0) {
-      await Promise.all(pending);
-    }
-    if (failures.length > 0) {
-      throw failures[0];
-    }
-  };
-
-  return { runTrackedTask, waitForIdle };
-}
-
 async function startMonitor(queue: SignalIngressQueue, dispatch: SignalIngressDispatch) {
-  const tasks = createTrackedTaskRunner();
   const monitor = await startSignalIngressMonitor({
     accountId: "default",
     queue,
     dispatch,
     runtime: { error: vi.fn(), log: vi.fn() },
-    runTrackedTask: tasks.runTrackedTask,
   });
-  return { monitor, waitForIdle: tasks.waitForIdle };
+  return { monitor, waitForIdle: monitor.waitForIdle };
 }
 
 function signalEvent(params?: {
@@ -114,7 +86,6 @@ describe("Signal durable ingress", () => {
         queue: failingQueue,
         dispatch,
         runtime: { error: vi.fn(), log: vi.fn() },
-        runTrackedTask: vi.fn(),
       });
       try {
         await expect(monitor.receive(signalEvent())).rejects.toBe(appendError);

--- a/extensions/signal/src/signal-ingress.ts
+++ b/extensions/signal/src/signal-ingress.ts
@@ -1,10 +1,9 @@
 // Signal plugin module owns raw-envelope durable ingress mapping and draining.
 import {
-  createChannelIngressDrain,
-  DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
-  DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
-  type ChannelIngressDrain,
+  createChannelIngressMonitor,
   type ChannelIngressQueue,
+  type ChannelIngressMonitorDeliveryResult,
+  type ChannelIngressMonitorLifecycle,
 } from "openclaw/plugin-sdk/channel-outbound";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import type { SignalSseEvent } from "./client-adapter.js";
@@ -37,18 +36,11 @@ type SignalIngressPayload = {
   event: SignalSseEvent;
 };
 
-export type SignalIngressLifecycle = {
-  abortSignal: AbortSignal;
-  onAdopted: () => void | Promise<void>;
-  onDeferred: () => void;
-  onAdoptionFinalizing: () => void;
-  onAbandoned: () => void | Promise<void>;
-};
+type SignalIngressBody = Omit<SignalIngressPayload, "version">;
 
-type SignalIngressDispatchResult =
-  | { kind: "completed" }
-  | { kind: "deferred" }
-  | { kind: "failed-retryable"; error: unknown };
+export type SignalIngressLifecycle = Omit<ChannelIngressMonitorLifecycle, "admission">;
+
+type SignalIngressDispatchResult = ChannelIngressMonitorDeliveryResult;
 
 type SignalIngressDispatch = (
   event: SignalSseEvent,
@@ -152,71 +144,16 @@ function inspectSignalIngressEvent(event: SignalSseEvent): SignalIngressEventFac
   };
 }
 
-type SignalIngressEnqueueResult =
-  | Awaited<ReturnType<ChannelIngressQueue<SignalIngressPayload>["enqueue"]>>
-  | { kind: "ignored" };
-
-/** Durable receive chokepoint. Metadata comes from raw fields; payload stays byte-equivalent JSON. */
-async function enqueueSignalIngressEvent(params: {
-  queue: ChannelIngressQueue<SignalIngressPayload>;
-  event: SignalSseEvent;
-  now?: number;
-}): Promise<SignalIngressEnqueueResult> {
-  const facts = inspectSignalIngressEvent(params.event);
-  if (!facts) {
-    return { kind: "ignored" };
-  }
-  const receivedAt = params.now ?? Date.now();
-  await params.queue.prune({
-    completedTtlMs: SIGNAL_INGRESS_COMPLETED_TTL_MS,
-    completedMaxEntries: SIGNAL_INGRESS_COMPLETED_MAX_ENTRIES,
-    failedTtlMs: SIGNAL_INGRESS_FAILED_TTL_MS,
-    failedMaxEntries: SIGNAL_INGRESS_FAILED_MAX_ENTRIES,
-    ...(params.now === undefined ? {} : { now: params.now }),
-  });
-  return await params.queue.enqueue(
-    facts.eventId,
-    { version: 1, receivedAt, event: params.event },
-    { receivedAt, laneKey: facts.laneKey },
-  );
-}
-
 function resolveSignalIngressNonRetryableFailure(error: unknown) {
   return error instanceof SignalIngressPermanentError
     ? { reason: error.reason, message: error.message }
     : null;
 }
 
-function createSignalIngressDrain(params: {
-  queue: ChannelIngressQueue<SignalIngressPayload>;
-  dispatch: SignalIngressDispatch;
-  abortSignal?: AbortSignal;
-  onLog?: (message: string) => void;
-}): ChannelIngressDrain {
-  return createChannelIngressDrain<SignalIngressPayload>({
-    queue: params.queue,
-    retryPolicy: {
-      maxAttempts: DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
-      deadLetterMinAgeMs: DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
-    },
-    resolveNonRetryableFailure: resolveSignalIngressNonRetryableFailure,
-    ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
-    ...(params.onLog ? { onLog: params.onLog } : {}),
-    dispatchClaimedEvent: async (record, lifecycle) => {
-      if (!inspectSignalIngressEvent(record.payload.event)) {
-        throw new SignalIngressPermanentError(
-          "unsupported-event",
-          "Signal ingress row no longer contains a dispatchable envelope",
-        );
-      }
-      return await params.dispatch(record.payload.event, lifecycle);
-    },
-  });
-}
-
 export type SignalIngressMonitor = {
   receive: (event: SignalSseEvent) => Promise<void>;
   stop: () => Promise<void>;
+  waitForIdle: () => Promise<void>;
 };
 
 /** Open the account queue, recover it, and keep newly appended rows draining. */
@@ -225,7 +162,6 @@ export async function startSignalIngressMonitor(params: {
   queue?: ChannelIngressQueue<SignalIngressPayload>;
   dispatch: SignalIngressDispatch;
   runtime: Pick<RuntimeEnv, "error" | "log">;
-  runTrackedTask: (task: () => Promise<void>) => void;
 }): Promise<SignalIngressMonitor> {
   let queue = params.queue;
   if (!queue) {
@@ -237,59 +173,49 @@ export async function startSignalIngressMonitor(params: {
       accountId: params.accountId,
     });
   }
-  const drain = createSignalIngressDrain({
+  const monitor = createChannelIngressMonitor<
+    SignalSseEvent,
+    SignalIngressBody,
+    SignalIngressPayload
+  >({
     queue,
-    dispatch: params.dispatch,
-    onLog: (message) => params.runtime.log?.(`signal ${message}`),
+    inspect: (event) => inspectSignalIngressEvent(event),
+    payload: {
+      version: 1,
+      serialize: (event, { receivedAt }) => ({ receivedAt, event }),
+      deserialize: (body) => body.event,
+      encode: ({ body }) => ({ version: 1, ...body }),
+      decode: (payload) => ({ version: payload.version, body: payload }),
+      createClaimError: (_kind, claim) =>
+        new SignalIngressPermanentError(
+          "unsupported-event",
+          `Signal ingress row ${claim.id} has an invalid payload`,
+        ),
+    },
+    deliver: (event, lifecycle) => params.dispatch(event, lifecycle),
+    pollIntervalMs: SIGNAL_INGRESS_DRAIN_INTERVAL_MS,
+    retention: {
+      // Signal previously pruned before every enqueue rather than on a timed cadence.
+      pruneIntervalMs: 0,
+      completedTtlMs: SIGNAL_INGRESS_COMPLETED_TTL_MS,
+      completedMaxEntries: SIGNAL_INGRESS_COMPLETED_MAX_ENTRIES,
+      failedTtlMs: SIGNAL_INGRESS_FAILED_TTL_MS,
+      failedMaxEntries: SIGNAL_INGRESS_FAILED_MAX_ENTRIES,
+    },
+    appendRetryDelaysMs: [0],
+    drain: {
+      resolveNonRetryableFailure: resolveSignalIngressNonRetryableFailure,
+      onLog: (message) => params.runtime.log?.(`signal ${message}`),
+    },
+    onError: (error) => params.runtime.error?.(`signal ingress drain failed: ${String(error)}`),
   });
-  let drainPass: Promise<void> | undefined;
-  let drainRequested = false;
-
-  const requestDrain = (): Promise<void> => {
-    drainRequested = true;
-    if (!drainPass) {
-      drainPass = (async () => {
-        while (drainRequested) {
-          drainRequested = false;
-          const result = await drain.drainOnce();
-          if (result.started > 0) {
-            params.runTrackedTask(async () => {
-              await drain.waitForIdle();
-              await requestDrain();
-            });
-          }
-        }
-      })().finally(() => {
-        drainPass = undefined;
-        if (drainRequested) {
-          void requestDrain().catch((error: unknown) => {
-            params.runtime.error?.(`signal ingress drain failed: ${String(error)}`);
-          });
-        }
-      });
-    }
-    return drainPass;
-  };
-
-  await requestDrain();
-  const timer = setInterval(() => {
-    void requestDrain().catch((error: unknown) => {
-      params.runtime.error?.(`signal ingress drain failed: ${String(error)}`);
-    });
-  }, SIGNAL_INGRESS_DRAIN_INTERVAL_MS);
-  timer.unref?.();
+  monitor.start();
 
   return {
     receive: async (event) => {
-      const result = await enqueueSignalIngressEvent({ queue, event });
-      if (result.kind !== "ignored") {
-        await requestDrain();
-      }
+      await monitor.admit(event);
     },
-    stop: async () => {
-      clearInterval(timer);
-      await drainPass?.catch(() => undefined);
-      drain.dispose();
-    },
+    stop: monitor.stop,
+    waitForIdle: monitor.waitForIdle,
   };
 }

--- a/extensions/slack/src/monitor/ingress.test.ts
+++ b/extensions/slack/src/monitor/ingress.test.ts
@@ -126,6 +126,57 @@ describe("Slack durable ingress", () => {
     });
   });
 
+  it("acknowledges a durable event before dispatch starts", async () => {
+    await withQueue(async (queue) => {
+      let releaseAck = () => {};
+      const ackGate = new Promise<void>((resolve) => {
+        releaseAck = resolve;
+      });
+      const order: string[] = [];
+      const processEvent = vi.fn(async (event: ReceiverEvent) => {
+        order.push("dispatch");
+        await resolveSlackIngressTurnLifecycle(event.customProperties)?.onAdopted();
+      });
+      const { ingress, receive } = attachIngress(queue, processEvent);
+      const ack = vi.fn(async () => {
+        order.push("ack-start");
+        await ackGate;
+        order.push("ack-complete");
+      });
+      ingress.start();
+
+      const receiving = receive(createReceiverEvent("Ev-ack-order", ack));
+      await vi.waitFor(() => expect(ack).toHaveBeenCalledTimes(1));
+      expect(processEvent).not.toHaveBeenCalled();
+
+      releaseAck();
+      await receiving;
+      await ingress.waitForIdle();
+
+      expect(order).toEqual(["ack-start", "ack-complete", "dispatch"]);
+      await ingress.stop();
+    });
+  });
+
+  it("drains a durable event when its acknowledgement fails", async () => {
+    await withQueue(async (queue) => {
+      const processEvent = vi.fn(async (event: ReceiverEvent) => {
+        await resolveSlackIngressTurnLifecycle(event.customProperties)?.onAdopted();
+      });
+      const { ingress, receive } = attachIngress(queue, processEvent);
+      const ackError = new Error("connection closed");
+      ingress.start();
+
+      await expect(
+        receive(createReceiverEvent("Ev-ack-failure", vi.fn().mockRejectedValue(ackError))),
+      ).rejects.toBe(ackError);
+      await ingress.waitForIdle();
+
+      expect(processEvent).toHaveBeenCalledTimes(1);
+      await ingress.stop();
+    });
+  });
+
   it("recovers an uncompleted event with a fresh drain and dispatches once", async () => {
     await withQueue(async (queue) => {
       const first = attachIngress(
@@ -147,6 +198,34 @@ describe("Slack durable ingress", () => {
       expect(dispatch).toHaveBeenCalledTimes(1);
       expect((await queue.enqueue("Ev-restart", {} as SlackIngressPayload)).kind).toBe("completed");
       await restarted.ingress.stop();
+    });
+  });
+
+  it("recovers a shipped row whose lane was derived only at drain time", async () => {
+    await withQueue(async (queue) => {
+      const body = createSlackEnvelope("Ev-legacy-lane");
+      await queue.enqueue(
+        "Ev-legacy-lane",
+        {
+          version: 1,
+          receivedAt: 1_700_000_000_000,
+          kind: "events-api",
+          body,
+        },
+        { receivedAt: 1_700_000_000_000 },
+      );
+      const dispatch = vi.fn(async (event: ReceiverEvent) => {
+        await resolveSlackIngressTurnLifecycle(event.customProperties)?.onAdopted();
+      });
+      const recovered = attachIngress(queue, dispatch);
+      recovered.ingress.start();
+      await recovered.ingress.waitForIdle();
+
+      expect(dispatch).toHaveBeenCalledTimes(1);
+      expect((await queue.enqueue("Ev-legacy-lane", {} as SlackIngressPayload)).kind).toBe(
+        "completed",
+      );
+      await recovered.ingress.stop();
     });
   });
 

--- a/extensions/slack/src/monitor/ingress.ts
+++ b/extensions/slack/src/monitor/ingress.ts
@@ -1,13 +1,9 @@
 // Slack plugin module owns durable Events API admission and replay.
 import type { App, Receiver, ReceiverEvent } from "@slack/bolt";
 import {
-  bindIngressLifecycleToReplyOptions,
-  createChannelIngressDrain,
-  DEFAULT_INGRESS_ADOPTION_STALL_MS,
-  DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
-  DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
-  type ChannelIngressDrain,
+  createChannelIngressMonitor,
   type ChannelIngressQueue,
+  type ChannelIngressMonitorLifecycle,
 } from "openclaw/plugin-sdk/channel-outbound";
 import {
   collectErrorGraphCandidates,
@@ -30,9 +26,10 @@ const SLACK_BOLT_AUTHORIZATION_ERROR = "slack_bolt_authorization_error";
 
 const SLACK_INGRESS_LIFECYCLE_CONTEXT_KEY = "openclawIngressLifecycle";
 
-export type SlackIngressTurnLifecycle = ReturnType<
-  typeof bindIngressLifecycleToReplyOptions
->["turnAdoptionLifecycle"];
+export type SlackIngressTurnLifecycle = Omit<
+  ChannelIngressMonitorLifecycle,
+  "onAdoptionFinalizing"
+>;
 
 type SlackIngressPayload = {
   version: number;
@@ -55,6 +52,30 @@ type SlackRelayIngressEvent = {
   deliveryId: string;
   message: { channel: string; ts?: string; team?: string };
 };
+
+type SlackIngressRawEvent =
+  | {
+      kind: "events-api";
+      body: PluginJsonValue;
+      retryNum?: number;
+      retryReason?: string;
+      afterDurableAdmission?: () => Promise<void>;
+    }
+  | {
+      kind: "relay";
+      deliveryId: string;
+      message: PluginJsonValue;
+    };
+
+type SlackIngressBody =
+  | {
+      receivedAt: number;
+      kind: "events-api";
+      body: PluginJsonValue;
+      retryNum?: number;
+      retryReason?: string;
+    }
+  | { receivedAt: number; kind: "relay"; message: PluginJsonValue };
 
 type SlackRelayIngressDispatch = (
   message: PluginJsonValue,
@@ -132,22 +153,38 @@ function isSlackEventCallback(body: unknown): boolean {
   return asOptionalRecord(body)?.type === "event_callback";
 }
 
-function assertSlackIngressPayload(
+function decodeSlackIngressPayload(
   payload: SlackIngressPayload,
   eventId: string,
-): asserts payload is SlackIngressPayload {
-  if (payload.version !== SLACK_INGRESS_PAYLOAD_VERSION) {
-    throw new SlackIngressPayloadError(`Slack ingress payload ${eventId} was invalid.`);
-  }
+): { version: unknown; body: SlackIngressBody } {
   if (payload.kind === "relay") {
     if (!asOptionalRecord(payload.message)) {
       throw new SlackIngressPayloadError(`Slack relay ingress payload ${eventId} was invalid.`);
     }
-    return;
+    return { version: payload.version, body: payload };
   }
   if (!asOptionalRecord(payload.body) || resolveSlackEventId(payload.body) !== eventId) {
     throw new SlackIngressPayloadError(`Slack ingress payload ${eventId} was invalid.`);
   }
+  return { version: payload.version, body: payload };
+}
+
+function inspectSlackIngress(raw: SlackIngressRawEvent): { eventId: string; laneKey: string } {
+  if (raw.kind === "relay") {
+    const eventId = resolveSlackRelayIngressEventId({
+      deliveryId: raw.deliveryId,
+      message: raw.message as SlackRelayIngressEvent["message"],
+    });
+    return {
+      eventId,
+      laneKey: resolveSlackIngressLane({ event: raw.message }, eventId),
+    };
+  }
+  const eventId = resolveSlackEventId(raw.body);
+  if (!eventId) {
+    throw new SlackIngressPayloadError("Slack Events API envelope missing event_id.");
+  }
+  return { eventId, laneKey: resolveSlackIngressLane(raw.body, eventId) };
 }
 
 function resolveSlackIngressNonRetryableFailure(error: unknown) {
@@ -185,116 +222,104 @@ export function resolveSlackIngressTurnLifecycle(
 export function createSlackDurableIngress(
   options: SlackDurableIngressOptions,
 ): SlackDurableIngress {
-  let queue = options.queue;
-  let drain: ChannelIngressDrain | undefined;
   let app: App | undefined;
   let relayDispatch: SlackRelayIngressDispatch | undefined;
-  let running = false;
-  let requested = false;
-  let pumping: Promise<void> | undefined;
-  let pollTimer: ReturnType<typeof setInterval> | undefined;
-  let lastPrunedAt = 0;
-
-  const getQueue = (): ChannelIngressQueue<SlackIngressPayload> => {
-    queue ??= getSlackRuntime().state.openChannelIngressQueue<SlackIngressPayload>({
-      accountId: options.accountId,
-    });
-    return queue;
-  };
-
-  const getDrain = (): ChannelIngressDrain => {
-    drain ??= createChannelIngressDrain<SlackIngressPayload>({
-      queue: getQueue(),
-      adoptionStallTimeoutMs: options.adoptionStallTimeoutMs ?? DEFAULT_INGRESS_ADOPTION_STALL_MS,
-      retryPolicy: {
-        maxAttempts: DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
-        deadLetterMinAgeMs: DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
-      },
-      resolveNonRetryableFailure: resolveSlackIngressNonRetryableFailure,
-      deriveLaneKey: (record) =>
-        record.payload.kind === "relay"
-          ? resolveSlackIngressLane({ event: record.payload.message }, record.id)
-          : resolveSlackIngressLane(record.payload.body, record.id),
-      ...(options.onLog ? { onLog: options.onLog } : {}),
-      ...(options.abortSignal ? { abortSignal: options.abortSignal } : {}),
-      dispatchClaimedEvent: async (event, lifecycle) => {
-        assertSlackIngressPayload(event.payload, event.id);
-        if (lifecycle.abortSignal.aborted) {
-          throw lifecycle.abortSignal.reason;
+  const monitor = createChannelIngressMonitor<
+    SlackIngressRawEvent,
+    SlackIngressBody,
+    SlackIngressPayload
+  >({
+    queue:
+      options.queue ??
+      (() =>
+        getSlackRuntime().state.openChannelIngressQueue<SlackIngressPayload>({
+          accountId: options.accountId,
+        })),
+    inspect: inspectSlackIngress,
+    payload: {
+      version: SLACK_INGRESS_PAYLOAD_VERSION,
+      serialize: (raw, { receivedAt }) =>
+        raw.kind === "relay"
+          ? { kind: "relay", receivedAt, message: raw.message }
+          : {
+              kind: "events-api",
+              receivedAt,
+              body: raw.body,
+              ...(raw.retryNum === undefined ? {} : { retryNum: raw.retryNum }),
+              ...(raw.retryReason === undefined ? {} : { retryReason: raw.retryReason }),
+            },
+      deserialize: (body, { claim }) =>
+        body.kind === "relay"
+          ? {
+              kind: "relay",
+              deliveryId: claim.id.startsWith("relay:") ? claim.id.slice(6) : claim.id,
+              message: body.message,
+            }
+          : {
+              kind: "events-api",
+              body: body.body,
+              ...(body.retryNum === undefined ? {} : { retryNum: body.retryNum }),
+              ...(body.retryReason === undefined ? {} : { retryReason: body.retryReason }),
+            },
+      encode: ({ body }) => ({ version: SLACK_INGRESS_PAYLOAD_VERSION, ...body }),
+      decode: (payload, { claim }) => decodeSlackIngressPayload(payload, claim.id),
+      createClaimError: (_kind, claim) =>
+        new SlackIngressPayloadError(`Slack ingress payload ${claim.id} was invalid.`),
+    },
+    // Slack's HTTP acknowledgement is transport-private and must complete after
+    // durable append but before the shared monitor makes the row drainable.
+    onDurableAdmission: async (raw) => {
+      if (raw.kind === "events-api") {
+        await raw.afterDurableAdmission?.();
+      }
+    },
+    deliver: async (raw, lifecycle) => {
+      if (raw.kind === "relay") {
+        if (!relayDispatch) {
+          // Transient by design: a claim recovered before the relay source
+          // reattaches must retry, not dead-letter, or restart recovery loses it.
+          throw new Error("Slack relay ingress dispatcher is not attached.");
         }
-        const bound = bindIngressLifecycleToReplyOptions(lifecycle);
-        if (event.payload.kind === "relay") {
-          if (!relayDispatch) {
-            // Transient by design: a claim recovered before the relay source
-            // reattaches must retry, not dead-letter, or restart recovery loses it.
-            throw new Error("Slack relay ingress dispatcher is not attached.");
-          }
-          await relayDispatch(event.payload.message, bound.turnAdoptionLifecycle);
-          return;
-        }
-        if (!app) {
-          throw new Error("Slack ingress receiver is not attached to a Bolt app.");
-        }
-        await app.processEvent({
-          body: event.payload.body as ReceiverEvent["body"],
-          ack: async () => {},
-          ...(event.payload.retryNum === undefined ? {} : { retryNum: event.payload.retryNum }),
-          ...(event.payload.retryReason === undefined
-            ? {}
-            : { retryReason: event.payload.retryReason }),
-          customProperties: {
-            [SLACK_INGRESS_LIFECYCLE_CONTEXT_KEY]: bound.turnAdoptionLifecycle,
-          },
-        });
-      },
-    });
-    return drain;
-  };
-
-  const pruneIfDue = async (): Promise<void> => {
-    const now = Date.now();
-    if (now - lastPrunedAt < SLACK_INGRESS_PRUNE_INTERVAL_MS) {
-      return;
-    }
-    await getQueue().prune({
+        await relayDispatch(raw.message, lifecycle);
+        return;
+      }
+      if (!app) {
+        throw new Error("Slack ingress receiver is not attached to a Bolt app.");
+      }
+      await app.processEvent({
+        body: raw.body as ReceiverEvent["body"],
+        ack: async () => {},
+        ...(raw.retryNum === undefined ? {} : { retryNum: raw.retryNum }),
+        ...(raw.retryReason === undefined ? {} : { retryReason: raw.retryReason }),
+        customProperties: {
+          [SLACK_INGRESS_LIFECYCLE_CONTEXT_KEY]: lifecycle,
+        },
+      });
+    },
+    pollIntervalMs: options.pollIntervalMs ?? SLACK_INGRESS_POLL_INTERVAL_MS,
+    retention: {
+      pruneIntervalMs: SLACK_INGRESS_PRUNE_INTERVAL_MS,
       completedTtlMs: SLACK_INGRESS_COMPLETED_TTL_MS,
       completedMaxEntries: SLACK_INGRESS_COMPLETED_MAX_ENTRIES,
       failedTtlMs: SLACK_INGRESS_FAILED_TTL_MS,
       failedMaxEntries: SLACK_INGRESS_FAILED_MAX_ENTRIES,
-      now,
-    });
-    lastPrunedAt = now;
-  };
-
-  const runPump = async (): Promise<void> => {
-    try {
-      for (;;) {
-        requested = false;
-        await pruneIfDue();
-        const activeDrain = getDrain();
-        const { started } = await activeDrain.drainOnce();
-        await activeDrain.waitForIdle();
-        if (!running || (!requested && started === 0)) {
-          break;
-        }
-      }
-    } catch (error) {
-      options.onLog?.(`slack ingress drain failed: ${formatErrorMessage(error)}`);
-    } finally {
-      pumping = undefined;
-      if (running && requested) {
-        requestDrain();
-      }
-    }
-  };
-
-  const requestDrain = (): void => {
-    requested = true;
-    if (!running || pumping) {
-      return;
-    }
-    pumping = runPump();
-  };
+    },
+    appendRetryDelaysMs: [0],
+    drain: {
+      resolveNonRetryableFailure: resolveSlackIngressNonRetryableFailure,
+      // Shipped Slack rows did not store lanes, so replay still derives them from payloads.
+      deriveLaneKey: (record) =>
+        record.payload.kind === "relay"
+          ? resolveSlackIngressLane({ event: record.payload.message }, record.id)
+          : resolveSlackIngressLane(record.payload.body, record.id),
+      ...(options.adoptionStallTimeoutMs === undefined
+        ? {}
+        : { adoptionStallTimeoutMs: options.adoptionStallTimeoutMs }),
+      ...(options.onLog ? { onLog: options.onLog } : {}),
+    },
+    ...(options.abortSignal ? { abortSignal: options.abortSignal } : {}),
+    onError: (error) => options.onLog?.(`slack ingress drain failed: ${formatErrorMessage(error)}`),
+  });
 
   const acceptReceiverEvent = async (event: ReceiverEvent): Promise<void> => {
     if (!isSlackEventCallback(event.body)) {
@@ -304,40 +329,21 @@ export function createSlackDurableIngress(
       await app.processEvent(event);
       return;
     }
-    const eventId = resolveSlackEventId(event.body);
-    if (!eventId) {
-      throw new SlackIngressPayloadError("Slack Events API envelope missing event_id.");
-    }
-    const receivedAt = Date.now();
-    await getQueue().enqueue(
-      eventId,
-      {
-        version: SLACK_INGRESS_PAYLOAD_VERSION,
-        receivedAt,
-        kind: "events-api",
-        body: event.body as PluginJsonValue,
-        ...(event.retryNum === undefined ? {} : { retryNum: event.retryNum }),
-        ...(event.retryReason === undefined ? {} : { retryReason: event.retryReason }),
-      },
-      { receivedAt },
-    );
-    await event.ack();
-    requestDrain();
+    await monitor.admit({
+      kind: "events-api",
+      body: event.body as PluginJsonValue,
+      ...(event.retryNum === undefined ? {} : { retryNum: event.retryNum }),
+      ...(event.retryReason === undefined ? {} : { retryReason: event.retryReason }),
+      afterDurableAdmission: () => event.ack(),
+    });
   };
 
   const acceptRelayEvent = async (event: SlackRelayIngressEvent): Promise<void> => {
-    const receivedAt = Date.now();
-    await getQueue().enqueue(
-      resolveSlackRelayIngressEventId(event),
-      {
-        version: SLACK_INGRESS_PAYLOAD_VERSION,
-        receivedAt,
-        kind: "relay",
-        message: event.message as PluginJsonValue,
-      },
-      { receivedAt },
-    );
-    requestDrain();
+    await monitor.admit({
+      kind: "relay",
+      deliveryId: event.deliveryId,
+      message: event.message as PluginJsonValue,
+    });
   };
 
   return {
@@ -358,37 +364,8 @@ export function createSlackDurableIngress(
     attachRelayDispatch: (dispatch) => {
       relayDispatch = dispatch;
     },
-    start: () => {
-      if (running) {
-        return;
-      }
-      running = true;
-      pollTimer = setInterval(
-        requestDrain,
-        options.pollIntervalMs ?? SLACK_INGRESS_POLL_INTERVAL_MS,
-      );
-      pollTimer.unref?.();
-      requestDrain();
-    },
-    stop: async () => {
-      running = false;
-      if (pollTimer) {
-        clearInterval(pollTimer);
-        pollTimer = undefined;
-      }
-      drain?.dispose();
-      await pumping;
-      await drain?.waitForIdle();
-    },
-    waitForIdle: async () => {
-      for (;;) {
-        const activePump = pumping;
-        if (!activePump) {
-          break;
-        }
-        await activePump;
-      }
-      await drain?.waitForIdle();
-    },
+    start: monitor.start,
+    stop: monitor.stop,
+    waitForIdle: monitor.waitForIdle,
   };
 }

--- a/extensions/tlon/src/monitor/ingress.ts
+++ b/extensions/tlon/src/monitor/ingress.ts
@@ -1,10 +1,9 @@
 // Tlon plugin module owns raw Urbit firehose durable ingress mapping and draining.
 import {
-  createChannelIngressDrain,
-  DEFAULT_INGRESS_ADOPTION_STALL_MS,
-  DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
-  DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
+  createChannelIngressMonitor,
   type ChannelIngressQueue,
+  type ChannelIngressMonitorDeliveryResult,
+  type ChannelIngressMonitorLifecycle,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { collectErrorGraphCandidates, formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
@@ -18,13 +17,7 @@ const TLON_INGRESS_FAILED_TTL_MS = 30 * 24 * 60 * 60 * 1_000;
 // Preserve the retired process-local guard's full 2,000-message key window.
 const TLON_INGRESS_TOMBSTONE_MAX_ENTRIES = 2_000;
 
-export type TlonIngressLifecycle = {
-  abortSignal: AbortSignal;
-  onAdopted: () => void | Promise<void>;
-  onDeferred: () => void;
-  onAdoptionFinalizing: () => void;
-  onAbandoned: () => void | Promise<void>;
-};
+export type TlonIngressLifecycle = Omit<ChannelIngressMonitorLifecycle, "admission">;
 
 type TlonIngressSource = "channels" | "chat";
 
@@ -35,16 +28,11 @@ type TlonIngressPayload = {
   rawEvent: string;
 };
 
-type TlonIngressDrain = {
-  drainOnce: (options?: { shouldStop?: () => boolean }) => Promise<{ started: number }>;
-  waitForIdle: () => Promise<void>;
-  dispose: () => void;
-};
+type TlonIngressBody = Omit<TlonIngressPayload, "version">;
 
-type TlonIngressDispatchResult =
-  | { kind: "completed" }
-  | { kind: "deferred" }
-  | { kind: "failed-retryable"; error: unknown };
+type TlonIngressRaw = { source: TlonIngressSource; event: unknown };
+
+type TlonIngressDispatchResult = ChannelIngressMonitorDeliveryResult;
 
 type TlonIngressDispatch = (
   source: TlonIngressSource,
@@ -118,9 +106,11 @@ function inspectTlonIngressEvent(
   return source === "channels" ? inspectChannelsEvent(event) : inspectChatEvent(event);
 }
 
-function parseClaimedEvent(payload: TlonIngressPayload, claimedId: string): unknown {
+function decodeTlonIngressPayload(
+  payload: TlonIngressPayload,
+  claimedId: string,
+): { version: unknown; body: TlonIngressBody } {
   if (
-    payload.version !== TLON_INGRESS_PAYLOAD_VERSION ||
     (payload.source !== "channels" && payload.source !== "chat") ||
     typeof payload.rawEvent !== "string"
   ) {
@@ -129,9 +119,20 @@ function parseClaimedEvent(payload: TlonIngressPayload, claimedId: string): unkn
       `Tlon ingress row ${claimedId} has an invalid payload.`,
     );
   }
+  return {
+    version: payload.version,
+    body: {
+      receivedAt: payload.receivedAt,
+      source: payload.source,
+      rawEvent: payload.rawEvent,
+    },
+  };
+}
+
+function deserializeTlonIngressEvent(body: TlonIngressBody, claimedId: string): TlonIngressRaw {
   let event: unknown;
   try {
-    event = JSON.parse(payload.rawEvent);
+    event = JSON.parse(body.rawEvent);
   } catch (error) {
     throw new TlonIngressPermanentError(
       "invalid-event",
@@ -139,14 +140,7 @@ function parseClaimedEvent(payload: TlonIngressPayload, claimedId: string): unkn
       { cause: error },
     );
   }
-  const facts = inspectTlonIngressEvent(payload.source, event);
-  if (!facts || facts.eventId !== claimedId) {
-    throw new TlonIngressPermanentError(
-      "invalid-event",
-      `Tlon ingress row ${claimedId} has invalid message identity.`,
-    );
-  }
-  return event;
+  return { source: body.source, event };
 }
 
 function resolveTlonIngressNonRetryableFailure(error: unknown) {
@@ -184,183 +178,62 @@ export function createTlonIngressMonitor(options: {
   adoptionStallTimeoutMs?: number;
   abortSignal?: AbortSignal;
 }): TlonIngressMonitor {
-  let queue = options.queue;
-  let drain: TlonIngressDrain | undefined;
-  let accepting = true;
-  let running = false;
-  let stopped = false;
-  let requested = false;
-  let pumping: Promise<void> | undefined;
-  let pollTimer: ReturnType<typeof setInterval> | undefined;
-  let lastPrunedAt = 0;
-  let stopPromise: Promise<void> | undefined;
-
-  const getQueue = (): ChannelIngressQueue<TlonIngressPayload> => {
-    queue ??= getTlonRuntime().state.openChannelIngressQueue<TlonIngressPayload>({
-      accountId: options.accountId,
-    });
-    return queue;
-  };
-
-  const getDrain = (): TlonIngressDrain => {
-    drain ??= createChannelIngressDrain<TlonIngressPayload>({
-      queue: getQueue(),
-      adoptionStallTimeoutMs: options.adoptionStallTimeoutMs ?? DEFAULT_INGRESS_ADOPTION_STALL_MS,
-      retryPolicy: {
-        maxAttempts: DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
-        deadLetterMinAgeMs: DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
-      },
-      resolveNonRetryableFailure: resolveTlonIngressNonRetryableFailure,
-      ...(options.abortSignal ? { abortSignal: options.abortSignal } : {}),
-      onLog: (message) => options.runtime.log?.(`tlon ${message}`),
-      dispatchClaimedEvent: async (record, lifecycle) => {
-        if (!running || lifecycle.abortSignal.aborted || options.abortSignal?.aborted) {
-          return { kind: "failed-retryable", error: new TlonIngressShutdownError() };
-        }
-        const event = parseClaimedEvent(record.payload, record.id);
-        try {
-          const result = await options.dispatch(record.payload.source, event, lifecycle);
-          return !running || options.abortSignal?.aborted
-            ? { kind: "failed-retryable", error: new TlonIngressShutdownError() }
-            : result;
-        } catch (error) {
-          if (!running || options.abortSignal?.aborted) {
-            return { kind: "failed-retryable", error };
-          }
-          throw error;
-        }
-      },
-    });
-    return drain;
-  };
-
-  const pruneIfDue = async (): Promise<void> => {
-    const now = Date.now();
-    if (now - lastPrunedAt < TLON_INGRESS_PRUNE_INTERVAL_MS) {
-      return;
-    }
-    await getQueue().prune({
+  const monitor = createChannelIngressMonitor<TlonIngressRaw, TlonIngressBody, TlonIngressPayload>({
+    queue:
+      options.queue ??
+      (() =>
+        getTlonRuntime().state.openChannelIngressQueue<TlonIngressPayload>({
+          accountId: options.accountId,
+        })),
+    inspect: (raw) => inspectTlonIngressEvent(raw.source, raw.event),
+    payload: {
+      version: TLON_INGRESS_PAYLOAD_VERSION,
+      serialize: (raw, { receivedAt }) => ({
+        receivedAt,
+        source: raw.source,
+        rawEvent: JSON.stringify(raw.event),
+      }),
+      deserialize: (body, { claim }) => deserializeTlonIngressEvent(body, claim.id),
+      encode: ({ body }) => ({ version: TLON_INGRESS_PAYLOAD_VERSION, ...body }),
+      decode: (payload, { claim }) => decodeTlonIngressPayload(payload, claim.id),
+      createClaimError: (kind, claim) =>
+        new TlonIngressPermanentError(
+          "invalid-event",
+          kind === "invalid-version"
+            ? `Tlon ingress row ${claim.id} has an invalid payload.`
+            : `Tlon ingress row ${claim.id} has invalid message identity.`,
+        ),
+    },
+    deliver: (raw, lifecycle) => options.dispatch(raw.source, raw.event, lifecycle),
+    pollIntervalMs: options.pollIntervalMs ?? TLON_INGRESS_POLL_INTERVAL_MS,
+    retention: {
+      pruneIntervalMs: TLON_INGRESS_PRUNE_INTERVAL_MS,
       completedMaxEntries: TLON_INGRESS_TOMBSTONE_MAX_ENTRIES,
       failedTtlMs: TLON_INGRESS_FAILED_TTL_MS,
       failedMaxEntries: TLON_INGRESS_TOMBSTONE_MAX_ENTRIES,
-      now,
-    });
-    lastPrunedAt = now;
-  };
-
-  const runPump = async (): Promise<void> => {
-    try {
-      for (;;) {
-        requested = false;
-        await pruneIfDue();
-        // stop() may race the async prune; never create a live drain afterward.
-        if (!running) {
-          break;
-        }
-        const activeDrain = getDrain();
-        const { started } = await activeDrain.drainOnce({ shouldStop: () => !running });
-        await activeDrain.waitForIdle();
-        if (!running || (!requested && started === 0)) {
-          break;
-        }
-      }
-    } catch (error) {
-      options.runtime.error?.(`tlon ingress drain failed: ${formatErrorMessage(error)}`);
-    } finally {
-      pumping = undefined;
-      if (running && requested) {
-        requestDrain();
-      }
-    }
-  };
-
-  const requestDrain = (): void => {
-    requested = true;
-    if (!running || pumping) {
-      return;
-    }
-    pumping = runPump();
-  };
-
-  // Stream callbacks are awaited, but serialize direct test/caller admissions too.
-  let admissionTail: Promise<void> = Promise.resolve();
-
-  const admitOnce = async (source: TlonIngressSource, event: unknown): Promise<boolean> => {
-    const facts = inspectTlonIngressEvent(source, event);
-    if (!facts) {
-      return false;
-    }
-    const receivedAt = Date.now();
-    await getQueue().enqueue(
-      facts.eventId,
-      {
-        version: TLON_INGRESS_PAYLOAD_VERSION,
-        receivedAt,
-        source,
-        rawEvent: JSON.stringify(event),
-      },
-      { receivedAt, laneKey: facts.laneKey },
-    );
-    requestDrain();
-    return true;
-  };
+    },
+    // The Tlon firehose has always surfaced a failed append to its awaited callback.
+    appendRetryDelaysMs: [0],
+    drain: {
+      resolveNonRetryableFailure: resolveTlonIngressNonRetryableFailure,
+      ...(options.adoptionStallTimeoutMs === undefined
+        ? {}
+        : { adoptionStallTimeoutMs: options.adoptionStallTimeoutMs }),
+      onLog: (message) => options.runtime.log?.(`tlon ${message}`),
+    },
+    ...(options.abortSignal ? { abortSignal: options.abortSignal } : {}),
+    createStoppedError: () => new TlonIngressShutdownError(),
+    onError: (error) =>
+      options.runtime.error?.(`tlon ingress drain failed: ${formatErrorMessage(error)}`),
+  });
 
   return {
     receive: async ({ source, event }) => {
-      if (!accepting) {
-        throw new TlonIngressShutdownError();
-      }
-      let accepted = false;
-      const admission = admissionTail.then(async () => {
-        accepted = await admitOnce(source, event);
-      });
-      admissionTail = admission.catch(() => undefined);
-      await admission;
-      return { kind: accepted ? "accepted" : "ignored" };
+      const result = await monitor.admit({ source, event });
+      return { kind: result.kind === "durable" ? "accepted" : "ignored" };
     },
-    start: () => {
-      if (running || stopped) {
-        return;
-      }
-      running = true;
-      pollTimer = setInterval(
-        requestDrain,
-        options.pollIntervalMs ?? TLON_INGRESS_POLL_INTERVAL_MS,
-      );
-      pollTimer.unref?.();
-      requestDrain();
-    },
-    stop: async () => {
-      if (stopPromise) {
-        await stopPromise;
-        return;
-      }
-      accepting = false;
-      running = false;
-      stopped = true;
-      if (pollTimer) {
-        clearInterval(pollTimer);
-        pollTimer = undefined;
-      }
-      stopPromise = (async () => {
-        await admissionTail;
-        drain?.dispose();
-        await pumping;
-        // A pump may have lazily created the drain before observing running=false.
-        drain?.dispose();
-        await drain?.waitForIdle();
-      })();
-      await stopPromise;
-    },
-    waitForIdle: async () => {
-      for (;;) {
-        const activePump = pumping;
-        if (!activePump) {
-          break;
-        }
-        await activePump;
-      }
-      await drain?.waitForIdle();
-    },
+    start: monitor.start,
+    stop: monitor.stop,
+    waitForIdle: monitor.waitForIdle,
   };
 }

--- a/extensions/twitch/src/twitch-ingress.test.ts
+++ b/extensions/twitch/src/twitch-ingress.test.ts
@@ -252,6 +252,73 @@ describe("Twitch durable ingress", () => {
     });
   });
 
+  it("waits for a deferred reply-lane claim before stop returns", async () => {
+    await withTwitchIngressTestQueue(async (queue) => {
+      let adoptDeferred = async () => {};
+      const deliver = vi.fn(async (message, lifecycle) => {
+        if (message.id === "deferred-stop") {
+          lifecycle.onDeferred();
+          adoptDeferred = lifecycle.onAdopted;
+          return;
+        }
+        await lifecycle.onAdopted();
+      });
+      const ingress = createTwitchIngress({
+        accountId: "default",
+        runtime: runtime(),
+        queue,
+        deliver,
+        pollIntervalMs: 5,
+      });
+      ingress.start();
+      await ingress.accept(createTwitchIngressTestMessage({ id: "deferred-stop" }));
+      await vi.waitFor(() => expect(deliver).toHaveBeenCalledOnce());
+      await ingress.accept(createTwitchIngressTestMessage({ id: "queued-during-stop" }));
+
+      let stopped = false;
+      const stopping = ingress.stop().then(() => {
+        stopped = true;
+      });
+      ingress.start();
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 30);
+      });
+      expect(stopped).toBe(false);
+      await adoptDeferred();
+      await stopping;
+      expect(stopped).toBe(true);
+      expect(deliver).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("aborts an active pre-adoption delivery before waiting for idle", async () => {
+    await withTwitchIngressTestQueue(async (queue) => {
+      const deliver = vi.fn(
+        async (_message, lifecycle) =>
+          await new Promise<void>((resolve) => {
+            lifecycle.abortSignal.addEventListener("abort", () => resolve(), { once: true });
+          }),
+      );
+      const ingress = createTwitchIngress({
+        accountId: "default",
+        runtime: runtime(),
+        queue,
+        deliver,
+        pollIntervalMs: 5,
+      });
+      ingress.start();
+      await ingress.accept(createTwitchIngressTestMessage({ id: "abort-on-stop" }));
+      await vi.waitFor(() => expect(deliver).toHaveBeenCalledOnce());
+
+      await ingress.stop();
+
+      expect(await queue.listClaims()).toHaveLength(0);
+      expect(await queue.listPending()).toEqual([
+        expect.objectContaining({ id: "abort-on-stop", lastError: expect.any(String) }),
+      ]);
+    });
+  });
+
   it("releases a pre-adoption delivery for retry during shutdown", async () => {
     await withTwitchIngressTestQueue(async (queue) => {
       let releaseDelivery = () => {};

--- a/extensions/twitch/src/twitch-ingress.ts
+++ b/extensions/twitch/src/twitch-ingress.ts
@@ -1,12 +1,9 @@
 // Twitch plugin owns raw chat-envelope durable admission and replay draining.
 import { HttpStatusCodeError } from "@twurple/api-call";
 import {
-  bindIngressLifecycleToReplyOptions,
-  createChannelIngressDrain,
-  DEFAULT_INGRESS_ADOPTION_STALL_MS,
-  DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
-  DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
+  createChannelIngressMonitor,
   type ChannelIngressQueue,
+  type ChannelIngressMonitorLifecycle,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { getTwitchRuntime } from "./runtime.js";
@@ -22,16 +19,13 @@ const TWITCH_INGRESS_COMPLETED_TTL_MS = 30 * 24 * 60 * 60 * 1_000;
 const TWITCH_INGRESS_COMPLETED_MAX_ENTRIES = 1_000;
 const TWITCH_INGRESS_FAILED_TTL_MS = 30 * 24 * 60 * 60 * 1_000;
 const TWITCH_INGRESS_FAILED_MAX_ENTRIES = 1_000;
-const TWITCH_INGRESS_APPEND_RETRY_DELAYS_MS = [0, 100, 300] as const;
 
 type TwitchIngressPayload = {
   version: typeof TWITCH_INGRESS_PAYLOAD_VERSION;
   rawEvent: string;
 };
 
-type TwitchIngressLifecycle = ReturnType<
-  typeof bindIngressLifecycleToReplyOptions
->["turnAdoptionLifecycle"];
+type TwitchIngressLifecycle = Omit<ChannelIngressMonitorLifecycle, "onAdoptionFinalizing">;
 
 type TwitchIngress = {
   accept: (message: TwitchChatMessage) => Promise<void>;
@@ -67,29 +61,20 @@ function inspectTwitchIngressEvent(event: unknown): { eventId: string; laneKey: 
   return { eventId, laneKey: `channel:${channel}` };
 }
 
-function parseClaimedTwitchMessage(
-  payload: TwitchIngressPayload,
-  claimedId: string,
-  claimedLaneKey: string | undefined,
-): TwitchChatMessage {
-  if (payload.version !== TWITCH_INGRESS_PAYLOAD_VERSION || typeof payload.rawEvent !== "string") {
-    throw new TwitchIngressPermanentError("Twitch ingress payload is invalid.");
-  }
+function deserializeTwitchIngressEvent(rawEvent: string): unknown {
   let parsed: unknown;
   try {
-    parsed = JSON.parse(payload.rawEvent);
+    parsed = JSON.parse(rawEvent);
   } catch (error) {
     throw new TwitchIngressPermanentError("Twitch ingress event JSON is invalid.", {
       cause: error,
     });
   }
-  const facts = inspectTwitchIngressEvent(parsed);
-  if (facts.eventId !== claimedId || facts.laneKey !== claimedLaneKey) {
-    throw new TwitchIngressPermanentError(
-      "Twitch ingress event identity changed after durable admission.",
-    );
-  }
-  const candidate = parsed as Partial<TwitchChatMessage>;
+  return parsed;
+}
+
+function normalizeClaimedTwitchMessage(event: unknown, claimedId: string): TwitchChatMessage {
+  const candidate = event as Partial<TwitchChatMessage>;
   const username = nonEmptyString(candidate.username);
   const rawChannel = nonEmptyString(candidate.channel);
   if (!username || typeof candidate.message !== "string" || !rawChannel) {
@@ -135,41 +120,25 @@ export function createTwitchIngress(options: {
       accountId: options.accountId,
     });
   const shutdown = new AbortController();
-  const activeDeliveries = new Set<Promise<void>>();
-  const deferredClaims = new Map<string, Promise<void>>();
-  let running = false;
   let stopped = false;
-  let drainRequested = false;
-  let drainTask: Promise<void> | undefined;
-  let drainTimer: ReturnType<typeof setInterval> | undefined;
-  let lastPrunedAt = 0;
-  let admissionTail: Promise<void> = Promise.resolve();
-  let stopTask: Promise<void> | undefined;
-
-  const drain = createChannelIngressDrain<TwitchIngressPayload>({
+  const deferredClaims = new Map<string, Promise<void>>();
+  const monitor = createChannelIngressMonitor<unknown, string, TwitchIngressPayload>({
     queue,
-    abortSignal: shutdown.signal,
-    adoptionStallTimeoutMs: DEFAULT_INGRESS_ADOPTION_STALL_MS,
-    retryPolicy: {
-      maxAttempts: DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,
-      deadLetterMinAgeMs: DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
+    inspect: (message) => inspectTwitchIngressEvent(message),
+    payload: {
+      storage: "raw-event",
+      version: TWITCH_INGRESS_PAYLOAD_VERSION,
+      serialize: (message) => JSON.stringify(message),
+      deserialize: (rawEvent) => deserializeTwitchIngressEvent(rawEvent),
+      createClaimError: (kind) =>
+        new TwitchIngressPermanentError(
+          kind === "invalid-version"
+            ? "Twitch ingress payload is invalid."
+            : "Twitch ingress event identity changed after durable admission.",
+        ),
     },
-    resolveNonRetryableFailure: (error) => {
-      if (error instanceof TwitchIngressPermanentError) {
-        return { reason: "invalid-event", message: error.message };
-      }
-      if (isTwitchAuthenticationFailure(error)) {
-        return { reason: "authentication-failed", message: formatErrorMessage(error) };
-      }
-      return null;
-    },
-    onLog: (message) => options.runtime.error?.(`twitch ingress: ${message}`),
-    dispatchClaimedEvent: async (claimed, lifecycle) => {
-      if (!running || lifecycle.abortSignal.aborted) {
-        return { kind: "failed-retryable", error: stoppedError() };
-      }
-      const message = parseClaimedTwitchMessage(claimed.payload, claimed.id, claimed.laneKey);
-      const bound = bindIngressLifecycleToReplyOptions(lifecycle).turnAdoptionLifecycle;
+    deliver: async (rawEvent, lifecycle, claim) => {
+      const message = normalizeClaimedTwitchMessage(rawEvent, claim.id);
       let handedOff = false;
       let resolveDeferredClaim!: () => void;
       const deferredClaim = new Promise<void>((resolve) => {
@@ -181,174 +150,100 @@ export function createTwitchIngress(options: {
           return;
         }
         deferredClaimSettled = true;
-        if (deferredClaims.get(claimed.id) === deferredClaim) {
-          deferredClaims.delete(claimed.id);
+        if (deferredClaims.get(claim.id) === deferredClaim) {
+          deferredClaims.delete(claim.id);
         }
         resolveDeferredClaim();
       };
-      const delivery = options.deliver(message, {
-        ...bound,
-        onAdopted: async () => {
-          handedOff = true;
-          try {
-            await bound.onAdopted();
-          } finally {
-            settleDeferredClaim();
-          }
-        },
-        onDeferred: () => {
-          handedOff = true;
-          if (!deferredClaimSettled) {
-            deferredClaims.set(claimed.id, deferredClaim);
-          }
-          bound.onDeferred();
-        },
-        onAbandoned: async () => {
-          handedOff = true;
-          try {
-            await bound.onAbandoned();
-          } finally {
-            settleDeferredClaim();
-          }
-        },
-      });
-      activeDeliveries.add(delivery);
+      const deliveryAbortSignal = AbortSignal.any([lifecycle.abortSignal, shutdown.signal]);
       try {
-        await delivery;
+        await options.deliver(message, {
+          admission: lifecycle.admission,
+          abortSignal: deliveryAbortSignal,
+          onAdopted: async () => {
+            handedOff = true;
+            try {
+              await lifecycle.onAdopted();
+            } finally {
+              settleDeferredClaim();
+            }
+          },
+          onDeferred: () => {
+            handedOff = true;
+            if (!deferredClaimSettled) {
+              deferredClaims.set(claim.id, deferredClaim);
+            }
+            lifecycle.onDeferred();
+          },
+          onAbandoned: async () => {
+            handedOff = true;
+            try {
+              await lifecycle.onAbandoned();
+            } finally {
+              settleDeferredClaim();
+            }
+          },
+        });
       } catch (error) {
-        if (!running || lifecycle.abortSignal.aborted) {
+        if (stopped || deliveryAbortSignal.aborted) {
           return { kind: "failed-retryable", error };
         }
         throw error;
-      } finally {
-        activeDeliveries.delete(delivery);
       }
-      if (!handedOff) {
-        if (!running || lifecycle.abortSignal.aborted) {
-          return { kind: "failed-retryable", error: stoppedError() };
-        }
-        // Echoes and access-gated messages are terminal no-dispatch events.
-        await bound.onAdopted();
+      if (!handedOff && (stopped || deliveryAbortSignal.aborted)) {
+        return { kind: "failed-retryable", error: stoppedError() };
       }
-      return deferredClaims.has(claimed.id) ? { kind: "deferred" } : { kind: "completed" };
+      return undefined;
     },
-  });
-
-  const pruneIfDue = async (): Promise<void> => {
-    const now = Date.now();
-    if (now - lastPrunedAt < TWITCH_INGRESS_PRUNE_INTERVAL_MS) {
-      return;
-    }
-    await queue.prune({
+    pollIntervalMs: options.pollIntervalMs ?? TWITCH_INGRESS_DRAIN_INTERVAL_MS,
+    retention: {
+      pruneIntervalMs: TWITCH_INGRESS_PRUNE_INTERVAL_MS,
       completedTtlMs: TWITCH_INGRESS_COMPLETED_TTL_MS,
       completedMaxEntries: TWITCH_INGRESS_COMPLETED_MAX_ENTRIES,
       failedTtlMs: TWITCH_INGRESS_FAILED_TTL_MS,
       failedMaxEntries: TWITCH_INGRESS_FAILED_MAX_ENTRIES,
-      now,
-    });
-    lastPrunedAt = now;
-  };
-
-  const requestDrain = (): void => {
-    if (!running || stopped || shutdown.signal.aborted) {
-      return;
-    }
-    drainRequested = true;
-    if (drainTask) {
-      return;
-    }
-    drainTask = (async () => {
-      while (drainRequested) {
-        if (!running) {
-          break;
+    },
+    drain: {
+      resolveNonRetryableFailure: (error) => {
+        if (error instanceof TwitchIngressPermanentError) {
+          return { reason: "invalid-event", message: error.message };
         }
-        drainRequested = false;
-        await pruneIfDue();
-        if (!running) {
-          break;
+        if (isTwitchAuthenticationFailure(error)) {
+          return { reason: "authentication-failed", message: formatErrorMessage(error) };
         }
-        const { started } = await drain.drainOnce({ shouldStop: () => !running });
-        if (!running || (!drainRequested && started === 0)) {
-          break;
-        }
-      }
-    })()
-      .catch((error: unknown) => {
-        options.runtime.error?.(`Twitch ingress drain failed: ${formatErrorMessage(error)}`);
-      })
-      .finally(() => {
-        drainTask = undefined;
-        if (running && drainRequested) {
-          requestDrain();
-        }
-      });
-  };
-
-  const admitOnce = async (message: TwitchChatMessage): Promise<void> => {
-    const facts = inspectTwitchIngressEvent(message);
-    const rawEvent = JSON.stringify(message);
-    const receivedAt = Date.now();
-    let lastError: unknown;
-    for (const delayMs of TWITCH_INGRESS_APPEND_RETRY_DELAYS_MS) {
-      if (delayMs > 0) {
-        await new Promise<void>((resolve) => {
-          setTimeout(resolve, delayMs);
-        });
-      }
-      try {
-        await queue.enqueue(
-          facts.eventId,
-          { version: TWITCH_INGRESS_PAYLOAD_VERSION, rawEvent },
-          { receivedAt, laneKey: facts.laneKey },
-        );
-        requestDrain();
-        return;
-      } catch (error) {
-        lastError = error;
-      }
-    }
-    throw lastError;
-  };
+        return null;
+      },
+      onLog: (message) => options.runtime.error?.(`twitch ingress: ${message}`),
+    },
+    abortSignal: shutdown.signal,
+    createStoppedError: stoppedError,
+    onError: (error) =>
+      options.runtime.error?.(`Twitch ingress drain failed: ${formatErrorMessage(error)}`),
+  });
+  let stopTask: Promise<void> | undefined;
 
   return {
     accept: (message) => {
       if (stopped) {
         return Promise.reject(stoppedError());
       }
-      // Preserve socket arrival order across append retry backoff.
-      const admission = admissionTail.then(() => admitOnce(message));
-      admissionTail = admission.catch(() => undefined);
-      return admission;
+      return monitor.admit(message).then(() => undefined);
     },
     start: () => {
-      if (running || stopped) {
-        return;
+      if (!stopped) {
+        monitor.start();
       }
-      running = true;
-      requestDrain();
-      drainTimer = setInterval(
-        requestDrain,
-        options.pollIntervalMs ?? TWITCH_INGRESS_DRAIN_INTERVAL_MS,
-      );
-      drainTimer.unref?.();
     },
     stop: () => {
       stopTask ??= (async () => {
         stopped = true;
-        running = false;
-        if (drainTimer) {
-          clearInterval(drainTimer);
-          drainTimer = undefined;
-        }
-        await admissionTail;
         shutdown.abort(stoppedError());
-        await drainTask;
-        await Promise.allSettled(activeDeliveries);
+        await monitor.pause();
+        await monitor.waitForIdle();
+        // Twitch waits for reply-lane ownership to settle before aborting the
+        // drain; queued channel turns would otherwise be replayed on restart.
         await Promise.allSettled(deferredClaims.values());
-        await drain.waitForIdle();
-        // Stop is idempotent, and drain disposal remains safe if cleanup repeats.
-        drain.dispose();
-        drain.dispose();
+        await monitor.stop();
       })();
       return stopTask;
     },

--- a/src/channels/message/ingress-monitor.test.ts
+++ b/src/channels/message/ingress-monitor.test.ts
@@ -115,4 +115,40 @@ describe("channel ingress monitor", () => {
       await monitor.stop();
     });
   });
+
+  it("rechecks identity against a derived lane for legacy rows", async () => {
+    await withQueue(async (queue) => {
+      await queue.enqueue("event-derived", {
+        version: 1,
+        rawEvent: JSON.stringify({ id: "event-derived", lane: "a", text: "hello" }),
+      });
+      const deliver = vi.fn();
+      const monitor = createChannelIngressMonitor<RawEvent, string, StoredEvent>({
+        queue,
+        inspect: (raw) => ({ eventId: raw.id, laneKey: `lane:${raw.lane}` }),
+        payload: {
+          storage: "raw-event",
+          version: 1,
+          serialize: (raw) => JSON.stringify(raw),
+          deserialize: (body) => JSON.parse(body) as RawEvent,
+          createClaimError: (kind) => new PermanentIngressError(kind),
+        },
+        deliver,
+        pollIntervalMs: 10,
+        retention: { pruneIntervalMs: 60_000 },
+        drain: {
+          deriveLaneKey: () => "lane:a",
+          resolveNonRetryableFailure: (error) =>
+            error instanceof PermanentIngressError
+              ? { reason: "invalid-event", message: error.message }
+              : null,
+        },
+      });
+      monitor.start();
+      await monitor.waitForIdle();
+
+      expect(deliver).toHaveBeenCalledOnce();
+      await monitor.stop();
+    });
+  });
 });

--- a/src/channels/message/ingress-monitor.test.ts
+++ b/src/channels/message/ingress-monitor.test.ts
@@ -64,7 +64,9 @@ describe("channel ingress monitor", () => {
     await withQueue(async (queue) => {
       const monitor = createMonitor(queue, vi.fn());
       monitor.start();
-      await monitor.admit({ id: "event-terminal", lane: "a", text: "ignored" });
+      await expect(
+        monitor.admit({ id: "event-terminal", lane: "a", text: "ignored" }),
+      ).resolves.toEqual({ kind: "durable" });
       await monitor.waitForIdle();
 
       await expect(

--- a/src/channels/message/ingress-monitor.ts
+++ b/src/channels/message/ingress-monitor.ts
@@ -1,5 +1,5 @@
 /** Shared durable channel-ingress admission, pump, retention, and shutdown lifecycle. */
-import { formatErrorMessage } from "../../infra/errors.js";
+import { formatErrorMessage, toErrorObject } from "../../infra/errors.js";
 import { sleep } from "../../utils/sleep.js";
 import {
   createChannelIngressDrain,
@@ -140,7 +140,37 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
   let pollTimer: ReturnType<typeof setInterval> | undefined;
   let lastPrunedAt = 0;
   let admissionTail: Promise<void> = Promise.resolve();
+  let admissionClaimLocked = false;
+  const admissionClaimWaiters: Array<() => void> = [];
   let stopTask: Promise<void> | undefined;
+
+  const withAdmissionClaimLock = <T>(task: () => Promise<T>): Promise<T> => {
+    const run = (): Promise<T> => {
+      admissionClaimLocked = true;
+      let result: Promise<T>;
+      try {
+        result = Promise.resolve(task());
+      } catch (error) {
+        result = Promise.reject(toErrorObject(error, "Channel ingress admission task failed"));
+      }
+      return result.finally(() => {
+        const next = admissionClaimWaiters.shift();
+        if (next) {
+          next();
+        } else {
+          admissionClaimLocked = false;
+        }
+      });
+    };
+    if (!admissionClaimLocked) {
+      return run();
+    }
+    return new Promise<T>((resolve, reject) => {
+      admissionClaimWaiters.push(() => {
+        void run().then(resolve, reject);
+      });
+    });
+  };
 
   const createStoppedError = () =>
     options.createStoppedError?.() ?? new Error("Channel ingress monitor is stopped.");
@@ -194,12 +224,13 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
           throw options.payload.createClaimError("invalid-version", claim);
         }
         const raw = options.payload.deserialize(decoded.body, { claim });
+        const claimedLaneKey = claim.laneKey ?? options.drain?.deriveLaneKey?.(claim);
         const facts = options.inspect(raw, {
           phase: "claim",
           claimedId: claim.id,
-          claimedLaneKey: claim.laneKey,
+          claimedLaneKey,
         });
-        if (!facts || facts.eventId !== claim.id || facts.laneKey !== claim.laneKey) {
+        if (!facts || facts.eventId !== claim.id || facts.laneKey !== claimedLaneKey) {
           throw options.payload.createClaimError("identity-mismatch", claim);
         }
 
@@ -287,13 +318,17 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
           break;
         }
         const activeDrain = getDrain();
-        const { started } = await activeDrain.drainOnce({
-          shouldStop: () =>
-            !running ||
-            isAborted() ||
-            (options.drain?.startLimit !== undefined &&
-              activeDeliveries.size >= options.drain.startLimit),
-        });
+        // Claiming and durable admission are mutually exclusive so a row cannot
+        // dispatch before its transport-owned post-append acknowledgement finishes.
+        const { started } = await withAdmissionClaimLock(() =>
+          activeDrain.drainOnce({
+            shouldStop: () =>
+              !running ||
+              isAborted() ||
+              (options.drain?.startLimit !== undefined &&
+                activeDeliveries.size >= options.drain.startLimit),
+          }),
+        );
         await waitForActiveDeliveries();
         await activeDrain.waitForIdle();
         if (!running || isAborted() || (!requested && started === 0)) {
@@ -345,7 +380,6 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
           receivedAt: params.receivedAt,
           laneKey: params.facts.laneKey,
         });
-        requestDrain();
         return;
       } catch (error) {
         lastError = error;
@@ -385,8 +419,27 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
         options.payload.storage === "raw-event"
           ? ({ version: options.payload.version, rawEvent: body } as TStoredPayload)
           : options.payload.encode({ version: options.payload.version, body });
-      // Append retries stay serialized so backoff cannot invert one lane's arrival order.
-      const admission = admissionTail.then(() => admitOnce({ facts, payload, receivedAt }));
+      // Append retries and transport-owned post-append work stay serialized so
+      // backoff or cursor/ack handling cannot invert arrival order.
+      const admission = admissionTail.then(() =>
+        withAdmissionClaimLock(async () => {
+          let durablyAdmitted = false;
+          try {
+            await admitOnce({ facts, payload, receivedAt });
+            durablyAdmitted = true;
+            await options.onDurableAdmission?.(raw, { facts, receivedAt });
+            return { kind: "durable" } as const;
+          } catch (error) {
+            await options.onAdmissionFailure?.(raw, error);
+            throw error;
+          } finally {
+            // A lost transport acknowledgement must not strand an already durable row.
+            if (durablyAdmitted) {
+              requestDrain();
+            }
+          }
+        }),
+      );
       admissionTail = admission.catch(() => undefined);
       await admission;
       return { kind: "durable" } as const;

--- a/src/channels/message/ingress-monitor.ts
+++ b/src/channels/message/ingress-monitor.ts
@@ -105,6 +105,11 @@ type CreateChannelIngressMonitorOptions<TRaw, TBody, TStoredPayload, TMetadata> 
   pollIntervalMs: number;
   retention: ChannelIngressMonitorRetention;
   appendRetryDelaysMs?: readonly number[];
+  onDurableAdmission?: (
+    raw: TRaw,
+    context: { facts: ChannelIngressMonitorFacts; receivedAt: number },
+  ) => void | Promise<void>;
+  onAdmissionFailure?: (raw: TRaw, error: unknown) => void | Promise<void>;
   drain?: ChannelIngressMonitorDrainOptions<TStoredPayload, TMetadata>;
   abortSignal?: AbortSignal;
   now?: () => number;
@@ -409,22 +414,20 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
       ) {
         throw createStoppedError();
       }
-      const facts = admitOptions?.facts ?? options.inspect(raw, { phase: "admission" });
-      if (!facts) {
-        return { kind: "ignored" } as const;
-      }
       const receivedAt = admitOptions?.receivedAt ?? now();
-      const body = options.payload.serialize(raw, { facts, receivedAt });
-      const payload =
-        options.payload.storage === "raw-event"
-          ? ({ version: options.payload.version, rawEvent: body } as TStoredPayload)
-          : options.payload.encode({ version: options.payload.version, body });
-      // Append retries and transport-owned post-append work stay serialized so
-      // backoff or cursor/ack handling cannot invert arrival order.
       const admission = admissionTail.then(() =>
         withAdmissionClaimLock(async () => {
           let durablyAdmitted = false;
           try {
+            const facts = admitOptions?.facts ?? options.inspect(raw, { phase: "admission" });
+            if (!facts) {
+              return { kind: "ignored" } as const;
+            }
+            const body = options.payload.serialize(raw, { facts, receivedAt });
+            const payload =
+              options.payload.storage === "raw-event"
+                ? ({ version: options.payload.version, rawEvent: body } as TStoredPayload)
+                : options.payload.encode({ version: options.payload.version, body });
             await admitOnce({ facts, payload, receivedAt });
             durablyAdmitted = true;
             await options.onDurableAdmission?.(raw, { facts, receivedAt });
@@ -440,9 +443,11 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
           }
         }),
       );
-      admissionTail = admission.catch(() => undefined);
-      await admission;
-      return { kind: "durable" } as const;
+      admissionTail = admission.then(
+        () => undefined,
+        () => undefined,
+      );
+      return await admission;
     },
     start: () => {
       if (running || stopped || isAborted()) {


### PR DESCRIPTION
## What Problem This Solves

Signal, Slack, Discord, iMessage, Twitch, and Tlon each carried local copies of the durable ingress admission, claim, retry, pruning, and shutdown machinery. Keeping those copies aligned made correctness fixes easy to miss across channels and left transport-specific behavior mixed into shared queue lifecycle code.

## Why This Change Was Made

This maintainer-requested batch migrates the shared lifecycle idioms onto `createChannelIngressMonitor` while retaining each channel's payload codec, delivery policy, retry classification, retention, and transport acknowledgement behavior. Signal keeps its debounce fan-out, and Twitch keeps its deferred-claim ownership and composed shutdown signal because those lifecycles are channel-specific; Slack's post-append acknowledgement ordering is protected by the shared admission/claim lock.

AI-assisted implementation; I reviewed the complete diff and understand the resulting ownership boundaries.

## User Impact

There is no intended user-visible behavior change. Durable ingress behavior is now implemented through one tested monitor path, reducing drift across these six channels while preserving their existing delivery and shutdown semantics.

## Evidence

- Post-rebase focused matrix: 10 test files across 6 Vitest shards, 244 tests passed.
- `pnpm deadcode:exports`: production, full-tree, and scripts scans passed with 0 entries.
- `pnpm deadcode:unused-files`: production and full-tree scans passed with 0 entries.
- Changed-files formatting gate passed; `git diff --check` passed.
- First exact-head CI lint findings were corrected; affected shared-helper and Twitch suites passed 15 tests.
- Final corrected branch autoreview: clean, no accepted/actionable findings (0.84 confidence).
- Diff: 13 files, 932 insertions, 1,032 deletions (net -100 lines).
