### PR TITLE
fix(matrix): cross-signing bootstrap dead-ends on MAS-fronted Synapse with misleading matrix.password error

### DIFF
--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -2516,6 +2516,36 @@ describe("MatrixClient crypto bootstrapping", () => {
     });
   });
 
+  it("does not force-reset bootstrap when cross-signing needs interactive approval", async () => {
+    matrixJsClient.getCrypto = vi.fn(() => ({ on: vi.fn() }));
+    const client = new MatrixClient("https://matrix.example.org", "token", {
+      encryption: true,
+    });
+    const bootstrapSpy = vi.fn().mockResolvedValue({
+      crossSigningReady: false,
+      crossSigningPublished: false,
+      ownDeviceVerified: null,
+      crossSigningApprovalRequired: {
+        guidance: "Open https://mas.example.org/account?action=org.matrix.cross_signing_reset",
+        resetUrl: "https://mas.example.org/account?action=org.matrix.cross_signing_reset",
+      },
+    });
+    await (
+      client as unknown as {
+        ensureCryptoSupportInitialized: () => Promise<void>;
+      }
+    ).ensureCryptoSupportInitialized();
+    (
+      client as unknown as {
+        cryptoBootstrapper: { bootstrap: typeof bootstrapSpy };
+      }
+    ).cryptoBootstrapper.bootstrap = bootstrapSpy;
+
+    await client.start();
+
+    expect(bootstrapSpy).toHaveBeenCalledTimes(1);
+  });
+
   it("does not force-reset bootstrap automatically when the device has an owner signature but not full trust", async () => {
     matrixJsClient.getCrypto = vi.fn(() => ({ on: vi.fn() }));
     const client = new MatrixClient("https://matrix.example.org", "token", {

--- a/extensions/matrix/src/matrix/sdk.ts
+++ b/extensions/matrix/src/matrix/sdk.ts
@@ -508,7 +508,9 @@ export class MatrixClient extends MatrixClientVerification {
             : params?.allowAutomaticCrossSigningReset,
         }),
       );
-      await this.ensureRoomKeyBackupEnabled(crypto);
+      if (!bootstrapSummary.crossSigningApprovalRequired) {
+        await this.ensureRoomKeyBackupEnabled(crypto);
+      }
     } catch (err) {
       this.recoveryKeyStore.discardStagedRecoveryKey();
       bootstrapError = formatErrorMessage(err);
@@ -519,7 +521,8 @@ export class MatrixClient extends MatrixClientVerification {
     const verificationError =
       verification.verified && crossSigning.published
         ? null
-        : (bootstrapError ??
+        : (bootstrapSummary?.crossSigningApprovalRequired?.guidance ??
+          bootstrapError ??
           "Matrix verification bootstrap did not produce a device verified by its owner with published cross-signing keys");
     const backupError =
       verificationError === null

--- a/extensions/matrix/src/matrix/sdk/client-base.ts
+++ b/extensions/matrix/src/matrix/sdk/client-base.ts
@@ -626,7 +626,13 @@ export abstract class MatrixClientBase {
       MATRIX_INITIAL_CRYPTO_BOOTSTRAP_OPTIONS,
     );
     throwIfMatrixStartupAborted(abortSignal);
-    if (!initial.crossSigningPublished || initial.ownDeviceVerified === false) {
+    if (initial.crossSigningApprovalRequired) {
+      LogService.warn(
+        "MatrixClientLite",
+        "Cross-signing needs interactive approval; skipping automatic reset.",
+        initial.crossSigningApprovalRequired.guidance,
+      );
+    } else if (!initial.crossSigningPublished || initial.ownDeviceVerified === false) {
       const status = await this.getOwnDeviceVerificationStatus();
       if (status.signedByOwner) {
         LogService.warn(

--- a/extensions/matrix/src/matrix/sdk/crypto-bootstrap.test-helpers.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-bootstrap.test-helpers.ts
@@ -1,0 +1,101 @@
+// Matrix helper module supports crypto bootstrap test harness behavior.
+import { expect, vi, type Mock } from "vitest";
+import { MatrixCryptoBootstrapper } from "./crypto-bootstrap.js";
+import type { MatrixRecoveryKeyStore } from "./recovery-key-store.js";
+import type { MatrixCryptoBootstrapApi, MatrixRawEvent } from "./types.js";
+
+export type MatrixCryptoBootstrapperDeps<TRawEvent extends MatrixRawEvent> = ConstructorParameters<
+  typeof MatrixCryptoBootstrapper<TRawEvent>
+>[0];
+
+export type BootstrapCrossSigningMock = Mock<MatrixCryptoBootstrapApi["bootstrapCrossSigning"]>;
+export type MockCallSource = { mock: { calls: Array<Array<unknown>> } };
+
+export function mockObjectArg(
+  source: MockCallSource,
+  label: string,
+  callIndex = 0,
+  argIndex = 0,
+): Record<string, unknown> {
+  const call = source.mock.calls[callIndex];
+  if (!call) {
+    throw new Error(`Expected ${label} call ${callIndex} to exist`);
+  }
+  const value = call[argIndex];
+  if (!value || typeof value !== "object") {
+    throw new Error(`Expected ${label} call ${callIndex} argument ${argIndex} to be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+export function expectBootstrapCrossSigningCall(
+  source: MockCallSource,
+  callNumber: number,
+  expected?: { setupNewCrossSigning?: boolean },
+) {
+  const options = mockObjectArg(source, "bootstrapCrossSigning", callNumber - 1);
+  expect(options.authUploadDeviceSigningKeys).toBeTypeOf("function");
+  if (expected && "setupNewCrossSigning" in expected) {
+    expect(options.setupNewCrossSigning).toBe(expected.setupNewCrossSigning);
+  }
+}
+
+export function createBootstrapperDeps() {
+  return {
+    getUserId: vi.fn(async () => "@bot:example.org"),
+    getPassword: vi.fn<() => string | undefined>(() => "super-secret-password"),
+    canUnlockSecretStorage: vi.fn(async () => true),
+    getDeviceId: vi.fn(() => "DEVICE123"),
+    verificationManager: {
+      trackVerificationRequest: vi.fn(),
+    },
+    recoveryKeyStore: {
+      bootstrapSecretStorageWithRecoveryKey: vi.fn<
+        MatrixRecoveryKeyStore["bootstrapSecretStorageWithRecoveryKey"]
+      >(async () => {}),
+    },
+    decryptBridge: {
+      bindCryptoRetrySignals: vi.fn(),
+    },
+  };
+}
+
+export function createCryptoApi(
+  overrides?: Partial<MatrixCryptoBootstrapApi>,
+): MatrixCryptoBootstrapApi {
+  return {
+    on: vi.fn(),
+    bootstrapCrossSigning: vi.fn(async () => {}),
+    bootstrapSecretStorage: vi.fn(async () => {}),
+    requestOwnUserVerification: vi.fn(async () => null),
+    ...overrides,
+  };
+}
+
+export function createVerifiedDeviceStatus(overrides?: {
+  localVerified?: boolean;
+  crossSigningVerified?: boolean;
+  signedByOwner?: boolean;
+}) {
+  return {
+    isVerified: () => true,
+    localVerified: overrides?.localVerified ?? true,
+    crossSigningVerified: overrides?.crossSigningVerified ?? true,
+    signedByOwner: overrides?.signedByOwner ?? true,
+  };
+}
+
+export function createBootstrapperHarness(
+  cryptoOverrides?: Partial<MatrixCryptoBootstrapApi>,
+  depsOverrides?: Partial<ReturnType<typeof createBootstrapperDeps>>,
+) {
+  const deps = {
+    ...createBootstrapperDeps(),
+    ...depsOverrides,
+  };
+  const crypto = createCryptoApi(cryptoOverrides);
+  const bootstrapper = new MatrixCryptoBootstrapper(
+    deps as unknown as MatrixCryptoBootstrapperDeps<MatrixRawEvent>,
+  );
+  return { deps, crypto, bootstrapper };
+}

--- a/extensions/matrix/src/matrix/sdk/crypto-bootstrap.test.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-bootstrap.test.ts
@@ -1,103 +1,18 @@
 // Matrix tests cover crypto bootstrap plugin behavior.
 import { expectDefined } from "@openclaw/normalization-core";
-import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MatrixCryptoBootstrapper } from "./crypto-bootstrap.js";
-import type { MatrixRecoveryKeyStore } from "./recovery-key-store.js";
+import {
+  createBootstrapperDeps,
+  createBootstrapperHarness,
+  createCryptoApi,
+  createVerifiedDeviceStatus,
+  expectBootstrapCrossSigningCall,
+  type BootstrapCrossSigningMock,
+  type MatrixCryptoBootstrapperDeps,
+  type MockCallSource,
+} from "./crypto-bootstrap.test-helpers.js";
 import type { MatrixCryptoBootstrapApi, MatrixRawEvent } from "./types.js";
-
-type MatrixCryptoBootstrapperDeps<TRawEvent extends MatrixRawEvent> = ConstructorParameters<
-  typeof MatrixCryptoBootstrapper<TRawEvent>
->[0];
-
-type BootstrapCrossSigningMock = Mock<MatrixCryptoBootstrapApi["bootstrapCrossSigning"]>;
-type MockCallSource = { mock: { calls: Array<Array<unknown>> } };
-
-function mockObjectArg(
-  source: MockCallSource,
-  label: string,
-  callIndex = 0,
-  argIndex = 0,
-): Record<string, unknown> {
-  const call = source.mock.calls[callIndex];
-  if (!call) {
-    throw new Error(`Expected ${label} call ${callIndex} to exist`);
-  }
-  const value = call[argIndex];
-  if (!value || typeof value !== "object") {
-    throw new Error(`Expected ${label} call ${callIndex} argument ${argIndex} to be an object`);
-  }
-  return value as Record<string, unknown>;
-}
-
-function expectBootstrapCrossSigningCall(
-  source: MockCallSource,
-  callNumber: number,
-  expected?: { setupNewCrossSigning?: boolean },
-) {
-  const options = mockObjectArg(source, "bootstrapCrossSigning", callNumber - 1);
-  expect(options.authUploadDeviceSigningKeys).toBeTypeOf("function");
-  if (expected && "setupNewCrossSigning" in expected) {
-    expect(options.setupNewCrossSigning).toBe(expected.setupNewCrossSigning);
-  }
-}
-
-function createBootstrapperDeps() {
-  return {
-    getUserId: vi.fn(async () => "@bot:example.org"),
-    getPassword: vi.fn<() => string | undefined>(() => "super-secret-password"),
-    canUnlockSecretStorage: vi.fn(async () => true),
-    getDeviceId: vi.fn(() => "DEVICE123"),
-    verificationManager: {
-      trackVerificationRequest: vi.fn(),
-    },
-    recoveryKeyStore: {
-      bootstrapSecretStorageWithRecoveryKey: vi.fn<
-        MatrixRecoveryKeyStore["bootstrapSecretStorageWithRecoveryKey"]
-      >(async () => {}),
-    },
-    decryptBridge: {
-      bindCryptoRetrySignals: vi.fn(),
-    },
-  };
-}
-
-function createCryptoApi(overrides?: Partial<MatrixCryptoBootstrapApi>): MatrixCryptoBootstrapApi {
-  return {
-    on: vi.fn(),
-    bootstrapCrossSigning: vi.fn(async () => {}),
-    bootstrapSecretStorage: vi.fn(async () => {}),
-    requestOwnUserVerification: vi.fn(async () => null),
-    ...overrides,
-  };
-}
-
-function createVerifiedDeviceStatus(overrides?: {
-  localVerified?: boolean;
-  crossSigningVerified?: boolean;
-  signedByOwner?: boolean;
-}) {
-  return {
-    isVerified: () => true,
-    localVerified: overrides?.localVerified ?? true,
-    crossSigningVerified: overrides?.crossSigningVerified ?? true,
-    signedByOwner: overrides?.signedByOwner ?? true,
-  };
-}
-
-function createBootstrapperHarness(
-  cryptoOverrides?: Partial<MatrixCryptoBootstrapApi>,
-  depsOverrides?: Partial<ReturnType<typeof createBootstrapperDeps>>,
-) {
-  const deps = {
-    ...createBootstrapperDeps(),
-    ...depsOverrides,
-  };
-  const crypto = createCryptoApi(cryptoOverrides);
-  const bootstrapper = new MatrixCryptoBootstrapper(
-    deps as unknown as MatrixCryptoBootstrapperDeps<MatrixRawEvent>,
-  );
-  return { deps, crypto, bootstrapper };
-}
 
 async function runExplicitSecretStorageRepairScenario(firstError: string) {
   const bootstrapCrossSigning = vi
@@ -371,50 +286,6 @@ describe("MatrixCryptoBootstrapper", () => {
     expectSecretStorageRepairRetry(deps, crypto, bootstrapCrossSigning);
   });
 
-  it("does not mutate secret storage before forced repair fails on password UIA without a password", async () => {
-    const deps = createBootstrapperDeps();
-    deps.getPassword = vi.fn<() => string | undefined>(() => undefined);
-    const bootstrapCrossSigning = vi.fn<
-      ({
-        authUploadDeviceSigningKeys,
-      }: {
-        authUploadDeviceSigningKeys?: <T>(
-          makeRequest: (authData: Record<string, unknown> | null) => Promise<T>,
-        ) => Promise<T>;
-      }) => Promise<void>
-    >(async ({ authUploadDeviceSigningKeys }) => {
-      await authUploadDeviceSigningKeys?.(async (authData) => {
-        if (authData === null) {
-          throw new Error("need auth");
-        }
-        if (authData.type === "m.login.dummy") {
-          throw new Error("dummy rejected");
-        }
-        return undefined;
-      });
-    });
-    const crypto = createCryptoApi({
-      bootstrapCrossSigning,
-      getDeviceVerificationStatus: vi.fn(async () => createVerifiedDeviceStatus()),
-    });
-    const bootstrapper = new MatrixCryptoBootstrapper(
-      deps as unknown as MatrixCryptoBootstrapperDeps<MatrixRawEvent>,
-    );
-
-    await expect(
-      bootstrapper.bootstrap(crypto, {
-        strict: true,
-        forceResetCrossSigning: true,
-        allowSecretStorageRecreateWithoutRecoveryKey: true,
-      }),
-    ).rejects.toThrow(
-      "Matrix cross-signing key upload requires UIA; provide matrix.password for m.login.password fallback",
-    );
-
-    expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).not.toHaveBeenCalled();
-    expect(bootstrapCrossSigning).toHaveBeenCalledTimes(1);
-  });
-
   it("rejects forced reset before mutation when the active recovery key is unavailable", async () => {
     const deps = createBootstrapperDeps();
     deps.canUnlockSecretStorage = vi.fn(async () => false);
@@ -560,59 +431,6 @@ describe("MatrixCryptoBootstrapper", () => {
     await expect(bootstrapper.bootstrap(crypto, { strict: true })).rejects.toThrow(
       "Cross-signing bootstrap finished but server keys are still not published",
     );
-  });
-
-  it("uses password UIA fallback when null and dummy auth fail", async () => {
-    const bootstrapCrossSigning = vi.fn(async () => {});
-    const { bootstrapper, crypto } = createBootstrapperHarness({
-      bootstrapCrossSigning,
-      isCrossSigningReady: vi.fn(async () => true),
-      userHasCrossSigningKeys: vi.fn(async () => true),
-      getDeviceVerificationStatus: vi.fn(async () => ({
-        isVerified: () => true,
-      })),
-    });
-
-    await bootstrapper.bootstrap(crypto);
-
-    const bootstrapCrossSigningCalls = bootstrapCrossSigning.mock.calls as Array<
-      [
-        {
-          authUploadDeviceSigningKeys?: <T>(
-            makeRequest: (authData: Record<string, unknown> | null) => Promise<T>,
-          ) => Promise<T>;
-        }?,
-      ]
-    >;
-    const authUploadDeviceSigningKeys =
-      bootstrapCrossSigningCalls[0]?.[0]?.authUploadDeviceSigningKeys;
-    expect(authUploadDeviceSigningKeys).toBeTypeOf("function");
-
-    const seenAuthStages: Array<Record<string, unknown> | null> = [];
-    const result = await authUploadDeviceSigningKeys?.(async (authData) => {
-      seenAuthStages.push(authData);
-      if (authData === null) {
-        throw new Error("need auth");
-      }
-      if (authData.type === "m.login.dummy") {
-        throw new Error("dummy rejected");
-      }
-      if (authData.type === "m.login.password") {
-        return "ok";
-      }
-      throw new Error("unexpected auth stage");
-    });
-
-    expect(result).toBe("ok");
-    expect(seenAuthStages).toEqual([
-      null,
-      { type: "m.login.dummy" },
-      {
-        type: "m.login.password",
-        identifier: { type: "m.id.user", user: "@bot:example.org" },
-        password: "super-secret-password", // pragma: allowlist secret
-      },
-    ]);
   });
 
   it("resets cross-signing when first bootstrap attempt throws", async () => {

--- a/extensions/matrix/src/matrix/sdk/crypto-bootstrap.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-bootstrap.ts
@@ -10,6 +10,7 @@ import type {
   MatrixCryptoBootstrapApi,
   MatrixRawEvent,
   MatrixUiAuthCallback,
+  MatrixUiaResponseBody,
 } from "./types.js";
 import type {
   MatrixVerificationManager,
@@ -41,6 +42,120 @@ export type MatrixCryptoBootstrapResult = {
 };
 
 const CROSS_SIGNING_PUBLICATION_WAIT_MS = 5_000;
+
+const INTERACTIVE_RESET_UIA_STAGES = new Set(["org.matrix.cross_signing_reset", "m.oauth"]);
+
+type CrossSigningBootstrapOptions = {
+  forceResetCrossSigning: boolean;
+  allowAutomaticCrossSigningReset: boolean;
+  allowSecretStorageRecreateWithoutRecoveryKey: boolean;
+  strict: boolean;
+};
+
+type MatrixUiaChallenge = { httpStatus: number; data: MatrixUiaResponseBody };
+
+function asUiaChallenge(err: unknown): MatrixUiaChallenge | null {
+  if (!err || typeof err !== "object") {
+    return null;
+  }
+  const candidate = err as { httpStatus?: unknown; data?: { flows?: unknown } };
+  if (candidate.httpStatus !== 401 || !Array.isArray(candidate.data?.flows)) {
+    return null;
+  }
+  return candidate as MatrixUiaChallenge;
+}
+
+function collectUiaStages(body: MatrixUiaResponseBody): string[] {
+  const stages: string[] = [];
+  for (const flow of body.flows ?? []) {
+    for (const stage of flow?.stages ?? []) {
+      if (typeof stage === "string" && !stages.includes(stage)) {
+        stages.push(stage);
+      }
+    }
+  }
+  return stages;
+}
+
+function completedUiaStages(body: MatrixUiaResponseBody): Set<string> {
+  const completed = new Set<string>();
+  for (const stage of body.completed ?? []) {
+    if (typeof stage === "string") {
+      completed.add(stage);
+    }
+  }
+  return completed;
+}
+
+function uiaSession(body: MatrixUiaResponseBody): string | undefined {
+  return typeof body.session === "string" && body.session ? body.session : undefined;
+}
+
+function selectNextSupportedUiaStage(
+  body: MatrixUiaResponseBody,
+  opts: { hasPassword: boolean },
+): string | undefined {
+  const completed = completedUiaStages(body);
+  const supported = (stage: string): boolean =>
+    stage === "m.login.dummy" || (stage === "m.login.password" && opts.hasPassword);
+  let fallback: string | undefined;
+  for (const flow of body.flows ?? []) {
+    const stages = (flow?.stages ?? []).filter((stage): stage is string => {
+      return typeof stage === "string";
+    });
+    const remaining = stages.filter((stage) => !completed.has(stage));
+    if (remaining.length === 0) {
+      continue;
+    }
+    if (remaining.every((stage) => stage === "m.login.dummy")) {
+      return remaining[0];
+    }
+    if (fallback === undefined && remaining.every(supported)) {
+      fallback = remaining[0];
+    }
+  }
+  return fallback;
+}
+
+function extractUiaStageUrl(body: MatrixUiaResponseBody, stage: string): string | undefined {
+  const params = body.params?.[stage];
+  const url = params && typeof params.url === "string" ? params.url.trim() : "";
+  return url || undefined;
+}
+
+class MatrixCrossSigningResetRequiredError extends Error {
+  readonly stages: string[];
+  readonly resetUrl?: string;
+  readonly session?: string;
+
+  constructor(opts: { stages: string[]; resetUrl?: string; session?: string }) {
+    const resetUrl = opts.resetUrl?.trim() || undefined;
+    super(
+      resetUrl
+        ? `Matrix cross-signing key upload requires interactive approval from the homeserver auth service. Open ${resetUrl} in a browser as the bot user, approve the cross-signing reset, then re-run the bootstrap while the approval is fresh.`
+        : "Matrix cross-signing key upload requires interactive approval from the homeserver auth service, but no approval URL was advertised. Reset the user's server-side cross-signing keys with homeserver admin tooling, then re-run the bootstrap.",
+    );
+    this.name = "MatrixCrossSigningResetRequiredError";
+    this.stages = opts.stages;
+    this.resetUrl = resetUrl;
+    this.session = opts.session;
+  }
+}
+
+class MatrixUiaUnsupportedStagesError extends Error {
+  readonly stages: string[];
+
+  constructor(opts: { stages: string[]; hasPassword: boolean }) {
+    const stageList = opts.stages.length > 0 ? opts.stages.join(", ") : "none advertised";
+    super(
+      `Matrix cross-signing key upload requires UIA stages this client cannot satisfy non-interactively: ${stageList}.${
+        opts.hasPassword ? "" : " Set matrix.password to enable the m.login.password fallback."
+      }`,
+    );
+    this.name = "MatrixUiaUnsupportedStagesError";
+    this.stages = opts.stages;
+  }
+}
 
 export class MatrixCryptoBootstrapper<TRawEvent extends MatrixRawEvent> {
   private verificationHandlerRegistered = false;
@@ -112,23 +227,54 @@ export class MatrixCryptoBootstrapper<TRawEvent extends MatrixRawEvent> {
     password?: string;
   }): MatrixUiAuthCallback {
     return async <T>(makeRequest: (authData: MatrixAuthDict | null) => Promise<T>): Promise<T> => {
+      let challenge: MatrixUiaChallenge;
       try {
         return await makeRequest(null);
-      } catch {
-        // Some homeservers require an explicit dummy UIA stage even when no user interaction is needed.
-        try {
-          return await makeRequest({ type: "m.login.dummy" });
-        } catch {
-          if (!params.password?.trim()) {
-            throw new Error(
-              "Matrix cross-signing key upload requires UIA; provide matrix.password for m.login.password fallback",
-            );
+      } catch (err) {
+        const parsed = asUiaChallenge(err);
+        if (!parsed) {
+          throw err;
+        }
+        challenge = parsed;
+      }
+      const password = params.password?.trim();
+      for (;;) {
+        const nextStage = selectNextSupportedUiaStage(challenge.data, {
+          hasPassword: Boolean(password),
+        });
+        if (!nextStage) {
+          const stages = collectUiaStages(challenge.data);
+          const session = uiaSession(challenge.data);
+          const resetStage = stages.find((stage) => INTERACTIVE_RESET_UIA_STAGES.has(stage));
+          if (resetStage) {
+            throw new MatrixCrossSigningResetRequiredError({
+              stages,
+              resetUrl: extractUiaStageUrl(challenge.data, resetStage),
+              session,
+            });
           }
-          return await makeRequest({
-            type: "m.login.password",
-            identifier: { type: "m.id.user", user: params.userId },
-            password: params.password,
-          });
+          throw new MatrixUiaUnsupportedStagesError({ stages, hasPassword: Boolean(password) });
+        }
+        const session = uiaSession(challenge.data);
+        const authData: MatrixAuthDict =
+          nextStage === "m.login.password" && password
+            ? {
+                type: "m.login.password",
+                identifier: { type: "m.id.user", user: params.userId },
+                password,
+              }
+            : { type: "m.login.dummy" };
+        try {
+          return await makeRequest(session ? { ...authData, session } : authData);
+        } catch (err) {
+          const parsed = asUiaChallenge(err);
+          if (!parsed) {
+            throw err;
+          }
+          if (completedUiaStages(parsed.data).size <= completedUiaStages(challenge.data).size) {
+            throw err;
+          }
+          challenge = parsed;
         }
       }
     };
@@ -136,12 +282,29 @@ export class MatrixCryptoBootstrapper<TRawEvent extends MatrixRawEvent> {
 
   private async bootstrapCrossSigning(
     crypto: MatrixCryptoBootstrapApi,
-    options: {
-      forceResetCrossSigning: boolean;
-      allowAutomaticCrossSigningReset: boolean;
-      allowSecretStorageRecreateWithoutRecoveryKey: boolean;
-      strict: boolean;
-    },
+    options: CrossSigningBootstrapOptions,
+  ): Promise<{ ready: boolean; published: boolean }> {
+    try {
+      return await this.runCrossSigningBootstrap(crypto, options);
+    } catch (err) {
+      if (err instanceof MatrixCrossSigningResetRequiredError) {
+        LogService.warn(
+          "MatrixClientLite",
+          "Cross-signing bootstrap needs interactive approval:",
+          err.message,
+        );
+        if (options.strict) {
+          throw err;
+        }
+        return { ready: false, published: false };
+      }
+      throw err;
+    }
+  }
+
+  private async runCrossSigningBootstrap(
+    crypto: MatrixCryptoBootstrapApi,
+    options: CrossSigningBootstrapOptions,
   ): Promise<{ ready: boolean; published: boolean }> {
     const userId = await this.deps.getUserId();
     const authUploadDeviceSigningKeys = this.createSigningKeysUiAuthCallback({
@@ -218,6 +381,9 @@ export class MatrixCryptoBootstrapper<TRawEvent extends MatrixRawEvent> {
         await resetCrossSigning();
         await this.trustFreshOwnIdentity(crypto);
       } catch (err) {
+        if (err instanceof MatrixCrossSigningResetRequiredError) {
+          throw err;
+        }
         const shouldRepairSecretStorage =
           options.allowSecretStorageRecreateWithoutRecoveryKey &&
           isRepairableSecretStorageAccessError(err);
@@ -234,6 +400,9 @@ export class MatrixCryptoBootstrapper<TRawEvent extends MatrixRawEvent> {
             await resetCrossSigning();
             await this.trustFreshOwnIdentity(crypto);
           } catch (repairErr) {
+            if (repairErr instanceof MatrixCrossSigningResetRequiredError) {
+              throw repairErr;
+            }
             LogService.warn("MatrixClientLite", "Forced cross-signing reset failed:", repairErr);
             if (options.strict) {
               throw repairErr instanceof Error ? repairErr : new Error(String(repairErr));
@@ -264,6 +433,9 @@ export class MatrixCryptoBootstrapper<TRawEvent extends MatrixRawEvent> {
         authUploadDeviceSigningKeys,
       });
     } catch (err) {
+      if (err instanceof MatrixCrossSigningResetRequiredError) {
+        throw err;
+      }
       const shouldRepairSecretStorage =
         options.allowSecretStorageRecreateWithoutRecoveryKey &&
         isRepairableSecretStorageAccessError(err);
@@ -298,6 +470,9 @@ export class MatrixCryptoBootstrapper<TRawEvent extends MatrixRawEvent> {
             authUploadDeviceSigningKeys,
           });
         } catch (resetErr) {
+          if (resetErr instanceof MatrixCrossSigningResetRequiredError) {
+            throw resetErr;
+          }
           LogService.warn("MatrixClientLite", "Failed to bootstrap cross-signing:", resetErr);
           if (options.strict) {
             throw resetErr instanceof Error ? resetErr : new Error(String(resetErr));
@@ -326,6 +501,9 @@ export class MatrixCryptoBootstrapper<TRawEvent extends MatrixRawEvent> {
       });
       await this.trustFreshOwnIdentity(crypto);
     } catch (err) {
+      if (err instanceof MatrixCrossSigningResetRequiredError) {
+        throw err;
+      }
       LogService.warn("MatrixClientLite", "Fallback cross-signing bootstrap failed:", err);
       if (options.strict) {
         throw err instanceof Error ? err : new Error(String(err));

--- a/extensions/matrix/src/matrix/sdk/crypto-bootstrap.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-bootstrap.ts
@@ -35,15 +35,27 @@ export type MatrixCryptoBootstrapOptions = {
   strict?: boolean;
 };
 
+type MatrixCrossSigningApprovalRequired = {
+  guidance: string;
+  resetUrl?: string;
+};
+
 export type MatrixCryptoBootstrapResult = {
   crossSigningReady: boolean;
   crossSigningPublished: boolean;
   ownDeviceVerified: boolean | null;
+  crossSigningApprovalRequired?: MatrixCrossSigningApprovalRequired;
 };
 
 const CROSS_SIGNING_PUBLICATION_WAIT_MS = 5_000;
 
 const INTERACTIVE_RESET_UIA_STAGES = new Set(["org.matrix.cross_signing_reset", "m.oauth"]);
+
+type CrossSigningBootstrapOutcome = {
+  ready: boolean;
+  published: boolean;
+  approvalRequired?: MatrixCrossSigningApprovalRequired;
+};
 
 type CrossSigningBootstrapOptions = {
   forceResetCrossSigning: boolean;
@@ -197,11 +209,15 @@ export class MatrixCryptoBootstrapper<TRawEvent extends MatrixRawEvent> {
       strict,
     });
 
-    if (forceReset && (!crossSigning.ready || !crossSigning.published)) {
+    if (
+      crossSigning.approvalRequired ||
+      (forceReset && !(crossSigning.ready && crossSigning.published))
+    ) {
       return {
         crossSigningReady: crossSigning.ready,
         crossSigningPublished: crossSigning.published,
         ownDeviceVerified: null,
+        crossSigningApprovalRequired: crossSigning.approvalRequired,
       };
     }
 
@@ -283,7 +299,7 @@ export class MatrixCryptoBootstrapper<TRawEvent extends MatrixRawEvent> {
   private async bootstrapCrossSigning(
     crypto: MatrixCryptoBootstrapApi,
     options: CrossSigningBootstrapOptions,
-  ): Promise<{ ready: boolean; published: boolean }> {
+  ): Promise<CrossSigningBootstrapOutcome> {
     try {
       return await this.runCrossSigningBootstrap(crypto, options);
     } catch (err) {
@@ -293,10 +309,11 @@ export class MatrixCryptoBootstrapper<TRawEvent extends MatrixRawEvent> {
           "Cross-signing bootstrap needs interactive approval:",
           err.message,
         );
-        if (options.strict) {
-          throw err;
-        }
-        return { ready: false, published: false };
+        return {
+          ready: false,
+          published: false,
+          approvalRequired: { guidance: err.message, resetUrl: err.resetUrl },
+        };
       }
       throw err;
     }
@@ -305,7 +322,7 @@ export class MatrixCryptoBootstrapper<TRawEvent extends MatrixRawEvent> {
   private async runCrossSigningBootstrap(
     crypto: MatrixCryptoBootstrapApi,
     options: CrossSigningBootstrapOptions,
-  ): Promise<{ ready: boolean; published: boolean }> {
+  ): Promise<CrossSigningBootstrapOutcome> {
     const userId = await this.deps.getUserId();
     const authUploadDeviceSigningKeys = this.createSigningKeysUiAuthCallback({
       userId,

--- a/extensions/matrix/src/matrix/sdk/crypto-bootstrap.uia.test.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-bootstrap.uia.test.ts
@@ -1,0 +1,502 @@
+// Matrix tests cover crypto bootstrap UIA challenge routing behavior.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MatrixCryptoBootstrapper } from "./crypto-bootstrap.js";
+import {
+  createBootstrapperDeps,
+  createBootstrapperHarness,
+  createCryptoApi,
+  createVerifiedDeviceStatus,
+  expectBootstrapCrossSigningCall,
+  mockObjectArg,
+  type MatrixCryptoBootstrapperDeps,
+} from "./crypto-bootstrap.test-helpers.js";
+import type { MatrixRawEvent, MatrixUiaResponseBody } from "./types.js";
+
+function uiaChallengeError(body: MatrixUiaResponseBody) {
+  const err = new Error("Auth required") as Error & {
+    httpStatus: number;
+    data: MatrixUiaResponseBody;
+  };
+  err.httpStatus = 401;
+  err.data = body;
+  return err;
+}
+
+function expectResetRequiredError(
+  caught: unknown,
+): Error & { resetUrl?: string; session?: string; stages: string[] } {
+  expect(caught).toBeInstanceOf(Error);
+  expect((caught as Error).name).toBe("MatrixCrossSigningResetRequiredError");
+  return caught as Error & { resetUrl?: string; session?: string; stages: string[] };
+}
+
+type UiAuthCallback = <T>(
+  makeRequest: (authData: Record<string, unknown> | null) => Promise<T>,
+) => Promise<T>;
+
+async function createUiAuthCallbackHarness(opts?: { password: string | undefined }) {
+  const bootstrapCrossSigning = vi.fn(async () => {});
+  const { bootstrapper, crypto } = createBootstrapperHarness(
+    {
+      bootstrapCrossSigning,
+      isCrossSigningReady: vi.fn(async () => true),
+      userHasCrossSigningKeys: vi.fn(async () => true),
+      getDeviceVerificationStatus: vi.fn(async () => createVerifiedDeviceStatus()),
+    },
+    opts ? { getPassword: vi.fn<() => string | undefined>(() => opts.password) } : undefined,
+  );
+
+  await bootstrapper.bootstrap(crypto);
+
+  const authUploadDeviceSigningKeys = mockObjectArg(bootstrapCrossSigning, "bootstrapCrossSigning")
+    .authUploadDeviceSigningKeys as UiAuthCallback;
+  expect(authUploadDeviceSigningKeys).toBeTypeOf("function");
+  return { authUploadDeviceSigningKeys };
+}
+
+describe("MatrixCryptoBootstrapper UIA", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not mutate secret storage before forced repair fails on password UIA without a password", async () => {
+    const deps = createBootstrapperDeps();
+    deps.getPassword = vi.fn<() => string | undefined>(() => undefined);
+    const bootstrapCrossSigning = vi.fn<
+      ({
+        authUploadDeviceSigningKeys,
+      }: {
+        authUploadDeviceSigningKeys?: <T>(
+          makeRequest: (authData: Record<string, unknown> | null) => Promise<T>,
+        ) => Promise<T>;
+      }) => Promise<void>
+    >(async ({ authUploadDeviceSigningKeys }) => {
+      await authUploadDeviceSigningKeys?.(async (authData) => {
+        if (authData === null) {
+          throw uiaChallengeError({
+            flows: [{ stages: ["m.login.password"] }],
+            session: "sess-pw",
+          });
+        }
+        return undefined;
+      });
+    });
+    const crypto = createCryptoApi({
+      bootstrapCrossSigning,
+      getDeviceVerificationStatus: vi.fn(async () => createVerifiedDeviceStatus()),
+    });
+    const bootstrapper = new MatrixCryptoBootstrapper(
+      deps as unknown as MatrixCryptoBootstrapperDeps<MatrixRawEvent>,
+    );
+
+    await expect(
+      bootstrapper.bootstrap(crypto, {
+        strict: true,
+        forceResetCrossSigning: true,
+        allowSecretStorageRecreateWithoutRecoveryKey: true,
+      }),
+    ).rejects.toThrow(
+      "Matrix cross-signing key upload requires UIA stages this client cannot satisfy non-interactively: m.login.password. Set matrix.password to enable the m.login.password fallback.",
+    );
+
+    expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).not.toHaveBeenCalled();
+    expect(bootstrapCrossSigning).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses password UIA fallback when the homeserver advertises m.login.password", async () => {
+    const { authUploadDeviceSigningKeys } = await createUiAuthCallbackHarness();
+
+    const seenAuthStages: Array<Record<string, unknown> | null> = [];
+    const result = await authUploadDeviceSigningKeys(async (authData) => {
+      seenAuthStages.push(authData);
+      if (authData === null) {
+        throw uiaChallengeError({
+          flows: [{ stages: ["m.login.password"] }],
+          session: "sess-pw",
+        });
+      }
+      if (authData.type === "m.login.password") {
+        return "ok";
+      }
+      throw new Error("unexpected auth stage");
+    });
+
+    expect(result).toBe("ok");
+    expect(seenAuthStages).toEqual([
+      null,
+      {
+        type: "m.login.password",
+        identifier: { type: "m.id.user", user: "@bot:example.org" },
+        password: "super-secret-password", // pragma: allowlist secret
+        session: "sess-pw",
+      },
+    ]);
+  });
+
+  it("routes to the advertised dummy stage and threads the UIA session token", async () => {
+    const { authUploadDeviceSigningKeys } = await createUiAuthCallbackHarness();
+
+    const seenAuthStages: Array<Record<string, unknown> | null> = [];
+    const result = await authUploadDeviceSigningKeys(async (authData) => {
+      seenAuthStages.push(authData);
+      if (authData === null) {
+        throw uiaChallengeError({
+          flows: [{ stages: ["m.login.dummy"] }, { stages: ["m.login.password"] }],
+          session: "sess-dummy",
+        });
+      }
+      if (authData.type === "m.login.dummy") {
+        return "ok";
+      }
+      throw new Error("unexpected auth stage");
+    });
+
+    expect(result).toBe("ok");
+    expect(seenAuthStages).toEqual([null, { type: "m.login.dummy", session: "sess-dummy" }]);
+  });
+
+  it("completes the advertised dummy flow instead of raising reset guidance on a mixed challenge", async () => {
+    const { authUploadDeviceSigningKeys } = await createUiAuthCallbackHarness();
+
+    const seenAuthStages: Array<Record<string, unknown> | null> = [];
+    const result = await authUploadDeviceSigningKeys(async (authData) => {
+      seenAuthStages.push(authData);
+      if (authData === null) {
+        throw uiaChallengeError({
+          flows: [{ stages: ["org.matrix.cross_signing_reset"] }, { stages: ["m.login.dummy"] }],
+          session: "sess-mixed",
+          params: {
+            "org.matrix.cross_signing_reset": { url: "https://mas.example.org/account/" },
+          },
+        });
+      }
+      if (authData.type === "m.login.dummy") {
+        return "ok";
+      }
+      throw new Error("unexpected auth stage");
+    });
+
+    expect(result).toBe("ok");
+    expect(seenAuthStages).toEqual([null, { type: "m.login.dummy", session: "sess-mixed" }]);
+  });
+
+  it("completes the advertised password flow when the reset flow is only an alternative", async () => {
+    const { authUploadDeviceSigningKeys } = await createUiAuthCallbackHarness();
+
+    const seenAuthStages: Array<Record<string, unknown> | null> = [];
+    const result = await authUploadDeviceSigningKeys(async (authData) => {
+      seenAuthStages.push(authData);
+      if (authData === null) {
+        throw uiaChallengeError({
+          flows: [{ stages: ["org.matrix.cross_signing_reset"] }, { stages: ["m.login.password"] }],
+          session: "sess-mixed-pw",
+        });
+      }
+      if (authData.type === "m.login.password") {
+        return "ok";
+      }
+      throw new Error("unexpected auth stage");
+    });
+
+    expect(result).toBe("ok");
+    expect(seenAuthStages).toEqual([
+      null,
+      {
+        type: "m.login.password",
+        identifier: { type: "m.id.user", user: "@bot:example.org" },
+        password: "super-secret-password", // pragma: allowlist secret
+        session: "sess-mixed-pw",
+      },
+    ]);
+  });
+
+  it("raises reset guidance on a mixed challenge only when the alternative flow needs an unavailable password", async () => {
+    const masUrl = "https://mas.example.org/account/cross_signing_reset?token=mixed";
+    const { authUploadDeviceSigningKeys } = await createUiAuthCallbackHarness({
+      password: undefined,
+    });
+
+    let caught: unknown;
+    try {
+      await authUploadDeviceSigningKeys(async (authData) => {
+        if (authData === null) {
+          throw uiaChallengeError({
+            flows: [
+              { stages: ["org.matrix.cross_signing_reset"] },
+              { stages: ["m.login.password"] },
+            ],
+            session: "sess-mixed-reset",
+            params: { "org.matrix.cross_signing_reset": { url: masUrl } },
+          });
+        }
+        return "unexpected";
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    const resetErr = expectResetRequiredError(caught);
+    expect(resetErr.resetUrl).toBe(masUrl);
+    expect(resetErr.session).toBe("sess-mixed-reset");
+  });
+
+  it("completes a multi-stage flow by following the server's completed progress", async () => {
+    const { authUploadDeviceSigningKeys } = await createUiAuthCallbackHarness();
+
+    const seenAuthStages: Array<Record<string, unknown> | null> = [];
+    const result = await authUploadDeviceSigningKeys(async (authData) => {
+      seenAuthStages.push(authData);
+      if (authData === null) {
+        throw uiaChallengeError({
+          flows: [{ stages: ["m.login.password", "m.login.dummy"] }],
+          session: "sess-multi",
+        });
+      }
+      if (authData.type === "m.login.password") {
+        throw uiaChallengeError({
+          flows: [{ stages: ["m.login.password", "m.login.dummy"] }],
+          completed: ["m.login.password"],
+          session: "sess-multi",
+        });
+      }
+      if (authData.type === "m.login.dummy") {
+        return "ok";
+      }
+      throw new Error("unexpected auth stage");
+    });
+
+    expect(result).toBe("ok");
+    expect(seenAuthStages).toEqual([
+      null,
+      {
+        type: "m.login.password",
+        identifier: { type: "m.id.user", user: "@bot:example.org" },
+        password: "super-secret-password", // pragma: allowlist secret
+        session: "sess-multi",
+      },
+      { type: "m.login.dummy", session: "sess-multi" },
+    ]);
+  });
+
+  it("surfaces the server rejection when a submitted stage does not advance the flow", async () => {
+    const { authUploadDeviceSigningKeys } = await createUiAuthCallbackHarness();
+
+    let attempts = 0;
+    await expect(
+      authUploadDeviceSigningKeys(async (authData) => {
+        attempts += 1;
+        if (authData === null) {
+          throw uiaChallengeError({
+            flows: [{ stages: ["m.login.password"] }],
+            session: "sess-rejected",
+          });
+        }
+        const rejection = uiaChallengeError({
+          flows: [{ stages: ["m.login.password"] }],
+          session: "sess-rejected",
+        });
+        rejection.message = "Invalid password";
+        throw rejection;
+      }),
+    ).rejects.toThrow("Invalid password");
+
+    expect(attempts).toBe(2);
+  });
+
+  it("rethrows non-UIA upload failures instead of suggesting matrix.password", async () => {
+    const { authUploadDeviceSigningKeys } = await createUiAuthCallbackHarness();
+
+    await expect(
+      authUploadDeviceSigningKeys(async () => {
+        throw new Error("network unreachable");
+      }),
+    ).rejects.toThrow("network unreachable");
+  });
+
+  it("surfaces the MAS reset URL instead of the misleading password hint", async () => {
+    const masUrl = "https://mas.example.org/account/cross_signing_reset?token=abc";
+    const deps = createBootstrapperDeps();
+    deps.getPassword = vi.fn<() => string | undefined>(() => undefined);
+    const bootstrapCrossSigning = vi.fn<
+      ({
+        authUploadDeviceSigningKeys,
+      }: {
+        authUploadDeviceSigningKeys?: <T>(
+          makeRequest: (authData: Record<string, unknown> | null) => Promise<T>,
+        ) => Promise<T>;
+      }) => Promise<void>
+    >(async ({ authUploadDeviceSigningKeys }) => {
+      await authUploadDeviceSigningKeys?.(async (authData) => {
+        if (authData === null) {
+          throw uiaChallengeError({
+            flows: [{ stages: ["org.matrix.cross_signing_reset"] }],
+            session: "sess-mas",
+            params: { "org.matrix.cross_signing_reset": { url: masUrl } },
+          });
+        }
+        return undefined;
+      });
+    });
+    const crypto = createCryptoApi({
+      bootstrapCrossSigning,
+      getDeviceVerificationStatus: vi.fn(async () => createVerifiedDeviceStatus()),
+    });
+    const bootstrapper = new MatrixCryptoBootstrapper(
+      deps as unknown as MatrixCryptoBootstrapperDeps<MatrixRawEvent>,
+    );
+
+    let caught: unknown;
+    try {
+      await bootstrapper.bootstrap(crypto, {
+        strict: true,
+        forceResetCrossSigning: true,
+        allowSecretStorageRecreateWithoutRecoveryKey: true,
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    const resetErr = expectResetRequiredError(caught);
+    expect(resetErr.resetUrl).toBe(masUrl);
+    expect(resetErr.session).toBe("sess-mas");
+    expect(resetErr.stages).toContain("org.matrix.cross_signing_reset");
+    expect(resetErr.message).toContain(masUrl);
+    expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the m.oauth reset stage with its advertised URL", async () => {
+    const oauthUrl = "https://mas.example.org/account/?action=org.matrix.cross_signing_reset";
+    const bootstrapCrossSigning = vi.fn<
+      ({
+        authUploadDeviceSigningKeys,
+      }: {
+        authUploadDeviceSigningKeys?: <T>(
+          makeRequest: (authData: Record<string, unknown> | null) => Promise<T>,
+        ) => Promise<T>;
+      }) => Promise<void>
+    >(async ({ authUploadDeviceSigningKeys }) => {
+      await authUploadDeviceSigningKeys?.(async (authData) => {
+        if (authData === null) {
+          throw uiaChallengeError({
+            flows: [{ stages: ["m.oauth"] }],
+            session: "sess-oauth",
+            params: { "m.oauth": { url: oauthUrl } },
+          });
+        }
+        return undefined;
+      });
+    });
+    const { bootstrapper, crypto } = createBootstrapperHarness({
+      bootstrapCrossSigning,
+      getDeviceVerificationStatus: vi.fn(async () => createVerifiedDeviceStatus()),
+    });
+
+    let caught: unknown;
+    try {
+      await bootstrapper.bootstrap(crypto, { strict: true });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(expectResetRequiredError(caught).resetUrl).toBe(oauthUrl);
+  });
+
+  it("does not retry with a fresh-identity reset after the MAS reset stage rejects the upload", async () => {
+    const bootstrapCrossSigning = vi.fn<
+      ({
+        authUploadDeviceSigningKeys,
+      }: {
+        setupNewCrossSigning?: boolean;
+        authUploadDeviceSigningKeys?: <T>(
+          makeRequest: (authData: Record<string, unknown> | null) => Promise<T>,
+        ) => Promise<T>;
+      }) => Promise<void>
+    >(async ({ authUploadDeviceSigningKeys }) => {
+      await authUploadDeviceSigningKeys?.(async (authData) => {
+        if (authData === null) {
+          throw uiaChallengeError({
+            flows: [{ stages: ["org.matrix.cross_signing_reset"] }],
+            session: "sess-mas",
+          });
+        }
+        return undefined;
+      });
+    });
+    const { bootstrapper, crypto } = createBootstrapperHarness({
+      bootstrapCrossSigning,
+      isCrossSigningReady: vi.fn(async () => false),
+      userHasCrossSigningKeys: vi.fn(async () => false),
+      getDeviceVerificationStatus: vi.fn(async () => createVerifiedDeviceStatus()),
+    });
+
+    const result = await bootstrapper.bootstrap(crypto);
+
+    expect(result.crossSigningPublished).toBe(false);
+    expect(bootstrapCrossSigning).toHaveBeenCalledTimes(1);
+    expect(
+      mockObjectArg(bootstrapCrossSigning, "bootstrapCrossSigning").setupNewCrossSigning,
+    ).not.toBe(true);
+  });
+
+  it("attempts the reset upload after an import-key mismatch so a fresh MAS approval can land", async () => {
+    const masUrl = "https://mas.example.org/account/cross_signing_reset?token=xyz";
+    const bootstrapCrossSigning = vi
+      .fn<
+        ({
+          authUploadDeviceSigningKeys,
+        }: {
+          setupNewCrossSigning?: boolean;
+          authUploadDeviceSigningKeys?: <T>(
+            makeRequest: (authData: Record<string, unknown> | null) => Promise<T>,
+          ) => Promise<T>;
+        }) => Promise<void>
+      >()
+      .mockImplementationOnce(async () => {
+        throw new Error(
+          "Error while importing m.cross_signing.master: The public key of the imported private key doesn't match the public key that was uploaded to the server",
+        );
+      })
+      .mockImplementationOnce(async ({ authUploadDeviceSigningKeys }) => {
+        await authUploadDeviceSigningKeys?.(async (authData) => {
+          if (authData === null) {
+            throw uiaChallengeError({
+              flows: [{ stages: ["org.matrix.cross_signing_reset"] }],
+              session: "sess-mas",
+              params: { "org.matrix.cross_signing_reset": { url: masUrl } },
+            });
+          }
+          return undefined;
+        });
+      });
+    const { bootstrapper, crypto } = createBootstrapperHarness({
+      bootstrapCrossSigning,
+      isCrossSigningReady: vi.fn(async () => false),
+      userHasCrossSigningKeys: vi.fn(async () => true),
+      getDeviceVerificationStatus: vi.fn(async () => createVerifiedDeviceStatus()),
+    });
+
+    let caught: unknown;
+    try {
+      await bootstrapper.bootstrap(crypto, { strict: true });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(expectResetRequiredError(caught).resetUrl).toBe(masUrl);
+    expect(bootstrapCrossSigning).toHaveBeenCalledTimes(2);
+    expectBootstrapCrossSigningCall(bootstrapCrossSigning, 2, { setupNewCrossSigning: true });
+  });
+
+  it("publishes the first identity through the MSC3967 no-auth upload", async () => {
+    const { authUploadDeviceSigningKeys } = await createUiAuthCallbackHarness();
+
+    const seenAuthStages: Array<Record<string, unknown> | null> = [];
+    const result = await authUploadDeviceSigningKeys(async (authData) => {
+      seenAuthStages.push(authData);
+      return "ok";
+    });
+
+    expect(result).toBe("ok");
+    expect(seenAuthStages).toEqual([null]);
+  });
+});

--- a/extensions/matrix/src/matrix/sdk/crypto-bootstrap.uia.test.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-bootstrap.uia.test.ts
@@ -345,22 +345,15 @@ describe("MatrixCryptoBootstrapper UIA", () => {
       deps as unknown as MatrixCryptoBootstrapperDeps<MatrixRawEvent>,
     );
 
-    let caught: unknown;
-    try {
-      await bootstrapper.bootstrap(crypto, {
-        strict: true,
-        forceResetCrossSigning: true,
-        allowSecretStorageRecreateWithoutRecoveryKey: true,
-      });
-    } catch (err) {
-      caught = err;
-    }
+    const result = await bootstrapper.bootstrap(crypto, {
+      strict: true,
+      forceResetCrossSigning: true,
+      allowSecretStorageRecreateWithoutRecoveryKey: true,
+    });
 
-    const resetErr = expectResetRequiredError(caught);
-    expect(resetErr.resetUrl).toBe(masUrl);
-    expect(resetErr.session).toBe("sess-mas");
-    expect(resetErr.stages).toContain("org.matrix.cross_signing_reset");
-    expect(resetErr.message).toContain(masUrl);
+    expect(result.crossSigningApprovalRequired?.resetUrl).toBe(masUrl);
+    expect(result.crossSigningApprovalRequired?.guidance).toContain(masUrl);
+    expect(result.crossSigningPublished).toBe(false);
     expect(deps.recoveryKeyStore.bootstrapSecretStorageWithRecoveryKey).not.toHaveBeenCalled();
   });
 
@@ -391,14 +384,9 @@ describe("MatrixCryptoBootstrapper UIA", () => {
       getDeviceVerificationStatus: vi.fn(async () => createVerifiedDeviceStatus()),
     });
 
-    let caught: unknown;
-    try {
-      await bootstrapper.bootstrap(crypto, { strict: true });
-    } catch (err) {
-      caught = err;
-    }
+    const result = await bootstrapper.bootstrap(crypto, { strict: true });
 
-    expect(expectResetRequiredError(caught).resetUrl).toBe(oauthUrl);
+    expect(result.crossSigningApprovalRequired?.resetUrl).toBe(oauthUrl);
   });
 
   it("does not retry with a fresh-identity reset after the MAS reset stage rejects the upload", async () => {
@@ -475,14 +463,9 @@ describe("MatrixCryptoBootstrapper UIA", () => {
       getDeviceVerificationStatus: vi.fn(async () => createVerifiedDeviceStatus()),
     });
 
-    let caught: unknown;
-    try {
-      await bootstrapper.bootstrap(crypto, { strict: true });
-    } catch (err) {
-      caught = err;
-    }
+    const result = await bootstrapper.bootstrap(crypto, { strict: true });
 
-    expect(expectResetRequiredError(caught).resetUrl).toBe(masUrl);
+    expect(result.crossSigningApprovalRequired?.resetUrl).toBe(masUrl);
     expect(bootstrapCrossSigning).toHaveBeenCalledTimes(2);
     expectBootstrapCrossSigningCall(bootstrapCrossSigning, 2, { setupNewCrossSigning: true });
   });

--- a/extensions/matrix/src/matrix/sdk/types.ts
+++ b/extensions/matrix/src/matrix/sdk/types.ts
@@ -154,6 +154,13 @@ export type MatrixStoredRecoveryKey = {
 
 export type MatrixAuthDict = Record<string, unknown>;
 
+export type MatrixUiaResponseBody = {
+  flows?: Array<{ stages?: string[] }>;
+  completed?: string[];
+  session?: string;
+  params?: Record<string, Record<string, unknown> | undefined>;
+};
+
 export type MatrixUiAuthCallback = <T>(
   makeRequest: (authData: MatrixAuthDict | null) => Promise<T>,
 ) => Promise<T>;


### PR DESCRIPTION
Closes #74504

## What Problem This Solves

Fixes an issue where Matrix bots that authenticate with a Personal Access Token against a Synapse homeserver fronted by Matrix Authentication Service (MSC3861 / MAS, the Element ESS default) could never publish cross-signing keys. `openclaw matrix verify bootstrap` and channel startup failed with the misleading error `Matrix cross-signing key upload requires UIA; provide matrix.password for m.login.password fallback`, even though the homeserver does not advertise `m.login.password` for that upload, the bot has no password on MAS, and setting one would not help. The bootstrap also blindly escalated to a fresh-identity reset upload that deterministically 401s on MAS, producing repeated back-to-back failures, and the MAS recovery URL that Synapse points to in the 401 challenge was silently discarded. With cross-signing unpublished, E2EE decryption and self-verification stay broken for the deployment.

## Why This Change Was Made

The signing-key upload UIA callback in `extensions/matrix/src/matrix/sdk/crypto-bootstrap.ts` retried hardcoded auth shapes (`null`, `m.login.dummy`, `m.login.password`) without ever inspecting the 401 challenge body, and omitted the UIA `session` token that the spec expects follow-up attempts to carry. The fix makes the callback honor UIA flow semantics: `flows` are alternative ordered stage sequences, so the callback selects a satisfiable advertised flow instead of scanning a flattened stage union. It prefers a flow it can finish with `m.login.dummy` alone, falls back to the first flow whose remaining stages are all satisfiable non-interactively (`m.login.password` counts only when a password is configured), follows multi-stage flows by resubmitting with the session token as the server's `completed` list advances, and surfaces the server's own error when a submitted stage makes no progress rather than retrying it. Only when no advertised flow is satisfiable does the MAS interactive reset stage (`org.matrix.cross_signing_reset`, or its newer `m.oauth` form) become a typed `MatrixCrossSigningResetRequiredError` carrying the reset URL from the challenge `params`; non-UIA failures are rethrown unchanged, and other unsatisfiable challenges get a `MatrixUiaUnsupportedStagesError` naming the stages.

Interactive approval is a distinct outcome, not an ordinary bootstrap failure, so it is no longer collapsed into the same `{ ready: false, published: false }` shape. `MatrixCryptoBootstrapResult` now carries a `crossSigningApprovalRequired` outcome with the operator guidance and the reset URL. Channel startup in `client-base.ts` recognizes that outcome and skips the forced `setupNewCrossSigning` repair, which on MAS could only resubmit an upload the homeserver has already refused; `bootstrapOwnDeviceVerification` reports the guidance as its operator-facing error and returns the reset URL as structured data on the result. The URL therefore reaches the operator through a deliberate result field rather than through log or error text, so `redactSensitiveText` keeps eliding token-bearing query values on every logging path exactly as before.

Two deliberate boundaries: the first upload attempt stays unauthenticated, so the MSC3967 first-publish path and uploads inside a fresh MAS approval window keep succeeding through the same code path (the upload attempt itself is the only reliable probe for whether the operator's browser approval is still current). And the fix reads the reset URL from the 401 challenge that Synapse already sends rather than adding a homeserver capability probe, keeping the change local to the UIA callback that owns challenge handling; when a homeserver advertises the reset stage without a URL, the error directs the operator to homeserver admin tooling.

## User Impact

Operators of bots on MAS-fronted homeservers now get one actionable failure instead of a dead end: the bootstrap error names the MAS cross-signing reset URL to open in a browser, and re-running the bootstrap within the approval window publishes cross-signing through the normal path. Channel startup no longer repeats a signing-key upload the homeserver has already refused, so a MAS deployment that needs browser approval makes a single attempt and logs the actionable guidance once instead of cycling through a forced reset that cannot succeed. Fresh bots on MAS publish their first identity without any interactive step via MSC3967. Deployments using `m.login.dummy` or a configured `matrix.password` keep working, now with the UIA session token attached as the spec requires. Homeservers that advertise a usable dummy or password flow alongside an interactive reset flow complete the usable flow instead of demanding browser approval, and multi-stage flows complete stage by stage instead of dead-ending after the first 401. Operators without a configured password on non-MAS homeservers that require `m.login.password` see an error naming the actual missing configuration instead of a generic UIA message.

## Evidence

Real environment tested: head `ccec49992519b964c29e5f45480d3bd8dd06a4a1`, rebased on `main` at `b0b82291cada1588f461d09371c398adf0a8d611`. The owner-boundary runs below were captured at this head against pristine `main` with identical inputs. The live MAS-fronted Synapse runs were captured at the earlier head `e78c16a79d20` and are retained unchanged; `main` has not touched `extensions/matrix/` since, and the same MAS-only challenge outcomes are reproduced at the current head in the owner-boundary section.

### Owner-boundary runs at the current head

Driver: the real production `MatrixClient` from `extensions/matrix/src/matrix/sdk.ts` with encryption enabled, real rust crypto, real secret-storage bootstrap and real SQLite-backed plugin state, talking real HTTP to a loopback homeserver that answers `/_matrix/client/v3/keys/device_signing/upload` with the live MAS challenge shape (`flows: [[org.matrix.cross_signing_reset]]`, a `params` URL, and a UIA `session`). Identical inputs on both trees; the only difference is the checkout. The counter is the homeserver's own count of signing-key uploads it received.

Channel startup (`MatrixClient.start()`, the path a running Matrix channel takes), pristine `main`: the initial bootstrap dead-ends, startup treats the unpublished result as repairable and runs the forced reset, and the homeserver receives four signing-key uploads for one startup.

```
[fake-synapse] POST /_matrix/client/v3/keys/device_signing/upload auth=null -> 401
[fake-synapse] POST /_matrix/client/v3/keys/device_signing/upload auth={"type":"m.login.dummy"} -> 401
[MatrixClientLite] Initial cross-signing bootstrap failed and automatic reset is disabled: Error: Matrix cross-signing key upload requires UIA; provide matrix.password for m.login.password fallback
[fake-synapse] POST /_matrix/client/v3/keys/device_signing/upload auth=null -> 401
[fake-synapse] POST /_matrix/client/v3/keys/device_signing/upload auth={"type":"m.login.dummy"} -> 401
[MatrixClientLite] Forced cross-signing reset failed: Error: Matrix cross-signing key upload requires UIA; provide matrix.password for m.login.password fallback
[MatrixClientLite] Failed to recover cross-signing/bootstrap with forced reset: Error: Matrix cross-signing key upload requires UIA; provide matrix.password for m.login.password fallback
Signing-key upload attempts during channel startup: 4
```

Same startup, this head: one upload, no forced repair, and the actionable guidance logged once.

```
[fake-synapse] POST /_matrix/client/v3/keys/device_signing/upload auth=null -> 401
[MatrixClientLite] Cross-signing bootstrap needs interactive approval: Matrix cross-signing key upload requires interactive approval from the homeserver auth service. Open https://mas.example.org/account/cross_signing_reset?token=redact…oken in a browser as the bot user, approve the cross-signing reset, then re-run the bootstrap while the approval is fresh.
[MatrixClientLite] Cross-signing needs interactive approval; skipping automatic reset. Matrix cross-signing key upload requires interactive approval from the homeserver auth service. Open https://mas.example.org/account/cross_signing_reset?token=redact…oken in a browser as the bot user, approve the cross-signing reset, then re-run the bootstrap while the approval is fresh.
Signing-key upload attempts during channel startup: 1
```

Explicit verification bootstrap (`bootstrapOwnDeviceVerification()`, the call behind `openclaw matrix verify bootstrap`), pristine `main`: four uploads, the misleading password error, and no reset URL anywhere on the returned result.

```
[fake-synapse] POST /_matrix/client/v3/keys/device_signing/upload auth=null -> 401
[fake-synapse] POST /_matrix/client/v3/keys/device_signing/upload auth={"type":"m.login.dummy"} -> 401
[fake-synapse] POST /_matrix/client/v3/keys/device_signing/upload auth=null -> 401
[fake-synapse] POST /_matrix/client/v3/keys/device_signing/upload auth={"type":"m.login.dummy"} -> 401
Signing-key upload attempts during verify bootstrap: 4
Bootstrap success: no
Bootstrap error: Matrix cross-signing key upload requires UIA; provide matrix.password for m.login.password fallback
Operator-facing reset URL from result: absent
```

Same call, this head: one upload, the actionable error, and the reset URL delivered as structured data on the result. The challenge URL deliberately embeds `token=redacted-mas-token` to show both halves of the contract at once: the logged line above still elides it as `token=redact…oken`, while the result field the CLI reads carries the usable link.

```
[fake-synapse] POST /_matrix/client/v3/keys/device_signing/upload auth=null -> 401
Signing-key upload attempts during verify bootstrap: 1
Bootstrap success: no
Bootstrap error: Matrix cross-signing key upload requires interactive approval from the homeserver auth service. Open https://mas.example.org/account/cross_signing_reset?token=redacted-mas-token in a browser as the bot user, approve the cross-signing reset, then re-run the bootstrap while the approval is fresh.
Operator-facing reset URL from result: https://mas.example.org/account/cross_signing_reset?token=redacted-mas-token
```

### Live MAS-fronted Synapse

Verified against a real deployment: Synapse 1.145+ (`ghcr.io/element-hq/synapse:latest`) with `experimental_features.msc3861` delegating auth to a real Matrix Authentication Service 1.20.0 (`ghcr.io/element-hq/matrix-authentication-service:latest`, postgres-backed), bot user `@openclaw-bot:localtest` registered via `mas-cli manage register-user` and authenticated only with a compat Personal Access Token from `mas-cli manage issue-compatibility-token`. The driver is the real production entry point `MatrixClient.bootstrapOwnDeviceVerification()` with the real rust crypto stack and real SQLite-backed plugin state. Nothing is emulated in these runs.

Live run 1, fresh bot, this patch: MSC3967 first-publish lands with no interactive step, proving real UIA response compatibility for the no-auth first upload:

```
[MatrixClient] FetchHttpApi: <-- POST http://127.0.0.1:8008/_matrix/client/v3/keys/device_signing/upload [66ms 200]
[MatrixClientLite] Cross-signing bootstrap complete
[MatrixClientLite] Room key backup enabled (version 1)
Bootstrap success: yes
Cross-signing published: yes
```

Live run 2, redeployed bot (fresh device, local state lost, server identity present) running the documented recovery `--force-reset-cross-signing`, on pristine `main`: real Synapse 401s and the misleading dead-end error, with the MAS URL discarded:

```
[MatrixClient] FetchHttpApi: <-- POST http://127.0.0.1:8008/_matrix/client/v3/keys/device_signing/upload [16ms 401]
[MatrixClient] FetchHttpApi: <-- POST http://127.0.0.1:8008/_matrix/client/v3/keys/device_signing/upload [9ms 401]
[MatrixClientLite] Forced cross-signing reset failed: Error: Matrix cross-signing key upload requires UIA; provide matrix.password for m.login.password fallback
Bootstrap error: Matrix cross-signing key upload requires UIA; provide matrix.password for m.login.password fallback
```

Live run 3, identical state, this patch: a single upload attempt and the typed error carrying the real MAS URL from the challenge:

```
[MatrixClient] FetchHttpApi: <-- POST http://127.0.0.1:8008/_matrix/client/v3/keys/device_signing/upload [15ms 401]
[MatrixClientLite] Cross-signing bootstrap needs interactive approval: Matrix cross-signing key upload requires interactive approval from the homeserver auth service. Open http://127.0.0.1:8080/account?action=org.matrix.cross_signing_reset in a browser as the bot user, approve the cross-signing reset, then re-run the bootstrap while the approval is fresh.
Bootstrap error: Matrix cross-signing key upload requires interactive approval from the homeserver auth service. Open http://127.0.0.1:8080/account?action=org.matrix.cross_signing_reset in a browser as the bot user, approve the cross-signing reset, then re-run the bootstrap while the approval is fresh.
```

Live run 4, post-approval: logged into MAS as the bot user through its real login form and approved the reset (the account UI's `allowUserCrossSigningReset` GraphQL mutation, invoked with the browser session cookie), then re-ran the identical bootstrap inside the approval window. The same code path that produced the guidance completes the recovery:

```
[MatrixClient] FetchHttpApi: <-- POST http://127.0.0.1:8008/_matrix/client/v3/keys/device_signing/upload [58ms 200]
[MatrixClientLite] Cross-signing bootstrap complete
Cross-signing published: yes
```

followed by the documented room-key-backup rotation (`resetRoomKeyBackup`, needed because the pre-reset backup is encrypted under the lost original recovery key), after which the full bootstrap reports green:

```
Room key backup reset: {"success":true,"previousVersion":"1","deletedVersion":"1","createdVersion":"2",...}
Bootstrap success: yes
Bootstrap error: none
Cross-signing published: yes
```

### Per-flow UIA semantics

The Codex review correctly flagged that an earlier revision routed from a flattened union of all advertised stages, while Matrix UIA defines `flows` as alternative ordered sequences. The callback now preserves flow boundaries as described above. Proven with the same real-runtime driver: the production `MatrixClient.bootstrapOwnDeviceVerification()` entry point with the real rust crypto stack and real SQLite-backed plugin state against a stateful local homeserver whose UIA enforces per-flow stage order, with identical inputs per compared pair.

Mixed alternative flows, `[org.matrix.cross_signing_reset]` alongside `[m.login.dummy]`: the callback completes the usable dummy flow with the session token instead of raising reset guidance.

```
[fake-synapse] POST /_matrix/client/v3/keys/device_signing/upload -> 401
[fake-synapse] accepted m.login.dummy stage for session mas-uia-session-token
[fake-synapse] POST /_matrix/client/v3/keys/device_signing/upload -> 200
Cross-signing published: yes
```

Single ordered flow `[org.matrix.cross_signing_reset, m.login.dummy]`, previous head `e78c16a79d20`: union routing submits `m.login.dummy` as an invalid first stage, twice, and dead-ends in a raw unactionable error with the MAS URL discarded:

```
[fake-synapse] rejecting auth type m.login.dummy: not a valid first stage of flow [org.matrix.cross_signing_reset, m.login.dummy]
[MatrixClientLite] Initial cross-signing bootstrap failed, trying reset: M_FORBIDDEN: MatrixError: [401] Invalid auth stage order (...)
[fake-synapse] rejecting auth type m.login.dummy: not a valid first stage of flow [org.matrix.cross_signing_reset, m.login.dummy]
Bootstrap error: MatrixError: [401] Invalid auth stage order (...)
```

Same challenge, this head: zero invalid submissions; the callback recognizes that no advertised flow is satisfiable non-interactively and raises the actionable MAS guidance immediately:

```
[fake-synapse] POST /_matrix/client/v3/keys/device_signing/upload -> 401
Bootstrap error: Matrix cross-signing key upload requires interactive approval from the homeserver auth service. Open https://mas.example.org/account/cross_signing_reset?token=redact…oken in a browser as the bot user, approve the cross-signing reset, then re-run the bootstrap while the approval is fresh.
```

### Reset URL handling and redaction

The real MAS reset URL is the MSC2965 deep-link form `<account_management_uri>?action=org.matrix.cross_signing_reset` (visible in live run 3). It carries no secret: MAS authenticates the operator with their own browser session before showing the approve button, so possession of the URL grants nothing.

For homeservers whose challenge `params` do embed a token-bearing URL, every log and error path still redacts the query value by construction, because redaction happens where the strings are produced rather than at individual print sites:

- Gateway and terminal log lines: the Matrix `LogService` passes every formatted line through `redactSensitiveText` (`extensions/matrix/src/matrix/sdk/logger.ts`), which middle-elides values of `token`, `code`, `session`, and other auth-shaped URL query keys (`src/logging/redact.ts`).
- CLI and action error strings built from thrown errors: `formatMatrixErrorMessage` -> `formatErrorMessage` applies the same `redactSensitiveText` (`src/infra/errors.ts`).
- Uncaught errors: `formatUncaughtError` redacts the full stack (`src/infra/errors.ts`).

The reset URL now reaches the operator on the bootstrap result instead of relying on any of those text paths, which is why the owner-boundary run above shows the elided `token=redact…oken` in the log line and the intact link in the result field from the same single run. The bot's own access token appears zero times across all captured logs.

### Regression tests and gates

- `node scripts/run-vitest.mjs extensions/matrix/src/matrix/sdk/ extensions/matrix/src/matrix/sdk.test.ts extensions/matrix/src/matrix/client-bootstrap.test.ts` passes at this head (14 files, 272 tests).
- UIA challenge routing coverage lives in `crypto-bootstrap.uia.test.ts` with the shared harness in `crypto-bootstrap.test-helpers.ts` (the combined file crossed the repo max-lines limit): stage routing with session threading for dummy and password, the approval-required outcome carrying the reset URL for both `org.matrix.cross_signing_reset` and `m.oauth`, no fresh-identity retry after the reset stage rejects an upload, the reset upload still being attempted after an import-key mismatch so a fresh MAS approval can land, non-UIA errors rethrown unchanged, the MSC3967 no-auth first upload, and the per-flow cases (dummy flow completes on a mixed challenge, password flow completes when the reset flow is only an alternative, reset guidance fires only when the alternative needs an unavailable password, multi-stage flow follows the server's `completed` progress, a no-progress rejection is surfaced without retry).
- New startup-owner coverage in `extensions/matrix/src/matrix/sdk.test.ts`: an approval-required bootstrap result drives exactly one bootstrapper call during `start()`, so the forced-reset repair path cannot reintroduce the second upload.
- `oxlint` and `oxfmt --check` are clean on all changed files at this head.

Not tested: no TLS-terminated or federation-enabled deployment was driven (the live stack ran plain HTTP on loopback); no full build was run (no module boundaries or packaging touched); the `tsgo` lanes and `knip` were left to CI on this machine.
