### PR TITLE
refactor(whatsapp): simplify doctor streaming migration

### DIFF
--- a/extensions/whatsapp/src/doctor-contract.ts
+++ b/extensions/whatsapp/src/doctor-contract.ts
@@ -1,9 +1,11 @@
 // Whatsapp plugin module implements doctor contract behavior.
+import { isDeepStrictEqual } from "node:util";
 import type {
   ChannelDoctorConfigMutation,
   ChannelDoctorLegacyConfigRule,
 } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { mergeDeep } from "openclaw/plugin-sdk/plugin-config-runtime";
 import { asObjectRecord, defineChannelAliasMigration } from "openclaw/plugin-sdk/runtime-doctor";
 import { normalizeCompatibilityConfig as normalizeAckReactionConfig } from "./doctor.js";
 
@@ -21,45 +23,14 @@ const streamingAliasMigration = defineChannelAliasMigration({
 export const legacyConfigRules: ChannelDoctorLegacyConfigRule[] =
   streamingAliasMigration.legacyConfigRules;
 
-/** Deep-fills fields missing from target with copies of source values. */
-function fillMissingStreamingFields(
-  target: Record<string, unknown>,
-  source: Record<string, unknown>,
-): { value: Record<string, unknown>; filled: boolean } {
-  let filled = false;
-  const value = { ...target };
-  for (const [key, sourceValue] of Object.entries(source)) {
-    if (sourceValue === undefined) {
-      continue;
-    }
-    const existing = value[key];
-    if (existing === undefined) {
-      value[key] = structuredClone(sourceValue);
-      filled = true;
-      continue;
-    }
-    const existingRecord = asObjectRecord(existing);
-    const sourceRecord = asObjectRecord(sourceValue);
-    if (!existingRecord || !sourceRecord) {
-      continue;
-    }
-    const merged = fillMissingStreamingFields(existingRecord, sourceRecord);
-    if (merged.filled) {
-      value[key] = merged.value;
-      filled = true;
-    }
-  }
-  return { value, filled };
-}
-
 // The runtime merge replaces `streaming` wholesale per layer (named account >
 // accounts.default > root), while the retired flat keys resolved per key
 // across those layers. Account objects that migration materializes must carry
 // the settings the account previously inherited, or `doctor --fix` silently
 // changes effective delivery behavior for that account.
-function seedMigratedAccountStreaming(params: {
+function materializeMigratedAccountStreaming(params: {
   cfg: OpenClawConfig;
-  accountsWithoutStreamingBefore: ReadonlySet<string>;
+  accountsBefore: Record<string, unknown> | null;
   changes: string[];
 }): OpenClawConfig {
   const channels = params.cfg.channels as Record<string, unknown> | undefined;
@@ -79,13 +50,17 @@ function seedMigratedAccountStreaming(params: {
   const nextAccounts = { ...accounts };
   // Seed the default account first: its final object is the inheritance
   // source for named accounts (default replaces root wholesale when set).
-  const seedOrder = Object.keys(accounts).toSorted((left, right) =>
+  const accountIds = Object.keys(accounts).toSorted((left, right) =>
     left === defaultKey ? -1 : right === defaultKey ? 1 : left.localeCompare(right),
   );
-  for (const accountId of seedOrder) {
+  for (const accountId of accountIds) {
+    const accountBefore = asObjectRecord(params.accountsBefore?.[accountId]);
+    if (accountBefore?.streaming !== undefined) {
+      continue;
+    }
     const account = asObjectRecord(nextAccounts[accountId]);
     const created = asObjectRecord(account?.streaming);
-    if (!account || !created || !params.accountsWithoutStreamingBefore.has(accountId)) {
+    if (!account || !created) {
       continue;
     }
     const defaultStreaming = defaultKey
@@ -96,16 +71,16 @@ function seedMigratedAccountStreaming(params: {
     if (!inheritedSource) {
       continue;
     }
-    const seeded = fillMissingStreamingFields(created, inheritedSource);
-    if (!seeded.filled) {
+    const materialized = asObjectRecord(mergeDeep(inheritedSource, created));
+    if (!materialized || isDeepStrictEqual(materialized, created)) {
       continue;
     }
-    nextAccounts[accountId] = { ...account, streaming: seeded.value };
+    nextAccounts[accountId] = { ...account, streaming: materialized };
     accountsChanged = true;
     const sourcePath =
-      accountId === defaultKey
-        ? "channels.whatsapp.streaming"
-        : "effective channels.whatsapp streaming defaults";
+      accountId !== defaultKey && defaultKey && defaultStreaming
+        ? `channels.whatsapp.accounts.${defaultKey}.streaming`
+        : "channels.whatsapp.streaming";
     params.changes.push(
       `Copied ${sourcePath} into channels.whatsapp.accounts.${accountId}.streaming to keep inherited settings while migrating flat streaming keys.`,
     );
@@ -132,19 +107,14 @@ export function normalizeCompatibilityConfig({
     asObjectRecord((ackReaction.config.channels as Record<string, unknown> | undefined)?.whatsapp)
       ?.accounts,
   );
-  const accountsWithoutStreamingBefore = new Set(
-    Object.entries(accountsBefore ?? {})
-      .filter(([, account]) => asObjectRecord(account)?.streaming === undefined)
-      .map(([accountId]) => accountId),
-  );
   const aliases = streamingAliasMigration.normalizeChannelConfig({
     cfg: ackReaction.config,
     changes: ackReaction.changes,
   });
   return {
-    config: seedMigratedAccountStreaming({
+    config: materializeMigratedAccountStreaming({
       cfg: aliases.config,
-      accountsWithoutStreamingBefore,
+      accountsBefore,
       changes: aliases.changes,
     }),
     changes: aliases.changes,


### PR DESCRIPTION
Related: #106018

## What Problem This Solves

The WhatsApp doctor migration used a bespoke recursive deep-fill helper to preserve effective streaming settings while converting retired flat keys. That duplicated the canonical plugin config merge semantics and made the compatibility path harder to reason about.

## Why This Change Was Made

This is the maintainer-requested follow-up refactor from the Google Chat doctor repair. It uses the shared `mergeDeep` contract to materialize the effective root/default/named-account streaming configuration in precedence order. Accounts that already had canonical `streaming` configuration remain untouched, and the obsolete recursive implementation is removed.

## User Impact

No user-visible behavior changes. `openclaw doctor --fix` preserves the same effective WhatsApp streaming settings with a smaller canonical migration path.

## Evidence

- `node scripts/run-vitest.mjs extensions/whatsapp/src/doctor-contract.test.ts extensions/whatsapp/src/doctor.test.ts` — 8 passed
- `node scripts/check-changed.mjs -- extensions/whatsapp/src/doctor-contract.ts` — passed on Blacksmith Testbox, including extension and extension-test typechecks, lint, formatting, SDK boundary checks, and import-cycle checks
- Mandatory autoreview — clean, no actionable findings

AI-assisted maintainer refactor; the implementation and migration semantics were reviewed and verified before publication.
