### PR TITLE
feat(gateway): auto-approve trusted-proxy browser device pairing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Trusted-proxy browser pairing:** optionally auto-approve new Control UI and WebChat devices from allowlisted proxy identities with non-admin scope caps, while keeping existing-device upgrades manual.
 - **Channel plugin ingress monitors:** add a shared plugin SDK monitor for durable admission, polling, pruning, claim identity validation, adoption handoff, and shutdown, and migrate IRC, Synology Chat, and Google Chat to the shared lifecycle.
 - **External gateway supervision:** add `OPENCLAW_SUPERVISOR_MODE=external` for lifecycle owners such as OCM, preserving verified restart and deferral behavior without exposing native service authority, blocking native service mutation and self-update, and providing a versioned atomic restart-handoff consume contract. Thanks @shakkernerd.
 - **ClickClack guided setup:** configure ClickClack from `openclaw onboard` or `openclaw channels add clickclack` with URL, token, and workspace prompts, default-account env fallback, nonfatal live connection validation, and gateway-aware next steps that connect automatically when OpenClaw is already running. Thanks @shakkernerd.

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -4120,6 +4120,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: How it works
   - H2: Configuration
   - H3: Configuration reference
+  - H2: Automatic device approval
   - H2: Control UI pairing behavior
   - H2: Operator scopes header
   - H2: TLS termination and HSTS

--- a/docs/gateway/trusted-proxy-auth.md
+++ b/docs/gateway/trusted-proxy-auth.md
@@ -72,6 +72,12 @@ read_when:
 
         // Optional: allow a same-host loopback proxy after explicit opt-in
         allowLoopback: false,
+
+        // Optional: let authenticated proxy users enroll new browser devices
+        deviceAutoApprove: {
+          enabled: false,
+          scopes: ["operator.read", "operator.write", "operator.approvals"],
+        },
       },
     },
   },
@@ -114,9 +120,48 @@ Internal Gateway clients that do not travel through the reverse proxy should use
 <ParamField path="gateway.auth.trustedProxy.allowLoopback" type="boolean" default="false">
   Opt-in support for same-host loopback reverse proxies.
 </ParamField>
+<ParamField path="gateway.auth.trustedProxy.deviceAutoApprove.enabled" type="boolean" default="false">
+  Automatically approve new Control UI and WebChat device identities after trusted-proxy authentication.
+</ParamField>
+<ParamField path="gateway.auth.trustedProxy.deviceAutoApprove.scopes" type="string[]" default='["operator.read", "operator.write", "operator.approvals"]'>
+  Maximum scopes granted to an auto-approved browser device. `operator.admin` is not allowed.
+</ParamField>
 
 <Warning>
 Only enable `allowLoopback` when the local reverse proxy is the intended trust boundary. Any local process that can connect to the Gateway can try to send proxy identity headers, so keep direct Gateway access private to the host and require proxy-owned headers such as `x-forwarded-proto`, or a signed assertion header where your proxy supports one.
+</Warning>
+
+## Automatic device approval
+
+Trusted-proxy auth can optionally use the proxy identity as the approval boundary for new browser devices:
+
+```json5
+{
+  gateway: {
+    auth: {
+      mode: "trusted-proxy",
+      trustedProxy: {
+        userHeader: "x-forwarded-user",
+        allowUsers: ["operator@example.com"],
+        deviceAutoApprove: {
+          enabled: true,
+          scopes: ["operator.read", "operator.write", "operator.approvals"],
+        },
+      },
+    },
+  },
+}
+```
+
+The default is `enabled: false`. When enabled, all of these rules apply:
+
+1. The WebSocket must have authenticated through the `trusted-proxy` method with a non-empty user identity that passed `allowUsers` when an allowlist is configured. Token, password, Tailscale, and unauthenticated connections never use this policy.
+2. Only a new Control UI or WebChat browser device can be approved automatically. Any request for an existing device, including a scope upgrade, remains pending for manual approval with `openclaw devices approve <requestId>`.
+3. The device is approved with role `operator`. If the connect request includes scopes, the grant is the exact intersection of the requested scopes and `deviceAutoApprove.scopes`. If the request omits scopes, the configured list is granted; when that list is omitted, it defaults to `operator.read`, `operator.write`, and `operator.approvals`.
+4. `operator.admin` cannot appear in `deviceAutoApprove.scopes`; configuration validation rejects it. Grant admin access manually with `openclaw devices approve` or `openclaw devices rotate`.
+
+<Warning>
+Enabling this option delegates new browser device enrollment entirely to the reverse-proxy identity. A compromised proxy account can enroll a persistent device with every configured scope. Keep the Gateway reachable only through the proxy, require strong proxy authentication, overwrite identity headers, and use a narrow `allowUsers` list.
 </Warning>
 
 ## Control UI pairing behavior
@@ -133,7 +178,7 @@ Reverse-proxy scope capping: if your proxy sends `x-openclaw-scopes` on the Cont
 
 Implications:
 
-- Pairing is no longer the primary gate for Control UI access in this mode.
+- Pairing is no longer the primary gate for device-less Control UI access. When `deviceAutoApprove.enabled` is true, the proxy identity also becomes the approval gate for new browser device enrollment.
 - Your reverse proxy auth policy and `allowUsers` become the effective access control.
 - Keep gateway ingress locked to trusted proxy IPs only (`gateway.trustedProxies` + firewall).
 
@@ -354,6 +399,7 @@ Before enabling trusted-proxy auth, verify:
 - [ ] **allowUsers is set** (recommended): Restrict to known users rather than allowing anyone authenticated.
 - [ ] **No mixed token config**: Do not set both `gateway.auth.token` and `gateway.auth.mode: "trusted-proxy"`.
 - [ ] **Local password fallback is private**: If you configure `gateway.auth.password` for internal direct callers, keep the Gateway port firewalled so non-proxy remote clients cannot reach it directly.
+- [ ] **Device auto-approval is deliberate**: If `deviceAutoApprove.enabled` is true, treat reverse-proxy account security as the device-enrollment boundary and keep the granted scope list non-admin and minimal.
 
 ## Security audit
 
@@ -366,6 +412,7 @@ The audit checks for:
 - Missing `userHeader` configuration.
 - Empty `allowUsers` (allows any authenticated user).
 - Enabled `allowLoopback` for same-host proxy sources.
+- Enabled browser device auto-approval (delegates new device pairing to the proxy identity).
 
 Separate, non-trusted-proxy-specific findings also apply whenever Control UI is exposed: wildcard or missing `gateway.controlUi.allowedOrigins`, and Host-header origin fallback.
 

--- a/src/config/schema.help.core.ts
+++ b/src/config/schema.help.core.ts
@@ -157,6 +157,12 @@ export const CORE_FIELD_HELP: Record<string, string> = {
     "Login/auth attempt throttling controls to reduce credential brute-force risk at the gateway boundary. Keep enabled in exposed environments and tune thresholds to your traffic baseline.",
   "gateway.auth.trustedProxy":
     "Trusted-proxy auth header mapping for upstream identity providers that inject user claims. Use only with known proxy CIDRs and strict header allowlists to prevent spoofed identity headers.",
+  "gateway.auth.trustedProxy.deviceAutoApprove":
+    "Optional policy for automatically approving new Control UI and WebChat device identities after trusted-proxy authentication. Existing-device scope upgrades always remain manual.",
+  "gateway.auth.trustedProxy.deviceAutoApprove.enabled":
+    "Automatically approves new browser device identities after the reverse proxy authenticates an allowed user. Default: false. Enable only when the proxy identity boundary is strong enough to replace manual device pairing.",
+  "gateway.auth.trustedProxy.deviceAutoApprove.scopes":
+    "Maximum scopes granted to auto-approved browser devices. Requested scopes are capped to this list; requests without scopes receive this list. operator.admin is rejected and must be approved manually.",
   "gateway.trustedProxies":
     "CIDR/IP allowlist of upstream proxies permitted to provide forwarded client identity headers. Keep this list narrow so untrusted hops cannot impersonate users.",
   "gateway.allowRealIpFallback":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -157,6 +157,10 @@ export const FIELD_LABELS: Record<string, string> = {
   "gateway.auth.allowTailscale": "Gateway Auth Allow Tailscale Identity",
   "gateway.auth.rateLimit": "Gateway Auth Rate Limit",
   "gateway.auth.trustedProxy": "Gateway Trusted Proxy Auth",
+  "gateway.auth.trustedProxy.deviceAutoApprove": "Trusted Proxy Device Auto-Approval",
+  "gateway.auth.trustedProxy.deviceAutoApprove.enabled":
+    "Trusted Proxy Device Auto-Approval Enabled",
+  "gateway.auth.trustedProxy.deviceAutoApprove.scopes": "Trusted Proxy Device Auto-Approval Scopes",
   "gateway.trustedProxies": "Gateway Trusted Proxy CIDRs",
   "gateway.allowRealIpFallback": "Gateway Allow x-real-ip Fallback",
   "gateway.tools": "Gateway Tool Exposure Policy",

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -200,6 +200,20 @@ export type GatewayTrustedProxyConfig = {
    * trust boundary and direct Gateway access is otherwise locked down.
    */
   allowLoopback?: boolean;
+  /**
+   * Automatically approve new browser device identities after trusted-proxy
+   * authentication. Disabled by default; existing-device upgrades stay manual.
+   */
+  deviceAutoApprove?: {
+    /** Enable automatic approval for new browser devices. @default false */
+    enabled?: boolean;
+    /**
+     * Maximum operator scopes granted by automatic approval. operator.admin
+     * is intentionally forbidden. @default operator.read, operator.write,
+     * operator.approvals
+     */
+    scopes?: string[];
+  };
 };
 
 export type GatewayAuthConfig = {

--- a/src/config/zod-schema.gateway-auth.test.ts
+++ b/src/config/zod-schema.gateway-auth.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "vitest";
+import { OpenClawSchema } from "./zod-schema.js";
+
+describe("gateway trusted-proxy device auto-approval config", () => {
+  test("accepts bounded non-admin scopes", () => {
+    const result = OpenClawSchema.safeParse({
+      gateway: {
+        auth: {
+          mode: "trusted-proxy",
+          trustedProxy: {
+            userHeader: "x-forwarded-user",
+            deviceAutoApprove: {
+              enabled: true,
+              scopes: ["operator.read", "operator.write", "operator.approvals"],
+            },
+          },
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  test.each(["operator.admin", " operator.admin "])("rejects %j", (adminScope) => {
+    const result = OpenClawSchema.safeParse({
+      gateway: {
+        auth: {
+          mode: "trusted-proxy",
+          trustedProxy: {
+            userHeader: "x-forwarded-user",
+            deviceAutoApprove: {
+              enabled: true,
+              scopes: ["operator.read", adminScope],
+            },
+          },
+        },
+      },
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: ["gateway", "auth", "trustedProxy", "deviceAutoApprove", "scopes"],
+            message: expect.stringContaining("operator.admin is not allowed"),
+          }),
+        ]),
+      );
+    }
+  });
+});

--- a/src/config/zod-schema.gateway.ts
+++ b/src/config/zod-schema.gateway.ts
@@ -83,6 +83,18 @@ export const GatewayConfigSchema = z
             requiredHeaders: z.array(z.string()).optional(),
             allowUsers: z.array(z.string()).optional(),
             allowLoopback: z.boolean().optional(),
+            deviceAutoApprove: z
+              .strictObject({
+                enabled: z.boolean().optional(),
+                scopes: z
+                  .array(z.string().min(1))
+                  .refine((scopes) => !scopes.some((scope) => scope.trim() === "operator.admin"), {
+                    message:
+                      "operator.admin is not allowed in trusted-proxy device auto-approval scopes; approve admin access manually",
+                  })
+                  .optional(),
+              })
+              .optional(),
           })
           .optional(),
       })

--- a/src/gateway/server.auth.trusted-proxy-device-autoapprove.test.ts
+++ b/src/gateway/server.auth.trusted-proxy-device-autoapprove.test.ts
@@ -1,0 +1,392 @@
+import { randomUUID } from "node:crypto";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+import { WebSocket } from "ws";
+import { PROTOCOL_VERSION } from "../../packages/gateway-protocol/src/index.js";
+import { writeConfigFile } from "../config/config.js";
+import {
+  loadOrCreateDeviceIdentity,
+  publicKeyRawBase64UrlFromPem,
+  signDevicePayload,
+} from "../infra/device-identity.js";
+import { getPairedDevice, listDevicePairing } from "../infra/device-pairing.js";
+import { buildDeviceAuthPayloadV3 } from "./device-auth.js";
+import { CONTROL_UI_CLIENT } from "./server.auth.test-helpers.js";
+import {
+  connectReq,
+  installGatewayTestHooks,
+  onceMessage,
+  readConnectChallengeNonce,
+  testState,
+  trackConnectChallengeNonce,
+  withGatewayServer,
+} from "./test-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+const BROWSER_ORIGIN = "https://control.example.com";
+const TRUSTED_PROXY_HEADERS = {
+  origin: BROWSER_ORIGIN,
+  "x-forwarded-for": "203.0.113.50",
+  "x-forwarded-proto": "https",
+  "x-forwarded-user": "operator@example.com",
+};
+
+function trustedProxyHeaders(declaredScopes?: string): Record<string, string> {
+  return {
+    ...TRUSTED_PROXY_HEADERS,
+    ...(declaredScopes === undefined ? {} : { "x-openclaw-scopes": declaredScopes }),
+  };
+}
+
+function deviceIdentityPath(label: string): string {
+  return path.join(os.tmpdir(), `openclaw-${label}-${randomUUID()}.sqlite`);
+}
+
+async function openBrowserWs(port: number, headers: Record<string, string>): Promise<WebSocket> {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}`, { headers });
+  trackConnectChallengeNonce(ws);
+  await new Promise<void>((resolve) => {
+    ws.once("open", () => resolve());
+  });
+  return ws;
+}
+
+async function writeGatewayAuthConfig(params: {
+  mode: "token" | "trusted-proxy";
+  deviceAutoApprove?: { enabled?: boolean; scopes?: string[] };
+}): Promise<void> {
+  testState.gatewayAuth = undefined;
+  await writeConfigFile({
+    gateway: {
+      auth:
+        params.mode === "trusted-proxy"
+          ? {
+              mode: "trusted-proxy",
+              trustedProxy: {
+                userHeader: "x-forwarded-user",
+                requiredHeaders: ["x-forwarded-proto"],
+                allowUsers: ["operator@example.com"],
+                allowLoopback: true,
+                ...(params.deviceAutoApprove
+                  ? { deviceAutoApprove: params.deviceAutoApprove }
+                  : {}),
+              },
+            }
+          : {
+              mode: "token",
+              token: "secret",
+              trustedProxy: {
+                userHeader: "x-forwarded-user",
+                ...(params.deviceAutoApprove
+                  ? { deviceAutoApprove: params.deviceAutoApprove }
+                  : {}),
+              },
+            },
+      trustedProxies: ["127.0.0.1"],
+      controlUi: { allowedOrigins: [BROWSER_ORIGIN] },
+    },
+  });
+}
+
+async function connectBrowser(params: {
+  port: number;
+  identityPath: string;
+  scopes?: string[];
+  token?: string;
+  trustedProxy?: boolean;
+  declaredProxyScopes?: string;
+}) {
+  const ws = await openBrowserWs(
+    params.port,
+    params.trustedProxy === false
+      ? { origin: BROWSER_ORIGIN, "x-forwarded-for": "203.0.113.50" }
+      : trustedProxyHeaders(params.declaredProxyScopes),
+  );
+  try {
+    return await connectReq(ws, {
+      ...(params.token ? { token: params.token } : { skipDefaultAuth: true }),
+      ...(params.scopes === undefined ? {} : { scopes: params.scopes }),
+      client: CONTROL_UI_CLIENT,
+      deviceIdentityPath: params.identityPath,
+    });
+  } finally {
+    ws.close();
+  }
+}
+
+async function connectBrowserWithoutScopes(params: {
+  port: number;
+  identityPath: string;
+  declaredProxyScopes?: string;
+}): Promise<{ ok: boolean }> {
+  const ws = await openBrowserWs(params.port, trustedProxyHeaders(params.declaredProxyScopes));
+  try {
+    const nonce = await readConnectChallengeNonce(ws);
+    if (!nonce) {
+      throw new Error("missing connect.challenge nonce");
+    }
+    const identity = loadOrCreateDeviceIdentity({ path: params.identityPath });
+    const signedAt = Date.now();
+    const payload = buildDeviceAuthPayloadV3({
+      deviceId: identity.deviceId,
+      clientId: CONTROL_UI_CLIENT.id,
+      clientMode: CONTROL_UI_CLIENT.mode,
+      role: "operator",
+      scopes: [],
+      signedAtMs: signedAt,
+      token: null,
+      nonce,
+      platform: CONTROL_UI_CLIENT.platform,
+    });
+    const id = randomUUID();
+    const response = onceMessage<{ type: "res"; id: string; ok: boolean }>(
+      ws,
+      (message) => message.type === "res" && message.id === id,
+    );
+    ws.send(
+      JSON.stringify({
+        type: "req",
+        id,
+        method: "connect",
+        params: {
+          minProtocol: PROTOCOL_VERSION,
+          maxProtocol: PROTOCOL_VERSION,
+          client: CONTROL_UI_CLIENT,
+          caps: [],
+          commands: [],
+          role: "operator",
+          device: {
+            id: identity.deviceId,
+            publicKey: publicKeyRawBase64UrlFromPem(identity.publicKeyPem),
+            signature: signDevicePayload(identity.privateKeyPem, payload),
+            signedAt,
+            nonce,
+          },
+        },
+      }),
+    );
+    return await response;
+  } finally {
+    ws.close();
+  }
+}
+
+describe("trusted-proxy browser device auto-approval", () => {
+  test("auto-approves a new browser device with the default scopes", async () => {
+    await writeGatewayAuthConfig({
+      mode: "trusted-proxy",
+      deviceAutoApprove: { enabled: true },
+    });
+    const identityPath = deviceIdentityPath("trusted-proxy-default-scopes");
+    const identity = loadOrCreateDeviceIdentity({ path: identityPath });
+
+    await withGatewayServer(async ({ port }) => {
+      const res = await connectBrowser({
+        port,
+        identityPath,
+        scopes: ["operator.read", "operator.write", "operator.approvals"],
+      });
+      expect(res.ok).toBe(true);
+    });
+
+    const pairing = await listDevicePairing();
+    expect(pairing.pending.filter((entry) => entry.deviceId === identity.deviceId)).toEqual([]);
+    const paired = await getPairedDevice(identity.deviceId);
+    expect(paired?.approvedScopes).toEqual([
+      "operator.approvals",
+      "operator.read",
+      "operator.write",
+    ]);
+    expect(paired?.approvedVia).toBe("trusted-proxy");
+  });
+
+  test("caps requested scopes to the configured intersection", async () => {
+    await writeGatewayAuthConfig({
+      mode: "trusted-proxy",
+      deviceAutoApprove: {
+        enabled: true,
+        scopes: ["operator.read", "operator.approvals"],
+      },
+    });
+    const identityPath = deviceIdentityPath("trusted-proxy-scope-cap");
+    const identity = loadOrCreateDeviceIdentity({ path: identityPath });
+
+    await withGatewayServer(async ({ port }) => {
+      const res = await connectBrowser({
+        port,
+        identityPath,
+        scopes: ["operator.read", "operator.write", "operator.approvals"],
+      });
+      expect(res.ok).toBe(true);
+    });
+
+    const pairing = await listDevicePairing();
+    expect(pairing.pending.filter((entry) => entry.deviceId === identity.deviceId)).toEqual([]);
+    expect((await getPairedDevice(identity.deviceId))?.approvedScopes).toEqual([
+      "operator.approvals",
+      "operator.read",
+    ]);
+  });
+
+  test("caps omitted scopes to the declared proxy scopes", async () => {
+    await writeGatewayAuthConfig({
+      mode: "trusted-proxy",
+      deviceAutoApprove: {
+        enabled: true,
+        scopes: ["operator.read", "operator.write", "operator.approvals"],
+      },
+    });
+    const identityPath = deviceIdentityPath("trusted-proxy-omitted-scopes-cap");
+    const identity = loadOrCreateDeviceIdentity({ path: identityPath });
+
+    await withGatewayServer(async ({ port }) => {
+      const res = await connectBrowserWithoutScopes({
+        port,
+        identityPath,
+        declaredProxyScopes: "operator.read",
+      });
+      expect(res.ok).toBe(true);
+    });
+
+    expect((await getPairedDevice(identity.deviceId))?.approvedScopes).toEqual(["operator.read"]);
+  });
+
+  test("caps requested scopes to the declared proxy scopes", async () => {
+    await writeGatewayAuthConfig({
+      mode: "trusted-proxy",
+      deviceAutoApprove: {
+        enabled: true,
+        scopes: ["operator.read", "operator.write", "operator.approvals"],
+      },
+    });
+    const identityPath = deviceIdentityPath("trusted-proxy-requested-scopes-cap");
+    const identity = loadOrCreateDeviceIdentity({ path: identityPath });
+
+    await withGatewayServer(async ({ port }) => {
+      const res = await connectBrowser({
+        port,
+        identityPath,
+        scopes: ["operator.read", "operator.write"],
+        declaredProxyScopes: "operator.read",
+      });
+      expect(res.ok).toBe(true);
+    });
+
+    expect((await getPairedDevice(identity.deviceId))?.approvedScopes).toEqual(["operator.read"]);
+  });
+
+  test("keeps configured and requested scope behavior when the proxy header is absent", async () => {
+    await writeGatewayAuthConfig({
+      mode: "trusted-proxy",
+      deviceAutoApprove: {
+        enabled: true,
+        scopes: ["operator.read", "operator.approvals"],
+      },
+    });
+    const omittedIdentityPath = deviceIdentityPath("trusted-proxy-omitted-scopes-no-cap");
+    const omittedIdentity = loadOrCreateDeviceIdentity({ path: omittedIdentityPath });
+    const requestedIdentityPath = deviceIdentityPath("trusted-proxy-requested-scopes-no-cap");
+    const requestedIdentity = loadOrCreateDeviceIdentity({ path: requestedIdentityPath });
+
+    await withGatewayServer(async ({ port }) => {
+      expect(
+        (await connectBrowserWithoutScopes({ port, identityPath: omittedIdentityPath })).ok,
+      ).toBe(true);
+      expect(
+        (
+          await connectBrowser({
+            port,
+            identityPath: requestedIdentityPath,
+            scopes: ["operator.read", "operator.write"],
+          })
+        ).ok,
+      ).toBe(true);
+    });
+
+    expect((await getPairedDevice(omittedIdentity.deviceId))?.approvedScopes).toEqual([
+      "operator.approvals",
+      "operator.read",
+    ]);
+    expect((await getPairedDevice(requestedIdentity.deviceId))?.approvedScopes).toEqual([
+      "operator.read",
+    ]);
+  });
+
+  test("keeps scope upgrades on existing devices pending for manual approval", async () => {
+    await writeGatewayAuthConfig({
+      mode: "trusted-proxy",
+      deviceAutoApprove: {
+        enabled: true,
+        scopes: ["operator.read", "operator.write"],
+      },
+    });
+    const identityPath = deviceIdentityPath("trusted-proxy-scope-upgrade");
+    const identity = loadOrCreateDeviceIdentity({ path: identityPath });
+
+    await withGatewayServer(async ({ port }) => {
+      const initial = await connectBrowser({ port, identityPath, scopes: ["operator.read"] });
+      expect(initial.ok).toBe(true);
+
+      const upgrade = await connectBrowser({
+        port,
+        identityPath,
+        scopes: ["operator.read", "operator.write"],
+      });
+      expect(upgrade.ok).toBe(false);
+      expect(upgrade.error?.message ?? "").toContain("pairing required");
+    });
+
+    const pairing = await listDevicePairing();
+    const pending = pairing.pending.filter((entry) => entry.deviceId === identity.deviceId);
+    expect(pending).toHaveLength(1);
+    expect(pending[0]).toMatchObject({
+      isRepair: true,
+      scopes: ["operator.read", "operator.write"],
+    });
+    expect((await getPairedDevice(identity.deviceId))?.approvedScopes).toEqual(["operator.read"]);
+  });
+
+  test("leaves trusted-proxy pairing unchanged when auto-approval is disabled", async () => {
+    await writeGatewayAuthConfig({ mode: "trusted-proxy" });
+    const identityPath = deviceIdentityPath("trusted-proxy-disabled");
+    const identity = loadOrCreateDeviceIdentity({ path: identityPath });
+
+    await withGatewayServer(async ({ port }) => {
+      const res = await connectBrowser({ port, identityPath, scopes: ["operator.read"] });
+      expect(res.ok).toBe(false);
+      expect(res.error?.message ?? "").toContain("pairing required");
+    });
+
+    const pairing = await listDevicePairing();
+    expect(pairing.pending.filter((entry) => entry.deviceId === identity.deviceId)).toHaveLength(1);
+    expect(await getPairedDevice(identity.deviceId)).toBeNull();
+  });
+
+  test("does not auto-approve token-authenticated browser devices", async () => {
+    await writeGatewayAuthConfig({
+      mode: "token",
+      deviceAutoApprove: { enabled: true, scopes: ["operator.approvals"] },
+    });
+    const identityPath = deviceIdentityPath("token-auth-disabled");
+    const identity = loadOrCreateDeviceIdentity({ path: identityPath });
+
+    await withGatewayServer(async ({ port }) => {
+      const res = await connectBrowser({
+        port,
+        identityPath,
+        scopes: ["operator.read"],
+        token: "secret",
+        trustedProxy: false,
+      });
+      expect(res.ok).toBe(true);
+    });
+
+    const pairing = await listDevicePairing();
+    expect(pairing.pending.filter((entry) => entry.deviceId === identity.deviceId)).toEqual([]);
+    const paired = await getPairedDevice(identity.deviceId);
+    expect(paired?.approvedScopes).toEqual(["operator.read"]);
+    expect(paired?.approvedVia).not.toBe("trusted-proxy");
+  });
+});

--- a/src/gateway/server/ws-connection/connect-auth.ts
+++ b/src/gateway/server/ws-connection/connect-auth.ts
@@ -80,6 +80,7 @@ export async function authenticateGatewayConnect(
     sendHandshakeErrorResponse,
   } = context;
   const resolvedAuth = getResolvedAuth();
+  const hasRequestedScopes = Array.isArray(connectParams.scopes);
   const admission = await admitGatewayConnect(context);
   if (!admission) {
     return undefined;
@@ -457,6 +458,7 @@ export async function authenticateGatewayConnect(
     usesLegacyNodeProtocol,
     role,
     scopes,
+    hasRequestedScopes,
     isControlUi,
     isBrowserOperatorUi,
     isWebchat,

--- a/src/gateway/server/ws-connection/connect-device-pairing.ts
+++ b/src/gateway/server/ws-connection/connect-device-pairing.ts
@@ -30,7 +30,9 @@ import { isBrowserCopilotClient } from "../../../utils/message-channel.js";
 import { pruneSupersededSilentPairingsAfterApproval } from "../../device-pairing-prune.js";
 import { shouldAutoApproveNodePairingFromTrustedCidrs } from "../../node-pairing-auto-approve.js";
 import { normalizeChromeExtensionOrigin } from "../../origin-check.js";
+import { formatForLog } from "../../ws-log.js";
 import { truncateCloseReason } from "../close-reason.js";
+import { resolveTrustedProxyControlUiScopes } from "./connect-admission.js";
 import {
   isControlUiOperatorBootstrapProfile,
   isMobileNodeBootstrapConnect,
@@ -47,6 +49,29 @@ import type {
   DeviceAuthorizedGatewayConnect,
   GatewayConnectPhaseContext,
 } from "./message-handler-types.js";
+
+const DEFAULT_TRUSTED_PROXY_DEVICE_AUTO_APPROVE_SCOPES = [
+  "operator.read",
+  "operator.write",
+  "operator.approvals",
+] as const;
+
+function resolveTrustedProxyDeviceAutoApproveScopes(params: {
+  requestedScopes: string[];
+  hasRequestedScopes: boolean;
+  configuredScopes?: string[];
+}): string[] {
+  const configuredScopes = normalizeSortedUniqueTrimmedStringList(
+    params.configuredScopes ?? [...DEFAULT_TRUSTED_PROXY_DEVICE_AUTO_APPROVE_SCOPES],
+  );
+  if (!params.hasRequestedScopes) {
+    return configuredScopes;
+  }
+  const configured = new Set(configuredScopes);
+  return normalizeSortedUniqueTrimmedStringList(params.requestedScopes).filter((scope) =>
+    configured.has(scope),
+  );
+}
 
 export async function authorizeGatewayConnectDevice(
   context: GatewayConnectPhaseContext,
@@ -70,7 +95,7 @@ export async function authorizeGatewayConnectDevice(
     reportedClientIpSource,
     hasBrowserOriginHeader,
   } = context;
-  const { scopes } = state;
+  let { scopes } = state;
   let { handoffBootstrapProfile } = state;
   const {
     role,
@@ -81,6 +106,8 @@ export async function authorizeGatewayConnectDevice(
     device,
     devicePublicKey,
     authMethod,
+    authResult,
+    hasRequestedScopes,
     bootstrapTokenCandidate,
     pairingLocality,
     skipLocalBackendSelfPairing,
@@ -172,6 +199,17 @@ export async function authorizeGatewayConnectDevice(
         reportedClientIp,
         autoApproveCidrs: configSnapshot.gateway?.nodes?.pairing?.autoApproveCidrs,
       });
+      const trustedProxyAutoApproveConfig =
+        configSnapshot.gateway?.auth?.trustedProxy?.deviceAutoApprove;
+      const trustedProxyUser = authResult.user?.trim();
+      const allowTrustedProxyDeviceAutoApproval =
+        reason === "not-paired" &&
+        !existingPairedDevice &&
+        role === "operator" &&
+        (isBrowserOperatorUi || isWebchat) &&
+        authMethod === "trusted-proxy" &&
+        Boolean(trustedProxyUser) &&
+        trustedProxyAutoApproveConfig?.enabled === true;
       const isSetupCodeMobileNodeConnect = isMobileNodeBootstrapConnect({
         role,
         scopes,
@@ -255,6 +293,17 @@ export async function authorizeGatewayConnectDevice(
               allowSetupCodeMobileBootstrapPairing ||
               allowControlUiOperatorBootstrapPairing,
       });
+      const trustedProxyAutoApproveScopes =
+        allowTrustedProxyDeviceAutoApproval && pairing.request.isRepair !== true
+          ? resolveTrustedProxyControlUiScopes({
+              requestedScopes: resolveTrustedProxyDeviceAutoApproveScopes({
+                requestedScopes: scopes,
+                hasRequestedScopes,
+                configuredScopes: trustedProxyAutoApproveConfig?.scopes,
+              }),
+              upgradeReq: context.handler.upgradeReq,
+            })
+          : null;
       const requestContext = buildRequestContext();
       // A replacement request obsoletes older pending requestIds; tell approval
       // UIs so they drop the stale prompts instead of stacking alerts forever.
@@ -287,28 +336,48 @@ export async function authorizeGatewayConnectDevice(
         );
         return replacementPending?.requestId;
       };
-      if (pairing.request.silent === true) {
-        approved = bootstrapApprovalProfile
-          ? await approveBootstrapDevicePairing(
-              pairing.request.requestId,
-              bootstrapApprovalProfile,
-              { accessMetadata: clientAccessMetadata },
-            )
-          : await approveDevicePairing(pairing.request.requestId, {
-              callerScopes: scopes,
-              accessMetadata: clientAccessMetadata,
-              // Same-host local approvals are prune-eligible "silent";
-              // trusted-CIDR approvals cross hosts and must never be
-              // auto-pruned, so they carry their own provenance.
-              approvedVia: allowSilentLocalPairing ? "silent" : "trusted-cidr",
-            });
+      const inlineApprovalAttempted =
+        trustedProxyAutoApproveScopes !== null || pairing.request.silent === true;
+      if (inlineApprovalAttempted) {
+        approved =
+          trustedProxyAutoApproveScopes !== null
+            ? await approveDevicePairing(pairing.request.requestId, {
+                callerScopes: trustedProxyAutoApproveScopes,
+                accessMetadata: clientAccessMetadata,
+                approvedVia: "trusted-proxy",
+                autoApproveNewDeviceScopes: trustedProxyAutoApproveScopes,
+              })
+            : bootstrapApprovalProfile
+              ? await approveBootstrapDevicePairing(
+                  pairing.request.requestId,
+                  bootstrapApprovalProfile,
+                  { accessMetadata: clientAccessMetadata },
+                )
+              : await approveDevicePairing(pairing.request.requestId, {
+                  callerScopes: scopes,
+                  accessMetadata: clientAccessMetadata,
+                  // Same-host local approvals are prune-eligible "silent";
+                  // trusted-CIDR approvals cross hosts and must never be
+                  // auto-pruned, so they carry their own provenance.
+                  approvedVia: allowSilentLocalPairing ? "silent" : "trusted-cidr",
+                });
         if (approved?.status === "approved") {
+          if (trustedProxyAutoApproveScopes !== null) {
+            scopes = trustedProxyAutoApproveScopes;
+            connectParams.scopes = scopes;
+          }
           if (bootstrapApprovalProfile) {
             handoffBootstrapProfile = bootstrapApprovalProfile;
           }
-          logGateway.info(
-            `device pairing auto-approved device=${approved.device.deviceId} role=${approved.device.role ?? "unknown"}`,
-          );
+          if (trustedProxyAutoApproveScopes !== null && trustedProxyUser) {
+            logGateway.warn(
+              `security audit: trusted-proxy browser device auto-approved user=${formatForLog(trustedProxyUser)} device=${formatForLog(approved.device.deviceId.slice(0, 12))} scopes=${formatAuditList(scopes)}`,
+            );
+          } else {
+            logGateway.info(
+              `device pairing auto-approved device=${approved.device.deviceId} role=${approved.device.role ?? "unknown"}`,
+            );
+          }
           requestContext.broadcast(
             "device.pair.resolved",
             {
@@ -334,6 +403,11 @@ export async function authorizeGatewayConnectDevice(
             }
           }
         } else {
+          // A concurrent connection approved this device first, so this
+          // invocation never replaces `scopes` with the trusted-proxy cap.
+          // That is safe: pairingStateAllowsRequestedAccess gates continuation
+          // on roleScopesAllow(scopes ⊆ device-granted scopes), so the session
+          // can never exceed what the device was actually approved for.
           const pairedAfterConcurrentApproval = await getPairedDevice(device.id);
           resolvedByConcurrentApproval = bootstrapApprovalProfile
             ? pairedDeviceAllowsBootstrapProfile({
@@ -371,7 +445,7 @@ export async function authorizeGatewayConnectDevice(
       recoveryRequestId = await resolveLivePendingRequestId();
       if (
         !(
-          pairing.request.silent === true &&
+          inlineApprovalAttempted &&
           (approved?.status === "approved" || resolvedByConcurrentApproval)
         )
       ) {

--- a/src/gateway/server/ws-connection/message-handler-types.ts
+++ b/src/gateway/server/ws-connection/message-handler-types.ts
@@ -119,6 +119,7 @@ export type AuthenticatedGatewayConnect = {
   usesLegacyNodeProtocol: boolean;
   role: GatewayRole;
   scopes: string[];
+  hasRequestedScopes: boolean;
   isControlUi: boolean;
   isBrowserOperatorUi: boolean;
   isWebchat: boolean;

--- a/src/infra/device-pairing-store.ts
+++ b/src/infra/device-pairing-store.ts
@@ -48,6 +48,7 @@ const APPROVAL_KIND_MEMBERS = {
   owner: true,
   silent: true,
   "trusted-cidr": true,
+  "trusted-proxy": true,
   "ssh-verified": true,
   bootstrap: true,
 } satisfies Record<PairedDeviceApprovalKind, true>;

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -494,6 +494,64 @@ describe("device pairing tokens", () => {
     ).resolves.toEqual({ ok: true });
   });
 
+  test("caps trusted-proxy auto-approval for new devices and refuses repairs", async () => {
+    const baseDir = await makeDevicePairingDir();
+    const initial = await requestDevicePairing(
+      {
+        deviceId: "browser-device-1",
+        publicKey: "public-key-browser-1",
+        role: "operator",
+        scopes: ["operator.read", "operator.write"],
+      },
+      baseDir,
+    );
+    const approved = await approveDevicePairing(
+      initial.request.requestId,
+      {
+        callerScopes: ["operator.read"],
+        approvedVia: "trusted-proxy",
+        autoApproveNewDeviceScopes: ["operator.read"],
+      },
+      baseDir,
+    );
+    expectRecordFields(approved, "trusted-proxy approved result", {
+      status: "approved",
+      requestId: initial.request.requestId,
+    });
+    expect(await getPairedDevice("browser-device-1", baseDir)).toMatchObject({
+      approvedScopes: ["operator.read"],
+      approvedVia: "trusted-proxy",
+    });
+
+    const repair = await requestDevicePairing(
+      {
+        deviceId: "browser-device-1",
+        publicKey: "public-key-browser-1",
+        role: "operator",
+        scopes: ["operator.read", "operator.write"],
+      },
+      baseDir,
+    );
+    await expect(
+      approveDevicePairing(
+        repair.request.requestId,
+        {
+          callerScopes: ["operator.read", "operator.write"],
+          approvedVia: "trusted-proxy",
+          autoApproveNewDeviceScopes: ["operator.read", "operator.write"],
+        },
+        baseDir,
+      ),
+    ).resolves.toBeNull();
+
+    expect((await listDevicePairing(baseDir)).pending).toContainEqual(
+      expect.objectContaining({ requestId: repair.request.requestId, isRepair: true }),
+    );
+    expect((await getPairedDevice("browser-device-1", baseDir))?.approvedScopes).toEqual([
+      "operator.read",
+    ]);
+  });
+
   test.each([
     {
       name: "node custom scope",

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -789,8 +789,14 @@ export async function approveDevicePairing(
     accessMetadata?: DevicePairingAccessMetadata;
     approvedVia?: Extract<
       PairedDeviceApprovalKind,
-      "owner" | "silent" | "trusted-cidr" | "ssh-verified"
+      "owner" | "silent" | "trusted-cidr" | "trusted-proxy" | "ssh-verified"
     >;
+    /**
+     * Replace the pending scopes only if this is still a brand-new device.
+     * Used by trusted-proxy auto-approval to cap grants without ever approving
+     * an existing-device repair or upgrade request.
+     */
+    autoApproveNewDeviceScopes?: readonly string[];
   },
   baseDir?: string,
 ): Promise<ApproveDevicePairingResult>;
@@ -802,8 +808,9 @@ export async function approveDevicePairing(
         accessMetadata?: DevicePairingAccessMetadata;
         approvedVia?: Extract<
           PairedDeviceApprovalKind,
-          "owner" | "silent" | "trusted-cidr" | "ssh-verified"
+          "owner" | "silent" | "trusted-cidr" | "trusted-proxy" | "ssh-verified"
         >;
+        autoApproveNewDeviceScopes?: readonly string[];
       }
     | string,
   maybeBaseDir?: string,
@@ -815,10 +822,19 @@ export async function approveDevicePairing(
   const baseDir = typeof optionsOrBaseDir === "string" ? optionsOrBaseDir : maybeBaseDir;
   return await withLock(async () => {
     const state = await loadState(baseDir);
-    const pending = state.pendingById[requestId];
-    if (!pending) {
+    const pendingRecord = state.pendingById[requestId];
+    if (!pendingRecord) {
       return null;
     }
+    if (
+      options?.autoApproveNewDeviceScopes &&
+      (pendingRecord.isRepair || state.pairedByDeviceId[pendingRecord.deviceId])
+    ) {
+      return null;
+    }
+    const pending = options?.autoApproveNewDeviceScopes
+      ? { ...pendingRecord, scopes: [...options.autoApproveNewDeviceScopes] }
+      : pendingRecord;
     const requestedRoles = mergeRoles(pending.roles, pending.role) ?? [];
     const requestedScopes = normalizeDeviceAuthScopes(pending.scopes);
     const roleMismatchScope = resolveScopeOutsideRequestedRoles({

--- a/src/infra/device-pairing.types.ts
+++ b/src/infra/device-pairing.types.ts
@@ -53,13 +53,15 @@ export type DeviceAuthToken = {
  * silently and cannot collide with another machine's records. "trusted-cidr"
  * and "ssh-verified" are also non-interactive but cross hosts, so they are
  * never pruned automatically (display metadata is not a machine identity).
- * "owner" and "bootstrap" approvals required a user action and are never
- * pruned.
+ * "trusted-proxy" records were approved from an authenticated proxy identity.
+ * "owner" and "bootstrap" approvals required a user action. None of these
+ * cross-host or interactive approval kinds are pruned automatically.
  */
 export type PairedDeviceApprovalKind =
   | "owner"
   | "silent"
   | "trusted-cidr"
+  | "trusted-proxy"
   | "ssh-verified"
   | "bootstrap";
 

--- a/src/security/audit-gateway-config.ts
+++ b/src/security/audit-gateway-config.ts
@@ -374,6 +374,18 @@ export function collectGatewayConfigFindings(
       });
     }
 
+    if (trustedProxyConfig?.deviceAutoApprove?.enabled === true) {
+      findings.push({
+        checkId: "gateway.trusted_proxy_device_auto_approve",
+        severity: "warn",
+        title: "Trusted-proxy browser device auto-approval enabled",
+        detail:
+          "gateway.auth.trustedProxy.deviceAutoApprove.enabled=true delegates new Control UI and WebChat device pairing entirely to the reverse-proxy identity.",
+        remediation:
+          "Enable this only when the proxy is the exclusive Gateway ingress, strongly authenticates users, overwrites identity headers, and restricts access with allowUsers.",
+      });
+    }
+
     const allowUsers = trustedProxyConfig?.allowUsers ?? [];
     if (allowUsers.length === 0) {
       findings.push({

--- a/src/security/audit-gateway-exposure.test.ts
+++ b/src/security/audit-gateway-exposure.test.ts
@@ -456,6 +456,25 @@ describe("security audit gateway exposure findings", () => {
         expectedCheckId: "gateway.trusted_proxy_allow_loopback",
         expectedSeverity: "warn",
       },
+      {
+        name: "browser device auto-approval enabled",
+        cfg: {
+          gateway: {
+            bind: "lan",
+            trustedProxies: ["10.0.0.1"],
+            auth: {
+              mode: "trusted-proxy",
+              trustedProxy: {
+                userHeader: "x-forwarded-user",
+                allowUsers: ["nick@example.com"],
+                deviceAutoApprove: { enabled: true },
+              },
+            },
+          },
+        },
+        expectedCheckId: "gateway.trusted_proxy_device_auto_approve",
+        expectedSeverity: "warn",
+      },
     ];
 
     for (const testCase of cases) {


### PR DESCRIPTION
## What

Adds `gateway.auth.trustedProxy.deviceAutoApprove` so a team gateway behind an identity-aware proxy (Cloudflare Access, oauth2-proxy, Pomerium, etc.) can skip the manual `openclaw devices approve` step for new browser devices. Today the first Control UI / WebChat connection from each browser ends in a `1008 pairing required` close and needs an operator to approve it out-of-band — pure ceremony when the proxy has already strongly authenticated the user and the gateway matched them against `allowUsers`.

```json5
{
  gateway: {
    auth: {
      mode: "trusted-proxy",
      trustedProxy: {
        userHeader: "cf-access-authenticated-user-email",
        allowUsers: ["alice@team.com", "bob@team.com"],
        deviceAutoApprove: {
          enabled: true,
          scopes: ["operator.read", "operator.write", "operator.approvals"], // default
        },
      },
    },
  },
}
```

## Behavior & guardrails

- Fires **only** for a new (unpaired) **operator browser** device (Control UI / WebChat) on a connection that already authenticated via `trusted-proxy` with a resolved `allowUsers` user. Token/password/tailscale auth, node pairing, and non-browser clients are never affected.
- **Scope upgrades on existing devices always stay manual.** The pairing-store approval rechecks new-device status under the store lock, so a repair/upgrade or a concurrent approval can never be silently widened.
- Granted scopes = configured set ∩ requested scopes ∩ the connection's `x-openclaw-scopes` proxy cap. A proxy that pins a user to `operator.read` still limits the persistent device grant even if the client omits its scope list.
- `operator.admin` is **rejected at config validation** — admin access is never auto-granted.
- Every auto-approval emits an audit log line with the proxy user, device id prefix, and granted scopes; `openclaw security audit` raises a `warn` finding while the mode is enabled.

## Tests

New `zod-schema.gateway-auth.test.ts` and `server.auth.trusted-proxy-device-autoapprove.test.ts` cover: default-scope approval, requested∩configured capping, `x-openclaw-scopes` capping in both omitted- and explicit-scope flows, scope-upgrade-stays-pending, disabled-by-default, token-auth isolation, and `operator.admin` rejection. Focused suites + `tsgo:core` pass; autoreview clean.

## Docs

New "Automatic device approval" section in `docs/gateway/trusted-proxy-auth.md` with the config reference and the security tradeoff.
