### PR TITLE
fix(pre-bootstrap): replace redundant dynamic imports with static import of config-env-vars

### DIFF
--- a/src/cli/gateway-cli/pre-bootstrap.ts
+++ b/src/cli/gateway-cli/pre-bootstrap.ts
@@ -1,4 +1,11 @@
-import { resetPublishedConfigRuntimeEnv } from "../../config/config-env-vars.js";
+import {
+  applyConfigEnvVars,
+  collectConfigRuntimeEnvOwnership,
+  collectConfigRuntimeEnvVars,
+  initializePublishedConfigRuntimeEnv,
+  isConfigRuntimeEnvVarAllowed,
+  resetPublishedConfigRuntimeEnv,
+} from "../../config/config-env-vars.js";
 // Gateway startup checks that must run before shared CLI bootstrap can migrate state.
 import { ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS_ENV } from "../../config/future-version-guard.js";
 import { GATEWAY_CONFIG_SELECTION_ENV_KEYS } from "../../config/gateway-env-selection.js";
@@ -243,14 +250,12 @@ async function guardGatewayRunSelectedConfig(
   lastGuardedGatewayRunSnapshot = undefined;
   const [
     path,
-    { applyConfigEnvVars, isConfigRuntimeEnvVarAllowed },
     { loadGlobalRuntimeDotEnvFiles },
     { normalizeEnv },
     { normalizeStateDirEnv, resolveStateDir },
     { resolveConfigDir },
   ] = await Promise.all([
     import("node:path"),
-    import("../../config/config-env-vars.js"),
     import("../../infra/dotenv-global.js"),
     import("../../infra/env.js"),
     import("../../config/paths.js"),
@@ -466,22 +471,12 @@ export async function applyFinalGatewayRunConfigEnv(params: {
   const invocationDestructiveOverride = resolveInvocationDestructiveOverride();
   const envBeforeApply = { ...process.env };
   const selectionSignature = resolveGatewayConfigSelectionSignature(process.env);
-  const [
-    {
-      applyConfigEnvVars,
-      collectConfigRuntimeEnvOwnership,
-      collectConfigRuntimeEnvVars,
-      initializePublishedConfigRuntimeEnv,
-    },
-    { normalizeEnv },
-    { normalizeStateDirEnv },
-    { clearShellEnvAppliedKeys },
-  ] = await Promise.all([
-    import("../../config/config-env-vars.js"),
-    import("../../infra/env.js"),
-    import("../../config/paths.js"),
-    import("../../infra/shell-env.js"),
-  ]);
+  const [{ normalizeEnv }, { normalizeStateDirEnv }, { clearShellEnvAppliedKeys }] =
+    await Promise.all([
+      import("../../infra/env.js"),
+      import("../../config/paths.js"),
+      import("../../infra/shell-env.js"),
+    ]);
   const finalConfigEnv = collectConfigRuntimeEnvVars(params.snapshot.sourceConfig);
   if (
     preparedSnapshot &&


### PR DESCRIPTION
## Summary

**What changed**: Consolidated all `config-env-vars.js` imports in `src/cli/gateway-cli/pre-bootstrap.ts` into a single static top-level `import` block, removing two redundant `await import()` calls from `Promise.all` arrays in `guardGatewayRunSelectedConfig` and `applyFinalGatewayRunConfigEnv`.

**What did NOT change**: No runtime logic, function signatures, module resolution order, error handling patterns, or async control flow semantics changed in any way. Node.js module cache ensures repeated dynamic imports of an already-loaded module return the exact same module object — this is a strictly behavior-preserving refactor.

Fixes #111195

## What Problem This Solves

**Problem**: `src/cli/gateway-cli/pre-bootstrap.ts` uses two separate `await import()` calls inside `Promise.all` to load functions from `../../config/config-env-vars.js`, even though the module is already imported statically at the top of the file for `resetPublishedConfigRuntimeEnv`. This adds unnecessary complexity and async overhead during gateway startup.

**Root Cause**: Historical evolution of the file — some imports were added inline as dynamic imports inside `Promise.all` blocks rather than consolidated at the top level alongside the existing static `resetPublishedConfigRuntimeEnv` import.

**Solution**: Move all `config-env-vars.js` exports to a single static top-level `import` statement, removing the two redundant `await import()` calls from the `Promise.all` arrays. The five additional exports (`applyConfigEnvVars`, `isConfigRuntimeEnvVarAllowed`, `collectConfigRuntimeEnvOwnership`, `collectConfigRuntimeEnvVars`, `initializePublishedConfigRuntimeEnv`) are now imported at the top level alongside `resetPublishedConfigRuntimeEnv`.

## Evidence

**Real environment tested**: Linux 6.17.0-40-generic / Node.js v25.9.0 / tsx v4.22.4 / Gateway port 19002 (isolated from production)

**Exact steps or command run after this patch**:
```bash
# 1. Start gateway from PR branch (exercises guardGatewayRunSelectedConfig + applyFinalGatewayRunConfigEnv)
OPENCLAW_GATEWAY_PORT=19002 pnpm gateway:dev
# 2. Verify health endpoint responds
curl -s http://127.0.0.1:19002/healthz
# 3. Verify CLI version (exercises pre-bootstrap import path)
npx tsx src/entry.ts --version
# 4. Verify config validate (exercises config-env-vars module resolution)
npx tsx src/entry.ts config validate
```

**After-fix evidence**:
```
$ curl -s http://127.0.0.1:19002/healthz
{"ok":true,"status":"live"}
HTTP status: 200

$ grep -E 'loading configuration|starting HTTP|listening|ready' /tmp/gateway-111195.log
2026-07-19T14:19:41.287+08:00 [gateway] loading configuration...       (guardGatewayRunSelectedConfig runs)
2026-07-19T14:19:42.234+08:00 [gateway] starting HTTP server...       (applyFinalGatewayRunConfigEnv runs)
2026-07-19T14:19:42.768+08:00 [gateway] http server listening (13 plugins)
2026-07-19T14:19:42.946+08:00 [gateway] ready

$ npx tsx src/entry.ts --version
OpenClaw 2026.7.2 (eb451fe)

$ npx tsx src/entry.ts config validate
Config valid: ~/.openclaw/openclaw.json
```

**Observed result after the fix**: Gateway starts successfully on port 19002, with both pre-bootstrap guard functions completing without error (loading configuration → starting HTTP server → listening → ready). CLI commands execute with exit code 0. All 6 config-env-vars exports resolve correctly via static imports.

**What was not tested**: N/A — behavior-preserving refactor (dynamic → static import) with no runtime logic changes. The Node.js module cache ensures repeated dynamic imports of an already-loaded module return identical module objects, so this change cannot alter runtime behavior.

## Tests and validation

```
$ npx tsx docs/.local/issue-111195/verify.ts
=== Static import verification for pre-bootstrap.ts ===
All 6 config-env-vars.js exports loaded via static imports:

  ✓ applyConfigEnvVars type: function
  ✓ collectConfigRuntimeEnvOwnership type: function
  ✓ collectConfigRuntimeEnvVars type: function
  ✓ initializePublishedConfigRuntimeEnv type: function
  ✓ isConfigRuntimeEnvVarAllowed type: function
  ✓ resetPublishedConfigRuntimeEnv type: function
```

## Risk checklist

- [x] This change is backwards compatible
- [x] This change has been tested with existing configurations
- [ ] I have updated relevant documentation
- [ ] Breaking changes (if any) are documented in Summary

merge-risk: low — behavior-preserving refactor with no logic changes
