### PR TITLE
fix(mcp-cli): replace redundant dynamic import with static import of agent-bundle-mcp-runtime

### DIFF
--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -10,7 +10,10 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { Command } from "commander";
 import { buildBundleMcpToolsFromCatalog } from "../agents/agent-bundle-mcp-materialize.js";
-import { createSessionMcpRuntime } from "../agents/agent-bundle-mcp-runtime.js";
+import {
+  createSessionMcpRuntime,
+  disposeAllSessionMcpRuntimes,
+} from "../agents/agent-bundle-mcp-runtime.js";
 import {
   buildMcpHttpFetch,
   withoutMcpAuthorizationHeader,
@@ -1335,8 +1338,6 @@ export function registerMcpCli(program: Command) {
     .command("reload")
     .description("Dispose cached MCP runtimes so new config is used on the next turn")
     .action(async () => {
-      const { disposeAllSessionMcpRuntimes } =
-        await import("../agents/agent-bundle-mcp-runtime.js");
       await disposeAllSessionMcpRuntimes();
       defaultRuntime.log(
         "Disposed cached MCP runtimes. Active agents use new MCP config on their next runtime build.",


### PR DESCRIPTION
## What Problem This Solves

`src/cli/mcp-cli.ts` uses a dynamic `await import()` inside the `reload` command action to load `disposeAllSessionMcpRuntimes` from `../agents/agent-bundle-mcp-runtime.js`, even though the same module is already imported statically at the top of the file for `createSessionMcpRuntime`.

## Why This Change Was Made

Node.js module cache ensures a second dynamic import of an already-loaded module returns the exact same module object. Adding `disposeAllSessionMcpRuntimes` to the existing static import removes the indirection with no behavioral change.

## User Impact

No user-visible impact.

## Evidence

- `npm run typecheck` passes.