### PR TITLE
fix(inworld): reject malformed base64 TTS audio

### DIFF
--- a/extensions/inworld/tts.test.ts
+++ b/extensions/inworld/tts.test.ts
@@ -237,6 +237,15 @@ describe("inworldTTS", () => {
     );
   });
 
+  it("rejects malformed base64 audio chunks", async () => {
+    const body = JSON.stringify({ result: { audioContent: "not-base64!" } });
+    queueGuardedResponse(new Response(body, { status: 200 }));
+
+    await expect(inworldTTS({ text: "test", apiKey: "fixture-api-key" })).rejects.toThrow(
+      "Inworld TTS returned malformed base64 audio data",
+    );
+  });
+
   it("throws on HTTP errors with response body", async () => {
     queueGuardedResponse(new Response("bad request body", { status: 400 }));
 

--- a/extensions/inworld/tts.ts
+++ b/extensions/inworld/tts.ts
@@ -1,5 +1,5 @@
 // Inworld plugin module implements tts behavior.
-import { MAX_AUDIO_BYTES } from "openclaw/plugin-sdk/media-runtime";
+import { canonicalizeBase64, MAX_AUDIO_BYTES } from "openclaw/plugin-sdk/media-runtime";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import type { SpeechVoiceOption } from "openclaw/plugin-sdk/speech-core";
 import { fetchWithSsrFGuard, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
@@ -186,7 +186,11 @@ export async function inworldTTS(params: {
       }
 
       if (parsed.result?.audioContent) {
-        const chunk = Buffer.from(parsed.result.audioContent, "base64");
+        const canonicalAudio = canonicalizeBase64(parsed.result.audioContent);
+        if (!canonicalAudio) {
+          throw new Error("Inworld TTS returned malformed base64 audio data");
+        }
+        const chunk = Buffer.from(canonicalAudio, "base64");
         const nextDecodedAudioBytes = decodedAudioBytes + chunk.length;
         if (nextDecodedAudioBytes > MAX_AUDIO_BYTES) {
           throw new Error(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users generating speech with Inworld TTS could receive silently corrupted audio when the provider returned malformed base64 in an otherwise successful response.

## Why This Change Was Made

The Inworld response path now validates and canonicalizes each audio chunk with the shared media-runtime base64 contract before concatenation, while preserving valid padded, unpadded, URL-safe, and whitespace-bearing base64. Risk note: rejecting a valid provider payload would break TTS, so the existing success cases and a real production-entry transport harness cover both valid decoding and malformed rejection.

## User Impact

Malformed Inworld audio now fails with a clear provider error instead of being decoded into plausible but corrupted bytes.

## Evidence

Node `v24.18.0` on Linux `x64` demonstrates the underlying runtime behavior: `Buffer.from("aGVs!bG8=", "base64")` silently returns `hello` even though the payload contains an invalid character. Inworld's voice preview contract exposes `audioContent` as base64: https://dev.docs.inworld.ai/api-reference/voiceAPI/voiceservice/get-voice-preview

Before, the real `inworldTTS` production entry at `upstream/main@c684b132133` accepted that malformed provider value through a transport-only fetch stub:

```text
{ surface: "inworld", malformed: "aGVs!bG8=", acceptedUtf8: "hello" }
```

After this change, the same production entry and transport-only harness rejects it:

```text
{ rejected: true, error: "Inworld TTS returned malformed base64 audio data" }
```

Focused repository test:

```text
$ OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/inworld/tts.test.ts
Test Files  1 passed (1)
Tests       31 passed (31)
```

Touched-file `oxfmt`, `oxlint`, and `git diff --check` passed. The final autoreview completed cleanly with 0.95 confidence.

AI-assisted: Codex helped implement and review the change; production-entry proof and focused validation were run manually.
