### PR TITLE
fix(xiaomi): reject malformed base64 TTS audio

### DIFF
--- a/extensions/xiaomi/speech-provider.test.ts
+++ b/extensions/xiaomi/speech-provider.test.ts
@@ -6,7 +6,8 @@ const transcodeAudioBufferToOpusMock = vi.hoisted(() => vi.fn());
 
 const PROVIDER_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
 
-vi.mock("openclaw/plugin-sdk/media-runtime", () => ({
+vi.mock("openclaw/plugin-sdk/media-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/media-runtime")>()),
   transcodeAudioBufferToOpus: transcodeAudioBufferToOpusMock,
 }));
 
@@ -218,6 +219,28 @@ describe("buildXiaomiSpeechProvider", () => {
       ]);
       expect(body.audio).toEqual({ format: "mp3", voice: "default_en" });
       expect(transcodeAudioBufferToOpusMock).not.toHaveBeenCalled();
+    });
+
+    it("rejects malformed audio base64", async () => {
+      vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ choices: [{ message: { audio: { data: "not-base64!" } } }] }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      );
+
+      await expect(
+        provider.synthesize({
+          text: "Test",
+          cfg: {} as never,
+          providerConfig: { apiKey: "fixture-api-key" },
+          target: "audio-file",
+          timeoutMs: 30000,
+        }),
+      ).rejects.toThrow("Xiaomi TTS API returned malformed audio base64");
     });
 
     it("omits voice and uses configured style for Xiaomi voice design models", async () => {

--- a/extensions/xiaomi/speech-provider.ts
+++ b/extensions/xiaomi/speech-provider.ts
@@ -1,5 +1,5 @@
 // Xiaomi provider module implements model/runtime integration.
-import { transcodeAudioBufferToOpus } from "openclaw/plugin-sdk/media-runtime";
+import { canonicalizeBase64, transcodeAudioBufferToOpus } from "openclaw/plugin-sdk/media-runtime";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import {
   assertOkOrThrowProviderError,
@@ -245,7 +245,11 @@ function decodeXiaomiAudioData(body: unknown): Buffer {
   if (!audioData) {
     throw new Error("Xiaomi TTS API returned no audio data");
   }
-  return Buffer.from(audioData, "base64");
+  const canonicalAudio = canonicalizeBase64(audioData);
+  if (!canonicalAudio) {
+    throw new Error("Xiaomi TTS API returned malformed audio base64");
+  }
+  return Buffer.from(canonicalAudio, "base64");
 }
 
 async function xiaomiTTS(params: {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users generating speech with Xiaomi MiMo TTS could receive silently corrupted audio when the API returned malformed base64 in a successful response.

## Why This Change Was Made

The Xiaomi audio decode boundary now validates and canonicalizes the returned audio with the shared media-runtime base64 contract before format detection and voice-note transcoding. Risk note: an overly strict decoder could reject legitimate Xiaomi audio, so existing valid response and transcoding coverage remains intact alongside production-entry malformed-response proof.

## User Impact

Malformed Xiaomi TTS audio now produces a clear provider error rather than continuing with corrupted decoded bytes.

## Evidence

Node `v24.18.0` on Linux `x64` silently decodes the invalid-character payload `aGVs!bG8=` to `hello`. The provider's base64 response behavior is also captured by the maintainer's live integration probe in #52376.

Before, the real Xiaomi speech provider `synthesize` entry at `upstream/main@c684b132133` accepted that malformed value through a transport-only fetch stub:

```text
{ surface: "xiaomi", malformed: "aGVs!bG8=", acceptedUtf8: "hello" }
```

After this change, the same production entry and transport-only harness rejects it:

```text
{ rejected: true, error: "Xiaomi TTS API returned malformed audio base64" }
```

Focused repository test:

```text
$ OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/xiaomi/speech-provider.test.ts
Test Files  1 passed (1)
Tests       23 passed (23)
```

Touched-file `oxfmt`, `oxlint`, and `git diff --check` passed. The final autoreview completed cleanly with 0.97 confidence.

AI-assisted: Codex helped implement and review the change; production-entry proof and focused validation were run manually.
