### PR TITLE
fix(volcengine): reject malformed base64 TTS audio

### DIFF
--- a/extensions/volcengine/tts.test.ts
+++ b/extensions/volcengine/tts.test.ts
@@ -276,6 +276,23 @@ describe("volcengineTTS", () => {
     expect(release).toHaveBeenCalledTimes(1);
   });
 
+  it("rejects malformed Seed Speech audio base64", async () => {
+    const release = vi.fn();
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(JSON.stringify({ code: 0, data: "not-base64!" })),
+      release,
+    });
+
+    await expect(
+      volcengineTTS({
+        text: "hello",
+        apiKey: "fixture-api-key",
+        timeoutMs: 1000,
+      }),
+    ).rejects.toThrow("BytePlus Seed Speech TTS returned malformed base64 audio data");
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
   it("reports Seed Speech provider errors without exposing credentials", async () => {
     const release = vi.fn();
     fetchWithSsrFGuardMock.mockResolvedValue({
@@ -346,6 +363,44 @@ describe("volcengineTTS", () => {
     expect(error).toBeInstanceOf(Error);
     expect((error as Error).message).toBe("Volcengine TTS error 3001: load grant failed");
     expect((error as Error).message).not.toContain("secret-token");
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("decodes valid legacy Volcengine audio base64", async () => {
+    const release = vi.fn();
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(
+        JSON.stringify({ code: 3000, data: Buffer.from("legacy-audio").toString("base64") }),
+      ),
+      release,
+    });
+
+    const audio = await volcengineTTS({
+      text: "hello",
+      appId: "app-id",
+      token: "fixture-token",
+      timeoutMs: 1000,
+    });
+
+    expect(audio.toString()).toBe("legacy-audio");
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects malformed legacy Volcengine audio base64", async () => {
+    const release = vi.fn();
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(JSON.stringify({ code: 3000, data: "not-base64!" })),
+      release,
+    });
+
+    await expect(
+      volcengineTTS({
+        text: "hello",
+        appId: "app-id",
+        token: "fixture-token",
+        timeoutMs: 1000,
+      }),
+    ).rejects.toThrow("Volcengine TTS returned malformed base64 audio data");
     expect(release).toHaveBeenCalledTimes(1);
   });
 

--- a/extensions/volcengine/tts.ts
+++ b/extensions/volcengine/tts.ts
@@ -1,5 +1,6 @@
 // Volcengine plugin module implements tts behavior.
 import * as crypto from "node:crypto";
+import { canonicalizeBase64 } from "openclaw/plugin-sdk/media-runtime";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 
@@ -112,6 +113,14 @@ function seedAudioFormat(encoding: VolcengineTtsEncoding): "ogg_opus" | "mp3" | 
   return encoding === "wav" ? "pcm" : encoding;
 }
 
+function decodeVolcengineAudioBase64(value: string, providerName: string): Buffer {
+  const canonicalAudio = canonicalizeBase64(value);
+  if (!canonicalAudio) {
+    throw new Error(`${providerName} returned malformed base64 audio data`);
+  }
+  return Buffer.from(canonicalAudio, "base64");
+}
+
 async function seedSpeechTTS(params: VolcengineTTSParams & { apiKey: string }): Promise<Buffer> {
   const {
     text,
@@ -171,7 +180,7 @@ async function seedSpeechTTS(params: VolcengineTTSParams & { apiKey: string }): 
     for (const frame of frames) {
       if (frame.code === 0) {
         if (frame.data) {
-          chunks.push(Buffer.from(frame.data, "base64"));
+          chunks.push(decodeVolcengineAudioBase64(frame.data, "BytePlus Seed Speech TTS"));
         }
         continue;
       }
@@ -260,7 +269,7 @@ async function legacyVolcengineTTS(
         `Volcengine TTS error ${body.code ?? response.status}: ${body.message ?? "unknown"}`,
       );
     }
-    return Buffer.from(body.data, "base64");
+    return decodeVolcengineAudioBase64(body.data, "Volcengine TTS");
   } finally {
     await release();
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users generating speech through either BytePlus Seed Speech or legacy Volcengine TTS could receive silently corrupted audio when the provider returned malformed base64.

## Why This Change Was Made

Both credential routes now pass provider audio through one local decoder backed by the shared media-runtime base64 contract. Risk note: the two routes return different envelopes, so focused tests and real production-entry transport harnesses exercise malformed rejection independently for both Seed and legacy responses.

## User Impact

Malformed BytePlus or Volcengine audio now fails with a route-specific provider error instead of being decoded into corrupted bytes.

## Evidence

Node `v24.18.0` on Linux `x64` silently decodes the invalid-character payload `aGVs!bG8=` to `hello`. BytePlus documents the response `data` field as synthesized base64 audio: https://docs.byteplus.com/en/docs/byteplusvoice/unidirectional_tts_http

Before, the real `volcengineTTS` production entry at `upstream/main@c684b132133` accepted the malformed value on both routes through transport-only fetch stubs:

```text
{ surface: "volcengine-seed", malformed: "aGVs!bG8=", acceptedUtf8: "hello" }
{ surface: "volcengine-legacy", malformed: "aGVs!bG8=", acceptedUtf8: "hello" }
```

After this change, those same production paths reject it:

```text
{ route: "seed", rejected: true, error: "BytePlus Seed Speech TTS returned malformed base64 audio data" }
{ route: "legacy", rejected: true, error: "Volcengine TTS returned malformed base64 audio data" }
```

Focused repository test:

```text
$ OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/volcengine/tts.test.ts
Test Files  1 passed (1)
Tests       18 passed (18)
```

Touched-file `oxfmt`, `oxlint`, and `git diff --check` passed. The final autoreview completed cleanly with 0.93 confidence.

AI-assisted: Codex helped implement and review the change; production-entry proof and focused validation were run manually.
