### PR TITLE
fix(sessions): stop persisting media-only caption placeholder into transcripts

### DIFF
--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -1661,7 +1661,6 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
         userInput: {
           text: "",
           media: [{ path: "/media/inbound/image-1.png", contentType: "image/png" }],
-          mediaOnlyText: "[User sent media without caption]",
         },
       }),
     );
@@ -4293,7 +4292,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     expect(attempt.suppressPromptPersistenceOnRetry).toBe(false);
     expect(attempt.userTurnTranscriptRecorder?.message).toMatchObject({
       role: "user",
-      content: "[User sent media without caption]",
+      content: "",
       MediaPath: "/media/inbound/image-1.png",
       MediaPaths: ["/media/inbound/image-1.png"],
       MediaType: "image/png",

--- a/src/agents/command/acp-execution.ts
+++ b/src/agents/command/acp-execution.ts
@@ -206,7 +206,6 @@ export async function runAcpAgentCommand(params: {
             userInput: {
               text: params.transcriptBody,
               media: params.opts.transcriptMedia,
-              mediaOnlyText: "[User sent media without caption]",
             },
           }
         : {}),

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -1591,7 +1591,6 @@ describe("CLI attempt execution", () => {
       userInput: {
         text: "",
         media: [{ path: "/media/inbound/image-1.png", contentType: "image/png" }],
-        mediaOnlyText: "[User sent media without caption]",
       },
       finalText: "",
       sessionId: sessionEntry.sessionId,
@@ -1615,9 +1614,11 @@ describe("CLI attempt execution", () => {
     ).toContainEqual(
       expect.objectContaining({
         role: "user",
-        content: "[User sent media without caption]",
+        content: "",
         MediaPath: "/media/inbound/image-1.png",
+        MediaPaths: ["/media/inbound/image-1.png"],
         MediaType: "image/png",
+        MediaTypes: ["image/png"],
       }),
     );
   });

--- a/src/agents/command/run-embedded-attempt.ts
+++ b/src/agents/command/run-embedded-attempt.ts
@@ -153,12 +153,7 @@ export async function runEmbeddedAgentAttempt(params: {
       ? {
           input: {
             text: recorderTranscriptText,
-            ...(hasTranscriptMedia
-              ? {
-                  media: transcriptMedia,
-                  mediaOnlyText: "[User sent media without caption]",
-                }
-              : {}),
+            ...(hasTranscriptMedia ? { media: transcriptMedia } : {}),
           },
         }
       : {}),

--- a/src/agents/embedded-agent-runner/replay-history.ts
+++ b/src/agents/embedded-agent-runner/replay-history.ts
@@ -185,7 +185,8 @@ function sanitizeUserReplayContent(message: AgentMessage): AgentMessage | null {
   }
   const replayContent = (message as { content?: unknown }).content;
   if (typeof replayContent === "string") {
-    return replayContent.trim() ? message : null;
+    const media = message as unknown as { MediaPath?: string; MediaPaths?: string[] };
+    return replayContent.trim() || media.MediaPath || media.MediaPaths?.length ? message : null;
   }
   if (!Array.isArray(replayContent)) {
     return message;

--- a/src/agents/embedded-agent-runner/run/attempt.llm-boundary.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.llm-boundary.test.ts
@@ -249,11 +249,11 @@ describe("normalizeMessagesForLlmBoundary", () => {
     const [normalizedPersisted] = normalizeMessagesForLlmBoundary(
       [persisted] as Parameters<typeof normalizeMessagesForLlmBoundary>[0],
       { timezone: "UTC" },
-    );
+    ) as unknown as Array<{ content?: unknown }>;
     const [normalizedLegacy] = normalizeMessagesForLlmBoundary(
       [legacy] as Parameters<typeof normalizeMessagesForLlmBoundary>[0],
       { timezone: "UTC" },
-    );
+    ) as unknown as Array<{ content?: unknown }>;
     const expectedText = `${buildTimestampPrefix(new Date(timestamp), { timezone: "UTC" })}${MEDIA_ONLY_USER_TEXT}`;
 
     expect(normalizedPersisted).toEqual(normalizedLegacy);
@@ -268,7 +268,7 @@ describe("normalizeMessagesForLlmBoundary", () => {
         },
       ] as Parameters<typeof normalizeMessagesForLlmBoundary>[0],
       { timezone: "UTC" },
-    );
+    ) as unknown as Array<{ content?: unknown }>;
     expect(normalizedArray?.content).toEqual([{ type: "text", text: expectedText }, image]);
   });
 

--- a/src/agents/embedded-agent-runner/run/attempt.llm-boundary.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.llm-boundary.test.ts
@@ -1,6 +1,7 @@
 // Coverage for sanitizing replay messages at the LLM boundary.
 import { describe, expect, it } from "vitest";
 import { buildTimestampPrefix } from "../../../gateway/server-methods/agent-timestamp.js";
+import { MEDIA_ONLY_USER_TEXT } from "../../../sessions/user-turn-media.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import {
   installRuntimeContextMessageForPrompt,
@@ -233,6 +234,42 @@ describe("normalizeMessagesForLlmBoundary", () => {
       timezone: "UTC",
     });
     expect(output[2]?.content).toBe(`${expectedCurrentPrefix}Current ask`);
+  });
+
+  it("injects media-only text before timestamping with legacy-identical provider bytes", () => {
+    const timestamp = 1717570800000;
+    const persisted = {
+      role: "user",
+      content: "",
+      timestamp,
+      MediaPath: "/tmp/input.png",
+      MediaPaths: ["/tmp/input.png"],
+    };
+    const legacy = { ...persisted, content: MEDIA_ONLY_USER_TEXT };
+    const [normalizedPersisted] = normalizeMessagesForLlmBoundary(
+      [persisted] as Parameters<typeof normalizeMessagesForLlmBoundary>[0],
+      { timezone: "UTC" },
+    );
+    const [normalizedLegacy] = normalizeMessagesForLlmBoundary(
+      [legacy] as Parameters<typeof normalizeMessagesForLlmBoundary>[0],
+      { timezone: "UTC" },
+    );
+    const expectedText = `${buildTimestampPrefix(new Date(timestamp), { timezone: "UTC" })}${MEDIA_ONLY_USER_TEXT}`;
+
+    expect(normalizedPersisted).toEqual(normalizedLegacy);
+    expect(normalizedPersisted?.content).toBe(expectedText);
+
+    const image = { type: "image", data: "aGVsbG8=", mimeType: "image/png" };
+    const [normalizedArray] = normalizeMessagesForLlmBoundary(
+      [
+        {
+          ...persisted,
+          content: [{ type: "text", text: "   " }, image],
+        },
+      ] as Parameters<typeof normalizeMessagesForLlmBoundary>[0],
+      { timezone: "UTC" },
+    );
+    expect(normalizedArray?.content).toEqual([{ type: "text", text: expectedText }, image]);
   });
 
   it("can leave user message bytes bare for cache-sensitive local providers", () => {

--- a/src/agents/embedded-agent-runner/run/attempt.llm-boundary.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.llm-boundary.ts
@@ -500,16 +500,16 @@ function stripHistoricalInboundMetadataFromUserMessages(
     // keeps such messages byte-stable across current↔historical (the envelope is
     // present in both forms) and avoids double-stamping.
     const transformText = (raw: string): string => {
-      raw = injectMediaText && !raw.trim() ? MEDIA_ONLY_USER_TEXT : raw;
-      const { body, envelope } = splitLeadingTimestampEnvelope(raw);
-      if (envelope || raw.includes(BOUNDARY_CRON_TIME_MARKER)) {
+      const sourceText = injectMediaText && !raw.trim() ? MEDIA_ONLY_USER_TEXT : raw;
+      const { body, envelope } = splitLeadingTimestampEnvelope(sourceText);
+      if (envelope || sourceText.includes(BOUNDARY_CRON_TIME_MARKER)) {
         if (isActive) {
-          return raw;
+          return sourceText;
         }
         // Strip metadata from the body but re-attach the original envelope.
         return `${envelope}${stripInboundMetadata(body)}`;
       }
-      const stripped = isActive ? raw : stripInboundMetadata(raw);
+      const stripped = isActive ? sourceText : stripInboundMetadata(sourceText);
       return stampUserTextWithMessageTimestamp(
         stripped,
         messageTimestamp,

--- a/src/agents/embedded-agent-runner/run/attempt.llm-boundary.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.llm-boundary.ts
@@ -4,6 +4,7 @@
 import { stripInboundMetadata } from "../../../auto-reply/reply/strip-inbound-meta.js";
 import { buildTimestampPrefix } from "../../../gateway/server-methods/agent-timestamp.js";
 import { INTER_SESSION_PROMPT_PREFIX_BASE } from "../../../sessions/input-provenance.js";
+import { MEDIA_ONLY_USER_TEXT } from "../../../sessions/user-turn-media.js";
 import { stripHistoricalRuntimeContextCustomMessages } from "../../internal-runtime-context.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import { stripToolResultDetails } from "../../session-transcript-repair.js";
@@ -465,6 +466,16 @@ function stripHistoricalInboundMetadataFromUserMessages(
       return message;
     }
     const content = (message as { content?: unknown }).content;
+    const media = message as unknown as { MediaPath?: unknown; MediaPaths?: unknown };
+    const hasMedia =
+      (typeof media.MediaPath === "string" && Boolean(media.MediaPath.trim())) ||
+      (Array.isArray(media.MediaPaths) &&
+        media.MediaPaths.some((value) => typeof value === "string" && value.trim()));
+    const injectMediaText =
+      hasMedia &&
+      (typeof content === "string"
+        ? !content.trim()
+        : Array.isArray(content) && !content.some((block) => readFirstUserText([block])?.trim()));
     const isActive = index === activeUserMessageIndex;
     const override = options?.currentUserTimestampOverride;
     const runtimeTimestamp = (message as { timestamp?: unknown }).timestamp;
@@ -479,8 +490,8 @@ function stripHistoricalInboundMetadataFromUserMessages(
 
     // Historical turns strip inbound metadata blocks (Conversation info, Sender
     // info, etc.); the active turn keeps its metadata for the current request.
-    // BOTH then get form-canonicalized and stamped from their own timestamp, so
-    // the SAME message serializes identically whether current or historical.
+    // BOTH then get media-only text if needed, form-canonicalize, and stamp from
+    // their own timestamp, so current and historical bytes stay identical.
     //
     // Channel-envelope preservation: a message that already carries its OWN
     // leading `[DOW YYYY-MM-DD HH:MM ...] ` envelope (Discord/Telegram, or a
@@ -489,6 +500,7 @@ function stripHistoricalInboundMetadataFromUserMessages(
     // keeps such messages byte-stable across current↔historical (the envelope is
     // present in both forms) and avoids double-stamping.
     const transformText = (raw: string): string => {
+      raw = injectMediaText && !raw.trim() ? MEDIA_ONLY_USER_TEXT : raw;
       const { body, envelope } = splitLeadingTimestampEnvelope(raw);
       if (envelope || raw.includes(BOUNDARY_CRON_TIME_MARKER)) {
         if (isActive) {
@@ -558,6 +570,10 @@ function stripHistoricalInboundMetadataFromUserMessages(
       contentChanged = true;
       return Object.assign({}, block, { text: nextText });
     });
+    if (!processedFirstText && injectMediaText) {
+      nextContent.unshift({ type: "text", text: transformText("") });
+      contentChanged = true;
+    }
     if (!contentChanged) {
       return message;
     }

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -732,6 +732,23 @@ describe("runPreparedReply media-only handling", () => {
     expect(call.followupRun.prompt).toContain("[User sent media without caption]");
   });
 
+  it("persists pure media turns without the model-facing placeholder", async () => {
+    const params = baseParams();
+    params.ctx.ThreadHistoryBody = undefined;
+    params.ctx.MediaPath = "/tmp/input.png";
+    params.sessionCtx.ThreadHistoryBody = undefined;
+
+    await runPreparedReply(params);
+
+    const call = requireRunReplyAgentCall();
+    expect(call.followupRun.prompt).toContain("[User sent media without caption]");
+    expect(call.followupRun.userTurnTranscriptRecorder?.message).toMatchObject({
+      role: "user",
+      content: "",
+      MediaPath: "/tmp/input.png",
+    });
+  });
+
   it.each([
     "discord",
     "telegram",

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -47,6 +47,7 @@ import {
   isSubagentSessionKey,
   normalizeMainKey,
 } from "../../routing/session-key.js";
+import { MEDIA_ONLY_USER_TEXT } from "../../sessions/user-turn-media.js";
 import {
   buildPersistedUserTurnMediaInputsFromFields,
   createUserTurnTranscriptRecorder,
@@ -1463,9 +1464,15 @@ export async function runPreparedReply(
   const userTurnMediaForPersistence = buildPersistedUserTurnMediaInputsFromFields(ctx);
   const inputProvenance = ctx.InputProvenance ?? sessionCtx.InputProvenance;
   const userTurnTimestamp = normalizeMessageTimestampMs(ctx.Timestamp);
-  const userTurnTranscriptText = resolvePersistedUserTurnText(transcriptBody, {
-    hasMedia: userTurnMediaForPersistence.length > 0,
-  });
+  // prompt-prelude substitutes MEDIA_ONLY_USER_TEXT as transcriptBody for
+  // bodyless turns; storage stays bare (the LLM boundary re-injects it), while
+  // room-event lines that merely contain the marker keep their real text.
+  const userTurnTranscriptText =
+    !hasUserBody && transcriptBody === MEDIA_ONLY_USER_TEXT
+      ? ""
+      : resolvePersistedUserTurnText(transcriptBody, {
+          hasMedia: userTurnMediaForPersistence.length > 0,
+        });
   const conversationIdentity = conversationIdentityFromMsgContext({ ctx: sessionCtx });
   const conversationRef = conversationIdentity?.conversationRef;
   const transportMessageId =
@@ -1507,12 +1514,7 @@ export async function runPreparedReply(
             ? { provenance: { kind: "internal_system" as const, sourceTool: "heartbeat" } }
             : {}),
           ...(transport ? { transport } : {}),
-          ...(userTurnMediaForPersistence.length > 0
-            ? {
-                media: userTurnMediaForPersistence,
-                mediaOnlyText: "[User sent media without caption]",
-              }
-            : {}),
+          ...(userTurnMediaForPersistence.length > 0 ? { media: userTurnMediaForPersistence } : {}),
           // Persist the message's own arrival timestamp so the single
           // LLM-boundary stamping site (normalizeMessagesForLlmBoundary) can
           // derive a stable per-message `[DOW YYYY-MM-DD HH:MM TZ]` prefix that

--- a/src/auto-reply/reply/prompt-prelude.ts
+++ b/src/auto-reply/reply/prompt-prelude.ts
@@ -4,6 +4,7 @@ import type { CurrentInboundPromptContext } from "../../agents/embedded-agent-ru
 import type { InboundEventKind } from "../../channels/inbound-event/kind.js";
 import { MESSAGE_TOOL_ONLY_DELIVERY_HINT } from "../../plugin-sdk/message-tool-delivery-hints.js";
 import { annotateInterSessionPromptText } from "../../sessions/input-provenance.js";
+import { MEDIA_ONLY_USER_TEXT } from "../../sessions/user-turn-media.js";
 import type { SourceReplyDeliveryMode } from "../get-reply-options.types.js";
 import { HEARTBEAT_TRANSCRIPT_PROMPT } from "../heartbeat.js";
 import { buildInboundMediaNote } from "../media-note.js";
@@ -137,7 +138,7 @@ function resolveRoomEventBody(params: ReplyPromptEnvelopeBaseParams): string {
     normalizeOptionalString(params.sessionCtx.CommandBody) ??
     normalizeOptionalString(params.sessionCtx.RawBody) ??
     (params.hasUserBody ? params.baseBody.trim() : undefined) ??
-    "[User sent media without caption]"
+    MEDIA_ONLY_USER_TEXT
   );
 }
 
@@ -226,7 +227,7 @@ export function buildReplyPromptEnvelopeBase(
     ? ROOM_EVENT_PROMPT
     : params.hasUserBody
       ? resetModelBody
-      : "[User sent media without caption]";
+      : MEDIA_ONLY_USER_TEXT;
   // Room-event transcript rows are plain chat lines; replay treats them as
   // conversation, while the OpenClaw marker remains current-turn context only.
   const transcriptBody = params.isHeartbeat
@@ -237,7 +238,7 @@ export function buildReplyPromptEnvelopeBase(
         ? resolveRoomEventTranscriptBody(params)
         : params.hasUserBody
           ? params.baseBody
-          : "[User sent media without caption]";
+          : MEDIA_ONLY_USER_TEXT;
   const currentInboundContext: CurrentInboundPromptContext | undefined =
     !params.isBareSessionReset && currentInboundContextText
       ? {

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -398,12 +398,7 @@ function createCollectUserTurnTranscriptRecorder(items: FollowupRun[]) {
       provenance: source.run.inputProvenance,
       idempotencyKey: `followup-collect:${source.run.sessionId}:${identityHash}`,
       ...(timestamp === undefined ? {} : { timestamp }),
-      ...(media.length === 0
-        ? {}
-        : {
-            media,
-            mediaOnlyText: "[User sent media without caption]",
-          }),
+      ...(media.length === 0 ? {} : { media }),
     };
   };
   const initialTranscriptPrompt = buildCollectTranscriptPrompt(transcriptSources);

--- a/src/gateway/server-methods/chat-send-user-turn.ts
+++ b/src/gateway/server-methods/chat-send-user-turn.ts
@@ -236,12 +236,7 @@ export function prepareChatSendUserTurn(params: {
   userTurn.setInputPromise(
     preparedUserTurnMediaPromise.then(buildChatSendUserTurnMedia).then((media) => ({
       ...userTurn.baseInput,
-      ...(media.length > 0
-        ? {
-            media,
-            mediaOnlyText: "[User sent media without caption]",
-          }
-        : {}),
+      ...(media.length > 0 ? { media } : {}),
     })),
   );
   const pluginBoundMediaFieldsPromise =

--- a/src/sessions/user-turn-media.ts
+++ b/src/sessions/user-turn-media.ts
@@ -1,0 +1,4 @@
+// Model-facing marker for user turns that carry media but no caption. Never
+// persist it as transcript content — UIs render content verbatim; the LLM
+// boundary (normalizeMessagesForLlmBoundary) injects it for blank media turns.
+export const MEDIA_ONLY_USER_TEXT = "[User sent media without caption]";

--- a/src/sessions/user-turn-transcript.ts
+++ b/src/sessions/user-turn-transcript.ts
@@ -216,7 +216,6 @@ function readOpenClawMessageMeta(message: AgentMessage): Record<string, unknown>
 
 export function buildPersistedUserTurnMessage(params: UserTurnInput): PersistedUserTurnMessage {
   const mediaFields = buildPersistedUserTurnMediaFields(params.media);
-  const hasMedia = Boolean(mediaFields.MediaPath);
   const text = normalizeTranscriptText(params.text);
   // Storage is BARE (no timestamp prefix). The per-message timestamp is added
   // at the single LLM-boundary stamping site (normalizeMessagesForLlmBoundary),
@@ -224,7 +223,6 @@ export function buildPersistedUserTurnMessage(params: UserTurnInput): PersistedU
   // every historical turn serialize identically on the wire. Persisting a stamp
   // here would NOT match the bare-current arrival (the gateway no longer stamps
   // the live turn) — see https://github.com/openclaw/openclaw/issues/3658.
-  const content = text || (hasMedia ? (params.mediaOnlyText ?? "") : "");
   const senderMeta = buildUserTurnSenderMeta(params.sender);
   const openClawMeta = {
     ...(params.senderIsOwner === undefined ? {} : { senderIsOwner: params.senderIsOwner }),
@@ -233,7 +231,7 @@ export function buildPersistedUserTurnMessage(params: UserTurnInput): PersistedU
   };
   const message = {
     role: "user",
-    content,
+    content: text,
     timestamp: params.timestamp ?? Date.now(),
     ...(params.idempotencyKey ? { idempotencyKey: params.idempotencyKey } : {}),
     ...mediaFields,

--- a/src/sessions/user-turn-transcript.types.ts
+++ b/src/sessions/user-turn-transcript.types.ts
@@ -29,7 +29,6 @@ export type UserTurnInput = {
   idempotencyKey?: string;
   senderIsOwner?: boolean;
   provenance?: InputProvenance;
-  mediaOnlyText?: string;
   /** Durable participant attribution. Callers must opt in at the product boundary. */
   sender?: { id?: string | null; name?: string | null; username?: string | null } | null;
   /** Durable transport correlation; stored privately and never rendered into model input. */


### PR DESCRIPTION
## What Problem This Solves

Sending media without a caption (e.g. dragging an image into the Control UI chat) shows a literal subtitle "[User sent media without caption]" under the image in every client. That string is model-facing scaffolding (providers reject empty user turns, and "media, no caption" is useful signal for the agent), but it was persisted as the user message `content` in the session transcript, and all UIs render transcript content verbatim.

## Why This Change Was Made

Storage should stay bare; per-message decoration belongs at the single LLM-boundary stamping site. This is the exact pattern already used for per-message timestamps (#3658): transcripts persist bare content, and `normalizeMessagesForLlmBoundary` stamps deterministically on the way to the provider.

- `buildPersistedUserTurnMessage` now persists bare text (`content: ""` for media-only turns); the `mediaOnlyText` input field is removed along with its five duplicated call-site literals (gateway chat.send, reply drain, get-reply-run, ACP, embedded attempt).
- The placeholder is defined once (`MEDIA_ONLY_USER_TEXT` in `src/sessions/user-turn-media.ts`) and injected at the LLM boundary for user turns that carry persisted media fields with blank text — before timestamp stamping, so provider-visible bytes are identical to what the persisted literal produced. Replay sanitization keeps blank media-bearing turns alive for that injection.
- `prompt-prelude` keeps emitting the placeholder into the current-turn prompt (unchanged model behavior); get-reply-run persists `""` only when the transcript body is exactly the model-facing fallback.
- Legacy transcripts that already contain the literal are non-empty, so injection skips them and they replay byte-identically.

## User Impact

Media-only messages now render as just the image in Control UI, macOS, iOS, and Android — no synthetic subtitle. No model-visible change: current turns, history replay, and legacy transcripts all serialize identically to before. Sidebar previews skip the now-empty text row and fall back to the preceding non-empty message.

## Evidence

- New boundary test proves a persisted media-only turn (`content: ""` + `MediaPath`) normalizes to the same provider bytes as a legacy turn persisted with the literal, including timestamp stamping and image-block arrays.
- New media-only regression test proves the run prompt still contains the placeholder while the persisted message is bare.
- Focused suites green via `node scripts/run-vitest.mjs`: `get-reply-run.media-only.test.ts` 101/101, `attempt.llm-boundary.test.ts` 29/29, `user-turn-transcript.test.ts` 36/36, `attempt-execution.cli.test.ts` 65/65, `agent-command.live-model-switch.test.ts` 107/107.
- Autoreview (Codex `gpt-5.6-sol`, xhigh): clean, "patch is correct (0.88)", no actionable findings.
- Net prod LOC ~flat (−1 before review comments); five duplicated literals collapsed into one constant.
