### PR TITLE
feat(gateway): attribute prompts to authenticated users

### DIFF
--- a/src/gateway/server-methods/agent-run-execution-phase.ts
+++ b/src/gateway/server-methods/agent-run-execution-phase.ts
@@ -187,6 +187,9 @@ export function startAgentRunExecution(params: {
                 text: params.effectiveTranscriptInputText,
                 timestamp: Date.now(),
                 idempotencyKey: buildRunUserTurnIdempotencyKey(params.runId),
+                ...(params.client?.authenticatedUserId
+                  ? { sender: { id: params.client.authenticatedUserId } }
+                  : {}),
                 ...(params.inputProvenance ? { provenance: params.inputProvenance } : {}),
               },
               target: () => {

--- a/src/gateway/server-methods/agent.base.test-utils.ts
+++ b/src/gateway/server-methods/agent.base.test-utils.ts
@@ -545,6 +545,35 @@ describe("gateway agent handler", () => {
     );
   });
 
+  it("attributes gateway agent prompts to the authenticated connection user", async () => {
+    primeMainAgentRun();
+
+    await invokeAgent(
+      {
+        message: "persist me",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        idempotencyKey: "idem-attributed-user-turn-recorder",
+      },
+      {
+        reqId: "idem-attributed-user-turn-recorder",
+        client: {
+          ...requireValue(operatorWriteCliClient(), "expected operator client"),
+          authenticatedUserId: "alice@example.com",
+        },
+      },
+    );
+
+    const call = await waitForAgentCommandCall<
+      AgentCommandCall & { userTurnTranscriptRecorder?: { message?: unknown } }
+    >();
+    expect(call.userTurnTranscriptRecorder?.message).toMatchObject({
+      role: "user",
+      content: "persist me",
+      __openclaw: { senderId: "alice@example.com" },
+    });
+  });
+
   it("dispatches with the session id reloaded during lifecycle admission", async () => {
     const sessionKey = "agent:main:main";
     const initialSessionId = "session-before-reset";

--- a/src/gateway/server-methods/chat-send-handler.ts
+++ b/src/gateway/server-methods/chat-send-handler.ts
@@ -191,6 +191,7 @@ export const handleChatSend: GatewayRequestHandlers["chat.send"] = async ({
       ...(systemInputProvenance ? { provenance: systemInputProvenance } : {}),
       rawMessage,
       ...(restartSafeAdmission ? { restartAdmission: restartSafeAdmission } : {}),
+      ...(client?.authenticatedUserId ? { sender: { id: client.authenticatedUserId } } : {}),
       senderIsOwner: hasGatewayAdminScope(client),
       sessionKey,
       ...(sessionLoadOptions ? { sessionLoadOptions } : {}),

--- a/src/gateway/server-methods/chat-user-turn-recorder.ts
+++ b/src/gateway/server-methods/chat-user-turn-recorder.ts
@@ -35,6 +35,7 @@ export function createGatewayChatUserTurnController(params: {
   provenance?: InputProvenance;
   rawMessage: string;
   restartAdmission?: RestartSafeChatAdmission;
+  sender?: UserTurnInput["sender"];
   senderIsOwner: boolean;
   sessionKey: string;
   sessionLoadOptions?: { agentId?: string; clone?: boolean };
@@ -46,6 +47,7 @@ export function createGatewayChatUserTurnController(params: {
     text: params.rawMessage,
     timestamp: params.now,
     idempotencyKey: buildRunUserTurnIdempotencyKey(params.clientRunId),
+    ...(params.sender ? { sender: params.sender } : {}),
     ...(params.senderIsOwner ? { senderIsOwner: true } : {}),
     ...(params.provenance ? { provenance: params.provenance } : {}),
   };

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -69,6 +69,7 @@ export type GatewayClient = {
   clientIp?: string;
   /** Client id verified against the server-approved device pairing record. */
   pairedClientId?: string;
+  authenticatedUserId?: string;
   pluginSurfaceUrls?: Record<string, string>;
   pluginNodeCapabilitySurfaces?: Record<string, PluginNodeCapabilitySurface>;
   pluginNodeCapabilities?: Record<string, { capability: string; expiresAtMs: number }>;

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -251,6 +251,7 @@ function createDirectChatContext(): GatewayRequestContext {
 }
 
 async function sendControlUiChat(params: {
+  authenticatedUserId?: string;
   context: GatewayRequestContext;
   expectedSessionRoutingContract?: string;
   idempotencyKey: string;
@@ -278,6 +279,7 @@ async function sendControlUiChat(params: {
     },
     params: requestParams,
     client: {
+      ...(params.authenticatedUserId ? { authenticatedUserId: params.authenticatedUserId } : {}),
       connect: {
         client: {
           id: GATEWAY_CLIENT_NAMES.CONTROL_UI,
@@ -2470,6 +2472,94 @@ describe("gateway server chat", () => {
       );
     } finally {
       dispatchRelease.resolve(undefined);
+      dispatchInboundMessageMock.mockReset();
+      testState.sessionStorePath = undefined;
+      clearConfigCache();
+      await removeTempDir(sessionDir);
+    }
+  });
+
+  test("chat.send persists optional connection identity per turn", async () => {
+    const sessionDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
+    try {
+      testState.sessionStorePath = path.join(sessionDir, "sessions.json");
+      await writeSessionStore({
+        entries: {
+          main: {
+            sessionId: "sess-main",
+            status: "done",
+            updatedAt: Date.now(),
+          },
+        },
+      });
+      const context = createDirectChatContext();
+      const send = async (params: {
+        authenticatedUserId?: string;
+        idempotencyKey: string;
+        message: string;
+      }) => {
+        const removeCount = (context.removeChatRun as ReturnType<typeof vi.fn>).mock.calls.length;
+        await sendControlUiChat({
+          context,
+          ...params,
+          respond: vi.fn() as RespondFn,
+        });
+        await waitForFast(
+          () => expect(context.removeChatRun).toHaveBeenCalledTimes(removeCount + 1),
+          FAST_WAIT_OPTS,
+        );
+      };
+
+      await send({
+        authenticatedUserId: "alice@example.com",
+        idempotencyKey: "idem-attributed-alice",
+        message: "prompt from alice",
+      });
+      await send({
+        authenticatedUserId: "bob@example.com",
+        idempotencyKey: "idem-attributed-bob",
+        message: "prompt from bob",
+      });
+      await send({
+        idempotencyKey: "idem-unattributed",
+        message: "prompt without identity",
+      });
+
+      const transcriptEvents = loadTranscriptEventsSync({
+        agentId: "main",
+        sessionId: "sess-main",
+        sessionKey: "agent:main:main",
+        storePath: testState.sessionStorePath,
+      });
+      expect(transcriptEvents).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "message",
+            message: expect.objectContaining({
+              role: "user",
+              content: "prompt from alice",
+              __openclaw: expect.objectContaining({ senderId: "alice@example.com" }),
+            }),
+          }),
+          expect.objectContaining({
+            type: "message",
+            message: expect.objectContaining({
+              role: "user",
+              content: "prompt from bob",
+              __openclaw: expect.objectContaining({ senderId: "bob@example.com" }),
+            }),
+          }),
+          expect.objectContaining({
+            type: "message",
+            message: expect.objectContaining({
+              role: "user",
+              content: "prompt without identity",
+              __openclaw: expect.not.objectContaining({ senderId: expect.anything() }),
+            }),
+          }),
+        ]),
+      );
+    } finally {
       dispatchInboundMessageMock.mockReset();
       testState.sessionStorePath = undefined;
       clearConfigCache();

--- a/ui/src/lib/chat/message-normalizer.test.ts
+++ b/ui/src/lib/chat/message-normalizer.test.ts
@@ -602,5 +602,22 @@ describe("message-normalizer", () => {
 
       expect(result.senderLabel).toBe("Iris");
     });
+
+    it("formats durable sender metadata for transcript attribution", () => {
+      expect(
+        normalizeMessage({
+          role: "user",
+          content: "Prompt from Alice",
+          __openclaw: { senderId: "alice@example.com" },
+        }).senderLabel,
+      ).toBe("alice");
+      expect(
+        normalizeMessage({
+          role: "user",
+          content: "Prompt from a profile",
+          __openclaw: { senderId: "profile_123", senderName: "Alice Example" },
+        }).senderLabel,
+      ).toBe("Alice Example");
+    });
   });
 });

--- a/ui/src/lib/chat/message-normalizer.ts
+++ b/ui/src/lib/chat/message-normalizer.ts
@@ -14,6 +14,7 @@ import { splitMediaFromOutput } from "../../../../src/media/parse.js";
 import { parseInlineDirectives } from "../../../../src/utils/directive-tags.js";
 import { getMediaFileExtension } from "../media-file-extension.ts";
 import type { NormalizedMessage, MessageContentItem } from "./chat-types.ts";
+import { formatSenderLabel } from "./sender-label.ts";
 
 export function normalizeRoleForGrouping(role: string): string {
   const lower = role.toLowerCase();
@@ -513,8 +514,19 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
 
   const timestamp = typeof m.timestamp === "number" ? m.timestamp : Date.now();
   const id = typeof m.id === "string" ? m.id : undefined;
+  const rawOpenClawMeta = m["__openclaw"];
+  const openClawMeta =
+    rawOpenClawMeta && typeof rawOpenClawMeta === "object" && !Array.isArray(rawOpenClawMeta)
+      ? (rawOpenClawMeta as Record<string, unknown>)
+      : undefined;
   const senderLabel =
-    typeof m.senderLabel === "string" && m.senderLabel.trim() ? m.senderLabel.trim() : null;
+    typeof m.senderLabel === "string" && m.senderLabel.trim()
+      ? m.senderLabel.trim()
+      : formatSenderLabel({
+          id: openClawMeta?.senderId,
+          name: openClawMeta?.senderName,
+          username: openClawMeta?.senderUsername,
+        });
 
   content = stripMessageDisplayMetadata(content);
 

--- a/ui/src/lib/chat/sender-label.ts
+++ b/ui/src/lib/chat/sender-label.ts
@@ -1,0 +1,22 @@
+type SenderIdentity = {
+  id?: unknown;
+  name?: unknown;
+  username?: unknown;
+};
+
+function normalizeLabelPart(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+/** Formats durable sender identity without assuming ids will always be email addresses. */
+export function formatSenderLabel(sender: SenderIdentity | null | undefined): string | null {
+  const displayName = normalizeLabelPart(sender?.name) ?? normalizeLabelPart(sender?.username);
+  if (displayName) {
+    return displayName;
+  }
+  const id = normalizeLabelPart(sender?.id);
+  if (!id) {
+    return null;
+  }
+  return /^([^@\s]+)@[^@\s]+$/.exec(id)?.[1] ?? id;
+}

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -1229,6 +1229,39 @@ describe("grouped chat rendering", () => {
     expect(avatar?.tagName).toBe("DIV");
   });
 
+  it("renders a durable sender label in the user message metadata", () => {
+    const container = document.createElement("div");
+    const group: MessageGroup = {
+      kind: "group",
+      key: "attributed-user-group",
+      role: "user",
+      senderLabel: "alice",
+      messages: [
+        {
+          key: "attributed-user-message",
+          message: { role: "user", content: "hello", timestamp: 1000 },
+        },
+      ],
+      timestamp: 1000,
+      isStreaming: false,
+    };
+
+    render(
+      renderMessageGroup(group, {
+        showReasoning: true,
+        showToolCalls: true,
+        assistantName: "OpenClaw",
+        assistantAvatar: null,
+        userName: "Local User",
+      }),
+      container,
+    );
+
+    expect(
+      container.querySelector<HTMLElement>(".chat-group.user .chat-sender-name")?.textContent,
+    ).toBe("alice");
+  });
+
   it("uses assistant senderLabel for forwarded assistant-side groups", () => {
     const container = document.createElement("div");
     const group: MessageGroup = {


### PR DESCRIPTION
## What Problem This Solves

On a shared gateway, prompts from different teammates are indistinguishable in session transcripts — everything reads as one anonymous operator. The persisted user-turn store already supports durable, opt-in `sender` attribution (built for channel senders like Telegram), but gateway clients never populate it.

Part of the multiplayer-identity program: #111133 (PR "attribution" of the train; builds on #111179).

## Why This Change Was Made

When an identified gateway client (trusted-proxy/Tailscale-authenticated) submits a prompt, the gateway now stamps the existing `UserTurnInput.sender` field with the connection's identity (`sender: { id: authenticatedUserId }`) on both the chat and agent execution paths. The Control UI renders a small attribution label on prompt bubbles via a new `formatSenderLabel` helper (display name → username → email local part → opaque id), so labels upgrade automatically once durable profile ids replace emails.

Scope lines held deliberately:
- Prompts only — tool calls, steering, and agent output remain the agent's, unattributed.
- `senderIsOwner` semantics untouched (admin-scope-derived, verified before changing nothing).
- Identity optional: unidentified connections persist exactly today's un-attributed turns (conditional spread; no field written).

## User Impact

Shared-gateway teams see who asked what in session transcripts. Single-user and token/password gateways see zero change.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/server.chat.gateway-server-chat-b.test.ts` — 87 tests, incl. two identified senders + one unidentified in a single session.
- `node scripts/run-vitest.mjs src/gateway/server-methods/agent.test.ts` — 246 tests (agent-path attribution).
- `node scripts/run-vitest.mjs src/sessions/user-turn-transcript.test.ts` — 36 tests (durable persistence unchanged semantics).
- `node scripts/run-vitest.mjs ui/src/lib/chat/message-normalizer.test.ts ui/src/pages/chat/components/chat-message.test.ts` — 138 tests (label precedence + rendering).
- Core/UI TypeScript lanes green on Blacksmith Testbox; targeted oxlint + format clean.
- Structured autoreview (codex/gpt-5.6-sol, xhigh): clean, no actionable findings ("patch is correct").

Production diff is 42 insertions / 1 deletion; the rest is tests.
