### PR TITLE
fix(ios): preserve Markdown lists and separators in chat

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -37155,7 +37155,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 548,
+      "line": 634,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownRenderer.swift",
       "source": "Image",
       "surface": "apple",

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownBlockSegmenter.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownBlockSegmenter.swift
@@ -2,10 +2,13 @@ import Foundation
 import Markdown
 
 /// One renderable block of a chat message. Prose stays on the
-/// AttributedString pipeline; headings, fenced code, display math, and GFM tables get dedicated views.
+/// AttributedString pipeline; headings, simple lists, thematic breaks, fenced code,
+/// display math, and GFM tables get dedicated views.
 enum ChatMarkdownBlock: Equatable {
     case prose(String)
     case heading(ChatMarkdownHeading)
+    case list(ChatMarkdownList)
+    case thematicBreak
     case code(ChatCodeBlock)
     case math(ChatMathBlock)
     case table(ChatMarkdownTable)
@@ -16,6 +19,27 @@ struct ChatMarkdownHeading: Equatable {
     /// Keep the complete source so Swift's Markdown parser continues to own
     /// inline formatting and both ATX and Setext heading syntax.
     let markdown: String
+}
+
+struct ChatMarkdownList: Equatable {
+    enum Style: Equatable {
+        case unordered
+        case ordered(start: UInt)
+    }
+
+    struct Item: Equatable {
+        enum Checkbox: Equatable {
+            case checked
+            case unchecked
+        }
+
+        let checkbox: Checkbox?
+        /// Inline Markdown for a simple, single-paragraph list item.
+        let markdown: String
+    }
+
+    let style: Style
+    let items: [Item]
 }
 
 struct ChatCodeBlock: Equatable {
@@ -70,10 +94,12 @@ enum ChatMarkdownBlockSegmenter {
     static let maxTableRows = 100
     static let maxTableColumns = 12
     static let maxTableCells = 600
+    static let maxListBytes = 20000
+    static let maxListItems = 100
 
-    /// Extracts only top-level headings, fenced code, display math, and GFM tables. The parser owns
-    /// CommonMark container and reference semantics; nested blocks stay in the
-    /// surrounding prose range unchanged.
+    /// Extracts only top-level blocks with dedicated native renderers. The parser owns CommonMark
+    /// container and reference semantics; complex and nested containers stay in the surrounding
+    /// prose range unchanged.
     static func segments(markdown: String, isComplete: Bool) -> [ChatMarkdownBlock] {
         let source = SourceBuffer(markdown)
         let document = Document(parsing: source.markdown)
@@ -95,6 +121,33 @@ enum ChatMarkdownBlockSegmenter {
                     block: .heading(ChatMarkdownHeading(
                         level: heading.level,
                         markdown: source.text(in: lineRange)))))
+                continue
+            }
+
+            if let orderedList = child as? Markdown.OrderedList,
+               let list = self.list(
+                   orderedList,
+                   style: .ordered(start: orderedList.startIndex),
+                   source: source,
+                   lineRange: lineRange)
+            {
+                extractions.append(Extraction(lineRange: lineRange, block: .list(list)))
+                continue
+            }
+
+            if let unorderedList = child as? Markdown.UnorderedList,
+               let list = self.list(
+                   unorderedList,
+                   style: .unordered,
+                   source: source,
+                   lineRange: lineRange)
+            {
+                extractions.append(Extraction(lineRange: lineRange, block: .list(list)))
+                continue
+            }
+
+            if child is Markdown.ThematicBreak {
+                extractions.append(Extraction(lineRange: lineRange, block: .thematicBreak))
                 continue
             }
 
@@ -258,7 +311,7 @@ enum ChatMarkdownBlockSegmenter {
         return [.prose(slice.joined(separator: "\n"))]
     }
 
-    private static func containsReferenceLink(_ document: Document, source: SourceBuffer) -> Bool {
+    private static func containsReferenceLink(_ markup: any Markup, source: SourceBuffer) -> Bool {
         func search(_ markup: any Markup) -> Bool {
             if markup is Markdown.Link || markup is Markdown.Image,
                let range = markup.range,
@@ -269,11 +322,60 @@ enum ChatMarkdownBlockSegmenter {
             }
             return markup.children.contains(where: search)
         }
-        return search(document)
+        return search(markup)
     }
 
     private static func dropStructuralCodeNewline(_ code: String) -> String {
         code.hasSuffix("\n") ? String(code.dropLast()) : code
+    }
+
+    private static func list(
+        _ list: some ListItemContainer,
+        style: ChatMarkdownList.Style,
+        source: SourceBuffer,
+        lineRange: Range<Int>) -> ChatMarkdownList?
+    {
+        let items = Array(list.listItems)
+        guard !items.isEmpty,
+              items.count <= self.maxListItems,
+              source.text(in: lineRange).utf8.count <= self.maxListBytes
+        else { return nil }
+
+        var renderedItems: [ChatMarkdownList.Item] = []
+        renderedItems.reserveCapacity(items.count)
+        for item in items {
+            let children = Array(item.blockChildren)
+            guard children.count == 1,
+                  let paragraph = children.first as? Markdown.Paragraph,
+                  let range = paragraph.range,
+                  let markdown = source.listParagraphText(in: range),
+                  !markdown.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                  !self.containsReferenceLink(paragraph, source: source),
+                  !self.containsMultilineInlineCode(paragraph),
+                  !markdown.contains("$$"),
+                  !markdown.contains(#"\["#)
+            else { return nil }
+
+            let checkbox: ChatMarkdownList.Item.Checkbox? = switch item.checkbox {
+            case .checked?: .checked
+            case .unchecked?: .unchecked
+            case nil: nil
+            }
+            renderedItems.append(ChatMarkdownList.Item(
+                checkbox: checkbox,
+                markdown: markdown))
+        }
+        return ChatMarkdownList(style: style, items: renderedItems)
+    }
+
+    private static func containsMultilineInlineCode(_ markup: any Markup) -> Bool {
+        if markup is Markdown.InlineCode,
+           let range = markup.range,
+           range.lowerBound.line != range.upperBound.line
+        {
+            return true
+        }
+        return markup.children.contains(where: self.containsMultilineInlineCode)
     }
 
     private struct Extraction {
@@ -398,6 +500,27 @@ enum ChatMarkdownBlockSegmenter {
             else { return nil }
             let middle = self.lines[(startLine + 1)..<endLine]
             return ([first] + middle + [last]).joined(separator: "\n")
+        }
+
+        func listParagraphText(in range: SourceRange) -> String? {
+            guard let text = self.text(in: range) else { return nil }
+            let lines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+            guard lines.count > 1 else { return text }
+
+            let continuationIndent = max(range.lowerBound.column - 1, 0)
+            return ([lines[0]] + lines.dropFirst().map {
+                Self.removingLeadingSpaces(from: $0, upTo: continuationIndent)
+            }).joined(separator: "\n")
+        }
+
+        private static func removingLeadingSpaces(from line: String, upTo limit: Int) -> String {
+            var cursor = line.startIndex
+            var removed = 0
+            while cursor < line.endIndex, removed < limit, line[cursor] == " " {
+                cursor = line.index(after: cursor)
+                removed += 1
+            }
+            return String(line[cursor...])
         }
 
         private func utf8Slice(_ line: String, from start: Int, to end: Int) -> String? {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownRenderer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownRenderer.swift
@@ -102,6 +102,18 @@ struct ChatMarkdownRenderer: View {
                 .lineSpacing(self.variant == .compact ? 2 : 4)
                 .modifier(ChatInlineMathAccessibilityModifier(label: prose.inlineAccessibilityText))
                 .accessibilityAddTraits(.isHeader)
+        case let .list(list):
+            ChatMarkdownListView(
+                list: list,
+                variant: self.variant,
+                font: self.font,
+                textColor: self.textColor,
+                linkColor: self.linkColor,
+                inlineMathFontSize: self.inlineMathFontSize,
+                colorScheme: self.colorScheme)
+        case .thematicBreak:
+            Divider()
+                .accessibilityHidden(true)
         case let .code(code):
             ChatCodeBlockView(block: code)
         case let .math(math):
@@ -157,6 +169,19 @@ struct ChatMarkdownRenderSnapshot {
                         markdown: heading.markdown,
                         isComplete: isComplete,
                         preparesReveal: false))
+            case let .list(list):
+                .list(ChatMarkdownRenderedList(
+                    style: list.style,
+                    items: list.items.map { item in
+                        ChatMarkdownRenderedList.Item(
+                            checkbox: item.checkbox,
+                            prose: ChatMarkdownProse(
+                                markdown: item.markdown,
+                                isComplete: isComplete,
+                                preparesReveal: false))
+                    }))
+            case .thematicBreak:
+                .thematicBreak
             case let .code(code):
                 .code(code)
             case let .math(math):
@@ -181,9 +206,70 @@ struct ChatMarkdownRenderSnapshot {
 enum ChatMarkdownRenderedBlock {
     case prose(ChatMarkdownProse)
     case heading(level: Int, prose: ChatMarkdownProse)
+    case list(ChatMarkdownRenderedList)
+    case thematicBreak
     case code(ChatCodeBlock)
     case math(ChatMathBlock)
     case table(ChatMarkdownTable)
+}
+
+@MainActor
+struct ChatMarkdownRenderedList {
+    struct Item {
+        let checkbox: ChatMarkdownList.Item.Checkbox?
+        let prose: ChatMarkdownProse
+    }
+
+    let style: ChatMarkdownList.Style
+    let items: [Item]
+
+    func marker(for item: Item, index: Int) -> String {
+        let checkbox = item.checkbox.map { $0 == .checked ? "☑︎" : "☐︎" }
+        switch self.style {
+        case .unordered:
+            return checkbox ?? "•"
+        case let .ordered(start):
+            let number = "\(start + UInt(index))."
+            return checkbox.map { "\(number) \($0)" } ?? number
+        }
+    }
+}
+
+@MainActor
+private struct ChatMarkdownListView: View {
+    let list: ChatMarkdownRenderedList
+    let variant: ChatMarkdownVariant
+    let font: Font
+    let textColor: Color
+    let linkColor: Color
+    let inlineMathFontSize: CGFloat
+    let colorScheme: ColorScheme
+
+    var body: some View {
+        Grid(alignment: .leading, horizontalSpacing: 8, verticalSpacing: self.variant == .compact ? 4 : 6) {
+            ForEach(Array(self.list.items.enumerated()), id: \.offset) { index, item in
+                GridRow(alignment: .firstTextBaseline) {
+                    Text(self.list.marker(for: item, index: index))
+                        .font(self.font)
+                        .foregroundStyle(self.textColor)
+                        .gridColumnAlignment(.trailing)
+
+                    item.prose.renderedText(
+                        fontSize: self.inlineMathFontSize,
+                        textColor: self.textColor,
+                        colorScheme: self.colorScheme)
+                        .font(self.font)
+                        .foregroundStyle(self.textColor)
+                        .tint(self.linkColor)
+                        .textSelection(.enabled)
+                        .lineSpacing(self.variant == .compact ? 2 : 4)
+                        .modifier(ChatInlineMathAccessibilityModifier(
+                            label: item.prose.inlineAccessibilityText))
+                        .gridColumnAlignment(.leading)
+                }
+            }
+        }
+    }
 }
 
 @MainActor
@@ -463,8 +549,8 @@ private struct ChatInlineMathAccessibilityModifier: ViewModifier {
     }
 }
 
-/// Headings, fenced code, display math, and GFM tables are split out by `ChatMarkdownBlockSegmenter`
-/// before this runs, so prose only needs chat-style soft-break preservation.
+/// Blocks with dedicated native renderers are split out by `ChatMarkdownBlockSegmenter` before this
+/// runs, so prose only needs chat-style soft-break preservation.
 enum ChatMarkdownDisplayPreprocessor {
     static func preserveChatSoftBreaks(in markdown: String) -> String {
         let normalized = markdown.replacingOccurrences(of: "\r\n", with: "\n")

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMarkdownBlockSegmenterTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMarkdownBlockSegmenterTests.swift
@@ -101,6 +101,146 @@ struct ChatMarkdownBlockSegmenterTests {
         })
     }
 
+    // MARK: - Lists and thematic breaks
+
+    @Test func `ordered list becomes a native block and preserves inline markdown`() {
+        let markdown = """
+        Here are the options:
+
+        1. **Option one** – first.
+        2. **Option two** – second.
+        3. **Option three** – third.
+        """
+
+        #expect(self.segments(markdown) == [
+            .prose("Here are the options:"),
+            .list(ChatMarkdownList(
+                style: .ordered(start: 1),
+                items: [
+                    .init(checkbox: nil, markdown: "**Option one** – first."),
+                    .init(checkbox: nil, markdown: "**Option two** – second."),
+                    .init(checkbox: nil, markdown: "**Option three** – third."),
+                ])),
+        ])
+    }
+
+    @Test func `unordered list becomes a native block`() {
+        #expect(self.segments("- alpha\n- beta") == [
+            .list(ChatMarkdownList(
+                style: .unordered,
+                items: [
+                    .init(checkbox: nil, markdown: "alpha"),
+                    .init(checkbox: nil, markdown: "beta"),
+                ])),
+        ])
+    }
+
+    @Test func `ordered list preserves its starting index`() {
+        #expect(self.segments("7. seven\n8. eight") == [
+            .list(ChatMarkdownList(
+                style: .ordered(start: 7),
+                items: [
+                    .init(checkbox: nil, markdown: "seven"),
+                    .init(checkbox: nil, markdown: "eight"),
+                ])),
+        ])
+    }
+
+    @Test func `task list preserves checkbox state`() {
+        #expect(self.segments("- [x] shipped\n- [ ] pending") == [
+            .list(ChatMarkdownList(
+                style: .unordered,
+                items: [
+                    .init(checkbox: .checked, markdown: "shipped"),
+                    .init(checkbox: .unchecked, markdown: "pending"),
+                ])),
+        ])
+    }
+
+    @Test func `multiline simple list item removes structural indentation`() {
+        #expect(self.segments("- first line\n  second line\n- third") == [
+            .list(ChatMarkdownList(
+                style: .unordered,
+                items: [
+                    .init(checkbox: nil, markdown: "first line\nsecond line"),
+                    .init(checkbox: nil, markdown: "third"),
+                ])),
+        ])
+    }
+
+    @Test func `complex list keeps its complete markdown container`() {
+        let nested = "- parent\n  - child"
+        let multiParagraph = "- first\n\n  second"
+        for markdown in [nested, multiParagraph] {
+            #expect(self.segments(markdown) == [.prose(markdown)])
+        }
+    }
+
+    @Test func `multiline inline code keeps its complete list container`() {
+        let markdown = "- `foo\n  bar`"
+        #expect(self.segments(markdown) == [.prose(markdown)])
+    }
+
+    @Test func `reference links keep their list scoped definitions`() {
+        let markdown = "- [docs]\n\n  [docs]: https://example.com"
+        #expect(self.segments(markdown) == [.prose(markdown)])
+    }
+
+    @Test func `bounded lists stay native and oversized lists fall back to prose`() {
+        let bounded = (1...ChatMarkdownBlockSegmenter.maxListItems)
+            .map { "- item \($0)" }
+            .joined(separator: "\n")
+        guard case let .list(list) = self.segments(bounded).first else {
+            Issue.record("expected bounded list")
+            return
+        }
+        #expect(list.items.count == ChatMarkdownBlockSegmenter.maxListItems)
+
+        let oversized = bounded + "\n- one too many"
+        #expect(self.segments(oversized) == [.prose(oversized)])
+    }
+
+    @Test func `thematic breaks become native blocks without stealing Setext headings`() {
+        #expect(self.segments("before\n\n---\n\nafter") == [
+            .prose("before"),
+            .thematicBreak,
+            .prose("after"),
+        ])
+        #expect(self.segments("Heading\n---") == [
+            .heading(ChatMarkdownHeading(level: 2, markdown: "Heading\n---")),
+        ])
+    }
+
+    @Test @MainActor func `native list snapshot retains inline attributes per item`() throws {
+        let snapshot = ChatMarkdownRenderSnapshot(
+            text: "1. **Status** and [docs](https://example.com)\n2. Ready",
+            isComplete: true)
+        guard case let .list(list) = try #require(snapshot.blocks.first) else {
+            Issue.record("expected list block")
+            return
+        }
+
+        #expect(list.items.count == 2)
+        #expect(String(list.items[0].prose.attributed.characters) == "Status and docs")
+        #expect(list.items[0].prose.attributed.runs.contains { $0.link != nil })
+        #expect(list.items[0].prose.attributed.runs.contains {
+            $0.inlinePresentationIntent?.contains(.stronglyEmphasized) == true
+        })
+    }
+
+    @Test @MainActor func `ordered task list keeps both number and checkbox`() throws {
+        let snapshot = ChatMarkdownRenderSnapshot(
+            text: "3. [ ] pending\n4. [x] shipped",
+            isComplete: true)
+        guard case let .list(list) = try #require(snapshot.blocks.first) else {
+            Issue.record("expected list block")
+            return
+        }
+
+        #expect(list.marker(for: list.items[0], index: 0) == "3. ☐︎")
+        #expect(list.marker(for: list.items[1], index: 1) == "4. ☑︎")
+    }
+
     // MARK: - Fenced code
 
     @Test func `fence with language and surrounding prose`() {


### PR DESCRIPTION
Related: #104548

## What Problem This Solves

Fixes an issue where iOS chat users reading Markdown replies with ordered lists, bullet lists, task lists, or thematic breaks would see the structure flattened into prose. In the reporter's exact three-option fixture, the `1.`, `2.`, and `3.` markers disappeared and adjacent items ran together, making normal agent replies difficult to scan.

## Why This Change Was Made

The shared Apple chat renderer now gives simple top-level CommonMark lists and thematic breaks dedicated SwiftUI rendering, matching the existing native treatment for headings, tables, code, and display math.

The extraction is intentionally conservative. Nested or multi-paragraph lists, display-math containers, multiline inline-code spans, reference-definition-dependent items, oversized input, and other complex containers remain on the complete prose path so document-scoped Markdown semantics are not lost. Ordered starts, task state, inline emphasis, links, text selection, Dynamic Type, and chat link colors are preserved. Ordered task rows retain both their number and checkbox.

This does not change `MEDIA:` directive handling or transport behavior.

## User Impact

iOS users can read common agent replies as real lists with stable markers, hanging alignment, preserved inline formatting, and visible separators. The fix applies to both user and assistant chat surfaces backed by `OpenClawChatUI`.

## Evidence

Reproduced on current `main` before the change with the exact reporter fixture:

```text
One – first.Two – second.Three – third.
```

After the change, the same fixture was installed and launched in the OpenClaw iOS app on an iOS 26.5 simulator. It rendered three separate numbered rows with bold option headings, correct wrapping and hanging alignment, plus a native thematic separator.

Validation on exact rebased head `cee7060f` (current `main` at `2f7da305`):

```text
swift test --package-path apps/shared/OpenClawKit --filter ChatMarkdownBlockSegmenterTests
86 tests passed

swift test --package-path apps/shared/OpenClawKit
52 XCTest + 1,031 Swift Testing tests passed; 0 failures

xcodebuild -scheme OpenClawChatUI -destination <iOS 26.5 simulator> build
BUILD SUCCEEDED

swiftlint lint --no-cache --strict --config config/swiftlint.yml apps/ios apps/shared/OpenClawKit
608 files linted; 0 violations

swiftformat --lint <three changed Swift files> --config config/swiftformat
0 files require formatting

node --import tsx scripts/native-app-i18n.ts sync
inventory current; changed=false
```

Regression coverage includes the reporter's ordered-list shape, bullets, non-default ordered starts, unordered and ordered tasks, multiline items, inline emphasis and links, reference definitions, multiline inline code, complex-container fallback, input bounds, and Setext-heading/thematic-break disambiguation.

AI-assisted: yes. I reviewed and understand the implementation, reproduced the defect, exercised the installed simulator build, and verified the exact rebased commit with the focused and full test suites above.

