### PR TITLE
fix(firecrawl): reject malformed 2xx response envelopes

### DIFF
--- a/extensions/firecrawl/src/firecrawl-client.ts
+++ b/extensions/firecrawl/src/firecrawl-client.ts
@@ -1,6 +1,6 @@
 // Firecrawl plugin module implements firecrawl client behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
+import { readProviderJsonObjectResponse } from "openclaw/plugin-sdk/provider-http";
 import {
   DEFAULT_CACHE_TTL_MINUTES,
   markdownToText,
@@ -71,7 +71,7 @@ async function readFirecrawlJsonResponse(
   label: string,
   opts?: { maxBytes?: number },
 ): Promise<Record<string, unknown>> {
-  return await readProviderJsonResponse<Record<string, unknown>>(response, label, opts);
+  return await readProviderJsonObjectResponse(response, label, opts);
 }
 
 type FirecrawlSearchParams = {

--- a/extensions/firecrawl/src/firecrawl-tools.test.ts
+++ b/extensions/firecrawl/src/firecrawl-tools.test.ts
@@ -1320,13 +1320,15 @@ describe("firecrawl tools", () => {
 
   it("respects positive numeric overrides for scrape and cache behavior", () => {
     const cfg = {
-      tools: {
-        web: {
-          fetch: {
-            firecrawl: {
-              onlyMainContent: false,
-              maxAgeMs: 1234,
-              timeoutSeconds: 42,
+      plugins: {
+        entries: {
+          firecrawl: {
+            config: {
+              webFetch: {
+                onlyMainContent: false,
+                maxAgeMs: 1234,
+                timeoutSeconds: 42,
+              },
             },
           },
         },

--- a/extensions/firecrawl/src/firecrawl-tools.test.ts
+++ b/extensions/firecrawl/src/firecrawl-tools.test.ts
@@ -1199,6 +1199,39 @@ describe("firecrawl tools", () => {
     ).rejects.toThrow("Firecrawl Search API error: malformed JSON response");
   });
 
+  it.each([
+    ["null", "null"],
+    ["array", "[]"],
+  ])("rejects a %s Firecrawl search envelope with a stable provider error", async (kind, body) => {
+    global.fetch = vi.fn(
+      async () =>
+        new Response(body, {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    ) as typeof fetch;
+
+    await expect(
+      runActualFirecrawlSearch({
+        cfg: {
+          plugins: {
+            entries: {
+              firecrawl: {
+                config: {
+                  webSearch: {
+                    baseUrl: "https://api.firecrawl.dev",
+                  },
+                },
+              },
+            },
+          },
+        } as OpenClawConfig,
+        query: `openclaw malformed ${kind} search`,
+        access: "keyless",
+      }),
+    ).rejects.toThrow("Firecrawl Search API error: malformed JSON response");
+  });
+
   it("bounds successful Firecrawl JSON bodies before parsing", async () => {
     const streamed = createStreamingResponse({
       chunkCount: 32,
@@ -1247,6 +1280,40 @@ describe("firecrawl tools", () => {
         } as OpenClawConfig,
         url: "https://example.com/firecrawl-malformed-scrape",
         extractMode: "markdown",
+      }),
+    ).rejects.toThrow("Firecrawl fetch failed: malformed JSON response");
+  });
+
+  it.each([
+    ["null", "null"],
+    ["array", "[]"],
+  ])("rejects a %s Firecrawl scrape envelope with a stable provider error", async (kind, body) => {
+    global.fetch = vi.fn(
+      async () =>
+        new Response(body, {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    ) as typeof fetch;
+
+    await expect(
+      runActualFirecrawlScrape({
+        cfg: {
+          plugins: {
+            entries: {
+              firecrawl: {
+                config: {
+                  webFetch: {
+                    baseUrl: "https://api.firecrawl.dev",
+                  },
+                },
+              },
+            },
+          },
+        } as OpenClawConfig,
+        url: `https://example.com/firecrawl-malformed-${kind}-scrape`,
+        extractMode: "markdown",
+        access: "keyless",
       }),
     ).rejects.toThrow("Firecrawl fetch failed: malformed JSON response");
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Firecrawl Search and Scrape could receive a successful HTTP response with a `null` or array JSON body, then either return an invalid empty result or throw a raw `TypeError` instead of a stable provider error.

## Why This Change Was Made

The shared Firecrawl response reader now uses `readProviderJsonObjectResponse`, which enforces the top-level object envelope already required by Firecrawl v2. The existing bounded body reader, endpoint guards, error labels, cache behavior, and valid payload handling remain unchanged.

## User Impact

Malformed upstream responses fail with the existing provider-owned `malformed JSON response` boundary. Valid Firecrawl responses continue through the same Search and Scrape paths.

## Evidence

- AI-assisted implementation: Codex.
- Base: `main` at `5e51c4bbcca3c3af767ebf1d74e2fcfd0c398195`.
- Head: `e48d9f1247446226a5b96d5396b338f4d0ded99f`.
- Focused tests: `node scripts/run-vitest.mjs extensions/firecrawl/src/firecrawl-tools.test.ts extensions/firecrawl/src/firecrawl-client.test.ts --run` -> 2 files, 101/101 tests passed.
- Formatting and static hygiene: targeted `oxfmt` and `git diff --check` passed.
- Controlled HTTP after-fix proof (trusted candidate checkout, loopback server only, no credentials): the server returned HTTP 200 with `null` for `/v2/search` and HTTP 200 with `[]` for `/v2/scrape`; the real `runFirecrawlSearch` and `runFirecrawlScrape` entry paths produced these exact redacted outputs:
  ```text
  MALFORMED_SHAPE search-null error="Firecrawl Search API error: malformed JSON response"
  MALFORMED_SHAPE scrape-array error="Firecrawl fetch failed: malformed JSON response"
  ```
- Reproducible public-run capture: [proof workflow run 29673678349](https://github.com/Alix-007/openclaw/actions/runs/29673678349) checked the immutable candidate head and reported 2 files / 101 tests passed plus the same two `MALFORMED_SHAPE` lines.
- Keyless production probe ran the real `runFirecrawlScrape` entry against `https://api.firecrawl.dev/v2/scrape` with no API key and returned an object result with `extractor=firecrawl`, `extractMode=markdown`, `textLength=304`, and the expected Example Domain content.
- The same proof command also checked the live endpoint contract and emitted: `LIVE_API status=200 topLevel=object successType=boolean dataType=object`; the successful production entry emitted: `LIVE_PRODUCTION resultType=object extractor=firecrawl extractMode=markdown textLength=304 exampleDomain=true`.
- Firecrawl's official [Search response](https://docs.firecrawl.dev/api-reference/endpoint/search) and [Scrape response](https://docs.firecrawl.dev/api-reference/endpoint/scrape?playground=open) contracts both describe a 200 JSON object with a boolean `success` and object `data`; `null` and arrays are outside that contract.
- Codex autoreview was attempted with the configured Sol and documented Terra fallback, but the account endpoint returned HTTP 401 before a review bundle could be evaluated. I completed a frozen-diff manual audit of the changed helper, both callers, the shared provider contract, and the focused tests; no actionable findings remained.
