### PR TITLE
fix(logs): systemd journal fallback no longer hangs on stalled journalctl

### DIFF
--- a/src/cli/logs-cli.runtime.test.ts
+++ b/src/cli/logs-cli.runtime.test.ts
@@ -49,6 +49,18 @@ describe("execFileUtf8Tail", () => {
     expect(result.truncated).toBe(false);
   });
 
+  it("terminates a stalled command at the configured deadline", async () => {
+    const startedAt = Date.now();
+
+    const result = await execFileUtf8Tail(process.execPath, ["-e", "setTimeout(() => {}, 1_000)"], {
+      maxBytes: 1024,
+      timeoutMs: 25,
+    });
+
+    expect(Date.now() - startedAt).toBeLessThan(500);
+    expect(result).toMatchObject({ code: 124, stdout: "", truncated: false });
+  });
+
   it("returns a soft failure when command launch fails", async () => {
     const command = `openclaw-missing-${process.pid}-${Date.now()}`;
     const result = await execFileUtf8Tail(command, [], { maxBytes: 1024 });

--- a/src/cli/logs-cli.runtime.ts
+++ b/src/cli/logs-cli.runtime.ts
@@ -7,17 +7,19 @@ export { readSystemdServiceRuntime } from "../daemon/systemd.js";
 
 type ExecFileTailResult = { stdout: string; stderr: string; code: number; truncated: boolean };
 
+const DEFAULT_LOG_SUBPROCESS_TIMEOUT_MS = 10_000;
 const STDERR_MAX_BYTES = 64 * 1024;
 
 export async function execFileUtf8Tail(
   command: string,
   args: string[],
-  options: { env?: NodeJS.ProcessEnv; maxBytes: number },
+  options: { env?: NodeJS.ProcessEnv; maxBytes: number; timeoutMs?: number },
 ): Promise<ExecFileTailResult> {
   try {
     const result = await runCommandWithTimeout([command, ...args], {
       baseEnv: options.env,
       maxOutputBytes: { stdout: options.maxBytes, stderr: STDERR_MAX_BYTES },
+      timeoutMs: options.timeoutMs ?? DEFAULT_LOG_SUBPROCESS_TIMEOUT_MS,
     });
     return {
       stdout: result.stdout,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where `openclaw logs` could wait indefinitely on Linux when its local systemd journal fallback launched `journalctl` and that subprocess stopped responding.

## Why This Change Was Made

The logs runtime helper now owns a 10-second default deadline for its bounded subprocess tail. The optional override is confined to the helper contract so the regression can exercise the real process lifecycle quickly; the systemd fallback call site, output caps, redaction, cursor parsing, successful journal output, and shared process-runner behavior are unchanged.

## User Impact

Linux users now regain control after a stalled local journal lookup instead of leaving `openclaw logs` blocked indefinitely. Healthy `journalctl` calls continue to return the same bounded log tail.

## Evidence

- Regression red: before the production change, the new 25ms stalled-child case took about 1.08 seconds and failed its 500ms completion bound.
- Regression green: `src/cli/logs-cli.runtime.test.ts` passed all 8 tests, including the real stalled-child deadline, output truncation, exit status, and launch-failure paths.
- Issue-path runtime: the production logs helper, without a timeout override, terminated a real stalled child after 10,031ms with exit code 124; a 20-second outer guard did not fire.
- Formatting: scoped `oxfmt --check` passed, and `git diff --check` reported no whitespace errors.
