### PR TITLE
fix(browser): cancel unread CDP probe response bodies

### DIFF
--- a/extensions/browser/src/browser/cdp.helpers.internal.test.ts
+++ b/extensions/browser/src/browser/cdp.helpers.internal.test.ts
@@ -157,7 +157,9 @@ describe("cdp.helpers internal", () => {
 
       expect(cancel).toHaveBeenCalledOnce();
       expect(release).toHaveBeenCalledOnce();
-      expect(cancel.mock.invocationCallOrder[0]).toBeLessThan(release.mock.invocationCallOrder[0]);
+      expect(cancel.mock.invocationCallOrder[0]!).toBeLessThan(
+        release.mock.invocationCallOrder[0]!,
+      );
     });
 
     it("registers a managed-proxy bypass for the exact sanitized fetch URL", async () => {

--- a/extensions/browser/src/browser/cdp.helpers.internal.test.ts
+++ b/extensions/browser/src/browser/cdp.helpers.internal.test.ts
@@ -132,6 +132,34 @@ describe("cdp.helpers internal", () => {
       expect(release).toHaveBeenCalledTimes(1);
     });
 
+    it("still releases the guarded fetch when unread body cancellation fails", async () => {
+      const cancel = vi.fn(async () => {
+        throw new Error("cancel failed");
+      });
+      const release = vi.fn(async () => {});
+      fetchWithSsrFGuardMock.mockResolvedValueOnce({
+        response: {
+          ok: true,
+          status: 200,
+          bodyUsed: false,
+          body: { cancel },
+        } as unknown as Response,
+        release,
+      });
+
+      const { release: guardedRelease } = await fetchCdpChecked(
+        "http://127.0.0.1:9222/json/version",
+        250,
+        undefined,
+        { dangerouslyAllowPrivateNetwork: false, allowedHostnames: ["127.0.0.1"] },
+      );
+      await expect(guardedRelease()).resolves.toBeUndefined();
+
+      expect(cancel).toHaveBeenCalledOnce();
+      expect(release).toHaveBeenCalledOnce();
+      expect(cancel.mock.invocationCallOrder[0]).toBeLessThan(release.mock.invocationCallOrder[0]);
+    });
+
     it("registers a managed-proxy bypass for the exact sanitized fetch URL", async () => {
       const release = vi.fn();
       registerManagedProxyBrowserCdpBypassMock.mockReturnValueOnce(release);

--- a/extensions/browser/src/browser/cdp.helpers.transport.test.ts
+++ b/extensions/browser/src/browser/cdp.helpers.transport.test.ts
@@ -1,8 +1,10 @@
 // Real-transport proof: CDP status-only probes must cancel unread bodies.
-import { createServer } from "node:http";
+import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
 import { describe, expect, it } from "vitest";
 import { fetchCdpChecked, fetchOk } from "./cdp.helpers.js";
+
+const CLIENT_CLOSE_TIMEOUT_MS = 1_000;
 
 async function listen(server: ReturnType<typeof createServer>): Promise<string> {
   await new Promise<void>((resolve, reject) => {
@@ -16,17 +18,56 @@ async function listen(server: ReturnType<typeof createServer>): Promise<string> 
   return `http://127.0.0.1:${address.port}`;
 }
 
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+    server.closeAllConnections();
+  });
+}
+
+async function waitForClientClose(clientClosed: Promise<void>): Promise<void> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      clientClosed,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error("timed out waiting for the CDP client socket to close")),
+          CLIENT_CLOSE_TIMEOUT_MS,
+        );
+        timeout.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+function createStalledResponseServer(status: number): {
+  server: Server;
+  clientClosed: Promise<void>;
+} {
+  let resolveClientClosed: (() => void) | undefined;
+  const clientClosed = new Promise<void>((resolve) => {
+    resolveClientClosed = resolve;
+  });
+  const server = createServer((request, response) => {
+    request.socket.once("close", () => resolveClientClosed?.());
+    response.writeHead(status, { "Content-Type": "application/json" });
+    response.write(
+      status === 200
+        ? '{"Browser":"Chrome","webSocketDebuggerUrl":"ws://127.0.0.1/devtools'
+        : '{"error":"unavailable"',
+    );
+  });
+  return { server, clientClosed };
+}
+
 describe("cdp helpers transport body cleanup", () => {
   it("fetchOk cancels unread bodies and closes the request socket", async () => {
-    let resolveClientClosed: (() => void) | undefined;
-    const clientClosed = new Promise<void>((resolve) => {
-      resolveClientClosed = resolve;
-    });
-    const server = createServer((request, response) => {
-      request.socket.once("close", () => resolveClientClosed?.());
-      response.writeHead(200, { "Content-Type": "application/json" });
-      response.write('{"Browser":"Chrome","webSocketDebuggerUrl":"ws://127.0.0.1/devtools');
-    });
+    const { server, clientClosed } = createStalledResponseServer(200);
 
     const baseUrl = await listen(server);
     try {
@@ -36,24 +77,14 @@ describe("cdp helpers transport body cleanup", () => {
           allowedHostnames: ["127.0.0.1"],
         }),
       ).resolves.toBeUndefined();
-      await expect(clientClosed).resolves.toBeUndefined();
+      await expect(waitForClientClose(clientClosed)).resolves.toBeUndefined();
     } finally {
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()));
-      });
+      await closeServer(server);
     }
   });
 
   it("fetchCdpChecked cancels unread bodies on non-OK status before throwing", async () => {
-    let resolveClientClosed: (() => void) | undefined;
-    const clientClosed = new Promise<void>((resolve) => {
-      resolveClientClosed = resolve;
-    });
-    const server = createServer((request, response) => {
-      request.socket.once("close", () => resolveClientClosed?.());
-      response.writeHead(503, { "Content-Type": "application/json" });
-      response.write('{"error":"unavailable"');
-    });
+    const { server, clientClosed } = createStalledResponseServer(503);
 
     const baseUrl = await listen(server);
     try {
@@ -63,11 +94,9 @@ describe("cdp helpers transport body cleanup", () => {
           allowedHostnames: ["127.0.0.1"],
         }),
       ).rejects.toThrow("HTTP 503");
-      await expect(clientClosed).resolves.toBeUndefined();
+      await expect(waitForClientClose(clientClosed)).resolves.toBeUndefined();
     } finally {
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()));
-      });
+      await closeServer(server);
     }
   });
 });

--- a/extensions/browser/src/browser/cdp.helpers.transport.test.ts
+++ b/extensions/browser/src/browser/cdp.helpers.transport.test.ts
@@ -1,0 +1,73 @@
+// Real-transport proof: CDP status-only probes must cancel unread bodies.
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { describe, expect, it } from "vitest";
+import { fetchCdpChecked, fetchOk } from "./cdp.helpers.js";
+
+async function listen(server: ReturnType<typeof createServer>): Promise<string> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address() as AddressInfo;
+  return `http://127.0.0.1:${address.port}`;
+}
+
+describe("cdp helpers transport body cleanup", () => {
+  it("fetchOk cancels unread bodies and closes the request socket", async () => {
+    let resolveClientClosed: (() => void) | undefined;
+    const clientClosed = new Promise<void>((resolve) => {
+      resolveClientClosed = resolve;
+    });
+    const server = createServer((request, response) => {
+      request.socket.once("close", () => resolveClientClosed?.());
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.write('{"Browser":"Chrome","webSocketDebuggerUrl":"ws://127.0.0.1/devtools');
+    });
+
+    const baseUrl = await listen(server);
+    try {
+      await expect(
+        fetchOk(`${baseUrl}/json/version`, 2_000, undefined, {
+          dangerouslyAllowPrivateNetwork: false,
+          allowedHostnames: ["127.0.0.1"],
+        }),
+      ).resolves.toBeUndefined();
+      await expect(clientClosed).resolves.toBeUndefined();
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
+  it("fetchCdpChecked cancels unread bodies on non-OK status before throwing", async () => {
+    let resolveClientClosed: (() => void) | undefined;
+    const clientClosed = new Promise<void>((resolve) => {
+      resolveClientClosed = resolve;
+    });
+    const server = createServer((request, response) => {
+      request.socket.once("close", () => resolveClientClosed?.());
+      response.writeHead(503, { "Content-Type": "application/json" });
+      response.write('{"error":"unavailable"');
+    });
+
+    const baseUrl = await listen(server);
+    try {
+      await expect(
+        fetchCdpChecked(`${baseUrl}/json/version`, 2_000, undefined, {
+          dangerouslyAllowPrivateNetwork: false,
+          allowedHostnames: ["127.0.0.1"],
+        }),
+      ).rejects.toThrow("HTTP 503");
+      await expect(clientClosed).resolves.toBeUndefined();
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+});

--- a/extensions/browser/src/browser/cdp.helpers.ts
+++ b/extensions/browser/src/browser/cdp.helpers.ts
@@ -606,6 +606,7 @@ export async function fetchCdpChecked(
   const t = setTimeout(ctrl.abort.bind(ctrl), normalizeBrowserTimerDelayMs(timeoutMs));
   const signal = init?.signal ? AbortSignal.any([ctrl.signal, init.signal]) : ctrl.signal;
   let guardedRelease: (() => Promise<void>) | undefined;
+  let response: Response | undefined;
   let released = false;
   const release = async () => {
     if (released) {
@@ -613,6 +614,12 @@ export async function fetchCdpChecked(
     }
     released = true;
     clearTimeout(t);
+    // fetchOk and !ok paths only need status; cancel unread bodies so undici
+    // releases the socket. fetchJson consumes the body first (bodyUsed), so
+    // cancel is a no-op there. release() alone does not cancel streams.
+    if (response && !response.bodyUsed) {
+      await response.body?.cancel().catch(() => undefined);
+    }
     await guardedRelease?.();
   };
   try {
@@ -637,6 +644,7 @@ export async function fetchCdpChecked(
         return guarded.response;
       }),
     );
+    response = res;
     if (!res.ok) {
       if (res.status === 429) {
         // Do not reflect upstream response text into the error surface (log/agent injection risk)


### PR DESCRIPTION
## What Problem This Solves

Browser CDP HTTP helpers (`fetchCdpChecked` / `fetchOk`) use `fetchWithSsrFGuard`
and often only need the HTTP status (`fetchOk`, non-OK error paths). `release()`
closes the SSRF dispatcher but does **not** cancel an unread response body, so
undici can keep the TCP connection pinned after tab/reachability probes return.

This is a different surface from sandbox `waitForSandboxCdp` (#109767): the bug
lives in `extensions/browser/src/browser/cdp.helpers.ts`, which backs browser-tool
CDP JSON/`fetchOk` callers.

## Why This Change Was Made

Make the shared `release()` hook in `fetchCdpChecked` cancel unread bodies when
`!response.bodyUsed` before calling the guarded release. That covers:

- `fetchOk` (status-only success)
- non-OK throws (catch path calls the same `release()`)
- `fetchJson` (body already consumed → cancel is a no-op)

## User Impact

**Before:** Status-only CDP probes against a streaming/stalled HTTP body could
leave the request socket open after `fetchOk` / failed `fetchCdpChecked` returned.

**After:** Those paths cancel the unread body; the server observes prompt socket
close. JSON consumers (`fetchJson`) are unchanged.

## Evidence

- Changed: `extensions/browser/src/browser/cdp.helpers.ts`,
  `extensions/browser/src/browser/cdp.helpers.transport.test.ts`
- Production path: `fetchOk` / `fetchCdpChecked` → `fetchWithSsrFGuard`
  (`auditContext: "browser-cdp"`) → cancel unread on `release()`
- Callers: tab close/selection `fetchOk`, chrome diagnostics `fetchCdpChecked`,
  `fetchJson` via `readProviderJsonResponse`

## Real behavior proof

### Behavior or issue addressed

Status-only CDP HTTP probes must cancel unread bodies so undici releases the
socket. Without cancel, a streaming `/json/version` body that never ends keeps
`serverObservedSocketClose: false` 250ms after `fetchOk` returns.

### Canonical reachability path

`fetchOk(url)` → `fetchCdpChecked` → `fetchWithSsrFGuard` → `release()` cancels
unread body → guarded dispatcher close. Non-OK: throw → same `release()`.

### Shared helper / provider constraint check

No new CDP timeout/config surface. Sibling: sandbox CDP probe body cancel
(#109767) on a different file; this lands the same undici contract on the
browser plugin helper used by browser-tool paths.

### Real environment tested

**Real Node HTTP + real `fetchWithSsrFGuard` (production `fetchOk`):**

- Loopback server writes headers + partial JSON and never ends the body
- macOS, Node v22.23.1

Negative control (cancel removed from `release()`):

```text
{"productionFunction":"fetchOk","status":200,"threw":null,"returnedAtMs":120,"serverObservedSocketClose":false,"socketCloseAfterStartMs":null}
```

After fix (200 and 503):

```text
{"productionFunction":"fetchOk","status":200,"threw":null,"returnedAtMs":19,"serverObservedSocketClose":true,"socketCloseAfterStartMs":19}
{"productionFunction":"fetchOk","status":503,"threw":"HTTP 503","returnedAtMs":18,"serverObservedSocketClose":true,"socketCloseAfterStartMs":18}
```

### Evidence after fix

```text
node scripts/run-vitest.mjs \
  extensions/browser/src/browser/cdp.helpers.transport.test.ts \
  extensions/browser/src/browser/cdp.helpers.test.ts \
  -t "releases guarded|fetchOk cancels|fetchCdpChecked cancels|bodyless" \
  --reporter=verbose

 ✓ fetchOk cancels unread bodies and closes the request socket
 ✓ fetchCdpChecked cancels unread bodies on non-OK status before throwing
 ✓ releases guarded CDP fetches for bodyless requests
 ✓ releases guarded CDP fetches after the response body is consumed

 Test Files  2 passed (2)
      Tests  4 passed | 29 skipped (33)
```

```text
./node_modules/.bin/oxfmt --check \
  extensions/browser/src/browser/cdp.helpers.ts \
  extensions/browser/src/browser/cdp.helpers.transport.test.ts
All matched files use the correct format.
```

Premise: Undici requires every response body to be consumed or canceled.

AI-assisted: Yes.
