### PR TITLE
fix(tlon): cancel unconsumed poke response body before guard release

### DIFF
--- a/extensions/tlon/src/channel.runtime.test.ts
+++ b/extensions/tlon/src/channel.runtime.test.ts
@@ -11,7 +11,7 @@ vi.mock("./urbit/fetch.js", () => ({
   urbitFetch: vi.fn(),
 }));
 
-import { probeTlonAccount } from "./channel.runtime.js";
+import { createHttpPokeApi, probeTlonAccount } from "./channel.runtime.js";
 
 const account = {
   accountId: "default",
@@ -83,6 +83,72 @@ describe("probeTlonAccount", () => {
     });
 
     await expect(probeTlonAccount(account)).resolves.toEqual({ ok: true });
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(release).toHaveBeenCalledOnce();
+    expect(events).toEqual(["cancel", "release"]);
+  });
+});
+
+describe("createHttpPokeApi", () => {
+  const pokeParams = {
+    url: "https://example.com",
+    code: "sample-code",
+    ship: "~zod",
+  };
+
+  beforeEach(() => {
+    vi.mocked(authenticate).mockReset();
+    vi.mocked(urbitFetch).mockReset();
+    vi.mocked(authenticate).mockResolvedValue("urbauth-~zod=fake-cookie");
+  });
+
+  it("cancels a successful poke response body before releasing the guard", async () => {
+    const events: string[] = [];
+    const cancelBody = vi.fn(() => {
+      events.push("cancel");
+    });
+    const release = vi.fn(async () => {
+      events.push("release");
+    });
+    vi.mocked(urbitFetch).mockResolvedValue({
+      response: responseWithCancelableBody(200, cancelBody),
+      finalUrl: "https://example.com/~/channel/test",
+      release,
+      refreshTimeout: vi.fn(),
+    });
+
+    const api = await createHttpPokeApi(pokeParams);
+    await expect(api.poke({ app: "test-app", mark: "test-mark", json: {} })).resolves.toBeTypeOf(
+      "number",
+    );
+
+    expect(cancelBody).toHaveBeenCalledOnce();
+    expect(release).toHaveBeenCalledOnce();
+    expect(events).toEqual(["cancel", "release"]);
+  });
+
+  it("still releases when poke response cancellation fails", async () => {
+    const events: string[] = [];
+    const response = new Response(new ReadableStream<Uint8Array>());
+    const cancel = vi.spyOn(response.body!, "cancel").mockImplementationOnce(async () => {
+      events.push("cancel");
+      throw new Error("cancel failed");
+    });
+    const release = vi.fn(async () => {
+      events.push("release");
+    });
+    vi.mocked(urbitFetch).mockResolvedValue({
+      response,
+      finalUrl: "https://example.com/~/channel/test",
+      release,
+      refreshTimeout: vi.fn(),
+    });
+
+    const api = await createHttpPokeApi(pokeParams);
+    await expect(api.poke({ app: "test-app", mark: "test-mark", json: {} })).resolves.toBeTypeOf(
+      "number",
+    );
+
     expect(cancel).toHaveBeenCalledOnce();
     expect(release).toHaveBeenCalledOnce();
     expect(events).toEqual(["cancel", "release"]);

--- a/extensions/tlon/src/channel.runtime.ts
+++ b/extensions/tlon/src/channel.runtime.ts
@@ -35,7 +35,7 @@ type ConfiguredTlonAccount = ResolvedTlonAccount & {
   code: string;
 };
 
-async function createHttpPokeApi(params: {
+export async function createHttpPokeApi(params: {
   url: string;
   code: string;
   ship: string;
@@ -84,6 +84,12 @@ async function createHttpPokeApi(params: {
 
         return pokeId;
       } finally {
+        // Guard release does not settle unread response streams; cancel first so
+        // the poke cannot leave its pinned connection open (same pattern as
+        // probeTlonAccount).
+        if (!response.bodyUsed) {
+          await response.body?.cancel().catch(() => undefined);
+        }
         await release();
       }
     },


### PR DESCRIPTION
## What Problem This Solves

When a Tlon channel poke succeeds (HTTP 200 or 204), the response body is
never read and never cancelled. The `release()` guard from
`fetchWithSsrFGuard` cleans up the abort signal and dispatcher, but does
not cancel unconsumed response streams — leaving the underlying HTTP
connection pinned open.

This is the same pattern that #111081 fixed for `probeTlonAccount` in the
same module.

## Why This Change Was Made

`createHttpPokeApi().poke()` calls `urbitFetch`, checks the response status,
and on success returns immediately — skipping body consumption entirely.
The `finally` block calls `release()` but does not cancel the unconsumed
body.

Add `response.body?.cancel()` in the finally block before `release()`,
matching the guard-cancel-release ordering applied to `probeTlonAccount`.

## User Impact

Tlon channel pokes no longer leave pinned HTTP connections open after
successful delivery. Under sustained poke traffic (e.g. typing indicators,
read receipts), the accumulated leak could exhaust available sockets.

## Evidence

```
$ node scripts/run-vitest.mjs extensions/tlon/src/channel.runtime.test.ts
Test Files  1 passed (1)
     Tests  5 passed (5)
```

New regression tests prove:
- Body cancel is called before guard release on successful poke
- Release is still called when body cancellation fails

## Relation to prior fixes

- #111081 fixed this pattern in `probeTlonAccount` (status-check path)
- #111106 fixed this pattern in `UrbitSSEClient.close()` (shutdown path)
- This PR fixes the same pattern in `createHttpPokeApi().poke()` (outbound path)