### PR TITLE
fix(ui): chat message copy and canvas buttons render as boxed buttons in light mode

### DIFF
--- a/ui/src/components/copy-button.ts
+++ b/ui/src/components/copy-button.ts
@@ -13,6 +13,9 @@ const ERROR_LABEL = "Copy failed";
 type CopyButtonOptions = {
   text: () => string;
   label?: string;
+  // Chat message footers style their buttons as ghost icons; the .btn chrome
+  // (light-mode background overrides) would outrank those rules and box them.
+  bare?: boolean;
 };
 
 function setButtonLabel(button: HTMLButtonElement, label: string) {
@@ -24,7 +27,7 @@ function createCopyButton(options: CopyButtonOptions): TemplateResult {
   return html`
     <openclaw-tooltip .content=${idleLabel}>
       <button
-        class="btn btn--xs chat-copy-btn"
+        class=${options.bare ? "chat-copy-btn" : "btn btn--xs chat-copy-btn"}
         type="button"
         aria-label=${idleLabel}
         @click=${async (e: Event) => {
@@ -87,5 +90,5 @@ export function renderCopyButton(text: string, label = COPY_LABEL): TemplateResu
 }
 
 export function renderCopyAsMarkdownButton(markdown: string): TemplateResult {
-  return renderCopyButton(markdown, COPY_LABEL);
+  return createCopyButton({ text: () => markdown, bare: true });
 }

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -144,10 +144,10 @@ function activityAlignmentHtml() {
 function chatFooterActionsHtml() {
   return `
     <div class="chat-group-footer-actions">
-      <button class="btn btn--xs chat-expand-btn" type="button" aria-label="Open in canvas">
+      <button class="chat-expand-btn" type="button" aria-label="Open in canvas">
         <span class="chat-expand-btn__icon" aria-hidden="true">${iconSvg()}</span>
       </button>
-      <button class="btn btn--xs chat-copy-btn" type="button" aria-label="Copy as markdown">
+      <button class="chat-copy-btn" type="button" aria-label="Copy as markdown">
         <span class="chat-copy-btn__icon" aria-hidden="true">${iconSvg()}</span>
       </button>
     </div>

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -2196,7 +2196,7 @@ function renderExpandButton(
   return html`
     <openclaw-tooltip .content=${t("chat.messages.openInCanvas")}>
       <button
-        class="btn btn--xs chat-expand-btn"
+        class="chat-expand-btn"
         type="button"
         aria-label=${t("chat.messages.openInCanvas")}
         @click=${() =>

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -426,8 +426,9 @@ img.chat-avatar {
   }
 }
 
-/* Skins .btn/.btn--xs buttons: background and svg sizing stay with the .btn
-   base so these match every other icon button; only the muted color is bespoke. */
+/* In chat these render bare (no .btn chrome) so the ghost footer-button rules
+   above own their look; the muted color also covers .btn hosts like the file
+   preview header. */
 .chat-copy-btn,
 .chat-expand-btn {
   color: var(--muted);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the copy-as-markdown and open-in-canvas buttons under assistant chat messages in the Control UI rendered as large boxed squares in light mode, while the hide (eye) button next to them stayed a small ghost icon. On narrow or touch viewports the 44px touch-target sizing made the boxes even more prominent.

## Why This Change Was Made

The two buttons carried the global `btn btn--xs` chrome, and the light-theme `:root[data-theme-mode="light"] .btn` background/border override outranks the chat footer's ghost-button reset on specificity, so the `.btn` box always won in light mode. The chat footer already fully styles its buttons as ghost icons, so the fix renders these two buttons bare in chat contexts and lets the existing footer rules own their look. The boxed copy-button variant is preserved for its non-chat consumers (file preview header, connect-command chip).

## User Impact

Message action buttons (hide, open in canvas, copy) now render as a uniform row of small muted icons in both themes and at all viewport sizes. Touch hit areas are unchanged (44px minimum on touch/narrow layouts).

## Evidence

Before / after (mock Control UI, light mode, 760px viewport):

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/chat-message-action-buttons/before.png) | ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/chat-message-action-buttons/after.png) |

- Computed-style verification in the mock harness: before, `.chat-copy-btn`/`.chat-expand-btn` carried `background: rgb(250, 249, 247)` from the light `.btn` override; after, all three action buttons measure identically (transparent, 24×24 resting on desktop, 44×44 hit area on touch/narrow), matching `.chat-group-delete`.
- Focused tests: `ui/src/pages/chat/components/chat-message.test.ts` 100/100, `ui/src/components/file-preview-modal.test.ts` 10/10 (via `node scripts/run-vitest.mjs`).
- `oxfmt --check` clean on touched files; autoreview (Codex gpt-5.6-sol) clean, no findings.
