### PR TITLE
fix(thread-ownership): cancel unread ownership response bodies

### DIFF
--- a/extensions/thread-ownership/index.transport.test.ts
+++ b/extensions/thread-ownership/index.transport.test.ts
@@ -1,0 +1,128 @@
+// Real-transport proof: ownership 200 path is status-only and must cancel unread bodies.
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawPluginApi } from "./api.js";
+import register from "./index.js";
+
+async function listen(server: ReturnType<typeof createServer>): Promise<string> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address() as AddressInfo;
+  return `http://127.0.0.1:${address.port}`;
+}
+
+describe("thread-ownership transport body cleanup", () => {
+  const hooks: Record<string, Function> = {};
+  const originalSlackForwarderUrl = process.env.SLACK_FORWARDER_URL;
+  const originalSlackBotUserId = process.env.SLACK_BOT_USER_ID;
+  let configFile: Record<string, unknown> = {};
+  const api = {
+    pluginConfig: {},
+    config: {
+      agents: {
+        list: [{ id: "test-agent", default: true, identity: { name: "TestBot" } }],
+      },
+    },
+    runtime: {
+      config: {
+        current: () => configFile,
+      },
+    },
+    id: "thread-ownership",
+    name: "Thread Ownership",
+    logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+    on: vi.fn((hookName: string, handler: Function) => {
+      hooks[hookName] = handler;
+    }),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    for (const key of Object.keys(hooks)) {
+      delete hooks[key];
+    }
+    api.pluginConfig = {};
+    configFile = { agents: api.config.agents };
+    process.env.SLACK_BOT_USER_ID = "U999";
+  });
+
+  afterEach(() => {
+    if (originalSlackForwarderUrl === undefined) {
+      delete process.env.SLACK_FORWARDER_URL;
+    } else {
+      process.env.SLACK_FORWARDER_URL = originalSlackForwarderUrl;
+    }
+    if (originalSlackBotUserId === undefined) {
+      delete process.env.SLACK_BOT_USER_ID;
+    } else {
+      process.env.SLACK_BOT_USER_ID = originalSlackBotUserId;
+    }
+  });
+
+  it("cancels unread 200 ownership bodies and closes the request socket", async () => {
+    let resolveClientClosed: (() => void) | undefined;
+    const clientClosed = new Promise<void>((resolve) => {
+      resolveClientClosed = resolve;
+    });
+    const server = createServer((request, response) => {
+      request.socket.once("close", () => resolveClientClosed?.());
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.write('{"ok":true,"agent_id":"test-agent"');
+    });
+
+    const forwarderUrl = await listen(server);
+    process.env.SLACK_FORWARDER_URL = forwarderUrl;
+    register.register(api as unknown as OpenClawPluginApi);
+    const send = expectDefined(hooks.message_sending, "message_sending hook");
+
+    try {
+      const result = await send(
+        { content: "hello", replyToId: "1234.5678", metadata: { channelId: "C123" }, to: "C123" },
+        { channelId: "slack", conversationId: "C123" },
+      );
+      expect(result).toBeUndefined();
+      await expect(clientClosed).resolves.toBeUndefined();
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
+  it("cancels unread unexpected-status bodies and closes the request socket", async () => {
+    let resolveClientClosed: (() => void) | undefined;
+    const clientClosed = new Promise<void>((resolve) => {
+      resolveClientClosed = resolve;
+    });
+    const server = createServer((request, response) => {
+      request.socket.once("close", () => resolveClientClosed?.());
+      response.writeHead(500, { "Content-Type": "application/json" });
+      response.write('{"error":"boom"');
+    });
+
+    const forwarderUrl = await listen(server);
+    process.env.SLACK_FORWARDER_URL = forwarderUrl;
+    register.register(api as unknown as OpenClawPluginApi);
+    const send = expectDefined(hooks.message_sending, "message_sending hook");
+
+    try {
+      const result = await send(
+        { content: "hello", replyToId: "1234.5678", metadata: { channelId: "C123" }, to: "C123" },
+        { channelId: "slack", conversationId: "C123" },
+      );
+      expect(result).toBeUndefined();
+      await expect(clientClosed).resolves.toBeUndefined();
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+});

--- a/extensions/thread-ownership/index.ts
+++ b/extensions/thread-ownership/index.ts
@@ -215,6 +215,11 @@ export default definePluginEntry({
           }
           api.logger.warn?.(`thread-ownership: unexpected status ${resp.status}, allowing send`);
         } finally {
+          // 200 / unexpected statuses leave the body unread; 409 may already have
+          // consumed it via readProviderJsonResponse. release() does not cancel streams.
+          if (!resp.bodyUsed) {
+            await resp.body?.cancel().catch(() => undefined);
+          }
           await release();
         }
       } catch (err) {


### PR DESCRIPTION
## What Problem This Solves

The `thread-ownership` Slack `message_sending` hook POSTs to the internal
forwarder ownership API via `fetchWithSsrFGuard`. On HTTP 200 (and other
non-409 statuses) it only needs the status code — the body stays unread —
then calls `release()`. `release()` tears down the SSRF dispatcher but does
**not** cancel the unread stream, so undici can keep the TCP connection pinned
on the hottest path (every Slack send when the plugin is enabled).

Conflict (`409`) already consumes the body via bounded
`readProviderJsonResponse`; that path is unchanged.

## Why This Change Was Made

In the ownership-check `finally`, cancel the response body when
`!resp.bodyUsed` before `release()`. That covers 200 and unexpected statuses
without touching the 409 read path (`bodyUsed` after a successful/failed bound
read).

## User Impact

**Before:** A forwarder that streams or holds the 200 body could leave the
ownership-check socket open after the send was allowed.

**After:** Unread ownership responses are cancelled promptly; send allow/cancel
semantics are unchanged.

## Evidence

- Changed: `extensions/thread-ownership/index.ts`,
  `extensions/thread-ownership/index.transport.test.ts`
- Production path: `message_sending` → `fetchWithSsrFGuard`
  (`auditContext: "thread-ownership"`) → status branch → cancel unread →
  `release()`
- Compatibility: 409 still cancels send; network errors still fail open

## Real behavior proof

### Behavior or issue addressed

Status-only ownership checks on 200 must cancel unread bodies so undici
releases the socket. Without cancel, a streaming 200 body that never ends keeps
`serverObservedSocketClose: false` 250ms after the hook allows the send.

### Canonical reachability path

`api.on("message_sending")` → `fetchWithSsrFGuard(POST …/ownership/…)` →
`resp.ok` → return allow → `finally` cancel unread body → `release()`

### Shared helper / provider constraint check

Uses existing `fetchWithSsrFGuard` + bounded `readProviderJsonResponse` on 409.
No new config/timeout surface. Same undici unread-body contract as cron
preflight / browser CDP status-only probes.

### Real environment tested

**Real Node HTTP + real `fetchWithSsrFGuard` (production `message_sending` hook):**

- Loopback forwarder writes headers + partial JSON and never ends the body
- Registers the real plugin entry and invokes `message_sending`
- macOS, Node v22.23.1

Negative control (cancel removed):

```text
{"productionFunction":"message_sending ownership check","result":null,"returnedAtMs":162,"serverObservedSocketClose":false,"socketCloseAfterStartMs":null}
```

After fix:

```text
{"productionFunction":"message_sending ownership check","result":null,"returnedAtMs":69,"serverObservedSocketClose":true,"socketCloseAfterStartMs":69}
```

`result: null` (allow send) is unchanged; only socket release changes.

### Evidence after fix

```text
node scripts/run-vitest.mjs \
  extensions/thread-ownership/index.test.ts \
  extensions/thread-ownership/index.transport.test.ts \
  --reporter=verbose

 ✓ cancels unread 200 ownership bodies and closes the request socket
 ✓ cancels unread unexpected-status bodies and closes the request socket
 … existing unit coverage …

 Test Files  2 passed (2)
      Tests  27 passed (27)
```

```text
./node_modules/.bin/oxfmt --check \
  extensions/thread-ownership/index.ts \
  extensions/thread-ownership/index.transport.test.ts
All matched files use the correct format.
```

Premise: Undici requires every response body to be consumed or canceled.

AI-assisted: Yes.
