### PR TITLE
fix(codex): guard loopback WebSocket URL host checks with isIP to prevent DNS SSRF bypass

### DIFF
--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -2899,29 +2899,3 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */
-
-describe("codex app-server loopback URL classification (#111102)", () => {
-  it("accepts ws://127.0.0.1 as literal IPv4 loopback", async () => {
-    const { resolveCodexAppServerRuntimeOptions } = await import("./config.js");
-    const opts = resolveCodexAppServerRuntimeOptions({
-      config: { codex: { appServer: { url: "ws://127.0.0.1:8080/ws" } } },
-    });
-    expect(opts.allowLocalExecServer).toBe(true);
-  });
-
-  it("rejects ws://127.evil.com as non-literal loopback via isIP guard", async () => {
-    const { resolveCodexAppServerRuntimeOptions } = await import("./config.js");
-    const opts = resolveCodexAppServerRuntimeOptions({
-      config: { codex: { appServer: { url: "ws://127.evil.com:8080/ws" } } },
-    });
-    expect(opts.allowLocalExecServer).toBe(false);
-  });
-
-  it("accepts ws://localhost as loopback", async () => {
-    const { resolveCodexAppServerRuntimeOptions } = await import("./config.js");
-    const opts = resolveCodexAppServerRuntimeOptions({
-      config: { codex: { appServer: { url: "ws://localhost:8080/ws" } } },
-    });
-    expect(opts.allowLocalExecServer).toBe(true);
-  });
-});

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -2899,3 +2899,29 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */
+
+describe("codex app-server loopback URL classification (#111102)", () => {
+  it("accepts ws://127.0.0.1 as literal IPv4 loopback", async () => {
+    const { resolveCodexAppServerRuntimeOptions } = await import("./config.js");
+    const opts = resolveCodexAppServerRuntimeOptions({
+      config: { codex: { appServer: { url: "ws://127.0.0.1:8080/ws" } } },
+    });
+    expect(opts.allowLocalExecServer).toBe(true);
+  });
+
+  it("rejects ws://127.evil.com as non-literal loopback via isIP guard", async () => {
+    const { resolveCodexAppServerRuntimeOptions } = await import("./config.js");
+    const opts = resolveCodexAppServerRuntimeOptions({
+      config: { codex: { appServer: { url: "ws://127.evil.com:8080/ws" } } },
+    });
+    expect(opts.allowLocalExecServer).toBe(false);
+  });
+
+  it("accepts ws://localhost as loopback", async () => {
+    const { resolveCodexAppServerRuntimeOptions } = await import("./config.js");
+    const opts = resolveCodexAppServerRuntimeOptions({
+      config: { codex: { appServer: { url: "ws://localhost:8080/ws" } } },
+    });
+    expect(opts.allowLocalExecServer).toBe(true);
+  });
+});

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -1,6 +1,7 @@
 // Codex helper module supports config behavior.
 import { createHash, createHmac, randomBytes } from "node:crypto";
 import { readFileSync } from "node:fs";
+import { isIP } from "node:net";
 import { homedir as readHomeDir, hostname as readHostName } from "node:os";
 import path from "node:path";
 import {
@@ -1344,7 +1345,7 @@ function isLoopbackWebSocketUrl(value: string): boolean {
     host === "127.0.0.1" ||
     host === "::1" ||
     host === "[::1]" ||
-    host.startsWith("127.")
+    (isIP(host) === 4 && host.startsWith("127."))
   );
 }
 


### PR DESCRIPTION
Closes #111102

## What Problem This Solves

DNS hostnames starting with private-octet prefixes (e.g. `127.evil.com`) incorrectly matched `isLoopbackWebSocketUrl`'s `host.startsWith("127.")` check and were classified as `local-loopback`. This allowed the Codex app-server WebSocket connection to be classified as a local-loopback connection to an untrusted remote host — a DNS SSRF bypass.

## Why This Change Was Made

Two changes in `extensions/codex/src/app-server/`:

1. **Runtime fix (`config.ts`)**: Add `node:net` `isIP()` guard to `isLoopbackWebSocketUrl`. Only real IPv4 literals (where `isIP(host) === 4`) now pass the string-prefix checks. DNS hostnames like `127.evil.com` (where `isIP` returns 0) are correctly rejected.

2. **Regression tests (`config.test.ts`)**: Three focused test cases exercising `resolveCodexAppServerRuntimeOptions`:
   - `ws://127.0.0.1:8080/ws` → `allowLocalExecServer: true` (literal IPv4 loopback)
   - `ws://127.evil.com:8080/ws` → `allowLocalExecServer: false` (DNS hostname, not an IP literal)
   - `ws://localhost:8080/ws` → `allowLocalExecServer: true` (canonical localhost name)

## Evidence

Before fix: `isLoopbackWebSocketUrl("ws://127.evil.com:8080/ws")` returned `true` because `host.startsWith("127.")` matched the DNS hostname.

After fix: `isIP("127.evil.com")` returns `0` (not an IP address), so the `host.startsWith("127.")` guard is skipped. The URL is correctly classified as `remote`.

## Scope

- 2 files changed
- No config/schema/default changes
- No plugin loading, network proxy, migration, or doctor behavior changes
- No changelog change

AI-assisted: yes. I understand the authorization lineage and tool-policy changes in this PR.