### PR TITLE
docs: explain Codex memory controls

### DIFF
--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -985,6 +985,42 @@ is enabled, that `plugins.allow` includes it when an allowlist is
 configured, and that any custom `appServer.command`, `url`, `authToken`, or
 headers are valid.
 
+**The Codex app-server uses too much memory:** distinguish the two processes
+first. OpenClaw runs the local Codex app-server as a separate Rust child.
+`NODE_OPTIONS=--max-old-space-size=...` changes only the Gateway's Node.js V8
+heap; it does not cap or enlarge Codex. Managed Gateway installs already choose
+an adaptive V8 heap, and raising it can leave less host memory for Codex. Use
+[Gateway memory troubleshooting](/gateway/troubleshooting#gateway-exits-during-high-memory-use)
+for Gateway pressure, and inspect host or container memory for the Codex child.
+
+The bundled Codex has no heap or RSS limit and no configurable idle-unload
+delay. After the last client unsubscribes, an inactive thread can remain loaded
+for up to 30 minutes. On constrained hosts, reduce native Codex subagent fan-out
+before increasing the Gateway heap:
+
+```json5
+{
+  plugins: {
+    entries: {
+      codex: {
+        config: {
+          appServer: {
+            args: ["-c", "agents.max_threads=3", "app-server", "--listen", "stdio://"],
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+That setting limits native child threads for the bundled Codex default
+multi-agent backend. If you explicitly enable Codex multi-agent v2, use
+`features.multi_agent_v2.max_concurrent_threads_per_session=3` instead; the v2
+limit includes the root thread and cannot be combined with `agents.max_threads`.
+For more Codex headroom, increase the host, container, or cgroup memory
+allocation. An OS hard limit can terminate Codex rather than backpressure it.
+
 **Model discovery is slow:** lower
 `plugins.entries.codex.config.discovery.timeoutMs` or disable discovery.
 See [Codex harness reference](/plugins/codex-harness-reference#model-discovery).


### PR DESCRIPTION
## What Problem This Solves

Operators could mistake high Codex app-server memory use for Gateway V8 pressure and tune the wrong process. Existing Codex harness docs also did not describe the available concurrency controls or the upstream idle-thread lifetime.

## Why This Change Was Made

Document the process boundary, explain why the Gateway Node.js heap setting does not affect Codex, and provide separate valid fan-out controls for the bundled default backend and explicit multi-agent v2.

## User Impact

Operators can diagnose which process consumes memory, reduce native Codex fan-out on constrained hosts, and make informed host or container memory changes without expecting a Gateway heap setting to cap Codex.

## Evidence

- `pnpm docs:check-mdx`
- `git diff --check`
- Exact bundled `codex-cli 0.144.6` startup smoke with `agents.max_threads=3`
- Exact bundled `codex-cli 0.144.6` startup smoke with `features.multi_agent_v2.max_concurrent_threads_per_session=3`
- Fresh branch autoreview: no accepted or actionable findings
- Anchor audit attempted; blocked before auditing by `@mintlify/link-rot` failing to import its `react` dependency
