### PR TITLE
fix(configure): treat blank OPENCLAW_GATEWAY_* env as unset in wizard probes

### DIFF
--- a/src/commands/configure.wizard.gateway-auth.proof.test.ts
+++ b/src/commands/configure.wizard.gateway-auth.proof.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Real Gateway auth proof for configure-wizard blank OPENCLAW_GATEWAY_* env.
+ * Exercises production probeGatewayReachable / waitForGatewayReachable against
+ * a token-auth Gateway — same credential resolution as configure.wizard.ts.
+ */
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { installGatewayTestHooks, startServer, testState } from "../gateway/test-helpers.js";
+import { probeGatewayReachable, waitForGatewayReachable } from "./onboard-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+const CONFIGURED_TOKEN = "wizard-configured-gateway-token";
+const WRONG_ENV_TOKEN = "wizard-wrong-env-token";
+
+/** Same contract as configure.wizard resolveWizardGatewayEnvOverride. */
+function resolveWizardGatewayEnvOverride(
+  envValue: string | undefined,
+  configured: string | undefined,
+): string | undefined {
+  return normalizeOptionalString(envValue) ?? configured;
+}
+
+function resolveLegacyEnvOverride(
+  envValue: string | undefined,
+  configured: string | undefined,
+): string | undefined {
+  return envValue ?? configured;
+}
+
+function redactEnv(env: string | undefined): string {
+  if (env === undefined) {
+    return "<unset>";
+  }
+  if (env.length === 0) {
+    return "<empty>";
+  }
+  if (env.trim().length === 0) {
+    return "<whitespace>";
+  }
+  return env === CONFIGURED_TOKEN
+    ? "<configured>"
+    : env === WRONG_ENV_TOKEN
+      ? "<wrong>"
+      : "<other>";
+}
+
+function redactToken(token: string | undefined): string {
+  if (token === undefined) {
+    return "<none>";
+  }
+  if (token === CONFIGURED_TOKEN) {
+    return "<configured>";
+  }
+  if (token === WRONG_ENV_TOKEN) {
+    return "<wrong>";
+  }
+  if (token.trim().length === 0) {
+    return token.length === 0 ? "<empty>" : "<whitespace>";
+  }
+  return "<other>";
+}
+
+function emitProof(row: Record<string, unknown>): void {
+  process.stdout.write(`PROOF ${JSON.stringify(row)}\n`);
+}
+
+describe("configure wizard blank gateway env — live Gateway proof", () => {
+  const originalGatewayAuth = testState.gatewayAuth;
+  let port = 0;
+  let server: Awaited<ReturnType<typeof startServer>>["server"];
+  let envSnapshot: Awaited<ReturnType<typeof startServer>>["envSnapshot"];
+
+  beforeAll(async () => {
+    const started = await startServer(CONFIGURED_TOKEN, { controlUiEnabled: false });
+    port = started.port;
+    server = started.server;
+    envSnapshot = started.envSnapshot;
+  }, 60_000);
+
+  afterAll(async () => {
+    await server?.close();
+    envSnapshot?.restore();
+    testState.gatewayAuth = originalGatewayAuth;
+  });
+
+  it("blank/whitespace env use configured token against a real token-auth Gateway", async () => {
+    const url = `ws://127.0.0.1:${port}`;
+    const cases: Array<{ name: string; env: string | undefined }> = [
+      { name: "empty", env: "" },
+      { name: "whitespace", env: "   " },
+      { name: "unset", env: undefined },
+      { name: "nonblank-wrong", env: WRONG_ENV_TOKEN },
+      { name: "nonblank-correct", env: CONFIGURED_TOKEN },
+    ];
+
+    for (const { name, env } of cases) {
+      const afterToken = resolveWizardGatewayEnvOverride(env, CONFIGURED_TOKEN);
+      const beforeToken = resolveLegacyEnvOverride(env, CONFIGURED_TOKEN);
+
+      const afterProbe = await probeGatewayReachable({
+        url,
+        token: afterToken,
+        timeoutMs: 5_000,
+      });
+      const beforeProbe = await probeGatewayReachable({
+        url,
+        token: beforeToken,
+        timeoutMs: 5_000,
+      });
+
+      const expectAfterOk = name !== "nonblank-wrong";
+      const expectBeforeOk = name === "unset" || name === "nonblank-correct";
+
+      emitProof({
+        case: name,
+        env: redactEnv(env),
+        afterToken: redactToken(afterToken),
+        beforeToken: redactToken(beforeToken),
+        afterOk: afterProbe.ok,
+        beforeOk: beforeProbe.ok,
+        afterDetail: afterProbe.ok ? null : (afterProbe.detail ?? "failed"),
+        beforeDetail: beforeProbe.ok ? null : (beforeProbe.detail ?? "failed"),
+      });
+
+      expect(afterProbe.ok, `after ${name}`).toBe(expectAfterOk);
+      expect(beforeProbe.ok, `before ${name}`).toBe(expectBeforeOk);
+    }
+  }, 60_000);
+
+  it("health wait with blank env token reaches a real Gateway using configured auth", async () => {
+    const url = `ws://127.0.0.1:${port}`;
+    const token = resolveWizardGatewayEnvOverride("", CONFIGURED_TOKEN);
+    const legacyToken = resolveLegacyEnvOverride("", CONFIGURED_TOKEN);
+
+    const afterWait = await waitForGatewayReachable({
+      url,
+      token,
+      deadlineMs: 8_000,
+      probeTimeoutMs: 2_000,
+      pollMs: 200,
+    });
+    const beforeWait = await waitForGatewayReachable({
+      url,
+      token: legacyToken,
+      deadlineMs: 3_000,
+      probeTimeoutMs: 1_000,
+      pollMs: 200,
+    });
+
+    emitProof({
+      case: "health-wait-empty-env",
+      afterToken: redactToken(token),
+      beforeToken: redactToken(legacyToken),
+      afterOk: afterWait.ok,
+      beforeOk: beforeWait.ok,
+      beforeDetail: beforeWait.ok ? null : (beforeWait.detail ?? "failed"),
+    });
+
+    expect(afterWait.ok).toBe(true);
+    expect(beforeWait.ok).toBe(false);
+  }, 60_000);
+});

--- a/src/commands/configure.wizard.test.ts
+++ b/src/commands/configure.wizard.test.ts
@@ -393,6 +393,119 @@ describe("runConfigureWizard", () => {
     expect(remoteProbe?.timeoutMs).toBe(300);
   });
 
+  it.each([
+    {
+      name: "empty",
+      tokenEnv: "",
+      passwordEnv: "",
+    },
+    {
+      name: "whitespace",
+      tokenEnv: "   ",
+      passwordEnv: "\t",
+    },
+  ])(
+    "ignores $name OPENCLAW_GATEWAY_* env overrides when probing configured auth",
+    async ({ tokenEnv, passwordEnv }) => {
+      vi.stubEnv("OPENCLAW_GATEWAY_TOKEN", tokenEnv);
+      vi.stubEnv("OPENCLAW_GATEWAY_PASSWORD", passwordEnv);
+      try {
+        setupBaseWizardState({
+          gateway: {
+            mode: "local",
+            auth: { token: "configured-token", password: "configured-password" },
+            remote: {
+              url: "wss://gateway.example.test",
+              token: "remote-token",
+            },
+          },
+        });
+        mocks.probeGatewayReachable.mockResolvedValue({ ok: true });
+
+        await runConfigureWizard({ command: "configure", sections: ["gateway"] }, createRuntime());
+
+        const probeRequests = mocks.probeGatewayReachable.mock.calls.map(([request]) =>
+          requireRecord(request, "probe request"),
+        );
+        const localHintProbe = probeRequests.find(
+          (request) => request.url === "ws://127.0.0.1:18789" && request.timeoutMs === 300,
+        );
+        const finalProbe = probeRequests.find(
+          (request) => request.url === "ws://127.0.0.1:18789" && request.timeoutMs !== 300,
+        );
+        expect(localHintProbe?.token).toBe("configured-token");
+        expect(localHintProbe?.password).toBe("configured-password");
+        expect(finalProbe?.token).toBe("configured-token");
+        expect(finalProbe?.password).toBe("configured-password");
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    },
+  );
+
+  it.each([
+    {
+      name: "empty",
+      tokenEnv: "",
+      passwordEnv: "",
+    },
+    {
+      name: "whitespace",
+      tokenEnv: "  ",
+      passwordEnv: " \t ",
+    },
+  ])(
+    "ignores $name OPENCLAW_GATEWAY_* env overrides during health-check wait",
+    async ({ tokenEnv, passwordEnv }) => {
+      vi.stubEnv("OPENCLAW_GATEWAY_TOKEN", tokenEnv);
+      vi.stubEnv("OPENCLAW_GATEWAY_PASSWORD", passwordEnv);
+      try {
+        setupBaseWizardState({
+          gateway: {
+            mode: "local",
+            auth: { token: "health-token", password: "health-password" },
+          },
+        });
+        mocks.waitForGatewayReachable.mockResolvedValue(undefined);
+
+        await runConfigureWizard({ command: "configure", sections: ["health"] }, createRuntime());
+
+        expect(mocks.waitForGatewayReachable).toHaveBeenCalledWith(
+          expect.objectContaining({
+            token: "health-token",
+            password: "health-password",
+          }),
+        );
+      } finally {
+        vi.unstubAllEnvs();
+      }
+    },
+  );
+
+  it("keeps nonblank OPENCLAW_GATEWAY_* env overrides ahead of configured auth", async () => {
+    vi.stubEnv("OPENCLAW_GATEWAY_TOKEN", "env-token");
+    vi.stubEnv("OPENCLAW_GATEWAY_PASSWORD", "env-password");
+    try {
+      setupBaseWizardState({
+        gateway: {
+          mode: "local",
+          auth: { token: "configured-token", password: "configured-password" },
+        },
+      });
+      mocks.probeGatewayReachable.mockResolvedValue({ ok: true });
+
+      await runConfigureWizard({ command: "configure", sections: ["gateway"] }, createRuntime());
+
+      const finalProbe = mocks.probeGatewayReachable.mock.calls
+        .map(([request]) => requireRecord(request, "probe request"))
+        .find((request) => request.url === "ws://127.0.0.1:18789" && request.timeoutMs !== 300);
+      expect(finalProbe?.token).toBe("env-token");
+      expect(finalProbe?.password).toBe("env-password");
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
   it("advertises LAN Control UI links while probing the local gateway", async () => {
     setupBaseWizardState({
       gateway: {

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -99,6 +99,14 @@ async function resolveGatewaySecretInputForWizard(params: {
   }
 }
 
+/** Env overrides must match runtime gateway auth: blank/whitespace means unset. */
+function resolveWizardGatewayEnvOverride(
+  envValue: string | undefined,
+  configured: string | undefined,
+): string | undefined {
+  return normalizeOptionalString(envValue) ?? configured;
+}
+
 async function runGatewayHealthCheck(params: {
   cfg: OpenClawConfig;
   runtime: RuntimeEnv;
@@ -123,8 +131,14 @@ async function runGatewayHealthCheck(params: {
     value: params.cfg.gateway?.auth?.password,
     path: "gateway.auth.password",
   });
-  const token = process.env.OPENCLAW_GATEWAY_TOKEN ?? configuredToken;
-  const password = process.env.OPENCLAW_GATEWAY_PASSWORD ?? configuredPassword;
+  const token = resolveWizardGatewayEnvOverride(
+    process.env.OPENCLAW_GATEWAY_TOKEN,
+    configuredToken,
+  );
+  const password = resolveWizardGatewayEnvOverride(
+    process.env.OPENCLAW_GATEWAY_PASSWORD,
+    configuredPassword,
+  );
 
   await waitForGatewayReachable({
     url: wsUrl,
@@ -439,8 +453,14 @@ export async function runConfigureWizard(
         ]);
         return probeGatewayReachable({
           url: localUrl,
-          token: process.env.OPENCLAW_GATEWAY_TOKEN ?? baseLocalProbeToken,
-          password: process.env.OPENCLAW_GATEWAY_PASSWORD ?? baseLocalProbePassword,
+          token: resolveWizardGatewayEnvOverride(
+            process.env.OPENCLAW_GATEWAY_TOKEN,
+            baseLocalProbeToken,
+          ),
+          password: resolveWizardGatewayEnvOverride(
+            process.env.OPENCLAW_GATEWAY_PASSWORD,
+            baseLocalProbePassword,
+          ),
           timeoutMs: GATEWAY_HINT_PROBE_TIMEOUT_MS,
         });
       })();
@@ -825,27 +845,30 @@ export async function runConfigureWizard(
       basePath: nextConfig.gateway?.controlUi?.basePath,
       tlsEnabled: nextConfig.gateway?.tls?.enabled === true,
     });
-    const newPassword =
-      process.env.OPENCLAW_GATEWAY_PASSWORD ??
-      (await resolveGatewaySecretInputForWizard({
+    const newPassword = resolveWizardGatewayEnvOverride(
+      process.env.OPENCLAW_GATEWAY_PASSWORD,
+      await resolveGatewaySecretInputForWizard({
         cfg: nextConfig,
         value: nextConfig.gateway?.auth?.password,
         path: "gateway.auth.password",
-      }));
-    const oldPassword =
-      process.env.OPENCLAW_GATEWAY_PASSWORD ??
-      (await resolveGatewaySecretInputForWizard({
+      }),
+    );
+    const oldPassword = resolveWizardGatewayEnvOverride(
+      process.env.OPENCLAW_GATEWAY_PASSWORD,
+      await resolveGatewaySecretInputForWizard({
         cfg: baseConfig,
         value: baseConfig.gateway?.auth?.password,
         path: "gateway.auth.password",
-      }));
-    const token =
-      process.env.OPENCLAW_GATEWAY_TOKEN ??
-      (await resolveGatewaySecretInputForWizard({
+      }),
+    );
+    const token = resolveWizardGatewayEnvOverride(
+      process.env.OPENCLAW_GATEWAY_TOKEN,
+      await resolveGatewaySecretInputForWizard({
         cfg: nextConfig,
         value: nextConfig.gateway?.auth?.token,
         path: "gateway.auth.token",
-      }));
+      }),
+    );
 
     let gatewayProbe = await probeGatewayReachable({
       url: probeLinks.wsUrl,


### PR DESCRIPTION
## What Problem This Solves

`openclaw configure` gateway probes use
`process.env.OPENCLAW_GATEWAY_TOKEN ?? configuredToken` (and the password twin).
`??` treats empty string as set, so Docker/Compose/shell
`OPENCLAW_GATEWAY_TOKEN=` (or whitespace-only) overrides a real configured
token/password during health waits and reachability probes. Runtime gateway auth
already uses `trimToUndefined` / `normalizeOptionalString` for the same env vars.

## Why This Change Was Made

Resolve wizard probe credentials through
`normalizeOptionalString(env) ?? configured` at every
`OPENCLAW_GATEWAY_TOKEN` / `OPENCLAW_GATEWAY_PASSWORD` override site in
`configure.wizard.ts`, matching runtime gateway credential planning and pairing
setup-code.

## User Impact

**Before:** Blank or whitespace gateway auth env vars could make configure
health/reachability probes send empty credentials even when
`gateway.auth.token` / `password` (or SecretRefs) resolve correctly → false
unreachable / auth failures during the wizard.

**After:** Blank/whitespace env is treated as unset; configured auth is used.
Nonblank env still overrides config (env-first), same as runtime.

## Evidence

- Changed: `src/commands/configure.wizard.ts`,
  `src/commands/configure.wizard.test.ts`,
  `src/commands/configure.wizard.gateway-auth.proof.test.ts`
- Production paths:
  - `runGatewayHealthCheck` → `waitForGatewayReachable`
  - startup hint `probeGatewayReachable` (300ms)
  - final Control UI `probeGatewayReachable`
- Compatibility: no new config/env surface; nonblank env override preserved

## Real behavior proof

### Behavior or issue addressed

Blank/whitespace `OPENCLAW_GATEWAY_*` must not override configured wizard probe
auth. Empty env previously won via `??`; after the fix probes receive configured
credentials and authenticate against a real token-auth Gateway.

### Canonical reachability path

`runConfigureWizard({ sections: ["gateway"|"health"] })` →
`resolveWizardGatewayEnvOverride(process.env.OPENCLAW_GATEWAY_*, configured)` →
`probeGatewayReachable` / `waitForGatewayReachable`

### Shared helper / provider constraint check

Uses existing `normalizeOptionalString` (same implementation as runtime
`trimToUndefined` in `src/gateway/credential-planner.ts`). No new env vars.

### Real environment tested

**Live token-auth Gateway (not mocked):**

- `startServer(configuredToken)` → real Gateway WebSocket listener
- Production `probeGatewayReachable` / `waitForGatewayReachable` from
  `onboard-helpers.ts` (same functions the wizard calls)
- Credential resolution matches `resolveWizardGatewayEnvOverride`
- macOS, Node v22.23.1

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs \
  src/commands/configure.wizard.gateway-auth.proof.test.ts \
  --reporter=verbose

node scripts/run-vitest.mjs src/commands/configure.wizard.test.ts \
  -t "OPENCLAW_GATEWAY" --reporter=verbose
```

### Evidence after fix

**Real Gateway WebSocket — blank/whitespace env vs legacy `??`:**

```text
PROOF {"case":"empty","env":"<empty>","afterToken":"<configured>","beforeToken":"<empty>","afterOk":true,"beforeOk":false,"afterDetail":null,"beforeDetail":"device identity required"}
PROOF {"case":"whitespace","env":"<whitespace>","afterToken":"<configured>","beforeToken":"<whitespace>","afterOk":true,"beforeOk":false,"afterDetail":null,"beforeDetail":"device identity required"}
PROOF {"case":"unset","env":"<unset>","afterToken":"<configured>","beforeToken":"<configured>","afterOk":true,"beforeOk":true,"afterDetail":null,"beforeDetail":null}
PROOF {"case":"nonblank-wrong","env":"<wrong>","afterToken":"<wrong>","beforeToken":"<wrong>","afterOk":false,"beforeOk":false,"afterDetail":"unauthorized: gateway token mismatch (provide gateway auth token)","beforeDetail":"unauthorized: gateway token mismatch (provide gateway auth token)"}
PROOF {"case":"nonblank-correct","env":"<configured>","afterToken":"<configured>","beforeToken":"<configured>","afterOk":true,"beforeOk":true,"afterDetail":null,"beforeDetail":null}
PROOF {"case":"health-wait-empty-env","afterToken":"<configured>","beforeToken":"<empty>","afterOk":true,"beforeOk":false,"beforeDetail":"gateway closed (1008): device identity required"}

 ✓ blank/whitespace env use configured token against a real token-auth Gateway 228ms
 ✓ health wait with blank env token reaches a real Gateway using configured auth 3019ms

 Test Files  1 passed (1)
      Tests  2 passed (2)
```

### Observed result after fix

Against a real token-auth Gateway:

1. Blank / whitespace `OPENCLAW_GATEWAY_TOKEN` with the fixed resolver → probe
   uses configured token → `ok: true`.
2. Same inputs with legacy `env ?? configured` → empty/whitespace token →
   probe fails (`device identity required` / closed 1008).
3. Nonblank wrong env still fails with `gateway token mismatch`; correct env
   still succeeds (env-first override preserved).
4. Health wait (`waitForGatewayReachable`) with blank env + configured token
   reaches the live Gateway; legacy empty token does not.

### What was not tested

- Full interactive `openclaw configure` TTY session (probes above are the
  production functions the wizard calls with the same credential resolution)
- Password-mode Gateway (same `normalizeOptionalString` path; token-mode
  proves the auth wire)

### Fix classification

bugfix — blank env override / credential precedence

## AI Assistance

AI-assisted. Author reviewed the wizard env override sites, live Gateway
probe before/after evidence, and focused Vitest regressions.
