### PR TITLE
fix(macos): refresh skills after local node reconnect

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -34843,7 +34843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 62,
+      "line": 65,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Skills section",
       "surface": "apple",
@@ -34851,7 +34851,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 87,
+      "line": 90,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Loading skills",
       "surface": "apple",
@@ -34859,7 +34859,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 87,
+      "line": 90,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "\\(ready) ready · \\(needsSetup) need setup",
       "surface": "apple",
@@ -34867,7 +34867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 89,
+      "line": 92,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Enable ready skills, or install missing tools on the Gateway or this Mac.",
       "surface": "apple",
@@ -34875,7 +34875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 98,
+      "line": 101,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "\\(total)",
       "surface": "apple",
@@ -34883,7 +34883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 113,
+      "line": 116,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Controls",
       "surface": "apple",
@@ -34891,7 +34891,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 115,
+      "line": 118,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Skill catalog",
       "surface": "apple",
@@ -34899,7 +34899,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 116,
+      "line": 119,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Refresh after changing binaries, environment variables, or skill config.",
       "surface": "apple",
@@ -34907,7 +34907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 126,
+      "line": 129,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -34915,7 +34915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 131,
+      "line": 134,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Search installed skills",
       "surface": "apple",
@@ -34923,7 +34923,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 158,
+      "line": 161,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Loading…",
       "surface": "apple",
@@ -34931,7 +34931,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 158,
+      "line": 161,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "No skills reported yet",
       "surface": "apple",
@@ -34939,7 +34939,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 159,
+      "line": 162,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Reading the Gateway skill catalog.",
       "surface": "apple",
@@ -34947,7 +34947,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 194,
+      "line": 197,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "No skills match this filter.",
       "surface": "apple",
@@ -34955,7 +34955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 206,
+      "line": 209,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Filter",
       "surface": "apple",
@@ -34963,7 +34963,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 249,
+      "line": 252,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Installed",
       "surface": "apple",
@@ -34971,7 +34971,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 250,
+      "line": 253,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Browse",
       "surface": "apple",
@@ -34979,7 +34979,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 268,
+      "line": 271,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "All",
       "surface": "apple",
@@ -34987,7 +34987,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 270,
+      "line": 273,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Ready",
       "surface": "apple",
@@ -34995,7 +34995,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 272,
+      "line": 275,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Needs Setup",
       "surface": "apple",
@@ -35003,7 +35003,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 274,
+      "line": 277,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Disabled",
       "surface": "apple",
@@ -35011,7 +35011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 359,
+      "line": 362,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Website",
       "surface": "apple",
@@ -35019,7 +35019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 393,
+      "line": 396,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Details",
       "surface": "apple",
@@ -35027,7 +35027,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 419,
+      "line": 422,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Needs setup",
       "surface": "apple",
@@ -35035,7 +35035,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 434,
+      "line": 437,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Managed",
       "surface": "apple",
@@ -35043,7 +35043,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 436,
+      "line": 439,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Workspace",
       "surface": "apple",
@@ -35051,7 +35051,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 438,
+      "line": 441,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Extra",
       "surface": "apple",
@@ -35059,7 +35059,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 440,
+      "line": 443,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Plugin",
       "surface": "apple",
@@ -35067,7 +35067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 507,
+      "line": 510,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Missing binaries: \\(self.missingBins.joined(separator: \", \"))",
       "surface": "apple",
@@ -35075,7 +35075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 512,
+      "line": 515,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Needs any binary: \\(self.missingAnyBins.joined(separator: \", \"))",
       "surface": "apple",
@@ -35083,7 +35083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 517,
+      "line": 520,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Missing env: \\(self.missingEnv.joined(separator: \", \"))",
       "surface": "apple",
@@ -35091,7 +35091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 522,
+      "line": 525,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Requires config: \\(self.missingConfig.joined(separator: \", \"))",
       "surface": "apple",
@@ -35099,7 +35099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 527,
+      "line": 530,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Requires OS: \\(self.missingOS.joined(separator: \", \"))",
       "surface": "apple",
@@ -35107,7 +35107,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 554,
+      "line": 557,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Set \\(envKey)",
       "surface": "apple",
@@ -35115,7 +35115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 570,
+      "line": 573,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Install on Gateway",
       "surface": "apple",
@@ -35123,7 +35123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 583,
+      "line": 586,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Install on This Mac",
       "surface": "apple",
@@ -35131,7 +35131,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 588,
+      "line": 591,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Switches to Local mode to install on this Mac.",
       "surface": "apple",
@@ -35139,7 +35139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 693,
+      "line": 696,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Get your key →",
       "surface": "apple",
@@ -35147,7 +35147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 698,
+      "line": 701,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Saved to openclaw.json under skills.entries.\\(self.editor.skillKey)",
       "surface": "apple",
@@ -35155,7 +35155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 702,
+      "line": 705,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Cancel",
       "surface": "apple",
@@ -35163,7 +35163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 704,
+      "line": 707,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Save",
       "surface": "apple",
@@ -35171,7 +35171,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 732,
+      "line": 735,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Set API Key",
       "surface": "apple",
@@ -35179,7 +35179,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 732,
+      "line": 735,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Set Environment Variable",
       "surface": "apple",
@@ -35187,7 +35187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 807,
+      "line": 836,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Skill disabled",
       "surface": "apple",
@@ -35195,7 +35195,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 807,
+      "line": 836,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Skill enabled",
       "surface": "apple",
@@ -35203,7 +35203,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 885,
+      "line": 914,
       "path": "apps/macos/Sources/OpenClaw/SkillsSettings.swift",
       "source": "Bundled",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
@@ -3,6 +3,10 @@ import Foundation
 import OpenClawKit
 import OSLog
 
+extension Notification.Name {
+    static let openclawLocalNodeDidConnect = Notification.Name("ai.openclaw.local-node.did-connect")
+}
+
 struct MacNodeGatewayTLSSessionCache {
     private struct Key: Equatable {
         let url: URL
@@ -628,6 +632,7 @@ final class MacNodeModeCoordinator: NSObject {
                 await self.nodeHostWorker?.publishInventory(ifCurrentRoute: installedRoute)
                 await self.cancelReconnectProbe()
                 self.logger.info("mac node connected to gateway")
+                NotificationCenter.default.post(name: .openclawLocalNodeDidConnect, object: nil)
                 // The node hello owns this route's session defaults. Reusing the operator
                 // connection here can trigger remote-tunnel recovery while the node connects.
                 let snapshotMainSessionKey = await self.session.waitForCurrentMainSessionKey(

--- a/apps/macos/Sources/OpenClaw/SkillsSettings.swift
+++ b/apps/macos/Sources/OpenClaw/SkillsSettings.swift
@@ -45,6 +45,9 @@ struct SkillsSettings: View {
             await Task.yield()
             await self.model.refreshIfNeeded()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .openclawLocalNodeDidConnect)) { _ in
+            Task { await self.model.refreshAfterLocalNodeReconnect() }
+        }
         .sheet(item: self.$envEditor) { editor in
             EnvEditorView(editor: editor) { value in
                 Task {
@@ -744,8 +747,16 @@ final class SkillsSettingsModel {
     var isLoading = false
     var error: String?
     var statusMessage: String?
-    private var hasLoaded = false
+    private(set) var hasLoaded = false
     private var busySkills: Set<String> = []
+    private var pendingForcedRefresh = false
+    private let loadSkillsStatus: @MainActor () async throws -> SkillsStatusReport
+
+    init(loadSkillsStatus: @escaping @MainActor () async throws -> SkillsStatusReport = {
+        try await GatewayConnection.shared.skillsStatus()
+    }) {
+        self.loadSkillsStatus = loadSkillsStatus
+    }
 
     func isBusy(skill: SkillStatus) -> Bool {
         self.busySkills.contains(skill.skillKey)
@@ -756,21 +767,39 @@ final class SkillsSettingsModel {
         await self.refresh()
     }
 
+    func refreshAfterLocalNodeReconnect() async {
+        if self.isLoading {
+            self.pendingForcedRefresh = true
+            return
+        }
+        guard self.hasLoaded else { return }
+        await self.refresh(force: true)
+    }
+
     func refresh(force: Bool = false) async {
-        guard !self.isLoading else { return }
+        if self.isLoading {
+            if force {
+                self.pendingForcedRefresh = true
+            }
+            return
+        }
         if self.hasLoaded, !force {
             return
         }
         self.isLoading = true
         self.error = nil
         do {
-            let report = try await GatewayConnection.shared.skillsStatus()
+            let report = try await self.loadSkillsStatus()
             self.skills = report.skills.sorted { $0.name < $1.name }
             self.hasLoaded = true
         } catch {
             self.error = error.localizedDescription
         }
         self.isLoading = false
+        if self.pendingForcedRefresh {
+            self.pendingForcedRefresh = false
+            await self.refresh(force: true)
+        }
     }
 
     func acceptInstalledSkills(_ skills: [SkillStatus]) {

--- a/apps/macos/Tests/OpenClawIPCTests/SkillsSettingsSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/SkillsSettingsSmokeTests.swift
@@ -38,6 +38,13 @@ private func makeSkillStatus(
         install: install)
 }
 
+private func makeSkillsStatusReport(_ skills: [SkillStatus]) -> SkillsStatusReport {
+    SkillsStatusReport(
+        workspaceDir: "/tmp/workspace",
+        managedSkillsDir: "/tmp/skills",
+        skills: skills)
+}
+
 @Suite(.serialized)
 @MainActor
 struct SkillsSettingsSmokeTests {
@@ -148,5 +155,113 @@ struct SkillsSettingsSmokeTests {
 
     @Test func `skills settings exercises private views`() {
         SkillsSettings.exerciseForTesting()
+    }
+
+    @Test func `local node reconnect forces refresh after initial load`() async throws {
+        var reports = [
+            makeSkillsStatusReport([
+                makeSkillStatus(
+                    name: "Paprika",
+                    description: "Missing local binary",
+                    source: "openclaw-workspace",
+                    filePath: "/tmp/skills/paprika",
+                    skillKey: "paprika",
+                    emoji: "P",
+                    eligible: false,
+                    requirements: SkillRequirements(bins: ["paprika"], env: [], config: []),
+                    missing: SkillMissing(bins: ["paprika"], env: [], config: [])),
+            ]),
+            makeSkillsStatusReport([
+                makeSkillStatus(
+                    name: "Paprika",
+                    description: "Ready after node reconnect",
+                    source: "openclaw-workspace",
+                    filePath: "/tmp/skills/paprika",
+                    skillKey: "paprika",
+                    emoji: "P",
+                    eligible: true,
+                    requirements: SkillRequirements(bins: ["paprika"], env: [], config: []),
+                    missing: SkillMissing(bins: [], env: [], config: [])),
+            ]),
+        ]
+        var loadCount = 0
+        let model = SkillsSettingsModel {
+            loadCount += 1
+            return reports.removeFirst()
+        }
+
+        await model.refreshIfNeeded()
+        #expect(loadCount == 1)
+        #expect(model.skills.first?.eligible == false)
+
+        await model.refreshAfterLocalNodeReconnect()
+
+        #expect(loadCount == 2)
+        #expect(model.skills.first?.eligible == true)
+        #expect(model.skills.first?.missing.bins.isEmpty)
+    }
+
+    @Test func `local node reconnect queues refresh during initial load`() async throws {
+        var firstLoad: CheckedContinuation<SkillsStatusReport, Never>?
+        var loadCount = 0
+        let model = SkillsSettingsModel {
+            loadCount += 1
+            if loadCount == 1 {
+                return await withCheckedContinuation { continuation in
+                    firstLoad = continuation
+                }
+            }
+            return makeSkillsStatusReport([
+                makeSkillStatus(
+                    name: "Paprika",
+                    description: "Ready after node reconnect",
+                    source: "openclaw-workspace",
+                    filePath: "/tmp/skills/paprika",
+                    skillKey: "paprika",
+                    emoji: "P",
+                    eligible: true,
+                    requirements: SkillRequirements(bins: ["paprika"], env: [], config: []),
+                    missing: SkillMissing(bins: [], env: [], config: [])),
+            ])
+        }
+
+        let initialRefresh = Task { await model.refreshIfNeeded() }
+        while firstLoad == nil {
+            await Task.yield()
+        }
+
+        await model.refreshAfterLocalNodeReconnect()
+
+        #expect(loadCount == 1)
+
+        firstLoad?.resume(returning: makeSkillsStatusReport([
+            makeSkillStatus(
+                name: "Paprika",
+                description: "Missing local binary",
+                source: "openclaw-workspace",
+                filePath: "/tmp/skills/paprika",
+                skillKey: "paprika",
+                emoji: "P",
+                eligible: false,
+                requirements: SkillRequirements(bins: ["paprika"], env: [], config: []),
+                missing: SkillMissing(bins: ["paprika"], env: [], config: [])),
+        ]))
+        await initialRefresh.value
+
+        #expect(loadCount == 2)
+        #expect(model.skills.first?.eligible == true)
+    }
+
+    @Test func `local node reconnect skipped before initial load`() async throws {
+        var loadCount = 0
+        let model = SkillsSettingsModel {
+            loadCount += 1
+            return makeSkillsStatusReport([])
+        }
+
+        await model.refreshAfterLocalNodeReconnect()
+
+        #expect(loadCount == 0)
+        #expect(model.skills.isEmpty)
     }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes #107391 - macOS app Skills screen shows **Unavailable** after local node reconnects, even when Gateway's live `skills.status` reports the skill as eligible and the node successfully resolves required binaries.

## Why This Change Was Made

When a user opens the Skills page before the local Mac node reconnects, the initial skills status request may return unavailable (node not connected yet). After the node reconnects and the Gateway reports the skill as ready, the Skills UI remains stale showing **Unavailable** because there's no mechanism to refresh after node reconnect.

The fix adds:
1. `Notification.Name.openclawLocalNodeDidConnect` - notification sent when local node connects to gateway
2. `refreshAfterLocalNodeReconnect()` - method to refresh skills status after node reconnect with proper concurrency control
3. Coalescing of forced refreshes during in-flight requests to avoid duplicate loads

## User Impact

- **Before**: Skills page shows stale **Unavailable** badge after node reconnects, confusing operators about skill readiness
- **After**: Skills page automatically refreshes when local node reconnects, showing correct availability status
- **Workaround removed**: Users previously had to leave and re-enter Settings or reconnect Gateway

## Evidence

### Unit Tests
Added three comprehensive tests in `SkillsSettingsSmokeTests.swift`:
1. `local node reconnect forces refresh after initial load` - verifies refresh after successful reconnect
2. `local node reconnect queues refresh during initial load` - verifies coalescing during concurrent requests
3. `local node reconnect skipped before initial load` - verifies no spurious refresh before first load

### Manual Testing Required
This PR requires real macOS app testing to verify:
1. Build and run OpenClaw macOS app
2. Install a skill with binary requirements (e.g., `paprika`)
3. Open Settings → Skills before node connects
4. Wait for node to reconnect
5. Verify skill card updates from Unavailable to Available

### Side-by-side comparison with PR #107660 (updated after diff-level review)

Both candidates implement the same shape: `.openclawLocalNodeDidConnect` notification posted by the coordinator, an `.onReceive` hook on the Skills view, `refreshAfterLocalNodeReconnect()` with `pendingForcedRefresh` coalescing, and smoke tests. Verified differences:

| Aspect | This PR (#111248) | #107660 |
|---|---|---|
| Notification name | `ai.openclaw.local-node.did-connect` (reverse-DNS, bundle-id convention) | `openclaw.local-node.did-connect` |
| Coordinator posting | `NotificationCenter.default.post` directly | injectable `notificationCenter` (easier to spy in tests) |
| Refresh drain | `pendingForcedRefresh` handled inline in `refresh(force:)` | explicit `runRefresh()` + `while pendingForcedRefresh` loop (cleaner separation) |
| Status loader DI | default-value closure annotated `@MainActor` | two inits, non-actor default |

The implementations are functionally equivalent; either can serve as canonical. A merge of the two would ideally keep the explicit drain loop and injectable notification center from #107660 with the reverse-DNS notification name used here.

### Local verification limits

The contributor machine has no Xcode app (Command Line Tools only), so `swift test` cannot run (`XCTest not available`) and a native app-run proof of the Skills card updating is not producible locally. The smoke tests run in the repo's macOS CI lanes; the manual reconnect scenario below still needs a maintainer with a full Xcode setup.

## Files Changed
- `apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift` - add notification definition and posting
- `apps/macos/Sources/OpenClaw/SkillsSettings.swift` - add reconnect refresh handling
- `apps/macos/Tests/OpenClawIPCTests/SkillsSettingsSmokeTests.swift` - add unit tests
