### PR TITLE
fix(gateway): reject altered approval history cursors

### DIFF
--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -722,7 +722,7 @@ methods. Treat this as feature discovery, not a full enumeration of
   </Accordion>
 
   <Accordion title="Approval families">
-    - `approval.history` returns newest-first terminal approvals retained for 30 days for exec, plugin, and system-agent requests (scope `operator.approvals`). It supports cursor pagination plus an optional kind filter; pending approvals are not history rows.
+    - `approval.history` returns newest-first terminal approvals retained for 30 days for exec, plugin, and system-agent requests (scope `operator.approvals`). It supports cursor pagination plus an optional kind filter; pending approvals are not history rows. Treat each cursor as an opaque server token and return the exact value without padding, rewriting, or adding fields.
     - `approval.get` and `approval.resolve` are the kind-agnostic durable approval methods (scope `operator.approvals`). `approval.get` returns a sanitized pending or retained terminal projection with a stable `urlPath`; `approval.resolve` accepts the canonical approval id, an explicit `kind`, and a decision, applies first-answer-wins resolution, and always returns the recorded canonical result.
     - `exec.approval.request`, `exec.approval.get`, `exec.approval.list`, and `exec.approval.resolve` cover one-shot exec approval requests plus pending approval lookup/replay. They are protocol-boundary adapters over the same durable approval registry.
     - `exec.approval.waitDecision` waits on one pending exec approval and returns the final decision (or `null` on timeout).

--- a/src/gateway/operator-approval-store.test.ts
+++ b/src/gateway/operator-approval-store.test.ts
@@ -28,6 +28,7 @@ import {
   listPendingOperatorApprovals,
   listTerminalOperatorApprovals,
   OPERATOR_APPROVAL_MAX_AUDIENCE_SESSION_KEYS,
+  OperatorApprovalHistoryCursorError,
   pruneTerminalOperatorApprovals,
   resolveOperatorApproval,
 } from "./operator-approval-store.js";
@@ -229,6 +230,26 @@ describe("operator approval store", () => {
     const firstPage = listTerminalOperatorApprovals({ limit: 2, nowMs: 3_000, databaseOptions });
     expect(firstPage.records.map((record) => record.id)).toEqual(["system-middle", "plugin-new"]);
     expect(firstPage.nextCursor).toEqual(expect.any(String));
+    if (!firstPage.nextCursor) {
+      throw new Error("expected terminal history cursor");
+    }
+
+    const cursorPayload = JSON.parse(
+      Buffer.from(firstPage.nextCursor, "base64url").toString("utf8"),
+    ) as Record<string, unknown>;
+    const nonEmittedCursor = Buffer.from(
+      JSON.stringify({ ...cursorPayload, extra: true }),
+      "utf8",
+    ).toString("base64url");
+    for (const cursor of [
+      `${firstPage.nextCursor}!`,
+      `${firstPage.nextCursor}=`,
+      nonEmittedCursor,
+    ]) {
+      expect(() =>
+        listTerminalOperatorApprovals({ cursor, nowMs: 3_000, databaseOptions }),
+      ).toThrow(OperatorApprovalHistoryCursorError);
+    }
 
     const secondPage = listTerminalOperatorApprovals({
       cursor: firstPage.nextCursor,

--- a/src/gateway/operator-approval-store.test.ts
+++ b/src/gateway/operator-approval-store.test.ts
@@ -27,6 +27,7 @@ import {
   listPendingOperatorApprovals,
   listTerminalOperatorApprovals,
   OPERATOR_APPROVAL_MAX_AUDIENCE_SESSION_KEYS,
+  OperatorApprovalHistoryCursorError,
   pruneTerminalOperatorApprovals,
   resolveOperatorApproval,
 } from "./operator-approval-store.js";
@@ -229,6 +230,26 @@ describe("operator approval store", () => {
     const firstPage = listTerminalOperatorApprovals({ limit: 2, nowMs: 3_000, databaseOptions });
     expect(firstPage.records.map((record) => record.id)).toEqual(["system-middle", "plugin-new"]);
     expect(firstPage.nextCursor).toEqual(expect.any(String));
+    if (!firstPage.nextCursor) {
+      throw new Error("expected terminal history cursor");
+    }
+
+    const cursorPayload = JSON.parse(
+      Buffer.from(firstPage.nextCursor, "base64url").toString("utf8"),
+    ) as Record<string, unknown>;
+    const nonEmittedCursor = Buffer.from(
+      JSON.stringify({ ...cursorPayload, extra: true }),
+      "utf8",
+    ).toString("base64url");
+    for (const cursor of [
+      `${firstPage.nextCursor}!`,
+      `${firstPage.nextCursor}=`,
+      nonEmittedCursor,
+    ]) {
+      expect(() =>
+        listTerminalOperatorApprovals({ cursor, nowMs: 3_000, databaseOptions }),
+      ).toThrow(OperatorApprovalHistoryCursorError);
+    }
 
     const secondPage = listTerminalOperatorApprovals({
       cursor: firstPage.nextCursor,

--- a/src/gateway/operator-approval-store.ts
+++ b/src/gateway/operator-approval-store.ts
@@ -240,7 +240,11 @@ function encodeOperatorApprovalHistoryCursor(cursor: OperatorApprovalHistoryCurs
 
 function decodeOperatorApprovalHistoryCursor(raw: string): OperatorApprovalHistoryCursor {
   try {
-    const parsed: unknown = JSON.parse(Buffer.from(raw, "base64url").toString("utf8"));
+    const bytes = Buffer.from(raw, "base64url");
+    if (bytes.toString("base64url") !== raw) {
+      throw new OperatorApprovalHistoryCursorError();
+    }
+    const parsed: unknown = JSON.parse(bytes.toString("utf8"));
     if (
       typeof parsed !== "object" ||
       parsed === null ||
@@ -257,7 +261,11 @@ function decodeOperatorApprovalHistoryCursor(raw: string): OperatorApprovalHisto
     ) {
       throw new OperatorApprovalHistoryCursorError();
     }
-    return { resolvedAtMs: parsed.resolvedAtMs, id: parsed.id };
+    const cursor = { resolvedAtMs: parsed.resolvedAtMs, id: parsed.id };
+    if (encodeOperatorApprovalHistoryCursor(cursor) !== raw) {
+      throw new OperatorApprovalHistoryCursorError();
+    }
+    return cursor;
   } catch (error) {
     if (error instanceof OperatorApprovalHistoryCursorError) {
       throw error;

--- a/src/gateway/operator-approval-store.ts
+++ b/src/gateway/operator-approval-store.ts
@@ -310,7 +310,11 @@ function encodeOperatorApprovalHistoryCursor(cursor: OperatorApprovalHistoryCurs
 
 function decodeOperatorApprovalHistoryCursor(raw: string): OperatorApprovalHistoryCursor {
   try {
-    const parsed: unknown = JSON.parse(Buffer.from(raw, "base64url").toString("utf8"));
+    const bytes = Buffer.from(raw, "base64url");
+    if (bytes.toString("base64url") !== raw) {
+      throw new OperatorApprovalHistoryCursorError();
+    }
+    const parsed: unknown = JSON.parse(bytes.toString("utf8"));
     if (
       typeof parsed !== "object" ||
       parsed === null ||
@@ -327,7 +331,11 @@ function decodeOperatorApprovalHistoryCursor(raw: string): OperatorApprovalHisto
     ) {
       throw new OperatorApprovalHistoryCursorError();
     }
-    return { resolvedAtMs: parsed.resolvedAtMs, id: parsed.id };
+    const cursor = { resolvedAtMs: parsed.resolvedAtMs, id: parsed.id };
+    if (encodeOperatorApprovalHistoryCursor(cursor) !== raw) {
+      throw new OperatorApprovalHistoryCursorError();
+    }
+    return cursor;
   } catch (error) {
     if (error instanceof OperatorApprovalHistoryCursorError) {
       throw error;


### PR DESCRIPTION
## What Problem This Solves

Operators paging terminal approval history could alter a server-issued cursor by appending junk, adding Base64URL padding, or adding JSON fields. OpenClaw accepted each altered spelling as the same keyset position.

## Why This Change Was Made

The approval-history decoder now requires an exact Base64URL byte round-trip and an exact round-trip through the existing cursor encoder. This keeps the cursor envelope canonical at its owner boundary.

Approval decisions, authorization, retention, database queries, and the SQLite schema are unchanged.

## User Impact

Canonical cursors emitted by OpenClaw continue normal two-page pagination. Altered or non-emitted cursors now return the existing invalid-cursor error.

Client contract: approval-history cursors are opaque server tokens. Clients must store and return the exact emitted value without padding, rewriting, or adding fields.

## Evidence

I ran the same external harness against the real exported `listTerminalOperatorApprovals()` function and an isolated OpenClaw SQLite state database on Node v24.18.1.

Exact current `main` at reproduction time, `79a119ef324977483a59eacb28de33da56edf646`:

```text
first page: proof-new, proof-middle
canonical: accepted -> proof-old
appended junk: accepted -> proof-old
padded: accepted -> proof-old
extra field: accepted -> proof-old
```

Exact repaired head, `fbc4e3b1c412d483849b844a3fed4b3ca5e331dd`:

```text
first page: proof-new, proof-middle
canonical: accepted -> proof-old
appended junk: rejected -> OperatorApprovalHistoryCursorError
padded: rejected -> OperatorApprovalHistoryCursorError
extra field: rejected -> OperatorApprovalHistoryCursorError
```

Focused validation on the repaired head:

```text
node scripts/run-vitest.mjs src/gateway/operator-approval-store.test.ts
Test Files  1 passed (1)
Tests  25 passed (25)

./node_modules/.bin/oxfmt --check src/gateway/operator-approval-store.ts src/gateway/operator-approval-store.test.ts
All matched files use the correct format.

./node_modules/.bin/oxlint src/gateway/operator-approval-store.ts src/gateway/operator-approval-store.test.ts
Found 0 warnings and 0 errors.

pnpm docs:list
pnpm docs:check-mdx
Both completed successfully.
```

AI-assisted: Codex helped refresh, reproduce, and validate the change. The contributor's original behavior and authorship are preserved.
