### PR TITLE
fix(chutes): cache-read usage is reported as free

### DIFF
--- a/extensions/chutes/models.test.ts
+++ b/extensions/chutes/models.test.ts
@@ -187,7 +187,7 @@ describe("chutes-models", () => {
             input_modalities: ["text", "image"],
             context_length: 200000,
             max_output_length: 16384,
-            pricing: { prompt: 0.1, completion: 0.2 },
+            pricing: { prompt: 0.1, completion: 0.2, input_cache_read: 0.05 },
           },
           { id: "new-provider/simple-model" },
         ],
@@ -201,6 +201,12 @@ describe("chutes-models", () => {
         const secondModel = requireChutesModel(models, 1);
         expect(firstModel.id).toBe("zai-org/GLM-5-TEE");
         expect(secondModel.reasoning).toBe(true);
+        expect(secondModel.cost).toEqual({
+          input: 0.1,
+          output: 0.2,
+          cacheRead: 0.05,
+          cacheWrite: 0,
+        });
         if (!secondModel.compat) {
           throw new Error("expected Chutes API model compat");
         }

--- a/extensions/chutes/models.ts
+++ b/extensions/chutes/models.ts
@@ -58,6 +58,7 @@ interface ChutesModelEntry {
   pricing?: {
     prompt?: number;
     completion?: number;
+    input_cache_read?: number;
   };
   [key: string]: unknown;
 }
@@ -127,7 +128,7 @@ export async function discoverChutesModels(accessToken?: string): Promise<ModelD
         cost: {
           input: entry.pricing?.prompt || 0,
           output: entry.pricing?.completion || 0,
-          cacheRead: 0,
+          cacheRead: entry.pricing?.input_cache_read || 0,
           cacheWrite: 0,
         },
         contextWindow: asPositiveSafeInteger(entry.context_length) ?? CHUTES_DEFAULT_CONTEXT_WINDOW,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users relying on Chutes live model discovery would have
cached input usage reported as free when the provider publishes a non-zero
cache-read price.

## Why This Change Was Made

The Chutes catalog already returns `pricing.input_cache_read` in the same
USD-per-million-token unit OpenClaw uses for model costs. This maps that value to
the existing `cost.cacheRead` field while preserving the current zero fallback
when the provider omits it. No endpoint, authentication, caching, model routing,
or other provider behavior changes.

## User Impact

OpenClaw can now account for cached input tokens at the price advertised by
Chutes instead of under-reporting their cost as zero.

## Evidence

- Regression test was red before the mapper change: expected `cacheRead: 0.05`,
  received `0`; it is green after the fix (13/13 focused tests).
- The affected Chutes extension suite passes: 3 files, 25 tests.
- Live third-party proof against `https://llm.chutes.ai/v1/models`: HTTP 200, 13
  models. Current samples advertise cache-read prices of `0.052` for
  `Qwen/Qwen3-32B-TEE`, `0.7` for `zai-org/GLM-5.2-TEE`, and `0.01225` for
  `unsloth/Mistral-Nemo-Instruct-2407-TEE`.
- Latest-main OpenClaw production discovery mapped all three live values to `0`;
  the patched production path maps them to `0.052`, `0.7`, and `0.01225`
  respectively.
- `openclaw models list --all --provider chutes --json` discovered the same 13
  live models, confirming this is the OpenClaw CLI discovery path. No CoClaw or
  real user credential was used.
- Formatting, focused lint, `git diff --check`, and a single Codex review passed
  with no actionable findings.
