### PR TITLE
fix(browser): detect Windows browsers when install roots are blank

### DIFF
--- a/extensions/browser/src/browser/chrome.default-browser.test.ts
+++ b/extensions/browser/src/browser/chrome.default-browser.test.ts
@@ -32,7 +32,8 @@ vi.mock("node:os", async () => {
 import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import os from "node:os";
-const { resolveBrowserExecutableForPlatform } = await import("./chrome.executables.js");
+const { resolveBrowserExecutableForPlatform, resolveGoogleChromeExecutableForPlatform } =
+  await import("./chrome.executables.js");
 
 describe("browser default executable detection", () => {
   const launchServicesPlist = "com.apple.launchservices.secure.plist";
@@ -218,23 +219,95 @@ describe("browser default executable detection", () => {
     expect(exe?.path.toLowerCase()).toMatch(/\\google\\chrome\\application\\chrome\.exe$/);
   });
 
-  it("uses standard Windows install roots when ProgramFiles overrides are blank", () => {
-    vi.stubEnv("ProgramFiles", "   ");
-    vi.stubEnv("ProgramFiles(x86)", "");
-    vi.mocked(fs.existsSync).mockImplementation(
-      (candidate) =>
-        String(candidate) === "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
-    );
+  it("treats blank Windows install roots as absent and preserves default path order", () => {
+    vi.stubEnv("LOCALAPPDATA", " \t ");
+    vi.stubEnv("ProgramFiles", "");
+    vi.stubEnv("ProgramFiles(x86)", "   ");
+    vi.mocked(os.homedir).mockReturnValue("C:\\Users\\test");
+    vi.mocked(fs.existsSync).mockReturnValue(false);
 
     expect(
       resolveBrowserExecutableForPlatform(
         {} as Parameters<typeof resolveBrowserExecutableForPlatform>[0],
         "win32",
       ),
-    ).toEqual({
+    ).toBeNull();
+    expect(vi.mocked(fs.existsSync).mock.calls.map(([candidate]) => String(candidate))).toEqual([
+      "C:\\Users\\test\\AppData\\Local\\Google\\Chrome\\Application\\chrome.exe",
+      "C:\\Users\\test\\AppData\\Local\\BraveSoftware\\Brave-Browser\\Application\\brave.exe",
+      "C:\\Users\\test\\AppData\\Local\\Microsoft\\Edge\\Application\\msedge.exe",
+      "C:\\Users\\test\\AppData\\Local\\Chromium\\Application\\chrome.exe",
+      "C:\\Users\\test\\AppData\\Local\\Google\\Chrome SxS\\Application\\chrome.exe",
+      "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
+      "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
+      "C:\\Program Files\\BraveSoftware\\Brave-Browser\\Application\\brave.exe",
+      "C:\\Program Files (x86)\\BraveSoftware\\Brave-Browser\\Application\\brave.exe",
+      "C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe",
+      "C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe",
+    ]);
+  });
+
+  it("keeps explicit Windows install roots and their discovery precedence", () => {
+    vi.stubEnv("LOCALAPPDATA", "D:\\User Apps");
+    vi.stubEnv("ProgramFiles", "D:\\System Apps");
+    vi.stubEnv("ProgramFiles(x86)", "D:\\System Apps x86");
+    const expected = "D:\\System Apps x86\\Google\\Chrome\\Application\\chrome.exe";
+    vi.mocked(fs.existsSync).mockImplementation((candidate) => String(candidate) === expected);
+
+    expect(
+      resolveBrowserExecutableForPlatform(
+        {} as Parameters<typeof resolveBrowserExecutableForPlatform>[0],
+        "win32",
+      ),
+    ).toEqual({ kind: "chrome", path: expected });
+    expect(vi.mocked(fs.existsSync).mock.calls.map(([candidate]) => String(candidate))).toEqual([
+      "D:\\User Apps\\Google\\Chrome\\Application\\chrome.exe",
+      "D:\\User Apps\\BraveSoftware\\Brave-Browser\\Application\\brave.exe",
+      "D:\\User Apps\\Microsoft\\Edge\\Application\\msedge.exe",
+      "D:\\User Apps\\Chromium\\Application\\chrome.exe",
+      "D:\\User Apps\\Google\\Chrome SxS\\Application\\chrome.exe",
+      "D:\\System Apps\\Google\\Chrome\\Application\\chrome.exe",
+      expected,
+    ]);
+  });
+
+  it("keeps custom-root precedence for Google Chrome-only discovery", () => {
+    vi.stubEnv("LOCALAPPDATA", "D:\\User Apps");
+    vi.stubEnv("ProgramFiles", "D:\\System Apps");
+    vi.stubEnv("ProgramFiles(x86)", "D:\\System Apps x86");
+    const expected = "D:\\System Apps x86\\Google\\Chrome\\Application\\chrome.exe";
+    vi.mocked(fs.existsSync).mockImplementation((candidate) => String(candidate) === expected);
+
+    expect(resolveGoogleChromeExecutableForPlatform("win32")).toEqual({
       kind: "chrome",
-      path: "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
+      path: expected,
     });
+    expect(vi.mocked(fs.existsSync).mock.calls.map(([candidate]) => String(candidate))).toEqual([
+      "D:\\User Apps\\Google\\Chrome\\Application\\chrome.exe",
+      "D:\\User Apps\\Google\\Chrome SxS\\Application\\chrome.exe",
+      "D:\\System Apps\\Google\\Chrome\\Application\\chrome.exe",
+      expected,
+    ]);
+  });
+
+  it("expands blank Windows registry roots with platform defaults before fallback scanning", () => {
+    vi.stubEnv("ProgramFiles", "   ");
+    const expected = "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe";
+    vi.mocked(execFileSync)
+      .mockReturnValueOnce("ProgId    REG_SZ    ChromeHTML")
+      .mockReturnValueOnce(
+        `(Default)    REG_SZ    "%ProgramFiles%\\Google\\Chrome\\Application\\chrome.exe" "%1"`,
+      );
+    vi.mocked(fs.existsSync).mockImplementation((candidate) => String(candidate) === expected);
+
+    expect(
+      resolveBrowserExecutableForPlatform(
+        {} as Parameters<typeof resolveBrowserExecutableForPlatform>[0],
+        "win32",
+      ),
+    ).toEqual({ kind: "chrome", path: expected });
+    expect(vi.mocked(fs.existsSync)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(fs.existsSync)).toHaveBeenCalledWith(expected);
   });
 
   it("canonicalizes an explicitly configured Opera launcher", () => {

--- a/extensions/browser/src/browser/chrome.default-browser.test.ts
+++ b/extensions/browser/src/browser/chrome.default-browser.test.ts
@@ -1,5 +1,5 @@
 // Browser tests cover chromeefault browser plugin behavior.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("node:child_process", async () => {
   const { mockNodeBuiltinModule } = await import("openclaw/plugin-sdk/test-node-mocks");
@@ -70,6 +70,10 @@ describe("browser default executable detection", () => {
     vi.mocked(fs.readFileSync).mockReset();
     vi.mocked(os.homedir).mockReset();
     vi.mocked(os.homedir).mockReturnValue("/Users/test");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it("prefers default Chromium browser on macOS", () => {
@@ -212,6 +216,25 @@ describe("browser default executable detection", () => {
     );
 
     expect(exe?.path.toLowerCase()).toMatch(/\\google\\chrome\\application\\chrome\.exe$/);
+  });
+
+  it("uses standard Windows install roots when ProgramFiles overrides are blank", () => {
+    vi.stubEnv("ProgramFiles", "   ");
+    vi.stubEnv("ProgramFiles(x86)", "");
+    vi.mocked(fs.existsSync).mockImplementation(
+      (candidate) =>
+        String(candidate) === "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
+    );
+
+    expect(
+      resolveBrowserExecutableForPlatform(
+        {} as Parameters<typeof resolveBrowserExecutableForPlatform>[0],
+        "win32",
+      ),
+    ).toEqual({
+      kind: "chrome",
+      path: "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
+    });
   });
 
   it("canonicalizes an explicitly configured Opera launcher", () => {

--- a/extensions/browser/src/browser/chrome.executables.ts
+++ b/extensions/browser/src/browser/chrome.executables.ts
@@ -25,6 +25,8 @@ const PLAYWRIGHT_BROWSERS_PATH_ENV = "PLAYWRIGHT_BROWSERS_PATH";
 const BROWSER_VERSION_TIMEOUT_MS = 6000;
 const MAC_PLISTBUDDY_TIMEOUT_MS = 800;
 const WINDOWS_FILE_METADATA_TIMEOUT_MS = 4000;
+const DEFAULT_WINDOWS_PROGRAM_FILES = "C:\\Program Files";
+const DEFAULT_WINDOWS_PROGRAM_FILES_X86 = "C:\\Program Files (x86)";
 
 const CHROMIUM_BUNDLE_IDS = new Set([
   "com.google.Chrome",
@@ -471,10 +473,37 @@ function readWindowsCommandForProgId(progId: string): string | null {
   return normalizeOptionalString(match?.[1]) ?? null;
 }
 
+function resolveWindowsBrowserInstallRoots() {
+  return {
+    localAppData:
+      normalizeOptionalString(process.env.LOCALAPPDATA) ??
+      path.win32.join(os.homedir(), "AppData", "Local"),
+    programFiles:
+      normalizeOptionalString(process.env.ProgramFiles) ?? DEFAULT_WINDOWS_PROGRAM_FILES,
+    // Must use bracket notation: variable name contains parentheses.
+    programFilesX86:
+      normalizeOptionalString(process.env["ProgramFiles(x86)"]) ??
+      DEFAULT_WINDOWS_PROGRAM_FILES_X86,
+  };
+}
+
 function expandWindowsEnvVars(value: string): string {
+  const installRoots = resolveWindowsBrowserInstallRoots();
+  const installRootByEnvName: Record<string, string> = {
+    localappdata: installRoots.localAppData,
+    programfiles: installRoots.programFiles,
+    "programfiles(x86)": installRoots.programFilesX86,
+  };
   return value.replace(/%([^%]+)%/g, (_match, name) => {
-    const key = normalizeOptionalString(name) ?? "";
-    return key ? (process.env[key] ?? `%${key}%`) : _match;
+    const key = normalizeOptionalString(name);
+    if (!key) {
+      return _match;
+    }
+    return (
+      normalizeOptionalString(process.env[key]) ??
+      installRootByEnvName[key.toLowerCase()] ??
+      `%${key}%`
+    );
   });
 }
 
@@ -666,11 +695,7 @@ function findGoogleChromeExecutableLinux(): BrowserExecutable | null {
 
 /** Find the best Chromium-family executable on Windows. */
 function findChromeExecutableWindows(): BrowserExecutable | null {
-  const localAppData = normalizeOptionalString(process.env.LOCALAPPDATA) ?? "";
-  const programFiles = normalizeOptionalString(process.env.ProgramFiles) ?? "C:\\Program Files";
-  // Must use bracket notation: variable name contains parentheses.
-  const programFilesX86 =
-    normalizeOptionalString(process.env["ProgramFiles(x86)"]) ?? "C:\\Program Files (x86)";
+  const { localAppData, programFiles, programFilesX86 } = resolveWindowsBrowserInstallRoots();
   const joinWin = path.win32.join;
   const candidates: Array<BrowserExecutable> = [];
 
@@ -737,10 +762,7 @@ function findChromeExecutableWindows(): BrowserExecutable | null {
 }
 
 function findGoogleChromeExecutableWindows(): BrowserExecutable | null {
-  const localAppData = normalizeOptionalString(process.env.LOCALAPPDATA) ?? "";
-  const programFiles = normalizeOptionalString(process.env.ProgramFiles) ?? "C:\\Program Files";
-  const programFilesX86 =
-    normalizeOptionalString(process.env["ProgramFiles(x86)"]) ?? "C:\\Program Files (x86)";
+  const { localAppData, programFiles, programFilesX86 } = resolveWindowsBrowserInstallRoots();
   const joinWin = path.win32.join;
   const candidates: string[] = [];
 

--- a/extensions/browser/src/browser/chrome.executables.ts
+++ b/extensions/browser/src/browser/chrome.executables.ts
@@ -666,10 +666,11 @@ function findGoogleChromeExecutableLinux(): BrowserExecutable | null {
 
 /** Find the best Chromium-family executable on Windows. */
 function findChromeExecutableWindows(): BrowserExecutable | null {
-  const localAppData = process.env.LOCALAPPDATA ?? "";
-  const programFiles = process.env.ProgramFiles ?? "C:\\Program Files";
+  const localAppData = normalizeOptionalString(process.env.LOCALAPPDATA) ?? "";
+  const programFiles = normalizeOptionalString(process.env.ProgramFiles) ?? "C:\\Program Files";
   // Must use bracket notation: variable name contains parentheses.
-  const programFilesX86 = process.env["ProgramFiles(x86)"] ?? "C:\\Program Files (x86)";
+  const programFilesX86 =
+    normalizeOptionalString(process.env["ProgramFiles(x86)"]) ?? "C:\\Program Files (x86)";
   const joinWin = path.win32.join;
   const candidates: Array<BrowserExecutable> = [];
 
@@ -736,9 +737,10 @@ function findChromeExecutableWindows(): BrowserExecutable | null {
 }
 
 function findGoogleChromeExecutableWindows(): BrowserExecutable | null {
-  const localAppData = process.env.LOCALAPPDATA ?? "";
-  const programFiles = process.env.ProgramFiles ?? "C:\\Program Files";
-  const programFilesX86 = process.env["ProgramFiles(x86)"] ?? "C:\\Program Files (x86)";
+  const localAppData = normalizeOptionalString(process.env.LOCALAPPDATA) ?? "";
+  const programFiles = normalizeOptionalString(process.env.ProgramFiles) ?? "C:\\Program Files";
+  const programFilesX86 =
+    normalizeOptionalString(process.env["ProgramFiles(x86)"]) ?? "C:\\Program Files (x86)";
   const joinWin = path.win32.join;
   const candidates: string[] = [];
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Windows browser auto-detection could miss standard Chrome, Edge, and Brave installations when `LOCALAPPDATA`, `ProgramFiles`, or `ProgramFiles(x86)` were present but blank.

## Why This Change Was Made

Windows install-root inputs are normalized once at the browser plugin boundary before candidate paths are built. Blank values now behave like absent values, while nonblank custom roots retain their existing precedence. Registry environment expansion consumes the same resolved roots so default-browser detection and fallback scanning cannot diverge.

## User Impact

Windows users can keep using browser auto-detection even when a launcher or service supplies blank install-root environment variables.

## Evidence

Exact repaired head: `0c0d34244847bfc59278a6feb1ee1f26cb691a95`

- `node scripts/run-vitest.mjs extensions/browser/src/browser/chrome.default-browser.test.ts` — 11/11 passed.
- `git diff --check origin/main...HEAD` — passed.
- Codex autoreview — clean, no accepted/actionable findings.
- Exact-head CI run `29957874365` — passed: https://github.com/openclaw/openclaw/actions/runs/29957874365
- `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 111256` — passed in `hosted_exact_or_recent_parent` mode; no standalone remote lease was dispatched.
- Tests cover blank/default roots and ordering, meaningful custom-root precedence for both discovery entry points, and blank-root registry expansion.

Fresh native Windows proof was attempted, but the broker returned HTTP 401. That boundary was not bypassed. Earlier PR history contains a real Windows run on the pre-repair head; it is not represented here as exact-head proof.
