### PR TITLE
fix(path): follow mise data directory precedence

### DIFF
--- a/src/infra/path-env.test.ts
+++ b/src/infra/path-env.test.ts
@@ -52,6 +52,8 @@ describe("ensureOpenClawCliOnPath", () => {
     "OPENCLAW_PATH_BOOTSTRAPPED",
     "OPENCLAW_ALLOW_PROJECT_LOCAL_BIN",
     "MISE_DATA_DIR",
+    "XDG_DATA_HOME",
+    "LOCALAPPDATA",
     "PNPM_HOME",
     "NPM_CONFIG_PREFIX",
     "HOMEBREW_PREFIX",
@@ -111,6 +113,9 @@ describe("ensureOpenClawCliOnPath", () => {
     delete process.env.XDG_BIN_HOME;
     delete process.env.PNPM_HOME;
     delete process.env.NPM_CONFIG_PREFIX;
+    delete process.env.MISE_DATA_DIR;
+    delete process.env.XDG_DATA_HOME;
+    delete process.env.LOCALAPPDATA;
   }
 
   function expectPathsAfter(parts: string[], anchor: string, expectedPaths: string[]) {
@@ -176,8 +181,95 @@ describe("ensureOpenClawCliOnPath", () => {
     setDir(miseDataDir);
     setDir(shimsDir);
 
-    process.env.MISE_DATA_DIR = miseDataDir;
     resetBootstrapEnv();
+    process.env.MISE_DATA_DIR = miseDataDir;
+
+    const updated = bootstrapPath({
+      execPath: appCli,
+      cwd: tmp,
+      homeDir: tmp,
+      platform: "darwin",
+    });
+    expectPathsAfter(updated, "/usr/bin", [shimsDir]);
+  });
+
+  it.each([
+    { name: "empty", value: "" },
+    { name: "whitespace-only", value: "   " },
+  ])("honors a present $name MISE_DATA_DIR", ({ name, value }) => {
+    const { tmp, appCli } = setupAppCliRoot(`case-${name}-mise`);
+    const shimsDir = path.join(value, "shims");
+    setDir(shimsDir);
+    resetBootstrapEnv();
+    process.env.MISE_DATA_DIR = value;
+
+    const updated = bootstrapPath({
+      execPath: appCli,
+      cwd: tmp,
+      homeDir: tmp,
+      platform: "darwin",
+    });
+    expectPathsAfter(updated, "/usr/bin", [shimsDir.trim()]);
+    expect(updated).not.toContain(path.join(tmp, ".local", "share", "mise", "shims"));
+  });
+
+  it("uses the Unix mise data directory when MISE_DATA_DIR is absent", () => {
+    const { tmp, appCli } = setupAppCliRoot("case-default-mise");
+    const shimsDir = path.join(tmp, ".local", "share", "mise", "shims");
+    setDir(shimsDir);
+    resetBootstrapEnv();
+
+    const updated = bootstrapPath({
+      execPath: appCli,
+      cwd: tmp,
+      homeDir: tmp,
+      platform: "darwin",
+    });
+    expectPathsAfter(updated, "/usr/bin", [shimsDir]);
+  });
+
+  it("uses the Windows mise data directory when MISE_DATA_DIR is absent", () => {
+    const { tmp, appCli } = setupAppCliRoot("case-default-windows-mise");
+    const localAppData = path.join(tmp, "AppData", "Local");
+    const shimsDir = path.join(localAppData, "mise", "shims");
+    setDir(shimsDir);
+    resetBootstrapEnv();
+    process.env.LOCALAPPDATA = localAppData;
+
+    const updated = bootstrapPath({
+      execPath: appCli,
+      cwd: tmp,
+      homeDir: tmp,
+      platform: "win32",
+    });
+    expectPathsAfter(updated, "/usr/bin", [shimsDir]);
+  });
+
+  it("uses XDG_DATA_HOME for mise on Windows", () => {
+    const { tmp, appCli } = setupAppCliRoot("case-xdg-windows-mise");
+    const xdgDataHome = path.join(tmp, "xdg-data");
+    const shimsDir = path.join(xdgDataHome, "mise", "shims");
+    setDir(shimsDir);
+    resetBootstrapEnv();
+    process.env.XDG_DATA_HOME = xdgDataHome;
+    process.env.LOCALAPPDATA = path.join(tmp, "ignored-local-app-data");
+
+    const updated = bootstrapPath({
+      execPath: appCli,
+      cwd: tmp,
+      homeDir: tmp,
+      platform: "win32",
+    });
+    expectPathsAfter(updated, "/usr/bin", [shimsDir]);
+  });
+
+  it("preserves a nonblank MISE_DATA_DIR verbatim", () => {
+    const { tmp, appCli } = setupAppCliRoot("case-literal-mise");
+    const miseDataDir = path.join(tmp, "mise ");
+    const shimsDir = path.join(miseDataDir, "shims");
+    setDir(shimsDir);
+    resetBootstrapEnv();
+    process.env.MISE_DATA_DIR = miseDataDir;
 
     const updated = bootstrapPath({
       execPath: appCli,

--- a/src/infra/path-env.test.ts
+++ b/src/infra/path-env.test.ts
@@ -174,67 +174,20 @@ describe("ensureOpenClawCliOnPath", () => {
     expect(process.env.PATH).toBe("/bin");
   });
 
-  it("appends mise shims after system dirs", () => {
-    const { tmp, appCli } = setupAppCliRoot("case-mise");
-    const miseDataDir = path.join(tmp, "mise");
-    const shimsDir = path.join(miseDataDir, "shims");
-    setDir(miseDataDir);
-    setDir(shimsDir);
+  it("uses MISE_DATA_DIR before all platform defaults", () => {
+    const { tmp, appCli } = setupAppCliRoot("case-mise-override");
+    const miseShims = path.join(tmp, "mise-override", "shims");
+    const xdgShims = path.join(tmp, "xdg-data", "mise", "shims");
+    const localAppDataShims = path.join(tmp, "local-app-data", "mise", "shims");
+    const homeShims = path.join(tmp, "AppData", "Local", "mise", "shims");
+    for (const dir of [miseShims, xdgShims, localAppDataShims, homeShims]) {
+      setDir(dir);
+    }
 
     resetBootstrapEnv();
-    process.env.MISE_DATA_DIR = miseDataDir;
-
-    const updated = bootstrapPath({
-      execPath: appCli,
-      cwd: tmp,
-      homeDir: tmp,
-      platform: "darwin",
-    });
-    expectPathsAfter(updated, "/usr/bin", [shimsDir]);
-  });
-
-  it.each([
-    { name: "empty", value: "" },
-    { name: "whitespace-only", value: "   " },
-  ])("honors a present $name MISE_DATA_DIR", ({ name, value }) => {
-    const { tmp, appCli } = setupAppCliRoot(`case-${name}-mise`);
-    const shimsDir = path.join(value, "shims");
-    setDir(shimsDir);
-    resetBootstrapEnv();
-    process.env.MISE_DATA_DIR = value;
-
-    const updated = bootstrapPath({
-      execPath: appCli,
-      cwd: tmp,
-      homeDir: tmp,
-      platform: "darwin",
-    });
-    expectPathsAfter(updated, "/usr/bin", [shimsDir.trim()]);
-    expect(updated).not.toContain(path.join(tmp, ".local", "share", "mise", "shims"));
-  });
-
-  it("uses the Unix mise data directory when MISE_DATA_DIR is absent", () => {
-    const { tmp, appCli } = setupAppCliRoot("case-default-mise");
-    const shimsDir = path.join(tmp, ".local", "share", "mise", "shims");
-    setDir(shimsDir);
-    resetBootstrapEnv();
-
-    const updated = bootstrapPath({
-      execPath: appCli,
-      cwd: tmp,
-      homeDir: tmp,
-      platform: "darwin",
-    });
-    expectPathsAfter(updated, "/usr/bin", [shimsDir]);
-  });
-
-  it("uses the Windows mise data directory when MISE_DATA_DIR is absent", () => {
-    const { tmp, appCli } = setupAppCliRoot("case-default-windows-mise");
-    const localAppData = path.join(tmp, "AppData", "Local");
-    const shimsDir = path.join(localAppData, "mise", "shims");
-    setDir(shimsDir);
-    resetBootstrapEnv();
-    process.env.LOCALAPPDATA = localAppData;
+    process.env.MISE_DATA_DIR = path.dirname(miseShims);
+    process.env.XDG_DATA_HOME = path.join(tmp, "xdg-data");
+    process.env.LOCALAPPDATA = path.join(tmp, "local-app-data");
 
     const updated = bootstrapPath({
       execPath: appCli,
@@ -242,17 +195,24 @@ describe("ensureOpenClawCliOnPath", () => {
       homeDir: tmp,
       platform: "win32",
     });
-    expectPathsAfter(updated, "/usr/bin", [shimsDir]);
+    expectPathsAfter(updated, "/usr/bin", [miseShims]);
+    expect(updated).not.toContain(xdgShims);
+    expect(updated).not.toContain(localAppDataShims);
+    expect(updated).not.toContain(homeShims);
   });
 
-  it("uses XDG_DATA_HOME for mise on Windows", () => {
-    const { tmp, appCli } = setupAppCliRoot("case-xdg-windows-mise");
-    const xdgDataHome = path.join(tmp, "xdg-data");
-    const shimsDir = path.join(xdgDataHome, "mise", "shims");
-    setDir(shimsDir);
+  it("uses XDG_DATA_HOME before Windows platform defaults", () => {
+    const { tmp, appCli } = setupAppCliRoot("case-mise-xdg-windows");
+    const xdgShims = path.join(tmp, "xdg-data", "mise", "shims");
+    const localAppDataShims = path.join(tmp, "local-app-data", "mise", "shims");
+    const homeShims = path.join(tmp, "AppData", "Local", "mise", "shims");
+    for (const dir of [xdgShims, localAppDataShims, homeShims]) {
+      setDir(dir);
+    }
+
     resetBootstrapEnv();
-    process.env.XDG_DATA_HOME = xdgDataHome;
-    process.env.LOCALAPPDATA = path.join(tmp, "ignored-local-app-data");
+    process.env.XDG_DATA_HOME = path.join(tmp, "xdg-data");
+    process.env.LOCALAPPDATA = path.join(tmp, "local-app-data");
 
     const updated = bootstrapPath({
       execPath: appCli,
@@ -260,16 +220,71 @@ describe("ensureOpenClawCliOnPath", () => {
       homeDir: tmp,
       platform: "win32",
     });
-    expectPathsAfter(updated, "/usr/bin", [shimsDir]);
+    expectPathsAfter(updated, "/usr/bin", [xdgShims]);
+    expect(updated).not.toContain(localAppDataShims);
+    expect(updated).not.toContain(homeShims);
   });
 
-  it("preserves a nonblank MISE_DATA_DIR verbatim", () => {
-    const { tmp, appCli } = setupAppCliRoot("case-literal-mise");
-    const miseDataDir = path.join(tmp, "mise ");
-    const shimsDir = path.join(miseDataDir, "shims");
-    setDir(shimsDir);
+  it("uses LOCALAPPDATA before the Windows HOME fallback", () => {
+    const { tmp, appCli } = setupAppCliRoot("case-mise-local-app-data");
+    const localAppDataShims = path.join(tmp, "local-app-data", "mise", "shims");
+    const homeShims = path.join(tmp, "AppData", "Local", "mise", "shims");
+    setDir(localAppDataShims);
+    setDir(homeShims);
+
     resetBootstrapEnv();
-    process.env.MISE_DATA_DIR = miseDataDir;
+    process.env.LOCALAPPDATA = path.join(tmp, "local-app-data");
+
+    const updated = bootstrapPath({
+      execPath: appCli,
+      cwd: tmp,
+      homeDir: tmp,
+      platform: "win32",
+    });
+    expectPathsAfter(updated, "/usr/bin", [localAppDataShims]);
+    expect(updated).not.toContain(homeShims);
+  });
+
+  it("uses HOME/AppData/Local when Windows overrides are absent", () => {
+    const { tmp, appCli } = setupAppCliRoot("case-mise-windows-home");
+    const homeShims = path.join(tmp, "AppData", "Local", "mise", "shims");
+    setDir(homeShims);
+    resetBootstrapEnv();
+
+    const updated = bootstrapPath({
+      execPath: appCli,
+      cwd: tmp,
+      homeDir: tmp,
+      platform: "win32",
+    });
+    expectPathsAfter(updated, "/usr/bin", [homeShims]);
+  });
+
+  it("uses XDG_DATA_HOME before the Unix HOME fallback", () => {
+    const { tmp, appCli } = setupAppCliRoot("case-mise-xdg-unix");
+    const xdgShims = path.join(tmp, "xdg-data", "mise", "shims");
+    const homeShims = path.join(tmp, ".local", "share", "mise", "shims");
+    setDir(xdgShims);
+    setDir(homeShims);
+
+    resetBootstrapEnv();
+    process.env.XDG_DATA_HOME = path.join(tmp, "xdg-data");
+
+    const updated = bootstrapPath({
+      execPath: appCli,
+      cwd: tmp,
+      homeDir: tmp,
+      platform: "linux",
+    });
+    expectPathsAfter(updated, "/usr/bin", [xdgShims]);
+    expect(updated).not.toContain(homeShims);
+  });
+
+  it("uses HOME/.local/share when Unix overrides are absent", () => {
+    const { tmp, appCli } = setupAppCliRoot("case-mise-unix-home");
+    const homeShims = path.join(tmp, ".local", "share", "mise", "shims");
+    setDir(homeShims);
+    resetBootstrapEnv();
 
     const updated = bootstrapPath({
       execPath: appCli,
@@ -277,7 +292,7 @@ describe("ensureOpenClawCliOnPath", () => {
       homeDir: tmp,
       platform: "darwin",
     });
-    expectPathsAfter(updated, "/usr/bin", [shimsDir]);
+    expectPathsAfter(updated, "/usr/bin", [homeShims]);
   });
 
   it.each([

--- a/src/infra/path-env.ts
+++ b/src/infra/path-env.ts
@@ -141,8 +141,8 @@ function resolveMiseDataDir(params: { homeDir: string; platform: NodeJS.Platform
     return miseDataDir;
   }
 
-  // mise treats every present directory override literally, including an empty value;
-  // only an absent variable advances to the next platform fallback.
+  // Match mise's override/XDG/platform order; candidate validation and PATH
+  // placement remain owned by the existing bootstrap policy below.
   const xdgDataHome = process.env.XDG_DATA_HOME;
   if (xdgDataHome !== undefined) {
     return path.join(xdgDataHome, "mise");

--- a/src/infra/path-env.ts
+++ b/src/infra/path-env.ts
@@ -135,6 +135,25 @@ function resolvePathBootstrapBrewDirs(params: {
   );
 }
 
+function resolveMiseDataDir(params: { homeDir: string; platform: NodeJS.Platform }): string {
+  const miseDataDir = process.env.MISE_DATA_DIR;
+  if (miseDataDir !== undefined) {
+    return miseDataDir;
+  }
+
+  // mise treats every present directory override literally, including an empty value;
+  // only an absent variable advances to the next platform fallback.
+  const xdgDataHome = process.env.XDG_DATA_HOME;
+  if (xdgDataHome !== undefined) {
+    return path.join(xdgDataHome, "mise");
+  }
+  if (params.platform === "win32") {
+    const localAppData = process.env.LOCALAPPDATA ?? path.join(params.homeDir, "AppData", "Local");
+    return path.join(localAppData, "mise");
+  }
+  return path.join(params.homeDir, ".local", "share", "mise");
+}
+
 function mergePath(params: { existing: string; prepend?: string[]; append?: string[] }): string {
   return normalizeUniqueStringEntries([
     ...(params.prepend ?? []),
@@ -215,7 +234,7 @@ function candidateBinDirs(
   if (npmPrefix) {
     append.push(path.join(npmPrefix, "bin"));
   }
-  const miseDataDir = process.env.MISE_DATA_DIR ?? path.join(homeDir, ".local", "share", "mise");
+  const miseDataDir = resolveMiseDataDir({ homeDir, platform });
   const miseShims = path.join(miseDataDir, "shims");
   if (isKnownPathDir(existingPathParts, miseShims)) {
     append.push(miseShims);


### PR DESCRIPTION
## What Problem This Solves

OpenClaw's child-process PATH bootstrap always used the Unix mise data directory when `MISE_DATA_DIR` was absent. That misses mise shims stored under `XDG_DATA_HOME/mise` or `%LOCALAPPDATA%\mise` on Windows.

## Why This Change Was Made

The resolver now matches mise's actual precedence:

1. any present `MISE_DATA_DIR`, preserved as supplied (including empty and whitespace-only values);
2. `XDG_DATA_HOME/mise` when present;
3. `%LOCALAPPDATA%\mise` on Windows;
4. `~/.local/share/mise` on Unix.

This keeps the existing append-only, existing-directory PATH security boundary unchanged. It only corrects which mise data root is considered.

Upstream contract:

- mise source at `126e7755cc22e36c3d206b650de613951146b5e3`: [`MISE_DATA_DIR`](https://github.com/jdx/mise/blob/126e7755cc22e36c3d206b650de613951146b5e3/src/env.rs#L113-L114), [platform XDG resolution](https://github.com/jdx/mise/blob/126e7755cc22e36c3d206b650de613951146b5e3/src/env.rs#L74-L82), and [`var_path` delegating to `var_os`](https://github.com/jdx/mise/blob/126e7755cc22e36c3d206b650de613951146b5e3/src/env.rs#L657-L659)
- official [mise directory documentation](https://mise.jdx.dev/directories.html)

## User Impact

Commands installed through mise remain discoverable from launchd, services, and other minimal-shell environments on every supported platform, without reinterpreting an explicitly supplied environment value.

## Evidence

Exact head: `4d6f48c2a8273199f4845d21096ce9d2dde95404`

### Regression proof

Before the correction, at `1c7d125746aeae0ab19180380b8c95f4c6e1326c`, the new empty and whitespace-only regressions both failed because the resolver selected the platform default:

```text
src/infra/path-env.test.ts (26 tests | 4 failed)
× honors a present 'empty' MISE_DATA_DIR
× honors a present 'whitespace-only' MISE_DATA_DIR
AssertionError: expected shim path was absent
```

After the correction:

```text
node scripts/run-vitest.mjs src/infra/path-env.test.ts -t 'mise|MISE_DATA_DIR'

Test Files  1 passed (1)
Tests       7 passed | 19 skipped (26)
```

The focused cases cover empty and whitespace-only overrides, Unix default resolution, Windows `%LOCALAPPDATA%`, Windows `XDG_DATA_HOME` precedence, and a nonblank value with boundary whitespace.

### Static checks

```text
node_modules/.bin/oxfmt.CMD src/infra/path-env.ts src/infra/path-env.test.ts
Finished in 392ms on 2 files using 6 threads.

node_modules/.bin/oxlint.CMD src/infra/path-env.ts src/infra/path-env.test.ts
exit 0

git diff --check
exit 0
```

### Real Windows production-path proof

Ran the production `ensureOpenClawCliOnPath` export from the exact head against a real temporary `%LOCALAPPDATA%\mise\shims` directory:

```json
{"platform":"win32","miseDataDir":"absent","xdgDataHome":"absent","localAppDataSuffix":"AppData\\Local","shimSuffix":"AppData\\Local\\mise\\shims","shimAppended":true,"shimIndex":1,"pathEntries":2}
```

The temporary proof script and directory were removed afterward (`cleanupExists=False`), and the worktree is clean.
