### PR TITLE
fix(streams): release guarded response reader locks

### DIFF
--- a/src/infra/net/guarded-body-stream.test.ts
+++ b/src/infra/net/guarded-body-stream.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { wrapGuardedBodyStream } from "./guarded-body-stream.js";
+
+describe("wrapGuardedBodyStream", () => {
+  it("releases the source reader lock after downstream cancellation", async () => {
+    const cancel = vi.fn();
+    const cleanup = vi.fn();
+    const source = new ReadableStream<Uint8Array>({ cancel });
+    const wrapped = wrapGuardedBodyStream({ body: source, cleanup });
+
+    expect(source.locked).toBe(true);
+    await wrapped.cancel("consumer stopped");
+
+    expect(cancel).toHaveBeenCalledExactlyOnceWith("consumer stopped");
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(source.locked).toBe(false);
+  });
+
+  it("propagates downstream cancellation failure after releasing resources", async () => {
+    const expected = new Error("source cancellation failed");
+    const cleanup = vi.fn();
+    const source = new ReadableStream<Uint8Array>({
+      async cancel() {
+        throw expected;
+      },
+    });
+    const wrapped = wrapGuardedBodyStream({ body: source, cleanup });
+
+    await expect(wrapped.cancel("consumer stopped")).rejects.toBe(expected);
+
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(source.locked).toBe(false);
+  });
+
+  it("releases the source reader lock after normal completion", async () => {
+    const cleanup = vi.fn();
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("done"));
+        controller.close();
+      },
+    });
+    const wrapped = wrapGuardedBodyStream({ body: source, cleanup });
+
+    await expect(new Response(wrapped).text()).resolves.toBe("done");
+
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(source.locked).toBe(false);
+  });
+
+  it("releases the source reader lock while preserving a read failure", async () => {
+    const expected = new Error("source read failed");
+    const cleanup = vi.fn();
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.error(expected);
+      },
+    });
+    const wrapped = wrapGuardedBodyStream({ body: source, cleanup });
+
+    await expect(new Response(wrapped).arrayBuffer()).rejects.toBe(expected);
+
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(source.locked).toBe(false);
+  });
+});

--- a/src/infra/net/guarded-body-stream.test.ts
+++ b/src/infra/net/guarded-body-stream.test.ts
@@ -41,8 +41,12 @@ describe("wrapGuardedBodyStream", () => {
       },
     });
     const wrapped = wrapGuardedBodyStream({ body: source, cleanup });
+    const reader = wrapped.getReader();
 
-    await expect(new Response(wrapped).text()).resolves.toBe("done");
+    const chunk = await reader.read();
+    expect(new TextDecoder().decode(chunk.value)).toBe("done");
+    await expect(reader.read()).resolves.toEqual({ done: true, value: undefined });
+    reader.releaseLock();
 
     expect(cleanup).toHaveBeenCalledOnce();
     expect(source.locked).toBe(false);
@@ -57,8 +61,10 @@ describe("wrapGuardedBodyStream", () => {
       },
     });
     const wrapped = wrapGuardedBodyStream({ body: source, cleanup });
+    const reader = wrapped.getReader();
 
-    await expect(new Response(wrapped).arrayBuffer()).rejects.toBe(expected);
+    await expect(reader.read()).rejects.toBe(expected);
+    reader.releaseLock();
 
     expect(cleanup).toHaveBeenCalledOnce();
     expect(source.locked).toBe(false);

--- a/src/infra/net/guarded-body-stream.ts
+++ b/src/infra/net/guarded-body-stream.ts
@@ -25,17 +25,28 @@ export function wrapGuardedBodyStream(params: {
   let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
   let finalized = false;
   const cleanupRegistrationToken = {};
-  const finalize = async () => {
+  const finalize = async (
+    cancelReader: () => Promise<void> = async () => {
+      await reader?.cancel().catch(() => undefined);
+    },
+  ) => {
     if (finalized) {
       return;
     }
     finalized = true;
     guardedBodyCleanupRegistry.unregister(cleanupRegistrationToken);
-    await reader?.cancel().catch(() => undefined);
     try {
-      await params.cleanup();
-    } catch {
-      // Best effort: guard cleanup must not surface into stream consumers.
+      await cancelReader();
+    } finally {
+      try {
+        reader?.releaseLock();
+      } finally {
+        try {
+          await params.cleanup();
+        } catch {
+          // Best effort: guard cleanup must not surface into stream consumers.
+        }
+      }
     }
   };
   const wrappedBody = new ReadableStream<Uint8Array>({
@@ -58,11 +69,7 @@ export function wrapGuardedBodyStream(params: {
       }
     },
     async cancel(reason) {
-      try {
-        await reader?.cancel(reason);
-      } finally {
-        await finalize();
-      }
+      await finalize(async () => await reader?.cancel(reason));
     },
   });
   guardedBodyCleanupRegistry.register(wrappedBody, { finalize }, cleanupRegistrationToken);


### PR DESCRIPTION
Related: #111245

## What Problem This Solves

Fixes an issue where MCP and provider HTTP response wrappers kept their source `ReadableStream` reader locked after the response completed, failed, was cancelled, or was finalized after abandonment.

## Why This Change Was Made

The shared guarded-body finalizer now releases its owned reader lock after cancellation settles and before guard cleanup finishes. Internal completion/error cleanup still suppresses cancellation failure, while explicit downstream cancellation preserves its existing rejection contract.

## User Impact

Guarded MCP and model-provider response streams now release all source-reader ownership on every terminal path, preventing stale locked streams and their retained resources. Existing cancellation and read-error behavior is unchanged.

## Evidence

- Native-stream regressions cover normal completion, read failure, downstream cancellation, and downstream cancellation failure; every path asserts guard cleanup and an unlocked source.
- `node scripts/run-vitest.mjs src/infra/net/guarded-body-stream.test.ts src/agents/mcp-http-fetch.test.ts src/agents/provider-transport-fetch.test.ts`: 117 tests passed across 3 shards.
- Targeted formatting and `git diff --check` pass.
- Fresh uncommitted autoreview first identified cancellation-error suppression; the implementation was corrected, then passed cleanly at 0.93 confidence. Fresh branch autoreview is clean at 0.97 confidence.
- Changed-surface Testbox attempt: https://github.com/openclaw/openclaw/actions/runs/29676650607. Blacksmith never reached the command because targeted and full file sync timed out; exact-head PR CI is the authoritative hosted gate.

AI-assisted: yes. The maintainer agent reviewed the shared wrapper, both production callers, adjacent provider/MCP tests, shipped provenance from #99901, and the Web Streams reader-lock contract.
