### PR TITLE
fix(cron): run Windows exit watchers when ComSpec is blank

### DIFF
--- a/src/gateway/cron-exit-watch-shell.ts
+++ b/src/gateway/cron-exit-watch-shell.ts
@@ -5,7 +5,7 @@ export function resolveExitWatchShell(platform: NodeJS.Platform = process.platfo
 } {
   if (platform === "win32") {
     return {
-      command: process.env.ComSpec ?? "cmd.exe",
+      command: process.env.ComSpec?.trim() || "cmd.exe",
       // /d skip AutoRun, /s strip outer quotes, /c run then exit.
       argsFor: (command: string) => ["/d", "/s", "/c", command],
     };

--- a/src/gateway/cron-exit-watchers.test.ts
+++ b/src/gateway/cron-exit-watchers.test.ts
@@ -1,5 +1,5 @@
 import { expectDefined } from "@openclaw/normalization-core";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { CronJob } from "../cron/types.js";
 import { resolveExitWatchShell } from "./cron-exit-watch-shell.js";
 import { createCronExitWatchers, type CronExitResult } from "./cron-exit-watchers.js";
@@ -437,10 +437,19 @@ describe("createCronExitWatchers", () => {
 });
 
 describe("resolveExitWatchShell", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("uses cmd.exe on Windows so native gateways without bash can run on-exit", () => {
     const shell = resolveExitWatchShell("win32");
     expect(shell.command).toMatch(/cmd\.exe$/i);
     expect(shell.argsFor("echo hi")).toEqual(["/d", "/s", "/c", "echo hi"]);
+  });
+
+  it("uses cmd.exe when ComSpec is blank", () => {
+    vi.stubEnv("ComSpec", "   ");
+    expect(resolveExitWatchShell("win32").command).toBe("cmd.exe");
   });
 
   it("uses bash -lc on POSIX", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Windows on-exit cron watchers could try to spawn a whitespace-only command when ComSpec was present but blank.

## Why This Change Was Made

The Windows shell resolver now trims ComSpec and uses cmd.exe when the result is empty, matching the existing terminal-launch contract.

## User Impact

On-exit cron jobs continue to arm and run on Windows under service environments with a blank ComSpec override.

## Evidence

- Base behavior: resolveExitWatchShell for win32 returned three spaces instead of cmd.exe.
- Exact head 1ab96fa3898d55173338d60154e2327767d30349: focused regression -> 1 passed, 15 skipped.
- Command: node scripts/run-vitest.mjs src/gateway/cron-exit-watchers.test.ts -- -t uses-cmd.exe-when-ComSpec-is-blank
- Full adjacent suite after the fix: 16 of 16 passed.
- Targeted oxfmt check and git diff --check passed.




### Real Windows production proof

Ran the current PR head on Windows with ComSpec set to whitespace through the complete production createCronExitWatchers and createProcessSupervisor path.

Observed redacted terminal output copied from the current-head run:

```text
ComSpec=<whitespace>
resolved shell=cmd.exe
watcher=armed (real process supervisor)
watched command output=OPENCLAW_CRON_LIVE
exit code=0 reason=exit timeout=false
lifecycle=watcher armed -> command exited -> persisted -> fired
```

- resolved shell: cmd.exe
- watcher armed using the real process supervisor
- watched command output: OPENCLAW_CRON_LIVE
- exit: code 0, reason exit, no timeout
- lifecycle order: watcher armed -> command exited -> persisted -> fired

This demonstrates the real Windows child-process launch, terminal persistence ordering, and on-exit fire path rather than only the resolver unit test.

