### PR TITLE
fix(custodian): show mode-appropriate guidance and defaults

### DIFF
--- a/src/system-agent/chat-engine.test.ts
+++ b/src/system-agent/chat-engine.test.ts
@@ -725,6 +725,36 @@ describe("SystemAgentChatEngine", () => {
     expect(wizardRuns).toEqual(["telegram", "token:123:abc", "mode:open"]);
   });
 
+  it("recommends the false option for opt-in confirm steps", async () => {
+    let enabled: boolean | undefined;
+    const engine = new SystemAgentChatEngine({
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      deps: { loadOverview: fakeOverviewLoader() },
+      runChannelSetupWizard: async (_channel: string, prompter: WizardPrompter) => {
+        enabled = await prompter.confirm({
+          message: "Enable delegated auth?",
+          initialValue: false,
+        });
+      },
+    });
+
+    const confirmStep = await engine.handle("connect telegram");
+
+    expect(confirmStep.question).toEqual({
+      id: expect.any(String),
+      header: "Confirm",
+      question: "Enable delegated auth?",
+      options: [
+        { label: "Yes", reply: "yes" },
+        { label: "No", reply: "no", recommended: true },
+      ],
+    });
+
+    await engine.handle("no");
+    expect(enabled).toBe(false);
+  });
+
   it("rejects a hosted channel commit after a concurrent inference-route change", async () => {
     useTempStateDir();
     const baseConfig: OpenClawConfig = {

--- a/src/system-agent/chat-engine.test.ts
+++ b/src/system-agent/chat-engine.test.ts
@@ -725,7 +725,7 @@ describe("SystemAgentChatEngine", () => {
     expect(wizardRuns).toEqual(["telegram", "token:123:abc", "mode:open"]);
   });
 
-  it("recommends the false option for opt-in confirm steps", async () => {
+  it("recommends the confirm option matching the initial value", async () => {
     let enabled: boolean | undefined;
     const engine = new SystemAgentChatEngine({
       runAgentTurn: async () => null,
@@ -753,6 +753,23 @@ describe("SystemAgentChatEngine", () => {
 
     await engine.handle("no");
     expect(enabled).toBe(false);
+
+    const defaultEngine = new SystemAgentChatEngine({
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      deps: { loadOverview: fakeOverviewLoader() },
+      runChannelSetupWizard: async (_channel: string, prompter: WizardPrompter) => {
+        await prompter.confirm({ message: "Continue?" });
+      },
+    });
+
+    const defaultConfirmStep = await defaultEngine.handle("connect telegram");
+
+    expect(defaultConfirmStep.question?.options).toEqual([
+      { label: "Yes", reply: "yes", recommended: true },
+      { label: "No", reply: "no" },
+    ]);
+    await defaultEngine.handle("yes");
   });
 
   it("rejects a hosted channel commit after a concurrent inference-route change", async () => {

--- a/src/system-agent/chat-engine.ts
+++ b/src/system-agent/chat-engine.ts
@@ -195,13 +195,14 @@ function wizardStepChatQuestion(step: WizardStep | null): SystemAgentChatQuestio
     return undefined;
   }
   if (step.type === "confirm") {
+    const yesRecommended = step.initialValue !== false;
     return {
       id: step.id,
       header: step.title ?? "Confirm",
       question: step.message ?? "Continue?",
       options: [
-        { label: "Yes", reply: "yes", recommended: true },
-        { label: "No", reply: "no" },
+        { label: "Yes", reply: "yes", ...(yesRecommended ? { recommended: true } : {}) },
+        { label: "No", reply: "no", ...(!yesRecommended ? { recommended: true } : {}) },
       ],
     };
   }

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1872,6 +1872,7 @@ export const en: TranslationMap = {
   custodian: {
     title: "OpenClaw",
     subtitle: "Your system setup guide",
+    subtitleCaretaker: "System setup and care.",
     exitSetup: "Exit setup",
     newAgent: "New agent",
     hatchDraft: "Wake up, my friend!",

--- a/ui/src/pages/custodian/custodian-page.ts
+++ b/ui/src/pages/custodian/custodian-page.ts
@@ -413,7 +413,7 @@ export class CustodianPage extends OpenClawLightDomElement {
             <div class="custodian__mark" aria-hidden="true">OC</div>
             <div>
               <h1>${t("custodian.title")}</h1>
-              <p>${t("custodian.subtitle")}</p>
+              <p>${t(this.onboarding ? "custodian.subtitle" : "custodian.subtitleCaretaker")}</p>
             </div>
           </div>
           ${this.onboarding

--- a/ui/src/pages/custodian/route.test.ts
+++ b/ui/src/pages/custodian/route.test.ts
@@ -69,7 +69,7 @@ describe("custodian route", () => {
     expect(loadRoute("?intent=new-agent")).toEqual({ onboarding: false, intent: "new-agent" });
   });
 
-  it("renders Exit setup only in onboarding mode", async () => {
+  it("renders mode-specific framing", async () => {
     const provider = createApplicationContextProvider(createContext());
     document.body.append(provider);
 
@@ -79,6 +79,9 @@ describe("custodian route", () => {
     );
     await normalPage?.updateComplete;
     expect(normalPage?.querySelector(".custodian__header > .btn")).toBeNull();
+    expect(normalPage?.querySelector(".custodian__header p")?.textContent?.trim()).toBe(
+      "System setup and care.",
+    );
 
     render(renderCustodianRoute({ onboarding: true, intent: null }), provider);
     const onboardingPage = provider.querySelector<
@@ -86,5 +89,8 @@ describe("custodian route", () => {
     >("openclaw-custodian-page");
     await onboardingPage?.updateComplete;
     expect(onboardingPage?.querySelector(".custodian__header > .btn")).not.toBeNull();
+    expect(onboardingPage?.querySelector(".custodian__header p")?.textContent?.trim()).toBe(
+      "Your system setup guide",
+    );
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes two option-card framing problems in Ask OpenClaw. Normal caretaker visits showed the onboarding-only “Your system setup guide” subtitle, and opt-in wizard confirmations with a false default still highlighted Yes as the recommended choice.

## Why This Change Was Made

The custodian header now selects copy from the route’s onboarding mode, reusing the established “System setup and care.” caretaker framing outside setup. Confirm cards now recommend the option that matches the wizard step’s initial value, while preserving Yes as the default when no initial value is supplied.

## User Impact

Ask OpenClaw now presents itself as ongoing system care outside onboarding, and wizard option cards no longer visually steer users away from an explicit opt-in default.

## Evidence

| Scenario | Before | After |
| --- | --- | --- |
| Normal Ask OpenClaw route | “Your system setup guide” | “System setup and care.” |
| Confirm with `initialValue: false` | Yes recommended | No recommended |
| Onboarding route | “Your system setup guide” | Unchanged |
| Confirm without an initial value | Yes recommended | Unchanged |

Regression proof was written first. The route test failed with `Received: "Your system setup guide"` for normal mode, and the engine test failed because the recommended flag was on Yes instead of No. Both pass after the fix.

Validation:

- `node scripts/run-vitest.mjs ui/src/pages/custodian` — 4 files, 38 tests passed
- `node scripts/run-vitest.mjs src/system-agent/chat-engine.test.ts` — 62 tests passed
- `pnpm ui:i18n:baseline` and `pnpm ui:i18n:verify` — passed; the raw-copy baseline remained unchanged because both subtitles are localized
- `pnpm tsgo` — passed
- `pnpm check:test-types` — passed across core, extensions, and root
- `node scripts/run-oxlint.mjs <touched files>` — passed
- `pnpm deadcode:exports` — all three scans passed with zero entries
- `pnpm format <touched files>` and `git diff --check` — passed
- fresh branch autoreview against `origin/main` — no accepted/actionable findings

AI-assisted change; the implementation and validation results were reviewed before submission.
