### PR TITLE
feat(ui): enable Swarm toggle in Labs

### DIFF
--- a/ui/src/pages/labs/labs-page.test.ts
+++ b/ui/src/pages/labs/labs-page.test.ts
@@ -77,20 +77,29 @@ describe("LabsPage", () => {
     vi.restoreAllMocks();
   });
 
-  it("renders the experimental Code Mode entry without the schema-pending Swarm entry", async () => {
-    const { page } = await mountPage({ tools: { codeMode: { enabled: true } } });
+  it("renders the experimental Code Mode and Swarm entries", async () => {
+    const { page } = await mountPage({
+      tools: { codeMode: { enabled: true }, swarm: { enabled: true } },
+    });
 
     expect(page.querySelector(".settings-page__intro")?.textContent).toContain("experimental");
-    expect(page.querySelectorAll(".settings-row")).toHaveLength(1);
+    expect(page.querySelectorAll(".settings-row")).toHaveLength(2);
     expect(page.textContent).toContain("Code Mode");
-    expect(page.textContent).not.toContain("Swarm");
+    expect(page.textContent).toContain("Swarm");
     expect(page.textContent).not.toContain("restart required");
     expect(codeModeToggle(page).checked).toBe(true);
+    expect([...page.querySelectorAll<HTMLElement & { checked: boolean }>("wa-switch")]).toEqual([
+      expect.objectContaining({ checked: true }),
+      expect.objectContaining({ checked: true }),
+    ]);
 
-    const docs = page.querySelector<HTMLAnchorElement>(".settings-row__desc a");
-    expect(docs?.href).toBe("https://docs.openclaw.ai/tools/code-mode");
-    expect(docs?.target).toBe("_blank");
-    expect(docs?.rel).toContain("noopener");
+    const docs = [...page.querySelectorAll<HTMLAnchorElement>(".settings-row__desc a")];
+    expect(docs.map((link) => link.href)).toEqual([
+      "https://docs.openclaw.ai/tools/code-mode",
+      "https://docs.openclaw.ai/tools/swarm",
+    ]);
+    expect(docs.every((link) => link.target === "_blank")).toBe(true);
+    expect(docs.every((link) => link.rel.includes("noopener"))).toBe(true);
   });
 
   it("reflects the supported boolean Code Mode shorthand", async () => {

--- a/ui/src/pages/labs/labs-registry.ts
+++ b/ui/src/pages/labs/labs-registry.ts
@@ -18,17 +18,14 @@ export const LAB_FEATURES = [
     configPath: ["tools", "codeMode", "enabled"],
     restartHint: null,
   },
-  // Swarm entry ships once tools.swarm exists in the config schema
-  // (zod-schema.agent-runtime.ts, #110325); rendering it earlier would write an
-  // unknown key and invalidate the operator's config on save.
-  // {
-  //   id: "swarm",
-  //   title: () => t("labsPage.swarm.title"),
-  //   description: () => t("labsPage.swarm.description"),
-  //   docsUrl: "https://docs.openclaw.ai/tools/swarm",
-  //   configPath: ["tools", "swarm", "enabled"],
-  //   restartHint: null,
-  // },
+  {
+    id: "swarm",
+    title: () => t("labsPage.swarm.title"),
+    description: () => t("labsPage.swarm.description"),
+    docsUrl: "https://docs.openclaw.ai/tools/swarm",
+    configPath: ["tools", "swarm", "enabled"],
+    restartHint: null,
+  },
 ] as const satisfies readonly LabFeature[];
 
 function recordAtPath(config: Record<string, unknown>, path: readonly string[]): unknown {


### PR DESCRIPTION
Closes #110325

## What Problem This Solves

Settings → Labs still hides the Swarm feature even though the supporting Swarm work has landed, leaving operators without a UI toggle for the available configuration.

## Why This Change Was Made

This enables the existing Swarm Labs registry entry now that the prerequisite work from #110359 is landed and the `tools.swarm` schema is available. It uses the existing immediate-save Labs behavior and does not require a Gateway restart.

## User Impact

Operators can enable or disable Swarm from Settings → Labs and open the Swarm documentation directly from the feature row.

## Evidence

- `node scripts/run-vitest.mjs ui/src/pages/labs/labs-page.test.ts` — 1 file passed, 4 tests passed.
- The rendered Labs page test verifies two entries, enabled Code Mode and Swarm toggles, both documentation links, and no restart hint.
- `pnpm format ui/src/pages/labs/labs-registry.ts ui/src/pages/labs/labs-page.test.ts`
- `git diff --check`
- Autoreview: clean, no accepted or actionable findings.
