### PR TITLE
fix(agents): reject identity updates for unknown agents

### DIFF
--- a/src/commands/agents.commands.identity.ts
+++ b/src/commands/agents.commands.identity.ts
@@ -2,12 +2,16 @@
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import {
+  listAgentIds,
+  resolveAgentWorkspaceDir,
+  resolveDefaultAgentId,
+} from "../agents/agent-scope.js";
 import { loadAgentIdentityFromFile } from "../agents/identity-file.js";
 import { DEFAULT_IDENTITY_FILENAME } from "../agents/workspace.js";
 import { replaceConfigFile } from "../config/config.js";
 import { logConfigUpdated } from "../config/logging.js";
-import type { IdentityConfig } from "../config/types.js";
+import type { AgentConfig, IdentityConfig } from "../config/types.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
@@ -112,13 +116,14 @@ export async function agentsSetIdentityCommand(
   }
 
   const resolvedAgentId = expectDefined(agentId, "agent id");
-  const list = listAgentEntries(cfg);
-  const index = findAgentEntryIndex(list, resolvedAgentId);
-  if (index < 0) {
+  const resolvedAgentIds = listAgentIds(cfg).map((id) => normalizeAgentId(id));
+  if (!resolvedAgentIds.includes(resolvedAgentId)) {
     runtime.error(`Agent "${resolvedAgentId}" not found. Create it with \`openclaw agents add\`.`);
     runtime.exit(1);
     return;
   }
+  const list = listAgentEntries(cfg);
+  const index = findAgentEntryIndex(list, resolvedAgentId);
 
   let identityFromFile: AgentIdentity | null = null;
   if (wantsIdentityFile) {
@@ -167,7 +172,8 @@ export async function agentsSetIdentityCommand(
     return;
   }
 
-  const base = expectDefined(list[index], "agent config");
+  const base: AgentConfig =
+    index >= 0 ? expectDefined(list[index], "agent config") : { id: resolvedAgentId };
   const nextIdentity: IdentityConfig = {
     ...base.identity,
     ...incomingIdentity,
@@ -179,7 +185,12 @@ export async function agentsSetIdentityCommand(
   };
 
   const nextList = [...list];
-  nextList[index] = nextEntry;
+  if (index >= 0) {
+    nextList[index] = nextEntry;
+  } else {
+    // An empty list still resolves to the implicit default agent; materialize only that known id.
+    nextList.push(nextEntry);
+  }
 
   const nextConfig = {
     ...cfg,

--- a/src/commands/agents.commands.identity.ts
+++ b/src/commands/agents.commands.identity.ts
@@ -7,7 +7,7 @@ import { loadAgentIdentityFromFile } from "../agents/identity-file.js";
 import { DEFAULT_IDENTITY_FILENAME } from "../agents/workspace.js";
 import { replaceConfigFile } from "../config/config.js";
 import { logConfigUpdated } from "../config/logging.js";
-import type { AgentConfig, IdentityConfig } from "../config/types.js";
+import type { IdentityConfig } from "../config/types.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
@@ -111,6 +111,15 @@ export async function agentsSetIdentityCommand(
     agentId = matches[0];
   }
 
+  const resolvedAgentId = expectDefined(agentId, "agent id");
+  const list = listAgentEntries(cfg);
+  const index = findAgentEntryIndex(list, resolvedAgentId);
+  if (index < 0) {
+    runtime.error(`Agent "${resolvedAgentId}" not found. Create it with \`openclaw agents add\`.`);
+    runtime.exit(1);
+    return;
+  }
+
   let identityFromFile: AgentIdentity | null = null;
   if (wantsIdentityFile) {
     if (identityFilePath) {
@@ -158,11 +167,7 @@ export async function agentsSetIdentityCommand(
     return;
   }
 
-  const resolvedAgentId = expectDefined(agentId, "agent id");
-  const list = listAgentEntries(cfg);
-  const index = findAgentEntryIndex(list, resolvedAgentId);
-  const base: AgentConfig =
-    index >= 0 ? expectDefined(list[index], "agent config") : { id: resolvedAgentId };
+  const base = expectDefined(list[index], "agent config");
   const nextIdentity: IdentityConfig = {
     ...base.identity,
     ...incomingIdentity,
@@ -174,15 +179,7 @@ export async function agentsSetIdentityCommand(
   };
 
   const nextList = [...list];
-  if (index >= 0) {
-    nextList[index] = nextEntry;
-  } else {
-    const defaultId = normalizeAgentId(resolveDefaultAgentId(cfg));
-    if (nextList.length === 0 && resolvedAgentId !== defaultId) {
-      nextList.push({ id: defaultId });
-    }
-    nextList.push(nextEntry);
-  }
+  nextList[index] = nextEntry;
 
   const nextConfig = {
     ...cfg,

--- a/src/commands/agents.identity.test.ts
+++ b/src/commands/agents.identity.test.ts
@@ -235,6 +235,60 @@ describe("agents set-identity command", () => {
     });
   });
 
+  it("errors without changing config when --agent names an unknown agent", async () => {
+    configMocks.readConfigFileSnapshot.mockResolvedValue({
+      ...baseConfigSnapshot,
+      config: { agents: { list: [{ id: "main" }] } },
+    });
+
+    await agentsSetIdentityCommand({ agent: "ghostzzz", name: "Ghost" }, runtime);
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      'Agent "ghostzzz" not found. Create it with `openclaw agents add`.',
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(configMocks.writeConfigFile).not.toHaveBeenCalled();
+  });
+
+  it.each(["main", "openclaw", "crestodian"])(
+    "does not create absent reserved agent %s",
+    async (agentId) => {
+      configMocks.readConfigFileSnapshot.mockResolvedValue({
+        ...baseConfigSnapshot,
+        config: { agents: { list: [{ id: "ops" }] } },
+      });
+
+      await agentsSetIdentityCommand({ agent: agentId, name: "Hijack" }, runtime);
+
+      expect(runtime.error).toHaveBeenCalledWith(
+        `Agent "${agentId}" not found. Create it with \`openclaw agents add\`.`,
+      );
+      expect(runtime.exit).toHaveBeenCalledWith(1);
+      expect(configMocks.writeConfigFile).not.toHaveBeenCalled();
+    },
+  );
+
+  it("still updates a real existing agent", async () => {
+    configMocks.readConfigFileSnapshot.mockResolvedValue({
+      ...baseConfigSnapshot,
+      config: {
+        agents: {
+          list: [{ id: "ops", identity: { emoji: "🛠️" } }],
+        },
+      },
+    });
+
+    await agentsSetIdentityCommand({ agent: "ops", name: "Operator" }, runtime);
+
+    expect(configMocks.writeConfigFile).toHaveBeenCalledTimes(1);
+    const [written] = configMocks.writeConfigFile.mock.calls[0] ?? [];
+    expect(written).toMatchObject({
+      agents: {
+        list: [{ id: "ops", identity: { name: "Operator", emoji: "🛠️" } }],
+      },
+    });
+  });
+
   it("errors when an explicit identity file exceeds the size cap", async () => {
     const { workspace } = await createIdentityWorkspace();
     const identityPath = await writeIdentityFile(workspace, [

--- a/src/commands/agents.identity.test.ts
+++ b/src/commands/agents.identity.test.ts
@@ -289,6 +289,29 @@ describe("agents set-identity command", () => {
     });
   });
 
+  it("still resolves and updates the implicit default agent by workspace", async () => {
+    const { workspace } = await createIdentityWorkspace("implicit-main");
+    configMocks.readConfigFileSnapshot.mockResolvedValue({
+      ...baseConfigSnapshot,
+      config: {
+        agents: {
+          defaults: { workspace },
+          list: [],
+        },
+      },
+    });
+
+    await agentsSetIdentityCommand({ workspace, name: "Default Agent" }, runtime);
+
+    expect(configMocks.writeConfigFile).toHaveBeenCalledTimes(1);
+    const [written] = configMocks.writeConfigFile.mock.calls[0] ?? [];
+    expect(written).toMatchObject({
+      agents: {
+        list: [{ id: "main", identity: { name: "Default Agent" } }],
+      },
+    });
+  });
+
   it("errors when an explicit identity file exceeds the size cap", async () => {
     const { workspace } = await createIdentityWorkspace();
     const identityPath = await writeIdentityFile(workspace, [


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw agents set-identity --agent <id>` could silently create an agent when the requested ID did not exist. This also allowed reserved system-agent IDs such as `openclaw` to be inserted into `agents.list`.

## Why This Change Was Made

`set-identity` now validates the selected ID against the canonical resolved agent set before reading identity data or mutating config. Configured agents and the implicit default agent still update normally, while any ID outside that resolved set exits with a clear instruction to use `openclaw agents add`.

## User Impact

Typos and reserved IDs can no longer create agents through an identity-only command. Users receive a non-zero exit and a direct creation command instead, while first-run identity setup by workspace continues to work for the implicit default agent.

## Evidence

- Before the fix, `set-identity --agent ghostzzz --name Ghost` and `set-identity --agent openclaw --name Hijack` both exited 0 and appended entries.
- Regression proof: `node scripts/run-vitest.mjs src/commands/agents.identity.test.ts` — 15 tests passed. The new unknown/reserved cases failed before the implementation change.
- Black-box CLI proof: unknown and reserved IDs exited 1 with config unchanged; an existing agent updated; an empty-list implicit `main` resolved and updated by workspace.
- Validation passed: `pnpm tsgo`, `pnpm check:test-types`, targeted oxlint, `pnpm deadcode:exports`, formatting, and `git diff --check`.
- Fresh branch autoreview reported no accepted/actionable findings.

AI-assisted: yes.
