### PR TITLE
fix(tlon): cancel unread channel-ops and SSE connect bodies

### DIFF
--- a/extensions/tlon/src/channel.runtime.test.ts
+++ b/extensions/tlon/src/channel.runtime.test.ts
@@ -52,11 +52,13 @@ describe("probeTlonAccount", () => {
     const cancelBody = vi.fn(() => {
       events.push("cancel");
     });
+    const response = responseWithCancelableBody(status, cancelBody);
     const release = vi.fn(async () => {
+      void response.body?.cancel().catch(() => undefined);
       events.push("release");
     });
     vi.mocked(urbitFetch).mockResolvedValue({
-      response: responseWithCancelableBody(status, cancelBody),
+      response,
       finalUrl: "https://example.com/~/name",
       release,
       refreshTimeout: vi.fn(),
@@ -80,6 +82,7 @@ describe("probeTlonAccount", () => {
       throw new Error("cancel failed");
     });
     const release = vi.fn(async () => {
+      void response.body?.cancel().catch(() => undefined);
       events.push("release");
     });
     vi.mocked(urbitFetch).mockResolvedValue({

--- a/extensions/tlon/src/channel.runtime.ts
+++ b/extensions/tlon/src/channel.runtime.ts
@@ -239,11 +239,6 @@ export async function probeTlonAccount(account: ConfiguredTlonAccount, timeoutMs
         }
         return { ok: true };
       } finally {
-        // Guard release does not settle unread response streams; cancel first so
-        // the probe cannot leave its pinned connection open.
-        if (!response.bodyUsed) {
-          await response.body?.cancel().catch(() => undefined);
-        }
         await release();
       }
     },

--- a/extensions/tlon/src/urbit/auth.ssrf.test.ts
+++ b/extensions/tlon/src/urbit/auth.ssrf.test.ts
@@ -96,4 +96,38 @@ describe("tlon urbit auth ssrf", () => {
     ).rejects.toMatchObject({ code: "auth_failed" });
     expect(canceled).toBe(true);
   });
+
+  it("rejects failed logins promptly when a response clone keeps cancellation pending", async () => {
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("login failed"));
+        },
+      }),
+      { status: 401 },
+    );
+    const clone = response.clone();
+    const mockFetch = vi.fn().mockResolvedValue(response);
+    const pending = authenticate("http://127.0.0.1:8080", "bad-code", {
+      ssrfPolicy: { allowPrivateNetwork: true },
+      lookupFn: privateLookupFn,
+      fetchImpl: mockFetch as typeof fetch,
+    });
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
+    try {
+      await expect(
+        Promise.race([
+          pending,
+          new Promise<never>((_resolve, reject) => {
+            timeout = setTimeout(() => reject(new Error("login cancellation stalled")), 1_000);
+          }),
+        ]),
+      ).rejects.toMatchObject({ code: "auth_failed" });
+    } finally {
+      clearTimeout(timeout);
+      void clone.body?.cancel().catch(() => undefined);
+      await pending.catch(() => undefined);
+    }
+  });
 });

--- a/extensions/tlon/src/urbit/auth.ts
+++ b/extensions/tlon/src/urbit/auth.ts
@@ -36,7 +36,6 @@ export async function authenticate(
 
   try {
     if (!response.ok) {
-      await response.body?.cancel().catch(() => undefined);
       throw new UrbitAuthError("auth_failed", `Login failed with status ${response.status}`);
     }
 

--- a/extensions/tlon/src/urbit/channel-ops.test.ts
+++ b/extensions/tlon/src/urbit/channel-ops.test.ts
@@ -17,6 +17,9 @@ const CHANNEL_DEPS = {
 function mockGuardedResponse(response: Response, finalUrl: string) {
   const state = { bodyUsedAtRelease: undefined as boolean | undefined };
   const release = vi.fn(async () => {
+    if (!response.bodyUsed) {
+      void response.body?.cancel().catch(() => undefined);
+    }
     state.bodyUsedAtRelease = response.bodyUsed;
   });
   vi.mocked(urbitFetch).mockResolvedValueOnce({ response, finalUrl, release });
@@ -99,6 +102,7 @@ describe("Urbit channel operations", () => {
     vi.spyOn(body, "cancel").mockImplementation(() => new Promise<void>(() => {}));
     let released = false;
     const release = vi.fn(async () => {
+      void body.cancel().catch(() => undefined);
       released = true;
     });
     vi.mocked(urbitFetch).mockResolvedValueOnce({

--- a/extensions/tlon/src/urbit/channel-ops.transport.test.ts
+++ b/extensions/tlon/src/urbit/channel-ops.transport.test.ts
@@ -1,0 +1,101 @@
+// Real-transport proof: channel create/wake/scry failure paths cancel unread bodies.
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
+import { describe, expect, it } from "vitest";
+import { ensureUrbitChannelOpen, scryUrbitPath } from "./channel-ops.js";
+
+const lookupLoopback = (async () => [{ address: "127.0.0.1", family: 4 }]) as unknown as LookupFn;
+
+async function listen(server: ReturnType<typeof createServer>): Promise<string> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address() as AddressInfo;
+  return `http://127.0.0.1:${address.port}`;
+}
+
+describe("Urbit channel-ops transport body cleanup", () => {
+  it("cancels unread create/wake bodies and closes the request socket", async () => {
+    let putCount = 0;
+    let resolveClosed: (() => void) | undefined;
+    const closed = new Promise<void>((resolve) => {
+      resolveClosed = resolve;
+    });
+
+    const server = createServer((request, response) => {
+      if (request.method !== "PUT") {
+        response.writeHead(404);
+        response.end();
+        return;
+      }
+      putCount += 1;
+      request.socket.once("close", () => {
+        // Assert against the first (create) PUT; wake also cancels.
+        if (putCount === 1) {
+          resolveClosed?.();
+        }
+      });
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.write('{"ok":true');
+    });
+
+    const baseUrl = await listen(server);
+    try {
+      await ensureUrbitChannelOpen(
+        {
+          baseUrl,
+          cookie: "urbauth-~zod=proof",
+          ship: "zod",
+          channelId: "channel-proof",
+          ssrfPolicy: { allowPrivateNetwork: true },
+          lookupFn: lookupLoopback,
+        },
+        { createBody: [], createAuditContext: "tlon-channel-ops-create-proof" },
+      );
+      expect(putCount).toBeGreaterThanOrEqual(1);
+      await expect(closed).resolves.toBeUndefined();
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
+  it("cancels unread scry failure bodies and closes the request socket", async () => {
+    let resolveClosed: (() => void) | undefined;
+    const closed = new Promise<void>((resolve) => {
+      resolveClosed = resolve;
+    });
+
+    const server = createServer((request, response) => {
+      request.socket.once("close", () => resolveClosed?.());
+      response.writeHead(503, { "Content-Type": "application/json" });
+      response.write('{"error":"unavailable"');
+    });
+
+    const baseUrl = await listen(server);
+    try {
+      await expect(
+        scryUrbitPath(
+          {
+            baseUrl,
+            cookie: "urbauth-~zod=proof",
+            ssrfPolicy: { allowPrivateNetwork: true },
+            lookupFn: lookupLoopback,
+          },
+          { path: "/chat/inbox.json", auditContext: "tlon-scry-proof" },
+        ),
+      ).rejects.toThrow(/Scry|503/);
+      await expect(closed).resolves.toBeUndefined();
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+});

--- a/extensions/tlon/src/urbit/channel-ops.transport.test.ts
+++ b/extensions/tlon/src/urbit/channel-ops.transport.test.ts
@@ -1,8 +1,10 @@
 // Real-transport proof: channel create/wake/scry failure paths cancel unread bodies.
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
 import { describe, expect, it } from "vitest";
+import { tlonRuntimeOutbound } from "../channel.runtime.js";
 import { ensureUrbitChannelOpen, scryUrbitPath } from "./channel-ops.js";
 
 const lookupLoopback = (async () => [{ address: "127.0.0.1", family: 4 }]) as unknown as LookupFn;
@@ -91,6 +93,63 @@ describe("Urbit channel-ops transport body cleanup", () => {
           { path: "/chat/inbox.json", auditContext: "tlon-scry-proof" },
         ),
       ).rejects.toThrow(/Scry|503/);
+      await expect(closed).resolves.toBeUndefined();
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
+  it("delivers an authenticated outbound message and closes its unread poke body", async () => {
+    const expectedCookie = "urbauth-~zod=outbound-proof";
+    let observedCookie: string | undefined;
+    let resolveClosed: (() => void) | undefined;
+    const closed = new Promise<void>((resolve) => {
+      resolveClosed = resolve;
+    });
+    const server = createServer((request, response) => {
+      if (request.method === "POST" && request.url === "/~/login") {
+        response.writeHead(200, { "Set-Cookie": `${expectedCookie}; Path=/; HttpOnly` });
+        response.end("ok");
+        return;
+      }
+      if (request.method === "PUT") {
+        observedCookie = request.headers.cookie;
+        request.socket.once("close", () => resolveClosed?.());
+        response.writeHead(200, { "Content-Type": "application/json" });
+        response.write('{"accepted":true');
+        return;
+      }
+      response.writeHead(404);
+      response.end();
+    });
+
+    const baseUrl = await listen(server);
+    try {
+      const sendText = tlonRuntimeOutbound.sendText;
+      if (!sendText) {
+        throw new Error("expected the Tlon outbound text adapter");
+      }
+      const result = await sendText({
+        cfg: {
+          channels: {
+            tlon: {
+              ship: "~zod",
+              url: baseUrl,
+              code: "outbound-proof",
+              network: { dangerouslyAllowPrivateNetwork: true },
+            },
+          },
+        } as OpenClawConfig,
+        to: "~nec",
+        text: "hello from the real outbound adapter",
+      });
+
+      expect(result.channel).toBe("tlon");
+      expect(result.messageId).toMatch(/^~zod\//);
+      expect(result.receipt?.primaryPlatformMessageId).toBe(result.messageId);
+      expect(observedCookie).toBe(expectedCookie);
       await expect(closed).resolves.toBeUndefined();
     } finally {
       await new Promise<void>((resolve, reject) => {

--- a/extensions/tlon/src/urbit/channel-ops.ts
+++ b/extensions/tlon/src/urbit/channel-ops.ts
@@ -85,7 +85,7 @@ export async function pokeUrbitChannel(
     }
     return pokeId;
   } finally {
-    await release();
+    await releaseChannelResponse(response, release);
   }
 }
 

--- a/extensions/tlon/src/urbit/channel-ops.ts
+++ b/extensions/tlon/src/urbit/channel-ops.ts
@@ -42,17 +42,6 @@ async function putUrbitChannel(
 
 const TLON_ERROR_BODY_LIMIT_BYTES = 16 * 1024;
 
-async function releaseChannelResponse(response: Response, release: () => Promise<void>) {
-  // Guard release closes the dispatcher, not an unread response stream. Error
-  // branches that throw without reading the body must cancel it first so the
-  // connection cannot dangle. Start cancellation without awaiting it: awaiting
-  // can deadlock when debug capture tees the stream (same shape as #115873).
-  if (!response.bodyUsed) {
-    void response.body?.cancel().catch(() => undefined);
-  }
-  await release();
-}
-
 export async function pokeUrbitChannel(
   deps: UrbitChannelDeps,
   params: { app: string; mark: string; json: unknown; auditContext: string },
@@ -85,7 +74,7 @@ export async function pokeUrbitChannel(
     }
     return pokeId;
   } finally {
-    await releaseChannelResponse(response, release);
+    await release();
   }
 }
 
@@ -119,7 +108,7 @@ export async function scryUrbitPath(
     // Keep the shared JSON ceiling while retaining the path needed to identify the endpoint.
     return await readProviderJsonResponse(response, `Tlon scry response for path ${params.path}`);
   } finally {
-    await releaseChannelResponse(response, release);
+    await release();
   }
 }
 
@@ -134,7 +123,7 @@ async function createUrbitChannel(
       throw new UrbitHttpError({ operation: "Channel creation", status: response.status });
     }
   } finally {
-    await releaseChannelResponse(response, release);
+    await release();
   }
 }
 
@@ -158,7 +147,7 @@ async function wakeUrbitChannel(deps: UrbitChannelDeps): Promise<void> {
       throw new UrbitHttpError({ operation: "Channel activation", status: response.status });
     }
   } finally {
-    await releaseChannelResponse(response, release);
+    await release();
   }
 }
 

--- a/extensions/tlon/src/urbit/fetch.test.ts
+++ b/extensions/tlon/src/urbit/fetch.test.ts
@@ -1,0 +1,158 @@
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { urbitFetch } from "./fetch.js";
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async () => ({
+  ...(await vi.importActual<typeof import("openclaw/plugin-sdk/ssrf-runtime")>(
+    "openclaw/plugin-sdk/ssrf-runtime",
+  )),
+  fetchWithSsrFGuard: vi.fn(),
+}));
+
+describe("urbitFetch guarded response ownership", () => {
+  beforeEach(() => {
+    vi.mocked(fetchWithSsrFGuard).mockReset();
+  });
+
+  it("keeps responses alive until release and preserves guarded metadata", async () => {
+    const events: string[] = [];
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        cancel() {
+          events.push("cancel");
+        },
+      }),
+    );
+    const release = vi.fn(async () => {
+      events.push("release");
+    });
+    const refreshTimeout = vi.fn();
+    const controller = new AbortController();
+    vi.mocked(fetchWithSsrFGuard).mockResolvedValue({
+      response,
+      finalUrl: "https://example.com/~/channel/1701",
+      release,
+      refreshTimeout,
+    });
+
+    const guarded = await urbitFetch({
+      baseUrl: "https://example.com",
+      path: "/~/channel/1701",
+      signal: controller.signal,
+      ssrfPolicy: { allowPrivateNetwork: true },
+    });
+
+    expect(guarded.response).toBe(response);
+    expect(guarded.finalUrl).toBe("https://example.com/~/channel/1701");
+    expect(guarded.refreshTimeout).toBe(refreshTimeout);
+    expect(events).toEqual([]);
+    expect(fetchWithSsrFGuard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        signal: controller.signal,
+        policy: { allowPrivateNetwork: true },
+      }),
+    );
+
+    await guarded.release();
+
+    expect(events).toEqual(["cancel", "release"]);
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("does not cancel a response that its owner already consumed", async () => {
+    const response = new Response("finished");
+    const body = response.body;
+    if (!body) {
+      throw new Error("expected a response body");
+    }
+    const cancel = vi.spyOn(body, "cancel");
+    const release = vi.fn(async () => {});
+    vi.mocked(fetchWithSsrFGuard).mockResolvedValue({
+      response,
+      finalUrl: "https://example.com/~/scry/chat.json",
+      release,
+    });
+
+    const guarded = await urbitFetch({
+      baseUrl: "https://example.com",
+      path: "/~/scry/chat.json",
+    });
+    await expect(guarded.response.text()).resolves.toBe("finished");
+    await guarded.release();
+
+    expect(cancel).not.toHaveBeenCalled();
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("releases a successful response without a body", async () => {
+    const response = new Response(null, { status: 204 });
+    const release = vi.fn(async () => {});
+    vi.mocked(fetchWithSsrFGuard).mockResolvedValue({
+      response,
+      finalUrl: "https://example.com/~/channel/1701",
+      release,
+    });
+
+    const guarded = await urbitFetch({
+      baseUrl: "https://example.com",
+      path: "/~/channel/1701",
+    });
+
+    await expect(guarded.release()).resolves.toBeUndefined();
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("releases promptly when a retained response clone keeps cancellation pending", async () => {
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("still streaming"));
+        },
+      }),
+    );
+    const clone = response.clone();
+    const release = vi.fn(async () => {});
+    vi.mocked(fetchWithSsrFGuard).mockResolvedValue({
+      response,
+      finalUrl: "https://example.com/~/channel/1701",
+      release,
+    });
+
+    const guarded = await urbitFetch({
+      baseUrl: "https://example.com",
+      path: "/~/channel/1701",
+    });
+    const releasing = guarded.release();
+
+    try {
+      expect(release).toHaveBeenCalledOnce();
+      await expect(releasing).resolves.toBeUndefined();
+    } finally {
+      void clone.body?.cancel().catch(() => undefined);
+    }
+  });
+
+  it("still releases when response cancellation rejects", async () => {
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        cancel() {
+          throw new Error("cancel failed");
+        },
+      }),
+    );
+    const release = vi.fn(async () => {});
+    vi.mocked(fetchWithSsrFGuard).mockResolvedValue({
+      response,
+      finalUrl: "https://example.com/~/channel/1701",
+      release,
+    });
+
+    const guarded = await urbitFetch({
+      baseUrl: "https://example.com",
+      path: "/~/channel/1701",
+    });
+
+    await expect(guarded.release()).resolves.toBeUndefined();
+    expect(release).toHaveBeenCalledOnce();
+  });
+});

--- a/extensions/tlon/src/urbit/fetch.ts
+++ b/extensions/tlon/src/urbit/fetch.ts
@@ -28,7 +28,7 @@ export async function urbitFetch(params: UrbitFetchOptions) {
   }
 
   const url = new URL(params.path, validated.baseUrl).toString();
-  return await fetchWithSsrFGuard({
+  const guarded = await fetchWithSsrFGuard({
     url,
     fetchImpl: params.fetchImpl,
     init: params.init,
@@ -40,4 +40,16 @@ export async function urbitFetch(params: UrbitFetchOptions) {
     auditContext: params.auditContext,
     pinDns: params.pinDns,
   });
+
+  return {
+    ...guarded,
+    release: async () => {
+      // Guard cleanup only closes the dispatcher; captured response clones can
+      // keep cancellation pending, so start it without delaying the release.
+      if (!guarded.response.bodyUsed) {
+        void guarded.response.body?.cancel().catch(() => undefined);
+      }
+      await guarded.release();
+    },
+  };
 }

--- a/extensions/tlon/src/urbit/sse-client.connect-fail.transport.test.ts
+++ b/extensions/tlon/src/urbit/sse-client.connect-fail.transport.test.ts
@@ -1,0 +1,52 @@
+// Real-transport proof: failed SSE connects cancel unread response bodies.
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
+import { describe, expect, it } from "vitest";
+import { UrbitSSEClient } from "./sse-client.js";
+
+const lookupLoopback = (async () => [{ address: "127.0.0.1", family: 4 }]) as unknown as LookupFn;
+
+async function listen(server: ReturnType<typeof createServer>): Promise<string> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address() as AddressInfo;
+  return `http://127.0.0.1:${address.port}`;
+}
+
+describe("UrbitSSEClient connect-fail body cleanup", () => {
+  it("cancels unread non-OK stream bodies and closes the request socket", async () => {
+    let resolveClosed: (() => void) | undefined;
+    const closed = new Promise<void>((resolve) => {
+      resolveClosed = resolve;
+    });
+
+    const server = createServer((request, response) => {
+      request.socket.once("close", () => resolveClosed?.());
+      response.writeHead(503, { "Content-Type": "text/event-stream" });
+      response.write("retry: 1000\n");
+    });
+
+    const baseUrl = await listen(server);
+    const client = new UrbitSSEClient(baseUrl, "urbauth-~zod=proof", {
+      autoReconnect: false,
+      ship: "zod",
+      ssrfPolicy: { allowPrivateNetwork: true },
+      lookupFn: lookupLoopback,
+    });
+
+    try {
+      await expect(client.openStream()).rejects.toThrow(/Stream connection|503/);
+      await expect(closed).resolves.toBeUndefined();
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+});

--- a/extensions/tlon/src/urbit/sse-client.connect-fail.transport.test.ts
+++ b/extensions/tlon/src/urbit/sse-client.connect-fail.transport.test.ts
@@ -49,4 +49,108 @@ describe("UrbitSSEClient connect-fail body cleanup", () => {
       });
     }
   });
+
+  it.each([
+    { action: "subscribe", status: 200 },
+    { action: "ack", status: 200 },
+    { action: "ack", status: 503 },
+  ])("closes the unread $action response with status $status", async ({ action, status }) => {
+    let observedAction: string | undefined;
+    let resolveClosed: (() => void) | undefined;
+    const closed = new Promise<void>((resolve) => {
+      resolveClosed = resolve;
+    });
+    const server = createServer((request, response) => {
+      const chunks: Buffer[] = [];
+      request.on("data", (chunk: Buffer) => chunks.push(chunk));
+      request.once("end", () => {
+        const [payload] = JSON.parse(Buffer.concat(chunks).toString("utf8")) as Array<{
+          action: string;
+        }>;
+        observedAction = payload?.action;
+        request.socket.once("close", () => resolveClosed?.());
+        response.writeHead(status, { "Content-Type": "application/json" });
+        response.write('{"result":"streaming');
+      });
+    });
+    const baseUrl = await listen(server);
+    const client = new UrbitSSEClient(baseUrl, "urbauth-~zod=proof", {
+      autoReconnect: false,
+      ship: "zod",
+      ssrfPolicy: { allowPrivateNetwork: true },
+      lookupFn: lookupLoopback,
+    });
+
+    try {
+      if (action === "subscribe") {
+        client.isConnected = true;
+        await client.subscribe({ app: "chat", path: "/inbox" });
+      } else {
+        const handled = client.processEvent('id: 20\ndata: {"json":{"ok":true}}');
+        if (status === 200) {
+          await handled;
+        } else {
+          await expect(handled).rejects.toThrow("Ack failed with status 503");
+        }
+      }
+
+      expect(observedAction).toBe(action);
+      await expect(closed).resolves.toBeUndefined();
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
+  it("keeps a successful event stream live until its owner closes the client", async () => {
+    let resolveEvent: ((value: unknown) => void) | undefined;
+    const delivered = new Promise<unknown>((resolve) => {
+      resolveEvent = resolve;
+    });
+    let resolveStreamClosed: (() => void) | undefined;
+    const streamClosed = new Promise<void>((resolve) => {
+      resolveStreamClosed = resolve;
+    });
+    let streamSocket: import("node:net").Socket | undefined;
+    const server = createServer((request, response) => {
+      if (request.method === "GET") {
+        streamSocket = request.socket;
+        streamSocket.once("close", () => resolveStreamClosed?.());
+        response.writeHead(200, { "Content-Type": "text/event-stream" });
+        response.write('id: 1\ndata: {"id":1,"json":{"message":"delivered"}}\n\n');
+        return;
+      }
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.write('{"ok":true');
+    });
+    const baseUrl = await listen(server);
+    const client = new UrbitSSEClient(baseUrl, "urbauth-~zod=proof", {
+      autoReconnect: false,
+      ship: "zod",
+      ssrfPolicy: { allowPrivateNetwork: true },
+      lookupFn: lookupLoopback,
+    });
+
+    try {
+      await client.subscribe({
+        app: "chat",
+        path: "/inbox",
+        event: (value) => resolveEvent?.(value),
+      });
+      await client.connect();
+
+      await expect(delivered).resolves.toEqual({ message: "delivered" });
+      expect(streamSocket?.destroyed).toBe(false);
+      expect(client.streamRelease).toBeTypeOf("function");
+
+      await client.close();
+      await expect(streamClosed).resolves.toBeUndefined();
+      expect(client.streamRelease).toBeNull();
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
 });

--- a/extensions/tlon/src/urbit/sse-client.test.ts
+++ b/extensions/tlon/src/urbit/sse-client.test.ts
@@ -172,13 +172,16 @@ describe("UrbitSSEClient", () => {
         const cancel = vi.fn(() => {
           throw new Error(`${label} cancel failed`);
         });
-        const release = vi.fn().mockResolvedValue(undefined);
+        const response = new Response(new ReadableStream<Uint8Array>({ cancel }));
+        const release = vi.fn(async () => {
+          void response.body?.cancel().catch(() => undefined);
+        });
         return {
           method,
           cancel,
           release,
           result: {
-            response: new Response(new ReadableStream<Uint8Array>({ cancel })),
+            response,
             finalUrl: "https://example.com",
             release,
           },

--- a/extensions/tlon/src/urbit/sse-client.ts
+++ b/extensions/tlon/src/urbit/sse-client.ts
@@ -240,6 +240,11 @@ export class UrbitSSEClient {
 
     if (!response.ok) {
       this.streamRelease = null;
+      // Failed connects never read the body; cancel before release so undici
+      // does not keep the socket pinned (release alone is not enough).
+      if (!response.bodyUsed) {
+        await response.body?.cancel().catch(() => undefined);
+      }
       await release();
       throw new UrbitHttpError({ operation: "Stream connection", status: response.status });
     }

--- a/extensions/tlon/src/urbit/sse-client.ts
+++ b/extensions/tlon/src/urbit/sse-client.ts
@@ -240,11 +240,6 @@ export class UrbitSSEClient {
 
     if (!response.ok) {
       this.streamRelease = null;
-      // Failed connects never read the body; cancel before release so undici
-      // does not keep the socket pinned (release alone is not enough).
-      if (!response.bodyUsed) {
-        await response.body?.cancel().catch(() => undefined);
-      }
       await release();
       throw new UrbitHttpError({ operation: "Stream connection", status: response.status });
     }
@@ -548,19 +543,15 @@ export class UrbitSSEClient {
       }));
 
       {
-        const { response, release } = await this.putChannelPayload(unsubscribes, {
+        const { release } = await this.putChannelPayload(unsubscribes, {
           timeoutMs: 30_000,
           auditContext: "tlon-urbit-unsubscribe",
         });
-        try {
-          void response.body?.cancel().catch(() => undefined);
-        } finally {
-          await release();
-        }
+        await release();
       }
 
       {
-        const { response, release } = await urbitFetch({
+        const { release } = await urbitFetch({
           baseUrl: this.url,
           path: `/~/channel/${this.channelId}`,
           init: {
@@ -575,11 +566,7 @@ export class UrbitSSEClient {
           timeoutMs: 30_000,
           auditContext: "tlon-urbit-channel-close",
         });
-        try {
-          void response.body?.cancel().catch(() => undefined);
-        } finally {
-          await release();
-        }
+        await release();
       }
     } catch (error) {
       this.logger.error?.(`Error closing channel: ${String(error)}`);


### PR DESCRIPTION
## What Problem This Solves

Tlon Urbit HTTP helpers in `channel-ops.ts` (create/wake/poke/scry) and the SSE
`openStream` failure path call `release()` without cancelling unread response
bodies. `release()` from `fetchWithSsrFGuard` does not cancel streams, so undici
can keep sockets pinned on status-only success (create/wake/poke 200) and on
`!ok` throws (scry / SSE connect).

**Maintainer completion:** The original contributor fix exposed the same invariant in sibling auth, account-probe, outbound-poke, and SSE subscribe/ack/close paths. The final implementation repairs the plugin-private `urbitFetch.release()` owner once, so every Tlon caller inherits cancellation before guarded release; this intentionally includes `extensions/tlon/src/channel.runtime.ts`. It fixes five socket-leak families and two cloned-response cancellation deadlocks while reducing production code by 13 net lines.

## Why This Change Was Made

- Centralize unread response-body cancellation in the existing plugin-private `urbitFetch.release()` owner rather than keeping separate channel-ops/SSE/runtime/auth cleanup helpers.
- Start cancellation without awaiting it, because a retained debug-capture `Response.clone()` can keep stream cancellation pending indefinitely; then await the original guarded dispatcher release.
- Preserve consumed response bodies, successful live SSE streams, authentication cookies, status/error behavior, SSRF policy, and original contributor regression coverage.

## User Impact

**Before:** Channel open / scry failures / failed SSE connects against a
streaming or held body could leave request sockets open after the error/success
returned. The same issue also affected Tlon auth, runtime probes/outbound pokes, and SSE subscribe/ack/close; retained cloned responses could deadlock cleanup.

**After:** All Tlon `urbitFetch` consumers cancel unread bodies promptly at their common owner. Successful scry still consumes JSON via `readProviderJsonResponse` (`bodyUsed` → cancel no-op). Successful SSE streams still hand the body to `processStream` and remain live until their owner closes them.

## Evidence

- Canonical owner: `extensions/tlon/src/urbit/fetch.ts` (`urbitFetch.release`).
- Migrated callers: `extensions/tlon/src/urbit/channel-ops.ts`, `extensions/tlon/src/urbit/sse-client.ts`, `extensions/tlon/src/urbit/auth.ts`, and `extensions/tlon/src/channel.runtime.ts`.
- Regression coverage includes real-transport channel operations, real SSE success/failure/ack, authenticated outbound delivery, failed login, account probes, cloned response cancellation, and shared fetch ownership.

## Real behavior proof

### Behavior or issue addressed

Unread bodies on Tlon channel-ops status-only / scry `!ok`, failed auth, runtime probe/outbound poke, and SSE connect/subscribe/ack/close must be cancelled so undici releases the socket without waiting on a retained response clone.

### Canonical reachability path

- `tlonRuntimeOutbound.sendText` → real login `POST` + auth cookie → outbound `PUT` → valid message receipt + observed socket close.
- `ensureUrbitChannelOpen` → create/wake `PUT` → shared `urbitFetch.release()` → observed socket close.
- `scryUrbitPath` → `!ok` throw → shared release → observed socket close.
- `UrbitSSEClient` → real subscribe/ack success or `503`, failed SSE open, and successful streamed event → shared release; successful SSE remains live until `close()`.
- Failed auth and direct `urbitFetch.release()` both complete promptly while a real `Response.clone()` keeps cancellation pending.

### Shared helper / provider constraint check

Uses existing plugin-private `urbitFetch` / `fetchWithSsrFGuard`; no new public SDK surface, dependency, configuration, or fallback. The old caller-local cancellation branches are deleted.

### Real environment tested

**Production `scryUrbitPath` before/after** (loopback 503 + open body):

Negative control (cancel removed from helper):

```text
{"productionFunction":"scryUrbitPath","threw":"Scry for path /chat/inbox.json failed: 503","returnedAtMs":143,"serverObservedSocketClose":false,"socketCloseAfterStartMs":null}
```

After fix:

```text
{"productionFunction":"scryUrbitPath","threw":"Scry for path /chat/inbox.json failed: 503","returnedAtMs":43,"serverObservedSocketClose":true,"socketCloseAfterStartMs":43}
```

macOS, Node v22.23.1. Throw text unchanged; only socket release changes.

Additional maintainer verification exercised real authenticated loopback HTTP delivery and socket close, real SSE subscribe/ack success and failure, real streamed event delivery through explicit close, and actual retained `Response.clone()` on both direct release and failed auth.

### Evidence after fix

```text
node scripts/run-vitest.mjs extensions/tlon/src/channel.runtime.test.ts extensions/tlon/src/urbit/sse-client.test.ts extensions/tlon/src/urbit/sse-client.connect-fail.transport.test.ts
# 3 files, 40 passed

node scripts/run-vitest.mjs extensions/tlon/src/urbit/channel-ops.transport.test.ts extensions/tlon/src/urbit/fetch.test.ts extensions/tlon/src/urbit/auth.ssrf.test.ts
# 3 files, 13 passed

node scripts/run-vitest.mjs extensions/tlon/src/urbit/error-body-boundary.test.ts extensions/tlon/src/urbit/sse-client.reconnect-close.test.ts extensions/tlon/src/urbit/sse-client.open-stream-timeout.proof.test.ts
# 3 files, 10 passed

node scripts/run-vitest.mjs extensions/tlon/src/urbit/channel-ops.test.ts extensions/tlon/src/urbit/sse-client.reconnect-close.unit.test.ts extensions/tlon/src/tlon-api.test.ts
# 3 files, 26 passed

# Total: 89 focused tests passed.
```

Premise: Undici requires every response body to be consumed or canceled.

AI-assisted: Yes.

