### PR TITLE
fix(network): guarded fetch callers can leave responses streaming

### DIFF
--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -172,11 +172,13 @@ are private-local.
     | `plugin-sdk/group-activation` | Private-local after July 2026; Narrow group activation mode and command parsing helpers |
   </Accordion>
 
-`createBoundedProviderBinaryStream` owns its source reader, not the request.
-Canceling the returned stream or calling `release()` detaches that reader and
-starts best-effort source cancellation; neither promise waits for a retained
-response clone to finish. The caller must still invoke and await its
-request-release callback afterward.
+`createBoundedProviderBinaryStream` requires a request `cleanup` callback.
+Stream cancellation and `release()` start source cancellation, unlock the reader,
+and run cleanup once, then wait for both operations. Cancellation propagates
+source failures; `release()` ignores them. Cleanup failures take precedence in
+both cases. Overflow preserves its fitting prefix and error without waiting for
+cleanup; later `release()` reports cleanup failure. After EOF or a read error,
+the caller must still invoke and await `release()`.
 
 Provider usage snapshots normally report one or more quota `windows`, each with
 a label, percent used, and optional reset time. Providers that expose balance or

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -172,6 +172,12 @@ are private-local.
     | `plugin-sdk/group-activation` | Private-local after July 2026; Narrow group activation mode and command parsing helpers |
   </Accordion>
 
+`createBoundedProviderBinaryStream` owns its source reader, not the request.
+Canceling the returned stream or calling `release()` detaches that reader and
+starts best-effort source cancellation; neither promise waits for a retained
+response clone to finish. The caller must still invoke and await its
+request-release callback afterward.
+
 Provider usage snapshots normally report one or more quota `windows`, each with
 a label, percent used, and optional reset time. Providers that expose balance or
 account-state text instead of resettable quota windows should return

--- a/extensions/elevenlabs/tts.ts
+++ b/extensions/elevenlabs/tts.ts
@@ -198,22 +198,12 @@ export async function elevenLabsTTSStream(params: ElevenLabsTtsRequestParams): P
       createOverflowError: ({ maxBytes }) =>
         new Error(`ElevenLabs API error: audio response exceeds ${maxBytes} bytes`),
       createReleaseError: () => new Error("ElevenLabs TTS stream released"),
+      cleanup: release,
     });
-    let releasePromise: Promise<void> | undefined;
-    const releaseAll = () => {
-      releasePromise ??= (async () => {
-        try {
-          await boundedStream.release();
-        } finally {
-          await release();
-        }
-      })();
-      return releasePromise;
-    };
     handedOff = true;
     return {
       audioStream: boundedStream.stream,
-      release: releaseAll,
+      release: boundedStream.release,
     };
   } finally {
     if (!handedOff) {

--- a/extensions/fish-audio-speech/tts.ts
+++ b/extensions/fish-audio-speech/tts.ts
@@ -112,20 +112,10 @@ export async function fishAudioTtsStream(params: FishAudioTtsRequest): Promise<{
       createOverflowError: ({ maxBytes }) =>
         new Error(`Fish Audio TTS API error: audio response exceeds ${maxBytes} bytes`),
       createReleaseError: () => new Error("Fish Audio TTS stream released"),
+      cleanup: release,
     });
-    let releasePromise: Promise<void> | undefined;
-    const releaseAll = () => {
-      releasePromise ??= (async () => {
-        try {
-          await bounded.release();
-        } finally {
-          await release();
-        }
-      })();
-      return releasePromise;
-    };
     handedOff = true;
-    return { audioStream: bounded.stream, release: releaseAll };
+    return { audioStream: bounded.stream, release: bounded.release };
   } finally {
     if (!handedOff) {
       await release();

--- a/extensions/googlechat/src/auth.capture.transport.test.ts
+++ b/extensions/googlechat/src/auth.capture.transport.test.ts
@@ -1,0 +1,175 @@
+import { createServer } from "node:http";
+import type { Socket } from "node:net";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { captureHttpExchange, type CaptureEventRecord } from "openclaw/plugin-sdk/proxy-capture";
+import { fetchWithRuntimeDispatcher } from "openclaw/plugin-sdk/runtime-fetch";
+import { afterAll, describe, expect, it, vi } from "vitest";
+
+const fixture = vi.hoisted(() => ({
+  url: "",
+  release: async () => {},
+  response: undefined as Response | undefined,
+  captured: undefined as ((event: CaptureEventRecord) => void) | undefined,
+}));
+
+// Change only the destination to our owned server; keep the real guard,
+// dispatcher, response reader, capture tee, and request cleanup.
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
+  return {
+    ...actual,
+    fetchWithSsrFGuard: async (...[params]: Parameters<typeof actual.fetchWithSsrFGuard>) => {
+      const guarded = await actual.fetchWithSsrFGuard({
+        ...params,
+        url: fixture.url,
+        policy: { allowPrivateNetwork: true, hostnameAllowlist: ["127.0.0.1"] },
+        fetchImpl: async (input, init) => {
+          const response = await fetchWithRuntimeDispatcher(input, init);
+          const captured = fixture.captured;
+          captureHttpExchange(
+            { url: fixture.url, method: "GET", response },
+            {
+              enabled: true,
+              required: false,
+              dbPath: "unused-memory-sink",
+              blobDir: "unused-memory-sink",
+              certDir: "unused-memory-sink",
+              sessionId: "googlechat-reader-test",
+              sourceProcess: "test",
+            },
+            {
+              getStore: () => ({
+                upsertSession() {},
+                endSession() {},
+                recordEvent(event) {
+                  if (event.kind === "response" || event.kind === "error") {
+                    captured?.(event);
+                  }
+                },
+              }),
+              persistEventPayload: (_store, { data }) =>
+                Buffer.isBuffer(data) ? { dataText: data.toString("utf8") } : {},
+            },
+          );
+          return response;
+        },
+      });
+      fixture.response = guarded.response;
+      fixture.release = guarded.release;
+      return guarded;
+    },
+  };
+});
+
+const { getGoogleAuthTransport, loadGoogleAuthRuntime } = await import("./google-auth.runtime.js");
+const { verifyGoogleChatRequest } = await import("./auth.js");
+
+afterAll(() => {
+  vi.doUnmock("openclaw/plugin-sdk/ssrf-runtime");
+  vi.resetModules();
+});
+
+describe("Google Chat captured response cleanup", () => {
+  it.each(["auth-overflow", "cert-error", "auth-complete"] as const)(
+    "settles %s through the guarded transport before fixture cleanup",
+    async (kind) => {
+      const closed = createDeferred<void>();
+      const captured = createDeferred<CaptureEventRecord>();
+      const sockets = new Map<Socket, Promise<void>>();
+      const completeBody = '{"access_token":"fixture"}';
+      fixture.response = undefined;
+      fixture.release = async () => {};
+      fixture.captured = captured.resolve;
+      const server = createServer((request, response) => {
+        request.resume();
+        request.socket.once("close", () => closed.resolve());
+        response.writeHead(kind === "cert-error" ? 503 : 200, {
+          "content-type": "application/json",
+          connection: "close",
+        });
+        if (kind === "auth-complete") {
+          response.end(completeBody);
+        } else {
+          response.write(kind === "auth-overflow" ? Buffer.alloc(1024 * 1024 + 1) : "unavailable");
+        }
+      });
+      server.on("connection", (socket) => {
+        sockets.set(
+          socket,
+          new Promise<void>((resolve) => {
+            socket.once("close", resolve);
+          }),
+        );
+      });
+      let operation: Promise<unknown> | undefined;
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const { OAuth2Client } = await loadGoogleAuthRuntime();
+      const verifyJwt = vi.spyOn(OAuth2Client.prototype, "verifySignedJwtWithCertsAsync");
+      try {
+        await new Promise<void>((resolve, reject) => {
+          server.once("error", reject);
+          server.listen(0, "127.0.0.1", resolve);
+        });
+        const address = server.address();
+        if (!address || typeof address === "string") {
+          throw new Error("Expected owned TCP listener");
+        }
+        fixture.url = `http://127.0.0.1:${address.port}/response`;
+        const transport = await getGoogleAuthTransport();
+        const deadline = new Promise<never>((_resolve, reject) => {
+          timer = setTimeout(() => reject(new Error("Google Chat cleanup did not settle")), 1_000);
+        });
+        operation =
+          kind === "cert-error"
+            ? verifyGoogleChatRequest({
+                bearer: "fixture",
+                audienceType: "project-number",
+                audience: "123",
+              })
+            : transport.request({ url: "https://oauth2.googleapis.com/token", retry: false });
+        const observed = operation.then(
+          (value) => ({ value }),
+          (error: unknown) => ({ error }),
+        );
+        const outcome = await Promise.race([observed, deadline]);
+        if (kind === "auth-overflow") {
+          expect(outcome).toHaveProperty(
+            "error.message",
+            "Google auth response exceeds 1048576 bytes.",
+          );
+        } else if (kind === "cert-error") {
+          expect(outcome).toEqual({
+            value: { ok: false, reason: "Failed to fetch Chat certs (503)" },
+          });
+          expect(verifyJwt).not.toHaveBeenCalled();
+        } else {
+          expect(outcome).toMatchObject({ value: { data: { access_token: "fixture" } } });
+        }
+        await Promise.race([closed.promise, deadline]);
+        expect(fixture.response?.body?.locked).toBe(false);
+        const event = await Promise.race([captured.promise, deadline]);
+        expect(event.kind).toBe(kind === "auth-complete" ? "response" : "error");
+        if (kind === "auth-complete") {
+          expect(event.dataText).toBe(completeBody);
+        }
+      } finally {
+        clearTimeout(timer);
+        const stopped = new Promise<void>((resolve) => {
+          server.close(() => resolve());
+        });
+        for (const socket of sockets.keys()) {
+          socket.destroy();
+        }
+        await stopped;
+        await Promise.all(sockets.values());
+        await operation?.catch(() => undefined);
+        await fixture.release();
+        if (fixture.response) {
+          await captured.promise;
+        }
+        verifyJwt.mockRestore();
+        fixture.captured = undefined;
+      }
+    },
+  );
+});

--- a/extensions/googlechat/src/auth.capture.transport.test.ts
+++ b/extensions/googlechat/src/auth.capture.transport.test.ts
@@ -8,7 +8,7 @@ import { afterAll, describe, expect, it, vi } from "vitest";
 const fixture = vi.hoisted(() => ({
   url: "",
   release: async () => {},
-  response: undefined as Response | undefined,
+  received: undefined as ((response: Response) => void) | undefined,
   captured: undefined as ((event: CaptureEventRecord) => void) | undefined,
 }));
 
@@ -54,7 +54,7 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
           return response;
         },
       });
-      fixture.response = guarded.response;
+      fixture.received?.(guarded.response);
       fixture.release = guarded.release;
       return guarded;
     },
@@ -75,9 +75,14 @@ describe("Google Chat captured response cleanup", () => {
     async (kind) => {
       const closed = createDeferred<void>();
       const captured = createDeferred<CaptureEventRecord>();
+      const received = createDeferred<Response>();
       const sockets = new Map<Socket, Promise<void>>();
       const completeBody = '{"access_token":"fixture"}';
-      fixture.response = undefined;
+      let receivedResponse = false;
+      fixture.received = (response) => {
+        receivedResponse = true;
+        received.resolve(response);
+      };
       fixture.release = async () => {};
       fixture.captured = captured.resolve;
       const server = createServer((request, response) => {
@@ -146,7 +151,8 @@ describe("Google Chat captured response cleanup", () => {
           expect(outcome).toMatchObject({ value: { data: { access_token: "fixture" } } });
         }
         await Promise.race([closed.promise, deadline]);
-        expect(fixture.response?.body?.locked).toBe(false);
+        const response = await Promise.race([received.promise, deadline]);
+        expect(response.body?.locked).toBe(false);
         const event = await Promise.race([captured.promise, deadline]);
         expect(event.kind).toBe(kind === "auth-complete" ? "response" : "error");
         if (kind === "auth-complete") {
@@ -164,11 +170,12 @@ describe("Google Chat captured response cleanup", () => {
         await Promise.all(sockets.values());
         await operation?.catch(() => undefined);
         await fixture.release();
-        if (fixture.response) {
+        if (receivedResponse) {
           await captured.promise;
         }
         verifyJwt.mockRestore();
         fixture.captured = undefined;
+        fixture.received = undefined;
       }
     },
   );

--- a/extensions/googlechat/src/auth.ts
+++ b/extensions/googlechat/src/auth.ts
@@ -120,7 +120,6 @@ async function fetchChatCerts(): Promise<Record<string, string>> {
   });
   try {
     if (!response.ok) {
-      await response.body?.cancel().catch(() => undefined);
       throw new Error(`Failed to fetch Chat certs (${response.status})`);
     }
     const certs = await readGoogleChatCertsResponse(response);

--- a/extensions/googlechat/src/google-auth.runtime.ts
+++ b/extensions/googlechat/src/google-auth.runtime.ts
@@ -474,16 +474,13 @@ async function readGoogleAuthResponseBytes(response: Response): Promise<Uint8Arr
       }
       total += value.byteLength;
       if (total > MAX_GOOGLE_AUTH_RESPONSE_BYTES) {
-        try {
-          await reader.cancel("Google auth response exceeded buffer limit");
-        } catch {
-          // Ignore cancellation errors; the caller still releases the dispatcher.
-        }
         throw new Error(`Google auth response exceeds ${MAX_GOOGLE_AUTH_RESPONSE_BYTES} bytes.`);
       }
       chunks.push(value);
     }
   } finally {
+    // A capture tee can retain cancellation until the caller releases its request.
+    void reader.cancel().catch(() => undefined);
     reader.releaseLock();
   }
 

--- a/extensions/googlechat/src/targets.test.ts
+++ b/extensions/googlechat/src/targets.test.ts
@@ -919,40 +919,6 @@ describe("verifyGoogleChatRequest", () => {
     expect(release).toHaveBeenCalledOnce();
   });
 
-  it("cancels a rejected Chat cert response before releasing the guard", async () => {
-    expireGoogleChatCertCache();
-    const cancel = vi.fn().mockResolvedValue(undefined);
-    const release = vi.fn().mockResolvedValue(undefined);
-    mocks.fetchWithSsrFGuard.mockResolvedValueOnce({
-      response: {
-        ok: false,
-        status: 503,
-        body: { cancel },
-      } as unknown as Response,
-      release,
-    });
-
-    await expect(
-      verifyGoogleChatRequest({
-        bearer: "token",
-        audienceType: "project-number",
-        audience: "123456789",
-      }),
-    ).resolves.toEqual({
-      ok: false,
-      reason: "Failed to fetch Chat certs (503)",
-    });
-
-    expect(cancel).toHaveBeenCalledOnce();
-    expect(release).toHaveBeenCalledOnce();
-    const cancelOrder = cancel.mock.invocationCallOrder[0];
-    const releaseOrder = release.mock.invocationCallOrder[0];
-    if (cancelOrder === undefined || releaseOrder === undefined) {
-      throw new Error("expected cancellation and guard release call-order records");
-    }
-    expect(cancelOrder).toBeLessThan(releaseOrder);
-  });
-
   it("reports malformed Chat cert JSON with a stable auth error", async () => {
     expireGoogleChatCertCache();
     const release = vi.fn(async () => {});

--- a/extensions/llama-cpp/src/llama-server-install.ts
+++ b/extensions/llama-cpp/src/llama-server-install.ts
@@ -130,17 +130,13 @@ export async function downloadVerifiedFile(params: {
         (Number.isFinite(contentLength) && contentLength > 0 ? contentLength : 0);
       const handle = await fsp.open(partialPath, "wx", 0o600);
       const hash = createHash("sha256");
-      const reader = response.body.getReader();
       let downloadedSize = 0;
       let previousSize = 0;
       let previousAt = Date.now();
       let rollingBytesPerSecond = 0;
       try {
-        for (;;) {
-          const { done, value } = await reader.read();
-          if (done) {
-            break;
-          }
+        // Unlock on every exit; the guard owns aborting an unfinished download.
+        for await (const value of response.body.values({ preventCancel: true })) {
           const chunk = Buffer.from(value);
           await handle.writeFile(chunk);
           hash.update(chunk);

--- a/packages/memory-host-sdk/src/host/batch-output.test.ts
+++ b/packages/memory-host-sdk/src/host/batch-output.test.ts
@@ -1,5 +1,5 @@
 // Memory Host SDK tests cover batch output behavior.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { applyEmbeddingBatchOutputLine, readEmbeddingBatchJsonl } from "./batch-output.js";
 
 function streamingResponse(chunks: Uint8Array[]): {
@@ -30,6 +30,55 @@ function streamingResponse(chunks: Uint8Array[]): {
 }
 
 describe("readEmbeddingBatchJsonl", () => {
+  it.each(["enough records", "invalid record"])(
+    "settles %s before a response clone is released",
+    async (kind) => {
+      const cancel = vi.fn();
+      const response = new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(
+              new TextEncoder().encode(kind === "enough records" ? '{"value":1}\n' : "invalid\n"),
+            );
+          },
+          cancel,
+        }),
+      );
+      const capture = response.clone();
+      const records: unknown[] = [];
+      const operation = readEmbeddingBatchJsonl(response, {
+        label: "fixture",
+        maxRecords: 1,
+        onRecord(record) {
+          records.push(record);
+          return false;
+        },
+      }).then(
+        () => ({ records }),
+        (error: unknown) => ({ error }),
+      );
+      try {
+        const result = await Promise.race([
+          operation,
+          new Promise<undefined>((resolve) => {
+            setImmediate(() => resolve(undefined));
+          }),
+        ]);
+        expect(result).toEqual(
+          kind === "enough records"
+            ? { records: [{ value: 1 }] }
+            : { error: new Error("fixture: malformed JSONL record") },
+        );
+        expect(response.body?.locked).toBe(false);
+        expect(cancel).not.toHaveBeenCalled();
+      } finally {
+        await capture.body?.cancel();
+        await operation;
+      }
+      expect(cancel).toHaveBeenCalledOnce();
+    },
+  );
+
   it("frames split UTF-8, CRLF, and an unterminated final record", async () => {
     const bytes = new TextEncoder().encode('{"value":"😀"}\r\n{"value":2}');
     const streamed = streamingResponse(Array.from(bytes, (byte) => Uint8Array.of(byte)));

--- a/packages/memory-host-sdk/src/host/batch-output.ts
+++ b/packages/memory-host-sdk/src/host/batch-output.ts
@@ -84,10 +84,6 @@ export async function readEmbeddingBatchJsonl<T>(
     return options.onRecord(parsed as T);
   };
 
-  const cancel = async () => {
-    await reader.cancel().catch(() => {});
-  };
-
   try {
     while (true) {
       const { done, value } = await reader.read();
@@ -102,7 +98,8 @@ export async function readEmbeddingBatchJsonl<T>(
         }
         appendRecordPart(value.subarray(offset, index));
         if (!emitRecord()) {
-          await cancel();
+          // Release the reader without waiting for a retained capture tee.
+          void reader.cancel().catch(() => {});
           return;
         }
         offset = index + 1;
@@ -113,7 +110,7 @@ export async function readEmbeddingBatchJsonl<T>(
       emitRecord();
     }
   } catch (error) {
-    await cancel();
+    void reader.cancel().catch(() => {});
     throw error;
   } finally {
     reader.releaseLock();

--- a/packages/memory-host-sdk/src/host/response-snippet.test.ts
+++ b/packages/memory-host-sdk/src/host/response-snippet.test.ts
@@ -1,11 +1,67 @@
 // Memory Host SDK tests cover response snippet behavior.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   readMemoryHostResponseTextSnippet,
   readResponseJsonWithLimit,
 } from "./response-snippet.js";
 
 describe("readMemoryHostResponseTextSnippet", () => {
+  it.each(["prefix", "overflow", "length", "preabort"] as const)(
+    "settles %s reads while a response clone remains open",
+    async (kind) => {
+      const cancel = vi.fn();
+      const response = new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("abcdefgh"));
+          },
+          cancel,
+        }),
+        { headers: kind === "length" ? { "content-length": "16" } : {} },
+      );
+      const capture = response.clone();
+      const parent = new AbortController();
+      const expected = new Error("reader aborted");
+      parent.abort(expected);
+      const operation = (
+        kind === "prefix" || kind === "preabort"
+          ? readMemoryHostResponseTextSnippet(response, {
+              maxBytes: 4,
+              signal: kind === "preabort" ? parent.signal : undefined,
+            })
+          : readResponseJsonWithLimit(response, { maxBytes: 4, errorPrefix: "fixture" })
+      ).then(
+        (value) => ({ value }),
+        (error: unknown) => ({ error }),
+      );
+      try {
+        const result = await Promise.race([
+          operation,
+          new Promise<undefined>((resolve) => {
+            setImmediate(() => resolve(undefined));
+          }),
+        ]);
+        if (kind === "prefix") {
+          expect(result).toEqual({ value: "abcd... [truncated]" });
+        } else if (kind === "preabort") {
+          expect(result).toEqual({ error: expected });
+        } else {
+          expect(result).toEqual({
+            error: new Error(
+              `fixture: response body too large: ${kind === "length" ? 16 : 8} bytes (limit: 4 bytes)`,
+            ),
+          });
+        }
+        expect(response.body?.locked).toBe(false);
+        expect(cancel).not.toHaveBeenCalled();
+      } finally {
+        await capture.body?.cancel();
+        await operation;
+      }
+      expect(cancel).toHaveBeenCalledOnce();
+    },
+  );
+
   function stallingResponse(onCancel: () => void): Response {
     const reader = {
       read: () => new Promise<ReadableStreamReadResult<Uint8Array>>(() => {}),

--- a/packages/memory-host-sdk/src/host/response-snippet.ts
+++ b/packages/memory-host-sdk/src/host/response-snippet.ts
@@ -85,7 +85,7 @@ async function readChunkWithAbort(
     return await reader.read();
   }
   if (signal.aborted) {
-    await reader.cancel().catch(() => undefined);
+    void reader.cancel().catch(() => undefined);
     throw toAbortError(signal, fallbackMessage);
   }
 
@@ -144,7 +144,8 @@ async function readResponsePrefix(
           length += remaining;
         }
         truncated = true;
-        await reader.cancel().catch(() => undefined);
+        // A capture tee can retain cancellation until the request owner releases.
+        void reader.cancel().catch(() => undefined);
         break;
       }
 
@@ -191,7 +192,7 @@ async function readResponseTextWithLimit(
 
       const nextLength = length + value.length;
       if (nextLength > maxBytes) {
-        await reader.cancel().catch(() => undefined);
+        void reader.cancel().catch(() => undefined);
         throw responseTooLarge(errorPrefix, nextLength, maxBytes);
       }
 
@@ -212,7 +213,7 @@ async function cancelResponseBody(res: Response): Promise<void> {
   if (!body || typeof body.cancel !== "function") {
     return;
   }
-  await body.cancel().catch(() => undefined);
+  void body.cancel().catch(() => undefined);
 }
 
 function parseContentLength(raw: string | null, errorPrefix: string): number | undefined {

--- a/src/infra/http-body.response.test.ts
+++ b/src/infra/http-body.response.test.ts
@@ -162,6 +162,55 @@ describe("readResponseWithLimit", () => {
     vi.useRealTimers();
   });
 
+  it.each(["prefix", "overflow", "deadline"] as const)(
+    "settles %s reads before a retained response clone is released",
+    async (kind) => {
+      const cancel = vi.fn();
+      const response = new Response(
+        makeStallingStream([new TextEncoder().encode("abcdefgh")], cancel),
+      );
+      const capture = response.clone();
+      const expected = new Error("read rejected");
+      const operation = (
+        kind === "prefix"
+          ? readResponseTextPrefix(response, 8)
+          : readResponseWithLimit(
+              response,
+              4,
+              kind === "overflow"
+                ? { onOverflow: () => expected }
+                : {
+                    timeoutMs: () => {
+                      throw expected;
+                    },
+                  },
+            )
+      ).then(
+        (value) => ({ value }),
+        (error: unknown) => ({ error }),
+      );
+      try {
+        const result = await Promise.race([
+          operation,
+          new Promise<undefined>((resolve) => {
+            setImmediate(() => resolve(undefined));
+          }),
+        ]);
+        expect(result).toEqual(
+          kind === "prefix"
+            ? { value: { text: "abcdefgh", size: 8, truncated: true } }
+            : { error: expected },
+        );
+        expect(response.body?.locked).toBe(false);
+        expect(cancel).not.toHaveBeenCalled();
+      } finally {
+        await capture.body?.cancel();
+        await operation;
+      }
+      expect(cancel).toHaveBeenCalledOnce();
+    },
+  );
+
   it.each([
     {
       name: "reads all chunks within the limit",

--- a/src/infra/http-body.ts
+++ b/src/infra/http-body.ts
@@ -226,9 +226,8 @@ async function readResponsePrefixFromReader(
         }
         size = nextTotal;
         truncated = true;
-        try {
-          await reader.cancel();
-        } catch {}
+        // A capture tee can retain cancellation until the caller releases its request.
+        void reader.cancel().catch(() => undefined);
         break;
       }
       chunks.push(value);
@@ -261,7 +260,7 @@ async function readResponsePrefix(
   try {
     timeoutMs = typeof options?.timeoutMs === "function" ? options.timeoutMs() : options?.timeoutMs;
   } catch (error) {
-    await response.body?.cancel(error).catch(() => undefined);
+    void response.body?.cancel(error).catch(() => undefined);
     throw error;
   }
   const body = response.body;

--- a/src/infra/net/fetch-guard.release.test.ts
+++ b/src/infra/net/fetch-guard.release.test.ts
@@ -1,12 +1,14 @@
 import type { ServerResponse } from "node:http";
 import type { Dispatcher } from "undici";
 import { describe, expect, it } from "vitest";
+import { createBoundedProviderBinaryStream } from "../../plugin-sdk/provider-binary-stream.js";
 import { withServer } from "../../plugin-sdk/test-helpers/http-test-server.js";
 import { captureHttpExchange } from "../../proxy-capture/runtime.js";
 import type { CaptureEventRecord } from "../../proxy-capture/types.js";
 import { createDeferredCore } from "../../shared/deferred.js";
-import { readResponseWithLimit } from "../http-body.js";
+import { readResponseTextPrefix, readResponseWithLimit } from "../http-body.js";
 import { fetchWithSsrFGuard } from "./fetch-guard.js";
+import { wrapGuardedBodyStream } from "./guarded-body-stream.js";
 import { PinnedDispatcherPool } from "./pinned-dispatcher-pool.js";
 import { fetchWithRuntimeDispatcher, type DispatcherAwareRequestInit } from "./runtime-fetch.js";
 
@@ -25,122 +27,185 @@ async function withinDeadline<T>(operation: Promise<T>): Promise<T> {
 }
 
 describe("guarded request release", () => {
-  it("ends only the released request while a captured sibling keeps its pooled transport", async () => {
-    const abandonedClosed = createDeferredCore();
-    const heldResponse = createDeferredCore<ServerResponse>();
-    const parent = new AbortController();
-    const pool = new PinnedDispatcherPool({ maxEntries: 1, idleTtlMs: 60_000 });
-    const dispatchers: Array<Dispatcher | undefined> = [];
-    const captures = new Map<string, ReturnType<typeof createDeferredCore<CaptureEventRecord>>>();
-    const releases: Array<() => Promise<void>> = [];
-    const fetchImpl = async (input: RequestInfo | URL, init?: DispatcherAwareRequestInit) => {
-      dispatchers.push(init?.dispatcher);
-      const url = input instanceof Request ? input.url : input.toString();
-      const captured = createDeferredCore<CaptureEventRecord>();
-      captures.set(new URL(url).pathname, captured);
-      const response = await fetchWithRuntimeDispatcher(input, init);
-      captureHttpExchange(
-        { url, method: "GET", response },
-        {
-          enabled: true,
-          required: false,
-          dbPath: "unused-memory-sink",
-          blobDir: "unused-memory-sink",
-          certDir: "unused-memory-sink",
-          sessionId: "guard-release-test",
-          sourceProcess: "test",
+  it.each(["unread", "prefix", "overflow", "wrapped", "binary"] as const)(
+    "ends only the %s request while a captured sibling keeps its pooled transport",
+    async (readerKind) => {
+      const abandonedClosed = createDeferredCore();
+      const heldResponse = createDeferredCore<ServerResponse>();
+      const parent = new AbortController();
+      const pool = new PinnedDispatcherPool({ maxEntries: 1, idleTtlMs: 60_000 });
+      const dispatchers: Array<Dispatcher | undefined> = [];
+      const captures = new Map<string, ReturnType<typeof createDeferredCore<CaptureEventRecord>>>();
+      const releases: Array<() => Promise<void>> = [];
+      const fetchImpl = async (input: RequestInfo | URL, init?: DispatcherAwareRequestInit) => {
+        dispatchers.push(init?.dispatcher);
+        const url = input instanceof Request ? input.url : input.toString();
+        const captured = createDeferredCore<CaptureEventRecord>();
+        captures.set(new URL(url).pathname, captured);
+        const response = await fetchWithRuntimeDispatcher(input, init);
+        captureHttpExchange(
+          { url, method: "GET", response },
+          {
+            enabled: true,
+            required: false,
+            dbPath: "unused-memory-sink",
+            blobDir: "unused-memory-sink",
+            certDir: "unused-memory-sink",
+            sessionId: "guard-release-test",
+            sourceProcess: "test",
+          },
+          {
+            getStore: () => ({
+              upsertSession() {},
+              endSession() {},
+              recordEvent(event) {
+                if (event.kind === "response" || event.kind === "error") {
+                  captured.resolve(event);
+                }
+              },
+            }),
+            persistEventPayload: (_store, { data }) =>
+              Buffer.isBuffer(data) ? { dataText: data.toString("utf8") } : {},
+          },
+        );
+        return response;
+      };
+
+      await withServer(
+        (request, response) => {
+          if (request.url === "/abandoned") {
+            request.socket.once("close", () => abandonedClosed.resolve());
+            response.writeHead(503);
+            response.write("unused error body");
+          } else if (request.url === "/held") {
+            response.write("kept");
+            heldResponse.resolve(response);
+          } else {
+            response.end("complete");
+          }
         },
-        {
-          getStore: () => ({
-            upsertSession() {},
-            endSession() {},
-            recordEvent(event) {
-              if (event.kind === "response" || event.kind === "error") {
-                captured.resolve(event);
+        async (baseUrl) => {
+          let heldBody: Promise<Buffer> | undefined;
+          let abandonedOperation: Promise<void> | undefined;
+          const get = async (path: string) => {
+            const result = await fetchWithSsrFGuard({
+              url: `${baseUrl}${path}`,
+              fetchImpl,
+              signal: parent.signal,
+              timeoutMs: 5_000,
+              policy: { allowPrivateNetwork: true, hostnameAllowlist: ["127.0.0.1"] },
+              dispatcherPool: pool,
+            });
+            releases.push(result.release);
+            return result;
+          };
+          try {
+            const abandoned = await get("/abandoned");
+            const held = await get("/held");
+            heldBody = readResponseWithLimit(held.response, 32);
+            void heldBody.catch(() => undefined);
+            expect(abandoned.response.status).toBe(503);
+            expect(held.dispatcherReused).toBe(true);
+            expect(dispatchers[0]).toBeDefined();
+            expect(dispatchers[1]).toBe(dispatchers[0]);
+
+            abandonedOperation = (async () => {
+              const reason = new Error("body limit reached");
+              if (readerKind === "wrapped") {
+                const wrapped = wrapGuardedBodyStream({
+                  body: abandoned.response.body!,
+                  cleanup: abandoned.release,
+                });
+                const reader = wrapped.getReader();
+                try {
+                  expect((await reader.read()).value?.byteLength).toBeGreaterThan(0);
+                  await reader.cancel(reason);
+                } finally {
+                  reader.releaseLock();
+                }
+                return;
               }
-            },
-          }),
-          persistEventPayload: (_store, { data }) =>
-            Buffer.isBuffer(data) ? { dataText: data.toString("utf8") } : {},
+              try {
+                if (readerKind === "prefix") {
+                  expect(await readResponseTextPrefix(abandoned.response, 4)).toMatchObject({
+                    text: "unus",
+                    truncated: true,
+                  });
+                } else if (readerKind === "overflow") {
+                  await expect(
+                    readResponseWithLimit(abandoned.response, 4, {
+                      onOverflow: () => reason,
+                    }),
+                  ).rejects.toBe(reason);
+                } else if (readerKind === "binary") {
+                  const bounded = createBoundedProviderBinaryStream(abandoned.response.body!, {
+                    maxBytes: 4,
+                    createOverflowError: () => reason,
+                    createReleaseError: () => reason,
+                  });
+                  const reader = bounded.stream.getReader();
+                  try {
+                    const chunks: Uint8Array[] = [];
+                    await expect(
+                      (async () => {
+                        while (true) {
+                          const chunk = await reader.read();
+                          if (chunk.done) {
+                            return;
+                          }
+                          chunks.push(chunk.value);
+                        }
+                      })(),
+                    ).rejects.toBe(reason);
+                    expect(Buffer.concat(chunks).toString()).toBe("unus");
+                  } finally {
+                    reader.releaseLock();
+                    await bounded.release();
+                  }
+                }
+              } finally {
+                await abandoned.release();
+              }
+            })();
+            await withinDeadline(abandonedOperation.then(() => abandonedClosed.promise));
+            expect(parent.signal.aborted).toBe(false);
+            expect(await withinDeadline(captures.get("/abandoned")!.promise)).toMatchObject({
+              kind: "error",
+            });
+
+            (await heldResponse.promise).end("-alive");
+            expect((await withinDeadline(heldBody)).toString("utf8")).toBe("kept-alive");
+            await held.release();
+            expect(await withinDeadline(captures.get("/held")!.promise)).toMatchObject({
+              kind: "response",
+              status: 200,
+              dataText: "kept-alive",
+            });
+
+            const completed = await get("/complete");
+            expect(completed.dispatcherReused).toBe(true);
+            expect(dispatchers[2]).toBe(dispatchers[0]);
+            expect((await readResponseWithLimit(completed.response, 32)).toString("utf8")).toBe(
+              "complete",
+            );
+            await completed.release();
+            expect(await withinDeadline(captures.get("/complete")!.promise)).toMatchObject({
+              kind: "response",
+              status: 200,
+              dataText: "complete",
+            });
+            expect(parent.signal.aborted).toBe(false);
+          } finally {
+            parent.abort();
+            await abandonedOperation?.catch(() => undefined);
+            await heldBody?.catch(() => undefined);
+            await Promise.all(releases.map((release) => release()));
+            await pool.closeAll();
+          }
         },
       );
-      return response;
-    };
-
-    await withServer(
-      (request, response) => {
-        if (request.url === "/abandoned") {
-          request.socket.once("close", () => abandonedClosed.resolve());
-          response.writeHead(503);
-          response.write("unused error body");
-        } else if (request.url === "/held") {
-          response.write("kept");
-          heldResponse.resolve(response);
-        } else {
-          response.end("complete");
-        }
-      },
-      async (baseUrl) => {
-        let heldBody: Promise<Buffer> | undefined;
-        const get = async (path: string) => {
-          const result = await fetchWithSsrFGuard({
-            url: `${baseUrl}${path}`,
-            fetchImpl,
-            signal: parent.signal,
-            timeoutMs: 5_000,
-            policy: { allowPrivateNetwork: true, hostnameAllowlist: ["127.0.0.1"] },
-            dispatcherPool: pool,
-          });
-          releases.push(result.release);
-          return result;
-        };
-        try {
-          const abandoned = await get("/abandoned");
-          const held = await get("/held");
-          heldBody = readResponseWithLimit(held.response, 32);
-          void heldBody.catch(() => undefined);
-          expect(abandoned.response.status).toBe(503);
-          expect(held.dispatcherReused).toBe(true);
-          expect(dispatchers[0]).toBeDefined();
-          expect(dispatchers[1]).toBe(dispatchers[0]);
-
-          await withinDeadline(abandoned.release().then(() => abandonedClosed.promise));
-          expect(parent.signal.aborted).toBe(false);
-          expect(await withinDeadline(captures.get("/abandoned")!.promise)).toMatchObject({
-            kind: "error",
-          });
-
-          (await heldResponse.promise).end("-alive");
-          expect((await withinDeadline(heldBody)).toString("utf8")).toBe("kept-alive");
-          await held.release();
-          expect(await withinDeadline(captures.get("/held")!.promise)).toMatchObject({
-            kind: "response",
-            status: 200,
-            dataText: "kept-alive",
-          });
-
-          const completed = await get("/complete");
-          expect(completed.dispatcherReused).toBe(true);
-          expect(dispatchers[2]).toBe(dispatchers[0]);
-          expect((await readResponseWithLimit(completed.response, 32)).toString("utf8")).toBe(
-            "complete",
-          );
-          await completed.release();
-          expect(await withinDeadline(captures.get("/complete")!.promise)).toMatchObject({
-            kind: "response",
-            status: 200,
-            dataText: "complete",
-          });
-          expect(parent.signal.aborted).toBe(false);
-        } finally {
-          parent.abort();
-          await heldBody?.catch(() => undefined);
-          await Promise.all(releases.map((release) => release()));
-          await pool.closeAll();
-        }
-      },
-    );
-  });
+    },
+  );
 
   it.each(
     (["signal", "init"] as const).flatMap((source) =>

--- a/src/infra/net/fetch-guard.release.test.ts
+++ b/src/infra/net/fetch-guard.release.test.ts
@@ -142,6 +142,7 @@ describe("guarded request release", () => {
                     maxBytes: 4,
                     createOverflowError: () => reason,
                     createReleaseError: () => reason,
+                    cleanup: abandoned.release,
                   });
                   const reader = bounded.stream.getReader();
                   try {

--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -65,6 +65,21 @@ function redirectResponse(location: string): Response {
   });
 }
 
+function streamingRedirectResponse(params: { location?: string; cancel: () => void }): Response {
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("redirecting"));
+      },
+      cancel: params.cancel,
+    }),
+    {
+      status: 302,
+      ...(params.location ? { headers: { location: params.location } } : {}),
+    },
+  );
+}
+
 function okResponse(body = "ok"): Response {
   return new Response(body, { status: 200 });
 }
@@ -949,6 +964,65 @@ describe("fetchWithSsrFGuard hardening", () => {
     await result.release();
   });
 
+  it("releases without waiting for a cloned unread response branch", async () => {
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("pending"));
+        },
+      }),
+      { status: 401 },
+    );
+    const captureBranch = response.clone();
+    const result = await fetchWithSsrFGuard({
+      url: "https://api.example.com/resource",
+      fetchImpl: vi.fn(async () => response),
+      lookupFn: createPublicLookup(),
+    });
+
+    let releaseState: "released" | "pending";
+    try {
+      releaseState = await Promise.race([
+        result.release().then(() => "released" as const),
+        new Promise<"pending">((resolve) => {
+          setImmediate(() => resolve("pending"));
+        }),
+      ]);
+    } finally {
+      await captureBranch.body?.cancel();
+    }
+
+    expect(releaseState).toBe("released");
+  });
+
+  it("cancels an unread successful response when released", async () => {
+    let resolveCancel: (() => void) | undefined;
+    const cancelObserved = new Promise<void>((resolve) => {
+      resolveCancel = resolve;
+    });
+    const cancel = vi.fn(() => {
+      resolveCancel?.();
+    });
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("pending"));
+        },
+        cancel,
+      }),
+      { status: 200 },
+    );
+    const result = await fetchWithSsrFGuard({
+      url: "https://api.example.com/resource",
+      fetchImpl: vi.fn(async () => response),
+      lookupFn: createPublicLookup(),
+    });
+
+    await result.release();
+    await cancelObserved;
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
   it("preserves redirects when response body cancellation rejects", async () => {
     const unhandledRejections: unknown[] = [];
     const onUnhandledRejection = (reason: unknown) => {
@@ -1410,36 +1484,42 @@ describe("fetchWithSsrFGuard hardening", () => {
   it.each([
     {
       name: "rejects redirects without a location header",
-      responses: [new Response(null, { status: 302 })],
+      locations: [undefined],
       expectedError: /missing location header/i,
       maxRedirects: undefined,
     },
     {
       name: "rejects redirect loops",
-      responses: [
-        redirectResponse("https://public.example/next"),
-        redirectResponse("https://public.example/next"),
-      ],
+      locations: ["https://public.example/next", "https://public.example/next"],
       expectedError: /redirect loop/i,
       maxRedirects: undefined,
     },
     {
       name: "rejects too many redirects",
-      responses: [
-        redirectResponse("https://public.example/one"),
-        redirectResponse("https://public.example/two"),
-      ],
+      locations: ["https://public.example/one", "https://public.example/two"],
       expectedError: /too many redirects/i,
       maxRedirects: 1,
     },
-  ])("$name", async ({ responses, expectedError, maxRedirects }) => {
+  ])("$name and cancels every discarded response body", async (params) => {
+    const cancels = params.locations.map(() => vi.fn());
+    const responses = params.locations.map((location, index) =>
+      streamingRedirectResponse({
+        ...(location ? { location } : {}),
+        cancel: cancels[index]!,
+      }),
+    );
+
     await expectRedirectFailure({
       url: "https://public.example/start",
       responses,
-      expectedError,
+      expectedError: params.expectedError,
       lookupFn: createPublicLookup(),
-      maxRedirects,
+      maxRedirects: params.maxRedirects,
     });
+
+    for (const cancel of cancels) {
+      expect(cancel).toHaveBeenCalledOnce();
+    }
   });
 
   it("rejects redirect loops that return to the original URL", async () => {
@@ -1964,6 +2044,45 @@ describe("fetchWithSsrFGuard hardening", () => {
     );
 
     expect(outcome).toBe("TimeoutError");
+  });
+
+  it("bounds release when an unread body and dispatcher close both stall", async () => {
+    const destroy = vi.fn();
+    agentCtor.mockImplementationOnce(
+      function MockAgent(this: { close: () => Promise<void>; destroy: () => void }) {
+        this.close = () => new Promise(() => {});
+        this.destroy = destroy;
+      },
+    );
+    (globalThis as Record<string, unknown>)[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+      Agent: agentCtor,
+      EnvHttpProxyAgent: envHttpProxyAgentCtor,
+      ProxyAgent: proxyAgentCtor,
+      fetch: vi.fn(async () => okResponse()),
+    };
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        cancel: () => new Promise<void>(() => {}),
+      }),
+      { status: 200 },
+    );
+    const result = await fetchWithSsrFGuard({
+      url: "https://public.example/resource",
+      fetchImpl: vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        expectDispatcherAttached((init as RequestInit & { dispatcher?: unknown }).dispatcher);
+        return response;
+      }),
+      lookupFn: createPublicLookup(),
+    });
+
+    const outcome = await raceWithTimeoutResult(
+      result.release().then(() => "released" as const),
+      250,
+      "hung" as const,
+    );
+
+    expect(outcome).toBe("released");
+    expect(destroy).toHaveBeenCalledOnce();
   });
 
   it("aborts a stalled DNS preflight from the caller signal without dispatching", async () => {

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -100,6 +100,10 @@ export type GuardedFetchOptions = {
 export type GuardedFetchResult = {
   response: Response;
   finalUrl: string;
+  /**
+   * Releases the guarded transport and cancels any unread response body.
+   * Callers must finish consuming, or intentionally discard, the body before releasing it.
+   */
   release: () => Promise<void>;
   refreshTimeout?: () => void;
 };
@@ -295,6 +299,12 @@ async function assertExplicitProxyAllowed(
 
 function isRedirectStatus(status: number): boolean {
   return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
+}
+
+function cancelResponseBodyBestEffort(response: Response | undefined): void {
+  // Debug capture can tee the body, and cancelling one branch may not settle until
+  // its sibling finishes. Start cleanup without letting it delay release or errors.
+  void response?.body?.cancel().catch(() => undefined);
 }
 
 function isAmbientGlobalFetch(params: {
@@ -501,12 +511,17 @@ async function fetchWithSsrFGuardInternal(
   });
 
   let released = false;
+  let responseToRelease: Response | undefined;
   const release = async (dispatcher?: Dispatcher | null) => {
     if (released) {
       return;
     }
     released = true;
+    cancelResponseBodyBestEffort(responseToRelease);
+    responseToRelease = undefined;
     cleanup();
+    // closeDispatcher bounds graceful shutdown and falls back to destroy, so release
+    // remains coupled to transport cleanup without waiting on an unread body forever.
     await closeDispatcher(dispatcher ?? undefined);
   };
 
@@ -642,6 +657,7 @@ async function fetchWithSsrFGuardInternal(
       const response = shouldUseRuntimeFetch
         ? await fetchWithRuntimeDispatcher(parsedUrl.toString(), init)
         : await defaultFetch(parsedUrl.toString(), init);
+      responseToRelease = response;
       const capturedByGlobalFetchPatch =
         !shouldUseRuntimeFetch &&
         isAmbientGlobalFetch({
@@ -665,12 +681,10 @@ async function fetchWithSsrFGuardInternal(
       if (isRedirectStatus(response.status)) {
         const location = response.headers.get("location");
         if (!location) {
-          await release(dispatcher);
           throw new Error(`Redirect missing location header (${response.status})`);
         }
         redirectCount += 1;
         if (redirectCount > maxRedirects) {
-          await release(dispatcher);
           throw new Error(`Too many redirects (limit: ${maxRedirects})`);
         }
         const nextParsedUrl = new URL(location, parsedUrl);
@@ -694,11 +708,11 @@ async function fetchWithSsrFGuardInternal(
         }
         const nextVisitKey = getRedirectVisitKey(nextUrl, currentInit);
         if (visited.has(nextVisitKey)) {
-          await release(dispatcher);
           throw new Error("Redirect loop detected");
         }
         visited.add(nextVisitKey);
-        void response.body?.cancel().catch(() => undefined);
+        cancelResponseBodyBestEffort(response);
+        responseToRelease = undefined;
         await closeDispatcher(dispatcher);
         currentUrl = nextUrl;
         continue;

--- a/src/infra/net/guarded-body-stream.test.ts
+++ b/src/infra/net/guarded-body-stream.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createDeferredCore } from "../../shared/deferred.js";
 import { wrapGuardedBodyStream } from "./guarded-body-stream.js";
 
 describe("wrapGuardedBodyStream", () => {
@@ -18,7 +19,12 @@ describe("wrapGuardedBodyStream", () => {
 
   it("propagates downstream cancellation failure after releasing resources", async () => {
     const expected = new Error("source cancellation failed");
-    const cleanup = vi.fn();
+    const started = createDeferredCore();
+    const released = createDeferredCore();
+    const cleanup = vi.fn(() => {
+      started.resolve();
+      return released.promise;
+    });
     const source = new ReadableStream<Uint8Array>({
       async cancel() {
         throw expected;
@@ -26,10 +32,57 @@ describe("wrapGuardedBodyStream", () => {
     });
     const wrapped = wrapGuardedBodyStream({ body: source, cleanup });
 
-    await expect(wrapped.cancel("consumer stopped")).rejects.toBe(expected);
+    let settled = false;
+    const operation = wrapped
+      .cancel("consumer stopped")
+      .catch((error: unknown) => error)
+      .finally(() => {
+        settled = true;
+      });
+    try {
+      await started.promise;
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(settled).toBe(false);
+      expect(cleanup).toHaveBeenCalledOnce();
+      expect(source.locked).toBe(false);
+    } finally {
+      released.resolve();
+    }
+    await expect(operation).resolves.toBe(expected);
+  });
 
-    expect(cleanup).toHaveBeenCalledOnce();
-    expect(source.locked).toBe(false);
+  it("runs owner cleanup before awaiting upstream cancellation", async () => {
+    const released = createDeferredCore();
+    const order: unknown[] = [];
+    const cancel = vi.fn((reason: unknown) => {
+      order.push(reason);
+      return released.promise;
+    });
+    const source = new ReadableStream<Uint8Array>({ cancel });
+    const reason = new Error("consumer stopped");
+    const cleanup = vi.fn(() => {
+      order.push("cleanup");
+      released.resolve();
+    });
+    const wrapped = wrapGuardedBodyStream({ body: source, cleanup });
+    const operation = wrapped.cancel(reason);
+    try {
+      const completed = await Promise.race([
+        operation.then(() => true),
+        new Promise<boolean>((resolve) => {
+          setImmediate(() => resolve(false));
+        }),
+      ]);
+      expect(completed).toBe(true);
+      expect(order).toEqual([reason, "cleanup"]);
+      expect(cleanup).toHaveBeenCalledOnce();
+      expect(source.locked).toBe(false);
+    } finally {
+      released.resolve();
+      await operation;
+    }
   });
 
   it("releases the source reader lock after normal completion", async () => {

--- a/src/infra/net/guarded-body-stream.ts
+++ b/src/infra/net/guarded-body-stream.ts
@@ -35,18 +35,27 @@ export function wrapGuardedBodyStream(params: {
     }
     finalized = true;
     guardedBodyCleanupRegistry.unregister(cleanupRegistrationToken);
-    try {
-      await cancelReader();
-    } finally {
-      try {
-        reader?.releaseLock();
-      } finally {
+    // Start cancellation before cleanup so its reason reaches the reader, but
+    // let request cleanup abort a retained capture tee before awaiting settlement.
+    const [cancellation, release] = await Promise.allSettled([
+      cancelReader(),
+      (async () => {
         try {
-          await params.cleanup();
-        } catch {
-          // Best effort: guard cleanup must not surface into stream consumers.
+          reader?.releaseLock();
+        } finally {
+          try {
+            await params.cleanup();
+          } catch {
+            // Best effort: guard cleanup must not surface into stream consumers.
+          }
         }
-      }
+      })(),
+    ]);
+    if (release.status === "rejected") {
+      throw release.reason;
+    }
+    if (cancellation.status === "rejected") {
+      throw cancellation.reason;
     }
   };
   const wrappedBody = new ReadableStream<Uint8Array>({

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -1691,6 +1691,49 @@ describe("readRemoteMediaBuffer", () => {
     expect(cancel).toHaveBeenCalledTimes(1);
   });
 
+  it.each(["streamed", "content-length"])(
+    "cleans up %s media overflow before a response clone is released",
+    async (kind) => {
+      const body = makeCancelableStream([new Uint8Array([1, 2, 3, 4, 5])]);
+      const response = new Response(body.stream, {
+        headers: kind === "content-length" ? { "content-length": "5" } : {},
+      });
+      const capture = response.clone();
+      const subdir = `captured-${kind}`;
+      let completed = false;
+      const operation = saveRemoteMedia({
+        url: "https://example.com/large.bin",
+        fetchImpl: async () => response,
+        lookupFn: makeLookupFn(),
+        maxBytes: 4,
+        subdir,
+      })
+        .catch((error: unknown) => error)
+        .finally(() => {
+          completed = true;
+        });
+      try {
+        await vi.waitFor(() => expect(completed).toBe(true), { timeout: 500 });
+        await expect(operation).resolves.toMatchObject({ code: "max_bytes" });
+        expect(response.body?.locked).toBe(false);
+        expect(body.wasCanceled()).toBe(false);
+        const dir = path.join(tempHome.home, ".openclaw", "media", subdir);
+        await expect(
+          fs.readdir(dir).catch((error: unknown) => {
+            if (hasErrnoCode(error, "ENOENT")) {
+              return [];
+            }
+            throw error;
+          }),
+        ).resolves.toEqual([]);
+      } finally {
+        await capture.body?.cancel();
+        await operation;
+      }
+      expect(body.wasCanceled()).toBe(true);
+    },
+  );
+
   it("retries saveRemoteMedia after a transient fetch failure", async () => {
     const transientError = Object.assign(new TypeError("socket reset"), { code: "ECONNRESET" });
     const fetchImpl = vi

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -1202,43 +1202,42 @@ describe("readRemoteMediaBuffer", () => {
     }
   });
 
-  it("cancels ignored content-length overflow bodies for saved responses", async () => {
-    const body = makeCancelableStream([new Uint8Array([1, 2, 3, 4, 5])]);
-
-    await expect(
-      saveResponseMedia(
-        new Response(body.stream, {
-          status: 200,
-          headers: { "content-length": "5" },
-        }),
-        {
-          maxBytes: 4,
-          sourceUrl: "https://example.com/file.bin",
-        },
-      ),
-    ).rejects.toThrow("content length 5 exceeds maxBytes 4");
-
-    expect(body.wasCanceled()).toBe(true);
-  });
-
-  it("rejects malformed content-length before saving responses", async () => {
-    const body = makeCancelableStream([new Uint8Array([1, 2, 3, 4, 5])]);
-
-    await expect(
-      saveResponseMedia(
-        new Response(body.stream, {
-          status: 200,
-          headers: { "content-length": "1e9" },
-        }),
-        {
-          maxBytes: 4,
-          sourceUrl: "https://example.com/file.bin",
-        },
-      ),
-    ).rejects.toThrow("invalid content-length header: 1e9");
-
-    expect(body.wasCanceled()).toBe(true);
-  });
+  it.each([
+    ["5", "content length 5 exceeds maxBytes 4", false],
+    ["5", "content length 5 exceeds maxBytes 4", true],
+    ["1e9", "invalid content-length header: 1e9", false],
+    ["1e9", "invalid content-length header: 1e9", true],
+  ] as const)(
+    "cancels saved-response content-length %s (%s; partially read: %s)",
+    async (contentLength, message, partiallyRead) => {
+      const body = makeCancelableStream([new Uint8Array([1]), new Uint8Array([2, 3, 4, 5])]);
+      const response = new Response(body.stream, {
+        status: 200,
+        headers: { "content-length": contentLength },
+      });
+      try {
+        if (partiallyRead) {
+          const reader = body.stream.getReader();
+          try {
+            expect(await reader.read()).toEqual({ done: false, value: new Uint8Array([1]) });
+          } finally {
+            reader.releaseLock();
+          }
+        }
+        expect(response.bodyUsed).toBe(partiallyRead);
+        await expect(
+          saveResponseMedia(response, {
+            maxBytes: 4,
+            sourceUrl: "https://example.com/file.bin",
+          }),
+        ).rejects.toThrow(message);
+        expect(body.wasCanceled()).toBe(true);
+        expect(body.stream.locked).toBe(false);
+      } finally {
+        await body.stream.cancel();
+      }
+    },
+  );
 
   it("decodes URL path basenames when deriving remote media filenames", async () => {
     const fetchImpl = vi.fn(

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -8,7 +8,6 @@ import { isAbortError } from "../infra/abort-signal.js";
 import { sleepWithAbort } from "../infra/backoff.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import {
-  cancelUnreadResponseBody,
   readChunkWithIdleTimeout,
   readResponseTextSnippet,
   readResponseWithLimit,
@@ -422,16 +421,17 @@ async function assertMediaResponseOk(params: {
   );
 }
 
-async function assertMediaContentLength(params: {
+// Caller-provided responses may already be partially read; discard their remaining bytes too.
+function assertMediaContentLength(params: {
   res: Response;
   sourceUrl: string;
   maxBytes: number;
-}): Promise<void> {
+}): void {
   let length: number | null;
   try {
     length = parseMediaContentLength(params.res.headers.get("content-length"));
   } catch (err) {
-    await cancelUnreadResponseBody(params.res);
+    void params.res.body?.cancel().catch(() => undefined);
     throw new MediaFetchError(
       "http_error",
       `Failed to fetch media from ${params.sourceUrl}: ${formatErrorMessage(err)}`,
@@ -442,7 +442,7 @@ async function assertMediaContentLength(params: {
     return;
   }
   if (length > params.maxBytes) {
-    await cancelUnreadResponseBody(params.res);
+    void params.res.body?.cancel().catch(() => undefined);
     throw new MediaFetchError(
       "max_bytes",
       `Failed to fetch media from ${params.sourceUrl}: content length ${length} exceeds maxBytes ${params.maxBytes}`,
@@ -552,7 +552,7 @@ async function saveOkMediaResponse(params: {
   subdir?: string;
   originalFilename?: string;
 }): Promise<SavedRemoteMedia> {
-  await assertMediaContentLength({
+  assertMediaContentLength({
     res: params.res,
     sourceUrl: params.sourceUrl,
     maxBytes: params.maxBytes,
@@ -717,7 +717,7 @@ async function readRemoteMediaBufferOnce(options: FetchMediaOptions): Promise<Fe
     });
 
     const effectiveMaxBytes = options.maxBytes ?? DEFAULT_FETCH_MEDIA_MAX_BYTES;
-    await assertMediaContentLength({ res, sourceUrl, maxBytes: effectiveMaxBytes });
+    assertMediaContentLength({ res, sourceUrl, maxBytes: effectiveMaxBytes });
     let buffer: Buffer;
     try {
       buffer = await readResponseWithLimit(res, effectiveMaxBytes, {

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -8,6 +8,7 @@ import { isAbortError } from "../infra/abort-signal.js";
 import { sleepWithAbort } from "../infra/backoff.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import {
+  cancelUnreadResponseBody,
   readChunkWithIdleTimeout,
   readResponseTextSnippet,
   readResponseWithLimit,
@@ -430,7 +431,7 @@ async function assertMediaContentLength(params: {
   try {
     length = parseMediaContentLength(params.res.headers.get("content-length"));
   } catch (err) {
-    await discardIgnoredResponseBody(params.res);
+    await cancelUnreadResponseBody(params.res);
     throw new MediaFetchError(
       "http_error",
       `Failed to fetch media from ${params.sourceUrl}: ${formatErrorMessage(err)}`,
@@ -441,23 +442,11 @@ async function assertMediaContentLength(params: {
     return;
   }
   if (length > params.maxBytes) {
-    await discardIgnoredResponseBody(params.res);
+    await cancelUnreadResponseBody(params.res);
     throw new MediaFetchError(
       "max_bytes",
       `Failed to fetch media from ${params.sourceUrl}: content length ${length} exceeds maxBytes ${params.maxBytes}`,
     );
-  }
-}
-
-async function discardIgnoredResponseBody(res: Response): Promise<void> {
-  const body = res.body;
-  if (!body) {
-    return;
-  }
-  try {
-    await body.cancel();
-  } catch {
-    // Best-effort cleanup after rejecting a response body.
   }
 }
 
@@ -539,7 +528,8 @@ async function* responseBodyChunks(
     }
   } finally {
     if (!completed) {
-      await reader.cancel().catch(() => undefined);
+      // Let the file writer close its handle and the request owner abort any capture tee.
+      void reader.cancel().catch(() => undefined);
     }
     try {
       reader.releaseLock();

--- a/src/plugin-sdk/provider-binary-stream.test.ts
+++ b/src/plugin-sdk/provider-binary-stream.test.ts
@@ -1,9 +1,258 @@
+import { setImmediate as waitForImmediate } from "node:timers/promises";
 import { describe, expect, it, vi } from "vitest";
+import { createDeferredCore } from "../shared/deferred.js";
 import { createBoundedProviderBinaryStream } from "./provider-binary-stream.js";
 
 describe("createBoundedProviderBinaryStream", () => {
+  it("shares finalization when source cancellation reenters release", async () => {
+    const reentered: Promise<void>[] = [];
+    const cancel = vi.fn(() => {
+      reentered.push(bounded.release());
+    });
+    const cleanup = vi.fn(async () => {});
+    const source = new ReadableStream<Uint8Array>({ cancel });
+    const bounded = createBoundedProviderBinaryStream(source, {
+      maxBytes: 8,
+      createOverflowError: () => new Error("overflow"),
+      createReleaseError: () => new Error("released"),
+      cleanup,
+    });
+    await bounded.release();
+    await Promise.all(reentered);
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(source.locked).toBe(false);
+  });
+
+  it.each(["eof", "error"] as const)(
+    "unlocks on %s and keeps request cleanup with explicit release",
+    async (ending) => {
+      const failure = new Error("read failed");
+      const cancel = vi.fn();
+      const source = new ReadableStream<Uint8Array>({
+        start(controller) {
+          if (ending === "eof") {
+            controller.close();
+          } else {
+            controller.error(failure);
+          }
+        },
+        cancel,
+      });
+      const cleanup = vi.fn(async () => {});
+      const bounded = createBoundedProviderBinaryStream(source, {
+        maxBytes: 8,
+        createOverflowError: () => new Error("overflow"),
+        createReleaseError: () => new Error("released"),
+        cleanup,
+      });
+      const reader = bounded.stream.getReader();
+      try {
+        if (ending === "eof") {
+          await expect(reader.read()).resolves.toEqual({ done: true, value: undefined });
+        } else {
+          await expect(reader.read()).rejects.toBe(failure);
+        }
+        expect(source.locked).toBe(false);
+        expect(cleanup).not.toHaveBeenCalled();
+        await bounded.release();
+        await bounded.release();
+        expect(cleanup).toHaveBeenCalledOnce();
+        expect(cancel).not.toHaveBeenCalled();
+      } finally {
+        reader.releaseLock();
+        await bounded.release();
+      }
+    },
+  );
+
+  it.each(
+    (["cancel", "release"] as const).flatMap((operation) =>
+      [false, true].flatMap((cancelRejects) =>
+        [false, true].map((cleanupRejects) => ({ operation, cancelRejects, cleanupRejects })),
+      ),
+    ),
+  )(
+    "settles $operation after source and request cleanup (cancel rejects: $cancelRejects, cleanup rejects: $cleanupRejects)",
+    async ({ operation, cancelRejects, cleanupRejects }) => {
+      const canceled = createDeferredCore();
+      const cleaned = createDeferredCore();
+      const reason = new Error("stop playback");
+      const cancelError = new Error("source cancellation failed");
+      const cleanupError = new Error("request cleanup failed");
+      const cancel = vi.fn(() => canceled.promise);
+      const source = new ReadableStream<Uint8Array>({ cancel });
+      const cleanup = vi.fn(async () => {
+        expect(cancel).toHaveBeenCalledExactlyOnceWith(reason);
+        expect(source.locked).toBe(false);
+        await cleaned.promise;
+      });
+      const options = {
+        maxBytes: 8,
+        createOverflowError: () => new Error("overflow"),
+        createReleaseError: () => reason,
+        cleanup,
+      };
+      const bounded = createBoundedProviderBinaryStream(source, options);
+      let settled = false;
+      const result = (
+        operation === "cancel" ? bounded.stream.cancel(reason) : bounded.release()
+      ).then(
+        () => {
+          settled = true;
+          return {};
+        },
+        (error: unknown) => {
+          settled = true;
+          return { error };
+        },
+      );
+      try {
+        await waitForImmediate();
+        expect(settled).toBe(false);
+        expect(cleanup).toHaveBeenCalledOnce();
+        if (cancelRejects) {
+          canceled.reject(cancelError);
+        } else {
+          canceled.resolve();
+        }
+        await waitForImmediate();
+        expect(settled).toBe(false);
+        if (cleanupRejects) {
+          cleaned.reject(cleanupError);
+        } else {
+          cleaned.resolve();
+        }
+        const observed = await result;
+        const expectedError = cleanupRejects
+          ? cleanupError
+          : operation === "cancel" && cancelRejects
+            ? cancelError
+            : undefined;
+        if (expectedError) {
+          expect("error" in observed && observed.error).toBe(expectedError);
+        } else {
+          expect(observed).toEqual({});
+        }
+        await bounded.release().catch(() => undefined);
+        await bounded.release().catch(() => undefined);
+        expect(cancel).toHaveBeenCalledOnce();
+        expect(cleanup).toHaveBeenCalledOnce();
+      } finally {
+        canceled.resolve();
+        cleaned.resolve();
+        await result;
+        await bounded.release().catch(() => undefined);
+      }
+    },
+  );
+
+  it.each(
+    (["cancel", "release"] as const).flatMap((first) =>
+      [false, true].map((cleanupRejects) => ({ first, cleanupRejects })),
+    ),
+  )(
+    "shares cleanup when $first starts first but waits for source cancellation (cleanup rejects: $cleanupRejects)",
+    async ({ first, cleanupRejects }) => {
+      const canceled = createDeferredCore();
+      const reason = new Error("stop playback");
+      const cancelError = new Error("source cancellation failed");
+      const cleanupError = new Error("request cleanup failed");
+      const cancel = vi.fn(() => canceled.promise);
+      const source = new ReadableStream<Uint8Array>({ cancel });
+      const cleanup = vi.fn(async () => {
+        if (cleanupRejects) {
+          throw cleanupError;
+        }
+      });
+      const options = {
+        maxBytes: 8,
+        createOverflowError: () => new Error("overflow"),
+        createReleaseError: () => reason,
+        cleanup,
+      };
+      const bounded = createBoundedProviderBinaryStream(source, options);
+      const operations =
+        first === "cancel"
+          ? [bounded.stream.cancel(reason), bounded.release()]
+          : [bounded.release(), bounded.stream.cancel(reason)].toReversed();
+      let settled = false;
+      const results = Promise.allSettled(operations).then((result) => {
+        settled = true;
+        return result;
+      });
+      try {
+        await waitForImmediate();
+        expect(cleanup).toHaveBeenCalledOnce();
+        expect(settled).toBe(false);
+        expect(source.locked).toBe(false);
+        canceled.reject(cancelError);
+        const [cancellation, release] = await results;
+        expect(cancellation.status === "rejected" && cancellation.reason).toBe(
+          cleanupRejects ? cleanupError : cancelError,
+        );
+        if (cleanupRejects) {
+          expect(release.status === "rejected" && release.reason).toBe(cleanupError);
+        } else {
+          expect(release).toEqual({ status: "fulfilled", value: undefined });
+        }
+        expect(cancel).toHaveBeenCalledExactlyOnceWith(reason);
+        expect(cleanup).toHaveBeenCalledOnce();
+      } finally {
+        canceled.resolve();
+        await results;
+        await bounded.release().catch(() => undefined);
+      }
+    },
+  );
+
+  it("delivers overflow before delayed cleanup and preserves its later release failure", async () => {
+    const cleaned = createDeferredCore();
+    const overflow = new Error("overflow");
+    const cleanupError = new Error("request cleanup failed");
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(Uint8Array.from([1, 2, 3, 4, 5]));
+      },
+      cancel: async () => {
+        throw new Error("best-effort source cancellation failed");
+      },
+    });
+    const cleanup = vi.fn(() => cleaned.promise);
+    const options = {
+      maxBytes: 4,
+      createOverflowError: () => overflow,
+      createReleaseError: () => new Error("released"),
+      cleanup,
+    };
+    const bounded = createBoundedProviderBinaryStream(source, options);
+    const reader = bounded.stream.getReader();
+    try {
+      await expect(reader.read()).resolves.toEqual({
+        done: false,
+        value: Uint8Array.from([1, 2, 3, 4]),
+      });
+      await expect(reader.read()).rejects.toBe(overflow);
+      expect(cleanup).toHaveBeenCalledOnce();
+      let settled = false;
+      const released = bounded.release().finally(() => {
+        settled = true;
+      });
+      void released.catch(() => undefined);
+      await waitForImmediate();
+      expect(settled).toBe(false);
+      cleaned.reject(cleanupError);
+      await expect(released).rejects.toBe(cleanupError);
+      expect(source.locked).toBe(false);
+    } finally {
+      cleaned.resolve();
+      reader.releaseLock();
+      await bounded.release().catch(() => undefined);
+    }
+  });
+
   it.each(["release", "overflow"] as const)(
-    "settles %s before a retained response clone is released",
+    "settles %s by releasing a retained response clone through request cleanup",
     async (kind) => {
       const cancel = vi.fn();
       const response = new Response(
@@ -16,10 +265,14 @@ describe("createBoundedProviderBinaryStream", () => {
       );
       const capture = response.clone();
       const expected = new Error(kind);
+      const cleanup = vi.fn(async () => {
+        await capture.body?.cancel();
+      });
       const bounded = createBoundedProviderBinaryStream(response.body!, {
         maxBytes: kind === "overflow" ? 4 : 8,
         createOverflowError: () => expected,
         createReleaseError: () => expected,
+        cleanup,
       });
       const reader = bounded.stream.getReader();
       const operation = (async () => {
@@ -45,7 +298,8 @@ describe("createBoundedProviderBinaryStream", () => {
         ]);
         expect(result).toEqual({});
         expect(response.body?.locked).toBe(false);
-        expect(cancel).not.toHaveBeenCalled();
+        expect(cleanup).toHaveBeenCalledOnce();
+        expect(cancel).toHaveBeenCalledOnce();
       } finally {
         await capture.body?.cancel();
         await operation;
@@ -69,6 +323,7 @@ describe("createBoundedProviderBinaryStream", () => {
       maxBytes: 4,
       createOverflowError: () => overflowError,
       createReleaseError: () => new Error("released"),
+      cleanup: async () => {},
     });
     const reader = bounded.stream.getReader();
 

--- a/src/plugin-sdk/provider-binary-stream.test.ts
+++ b/src/plugin-sdk/provider-binary-stream.test.ts
@@ -2,6 +2,59 @@ import { describe, expect, it, vi } from "vitest";
 import { createBoundedProviderBinaryStream } from "./provider-binary-stream.js";
 
 describe("createBoundedProviderBinaryStream", () => {
+  it.each(["release", "overflow"] as const)(
+    "settles %s before a retained response clone is released",
+    async (kind) => {
+      const cancel = vi.fn();
+      const response = new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(Uint8Array.from([1, 2, 3, 4, 5]));
+          },
+          cancel,
+        }),
+      );
+      const capture = response.clone();
+      const expected = new Error(kind);
+      const bounded = createBoundedProviderBinaryStream(response.body!, {
+        maxBytes: kind === "overflow" ? 4 : 8,
+        createOverflowError: () => expected,
+        createReleaseError: () => expected,
+      });
+      const reader = bounded.stream.getReader();
+      const operation = (async () => {
+        await expect(reader.read()).resolves.toEqual({
+          done: false,
+          value: Uint8Array.from(kind === "overflow" ? [1, 2, 3, 4] : [1, 2, 3, 4, 5]),
+        });
+        if (kind === "overflow") {
+          await expect(reader.read()).rejects.toBe(expected);
+        }
+        await bounded.release();
+        await bounded.release();
+      })().then(
+        () => ({}),
+        (error: unknown) => ({ error }),
+      );
+      try {
+        const result = await Promise.race([
+          operation,
+          new Promise<undefined>((resolve) => {
+            setImmediate(() => resolve(undefined));
+          }),
+        ]);
+        expect(result).toEqual({});
+        expect(response.body?.locked).toBe(false);
+        expect(cancel).not.toHaveBeenCalled();
+      } finally {
+        await capture.body?.cancel();
+        await operation;
+        reader.releaseLock();
+      }
+      expect(cancel).toHaveBeenCalledExactlyOnceWith([expected, undefined]);
+    },
+  );
+
   it("delivers the fitting prefix, then cancels and releases on overflow", async () => {
     const cancel = vi.fn(async () => {});
     const source = new ReadableStream<Uint8Array>({

--- a/src/plugin-sdk/provider-binary-stream.test.ts
+++ b/src/plugin-sdk/provider-binary-stream.test.ts
@@ -172,12 +172,11 @@ describe("createBoundedProviderBinaryStream", () => {
         cleanup,
       };
       const bounded = createBoundedProviderBinaryStream(source, options);
-      const operations =
-        first === "cancel"
-          ? [bounded.stream.cancel(reason), bounded.release()]
-          : [bounded.release(), bounded.stream.cancel(reason)].toReversed();
+      const earlyCancel = first === "cancel" ? bounded.stream.cancel(reason) : undefined;
+      const pendingRelease = bounded.release();
+      const pendingCancel = earlyCancel ?? bounded.stream.cancel(reason);
       let settled = false;
-      const results = Promise.allSettled(operations).then((result) => {
+      const results = Promise.allSettled([pendingCancel, pendingRelease]).then((result) => {
         settled = true;
         return result;
       });

--- a/src/plugin-sdk/provider-binary-stream.ts
+++ b/src/plugin-sdk/provider-binary-stream.ts
@@ -10,7 +10,6 @@ export function createBoundedProviderBinaryStream(
   // Keep direct reader ownership: transform writer rejection can leak when
   // playback cancellation races overflow.
   let reader: ReadableStreamDefaultReader<Uint8Array> | undefined = source.getReader();
-  let cancelPromise: Promise<void> | undefined;
   let releasePromise: Promise<void> | undefined;
   let pendingError: Error | undefined;
   let totalBytes = 0;
@@ -23,19 +22,14 @@ export function createBoundedProviderBinaryStream(
     activeReader.releaseLock();
   };
 
-  const cancelReader = (reason?: unknown): Promise<void> => {
+  const cancelReader = async (reason?: unknown): Promise<void> => {
     const activeReader = reader;
     if (!activeReader) {
-      return Promise.resolve();
+      return;
     }
-    cancelPromise ??= (async () => {
-      try {
-        await activeReader.cancel(reason).catch(() => undefined);
-      } finally {
-        releaseReader(activeReader);
-      }
-    })();
-    return cancelPromise;
+    // Caller-owned request release must be able to abort a retained capture tee.
+    void activeReader.cancel(reason).catch(() => undefined);
+    releaseReader(activeReader);
   };
 
   const stream = new ReadableStream<Uint8Array>({

--- a/src/plugin-sdk/provider-binary-stream.ts
+++ b/src/plugin-sdk/provider-binary-stream.ts
@@ -1,16 +1,17 @@
-/** Create a byte-limited stream while retaining direct ownership of the source reader. */
+/** Create a byte-limited stream that owns its source reader and request cleanup. */
 export function createBoundedProviderBinaryStream(
   source: ReadableStream<Uint8Array>,
   options: {
     maxBytes: number;
     createOverflowError: (params: { size: number; maxBytes: number }) => Error;
     createReleaseError: () => Error;
+    cleanup: () => Promise<void>;
   },
 ): { stream: ReadableStream<Uint8Array>; release: () => Promise<void> } {
   // Keep direct reader ownership: transform writer rejection can leak when
   // playback cancellation races overflow.
   let reader: ReadableStreamDefaultReader<Uint8Array> | undefined = source.getReader();
-  let releasePromise: Promise<void> | undefined;
+  let completion: Promise<PromiseSettledResult<void>> | undefined;
   let pendingError: Error | undefined;
   let totalBytes = 0;
 
@@ -22,14 +23,28 @@ export function createBoundedProviderBinaryStream(
     activeReader.releaseLock();
   };
 
-  const cancelReader = async (reason?: unknown): Promise<void> => {
-    const activeReader = reader;
-    if (!activeReader) {
-      return;
-    }
-    // Caller-owned request release must be able to abort a retained capture tee.
-    void activeReader.cancel(reason).catch(() => undefined);
-    releaseReader(activeReader);
+  const finalize = (reason?: unknown) => {
+    // Memoize before callbacks can reenter. Start cancellation before request
+    // cleanup, but await both so cleanup can abort a retained capture tee.
+    return (completion ??= Promise.resolve().then(async () => {
+      const activeReader = reader;
+      const [cancellation, cleanup] = await Promise.allSettled([
+        activeReader?.cancel(reason),
+        (async () => {
+          try {
+            if (activeReader) {
+              releaseReader(activeReader);
+            }
+          } finally {
+            await options.cleanup();
+          }
+        })(),
+      ]);
+      if (cleanup.status === "rejected") {
+        throw cleanup.reason;
+      }
+      return cancellation;
+    }));
   };
 
   const stream = new ReadableStream<Uint8Array>({
@@ -63,7 +78,8 @@ export function createBoundedProviderBinaryStream(
             controller.enqueue(chunk.value.subarray(0, remainingBytes));
             pendingError = error;
           }
-          await cancelReader(error);
+          // Preserve the overflow outcome even if request cleanup is delayed or fails.
+          void finalize(error).catch(() => undefined);
           if (remainingBytes <= 0) {
             controller.error(error);
           }
@@ -77,12 +93,17 @@ export function createBoundedProviderBinaryStream(
       }
     },
     async cancel(reason) {
-      await cancelReader(reason);
+      const cancellation = await finalize(reason);
+      if (cancellation.status === "rejected") {
+        throw cancellation.reason;
+      }
     },
   });
 
   return {
     stream,
-    release: () => (releasePromise ??= cancelReader(options.createReleaseError())),
+    release: async () => {
+      await finalize(options.createReleaseError());
+    },
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Debug HTTP capture clones a response body. Canceling one consumed branch can then wait for the capture branch or the upstream response to finish. Several bounded readers awaited that cancellation before their caller could release the guarded request, so an already-known size error, an early successful prefix, or a public stream release could remain pending. Media overflow also delayed closing its temporary file handle.

This updates the existing contributor repair rather than opening a duplicate. The original Copilot device-flow example was already fixed by #112268. Guard-owned redirects, unread responses, and per-request abort are now handled by #130804. The remaining repair belongs to consumed-reader owners, including Google Chat's private auth reader and its certificate-error path.

## Why This Change Was Made

Best-effort readers now start cancellation, handle rejection immediately, and release their reader lock without waiting for a capture tee. Their existing caller-owned request cleanup can then abort the unfinished transport. The guarded body wrapper has a stronger contract: it starts cancellation first, lets cleanup proceed, and waits for both before surfacing the original explicit cancellation failure. Cleanup errors stay best-effort, lock-release error precedence stays unchanged, and caller-provided cancellation reasons still reach the reader first.

The repair covers core bounded readers, the guarded body wrapper, the provider binary-stream helper, media downloads, memory response/JSONL readers, and Google Chat auth. It removes pending-cancellation bookkeeping, a duplicate body cleanup helper, and a redundant certificate-error cancellation. Media header rejection still cancels caller-provided bodies that were partially read and unlocked; it must not use the shared unread-only helper for that broader contract. Fish Audio and ElevenLabs inherit the binary helper repair without provider-specific release workarounds. Google Chat keeps its own strict Content-Length handling, 1 MiB limit, missing-stream refusal, and exact auth errors.

The binary helper now owns the request-cleanup callback as well as its reader, replacing duplicate Fish Audio and ElevenLabs release wrappers. Cancellation starts with the supplied reason, the reader unlocks, and request cleanup can abort a retained capture branch while both operations settle. Public stream cancellation propagates the source cancellation error only after both finish; `release()` treats source cancellation as best-effort but still reports cleanup failure. Cleanup failure takes precedence when both fail. Overflow delivers the fitting prefix and original error promptly while observing cleanup in the background; later `release()` reports cleanup failure. EOF and read errors still require the caller to invoke `release()`.

This corrects the initial rewrite's overly broad compatibility reasoning. The helper introduced by [#124835](https://github.com/openclaw/openclaw/pull/124835) is absent from [stable v2026.7.1-2](https://github.com/openclaw/openclaw/tree/v2026.7.1-2/src/plugin-sdk) and present in [v2026.8.1-beta.3](https://github.com/openclaw/openclaw/blob/v2026.8.1-beta.3/src/plugin-sdk/provider-binary-stream.ts), allowing its required callback to change without a beta-only compatibility shim. However, stable ElevenLabs already returned a public native response stream, so its cancellation settlement/error contract matters independently of the helper's age. The repair preserves that distinction and documents the new cleanup ownership in this PR's [SDK subpath documentation](https://docs.openclaw.ai/plugins/sdk-subpaths). It does not promise synchronous server-side TCP closure at cancellation-promise settlement.

The llama.cpp installer is a related behavior-neutral ownership simplification: its baseline already closed the network and partial files correctly. Native async iteration releases its reader lock on every exit, with `preventCancel: true` leaving network abort to the existing guard. No new installer leak is claimed.

Current main's per-hop release contract remains intact; the old PR's unread-body-after-release assertion is not restored. Generic dispatcher graceful-close behavior, parent signals, pooled sibling requests, limits, UTF-8 handling, auth decisions, configuration, persistence, dependencies, and stable public SDK signatures are unchanged. The beta-only binary helper gains the required cleanup callback described above.

Production: +80/-97, net **-17**, across eleven production files. Tests: +960/-190, net +770, across nine files; table conversions include consolidation and indentation churn. Documentation: +8/-0 in one file. Twenty-one files total. These are line counts, not counts of independent assertions.

## User Impact

Captured bounded HTTP reads and streaming-provider release can finish promptly instead of waiting on their own cleanup dependency. Existing errors, fitting response bytes, successful full capture, and temporary-file cleanup are preserved. Google Chat reports the existing oversize/certificate failures without waiting on the capture branch. No new setting or operator action is required.

The awaited-reader pattern is present in stable v2026.7.1-2 for several core/media/memory and Google auth paths; this does not establish that the same capture deployment existed in that release. The binary helper and streaming batch reader are newer. Local history is shallow, so no unsupported introducing-commit or author attribution is made.

Remaining separate follow-ups: `responseWithRelease` has different cleanup/error contracts, including Telegram cleanup that only clears a timeout; it is not safe to rewrite mechanically. A separate actual Mattermost-client probe now reproduces its captured-cancellation stall on current source, while no-capture cancellation and captured EOF controls pass; that path is not fixed here. The analogous input-file unread-body helper lacks this task's dedicated boundary reproduction. #123194 proposes a distinct MCP response-size policy and is not subsumed here. This PR does not claim every cancellation path is repaired.

## Evidence

Merged on August 27, 2026 at 18:25 UTC as [474624a5c730](https://github.com/openclaw/openclaw/commit/474624a5c73039c04fe5998982ba75346dba4dbf), from reviewed head `0644dda34fc5cd036c1531f65ba12f4adc014ffa`. Exact-head full CI, type/static checks, precise scanning and dependency checks passed before native validation, preparation and merge.

Before changes, 14 new owner regressions failed on the cancellation wait. A causal inverse of the original three core/binary owners made all four new real pooled-transport rows fail while six existing controls passed; the exact candidate files were restored and all ten rows passed. These rows retain a second in-flight request on the same real pooled dispatcher and parent signal, preserve its complete captured bytes, and prove a third successful reuse.

Real owned-loopback evidence; guarded/captured cases use actual Undici transport and native capture cloning into a memory-only sink:

- Six core/wrapper HTTP scenarios: four baseline waits at the unchanged 500 ms deadline and two EOF controls; all six pass after repair in 2–28 ms.
- Ten media/memory HTTP scenarios: eight baseline waits and two controls; all ten pass in 1–34 ms, including actual file-handle closure, temporary-file removal, exact errors, early JSONL completion, and complete successful capture bytes.
- Seven public Fish Audio/ElevenLabs/SDK HTTP scenarios: the original release/overflow/EOF cases plus two public-cancel cases. On the initial rewrite, public cancellation resolved in 42/10 ms but left TCP open and capture unfinished at the unchanged one-second observation deadline without a separate release call. The final ownership correction passes all seven cases in 3–54 ms, including public cancellation with natural socket/capture completion before any separate release call, held-consumer-reader release, fitting-prefix overflow, repeated release, and full eight-byte EOF capture. Nineteen helper tests cover cancellation/cleanup failure order in both directions, reentrant cleanup, EOF/read-error release, and exact reason/error propagation.
- Three retained Google Chat transport scenarios: overflow and certificate-503 fail before repair, completed auth is the control. All pass after repair with exact errors, no JWT verification on HTTP503, natural socket closure, and successful captured bytes.
- One caller-provided, partially read HTTP response: the initial rewrite returned the size error but left the socket open at 501 ms. The corrected media owner closes it naturally in 6 ms, with the same error and live parent signal. This deliberately uses no guard/capture, proving the public response-saving boundary owns cancellation even without a release callback. Four retained header cases cover unread/partially read bodies with oversized/malformed headers.
- Three real HTTPS llama.cpp installer equivalence scenarios: progress callback failure, actual file-write fault, and verified successful download already pass before the refactor; they still pass afterward, with the reader now unlocked. Hash, rename, mode 0600, parent signal, file handle, and partial-file cleanup are preserved. Only a task-local certificate trust addition was used and restored; TLS verification was never disabled.

The external probes contain 24 HTTP scenarios plus three HTTPS installer scenarios. The three Google scenarios are retained tests already counted below, not additional unique tests. All success observations precede forced fixture cleanup. These are actual local transport/provider-entrypoint proofs, not authenticated Google, Fish Audio, ElevenLabs, or Hugging Face API tests. No real credentials, provider usage, model load, operator service, or user capture database was involved.

Local validation: **758 tests across 34 distinct files passed**, including all changed owner tests and relevant managed-provider/MCP, capture, SSRF, media, memory, TTS, embedding-batch, Google auth, QA bus, model-catalog, and llama.cpp siblings. Post-format and corrective reruns are included, not counted twice. The final ownership correction passed all nineteen binary-helper tests, ten pooled-transport tests, sixteen ElevenLabs tests, six Fish Audio provider tests, and the seven actual transport scenarios above. The earlier media/Google correction also reran all 85 media tests, three Google transport tests, and ten capture/file-cleanup scenarios. Targeted official type-aware lint passed for the original 13 core/package files, two-file media correction, and final three core/helper test files. Extension lint preparation remains blocked locally by eleven installed-dependency declaration errors (`FinishReason`, `markdown-it`, and `pi-tui`), with no changed-file diagnostic; this is not a plugin lint pass. The actual local changed-check command passed eight guards, then its 180-second process bound interrupted the coercion guard; it is partial validation, not a full pass or a proven code failure. No dependency reconciliation or checker bypass was used. Formatting, one-file MDX, and `git diff --check` pass.

Exact repository commands for the final code/test correction are below. The test processes ran serially with `OPENCLAW_DEBUG_PROXY_ENABLED=0`, `OPENCLAW_VITEST_MAX_WORKERS=1`, task-local module caches, and a 180-second process watchdog. Type-aware lint used `GOMAXPROCS=2` and the same process bound; no checker rules or test deadlines were relaxed. The documentation also passed its one-file formatting and MDX checks.

```sh
node scripts/run-vitest.mjs src/media/fetch.test.ts src/infra/net/fetch-guard.release.test.ts
node scripts/run-vitest.mjs extensions/googlechat/src/auth.capture.transport.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json --threads=1 src/media/fetch.ts src/media/fetch.test.ts
node scripts/run-vitest.mjs src/plugin-sdk/provider-binary-stream.test.ts src/infra/net/fetch-guard.release.test.ts extensions/elevenlabs/tts.test.ts extensions/fish-audio-speech/speech-provider.test.ts
node scripts/run-vitest.mjs src/plugin-sdk/provider-binary-stream.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json --threads=1 src/plugin-sdk/provider-binary-stream.ts src/plugin-sdk/provider-binary-stream.test.ts src/infra/net/fetch-guard.release.test.ts
git diff --check
```

The exact head's [full CI run](https://github.com/openclaw/openclaw/actions/runs/33098773425) completed successfully on its first attempt: 202 jobs, 185 successful and 17 skipped, including the [aggregate gate](https://github.com/openclaw/openclaw/actions/runs/33098773425/job/98615758234). The complete 260-check inventory has 218 successes, 40 skips, one neutral result and one historical label cancellation superseded by a newer skipped label job; no failed or unfinished check remains. The [precise scan](https://github.com/openclaw/openclaw/actions/runs/33098773415/job/98610570212) and [dependency guard](https://github.com/openclaw/openclaw/actions/runs/33098640001/job/98610297925) pass.

Actual hosted execution on this head passed the [19 helper tests](https://github.com/openclaw/openclaw/actions/runs/33098773425/job/98610952072) (9 ms), [ten real pooled-transport tests](https://github.com/openclaw/openclaw/actions/runs/33098773425/job/98610951815) (106 ms), [three Google capture tests](https://github.com/openclaw/openclaw/actions/runs/33098773425/job/98610956618) (55 ms), [85 media tests](https://github.com/openclaw/openclaw/actions/runs/33098773425/job/98610951855) (408 ms), [16 ElevenLabs tests](https://github.com/openclaw/openclaw/actions/runs/33098773425/job/98610956323) (36 ms), and [six Fish Audio speech-provider tests](https://github.com/openclaw/openclaw/actions/runs/33098773425/job/98610956336) (15 ms). The [core5 type check](https://github.com/openclaw/openclaw/actions/runs/33098773425/job/98610946574) actually executed its canonical stripe for 68 seconds and passed; it did not take the historical-target skip branch.

Local runtime was Node 26.7.0 with external Undici 8.9.0. Exact upstream [Undici 8.10.0 cloning](https://github.com/nodejs/undici/blob/v8.10.0/lib/web/fetch/body.js#L254-L269) and [request abort](https://github.com/nodejs/undici/blob/v8.10.0/lib/web/fetch/index.js#L346-L375) were inspected. The current hosted transport job checked out the synthetic merge of 0644 into 834368b7 and completed its frozen-lockfile installation. The unchanged root pin and external-runtime import resolve Undici 8.10.0: this is dependency/install provenance, not a claim that the tests printed a runtime version.

CI and review corrections are retained rather than hidden. Initial CI caught a Google test's Response narrowing error; a per-case deferred preserves the same transport deadline and assertions. Review then caught the partially-read media cleanup regression described above, which received real before/after proof. The later [f488 core5 failure](https://github.com/openclaw/openclaw/actions/runs/33095549268/job/98599856241) found a test-only tuple-inference error: selecting/reversing dynamic arrays widened the two outcomes. The fixture now starts cancellation/release in the same two orders and passes their literal pair to `Promise.allSettled`; all four cases and exact error/reason assertions remain unchanged. No cast, non-null assertion, weakened assertion or production edit was added. The same local owning services graph reproduced all six errors before and removed them after; eleven installed-dependency errors remained locally, so only the new hosted success closes the full type gate.

```sh
node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.services.json --builders 1
node scripts/run-vitest.mjs src/plugin-sdk/provider-binary-stream.test.ts
```

A separate initial Linux session-lifecycle failure was traced to an independently landed [#130975](https://github.com/openclaw/openclaw/pull/130975), [22c23ba](https://github.com/openclaw/openclaw/commit/22c23ba580c676eb64adc1d5914fa37acb35d015): a provider-test fixture must restore individual environment keys instead of replacing Node's native `process.env`. An explicit same-process, provider-before-lifecycle pair changed from 33 passing/two failing to all 35 passing with that fix. The 131-file/2083-test green replay was sibling coverage because its failed-first ordering differed. This PR does not duplicate that fix; the current CI merge includes it.

The initial startup-memory gate reported 402.9 MB against a 401 MB ceiling. Paired Linux baseline/candidate diagnostics passed but had a 4-core/32-core hardware limitation. The [current head's hosted build](https://github.com/openclaw/openclaw/actions/runs/33098773425/job/98610945998) passes at 399.8 MB median against the unchanged 401 MB ceiling (samples 400.6, 317.7, 399.8 MB). No budget increase or unproved flaky classification is claimed. On an earlier efa4 head, the precise scan failed before scanning during bounded base fetches, and the dependency guard stopped during checkout before enforcement; each received one successful failed-job-only recovery. Those historical recoveries are not substitutes for the new head's results, and the new full CI was not retried.

Fresh complete twenty-one-file P2 autoreview found no actionable P0–P2 defect (0.90 confidence); separate independent source/proof and read-only Codex reviews approved every file and verified exact hashes. The committed head matches that snapshot. The latest completed ClawSweeper review covered exact head 0644 (reviewed 17:37 UTC, updated 17:52 UTC), reported no actionable finding, and independently passed all ten TCP tests. Its only remaining rank-up was green exact-head CI, which passed before landing. Canonical native review initialization, main/PR guards, artifact validation, hosted-gate preparation and the single merge command all completed successfully. Native verification reported an advisory about 25 changed infrastructure files on main; none of the 21 reviewed paths overlapped, and the default non-strict policy permitted merging without a speculative rebase. Post-merge verification confirms all 21 landed blobs match the approved snapshot and the merge is an ancestor of fetched main. The native worktree, operation lock and temporary refs were removed; the original contributor backup was preserved. [Native completion receipt](https://github.com/openclaw/openclaw/pull/111277#issuecomment-5443472056).

Contributor credit preserved: the landed commit's author is xingzhou (@zhangguiping-xydt), and its body retains the original `Co-authored-by: zhang-guiping <zhang.guiping@xydigit.com>` credit. The original PR identified the shared response-ownership problem. The rewrite is built from the trusted frozen-main baseline and separately reviewed changes; the original fork code was not executed locally.
