### PR TITLE
fix(memory-host-sdk): decode JSON response bodies with fatal UTF-8 validation

### DIFF
--- a/packages/memory-host-sdk/src/host/response-snippet.test.ts
+++ b/packages/memory-host-sdk/src/host/response-snippet.test.ts
@@ -96,4 +96,16 @@ describe("readMemoryHostResponseTextSnippet", () => {
     await expect(read).rejects.toThrow("json aborted");
     expect(canceled).toBe(true);
   });
+
+  it("rejects a JSON body with invalid UTF-8 bytes", async () => {
+    const body = new Uint8Array([
+      ...new TextEncoder().encode('{"ok":"val'),
+      0xff,
+      ...new TextEncoder().encode('ue"}'),
+    ]);
+
+    await expect(
+      readResponseJsonWithLimit(new Response(body), { errorPrefix: "remote memory" }),
+    ).rejects.toThrow(/not valid for encoding/);
+  });
 });

--- a/packages/memory-host-sdk/src/host/response-snippet.ts
+++ b/packages/memory-host-sdk/src/host/response-snippet.ts
@@ -204,7 +204,7 @@ async function readResponseTextWithLimit(
     } catch {}
   }
 
-  return new TextDecoder().decode(joinChunks(chunks, length));
+  return new TextDecoder("utf-8", { fatal: true }).decode(joinChunks(chunks, length));
 }
 
 async function cancelResponseBody(res: Response): Promise<void> {


### PR DESCRIPTION
## Summary

Decode memory-host JSON response bodies with `TextDecoder("utf-8", { fatal: true })` so malformed UTF-8 bytes throw immediately, instead of silently becoming U+FFFD inside JSON string values that `JSON.parse` then accepts.

## What Problem This Solves

`readResponseJsonWithLimit` (in `packages/memory-host-sdk/src/host/response-snippet.ts`) reads JSON response bodies for the memory-host SDK request paths (`post-json.ts`, `batch-upload.ts`). The body is read with a hard byte cap (oversized responses throw; nothing is truncated), then decoded and parsed.

- The full body was decoded with a forgiving `TextDecoder` (default `fatal: false`), so invalid byte sequences silently became U+FFFD.
- When the corruption lands inside a JSON string value, `JSON.parse` still succeeds — the corrupted payload is returned to the SDK caller as if the host had sent it.
- Since the reader enforces a byte cap by throwing (never by truncating), a strict decode cannot confuse a legitimate cap with corruption; any invalid byte is real corruption.

**Code evidence**: at [response-snippet.ts:207](packages/memory-host-sdk/src/host/response-snippet.ts#L207), `new TextDecoder().decode(...)` decodes the JSON body without UTF-8 validation.

## Root Cause

- Per the WHATWG Encoding standard, `TextDecoder()` defaults to `fatal: false`, which substitutes U+FFFD for malformed sequences instead of throwing.
- The same package already decodes batch output strictly (`batch-output.ts:24` uses `{ fatal: true }`); this JSON body path was left on the forgiving default.
- Invariant violated: "memory-host JSON response bytes are always valid UTF-8" — not guaranteed for bytes traversing the network or a misbehaving host.

## Why This Fix

Add `{ fatal: true }` to the decoder:

- Invalid bytes now throw a `TypeError` that propagates to the SDK caller alongside the path's existing hard failures (`response body too large`, `malformed JSON response`) — corrupted data is never parsed or returned.
- This matches the strict-decode pattern the package already uses in `batch-output.ts:24` and the pattern used for provider JSON bodies in `readProviderJsonResponse` ([provider-http-errors.ts:344](src/agents/provider-http-errors.ts#L344)).
- The neighboring snippet path (`readMemoryHostResponseTextSnippet`) is intentionally unchanged: it truncates at a byte cap and already handles partial trailing sequences correctly via `decodeTextPrefix({ truncated })`.
- Alternative considered: validating the parsed result for U+FFFD — rejected, because U+FFFD can be legitimate content and post-hoc scanning cannot distinguish corruption from real data.

## User Impact

- **Before**: a corrupted memory-host JSON response is silently accepted with `�` inside string values, and the corrupted result flows into batch upload/post-json callers.
- **After**: the corrupted response is rejected with a clear error (`The encoded data was not valid for encoding utf-8`) before parsing.

## Evidence

- **Before** (upstream/main): `JSON body accepted: {"ok":"val�ue"}` — **FAIL**: invalid UTF-8 byte silently became U+FFFD in the parsed JSON body
- **After** (with fix): `JSON body rejected: The encoded data was not valid for encoding utf-8` — **PASS**: corrupted JSON body rejected by fatal UTF-8 decoding

## Real Behavior Proof

Proof serves a JSON body containing a raw `0xFF` byte inside a string value from a real local HTTP server, fetches it with the real `fetch`, and passes the real `Response` through the real `readResponseJsonWithLimit`.

### Before (on main)

```bash
$ node --import tsx proof.mjs
JSON body accepted: {"ok":"val�ue"}
FAIL: invalid UTF-8 byte silently became U+FFFD in the parsed JSON body
```

### After (with fix)

```bash
$ node --import tsx proof.mjs
JSON body rejected: The encoded data was not valid for encoding utf-8
PASS: corrupted JSON body rejected by fatal UTF-8 decoding
```

## Tests and Validation

- `npx vitest run packages/memory-host-sdk/src/host/response-snippet.test.ts` — 6 passed (5 existing + 1 new)
- New regression test: `rejects a JSON body with invalid UTF-8 bytes`
- `tsgo:core` typecheck passed; `oxlint` and `oxfmt --check` clean on the changed files


## Maintainer validation on current main

The sole original contributor commit is refreshed onto upstream main `bba7b939ce3df46f6a3cc9403fd8448d023cf33f`, which already contains the canonical fixes for both previously unrelated CI failures:

- #117331 runs the existing real local/Gateway TUI PTY suite against the already-built CLI.
- Commit `20ac22f647a4212fb801930603ae7e98103208cf` enables verbose per-case PTY progress in `test/vitest/vitest.tui-pty.config.ts`, preventing buffered silent progress from tripping the nested Vitest watchdog.
- #117380 / `9214183f4528784a030402a9d0c7969fa08484a4` removes the immediately scheduled legacy gateway session-lock sidecar, duplicate dynamic imports, and session-directory scans; the unchanged real localhost health responsiveness regression passed on this base with its original strict `<1000ms` assertion.

These fixes are inherited from main and do not change the contributor patch. Refreshed exact head `3d5229531edda7b555bdd5012c387629e7b7cb47` preserves original author @zenglingbiao, original authored timestamp, commit subject, and stable patch ID `02e53f50915b8e05884b695701136bd4d5b405ee`.

Maintainer proof: **21/21 focused SDK cases**, **8/8 real SSRF-guarded localhost HTTP requests** through both production JSON POST and multipart clients (malformed raw bytes rejected before parse; valid Unicode/BOM/literal U+FFFD preserved), clean targeted formatting, and a fresh clean Sol **xhigh** review. Full hosted CI is required on this exact head before landing.

Updated proof: https://github.com/openclaw/openclaw/pull/111279#issuecomment-5150902800