### PR TITLE
fix(agents): reject non-UTF-8 MCP App sandbox CSP metadata

### DIFF
--- a/src/agents/mcp-app-sandbox.ts
+++ b/src/agents/mcp-app-sandbox.ts
@@ -102,7 +102,9 @@ export function decodeMcpAppSandboxCsp(value: string | null): McpAppCsp | undefi
   if (value.length > MCP_APP_SANDBOX_CSP_MAX_ENCODED_BYTES) {
     throw new Error("MCP App CSP metadata is too large");
   }
-  const decoded = JSON.parse(Buffer.from(value, "base64url").toString("utf8")) as unknown;
+  const decoded = JSON.parse(
+    new TextDecoder("utf-8", { fatal: true }).decode(Buffer.from(value, "base64url")),
+  ) as unknown;
   const normalized = normalizeMcpAppCsp(decoded);
   if (!normalized) {
     throw new Error("MCP App CSP metadata is not a valid policy");

--- a/src/agents/mcp-ui-resource.test.ts
+++ b/src/agents/mcp-ui-resource.test.ts
@@ -208,6 +208,17 @@ describe("MCP App UI resources", () => {
     },
   );
 
+  it("rejects CSP metadata with invalid UTF-8 instead of silently narrowing it", () => {
+    const value = Buffer.concat([
+      Buffer.from('{"connectDomains":["https://api.example.com","https://cdn-'),
+      Buffer.from([0xff]),
+      Buffer.from('.example.com"]}'),
+    ]).toString("base64url");
+    // A forgiving decode would drop the corrupted domain and accept the rest of
+    // the policy, violating the malformed-input-must-throw contract.
+    expect(() => decodeMcpAppSandboxCsp(value)).toThrow();
+  });
+
   it("builds proxy HTML", () => {
     const proxyHtml = buildMcpAppSandboxProxyHtml();
     expect(proxyHtml).toContain('inner.setAttribute("sandbox", "allow-scripts allow-forms")');


### PR DESCRIPTION
## Summary

Reject MCP App sandbox CSP metadata whose base64url payload is not valid UTF-8, so a corrupted policy can no longer be silently narrowed (corrupted domain entries dropped) and served as if it were the declared one.

## What Problem This Solves

The gateway sandbox endpoint (`src/gateway/mcp-app-sandbox-http.ts`) decodes untrusted CSP metadata from the `csp` query parameter via `decodeMcpAppSandboxCsp` (`src/agents/mcp-app-sandbox.ts`). The module documents its contract explicitly: *"Malformed input must throw: the gateway sandbox endpoint relies on it to fail closed with 400 instead of serving proxy HTML under a default policy."*

- The payload was decoded with a forgiving UTF-8 conversion (`Buffer.from(value, "base64url").toString("utf8")`), so invalid byte sequences silently became U+FFFD.
- `JSON.parse` still succeeds when the corruption lands inside a string value.
- Domain entries are validated against an ASCII pattern that U+FFFD never matches, so corrupted entries are **silently dropped** — and the remaining policy is accepted. The sandbox is then served under a narrowed CSP with no error: declared domains disappear, app requests get blocked, and nobody is told the metadata was malformed.

**Code evidence**: at [mcp-app-sandbox.ts:105](src/agents/mcp-app-sandbox.ts#L105), the CSP metadata is decoded without UTF-8 validation.

## Root Cause

- Node's `Buffer.toString("utf8")` (like `TextDecoder` with `fatal: false`) substitutes U+FFFD for malformed byte sequences instead of throwing.
- Structural validation (`normalizeMcpAppCsp`) operates on the already-decoded value and can only drop what does not match — it cannot tell "entry corrupted by U+FFFD" from "entry the author never wrote", so the fail-closed contract is bypassed one entry at a time.
- Invariant violated: "a present CSP metadata value is always valid UTF-8 JSON" — the value is attacker-influenced input to a public endpoint.

## Why This Fix

Decode with `TextDecoder("utf-8", { fatal: true })`:

- Invalid bytes now throw a `TypeError` before parsing, which the endpoint's existing `try/catch` maps to the designed `400 invalid MCP App sandbox policy` response — malformed input fails closed exactly as the module contract requires, instead of being served in silently narrowed form.
- Well-formed policies are unaffected (round-trip unchanged), and the endpoint's behavior for every other malformed-input class (non-base64url, non-JSON, invalid policy) is unchanged.
- This is the same strict-decode pattern already used for provider JSON bodies in `readProviderJsonResponse` ([provider-http-errors.ts:344](src/agents/provider-http-errors.ts#L344)).
- Alternative considered: treating dropped domains as an error inside `normalizeMcpAppCsp` — rejected, because normalization is also used on the trusted encode path, where silently filtering unsupported entries is intentional; the decode boundary is the right place to fail closed.

## User Impact

- **Before**: a corrupted (or crafted) CSP metadata value is accepted with corrupted domains silently removed; the sandboxed app breaks (its declared connections are blocked) with no indication the metadata was malformed.
- **After**: malformed metadata is rejected with a 400, and only byte-valid policies are served.

## Evidence

- **Before** (upstream/main): `corrupt metadata accepted as: {"connectDomains":["https://api.example.com"]}` — **FAIL**: corrupted domain silently dropped, sandbox served under a narrowed policy
- **After** (with fix): `corrupt metadata rejected: The encoded data was not valid for encoding utf-8` — **PASS**: malformed CSP metadata throws, gateway fails closed with 400

## Real Behavior Proof

Proof calls the real `buildMcpAppSandboxPath`/`decodeMcpAppSandboxCsp` with a metadata payload containing a raw `0xFF` byte inside one of two declared connect domains, plus a well-formed policy as a round-trip control.

### Before (on main)

```bash
$ node --import tsx proof.mjs
valid policy round-trips: {"connectDomains":["https://api.example.com","https://cdn.example.com"]}
corrupt metadata accepted as: {"connectDomains":["https://api.example.com"]}
FAIL: corrupted domain silently dropped, sandbox served under a narrowed policy
```

### After (with fix)

```bash
$ node --import tsx proof.mjs
valid policy round-trips: {"connectDomains":["https://api.example.com","https://cdn.example.com"]}
corrupt metadata rejected: The encoded data was not valid for encoding utf-8
PASS: malformed CSP metadata throws, gateway fails closed with 400
```

## Tests and Validation

- `npx vitest run src/agents/mcp-ui-resource.test.ts` — 30 passed (29 existing + 1 new)
- New regression test: `rejects CSP metadata with invalid UTF-8 instead of silently narrowing it`
- `tsgo:core` typecheck passed; `oxlint` and `oxfmt --check` clean on the changed files
