### PR TITLE
fix(plugin-sdk): decode live model catalog JSON with fatal UTF-8 validation

### DIFF
--- a/src/plugin-sdk/provider-catalog-live-runtime.test.ts
+++ b/src/plugin-sdk/provider-catalog-live-runtime.test.ts
@@ -149,6 +149,29 @@ describe("provider-catalog-live-runtime", () => {
     expect(release).toHaveBeenCalledTimes(1);
   });
 
+  it("rejects a live catalog response with invalid UTF-8 bytes", async () => {
+    const release = vi.fn(async () => undefined);
+    const body = new Uint8Array([
+      ...new TextEncoder().encode('{"data":[{"id":"model-a","object":"model"},{"id":"model-b'),
+      0xff,
+      ...new TextEncoder().encode('","object":"model"}]}'),
+    ]);
+    const fetchGuardMock: MockedFunction<LiveModelCatalogFetchGuard> = vi.fn(async () => ({
+      response: new Response(body),
+      finalUrl: "https://provider.example.test/v1/models",
+      release,
+    }));
+
+    await expect(
+      fetchLiveProviderModelIds({
+        providerId: "provider",
+        endpoint: "https://provider.example.test/v1/models",
+        fetchGuard: fetchGuardMock,
+      }),
+    ).rejects.toThrow(/not valid for encoding/);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
   it("follows next_cursor pagination before projecting model ids", async () => {
     const release = vi.fn(async () => undefined);
     const fetchGuardMock: MockedFunction<LiveModelCatalogFetchGuard> = vi

--- a/src/plugin-sdk/provider-catalog-live-runtime.ts
+++ b/src/plugin-sdk/provider-catalog-live-runtime.ts
@@ -157,7 +157,7 @@ async function readLiveModelCatalogJson(response: Response, timeoutMs: number): 
     onIdleTimeout: ({ chunkTimeoutMs }) =>
       new Error(`Live model catalog response stalled: no data received for ${chunkTimeoutMs}ms`),
   });
-  return JSON.parse(new TextDecoder().decode(buffer));
+  return JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(buffer));
 }
 
 function readLiveModelCatalogString(value: unknown): string | undefined {


### PR DESCRIPTION
## Summary

Decode live model catalog responses with `TextDecoder("utf-8", { fatal: true })` so malformed UTF-8 bytes throw immediately, instead of silently becoming U+FFFD inside model IDs that then enter model selection.

## What Problem This Solves

`readLiveModelCatalogJson` (in `src/plugin-sdk/provider-catalog-live-runtime.ts`) parses the JSON body of live provider model-catalog endpoints (`/v1/models`-style discovery). Those endpoints are external infrastructure — proxies, gateways, or the provider itself can deliver invalid UTF-8 byte sequences.

- The body was decoded with a forgiving `TextDecoder` (default `fatal: false`), so invalid bytes silently became U+FFFD.
- When the corruption lands inside a JSON string value (e.g. inside a model id), `JSON.parse` still succeeds.
- The corrupted model id (e.g. `model-b�`) is returned by `fetchLiveProviderModelIds` and enters model selection; every subsequent request against that id then fails on the provider side with an unknown-model error.

**Code evidence**: at [provider-catalog-live-runtime.ts:160](src/plugin-sdk/provider-catalog-live-runtime.ts#L160), `JSON.parse(new TextDecoder().decode(buffer))` decodes the catalog response without UTF-8 validation.

## Root Cause

- Per the WHATWG Encoding standard, `TextDecoder()` defaults to `fatal: false`, which substitutes U+FFFD for malformed sequences instead of throwing.
- Model id projection (`readLiveModelCatalogString`) only checks that values are non-empty strings, so it cannot detect byte-level corruption after U+FFFD substitution.
- Invariant violated: "catalog response bytes are always valid UTF-8" — not guaranteed for bytes traversing external infrastructure.

## Why This Fix

Add `{ fatal: true }` to the decoder:

- Invalid bytes now throw a `TypeError`, which propagates through the same path a malformed JSON body already takes (`JSON.parse` errors were never wrapped here), and live discovery fails instead of accepting corrupted ids; the existing fallback-to-static-rows behavior for failed discovery still applies downstream.
- **BOM compatibility is deliberately preserved**: the existing `accepts UTF-8 BOM-prefixed catalog responses` behavior depends on the decoder's default BOM stripping (a leading BOM is valid UTF-8, so it decodes fine and is stripped before `JSON.parse`). Only `fatal: true` is added; `ignoreBOM` stays at its default so BOM-prefixed catalogs from real-world providers keep working.
- This is the same strict-decode pattern already used for provider JSON bodies in `readProviderJsonResponse` ([provider-http-errors.ts:344](src/agents/provider-http-errors.ts#L344)).
- Alternative considered: validating projected model ids for U+FFFD — rejected, because U+FFFD can be legitimate content and post-hoc scanning cannot distinguish corruption from real data.

## User Impact

- **Before**: a corrupted catalog response silently registers a model id containing `�`; selecting that model makes every request fail with an unknown-model error.
- **After**: the corrupted catalog response is rejected with a clear decode error, and discovery falls back instead of accepting corrupted ids.

## Evidence

- **Before** (upstream/main): `discovered model ids: ["model-a","model-b�"]` — **FAIL**: invalid UTF-8 byte silently became U+FFFD in a discovered model id
- **After** (with fix): `discovery rejected: The encoded data was not valid for encoding utf-8` — **PASS**: corrupted catalog response rejected, no model id accepted

## Real Behavior Proof

Proof serves a catalog body containing a raw `0xFF` byte inside the second model id from a real local HTTP server, then runs the real `fetchLiveProviderModelIds` against it through the default guarded fetch.

### Before (on main)

```bash
$ node --import tsx proof.mjs
discovered model ids: ["model-a","model-b�"]
FAIL: invalid UTF-8 byte silently became U+FFFD in a discovered model id
```

### After (with fix)

```bash
$ node --import tsx proof.mjs
discovery rejected: The encoded data was not valid for encoding utf-8
PASS: corrupted catalog response rejected, no model id accepted
```

## Tests and Validation

- `npx vitest run src/plugin-sdk/provider-catalog-live-runtime.test.ts` — 20 passed (19 existing + 1 new), including the pre-existing `accepts UTF-8 BOM-prefixed catalog responses` compatibility test
- New regression test: `rejects a live catalog response with invalid UTF-8 bytes`
- `tsgo:core` typecheck passed; `oxlint` and `oxfmt --check` clean on the changed files
