### PR TITLE
fix(docs): decode docs search responses with fatal UTF-8 validation

### DIFF
--- a/src/commands/docs.test.ts
+++ b/src/commands/docs.test.ts
@@ -105,6 +105,25 @@ describe("docsSearchCommand", () => {
     expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 
+  it("reports docs search responses with invalid UTF-8 bytes as malformed", async () => {
+    const body = new Uint8Array([
+      ...new TextEncoder().encode('{"results":[{"title":"Plugin allow'),
+      0xff,
+      ...new TextEncoder().encode('list","link":"https://docs.openclaw.ai/plugins/allowlist"}]}'),
+    ]);
+    fetchMock.mockResolvedValueOnce(
+      new Response(body, { headers: { "Content-Type": "application/json" } }),
+    );
+    const runtime = makeRuntime();
+
+    await docsSearchCommand(["plugin"], runtime);
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      "Docs search failed: Docs search response is malformed JSON",
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+
   it("renders successful results from the Cloudflare docs search API", async () => {
     fetchMock.mockResolvedValueOnce(
       new Response(

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -83,7 +83,9 @@ async function fetchDocsSearch(query: string): Promise<DocResult[]> {
     });
     let payload: DocsSearchResponse;
     try {
-      payload = JSON.parse(new TextDecoder().decode(bytes)) as DocsSearchResponse;
+      payload = JSON.parse(
+        new TextDecoder("utf-8", { fatal: true }).decode(bytes),
+      ) as DocsSearchResponse;
     } catch (cause) {
       throw new Error("Docs search response is malformed JSON", { cause });
     }


### PR DESCRIPTION
## Summary

Decode docs search API responses with `TextDecoder("utf-8", { fatal: true })` so malformed UTF-8 bytes throw immediately, instead of silently becoming U+FFFD inside result titles, links, and snippets rendered to the user's terminal.

## What Problem This Solves

`openclaw docs <query>` fetches the hosted docs search API (`fetchDocsSearch` in `src/commands/docs.ts`) and renders the returned titles, links, and snippets directly to the terminal.

- The response body was decoded with a forgiving `TextDecoder` (default `fatal: false`), so invalid byte sequences silently became U+FFFD.
- When the corruption lands inside a JSON string value (a title, link, or snippet), `JSON.parse` still succeeds and `parseDocsSearchResults` accepts the entry — it only checks field types.
- The user then sees silently corrupted search results (e.g. `Plugin allow�list`) presented as genuine docs content, with no error anywhere.

**Code evidence**: at [docs.ts:86](src/commands/docs.ts#L86), `JSON.parse(new TextDecoder().decode(bytes))` decodes the search API response without UTF-8 validation.

## Root Cause

- Per the WHATWG Encoding standard, `TextDecoder()` defaults to `fatal: false`, which substitutes U+FFFD for malformed sequences instead of throwing.
- `parseDocsSearchResults` validates only that `title`/`link`/`snippet` are strings, so it cannot detect byte-level corruption after U+FFFD substitution.
- Invariant violated: "docs search response bytes are always valid UTF-8" — not guaranteed for bytes served through a CDN edge or proxy.

## Why This Fix

Add `{ fatal: true }` to the decoder:

- Invalid bytes now throw a `TypeError`, which the adjacent existing `try/catch` wraps into the established `Docs search response is malformed JSON` error; the command follows its current report-and-`exit(1)` path — fully backward compatible.
- This is the same strict-decode pattern already used for provider JSON bodies in `readProviderJsonResponse` ([provider-http-errors.ts:344](src/agents/provider-http-errors.ts#L344)).
- Alternative considered: filtering rendered results for U+FFFD — rejected, because U+FFFD can be legitimate content and post-hoc scanning cannot distinguish corruption from real data.

## User Impact

- **Before**: a corrupted docs search response renders titles/snippets containing `�` to the user as if they were genuine docs content.
- **After**: the corrupted response is reported as malformed (`Docs search failed: Docs search response is malformed JSON`) and nothing corrupted is rendered.

## Evidence

- **Before** (upstream/main @ 59b2fbbb4b4): real CLI run prints `- [Plugin allow�list](https://docs.openclaw.ai/plugins/allowlist) - Configure plugin allowlists` and exits 0 — **FAIL**: invalid UTF-8 byte silently became U+FFFD in rendered docs results
- **After** (with fix): real CLI run prints `Docs search failed: Docs search response is malformed JSON` and exits 1 — **PASS**: corrupted docs response reported as malformed, nothing corrupted rendered

## Real Behavior Proof

Setup: `docs.openclaw.ai` is pointed at a local HTTPS stand-in (`127.0.0.1` via `/etc/hosts`; leaf certificate for `docs.openclaw.ai` issued by a throwaway local CA, trusted through `NODE_EXTRA_CA_CERTS`) that serves a docs search body containing a raw `0xFF` byte inside a result title. The real CLI entry (`src/entry.ts` — the source file of `dist/entry.js`) is then executed end-to-end with proxy environment variables cleared, and its actual terminal output and exit code are captured. No fetch stubbing: the corrupted bytes arrive over a real TLS socket from a real HTTP server, exercising the full `openclaw docs` command path (argument parsing → `fetchDocsSearch` → byte-capped read → decode → render).

### Before (on main)

```bash
$ node --import tsx src/entry.ts docs "plugin allowlist"
# Docs search: plugin allowlist

- [Plugin allow�list](https://docs.openclaw.ai/plugins/allowlist) - Configure plugin allowlists
EXIT=0
```

FAIL: the invalid UTF-8 byte silently became U+FFFD inside the rendered result title, and the command exits 0 presenting corrupted docs content as genuine.

### After (with fix)

```bash
$ node --import tsx src/entry.ts docs "plugin allowlist"
Docs search failed: Docs search response is malformed JSON
EXIT=1
```

PASS: the corrupted response is rejected through the established error path and nothing corrupted is rendered.

## Tests and Validation

- `npx vitest run src/commands/docs.test.ts` — 6 passed (5 existing + 1 new)
- New regression test: `reports docs search responses with invalid UTF-8 bytes as malformed`
- `tsgo:core` typecheck passed; `oxlint` and `oxfmt --check` clean on the changed files
