### PR TITLE
fix(googlechat): cancel unread fetchOk bodies before release

### DIFF
--- a/extensions/googlechat/src/api.fetchok.transport.test.ts
+++ b/extensions/googlechat/src/api.fetchok.transport.test.ts
@@ -1,0 +1,113 @@
+// Real-transport proof: Google Chat fetchOk (DELETE) cancels unread bodies.
+// fetchWithSsrFGuard is proxied to undici fetch and rewritten onto loopback so
+// production withGoogleChatResponse cancel/release still runs on a real Response.
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ResolvedGoogleChatAccount } from "./accounts.js";
+
+const loopback = vi.hoisted(() => ({ baseUrl: "" }));
+
+const fetchWithSsrFGuardMock = vi.hoisted(() =>
+  vi.fn(async (params: { url: string; init?: RequestInit }) => {
+    const url = params.url.replace("https://chat.googleapis.com", loopback.baseUrl);
+    const response = await fetch(url, params.init);
+    return {
+      response,
+      finalUrl: url,
+      release: async () => {},
+    };
+  }),
+);
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
+  return {
+    ...actual,
+    fetchWithSsrFGuard: (...args: unknown[]) =>
+      fetchWithSsrFGuardMock(...(args as [{ url: string; init?: RequestInit }])),
+  };
+});
+
+vi.mock("./auth.js", () => ({
+  getGoogleChatAccessToken: vi.fn(async () => "test-access-token"),
+}));
+
+let deleteGoogleChatMessage: typeof import("./api.js").deleteGoogleChatMessage;
+
+async function listen(server: ReturnType<typeof createServer>): Promise<string> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address() as AddressInfo;
+  return `http://127.0.0.1:${address.port}`;
+}
+
+describe("deleteGoogleChatMessage fetchOk body cleanup", () => {
+  beforeAll(async () => {
+    ({ deleteGoogleChatMessage } = await import("./api.js"));
+  });
+
+  beforeEach(() => {
+    fetchWithSsrFGuardMock.mockClear();
+    loopback.baseUrl = "";
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("cancels unread successful DELETE bodies and closes the request socket", async () => {
+    let resolveClosed: (() => void) | undefined;
+    const closed = new Promise<void>((resolve) => {
+      resolveClosed = resolve;
+    });
+    let deleteSeen = false;
+
+    const server = createServer((request, response) => {
+      if (request.method === "DELETE") {
+        deleteSeen = true;
+        request.socket.once("close", () => resolveClosed?.());
+        // Keep the success body open: status-only fetchOk must cancel.
+        response.writeHead(200, { "Content-Type": "application/json" });
+        response.write("{}");
+        return;
+      }
+      response.writeHead(404);
+      response.end();
+    });
+
+    loopback.baseUrl = await listen(server);
+    const account = {
+      accountId: "default",
+      enabled: true,
+      config: {},
+      credentialSource: "env",
+    } as ResolvedGoogleChatAccount;
+
+    try {
+      await expect(
+        deleteGoogleChatMessage({
+          account,
+          messageName: "spaces/AAA/messages/BBB",
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(deleteSeen).toBe(true);
+      await expect(closed).resolves.toBeUndefined();
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          auditContext: "googlechat.api.ok",
+        }),
+      );
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+});

--- a/extensions/googlechat/src/api.ts
+++ b/extensions/googlechat/src/api.ts
@@ -99,6 +99,11 @@ async function withGoogleChatResponse<T>(params: {
     }
     return await handleResponse(response);
   } finally {
+    // fetchOk (status-only) leaves the body unread. JSON/buffer handlers set
+    // bodyUsed first. release() does not cancel streams.
+    if (!response.bodyUsed) {
+      await response.body?.cancel().catch(() => undefined);
+    }
     await release();
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Google Chat status-only API calls (`fetchOk`, used by `deleteGoogleChatMessage`)
go through `withGoogleChatResponse` → `fetchWithSsrFGuard`, then only need the
HTTP status. The `finally` path called `release()` without cancelling an unread
response body. `release()` tears down the SSRF dispatcher but does **not**
cancel streams, so undici can keep the TCP connection pinned after a successful
DELETE (or any other `fetchOk` caller).

JSON/buffer helpers already consume the body (`bodyUsed`), so only status-only
success paths leaked.

## Why This Change Was Made

In `withGoogleChatResponse`'s `finally`, cancel the unread body when
`!response.bodyUsed` before `release()`. That covers `fetchOk` without changing
`fetchJson` / `fetchBuffer` (they set `bodyUsed` first). Error responses already
consume the body via `readGoogleChatErrorResponse`.

## User Impact

**Before:** A Chat API endpoint that streams or holds a successful status-only
body could leave the request socket open after delete (or other `fetchOk`)
returned.

**After:** Status-only successes cancel the unread body and release the socket
promptly. JSON/media reads and error parsing are unchanged.

## Evidence

- Changed: `extensions/googlechat/src/api.ts`,
  `extensions/googlechat/src/api.fetchok.transport.test.ts`
- Production path: `deleteGoogleChatMessage` → `fetchOk` →
  `withGoogleChatResponse` → `fetchWithSsrFGuard`
  (`auditContext: "googlechat.api.ok"`) → cancel unread → `release()`
- Compatibility: no Google Chat API / timeout / SSRF policy changes

## Real behavior proof

### Behavior or issue addressed

Successful Google Chat `fetchOk` (DELETE) must cancel unread bodies. Without
cancel, a streaming 200 body that never ends keeps
`serverObservedSocketClose: false` 250ms after the call returns.

### Canonical reachability path

`deleteGoogleChatMessage` → `fetchOk` → `withGoogleChatResponse` →
`fetchWithSsrFGuard` DELETE → status OK → `finally` cancel unread → `release()`

### Shared helper / provider constraint check

Uses existing `fetchWithSsrFGuard`. Same undici consume-or-cancel contract as
cron preflight / Discord voice CDN status-only paths
(#111226 / #111269).

### Real environment tested

**Production `deleteGoogleChatMessage` transport test** (committed): loopback
open-body DELETE; SSRF guard proxied to undici `fetch` and rewritten onto
loopback so the Chat hostname can be exercised locally; production
cancel/`release` still run on a real `Response`. Auth is stubbed
(`getGoogleChatAccessToken`).

**Cancel+release contract before/after** (same open-stream DELETE shape):

Negative control (no cancel):

```text
{"productionPath":"withGoogleChatResponse finally cancel+release (fetchOk/DELETE)","cancel":false,"returnedAtMs":23,"serverObservedSocketClose":false,"socketCloseAfterStartMs":null,"status":200}
```

After cancel:

```text
{"productionPath":"withGoogleChatResponse finally cancel+release (fetchOk/DELETE)","cancel":true,"returnedAtMs":22,"serverObservedSocketClose":true,"socketCloseAfterStartMs":23,"status":200}
```

macOS, Node v22.23.1.

### Evidence after fix

```text
node scripts/run-vitest.mjs \
  extensions/googlechat/src/api.fetchok.transport.test.ts \
  --reporter=verbose

 Test Files  1 passed (1)
      Tests  1 passed (1)
[test] passed 1 Vitest shard in 36.58s
```

```text
./node_modules/.bin/oxfmt --check \
  extensions/googlechat/src/api.ts \
  extensions/googlechat/src/api.fetchok.transport.test.ts
All matched files use the correct format.
```

Premise: Undici requires every response body to be consumed or canceled.

AI-assisted: Yes.
