### PR TITLE
fix: keep release check output tails utf8-safe

### DIFF
--- a/scripts/lib/cross-os-release-checks/process.ts
+++ b/scripts/lib/cross-os-release-checks/process.ts
@@ -13,6 +13,7 @@ import {
   type Socket,
 } from "node:net";
 import { dirname } from "node:path";
+import { StringDecoder } from "node:string_decoder";
 import { buildCmdExeCommandLine, resolveWindowsCmdExePath } from "../../windows-cmd-helpers.mjs";
 import { resolveWindowsTaskkillPath } from "../windows-taskkill.mjs";
 import type {
@@ -235,10 +236,18 @@ function resolveCommandCaptureLimit(options: CommandOptions) {
   return Math.max(1, Math.floor(value));
 }
 
+function decodeUtf8SuffixTail(buffer: Buffer) {
+  let start = 0;
+  while (start < buffer.length && (buffer[start]! & 0b1100_0000) === 0b1000_0000) {
+    start += 1;
+  }
+  return new StringDecoder("utf8").write(buffer.subarray(start));
+}
+
 function appendBoundedCommandOutput(current: string, chunk: Uint8Array | string, maxBytes: number) {
   const chunkBuffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk));
   if (chunkBuffer.byteLength >= maxBytes) {
-    return chunkBuffer.subarray(chunkBuffer.byteLength - maxBytes).toString("utf8");
+    return decodeUtf8SuffixTail(chunkBuffer.subarray(chunkBuffer.byteLength - maxBytes));
   }
 
   const currentBuffer = Buffer.from(current);
@@ -249,7 +258,7 @@ function appendBoundedCommandOutput(current: string, chunk: Uint8Array | string,
 
   const currentTailBytes = maxBytes - chunkBuffer.byteLength;
   const currentTail = currentBuffer.subarray(currentBuffer.byteLength - currentTailBytes);
-  return Buffer.concat([currentTail, chunkBuffer], maxBytes).toString("utf8");
+  return decodeUtf8SuffixTail(Buffer.concat([currentTail, chunkBuffer], maxBytes));
 }
 
 export async function runCommand(

--- a/test/scripts/openclaw-cross-os-release-checks.test.ts
+++ b/test/scripts/openclaw-cross-os-release-checks.test.ts
@@ -1444,6 +1444,39 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
     }
   });
 
+  it("keeps bounded command stdout and stderr tails UTF-8 safe", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "openclaw-cross-os-run-command-utf8-"));
+    try {
+      const logPath = join(dir, "command.log");
+      const result = await runCommand(
+        process.execPath,
+        [
+          "-e",
+          [
+            "const payload = 'old\\u{1f4a5}tail';",
+            "process.stdout.write(payload);",
+            "process.stderr.write(payload);",
+          ].join(""),
+        ],
+        {
+          cwd: dir,
+          env: process.env,
+          logPath,
+          maxOutputBytes: 7,
+        },
+      );
+
+      expect(result.stdout).toBe("tail");
+      expect(result.stderr).toBe("tail");
+      expect(result.stdout).not.toContain("\uFFFD");
+      expect(result.stderr).not.toContain("\uFFFD");
+      expect(Buffer.byteLength(result.stdout, "utf8")).toBeLessThanOrEqual(7);
+      expect(Buffer.byteLength(result.stderr, "utf8")).toBeLessThanOrEqual(7);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("flushes command logs before resolving", async () => {
     const dir = mkdtempSync(join(tmpdir(), "openclaw-cross-os-run-command-flush-"));
     try {


### PR DESCRIPTION
AI-assisted: yes

## What Problem This Solves

Fixes an issue where cross-OS release-check command diagnostics could print malformed replacement characters when the bounded output tail began inside a multibyte UTF-8 character. That made release-check failures harder to inspect for non-ASCII logs.

## Why This Change Was Made

The release-check process helper now decodes retained output tails from a valid UTF-8 boundary while preserving the existing byte cap. This keeps diagnostics bounded and readable without changing command execution behavior.

Related independent bug-family PRs: this is one UTF-8-safe bounded-output fix. It is independent of the plugin update proof-tail fix and does not depend on any other branch.

## User Impact

Release-check diagnostics remain size-bounded and are easier to read when command output contains non-ASCII text near the retained tail boundary.

## Evidence

Current head: `7c3c2b371440cabcf56eb761605f0e9ea91f1852`

- `node scripts/run-vitest.mjs test/scripts/openclaw-cross-os-release-checks.test.ts -t "UTF-8"` passed after rebasing onto current `upstream/main`.
- `git diff --check upstream/main..HEAD` passed.