### PR TITLE
fix(memory-wiki): bound apply body file reads

### DIFF
--- a/extensions/memory-wiki/src/cli.test.ts
+++ b/extensions/memory-wiki/src/cli.test.ts
@@ -192,6 +192,95 @@ describe("memory-wiki cli", () => {
     );
   });
 
+  it("registers apply synthesis with --body-file and writes a synthesis page", async () => {
+    const { rootDir, config } = await createCliVault();
+    const bodyFile = path.join(rootDir, "synthesis-body.md");
+    await fs.mkdir(rootDir, { recursive: true });
+    await fs.writeFile(bodyFile, "Alpha from body file.", "utf8");
+    const program = new Command();
+    program.name("test");
+    registerWikiCli(program, { config });
+
+    await program.parseAsync(
+      [
+        "wiki",
+        "apply",
+        "synthesis",
+        "CLI Body File",
+        "--body-file",
+        bodyFile,
+        "--source-id",
+        "source.alpha",
+      ],
+      { from: "user" },
+    );
+
+    const page = await fs.readFile(path.join(rootDir, "syntheses", "cli-body-file.md"), "utf8");
+    expect(page).toContain("Alpha from body file.");
+    expect(page).toContain("source.alpha");
+  });
+
+  it("accepts apply synthesis --body-file at the byte limit", async () => {
+    const { rootDir, config } = await createCliVault();
+    const bodyFile = path.join(rootDir, "limit-synthesis-body.md");
+    await fs.mkdir(rootDir, { recursive: true });
+    await fs.writeFile(bodyFile, "A".repeat(1_048_576), "utf8");
+    const program = new Command();
+    program.name("test");
+    registerWikiCli(program, { config });
+
+    await program.parseAsync(
+      [
+        "wiki",
+        "apply",
+        "synthesis",
+        "Limit Body File",
+        "--body-file",
+        bodyFile,
+        "--source-id",
+        "source.alpha",
+      ],
+      { from: "user" },
+    );
+
+    await expect(
+      fs.stat(path.join(rootDir, "syntheses", "limit-body-file.md")),
+    ).resolves.toBeDefined();
+  });
+
+  it("rejects oversized apply synthesis --body-file before writing a synthesis page", async () => {
+    const { rootDir, config } = await createCliVault();
+    const bodyFile = path.join(rootDir, "oversized-synthesis-body.md");
+    await fs.mkdir(rootDir, { recursive: true });
+    await fs.writeFile(bodyFile, "A".repeat(1_048_577), "utf8");
+    const program = new Command();
+    program.name("test");
+    registerWikiCli(program, { config });
+
+    await expect(
+      program.parseAsync(
+        [
+          "wiki",
+          "apply",
+          "synthesis",
+          "Too Large",
+          "--body-file",
+          bodyFile,
+          "--source-id",
+          "source.alpha",
+        ],
+        { from: "user" },
+      ),
+    ).rejects.toThrow(
+      "wiki apply synthesis --body-file is limited to 1048576 bytes.",
+    );
+    await expect(
+      fs.stat(path.join(rootDir, "syntheses", "too-large.md")),
+    ).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
   it("resolves --agent for local commands and requires it with multiple agent vaults", async () => {
     const { rootDir, config } = await createCliVault({
       config: { vault: { scope: "agent" } },

--- a/extensions/memory-wiki/src/cli.ts
+++ b/extensions/memory-wiki/src/cli.ts
@@ -58,12 +58,42 @@ const GATEWAY_TERMINAL_STRING_MAX_CHARS = 2_000;
 const GATEWAY_RESPONSE_MAX_ARRAY_ITEMS = 10_000;
 const GATEWAY_RESPONSE_MAX_STRING_CHARS = 10_000;
 const GATEWAY_RESPONSE_MAX_CODE_CHARS = 256;
+const WIKI_APPLY_BODY_FILE_MAX_BYTES = 1_048_576;
+const WIKI_APPLY_BODY_FILE_READ_CHUNK_BYTES = 64 * 1024;
 const ANSI_ESCAPE_SEQUENCE_PATTERN = new RegExp(
   String.raw`(?:\x1B\[[0-?]*[ -/]*[@-~]|\x1B[@-Z\\-_]|\x9B[0-?]*[ -/]*[@-~])`,
   "g",
 );
 const TERMINAL_CONTROL_CHARACTER_PATTERN = new RegExp(String.raw`[\x00-\x1F\x7F-\x9F]+`, "g");
 const UNICODE_FORMAT_CONTROL_PATTERN = /[\u061C\u200B-\u200F\u202A-\u202E\u2060-\u206F\uFEFF]/g;
+
+async function readWikiApplyBodyFile(bodyFile: string): Promise<string> {
+  const handle = await fs.open(bodyFile, "r");
+  try {
+    const chunks: Buffer[] = [];
+    let totalBytesRead = 0;
+    while (totalBytesRead <= WIKI_APPLY_BODY_FILE_MAX_BYTES) {
+      const remainingBytes = WIKI_APPLY_BODY_FILE_MAX_BYTES + 1 - totalBytesRead;
+      const buffer = Buffer.alloc(
+        Math.min(WIKI_APPLY_BODY_FILE_READ_CHUNK_BYTES, remainingBytes),
+      );
+      const { bytesRead } = await handle.read(buffer, 0, buffer.length, totalBytesRead);
+      if (bytesRead === 0) {
+        break;
+      }
+      chunks.push(buffer.subarray(0, bytesRead));
+      totalBytesRead += bytesRead;
+    }
+    if (totalBytesRead > WIKI_APPLY_BODY_FILE_MAX_BYTES) {
+      throw new Error(
+        `wiki apply synthesis --body-file is limited to ${WIKI_APPLY_BODY_FILE_MAX_BYTES} bytes.`,
+      );
+    }
+    return Buffer.concat(chunks, totalBytesRead).toString("utf8");
+  } finally {
+    await handle.close();
+  }
+}
 
 type WikiStatusCommandOptions = {
   json?: boolean;
@@ -380,7 +410,7 @@ async function resolveWikiApplyBody(params: { body?: string; bodyFile?: string }
     return params.body;
   }
   if (params.bodyFile?.trim()) {
-    return await fs.readFile(params.bodyFile, "utf8");
+    return await readWikiApplyBodyFile(params.bodyFile);
   }
   throw new Error("wiki apply synthesis requires --body or --body-file.");
 }


### PR DESCRIPTION
AI-assisted: yes

## What Problem This Solves

Fixes an issue where `openclaw wiki apply synthesis --body-file` could read an arbitrarily large file into memory before writing a synthesis page. Large or accidental inputs could make the local CLI consume much more memory than the command needs.

## Why This Change Was Made

The CLI now reads at most one byte past the accepted body-file limit and rejects oversized inputs before creating the synthesis page. Inline `--body` behavior is unchanged.

Related independent bug-family PRs: this is the bounded file-read fix in the wave. It is independent of the UTF-8 tail fixes and has no stacked dependency.

## User Impact

Users get a clear error for oversized synthesis body files, and normal body-file synthesis still works at and below the documented limit.

## Evidence

Current head: `53df762bb860699a65ee9c21d3e72412d3e3fbde`

- `node scripts/run-vitest.mjs extensions/memory-wiki/src/cli.test.ts -t "body-file"` passed after rebasing onto current `upstream/main`.
- `git diff --check upstream/main..HEAD` passed.