### PR TITLE
feat(ui): Swarm progress widget — dot grid per swarm group (#110325)

### DIFF
--- a/src/gateway/session-event-payload.ts
+++ b/src/gateway/session-event-payload.ts
@@ -43,6 +43,7 @@ export function buildGatewaySessionEventFields(params: {
     lastReadAt: sessionRow.lastReadAt,
     lastActivityAt: sessionRow.lastActivityAt,
     spawnedBy: sessionRow.spawnedBy,
+    swarmGroupId: sessionRow.swarmGroupId,
     spawnedWorkspaceDir: sessionRow.spawnedWorkspaceDir,
     spawnedCwd: sessionRow.spawnedCwd,
     forkedFromParent: sessionRow.forkedFromParent,

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -208,6 +208,23 @@ describe("gateway session utils", () => {
     expect(row.unread).toBe(expected);
   });
 
+  test("projects swarm collector group ids to list and live session payloads", () => {
+    const row = buildGatewaySessionRow({
+      cfg: createModelDefaultsConfig({ primary: "openai/gpt-5.4" }),
+      storePath: "",
+      store: {},
+      key: "agent:main:child",
+      entry: {
+        swarmGroupId: "swarm:agent:main:parent:turn-42",
+      } as SessionEntry,
+    });
+
+    expect(row.swarmGroupId).toBe("swarm:agent:main:parent:turn-42");
+    expect(buildGatewaySessionEventFields({ sessionRow: row }).swarmGroupId).toBe(
+      "swarm:agent:main:parent:turn-42",
+    );
+  });
+
   test("session lists apply a bounded default and expose truncation metadata", async () => {
     const cfg = createModelDefaultsConfig({ primary: "openai/gpt-5.4" });
     const store = Object.fromEntries(

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -2205,6 +2205,7 @@ export function buildGatewaySessionRow(params: {
   return {
     key,
     spawnedBy: subagentOwner || entry?.spawnedBy,
+    swarmGroupId: entry?.swarmGroupId,
     spawnedWorkspaceDir: entry?.spawnedWorkspaceDir,
     spawnedCwd: entry?.spawnedCwd,
     worktree: entry?.worktree,

--- a/src/gateway/session-utils.types.ts
+++ b/src/gateway/session-utils.types.ts
@@ -45,6 +45,8 @@ type SessionCompactionCheckpointPreview = Pick<
 export type GatewaySessionRow = {
   key: string;
   spawnedBy?: string;
+  /** Collector swarm group that owns this child session, when applicable. */
+  swarmGroupId?: string;
   spawnedWorkspaceDir?: string;
   spawnedCwd?: string;
   /** Managed worktree bound to this session (repo checkout + branch). */

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -475,6 +475,8 @@ type SessionCompactionCheckpointPreview = Pick<
 export type GatewaySessionRow = {
   key: string;
   spawnedBy?: string;
+  /** Collector swarm group that owns this child session, when applicable. */
+  swarmGroupId?: string;
   parentSessionKey?: string;
   /** Managed worktree bound to this session (repo checkout + branch). */
   worktree?: { id: string; branch: string; repoRoot: string };

--- a/ui/src/components/board/board-view.test.ts
+++ b/ui/src/components/board/board-view.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { GatewaySessionRow } from "../../api/types.ts";
 import type { BoardSnapshot, BoardViewCallbacks, BoardWidget } from "../../lib/board/view-types.ts";
 import { applyBoardFixtureOps } from "../../test-helpers/board-fixture.ts";
 import "./board-view.ts";
@@ -85,6 +86,7 @@ async function mount(
     activeTabId?: string;
     callbacks?: BoardViewCallbacks;
     widgetFrameUrl?: (name: string, revision: number) => string;
+    sessions?: readonly GatewaySessionRow[];
   } = {},
 ): Promise<OpenClawBoardView> {
   const view = document.createElement("openclaw-board-view");
@@ -92,6 +94,7 @@ async function mount(
   view.activeTabId = options.activeTabId ?? "main";
   view.widgetFrameUrl = options.widgetFrameUrl ?? (() => "about:blank");
   view.callbacks = options.callbacks ?? callbacks();
+  view.sessions = options.sessions ?? [];
   document.body.append(view);
   await settleCells(view);
   return view;
@@ -116,6 +119,42 @@ describe("openclaw-board-view", () => {
       expect(frame.getAttribute("sandbox")).toBe("allow-scripts");
       expect(frame.getAttribute("referrerpolicy")).toBe("no-referrer");
     }
+  });
+
+  it("renders the native swarm card without a frame or persisted widget controls", async () => {
+    const swarm = boardWidget({
+      name: "builtin:swarm",
+      tabId: "builtin-swarm",
+      title: "Swarm progress",
+      contentKind: "builtin",
+      builtin: "swarm",
+      readOnly: true,
+    });
+    const source = snapshot({
+      sessionKey: "agent:main:parent",
+      tabs: [{ tabId: "builtin-swarm", title: "Swarm progress", position: 0, chatDock: "right" }],
+      widgets: [swarm],
+    });
+    const view = await mount({
+      snapshot: source,
+      activeTabId: "builtin-swarm",
+      sessions: [
+        {
+          key: "agent:main:child",
+          kind: "direct",
+          updatedAt: 1,
+          parentSessionKey: "agent:main:parent",
+          swarmGroupId: "swarm:agent:main:parent:turn-42",
+          label: "Worker A",
+          status: "running",
+        },
+      ],
+    });
+
+    expect(view.querySelector("[data-test-id=swarm-widget]")).not.toBeNull();
+    expect(view.querySelector("iframe")).toBeNull();
+    expect(view.querySelector(".board-widget__menu")).toBeNull();
+    expect(view.querySelector(".board-widget__resize-handle")).toBeNull();
   });
 
   it("preserves each widget cell and iframe identity when order changes", async () => {

--- a/ui/src/components/board/board-view.ts
+++ b/ui/src/components/board/board-view.ts
@@ -2,6 +2,7 @@ import { html, nothing, type PropertyValues, type TemplateResult } from "lit";
 import { property, state } from "lit/decorators.js";
 import { keyed } from "lit/directives/keyed.js";
 import { repeat } from "lit/directives/repeat.js";
+import type { GatewaySessionRow } from "../../api/types.ts";
 import { t } from "../../i18n/index.ts";
 import {
   BOARD_GRID_COLUMNS,
@@ -70,6 +71,7 @@ class OpenClawBoardView extends OpenClawLightDomElement {
   @property({ attribute: false }) activeTabId = "";
   @property({ attribute: false }) widgetFrameUrl?: BoardWidgetFrameUrl;
   @property({ attribute: false }) callbacks?: BoardViewCallbacks;
+  @property({ attribute: false }) sessions: readonly GatewaySessionRow[] = [];
 
   @state() private previewItems: BoardGridItem[] | null = null;
   @state() private gestureName = "";
@@ -561,6 +563,8 @@ class OpenClawBoardView extends OpenClawLightDomElement {
                 .tabs=${tabs}
                 .widgetFrameUrl=${this.widgetFrameUrl}
                 .callbacks=${this.cellCallbacks}
+                .sessions=${this.sessions}
+                .sessionKey=${sessionKey}
                 .dragging=${widget.name === this.gestureName}
                 .focusTabIndex=${widget.name === focusName ? 0 : -1}
                 .positionInSet=${(logicalPosition.get(widget.name) ?? 0) + 1}

--- a/ui/src/components/board/board-widget-cell.ts
+++ b/ui/src/components/board/board-widget-cell.ts
@@ -1,5 +1,6 @@
 import { html, nothing, type PropertyValues, type TemplateResult } from "lit";
 import { property, state } from "lit/decorators.js";
+import type { GatewaySessionRow } from "../../api/types.ts";
 import { t } from "../../i18n/index.ts";
 import type { BoardGridDirection, BoardGridRect } from "../../lib/board/grid.ts";
 import { toCssPlacement } from "../../lib/board/grid.ts";
@@ -9,6 +10,7 @@ import type {
   BoardWidget,
   BoardWidgetFrameUrl,
 } from "../../lib/board/view-types.ts";
+import { getBuiltinWidgetRenderer } from "../../lib/board/widgets/index.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import "../web-awesome.ts";
 
@@ -37,6 +39,8 @@ class OpenClawBoardWidgetCell extends OpenClawLightDomElement {
   @property({ attribute: false }) tabs: readonly BoardTab[] = [];
   @property({ attribute: false }) widgetFrameUrl?: BoardWidgetFrameUrl;
   @property({ attribute: false }) callbacks?: BoardWidgetCellCallbacks;
+  @property({ attribute: false }) sessions: readonly GatewaySessionRow[] = [];
+  @property({ type: String }) sessionKey = "";
   @property({ type: Boolean }) dragging = false;
   @property({ type: Number }) focusTabIndex = -1;
   @property({ type: Number }) positionInSet = 1;
@@ -227,6 +231,13 @@ class OpenClawBoardWidgetCell extends OpenClawLightDomElement {
     if (widget.grantState === "rejected") {
       return this.renderRejected(widget, callbacks);
     }
+    if (widget.contentKind === "builtin") {
+      const renderer = getBuiltinWidgetRenderer(widget.builtin);
+      if (!renderer) {
+        throw new Error(t("board.widget.frameResolverMissing"));
+      }
+      return renderer({ sessions: this.sessions, sessionKey: this.sessionKey });
+    }
     return this.renderFrame(widget);
   }
 
@@ -266,7 +277,7 @@ class OpenClawBoardWidgetCell extends OpenClawLightDomElement {
     widget: BoardWidget,
     callbacks: BoardWidgetCellCallbacks,
   ): void {
-    if (event.target !== event.currentTarget) {
+    if (event.target !== event.currentTarget || widget.readOnly) {
       return;
     }
     const direction =
@@ -306,6 +317,7 @@ class OpenClawBoardWidgetCell extends OpenClawLightDomElement {
       bodyErrored = true;
     }
     const label = widget.title || widget.name;
+    const readOnly = widget.readOnly === true;
     const bodyScrollable =
       bodyErrored ||
       this.actionError !== "" ||
@@ -319,28 +331,32 @@ class OpenClawBoardWidgetCell extends OpenClawLightDomElement {
         tabindex=${this.focusTabIndex}
         aria-posinset=${this.positionInSet}
         aria-setsize=${this.setSize}
-        aria-label=${t("board.widget.cellLabel", { title: label })}
+        aria-label=${readOnly ? label : t("board.widget.cellLabel", { title: label })}
         data-widget-name=${widget.name}
         data-test-id="board-widget"
         @focus=${() => callbacks.focusChanged(widget.name)}
         @keydown=${(event: KeyboardEvent) => this.handleKeyDown(event, widget, callbacks)}
       >
         <header class="board-widget__bar">
-          <span
-            class="board-widget__drag-handle"
-            aria-hidden="true"
-            title=${t("board.widget.moveHandle", { title: label })}
-            @pointerdown=${(event: PointerEvent) => callbacks.movePointerDown(widget, event)}
-          >
-            <span aria-hidden="true">⠿</span>
-          </span>
+          ${readOnly
+            ? nothing
+            : html`<span
+                class="board-widget__drag-handle"
+                aria-hidden="true"
+                title=${t("board.widget.moveHandle", { title: label })}
+                @pointerdown=${(event: PointerEvent) => callbacks.movePointerDown(widget, event)}
+              >
+                <span aria-hidden="true">⠿</span>
+              </span>`}
           <span class="board-widget__title" title=${label}>${label}</span>
-          <span class="board-widget__kind"
-            >${widget.contentKind === "mcp-app"
-              ? t("board.widget.kindMcp")
-              : t("board.widget.kindHtml")}</span
-          >
-          ${this.renderMenu(widget, callbacks)}
+          ${widget.contentKind === "builtin"
+            ? nothing
+            : html`<span class="board-widget__kind"
+                >${widget.contentKind === "mcp-app"
+                  ? t("board.widget.kindMcp")
+                  : t("board.widget.kindHtml")}</span
+              >`}
+          ${readOnly ? nothing : this.renderMenu(widget, callbacks)}
         </header>
         <div
           class=${`board-widget__body ${bodyScrollable ? "board-widget__body--scrollable" : ""}`}
@@ -352,12 +368,14 @@ class OpenClawBoardWidgetCell extends OpenClawLightDomElement {
               </div>`
             : nothing}
         </div>
-        <span
-          class="board-widget__resize-handle"
-          aria-hidden="true"
-          title=${t("board.widget.resizeHandle", { title: label })}
-          @pointerdown=${(event: PointerEvent) => callbacks.resizePointerDown(widget, event)}
-        ></span>
+        ${readOnly
+          ? nothing
+          : html`<span
+              class="board-widget__resize-handle"
+              aria-hidden="true"
+              title=${t("board.widget.resizeHandle", { title: label })}
+              @pointerdown=${(event: PointerEvent) => callbacks.resizePointerDown(widget, event)}
+            ></span>`}
       </section>
     `;
   }

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -2081,6 +2081,7 @@ export const en: TranslationMap = {
     swarm: {
       title: "Swarm",
       description: "Let Code Mode orchestrate groups of subagents in parallel.",
+      empty: "No active swarms.",
     },
   },
   aboutPage: {

--- a/ui/src/lib/board/swarm-dashboard.ts
+++ b/ui/src/lib/board/swarm-dashboard.ts
@@ -1,0 +1,65 @@
+import type { GatewaySessionRow } from "../../api/types.ts";
+import { t } from "../../i18n/index.ts";
+import { areUiSessionKeysEquivalent } from "../sessions/session-key.ts";
+import type { BoardSnapshot } from "./types.ts";
+
+const SWARM_TAB_ID = "builtin-swarm";
+const SWARM_WIDGET_NAME = "builtin:swarm";
+
+function hasSwarmRowsForSession(
+  sessions: readonly GatewaySessionRow[],
+  sessionKey: string,
+): boolean {
+  return sessions.some(
+    (row) =>
+      Boolean(row.swarmGroupId?.trim()) &&
+      ((row.parentSessionKey && areUiSessionKeysEquivalent(row.parentSessionKey, sessionKey)) ||
+        (row.spawnedBy && areUiSessionKeysEquivalent(row.spawnedBy, sessionKey)) ||
+        ((): boolean => {
+          const owner = row.swarmGroupId?.split(":").slice(1, -1).join(":");
+          return Boolean(owner && areUiSessionKeysEquivalent(owner, sessionKey));
+        })()),
+  );
+}
+
+/** Creates the ephemeral board card from the live session roster, never from persisted board state. */
+export function withSwarmWidget(
+  snapshot: BoardSnapshot,
+  sessions: readonly GatewaySessionRow[],
+): BoardSnapshot {
+  // Keep the card mounted through terminal collector updates so its explicit
+  // empty state is visible before the retention sweep removes the group.
+  if (!hasSwarmRowsForSession(sessions, snapshot.sessionKey)) {
+    return snapshot;
+  }
+  const tabs = snapshot.tabs.some((tab) => tab.tabId === SWARM_TAB_ID)
+    ? snapshot.tabs
+    : [
+        ...snapshot.tabs,
+        {
+          tabId: SWARM_TAB_ID,
+          title: t("labsPage.swarm.title"),
+          position: Math.max(-1, ...snapshot.tabs.map((tab) => tab.position)) + 1,
+          chatDock: "right" as const,
+        },
+      ];
+  const widget = {
+    name: SWARM_WIDGET_NAME,
+    tabId: SWARM_TAB_ID,
+    title: t("labsPage.swarm.title"),
+    contentKind: "builtin" as const,
+    builtin: "swarm" as const,
+    readOnly: true,
+    sizeW: 12,
+    sizeH: 4,
+    position: 0,
+    grantState: "granted" as const,
+    revision: snapshot.revision,
+  };
+  const widgets = snapshot.widgets.some((candidate) => candidate.name === SWARM_WIDGET_NAME)
+    ? snapshot.widgets.map((candidate) =>
+        candidate.name === SWARM_WIDGET_NAME ? widget : candidate,
+      )
+    : [...snapshot.widgets, widget];
+  return { ...snapshot, tabs, widgets };
+}

--- a/ui/src/lib/board/types.ts
+++ b/ui/src/lib/board/types.ts
@@ -9,7 +9,11 @@ export type BoardWidget = {
   name: string;
   tabId: string;
   title?: string;
-  contentKind: "html" | "mcp-app";
+  contentKind: "html" | "mcp-app" | "builtin";
+  /** Named native Control UI card; unlike framed widgets it never persists board mutations. */
+  builtin?: "swarm";
+  /** Virtual cards are derived from live session state and cannot be moved or removed. */
+  readOnly?: boolean;
   sizeW: number;
   sizeH: number;
   position: number;

--- a/ui/src/lib/board/view-types.ts
+++ b/ui/src/lib/board/view-types.ts
@@ -15,7 +15,11 @@ export type BoardWidget = {
   name: string;
   tabId: string;
   title?: string;
-  contentKind: "html" | "mcp-app";
+  contentKind: "html" | "mcp-app" | "builtin";
+  /** Named native Control UI card; unlike framed widgets it never persists board mutations. */
+  builtin?: "swarm";
+  /** Virtual cards are derived from live session state and cannot be moved or removed. */
+  readOnly?: boolean;
   sizeW: number;
   sizeH: number;
   position: number;

--- a/ui/src/lib/board/widgets/index.ts
+++ b/ui/src/lib/board/widgets/index.ts
@@ -1,0 +1,18 @@
+import type { TemplateResult } from "lit";
+import type { GatewaySessionRow } from "../../../api/types.ts";
+import { renderSwarmWidget } from "./swarm.ts";
+
+export type BuiltinBoardWidgetRenderer = (context: {
+  sessions: readonly GatewaySessionRow[];
+  sessionKey: string;
+}) => TemplateResult;
+
+export const BUILTIN_WIDGET_RENDERERS: Record<string, BuiltinBoardWidgetRenderer> = {
+  swarm: renderSwarmWidget,
+};
+
+export function getBuiltinWidgetRenderer(
+  name: string | undefined,
+): BuiltinBoardWidgetRenderer | null {
+  return name ? (BUILTIN_WIDGET_RENDERERS[name] ?? null) : null;
+}

--- a/ui/src/lib/board/widgets/index.ts
+++ b/ui/src/lib/board/widgets/index.ts
@@ -2,12 +2,12 @@ import type { TemplateResult } from "lit";
 import type { GatewaySessionRow } from "../../../api/types.ts";
 import { renderSwarmWidget } from "./swarm.ts";
 
-export type BuiltinBoardWidgetRenderer = (context: {
+type BuiltinBoardWidgetRenderer = (context: {
   sessions: readonly GatewaySessionRow[];
   sessionKey: string;
 }) => TemplateResult;
 
-export const BUILTIN_WIDGET_RENDERERS: Record<string, BuiltinBoardWidgetRenderer> = {
+const BUILTIN_WIDGET_RENDERERS: Record<string, BuiltinBoardWidgetRenderer> = {
   swarm: renderSwarmWidget,
 };
 

--- a/ui/src/lib/board/widgets/swarm.test.ts
+++ b/ui/src/lib/board/widgets/swarm.test.ts
@@ -1,0 +1,77 @@
+/* @vitest-environment jsdom */
+
+import { render } from "lit";
+import { afterEach, describe, expect, it } from "vitest";
+import type { GatewaySessionRow } from "../../../api/types.ts";
+import { collectActiveSwarmGroups, renderSwarmWidget } from "./swarm.ts";
+
+const parentSessionKey = "agent:main:parent";
+
+function session(overrides: Partial<GatewaySessionRow>): GatewaySessionRow {
+  return {
+    key: "agent:main:child",
+    kind: "direct",
+    updatedAt: 1,
+    parentSessionKey,
+    swarmGroupId: "swarm:agent:main:parent:turn-42",
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe("swarm board widget", () => {
+  it("groups live collector children and maps their dot states", () => {
+    const groups = collectActiveSwarmGroups(
+      [
+        session({ key: "queued", label: "Queued child", subagentRunState: "active" }),
+        session({ key: "running", label: "Running child", status: "running" }),
+        session({ key: "done", label: "Done child", status: "done" }),
+        session({ key: "failed", label: "Timed out child", status: "timeout" }),
+        session({
+          key: "finished-group",
+          swarmGroupId: "swarm:agent:main:parent:finished",
+          status: "done",
+        }),
+      ],
+      parentSessionKey,
+    );
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]).toMatchObject({ label: "turn-42", running: 1, done: 1, failed: 1 });
+    expect(groups[0]?.phases).toEqual([
+      {
+        dots: [
+          { key: "queued", label: "Queued child", status: "queued" },
+          { key: "running", label: "Running child", status: "running" },
+          { key: "done", label: "Done child", status: "done" },
+          { key: "failed", label: "Timed out child", status: "failed" },
+        ],
+      },
+    ]);
+  });
+
+  it("renders dot tooltips and keeps an empty state when no group is active", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    render(
+      renderSwarmWidget({
+        sessionKey: parentSessionKey,
+        sessions: [session({ label: "Worker A", status: "running" })],
+      }),
+      container,
+    );
+
+    const dot = container.querySelector<HTMLElement>(".swarm-widget__dot--running");
+    expect(dot?.title).toBe("Worker A: Running");
+    expect(container.textContent).toContain("turn-42");
+    expect(container.textContent?.replace(/\s+/g, " ")).toContain("1 Running · 0 Done · 0 Failed");
+
+    render(renderSwarmWidget({ sessionKey: parentSessionKey, sessions: [] }), container);
+    expect(container.querySelector("[data-test-id=swarm-empty]")?.textContent?.trim()).toBe(
+      "No active swarms.",
+    );
+  });
+});

--- a/ui/src/lib/board/widgets/swarm.test.ts
+++ b/ui/src/lib/board/widgets/swarm.test.ts
@@ -3,7 +3,7 @@
 import { render } from "lit";
 import { afterEach, describe, expect, it } from "vitest";
 import type { GatewaySessionRow } from "../../../api/types.ts";
-import { collectActiveSwarmGroups, renderSwarmWidget } from "./swarm.ts";
+import { renderSwarmWidget } from "./swarm.ts";
 
 const parentSessionKey = "agent:main:parent";
 
@@ -24,32 +24,37 @@ afterEach(() => {
 
 describe("swarm board widget", () => {
   it("groups live collector children and maps their dot states", () => {
-    const groups = collectActiveSwarmGroups(
-      [
-        session({ key: "queued", label: "Queued child", subagentRunState: "active" }),
-        session({ key: "running", label: "Running child", status: "running" }),
-        session({ key: "done", label: "Done child", status: "done" }),
-        session({ key: "failed", label: "Timed out child", status: "timeout" }),
-        session({
-          key: "finished-group",
-          swarmGroupId: "swarm:agent:main:parent:finished",
-          status: "done",
-        }),
-      ],
-      parentSessionKey,
+    const container = document.createElement("div");
+    document.body.append(container);
+    render(
+      renderSwarmWidget({
+        sessionKey: parentSessionKey,
+        sessions: [
+          session({ key: "queued", label: "Queued child", subagentRunState: "active" }),
+          session({ key: "running", label: "Running child", status: "running" }),
+          session({ key: "done", label: "Done child", status: "done" }),
+          session({ key: "failed", label: "Timed out child", status: "timeout" }),
+          session({
+            key: "finished-group",
+            swarmGroupId: "swarm:agent:main:parent:finished",
+            status: "done",
+          }),
+        ],
+      }),
+      container,
     );
 
-    expect(groups).toHaveLength(1);
-    expect(groups[0]).toMatchObject({ label: "turn-42", running: 1, done: 1, failed: 1 });
-    expect(groups[0]?.phases).toEqual([
-      {
-        dots: [
-          { key: "queued", label: "Queued child", status: "queued" },
-          { key: "running", label: "Running child", status: "running" },
-          { key: "done", label: "Done child", status: "done" },
-          { key: "failed", label: "Timed out child", status: "failed" },
-        ],
-      },
+    const group = container.querySelector("[data-swarm-group]");
+    expect(group?.getAttribute("data-swarm-group")).toBe("swarm:agent:main:parent:turn-42");
+    expect(group?.textContent).toContain("turn-42");
+    expect(group?.textContent?.replace(/\s+/g, " ")).toContain("1 Running · 1 Done · 1 Failed");
+    expect(
+      [...container.querySelectorAll(".swarm-widget__dot")].map((dot) => dot.className),
+    ).toEqual([
+      "swarm-widget__dot swarm-widget__dot--queued",
+      "swarm-widget__dot swarm-widget__dot--running",
+      "swarm-widget__dot swarm-widget__dot--done",
+      "swarm-widget__dot swarm-widget__dot--failed",
     ]);
   });
 

--- a/ui/src/lib/board/widgets/swarm.ts
+++ b/ui/src/lib/board/widgets/swarm.ts
@@ -1,0 +1,182 @@
+import { html, nothing, type TemplateResult } from "lit";
+import type { GatewaySessionRow } from "../../../api/types.ts";
+import { t } from "../../../i18n/index.ts";
+import { areUiSessionKeysEquivalent } from "../../sessions/session-key.ts";
+
+type SwarmDotStatus = "queued" | "running" | "done" | "failed";
+
+export type SwarmDot = {
+  key: string;
+  label: string;
+  status: SwarmDotStatus;
+};
+
+export type SwarmPhase = {
+  title?: string;
+  dots: SwarmDot[];
+};
+
+export type SwarmGroup = {
+  groupId: string;
+  label: string;
+  running: number;
+  done: number;
+  failed: number;
+  phases: SwarmPhase[];
+};
+
+type SwarmPhaseCarrier = {
+  swarmPhase?: unknown;
+};
+
+function swarmStatusLabel(status: SwarmDotStatus): string {
+  if (status === "queued") {
+    return t("tasksPage.status.queued");
+  }
+  if (status === "running") {
+    return t("tasksPage.status.running");
+  }
+  if (status === "done") {
+    return t("activity.status.done");
+  }
+  return t("tasksPage.status.failed");
+}
+
+function swarmDotStatus(row: GatewaySessionRow): SwarmDotStatus | null {
+  if (row.status === "running" || row.hasActiveRun === true) {
+    return "running";
+  }
+  if (row.status === "done") {
+    return "done";
+  }
+  if (row.status === "failed" || row.status === "killed" || row.status === "timeout") {
+    return "failed";
+  }
+  return row.subagentRunState === "active" ? "queued" : null;
+}
+
+function groupTail(groupId: string): string {
+  return groupId.split(":").filter(Boolean).at(-1) ?? groupId;
+}
+
+function swarmPhase(row: GatewaySessionRow): string | undefined {
+  // Phase events will attach this optional display bucket. Until then every
+  // collector child belongs to the single unlabelled phase below.
+  const phase = (row as GatewaySessionRow & SwarmPhaseCarrier).swarmPhase;
+  return typeof phase === "string" && phase.trim() ? phase.trim() : undefined;
+}
+
+function isSwarmChildForSession(row: GatewaySessionRow, sessionKey: string): boolean {
+  if (
+    (row.parentSessionKey && areUiSessionKeysEquivalent(row.parentSessionKey, sessionKey)) ||
+    (row.spawnedBy && areUiSessionKeysEquivalent(row.spawnedBy, sessionKey))
+  ) {
+    return true;
+  }
+  const owner = row.swarmGroupId?.split(":").slice(1, -1).join(":");
+  return Boolean(owner && areUiSessionKeysEquivalent(owner, sessionKey));
+}
+
+/** Groups the live session roster into the active collector swarms for one dashboard. */
+export function collectActiveSwarmGroups(
+  sessions: readonly GatewaySessionRow[],
+  sessionKey: string,
+): SwarmGroup[] {
+  const byGroup = new Map<string, Array<{ phase?: string; dot: SwarmDot }>>();
+  for (const row of sessions) {
+    const groupId = row.swarmGroupId?.trim();
+    if (!groupId || !isSwarmChildForSession(row, sessionKey)) {
+      continue;
+    }
+    const dots = byGroup.get(groupId) ?? [];
+    const status = swarmDotStatus(row);
+    if (!status) {
+      continue;
+    }
+    dots.push({
+      phase: swarmPhase(row),
+      dot: {
+        key: row.key,
+        label: row.label?.trim() || row.displayName?.trim() || row.derivedTitle?.trim() || row.key,
+        status,
+      },
+    });
+    byGroup.set(groupId, dots);
+  }
+
+  return [...byGroup.entries()]
+    .map(([groupId, entries]) => {
+      const dots = entries.map((entry) => entry.dot);
+      const phases = new Map<string | undefined, SwarmDot[]>();
+      for (const entry of entries) {
+        const phaseDots = phases.get(entry.phase) ?? [];
+        phaseDots.push(entry.dot);
+        phases.set(entry.phase, phaseDots);
+      }
+      return {
+        groupId,
+        label: groupTail(groupId),
+        running: dots.filter((dot) => dot.status === "running").length,
+        done: dots.filter((dot) => dot.status === "done").length,
+        failed: dots.filter((dot) => dot.status === "failed").length,
+        phases: [...phases.entries()].map(([title, phaseDots]) => ({ title, dots: phaseDots })),
+      } satisfies SwarmGroup;
+    })
+    .filter((group) =>
+      group.phases.some((phase) =>
+        phase.dots.some((dot) => dot.status === "queued" || dot.status === "running"),
+      ),
+    )
+    .toSorted((left, right) => left.groupId.localeCompare(right.groupId));
+}
+
+export function renderSwarmWidget({
+  sessions,
+  sessionKey,
+}: {
+  sessions: readonly GatewaySessionRow[];
+  sessionKey: string;
+}): TemplateResult {
+  const groups = collectActiveSwarmGroups(sessions, sessionKey);
+  if (groups.length === 0) {
+    return html`<p class="swarm-widget__empty" data-test-id="swarm-empty">
+      ${t("labsPage.swarm.empty")}
+    </p>`;
+  }
+  return html`
+    <div class="swarm-widget" data-test-id="swarm-widget">
+      ${groups.map(
+        (group) => html`
+          <section class="swarm-widget__group" data-swarm-group=${group.groupId}>
+            <header class="swarm-widget__group-header">
+              <strong title=${group.groupId}>${group.label}</strong>
+              <span
+                >${group.running} ${swarmStatusLabel("running")} · ${group.done}
+                ${swarmStatusLabel("done")} · ${group.failed} ${swarmStatusLabel("failed")}</span
+              >
+            </header>
+            ${group.phases.map(
+              (phase) => html`
+                ${phase.title
+                  ? html`<div class="swarm-widget__phase">${phase.title}</div>`
+                  : nothing}
+                <div class="swarm-widget__dots" role="list">
+                  ${phase.dots.map(
+                    (dot) => html`
+                      <span
+                        class=${`swarm-widget__dot swarm-widget__dot--${dot.status}`}
+                        role="listitem"
+                        title=${`${dot.label}: ${swarmStatusLabel(dot.status)}`}
+                        aria-label=${`${dot.label}: ${swarmStatusLabel(dot.status)}`}
+                      ></span>
+                    `,
+                  )}
+                </div>
+              `,
+            )}
+          </section>
+        `,
+      )}
+    </div>
+  `;
+}

--- a/ui/src/lib/board/widgets/swarm.ts
+++ b/ui/src/lib/board/widgets/swarm.ts
@@ -5,18 +5,18 @@ import { areUiSessionKeysEquivalent } from "../../sessions/session-key.ts";
 
 type SwarmDotStatus = "queued" | "running" | "done" | "failed";
 
-export type SwarmDot = {
+type SwarmDot = {
   key: string;
   label: string;
   status: SwarmDotStatus;
 };
 
-export type SwarmPhase = {
+type SwarmPhase = {
   title?: string;
   dots: SwarmDot[];
 };
 
-export type SwarmGroup = {
+type SwarmGroup = {
   groupId: string;
   label: string;
   running: number;
@@ -56,7 +56,7 @@ function swarmDotStatus(row: GatewaySessionRow): SwarmDotStatus | null {
 }
 
 function groupTail(groupId: string): string {
-  return groupId.split(":").filter(Boolean).at(-1) ?? groupId;
+  return groupId.split(":").findLast(Boolean) ?? groupId;
 }
 
 function swarmPhase(row: GatewaySessionRow): string | undefined {
@@ -78,7 +78,7 @@ function isSwarmChildForSession(row: GatewaySessionRow, sessionKey: string): boo
 }
 
 /** Groups the live session roster into the active collector swarms for one dashboard. */
-export function collectActiveSwarmGroups(
+function collectActiveSwarmGroups(
   sessions: readonly GatewaySessionRow[],
   sessionKey: string,
 ): SwarmGroup[] {

--- a/ui/src/main.ts
+++ b/ui/src/main.ts
@@ -1,7 +1,6 @@
 // Control UI module implements main behavior.
 import "./styles.css";
 import "./app/app-host.ts";
-import "./components/board/board-view.ts";
 import { inferControlUiPublicAssetPath } from "./app/public-assets.ts";
 import {
   installMissingStylesheetRecovery,

--- a/ui/src/pages/chat/board-session-surface.test.ts
+++ b/ui/src/pages/chat/board-session-surface.test.ts
@@ -66,6 +66,7 @@ describe("board session shell", () => {
     render(
       renderBoardSessionSurface({
         snapshot: provider.snapshot$.value,
+        sessions: [],
         activeTabId: "main",
         dock,
         reopenDock: "right",
@@ -95,6 +96,7 @@ describe("board session shell", () => {
     render(
       renderBoardSessionSurface({
         snapshot: provider.snapshot$.value,
+        sessions: [],
         activeTabId: "main",
         dock: "hidden",
         reopenDock: "left",
@@ -123,6 +125,7 @@ describe("board session shell", () => {
     const provider = boardProviderForSession("agent:main:main");
     const props = {
       snapshot: provider.snapshot$.value,
+      sessions: [],
       activeTabId: "main",
       reopenDock: "left" as const,
       dockSize: { height: 300, width: 420 },

--- a/ui/src/pages/chat/board-session-surface.ts
+++ b/ui/src/pages/chat/board-session-surface.ts
@@ -1,4 +1,5 @@
 import { html, nothing, type TemplateResult } from "lit";
+import type { GatewaySessionRow } from "../../api/types.ts";
 import { icons } from "../../components/icons.ts";
 import { renderSettingsSegmented } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
@@ -13,6 +14,7 @@ export type BoardChatDockSize = {
 
 type BoardSessionSurfaceProps = {
   snapshot: BoardSnapshot;
+  sessions: readonly GatewaySessionRow[];
   activeTabId: string;
   dock: BoardTab["chatDock"];
   reopenDock: BoardVisibleChatDock;
@@ -23,14 +25,16 @@ type BoardSessionSurfaceProps = {
   onDockChange: (dock: BoardTab["chatDock"]) => void;
 };
 
-let placeholderLoad: Promise<unknown> | null = null;
+let boardViewLoad: Promise<unknown> | null = null;
 
 export async function ensureBoardViewElement(): Promise<boolean> {
-  if (customElements.get("openclaw-board-view") || !isMockBoardEnabled()) {
+  if (customElements.get("openclaw-board-view")) {
     return false;
   }
-  placeholderLoad ??= import("../../components/board-view-placeholder.ts");
-  await placeholderLoad;
+  boardViewLoad ??= isMockBoardEnabled()
+    ? import("../../components/board-view-placeholder.ts")
+    : import("../../components/board/board-view.ts");
+  await boardViewLoad;
   return true;
 }
 
@@ -134,6 +138,7 @@ function renderBoardView(props: BoardSessionSurfaceProps) {
         .activeTabId=${props.activeTabId}
         .widgetFrameUrl=${widgetFrameUrl}
         .callbacks=${props.callbacks}
+        .sessions=${props.sessions}
       ></openclaw-board-view>
     </div>
   `;

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -224,6 +224,7 @@ type ResolvedBoardView = {
   hasBoard: boolean;
   face: BoardFace;
   activeTabId: string;
+  activeTabReadOnly: boolean;
   dock: BoardTab["chatDock"];
   reopenDock: VisibleBoardDock;
 };
@@ -401,6 +402,9 @@ class ChatPane extends OpenClawLightDomElement {
       }
     | undefined;
   private readonly lastVisibleBoardDock = new Map<string, VisibleBoardDock>();
+  private swarmBoardSnapshot: BoardSnapshot | null = null;
+  private swarmBoardSnapshotBase: BoardSnapshot | null = null;
+  private swarmBoardSnapshotRequest = 0;
   private headerRenameInitialLabel: string | null = null;
   private headerRenameInitialValue = "";
   private headerRenameSessionKey = "";
@@ -411,7 +415,11 @@ class ChatPane extends OpenClawLightDomElement {
     void new SubscriptionsController(this)
       .watch(
         () => this.resolveBoardProvider(),
-        (provider, notify) => provider.snapshot$.subscribe(notify),
+        (provider, notify) =>
+          provider.snapshot$.subscribe(() => {
+            this.refreshSwarmBoardSnapshot();
+            notify();
+          }),
       )
       .effect(
         () => this.resolveBoardProvider(),
@@ -1493,9 +1501,31 @@ class ChatPane extends OpenClawLightDomElement {
     return normalized === "main" ? buildAgentMainSessionKey({ agentId: "main" }) : normalized;
   }
 
+  private refreshSwarmBoardSnapshot(): void {
+    const state = this.state;
+    if (!state) {
+      return;
+    }
+    const request = ++this.swarmBoardSnapshotRequest;
+    const sessions = state.sessionsResult?.sessions ?? [];
+    void import("../../lib/board/swarm-dashboard.ts").then(({ withSwarmWidget }) => {
+      if (request !== this.swarmBoardSnapshotRequest) {
+        return;
+      }
+      const currentBase = this.resolveBoardProvider().snapshot$.value;
+      this.swarmBoardSnapshotBase = currentBase;
+      this.swarmBoardSnapshot = withSwarmWidget(currentBase, sessions);
+      this.requestUpdate();
+    });
+  }
+
   private resolveBoardView(): ResolvedBoardView {
     const provider = this.resolveBoardProvider();
-    const snapshot = provider.snapshot$.value;
+    const baseSnapshot = provider.snapshot$.value;
+    const snapshot =
+      this.swarmBoardSnapshotBase === baseSnapshot
+        ? (this.swarmBoardSnapshot ?? baseSnapshot)
+        : baseSnapshot;
     const hasBoard = boardExists(snapshot);
     const sessionKey = this.resolveBoardSessionKey(snapshot.sessionKey);
     const saved =
@@ -1504,8 +1534,16 @@ class ChatPane extends OpenClawLightDomElement {
     const savedTab = snapshot.tabs.some((tab) => tab.tabId === saved?.activeTabId)
       ? saved?.activeTabId
       : undefined;
-    const activeTabId = savedTab ?? snapshot.tabs[0]?.tabId ?? snapshot.widgets[0]?.tabId ?? "";
+    const activeTabId =
+      savedTab ??
+      snapshot.widgets.find((candidate) => candidate.builtin === "swarm")?.tabId ??
+      snapshot.tabs[0]?.tabId ??
+      snapshot.widgets[0]?.tabId ??
+      "";
     const tab = snapshot.tabs.find((candidate) => candidate.tabId === activeTabId);
+    const activeTabReadOnly = snapshot.widgets.some(
+      (candidate) => candidate.tabId === activeTabId && candidate.readOnly === true,
+    );
     const commandDock =
       this.boardCommandDock?.sessionKey === sessionKey &&
       this.boardCommandDock.tabId === activeTabId
@@ -1522,6 +1560,7 @@ class ChatPane extends OpenClawLightDomElement {
       hasBoard,
       face: hasBoard ? (saved?.face ?? "chat") : "chat",
       activeTabId,
+      activeTabReadOnly,
       dock,
       reopenDock:
         this.lastVisibleBoardDock.get(dockKey) ?? saved?.reopenDockByTab?.[activeTabId] ?? "right",
@@ -1596,7 +1635,7 @@ class ChatPane extends OpenClawLightDomElement {
 
   private handleBoardDockChange(dock: BoardTab["chatDock"]): void {
     const board = this.resolveBoardView();
-    if (!board.activeTabId) {
+    if (!board.activeTabId || board.activeTabReadOnly) {
       return;
     }
     const sessionKey = this.resolveBoardSessionKey(board.snapshot.sessionKey);
@@ -2210,6 +2249,7 @@ class ChatPane extends OpenClawLightDomElement {
     state.sessionsResultAgentId = stateValue.agentId;
     state.sessionsLoading = stateValue.loading;
     state.sessionsError = stateValue.error;
+    this.refreshSwarmBoardSnapshot();
     const selectedSession = stateValue.result?.sessions.find((row) =>
       areUiSessionKeysEquivalent(row.key, state.sessionKey),
     );
@@ -2694,8 +2734,11 @@ class ChatPane extends OpenClawLightDomElement {
       faceControl: renderBoardFaceToggle(board.hasBoard, board.face, (face) => {
         this.persistBoardSessionView({ face });
       }),
-      boardDockAction: renderBoardDockMenu(board.hasBoard, board.face, board.dock, (dock) =>
-        this.handleBoardDockChange(dock),
+      boardDockAction: renderBoardDockMenu(
+        board.hasBoard && !board.activeTabReadOnly,
+        board.face,
+        board.dock,
+        (dock) => this.handleBoardDockChange(dock),
       ),
       onBeginRename: () => row && this.beginHeaderRename(row),
       onRenameInput: (value) => {
@@ -3088,6 +3131,7 @@ class ChatPane extends OpenClawLightDomElement {
       board.hasBoard && board.face === "dashboard"
         ? renderBoardSessionSurface({
             snapshot: board.snapshot,
+            sessions: state.sessionsResult?.sessions ?? [],
             activeTabId: board.activeTabId,
             dock: board.dock,
             reopenDock: board.reopenDock,

--- a/ui/src/styles/board.css
+++ b/ui/src/styles/board.css
@@ -303,6 +303,86 @@ openclaw-board-widget-cell {
   width: 100%;
 }
 
+.swarm-widget {
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+}
+
+.swarm-widget__empty {
+  color: var(--muted, #8a919e);
+  font-size: 12px;
+  margin: 0;
+  padding: 12px;
+}
+
+.swarm-widget__group {
+  background: color-mix(in srgb, var(--text, #d7dae0) 3%, transparent);
+  border: 1px solid var(--board-line);
+  border-radius: 8px;
+  display: grid;
+  gap: 7px;
+  padding: 8px;
+}
+
+.swarm-widget__group-header {
+  align-items: baseline;
+  display: flex;
+  gap: 8px;
+  min-width: 0;
+}
+
+.swarm-widget__group-header strong {
+  color: var(--text, #d7dae0);
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.swarm-widget__group-header span,
+.swarm-widget__phase {
+  color: var(--muted, #8a919e);
+  font-size: 10px;
+}
+
+.swarm-widget__phase {
+  margin-top: 2px;
+}
+
+.swarm-widget__dots {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.swarm-widget__dot {
+  background: var(--muted, #8a919e);
+  border-radius: 50%;
+  height: 9px;
+  width: 9px;
+}
+
+.swarm-widget__dot--running {
+  animation: swarm-widget-pulse 1.25s ease-in-out infinite;
+  background: var(--accent, #ff5c5c);
+}
+
+.swarm-widget__dot--done {
+  background: var(--success, #45c486);
+}
+
+.swarm-widget__dot--failed {
+  background: var(--danger, #ff6b6b);
+}
+
+@keyframes swarm-widget-pulse {
+  50% {
+    box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent, #ff5c5c) 25%, transparent);
+    opacity: 0.55;
+  }
+}
+
 .board-widget__resize-handle {
   bottom: 1px;
   cursor: nwse-resize;
@@ -442,7 +522,9 @@ openclaw-board-widget-cell {
 
 @media (prefers-reduced-motion: reduce) {
   .board-widget,
-  .board-tabs__tab {
+  .board-tabs__tab,
+  .swarm-widget__dot--running {
+    animation: none;
     transition: none;
   }
 }


### PR DESCRIPTION
## What

Adds a native Swarm progress card to the session dashboard. Active collector groups render as compact dot grids with queued, running, done, and failed states, count labels, and per-child tooltips.

## Why

Collector child sessions already persist their swarm group metadata, but the Control UI did not project or visualize it. This makes live swarm progress visible without reviving the retired Workspaces renderer path.

## User Impact

Operators can open a swarm-backed session dashboard to see active group progress at a glance. The card is read-only, keeps virtual dashboard state out of persisted board mutations, and reports an explicit empty state after active groups finish.

## Evidence

- `node scripts/run-vitest.mjs ui/src/lib/board/widgets/swarm.test.ts ui/src/components/board/board-view.test.ts src/gateway/session-utils.test.ts`
  - 126 gateway tests and 24 UI tests passed.
- `pnpm ui:build`
  - production build, finalized sidecars, and Control UI performance budget passed (301.2 KiB startup JS gzip / 310 KiB limit).
- `pnpm format` on all touched files.

Closes #110325.
