### PR TITLE
fix(agents): bound stalled SSH directory uploads with an idle watchdog

### DIFF
--- a/src/agents/sandbox/ssh.stream-errors.test.ts
+++ b/src/agents/sandbox/ssh.stream-errors.test.ts
@@ -100,4 +100,25 @@ describe("SSH sandbox stream errors", () => {
       expect(ssh.kill).toHaveBeenCalledOnce();
     },
   );
+
+  it("rejects an upload whose children never close after the timeout", async () => {
+    const localDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ssh-timeout-test-"));
+    tempDirs.push(localDir);
+    const tar = createMockChildProcess();
+    const ssh = createMockChildProcess();
+    spawnMock
+      .mockReturnValueOnce(tar as unknown as ChildProcess)
+      .mockReturnValueOnce(ssh as unknown as ChildProcess);
+
+    await expect(
+      uploadDirectoryToSshTarget({
+        session: fakeSession(),
+        localDir,
+        remoteDir: "/remote/workspace",
+        timeoutMs: 25,
+      }),
+    ).rejects.toThrow(/timed out/);
+    expect(tar.kill).toHaveBeenCalledExactlyOnceWith("SIGKILL");
+    expect(ssh.kill).toHaveBeenCalledExactlyOnceWith("SIGKILL");
+  });
 });

--- a/src/agents/sandbox/ssh.stream-errors.test.ts
+++ b/src/agents/sandbox/ssh.stream-errors.test.ts
@@ -101,7 +101,7 @@ describe("SSH sandbox stream errors", () => {
     },
   );
 
-  it("rejects an upload whose children never close after the timeout", async () => {
+  it("rejects an upload whose children never transfer data after the idle timeout", async () => {
     const localDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ssh-timeout-test-"));
     tempDirs.push(localDir);
     const tar = createMockChildProcess();
@@ -115,9 +115,124 @@ describe("SSH sandbox stream errors", () => {
         session: fakeSession(),
         localDir,
         remoteDir: "/remote/workspace",
-        timeoutMs: 25,
+        idleTimeoutMs: 25,
       }),
-    ).rejects.toThrow(/timed out/);
+    ).rejects.toThrow(/stalled/);
+    expect(tar.kill).toHaveBeenCalledExactlyOnceWith("SIGKILL");
+    expect(ssh.kill).toHaveBeenCalledExactlyOnceWith("SIGKILL");
+  });
+
+  it("rejects an upload that stalls after initial progress", async () => {
+    const localDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ssh-stall-test-"));
+    tempDirs.push(localDir);
+    const tar = createMockChildProcess();
+    const ssh = createMockChildProcess();
+    spawnMock
+      .mockReturnValueOnce(tar as unknown as ChildProcess)
+      .mockReturnValueOnce(ssh as unknown as ChildProcess);
+
+    const upload = uploadDirectoryToSshTarget({
+      session: fakeSession(),
+      localDir,
+      remoteDir: "/remote/workspace",
+      idleTimeoutMs: 25,
+    });
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(2), { timeout: 10_000 });
+    // A first chunk flows (banner/early progress) and then the pipeline goes
+    // silent; the idle watchdog must still bound the upload.
+    tar.stdout.write("early-progress");
+
+    await expect(upload).rejects.toThrow(/stalled/);
+    expect(tar.kill).toHaveBeenCalledExactlyOnceWith("SIGKILL");
+    expect(ssh.kill).toHaveBeenCalledExactlyOnceWith("SIGKILL");
+  });
+
+  it("does not kill a slow upload that keeps transferring data", async () => {
+    const localDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ssh-progress-test-"));
+    tempDirs.push(localDir);
+    const tar = createMockChildProcess();
+    const ssh = createMockChildProcess();
+    spawnMock
+      .mockReturnValueOnce(tar as unknown as ChildProcess)
+      .mockReturnValueOnce(ssh as unknown as ChildProcess);
+
+    const upload = uploadDirectoryToSshTarget({
+      session: fakeSession(),
+      localDir,
+      remoteDir: "/remote/workspace",
+      idleTimeoutMs: 50,
+    });
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(2), { timeout: 10_000 });
+    // Transfer steadily for well beyond one idle window before closing cleanly.
+    const progress = setInterval(() => tar.stdout.write("chunk"), 10);
+    await new Promise((resolve) => {
+      setTimeout(resolve, 200);
+    });
+    clearInterval(progress);
+    tar.emit("close", 0);
+    ssh.emit("close", 0);
+
+    await expect(upload).resolves.toBeUndefined();
+    expect(tar.kill).not.toHaveBeenCalled();
+    expect(ssh.kill).not.toHaveBeenCalled();
+  });
+
+  it("does not kill the SSH client after the local tar producer has finished", async () => {
+    const localDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ssh-late-close-test-"));
+    tempDirs.push(localDir);
+    const tar = createMockChildProcess();
+    const ssh = createMockChildProcess();
+    spawnMock
+      .mockReturnValueOnce(tar as unknown as ChildProcess)
+      .mockReturnValueOnce(ssh as unknown as ChildProcess);
+
+    const upload = uploadDirectoryToSshTarget({
+      session: fakeSession(),
+      localDir,
+      remoteDir: "/remote/workspace",
+      idleTimeoutMs: 25,
+      postProducerTimeoutMs: 200,
+    });
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(2), { timeout: 10_000 });
+    // A small archive is fully handed to SSH almost immediately; the SSH client
+    // may then legitimately stay quiet for longer than one idle window while it
+    // finishes authentication, the remote command, or a buffered drain.
+    tar.stdout.write("small-archive");
+    tar.emit("close", 0);
+    await new Promise((resolve) => {
+      setTimeout(resolve, 100);
+    });
+    expect(tar.kill).not.toHaveBeenCalled();
+    expect(ssh.kill).not.toHaveBeenCalled();
+
+    ssh.emit("close", 0);
+    await expect(upload).resolves.toBeUndefined();
+  });
+
+  it("bounds an upload whose SSH child stays stalled after the tar producer finished", async () => {
+    const localDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ssh-post-stall-test-"));
+    tempDirs.push(localDir);
+    const tar = createMockChildProcess();
+    const ssh = createMockChildProcess();
+    spawnMock
+      .mockReturnValueOnce(tar as unknown as ChildProcess)
+      .mockReturnValueOnce(ssh as unknown as ChildProcess);
+
+    const upload = uploadDirectoryToSshTarget({
+      session: fakeSession(),
+      localDir,
+      remoteDir: "/remote/workspace",
+      idleTimeoutMs: 10_000,
+      postProducerTimeoutMs: 25,
+    });
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(2), { timeout: 10_000 });
+    // The small archive is accepted locally at once, then the peer stalls
+    // post-banner: the upload must still fail instead of waiting for close
+    // forever, but only via the post-producer grace, not the idle watchdog.
+    tar.stdout.write("small-archive");
+    tar.emit("close", 0);
+
+    await expect(upload).rejects.toThrow(/did not exit/);
     expect(tar.kill).toHaveBeenCalledExactlyOnceWith("SIGKILL");
     expect(ssh.kill).toHaveBeenCalledExactlyOnceWith("SIGKILL");
   });

--- a/src/agents/sandbox/ssh.ts
+++ b/src/agents/sandbox/ssh.ts
@@ -753,6 +753,8 @@ export const ENSURE_REMOTE_REAL_DIRECTORY_SCRIPT = [
   "done",
 ].join("\n");
 
+const SSH_UPLOAD_TIMEOUT_MS = 30_000;
+
 /** Stream a local directory to the remote sandbox with tar over ssh. */
 export async function uploadDirectoryToSshTarget(params: {
   session: SshSandboxSession;
@@ -760,6 +762,7 @@ export async function uploadDirectoryToSshTarget(params: {
   remoteDir: string;
   remoteRootDir?: string;
   signal?: AbortSignal;
+  timeoutMs?: number;
 }): Promise<void> {
   await assertSafeUploadSymlinks(params.localDir);
   const remoteCommand = buildRemoteCommand([
@@ -797,12 +800,19 @@ export async function uploadDirectoryToSshTarget(params: {
     let tarCode = 0;
     let sshCode = 0;
     let settled = false;
+    const timeoutMs = params.timeoutMs ?? SSH_UPLOAD_TIMEOUT_MS;
+    // An SSH peer that accepts TCP but never completes the banner keeps both
+    // children alive forever, so bound the pipeline even when no signal is set.
+    const timeout = setTimeout(() => {
+      fail(new Error(`SSH directory upload timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
 
     const fail = (error: unknown) => {
       if (settled) {
         return;
       }
       settled = true;
+      clearTimeout(timeout);
       for (const child of [tar, ssh]) {
         try {
           child.kill("SIGKILL");
@@ -841,6 +851,7 @@ export async function uploadDirectoryToSshTarget(params: {
         return;
       }
       settled = true;
+      clearTimeout(timeout);
       if (tarCode !== 0) {
         reject(
           new Error(

--- a/src/agents/sandbox/ssh.ts
+++ b/src/agents/sandbox/ssh.ts
@@ -753,7 +753,8 @@ export const ENSURE_REMOTE_REAL_DIRECTORY_SCRIPT = [
   "done",
 ].join("\n");
 
-const SSH_UPLOAD_TIMEOUT_MS = 30_000;
+const SSH_UPLOAD_IDLE_TIMEOUT_MS = 30_000;
+const SSH_UPLOAD_POST_PRODUCER_TIMEOUT_MS = 60_000;
 
 /** Stream a local directory to the remote sandbox with tar over ssh. */
 export async function uploadDirectoryToSshTarget(params: {
@@ -762,7 +763,10 @@ export async function uploadDirectoryToSshTarget(params: {
   remoteDir: string;
   remoteRootDir?: string;
   signal?: AbortSignal;
-  timeoutMs?: number;
+  /** Maximum time the pipeline may transfer no data before it is killed. */
+  idleTimeoutMs?: number;
+  /** Maximum time the SSH client may take to exit after the local archive finished. */
+  postProducerTimeoutMs?: number;
 }): Promise<void> {
   await assertSafeUploadSymlinks(params.localDir);
   const remoteCommand = buildRemoteCommand([
@@ -800,19 +804,50 @@ export async function uploadDirectoryToSshTarget(params: {
     let tarCode = 0;
     let sshCode = 0;
     let settled = false;
-    const timeoutMs = params.timeoutMs ?? SSH_UPLOAD_TIMEOUT_MS;
-    // An SSH peer that accepts TCP but never completes the banner keeps both
-    // children alive forever, so bound the pipeline even when no signal is set.
-    const timeout = setTimeout(() => {
-      fail(new Error(`SSH directory upload timed out after ${timeoutMs}ms`));
-    }, timeoutMs);
+    const idleTimeoutMs = params.idleTimeoutMs ?? SSH_UPLOAD_IDLE_TIMEOUT_MS;
+    const postProducerTimeoutMs =
+      params.postProducerTimeoutMs ?? SSH_UPLOAD_POST_PRODUCER_TIMEOUT_MS;
+    // An SSH peer that accepts TCP but never completes the banner (or a
+    // connection that stalls mid-transfer) leaves both children alive forever
+    // while transferring no data. Bound that no-progress phase with the idle
+    // watchdog: every byte read from tar resets it, so slow-but-alive uploads
+    // of large workspaces are never cut off. Once tar exits, every workspace
+    // byte is already handed to the SSH client, so the idle watchdog would
+    // mistake legitimate post-producer SSH work (authentication, remote
+    // command, buffered drain) for a stall; switch to a separate, more
+    // generous exit grace instead, so a small-upload peer that never
+    // finishes its handshake is still bounded instead of hanging forever.
+    let idleTimer: ReturnType<typeof setTimeout> | undefined;
+    const clearIdleWatchdog = () => {
+      if (idleTimer !== undefined) {
+        clearTimeout(idleTimer);
+        idleTimer = undefined;
+      }
+    };
+    const armIdleWatchdog = () => {
+      clearIdleWatchdog();
+      idleTimer = setTimeout(() => {
+        fail(new Error(`SSH directory upload stalled: no data transferred for ${idleTimeoutMs}ms`));
+      }, idleTimeoutMs);
+    };
+    const armPostProducerWatchdog = () => {
+      clearIdleWatchdog();
+      idleTimer = setTimeout(() => {
+        fail(
+          new Error(
+            `SSH directory upload stalled: SSH client did not exit within ${postProducerTimeoutMs}ms of the local archive finishing`,
+          ),
+        );
+      }, postProducerTimeoutMs);
+    };
+    armIdleWatchdog();
 
     const fail = (error: unknown) => {
       if (settled) {
         return;
       }
       settled = true;
-      clearTimeout(timeout);
+      clearIdleWatchdog();
       for (const child of [tar, ssh]) {
         try {
           child.kill("SIGKILL");
@@ -825,6 +860,7 @@ export async function uploadDirectoryToSshTarget(params: {
 
     tar.stderr.on("data", (chunk) => tarStderr.push(Buffer.from(chunk)));
     tar.stderr.on("error", fail);
+    tar.stdout.on("data", armIdleWatchdog);
     tar.stdout.on("error", fail);
     ssh.stdout.on("data", (chunk) => sshStdout.push(Buffer.from(chunk)));
     ssh.stdout.on("error", fail);
@@ -838,6 +874,9 @@ export async function uploadDirectoryToSshTarget(params: {
     tar.on("close", (code) => {
       tarClosed = true;
       tarCode = code ?? 0;
+      // Producer finished: stop measuring remote liveness by tar output, but
+      // keep the remaining SSH exit bounded with a separate grace timer.
+      armPostProducerWatchdog();
       maybeResolve();
     });
     ssh.on("close", (code) => {
@@ -851,7 +890,7 @@ export async function uploadDirectoryToSshTarget(params: {
         return;
       }
       settled = true;
-      clearTimeout(timeout);
+      clearIdleWatchdog();
       if (tarCode !== 0) {
         reject(
           new Error(


### PR DESCRIPTION
## Summary

Bound `uploadDirectoryToSshTarget` with an **idle (no-progress) watchdog** while the archive streams, plus a **post-producer exit grace** once `tar` has finished, so a stalled SSH peer can no longer hang a sandbox directory upload forever — while valid long-running uploads of large workspaces keep flowing and are never cut off.

## What Problem This Solves

`uploadDirectoryToSshTarget` (in `src/agents/sandbox/ssh.ts`) streams a local directory to a remote sandbox by piping `tar` into `ssh`. The returned promise settles only on stream errors or when **both** child processes emit `close`.

- If the peer accepts TCP and sends a valid SSH banner but then goes silent (a stuck sshd, or a dead backend behind a relay/LB that never sends RST), the `ssh` child waits in key exchange forever: no client-side timeout covers this phase (`ConnectTimeout` covers TCP connect + banner exchange only; `ServerAliveInterval` keepalives start only after the session is established; `LoginGraceTime` is enforced by the *server*, which a misbehaving endpoint never runs).
- The `signal` parameter is optional, and callers that don't provide one have no deadline at all: the upload promise — and whatever sandbox setup awaited it — hangs forever.

**Verified with the real OpenSSH client** (see Real Behavior Proof): against a banner-then-silent endpoint, the upload on `main` never settles on its own.

Scope correction from real-client testing: a peer that stays silent *before* the banner is already rejected by the real client via `ConnectTimeout` (observed 5.5s). The unbounded phase demonstrated with the real client is a **post-banner handshake stall**, and the fix targets exactly that no-progress phase.

## Root Cause

- The pipeline's settle condition requires both `tarClosed && sshClosed`; a peer that stalls after the banner keeps the `ssh` child alive indefinitely.
- `signal` is optional, so in the common case there is no external cancellation either.
- Invariant violated: "every spawned pipeline settles" — not true when the remote endpoint stops progressing.

## Why This Fix

Add an idle watchdog inside the pipeline promise (`SSH_UPLOAD_IDLE_TIMEOUT_MS = 30_000`, overridable via a new optional `idleTimeoutMs` parameter), plus a separate post-producer exit grace (`SSH_UPLOAD_POST_PRODUCER_TIMEOUT_MS = 60_000`, overridable via a new optional `postProducerTimeoutMs` parameter):

- The idle timer fires only when **no data has flowed** from `tar` for the whole window — every byte read from `tar.stdout` re-arms it. A stalled handshake (zero progress) is bounded; a slow-but-alive transfer of any length is never killed.
- Once `tar` exits, every workspace byte is already handed to the SSH client, so `tar.stdout` can no longer distinguish a stalled peer from legitimate post-producer SSH work (authentication, remote command, buffered drain). The pipeline therefore swaps the idle watchdog for the exit grace: the `ssh` child must exit within that window or the upload rejects with `SSH directory upload stalled: SSH client did not exit within <n>ms of the local archive finishing`. A small archive whose producer closed while the peer never finishes its session stays bounded, without ever measuring remote liveness by local producer output.
- On expiry either timer calls the existing `fail()` path, which SIGKILLs both children and rejects — the same teardown semantics as any other pipeline failure, no new cleanup logic.
- The active timer is cleared on every settle path (failure and success), so completed uploads are unaffected and no timers leak.
- This is deliberately **not** a process-wide maximum duration: the production phase is bounded only by zero progress, and the post-producer phase by a clearly-delimited exit grace — answering both review findings about the producer-completion boundary.
- Alternative considered: a fixed transfer-wide deadline — rejected, because it can kill valid uploads of large workspaces to slow hosts (review finding).

## User Impact

- **Before**: pointing a sandbox at an SSH endpoint that stalls mid-handshake hangs the upload (and the surrounding operation) forever; only a manual caller-provided abort could unstick it.
- **After**: a no-progress upload fails with a clear stall error after 30s and both pipeline children are terminated; an upload whose SSH client never exits after the local archive finished fails after the 60s exit grace; uploads that keep transferring data complete regardless of duration.

## Real Behavior Proof

**Behavior or issue addressed**: an SSH directory upload must settle even when the remote endpoint stalls after sending its SSH banner, and a valid long transfer must never be killed by the new bound.

**Real environment tested**: Linux, Node v22.22.3, OpenClaw built from this branch; real `/usr/bin/ssh` (OpenSSH_8.6p1, OpenSSL 1.1.1o), real GNU tar 1.30, and a real user-mode `sshd` for the long-transfer run. Standalone `node --import tsx` scripts drove the real `uploadDirectoryToSshTarget`.

**Exact steps or command run after this patch**: two scripts — (1) point the session config at a local TCP listener that sends one valid `SSH-2.0-OpenSSH_8.6` banner and then stays silent forever, then run the upload (before: `main` code from a detached worktree; after: this branch); (2) start a real user-mode `sshd` on a high port and upload a real 1GB payload with `idleTimeoutMs: 2000`.

**Evidence before fix**:

```text
repo: /tmp/openclaw-main-proof-111299
fake ssh endpoint: 127.0.0.1:33365 (mode=banner: sends one SSH banner, then silence)
ssh client: OpenSSH_8.6p1, OpenSSL 1.1.1o  NSDL FIPS 16 May 2022
tar: tar (GNU tar) 1.30
mode: before-fix (upstream/main, no upload bound)
outcome after 12.0s: STILL PENDING (external watchdog 12s)
FAIL: real OpenSSH stalled pre-banner and the upload was not bounded
```

**Evidence after fix**:

```text
repo: /home/0668001395/openclawProject3
fake ssh endpoint: 127.0.0.1:36495 (mode=banner: sends one SSH banner, then silence)
ssh client: OpenSSH_8.6p1, OpenSSL 1.1.1o  NSDL FIPS 16 May 2022
tar: tar (GNU tar) 1.30
mode: after-fix (idleTimeoutMs=3000)
outcome after 3.5s: REJECTED: SSH directory upload stalled: no data transferred for 3000ms
PASS: stalled pre-banner upload bounded by the idle watchdog
```

**Valid long transfer is not killed** (real sshd, 1GB payload, 2s idle window):

```text
real sshd on 127.0.0.1:23401
payload: 1024MB random data; idleTimeoutMs=2000
Accepted publickey for 0668001395 from 127.0.0.1 port 47292 ssh2: RSA SHA256:IRy+...
outcome: RESOLVED after 5.7s — 1073741824 bytes extracted on the remote side
PASS: a valid transfer lasting 5.7s (>> 2000ms idle window) was not killed
```

**Decisive case: producer already closed while the SSH session never completes** (real OpenSSH 8.6p1 client against an asyncssh stand-in that completes KEX + authentication, accepts the session/exec, answers keepalives, but never closes the channel — verified to hold a real client past 20s with `ServerAliveInterval 2`/`ServerAliveCountMax 2`; a ~14-byte workspace so `tar` exits immediately):

```text
### Before (upstream/main @ 29ca6322, no upload bound)
[15.0s] still pending (tar producer already closed)
[30.0s] still pending (tar producer already closed)
[45.0s] still pending (tar producer already closed)
[60.1s] still pending (tar producer already closed)
[75.0s] STILL PENDING at proof limit -> unresolved hang
FAIL: producer-finished stalled session never settles (exit 2 = proof-limit kill)

### After (with fix, default postProducerTimeoutMs=60000)
[15.0s] still pending (tar producer already closed)
[30.0s] still pending (tar producer already closed)
[45.0s] still pending (tar producer already closed)
[60.0s] still pending (tar producer already closed)
[60.5s] upload REJECTED: SSH directory upload stalled: SSH client did not exit within 60000ms of the local archive finishing
PASS: post-producer exit grace bounds the stalled session and SIGKILLs both children
```

**Observed result after fix**: against the real OpenSSH client, the post-banner stall is rejected after the idle window and both children are SIGKILLed; a 1GB transfer through real sshd completes because progress re-arms the watchdog. Also observed with the real client: a fully silent pre-banner peer is already rejected by ssh itself after ~5.5s via `ConnectTimeout`, so no unbounded gap remains there.

**What was not tested**: a stall after the SSH session is fully established (mid-transfer blackout) was not separately reproduced; the generated ssh config already bounds that phase via `ServerAliveInterval`/`ServerAliveCountMax`, and the watchdog bounds it as well. Windows runners were not exercised.

**Repro confirmation**: regression coverage in `src/agents/sandbox/ssh.stream-errors.test.ts` — children that transfer nothing are rejected and SIGKILLed; a pipeline that stalls after initial progress is rejected; a slow pipeline that keeps transferring well past the idle window completes without kills; an SSH child that stays quiet after the `tar` producer finished is left alone inside the exit grace but rejected once the grace expires.

## Risk / Mitigation

- **Risk**: an extremely latent link whose handshake legitimately exceeds the idle window could be cut off.
  **Mitigation**: the 30s default is far above observed real handshakes (<1s locally; slow connects are additionally covered by ssh's own `ConnectTimeout`); `idleTimeoutMs` lets callers raise it.
- **Risk**: a transfer that pauses longer than 30s with zero bytes (e.g. remote tar blocked on a hung filesystem) now fails instead of hanging forever.
  **Mitigation**: that is precisely the failure mode this PR exists to surface; the error message names the stall explicitly, and the bound applies only to zero-progress windows.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] agents / ssh sandbox upload (`src/agents/sandbox/ssh.ts`)

## Regression Test Plan

- `node scripts/run-vitest.mjs src/agents/sandbox/ssh.stream-errors.test.ts` — 10 cases incl. the idle-watchdog cases and both post-producer boundary cases
- `node scripts/run-vitest.mjs src/agents/sandbox/ssh.test.ts src/agents/sandbox/ssh-backend.test.ts` — 43 cases

## Review Findings Addressed

- [P1] *Avoid a fixed transfer-wide 30-second deadline* (`ssh.ts:803-806`) → replaced with an idle watchdog that bounds only zero-progress phases; proven with a real 1GB transfer under a 2s idle window completing untouched.
- [P1] *Proof uses a non-OpenSSH substitute* → all before/after evidence now runs the real OpenSSH 8.6p1 client (banner-then-silent endpoint) plus a real user-mode sshd for the long-transfer run.
- [P1] *Avoid timing out after the local archive producer has finished* (`ssh.ts:817-819`) → once `tar` closes, the idle watchdog keyed on `tar.stdout` is replaced by a separate 60s post-producer exit grace, so legitimate quiet post-producer SSH work is never measured by local producer output.
- [P1] *Keep the stalled SSH path bounded after `tar` closes* (`ssh.ts:866`) → the exit grace bounds exactly that case; proven live with a producer-finished stalled session (real OpenSSH client, before: pending >75s; after: rejected at 60.5s) and covered by two new regression tests.
- Maintainer question (*fixed process-wide max duration vs handshake-scoped handling*) → this revision keeps timeout handling scoped to the demonstrated no-progress phase; no transfer-wide cap is imposed, so no compatibility carve-out for slow hosts is needed.
- Correction from real-client testing: the pre-banner phase is already bounded by `ConnectTimeout`; the problem statement was narrowed accordingly.

## Merge Risk

- Low: two optional parameters added; the new defaults activate only after 30s of zero transferred bytes during production, or 60s without SSH exit after the local archive finished; existing callers unchanged.

