### PR TITLE
fix(feishu): deliver recovered final answer after tool-failure card close (#110352)

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -1016,6 +1016,33 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
   });
 
+  it("delivers a recovered final answer after a tool-failure card close (#110352)", async () => {
+    const { options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+
+    // First reply run: the tool-failure warning is the only final, and idle
+    // closes the streaming card with just the warning.
+    await options.onReplyStart?.();
+    await options.deliver({ text: "⚠️ Exec failed", isError: true }, { kind: "final" });
+    await options.onIdle?.();
+
+    // Follow-up run within the same inbound turn: the agent recovered and
+    // produced the real answer; the closed-streaming skip must not swallow it.
+    await options.onReplyStart?.();
+    await options.deliver({ text: "Recovered final answer" }, { kind: "final" });
+    await options.onIdle?.();
+
+    expect(streamingInstances).toHaveLength(2);
+    expect(requireStreamingInstance(0).close).toHaveBeenCalledWith("⚠️ Exec failed", {
+      note: "Agent: agent",
+    });
+    expect(requireStreamingInstance(1).close).toHaveBeenCalledWith("Recovered final answer", {
+      note: "Agent: agent",
+    });
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+  });
+
   it("skips final text already closed by idle streaming", async () => {
     resolveFeishuAccountMock.mockReturnValue({
       accountId: "main",

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -679,11 +679,17 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         replyLifecycleStateInitialized = true;
         deliveredFinalTexts.clear();
         sentIndependentBlockText = false;
-        streamingClosedForReply = false;
-        streamingCloseErroredForReply = false;
         visibleReplySent = false;
         skippedFinalReason = null;
       }
+      // A new reply run within the same turn must not inherit the previous
+      // run's closed-streaming terminal state: after a tool-failure warning
+      // closed the card, the recovered final answer would otherwise be
+      // swallowed by the closed-streaming skip (#110352). Exact duplicates are
+      // still suppressed via deliveredFinalTexts, and visibleReplySent /
+      // skippedFinalReason stay sticky across keepalives (#87896).
+      streamingClosedForReply = false;
+      streamingCloseErroredForReply = false;
       if (streamingEnabled && renderMode === "card") {
         startStreaming();
       }


### PR DESCRIPTION
## What Problem This Solves

When an exec/tool call fails mid-turn while a Feishu streaming reply card is open and that run produced no user-facing answer, the tool-failure warning is the run's only final payload, so `onIdle` closes the card showing just "⚠️ Exec failed". The agent then recovers in a follow-up run within the same inbound turn and produces the real final answer — but that answer never reaches the user (#110352). Transcript and visible chat permanently disagree; affected users must re-ask.

Root cause: `streamingClosedForReply` / `streamingCloseErroredForReply` are reset only once per dispatcher lifetime (the `replyLifecycleStateInitialized` guard introduced in #87896). A follow-up reply run in the same turn therefore inherits the terminal "card closed" state, and `deliver()`'s `skipTextForClosedStreamingFinal` drops the recovered final before any card/message code runs. Before #87896 the flag was reset on every reply start (#72294 era), so later runs still delivered. Feishu is the only channel with this sticky terminal flag; Telegram delivers an error final as a durable standalone message and still delivers a later non-error final, and Discord keeps the failed draft but falls through to a fresh send.

## Why This Change Was Made

Reset only the two closed-streaming flags on every `onReplyStart`, so each new reply run in the same turn can deliver its final answer (a fresh streaming card). The state #87896 needed sticky across keepalives — `visibleReplySent` and `skippedFinalReason` — stays inside the once-guard (its "keeps visible reply state across repeated reply-start keepalives" test still passes), and exact-duplicate finals are still suppressed via `deliveredFinalTexts` (#72294). Single-run turns and late same-run finals (no intervening reply start) are unchanged, as codified by the existing "skips distinct late final text after streaming card close" tests.

## User Impact

Feishu users now receive the agent's recovered final answer after a mid-turn tool failure: the failure notice remains as its own closed card, and the recovered answer is delivered as a new card in the same turn. No behavior change for single-run turns, duplicate finals, or keepalive reply starts.

## Evidence

Fixes #110352.

New regression test `delivers a recovered final answer after a tool-failure card close (#110352)` replays the exact incident sequence against the real dispatcher: run 1 emits only the error final → idle closes the card → follow-up `onReplyStart` → recovered final → idle.

Before (current main `reply-dispatcher.ts` + this test): the recovered answer is swallowed — no second card is ever created:

```
× delivers a recovered final answer after a tool-failure card close (#110352)
AssertionError: expected [ FeishuStreamingSession{ … } ] to have a length of 2 but got 1
Tests  1 failed | 92 skipped (93)
```

After (with the fix): the failure card closes with the warning and a second card closes with the recovered answer:

```
✓ delivers a recovered final answer after a tool-failure card close (#110352)
Tests  93 passed (93)
```

Full `extensions/feishu` suite: 1265 passed / 1266 — the single failure is `setup-surface.test.ts` locale-dependent (`connected as` vs `已连接为`), which fails identically on unmodified main in a zh locale and is unrelated. `oxlint` + `oxfmt` clean on touched files.

Live Feishu verification against a real bot (websocket, group chat, streaming cards, failing exec followed by a recovered answer) is being run with a test tenant and will be posted as a follow-up comment.


## Evidence — live Feishu runs (PR head, 2026-07-19)

A gateway built from the PR head ran against the **real Feishu service** (websocket mode, streaming cards enabled after granting `cardkit:card:read/write`, isolated state dir). Three consecutive DM runs, each forcing a real tool failure (`read` on a nonexistent path → ENOENT) followed by model recovery:

```text
21:17:20 [tools] read failed: ENOENT ... '/nonexistent-proof-110352.txt'
21:17:26 [feishu] Started streaming: cardId=7664227599527284010, messageId=om_x100b6af8a…
21:17:29 [feishu] dispatch complete (queuedFinal=true, replies=1)
21:17:40 [feishu] Closed streaming: cardId=7664227599527284010

21:21:16 [tools] read failed: ENOENT ... '/nonexistent-proof-110352.txt'
21:21:25 [feishu] Started streaming: cardId=7664228624417770770, messageId=om_x100b6af8b…
21:21:28 [feishu] dispatch complete (queuedFinal=true, replies=1)
21:21:45 [feishu] Closed streaming: cardId=7664228624417770770

21:24:07 [tools] read failed: ENOENT ... '/nonexistent-proof-110352.txt'
21:24:08 [feishu] Started streaming: cardId=7664229327127547079, messageId=om_x100b6af8b…
21:24:15 [feishu] dispatch complete (queuedFinal=true, replies=1)
21:24:17 [feishu] Closed streaming: cardId=7664229327127547079
```

Chat history read back via the Feishu API (`im:message:readonly`) confirms each run delivered a visible interactive card plus the TTS audio reply into the DM.

**Limitation (honest):** the exact mid-stream tool-failure close could not be forced with this tenant's model (`glm-5` batches tool calls before emitting any text, so the streaming card only ever opens *after* the failure and recovery are complete). The close-state-reset path itself is covered by the dispatcher regression test (`error-final → idle-close → new reply start → recovered final creates a second card`); the live runs above prove the PR head end-to-end against real Feishu streaming cards, including failure/recovery cycles delivering visible recovered answers. Card IDs and message IDs are unredacted public-tenant artifacts; no credentials included.
