### PR TITLE
fix(doctor): stream oversized legacy sessions.json during SQLite migrate

### DIFF
--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -299,6 +299,13 @@ openclaw doctor --session-sqlite compact --session-sqlite-all-agents
 openclaw doctor --session-sqlite recover --github-issue
 ```
 
+Legacy `sessions.json` files at or under 16 MiB are parsed inline. Larger valid
+stores stream top-level session entries (1 MiB per entry, 256 MiB file ceiling)
+so `inspect`, `dry-run`, `import`, and `validate` can still migrate without
+loading the whole file as one JSON string. Stores that exceed the streamed
+ceilings, or that are not a top-level object of session entries, fail closed
+with `store_unreadable`.
+
 Back up the OpenClaw state directory before running `import` on an install with
 important history. `validate` exits non-zero when a selected legacy entry is
 missing from SQLite, a session id differs, or a transcript event count differs.

--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -117,6 +117,105 @@ describe("runDoctorSessionSqlite", () => {
     expect(fs.existsSync(report.targets[0]?.sqlitePath ?? "")).toBe(false);
   });
 
+  for (const mode of ["inspect", "dry-run"] as const) {
+    it(`streams ${mode} when legacy sessions.json exceeds the 16 MiB inline ceiling`, async () => {
+      const store = createLegacyStore();
+      writeOversizedValidLegacyStore(store.storePath, {
+        channel: "cli",
+        chatType: "direct",
+        sessionFile: "session-1.jsonl",
+        sessionId: "session-1",
+        sessionStartedAt: 1000,
+        updatedAt: 2000,
+      });
+      expect(fs.statSync(store.storePath).size).toBeGreaterThan(16 * 1024 * 1024);
+
+      const report = await runDoctorSessionSqlite({
+        env: store.env,
+        mode,
+        store: store.storePath,
+      });
+
+      expect(report.totals.issues).toBe(0);
+      expect(report.totals.legacyEntries).toBeGreaterThan(1);
+      expect(report.targets[0]?.legacyEntries).toBeGreaterThan(1);
+      expect(fs.existsSync(store.storePath)).toBe(true);
+    });
+  }
+
+  it("imports a streamed legacy sessions.json above the 16 MiB inline ceiling", async () => {
+    const store = createLegacyStore();
+    writeOversizedValidLegacyStore(store.storePath, {
+      channel: "cli",
+      chatType: "direct",
+      sessionFile: "session-1.jsonl",
+      sessionId: "session-1",
+      sessionStartedAt: 1000,
+      updatedAt: 2000,
+    });
+
+    const report = await runDoctorSessionSqlite({
+      env: store.env,
+      mode: "import",
+      store: store.storePath,
+    });
+
+    expect(report.totals.issues).toBe(0);
+    expect(report.totals.importedEntries).toBeGreaterThanOrEqual(1);
+    expect(report.totals.legacyEntries).toBeGreaterThan(1);
+    expect(fs.existsSync(report.targets[0]?.sqlitePath ?? "")).toBe(true);
+    expect(
+      loadExactSqliteSessionEntry({
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        storePath: store.storePath,
+      })?.entry.sessionId,
+    ).toBe("session-1");
+  });
+
+  it("fail-closes when a streamed legacy session entry exceeds 1 MiB", async () => {
+    const store = createLegacyStore();
+    writeOversizedLegacyStoreWithHugeEntry(store.storePath);
+    expect(fs.statSync(store.storePath).size).toBeGreaterThan(16 * 1024 * 1024);
+
+    const report = await runDoctorSessionSqlite({
+      env: store.env,
+      mode: "inspect",
+      store: store.storePath,
+    });
+
+    expect(report.totals.legacyEntries).toBe(0);
+    expect(report.targets[0]?.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "store_unreadable",
+          message: expect.stringMatching(/streaming limit/s),
+        }),
+      ]),
+    );
+  });
+
+  it("fail-closes when an oversized legacy sessions.json is not valid JSON", async () => {
+    const store = createLegacyStore();
+    fs.writeFileSync(store.storePath, Buffer.alloc(16 * 1024 * 1024 + 1, 0x7b), { mode: 0o600 });
+
+    const report = await runDoctorSessionSqlite({
+      env: store.env,
+      mode: "inspect",
+      store: store.storePath,
+    });
+
+    expect(report.totals.legacyEntries).toBe(0);
+    expect(report.targets[0]?.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "store_unreadable",
+        }),
+      ]),
+    );
+    expect(fs.existsSync(report.targets[0]?.sqlitePath ?? "")).toBe(false);
+  });
+
   it("inspects SQLite-only all-agent targets without requiring a legacy store", async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-doctor-session-sqlite-"));
     try {
@@ -2697,6 +2796,57 @@ function createUnsafeIndexDrift(sqlitePath: string): void {
   } finally {
     database.close();
   }
+}
+
+/** Valid top-level sessions.json larger than the 16 MiB inline JSON.parse path. */
+function writeOversizedValidLegacyStore(
+  storePath: string,
+  primaryEntry: Record<string, unknown>,
+): void {
+  const targetBytes = 16 * 1024 * 1024 + 64 * 1024;
+  // Keep each pad entry under LEGACY_SESSION_ENTRY_MAX_BYTES (1 MiB).
+  const padLabel = "x".repeat(900 * 1024);
+  const handle = fs.openSync(storePath, "w", 0o600);
+  let written = 0;
+  const write = (chunk: string) => {
+    written += fs.writeSync(handle, chunk);
+  };
+  write("{\n");
+  write(`"agent:main:main": ${JSON.stringify(primaryEntry)}`);
+  let index = 0;
+  while (written < targetBytes) {
+    write(
+      `,"agent:main:pad-${index}":{"sessionId":"pad-${index}","updatedAt":1,"label":"${padLabel}"}`,
+    );
+    index += 1;
+  }
+  write("\n}\n");
+  fs.closeSync(handle);
+}
+
+/** Force the streaming path with one entry above the 1 MiB per-entry ceiling. */
+function writeOversizedLegacyStoreWithHugeEntry(storePath: string): void {
+  const targetBytes = 16 * 1024 * 1024 + 64 * 1024;
+  const handle = fs.openSync(storePath, "w", 0o600);
+  let written = 0;
+  const write = (chunk: string) => {
+    written += fs.writeSync(handle, chunk);
+  };
+  write("{");
+  write(
+    `"agent:main:huge":{"sessionId":"huge","updatedAt":1,"label":"${"x".repeat(1 * 1024 * 1024 + 32)}"}`,
+  );
+  written = fs.fstatSync(handle).size;
+  let index = 0;
+  while (written < targetBytes) {
+    written += fs.writeSync(
+      handle,
+      `,"agent:main:pad-${index}":{"sessionId":"pad-${index}","updatedAt":1}`,
+    );
+    index += 1;
+  }
+  fs.writeSync(handle, "}");
+  fs.closeSync(handle);
 }
 
 function createLegacyStore(

--- a/src/commands/doctor-session-sqlite.ts
+++ b/src/commands/doctor-session-sqlite.ts
@@ -22,6 +22,8 @@ import {
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveStoredSessionOwnerAgentId } from "../gateway/session-store-key.js";
+import { streamLegacyJsonTopLevelObjectEntries } from "../infra/legacy-json-object-stream.js";
+import { readRegularFileSync } from "../infra/regular-file.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { closeOpenClawAgentDatabaseByPath } from "../state/openclaw-agent-db.js";
 import { compactDoctorSessionSqliteTarget } from "./doctor-session-sqlite-compact.js";
@@ -77,6 +79,14 @@ export type {
   DoctorSessionSqliteTargetReport,
 } from "./doctor-session-sqlite-types.js";
 
+// Inline JSON.parse is safe at or under this size. Larger valid stores stream
+// entry-by-entry so doctor does not allocate the whole file as one string.
+const LEGACY_SESSION_STORE_INLINE_MAX_BYTES = 16 * 1024 * 1024;
+// Per-entry value ceiling while streaming (SessionEntry objects stay small).
+const LEGACY_SESSION_ENTRY_MAX_BYTES = 1 * 1024 * 1024;
+// Absolute streamed-file ceiling; above this doctor still fails closed.
+const LEGACY_SESSION_STORE_STREAM_MAX_BYTES = 256 * 1024 * 1024;
+
 type LegacySessionRecord = {
   entry: SessionEntry;
   sessionKey: string;
@@ -117,7 +127,7 @@ export async function runDoctorSessionSqlite(
       : undefined;
   const fullyCoveredStorePaths =
     options.mode === "import"
-      ? resolveFullyCoveredLegacyStorePaths(cfg, targets)
+      ? await resolveFullyCoveredLegacyStorePaths(cfg, targets)
       : new Set<string>();
   const reports: DoctorSessionSqliteTargetReport[] = [];
   for (const target of targets) {
@@ -216,7 +226,7 @@ async function inspectOrMigrateTarget(params: {
   target: SessionStoreTarget;
 }): Promise<DoctorSessionSqliteTargetReport> {
   const issues: DoctorSessionSqliteIssue[] = [];
-  const allRecords = readLegacySessionRecords(params.target, issues, {
+  const allRecords = await readLegacySessionRecords(params.target, issues, {
     allowMissingStore: params.mode === "inspect" || params.mode === "compact",
   });
   const records = shouldFilterLegacySessionRecordsByTarget(params.target)
@@ -311,10 +321,10 @@ async function inspectOrMigrateTarget(params: {
   return report;
 }
 
-function resolveFullyCoveredLegacyStorePaths(
+async function resolveFullyCoveredLegacyStorePaths(
   cfg: OpenClawConfig,
   targets: readonly SessionStoreTarget[],
-): Set<string> {
+): Promise<Set<string>> {
   const covered = new Set<string>();
   const targetsByStore = new Map<string, SessionStoreTarget[]>();
   for (const target of targets) {
@@ -327,7 +337,7 @@ function resolveFullyCoveredLegacyStorePaths(
       continue;
     }
     const issues: DoctorSessionSqliteIssue[] = [];
-    const records = readLegacySessionRecords(firstStoreTarget, issues);
+    const records = await readLegacySessionRecords(firstStoreTarget, issues);
     const coversEveryRecord = records.every((record) =>
       storeTargets.some(
         (target) =>
@@ -342,14 +352,38 @@ function resolveFullyCoveredLegacyStorePaths(
   return covered;
 }
 
-function readLegacySessionRecords(
+function pushLegacySessionRecord(
+  target: SessionStoreTarget,
+  issues: DoctorSessionSqliteIssue[],
+  records: LegacySessionRecord[],
+  sessionKey: string,
+  value: unknown,
+): void {
+  if (!isSessionEntry(value)) {
+    issues.push({
+      code: "entry_invalid",
+      message: "Session entry is missing a valid sessionId.",
+      sessionKey,
+    });
+    return;
+  }
+  records.push({
+    // Import is the migration boundary: repair legacy delivery/route shapes
+    // here because the SQLite runtime read path assumes canonical entries.
+    entry: normalizeSessionEntryDelivery(value),
+    sessionKey,
+    transcriptPath: resolveLegacyTranscriptPath(target, value),
+  });
+}
+
+async function readLegacySessionRecords(
   target: SessionStoreTarget,
   issues: DoctorSessionSqliteIssue[],
   options: { allowMissingStore?: boolean } = {},
-): LegacySessionRecord[] {
-  let parsed: unknown;
+): Promise<LegacySessionRecord[]> {
+  let storeSize = 0;
   try {
-    parsed = JSON.parse(fs.readFileSync(target.storePath, "utf-8"));
+    storeSize = fs.statSync(target.storePath).size;
   } catch (err) {
     if (
       options.allowMissingStore === true &&
@@ -363,30 +397,67 @@ function readLegacySessionRecords(
     });
     return [];
   }
-  if (!isRecord(parsed)) {
+
+  const records: LegacySessionRecord[] = [];
+
+  if (storeSize <= LEGACY_SESSION_STORE_INLINE_MAX_BYTES) {
+    let parsed: unknown;
+    try {
+      const { buffer } = readRegularFileSync({
+        filePath: target.storePath,
+        maxBytes: LEGACY_SESSION_STORE_INLINE_MAX_BYTES,
+      });
+      parsed = JSON.parse(buffer.toString("utf-8"));
+    } catch (err) {
+      issues.push({
+        code: "store_unreadable",
+        message: `${target.storePath}: ${String(err)}`,
+      });
+      return [];
+    }
+    if (!isRecord(parsed)) {
+      issues.push({
+        code: "store_not_object",
+        message: `${target.storePath} does not contain an object session store.`,
+      });
+      return [];
+    }
+    for (const [sessionKey, value] of Object.entries(parsed)) {
+      pushLegacySessionRecord(target, issues, records, sessionKey, value);
+    }
+    return records;
+  }
+
+  // Oversized but still within the streamed support ceiling: parse top-level
+  // entries without buffering the whole file as one JSON string.
+  try {
+    await streamLegacyJsonTopLevelObjectEntries({
+      filePath: target.storePath,
+      maxEntryBytes: LEGACY_SESSION_ENTRY_MAX_BYTES,
+      maxFileBytes: LEGACY_SESSION_STORE_STREAM_MAX_BYTES,
+      onEntry: (sessionKey, value) => {
+        pushLegacySessionRecord(target, issues, records, sessionKey, value);
+      },
+    });
+  } catch (err) {
+    const errMessage = err instanceof Error ? err.message : String(err);
+    if (errMessage.startsWith("File exceeds")) {
+      issues.push({
+        code: "store_unreadable",
+        message:
+          `${target.storePath}: exceeds a legacy sessions.json streaming limit ` +
+          `(per-entry ${LEGACY_SESSION_ENTRY_MAX_BYTES} bytes / file ` +
+          `${LEGACY_SESSION_STORE_STREAM_MAX_BYTES} bytes). Doctor will not migrate ` +
+          `or import this store until oversized entries or the file are reduced ` +
+          `(back up the file, prune with openclaw sessions cleanup, then retry).`,
+      });
+      return [];
+    }
     issues.push({
-      code: "store_not_object",
-      message: `${target.storePath} does not contain an object session store.`,
+      code: "store_unreadable",
+      message: `${target.storePath}: ${String(err)}`,
     });
     return [];
-  }
-  const records: LegacySessionRecord[] = [];
-  for (const [sessionKey, value] of Object.entries(parsed)) {
-    if (!isSessionEntry(value)) {
-      issues.push({
-        code: "entry_invalid",
-        message: "Session entry is missing a valid sessionId.",
-        sessionKey,
-      });
-      continue;
-    }
-    records.push({
-      // Import is the migration boundary: repair legacy delivery/route shapes
-      // here because the SQLite runtime read path assumes canonical entries.
-      entry: normalizeSessionEntryDelivery(value),
-      sessionKey,
-      transcriptPath: resolveLegacyTranscriptPath(target, value),
-    });
   }
   return records;
 }

--- a/src/infra/legacy-json-object-stream.test.ts
+++ b/src/infra/legacy-json-object-stream.test.ts
@@ -1,0 +1,77 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { streamLegacyJsonTopLevelObjectEntries } from "./legacy-json-object-stream.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+function tempFile(name: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-legacy-json-stream-"));
+  tempDirs.push(dir);
+  return path.join(dir, name);
+}
+
+describe("streamLegacyJsonTopLevelObjectEntries", () => {
+  it("streams top-level object entries without requiring a wrapper property", async () => {
+    const filePath = tempFile("sessions.json");
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        "agent:main:a": { sessionId: "a", updatedAt: 1 },
+        "agent:main:b": { sessionId: "b", updatedAt: 2 },
+      }),
+      { mode: 0o600 },
+    );
+    const entries: Array<[string, unknown]> = [];
+    const snapshot = await streamLegacyJsonTopLevelObjectEntries({
+      filePath,
+      maxEntryBytes: 1024,
+      onEntry: (key, value) => {
+        entries.push([key, value]);
+      },
+    });
+    expect(snapshot.size).toBe(fs.statSync(filePath).size);
+    expect(entries).toEqual([
+      ["agent:main:a", { sessionId: "a", updatedAt: 1 }],
+      ["agent:main:b", { sessionId: "b", updatedAt: 2 }],
+    ]);
+  });
+
+  it("rejects a single entry above maxEntryBytes", async () => {
+    const filePath = tempFile("huge-entry.json");
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        huge: { sessionId: "huge", label: "x".repeat(200) },
+      }),
+      { mode: 0o600 },
+    );
+    await expect(
+      streamLegacyJsonTopLevelObjectEntries({
+        filePath,
+        maxEntryBytes: 64,
+        onEntry: () => undefined,
+      }),
+    ).rejects.toThrow(/File exceeds 64 bytes/);
+  });
+
+  it("rejects a file above maxFileBytes before parsing", async () => {
+    const filePath = tempFile("big-file.json");
+    fs.writeFileSync(filePath, `${"x".repeat(128)}`, { mode: 0o600 });
+    await expect(
+      streamLegacyJsonTopLevelObjectEntries({
+        filePath,
+        maxEntryBytes: 1024,
+        maxFileBytes: 64,
+        onEntry: () => undefined,
+      }),
+    ).rejects.toThrow(/File exceeds 64 bytes/);
+  });
+});

--- a/src/infra/legacy-json-object-stream.ts
+++ b/src/infra/legacy-json-object-stream.ts
@@ -1,7 +1,9 @@
-// Streams one-property legacy JSON object stores without buffering the whole file.
+// Streams one-property or top-level legacy JSON object stores without buffering
+// the whole file. Entry values are still parsed as bounded objects.
 import { createHash } from "node:crypto";
 import type { FileHandle } from "node:fs/promises";
 import type { Root } from "@openclaw/fs-safe";
+import { openLocalFileSafely } from "./fs-safe.js";
 
 const JSON_WHITESPACE = new Set([" ", "\t", "\r", "\n"]);
 
@@ -105,7 +107,10 @@ async function readJsonString(cursor: JsonCharacterCursor): Promise<string> {
   }
 }
 
-async function readJsonObject(cursor: JsonCharacterCursor): Promise<unknown> {
+async function readJsonObject(
+  cursor: JsonCharacterCursor,
+  maxEntryBytes?: number,
+): Promise<unknown> {
   await cursor.skipWhitespace();
   if ((await cursor.take()) !== "{") {
     throw new Error("legacy JSON entries must be objects");
@@ -120,6 +125,11 @@ async function readJsonObject(cursor: JsonCharacterCursor): Promise<unknown> {
       throw new Error("unterminated object in legacy JSON store");
     }
     raw += character;
+    // Session JSON is ASCII-heavy; string length is a tight enough byte proxy
+    // for the per-entry support ceiling without encoding every character.
+    if (maxEntryBytes !== undefined && raw.length > maxEntryBytes) {
+      throw new Error(`File exceeds ${maxEntryBytes} bytes`);
+    }
     if (inString) {
       if (escaped) {
         escaped = false;
@@ -141,6 +151,31 @@ async function readJsonObject(cursor: JsonCharacterCursor): Promise<unknown> {
   return parseLegacyJson(raw);
 }
 
+async function parseObjectEntries(params: {
+  cursor: JsonCharacterCursor;
+  maxEntryBytes?: number;
+  onEntry: (key: string, value: unknown) => void;
+}): Promise<void> {
+  await params.cursor.skipWhitespace();
+  if ((await params.cursor.peek()) === "}") {
+    await params.cursor.take();
+    return;
+  }
+  while (true) {
+    const key = await readJsonString(params.cursor);
+    await expectCharacter(params.cursor, ":");
+    params.onEntry(key, await readJsonObject(params.cursor, params.maxEntryBytes));
+    await params.cursor.skipWhitespace();
+    const separator = await params.cursor.take();
+    if (separator === "}") {
+      return;
+    }
+    if (separator !== ",") {
+      throw new Error("expected comma or object end in legacy JSON store");
+    }
+  }
+}
+
 async function parseSinglePropertyObject(params: {
   chunks: AsyncIterable<string>;
   property: string;
@@ -154,25 +189,26 @@ async function parseSinglePropertyObject(params: {
   }
   await expectCharacter(cursor, ":");
   await expectCharacter(cursor, "{");
-  await cursor.skipWhitespace();
-  if ((await cursor.peek()) !== "}") {
-    while (true) {
-      const key = await readJsonString(cursor);
-      await expectCharacter(cursor, ":");
-      params.onEntry(key, await readJsonObject(cursor));
-      await cursor.skipWhitespace();
-      const separator = await cursor.take();
-      if (separator === "}") {
-        break;
-      }
-      if (separator !== ",") {
-        throw new Error("expected comma or object end in legacy JSON store");
-      }
-    }
-  } else {
-    await cursor.take();
-  }
+  await parseObjectEntries({ cursor, onEntry: params.onEntry });
   await expectCharacter(cursor, "}");
+  await cursor.skipWhitespace();
+  if ((await cursor.take()) !== null) {
+    throw new Error("legacy JSON store has trailing content");
+  }
+}
+
+async function parseTopLevelObjectEntries(params: {
+  chunks: AsyncIterable<string>;
+  maxEntryBytes: number;
+  onEntry: (key: string, value: unknown) => void;
+}): Promise<void> {
+  const cursor = new JsonCharacterCursor(params.chunks);
+  await expectCharacter(cursor, "{");
+  await parseObjectEntries({
+    cursor,
+    maxEntryBytes: params.maxEntryBytes,
+    onEntry: params.onEntry,
+  });
   await cursor.skipWhitespace();
   if ((await cursor.take()) !== null) {
     throw new Error("legacy JSON store has trailing content");
@@ -181,14 +217,20 @@ async function parseSinglePropertyObject(params: {
 
 async function* decodeUtf8Chunks(params: {
   handle: FileHandle;
-  hash: ReturnType<typeof createHash>;
+  hash?: ReturnType<typeof createHash>;
   onBytes: (length: number) => void;
+  maxBytes?: number;
 }): AsyncGenerator<string> {
   const decoder = new TextDecoder("utf-8", { fatal: true });
   const stream = params.handle.createReadStream({ autoClose: false, start: 0 });
+  let size = 0;
   for await (const rawChunk of stream) {
     const chunk = Buffer.isBuffer(rawChunk) ? rawChunk : Buffer.from(rawChunk);
-    params.hash.update(chunk);
+    size += chunk.byteLength;
+    if (params.maxBytes !== undefined && size > params.maxBytes) {
+      throw new Error(`File exceeds ${params.maxBytes} bytes`);
+    }
+    params.hash?.update(chunk);
     params.onBytes(chunk.byteLength);
     const text = decoder.decode(chunk, { stream: true });
     if (text) {
@@ -262,6 +304,48 @@ export async function readLegacyJsonObjectStream(params: {
       sha256: hash.digest("hex"),
       size,
     };
+  } catch (error) {
+    if (error instanceof TypeError && /encoded data was not valid/i.test(error.message)) {
+      throw new Error("legacy JSON store is not valid UTF-8", { cause: error });
+    }
+    throw error;
+  } finally {
+    await opened[Symbol.asyncDispose]();
+  }
+}
+
+/**
+ * Stream a top-level `{ key: object, ... }` legacy store entry-by-entry.
+ * Used when the whole-file JSON.parse path would exceed the inline byte ceiling.
+ */
+export async function streamLegacyJsonTopLevelObjectEntries(params: {
+  filePath: string;
+  maxEntryBytes: number;
+  maxFileBytes?: number;
+  onEntry: (key: string, value: unknown) => void;
+}): Promise<{ size: number }> {
+  const opened = await openLocalFileSafely({ filePath: params.filePath });
+  let size = 0;
+  try {
+    if (params.maxFileBytes !== undefined && opened.stat.size > params.maxFileBytes) {
+      throw new Error(`File exceeds ${params.maxFileBytes} bytes`);
+    }
+    const before = opened.stat;
+    const chunks = decodeUtf8Chunks({
+      handle: opened.handle,
+      maxBytes: params.maxFileBytes,
+      onBytes: (length) => {
+        size += length;
+      },
+    });
+    await parseTopLevelObjectEntries({
+      chunks,
+      maxEntryBytes: params.maxEntryBytes,
+      onEntry: params.onEntry,
+    });
+    const after = await opened.handle.stat();
+    assertStableRead(before, after, size);
+    return { size };
   } catch (error) {
     if (error instanceof TypeError && /encoded data was not valid/i.test(error.message)) {
       throw new Error("legacy JSON store is not valid UTF-8", { cause: error });


### PR DESCRIPTION
## What Problem This Solves

Doctor's legacy `sessions.json` → SQLite inspect/migrate path used unbounded
`fs.readFileSync`, so a corrupted or adversarial store could force a large
in-memory allocation during `openclaw doctor --session-sqlite`. A hard-fail
above 16 MiB would block migration of valid oversized stores.

## Why This Change Was Made

Keep a bounded inline `JSON.parse` path at ≤16 MiB, and for larger valid stores
stream top-level session entries via `streamLegacyJsonTopLevelObjectEntries`
(1 MiB per entry, 256 MiB file ceiling). That preserves migration for oversized
history while avoiding whole-file string allocation. Invalid/oversized-entry
stores still fail closed as `store_unreadable`.

## User Impact

- Legacy stores ≤16 MiB: same inline parse/migrate path as before this campaign.
- Valid stores >16 MiB and ≤256 MiB with entries ≤1 MiB: inspect / dry-run /
  import / validate continue via streaming.
- Stores above the streamed ceilings, or with non-object/invalid JSON: fail
  closed with `store_unreadable` and recovery guidance.

## Evidence

### Code

- `src/infra/legacy-json-object-stream.ts`: top-level object streaming helper
  (`streamLegacyJsonTopLevelObjectEntries`) with per-entry / file ceilings.
- `src/commands/doctor-session-sqlite.ts`: inline ≤16 MiB; stream above that.
- `docs/cli/doctor.md`: documents the dual-path contract.
- CLI wiring unchanged: `openclaw doctor --session-sqlite` → `doctorCommand` →
  `runDoctorSessionSqlite`.

### Focused tests

```bash
node scripts/run-vitest.mjs \
  src/infra/legacy-json-object-stream.test.ts \
  src/commands/doctor-session-sqlite.test.ts \
  -t "streams|imports a streamed|fail-closes when a streamed|fail-closes when an oversized|top-level object|rejects a single|rejects a file" \
  --reporter=verbose
```

Result (8 passed):

- streams inspect / dry-run above 16 MiB inline ceiling
- imports streamed store above 16 MiB
- fail-closes streamed entry >1 MiB
- fail-closes invalid oversized JSON
- helper: top-level stream, entry ceiling, file ceiling

## Real behavior proof

### Behavior or issue addressed

A valid legacy `sessions.json` larger than 16 MiB must still inspect and import
without loading the whole file as one JSON string, while per-entry / absolute
stream ceilings remain fail-closed.

### Canonical reachability path

`openclaw doctor --session-sqlite inspect|import --session-sqlite-store <sessions.json>`
→ `runDoctorSessionSqlite`
→ `readLegacySessionRecords`
→ (size > 16 MiB) `streamLegacyJsonTopLevelObjectEntries`
→ session entries → inspect counts / import rows

### Shared helper / provider constraint check

Reuses and extends the existing doctor legacy JSON object streamer used by APNs
state migration. No new config/env surface.

### Real environment tested

- Host: macOS, Node v22.23.1
- Isolated `HOME` + `OPENCLAW_STATE_DIR` + `OPENCLAW_CONFIG_PATH`
- Valid store: **17511830** bytes (~16.7 MiB), 20 entries (1 real + 19 padded)

### Evidence after fix

**Live inspect**

```text
{
  "productionPath": "runDoctorSessionSqlite (doctor --session-sqlite)",
  "mode": "inspect",
  "elapsedMs": 9613,
  "issues": 0,
  "legacyEntries": 20,
  "importedEntries": 0,
  "storeBytes": 17511830,
  "storePresent": true,
  "sqlitePresent": false,
  "padEntries": 19,
  "issueCodes": []
}
```

**Live import**

```text
{
  "productionPath": "runDoctorSessionSqlite (doctor --session-sqlite)",
  "mode": "import",
  "elapsedMs": 22825,
  "issues": 0,
  "legacyEntries": 20,
  "importedEntries": 20,
  "storeBytes": null,
  "storePresent": false,
  "sqlitePresent": true,
  "padEntries": 19,
  "issueCodes": []
}
```

**Focused vitest**

```text
 ✓ streams inspect when legacy sessions.json exceeds the 16 MiB inline ceiling
 ✓ streams dry-run when legacy sessions.json exceeds the 16 MiB inline ceiling
 ✓ imports a streamed legacy sessions.json above the 16 MiB inline ceiling
 ✓ fail-closes when a streamed legacy session entry exceeds 1 MiB
 ✓ fail-closes when an oversized legacy sessions.json is not valid JSON
 ✓ streams top-level object entries without requiring a wrapper property
 ✓ rejects a single entry above maxEntryBytes
 ✓ rejects a file above maxFileBytes before parsing
 Test Files  2 passed (2)
      Tests  8 passed | 69 skipped (77)
```

### Observed result after fix

1. Inspect of a ~16.7 MiB valid store reports 20 legacy entries, 0 issues, no SQLite create.
2. Import migrates all 20 entries, creates agent SQLite, archives the legacy store.
3. Per-entry >1 MiB and invalid oversized JSON still fail closed.

### What was not tested

- Built packaged `dist/entry.js` / global `openclaw` binary on this host
- Live operator gateway with a multi-year production oversized store

### Fix classification

bugfix / hardening — bounded inline read + Option A streamed migrate for oversized valid stores

## AI Assistance

AI-assisted. Author reviewed the dual-path ceilings, streaming helper, focused
tests, and live `runDoctorSessionSqlite` inspect/import proof.
