### PR TITLE
fix(auto-reply): degrade gracefully when preflight compaction hard-fails (#100778)

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.preflight-stale-tokens.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.preflight-stale-tokens.test.ts
@@ -151,4 +151,36 @@ describe("runPreflightCompactionIfNeeded stale totalTokens gating", () => {
 
     expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(1);
   });
+
+  it("degrades gracefully when preflight compaction hard-fails (does not throw, returns entry) (#100778)", async () => {
+    const sessionFile = path.join(rootDir, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify({ message: { role: "user", content: "x".repeat(2_000) } })}\n`,
+      "utf8",
+    );
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      sessionFile,
+      updatedAt: Date.now(),
+      totalTokens: 200_000,
+      totalTokensFresh: true,
+    };
+    await writeTestSessionStore(
+      path.join(rootDir, "sessions.json"),
+      "agent:main:main",
+      sessionEntry,
+    );
+    // Simulate a provider/timeout failure of the compaction LLM call.
+    compactEmbeddedAgentSessionMock.mockResolvedValue({
+      ok: false,
+      reason: "provider_error_5xx",
+    });
+
+    // Must not throw: preflight compaction is a guardrail, not a hard
+    // dependency. The reply should continue and the Composer must not be
+    // left permanently "terminated".
+    const entry = await runWithEntry(sessionEntry, sessionFile);
+    expect(entry).toBe(sessionEntry);
+  });
 });

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -1017,9 +1017,16 @@ export async function runPreflightCompactionIfNeeded(params: {
         logVerbose(`preflightCompaction skipped: sessionKey=${params.sessionKey} reason=${reason}`);
         return entry ?? params.sessionEntry;
       }
+      // A hard preflight compaction failure (timeout, rate limit, provider 5xx)
+      // must not abort the whole reply — compaction is a guardrail, not a hard
+      // dependency. Degrade gracefully: skip compaction and let the agent run
+      // continue so the user can still send messages and the Composer is not
+      // left in a permanently "terminated" state. See #100778.
       await notifyTerminalCompaction("incomplete");
-      logVerbose(`preflightCompaction failed: sessionKey=${params.sessionKey} reason=${reason}`);
-      throw new Error(`Preflight compaction required but failed: ${reason}`);
+      logVerbose(
+        `preflightCompaction failed but continuing without it: sessionKey=${params.sessionKey} reason=${reason}`,
+      );
+      return entry ?? params.sessionEntry;
     }
 
     if (!result.compacted) {
@@ -1029,9 +1036,13 @@ export async function runPreflightCompactionIfNeeded(params: {
         logVerbose(`preflightCompaction skipped: sessionKey=${params.sessionKey} reason=${reason}`);
         return entry ?? params.sessionEntry;
       }
+      // Hard compaction failure: degrade gracefully (guardrail, not a hard
+      // dependency) instead of aborting the reply and locking the Composer.
       await notifyTerminalCompaction("incomplete");
-      logVerbose(`preflightCompaction failed: sessionKey=${params.sessionKey} reason=${reason}`);
-      throw new Error(`Preflight compaction required but failed: ${reason}`);
+      logVerbose(
+        `preflightCompaction did not compact but continuing without it: sessionKey=${params.sessionKey} reason=${reason}`,
+      );
+      return entry ?? params.sessionEntry;
     }
 
     await deps.incrementCompactionCount({


### PR DESCRIPTION
Focused, single-commit resubmission (supersedes #111018, which accidentally carried unrelated stacked commits). Touches ONLY the preflight-compaction fix: 2 files, +47/-4.

## Summary

When preflight compaction failed hard (e.g. a provider 5xx), `runPreflightCompactionIfNeeded` threw, which left the Composer permanently stuck in the "terminated" state (#100778). Preflight compaction is a guardrail, not a hard dependency — a recoverable failure should not kill the run.

## Fix

In `src/auto-reply/reply/agent-runner-memory.ts`, the two hard-throw sites now degrade gracefully on a non-skip failure reason: notify terminal compaction as "incomplete", log a verbose warning, and return the existing entry so the run continues instead of throwing.

## Behavior

```
BEFORE:  preflight compaction fails  ->  throw  ->  Composer stuck "terminated"
AFTER:   preflight compaction fails  ->  log + notify "incomplete"  ->  run continues
```

## Tests

`vitest run --pool forks src/auto-reply/reply/agent-runner-memory.preflight-stale-tokens.test.ts` -> **3/3 pass**, including the new regression test ("does not throw when preflight compaction fails hard (provider_error_5xx)"). oxlint 0/0; oxfmt clean.

Closes #100778