### PR TITLE
fix(agents): bound SSH sandbox commands with a default timeout

### DIFF
--- a/src/agents/sandbox/ssh.test.ts
+++ b/src/agents/sandbox/ssh.test.ts
@@ -14,6 +14,7 @@ import {
   createSshSandboxSessionFromSettings,
   disposeSshSandboxSession,
   ENSURE_REMOTE_REAL_DIRECTORY_SCRIPT,
+  runSshSandboxCommand,
   type SshSandboxSession,
   uploadDirectoryToSshTarget,
 } from "./ssh.js";
@@ -383,6 +384,30 @@ describe("sandbox ssh helpers", () => {
           remoteDir: "/remote/workspace",
         }),
       ).resolves.toBeUndefined();
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "rejects a sandbox command that stalls past the timeout",
+    async () => {
+      const localDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-ssh-cmd-timeout-"));
+      tempDirs.push(localDir);
+      const hangingSsh = path.join(localDir, "hang-ssh.mjs");
+      await fs.writeFile(hangingSsh, "#!/usr/bin/env node\nsetInterval(() => {}, 1e9);\n", {
+        mode: 0o755,
+      });
+
+      await expect(
+        runSshSandboxCommand({
+          session: {
+            command: hangingSsh,
+            configPath: "/tmp/openclaw-test-ssh-config",
+            host: "openclaw-sandbox",
+          },
+          remoteCommand: "true",
+          timeoutMs: 100,
+        }),
+      ).rejects.toThrow(/timed out/i);
     },
   );
 });

--- a/src/agents/sandbox/ssh.ts
+++ b/src/agents/sandbox/ssh.ts
@@ -46,6 +46,7 @@ export type RunSshSandboxCommandParams = {
   allowFailure?: boolean;
   signal?: AbortSignal;
   tty?: boolean;
+  timeoutMs?: number;
 };
 
 function normalizeInlineSshMaterial(contents: string, filename: string): string {
@@ -670,6 +671,8 @@ export async function disposeSshSandboxSession(session: SshSandboxSession): Prom
   await fs.rm(path.dirname(session.configPath), { recursive: true, force: true });
 }
 
+const SSH_COMMAND_TIMEOUT_MS = 60_000;
+
 /** Run a remote command through ssh and return buffered stdout/stderr. */
 export async function runSshSandboxCommand(
   params: RunSshSandboxCommandParams,
@@ -692,6 +695,9 @@ export async function runSshSandboxCommand(
     maxBuffer: SANDBOX_COMMAND_MAX_BUFFER_BYTES,
     reject: false,
     stripFinalNewline: false,
+    // An SSH peer that accepts TCP but stalls before the banner never exits, so
+    // bound the command even when the caller provides no abort signal.
+    timeout: params.timeoutMs ?? SSH_COMMAND_TIMEOUT_MS,
   });
   if (params.signal?.aborted || result.isCanceled) {
     throw createAbortError("Aborted");


### PR DESCRIPTION
## Summary

Bound `runSshSandboxCommand` with a default 60s timeout so an SSH peer that accepts TCP but never completes the handshake can no longer hang sandbox commands forever when the caller provides no abort signal.

## What Problem This Solves

`runSshSandboxCommand` (in `src/agents/sandbox/ssh.ts`) runs remote commands for sandbox setup operations (directory checks, workdir validation, runtime cleanup). It spawned the `ssh` child with only a `cancelSignal` and no deadline.

- `signal` is optional (`params.signal?`), and the sandbox-backend call sites do not pass one.
- If the SSH endpoint accepts TCP but stalls before the banner, the `ssh` child never exits, and the awaited command — including sandbox provisioning flows — hangs forever.
- The existing SSH config only sets `ConnectTimeout 5` (TCP connect) and server-alive keepalives (post-handshake), neither of which covers a stalled pre-banner handshake.

**Code evidence**: at [ssh.ts:687-696](src/agents/sandbox/ssh.ts#L687-L696), `spawnCommand` is called without any timeout option.

## Root Cause

- The underlying `spawnCommand` (execa) supports a `timeout` option, but the call site never set it.
- With no `signal` from callers and no timeout, nothing can settle the child when the peer accepts and stalls.
- Invariant violated: "every sandbox command settles" — not true when the remote endpoint accepts and stalls.

## Why This Fix

Pass a `timeout` to `spawnCommand` (`SSH_COMMAND_TIMEOUT_MS = 60_000`, overridable via a new optional `timeoutMs` parameter):

- On expiry, execa kills the child and the result surfaces through the existing failure path (`result.failed` → `toErrorObject`), producing a clear `Command timed out after ...` error — no new error-handling logic.
- The default only bounds the stuck-peer case: the sandbox-backend commands covered by this path (existence checks, workdir validation, cleanup) complete in well under 60s on any healthy endpoint, while the failure mode being addressed produces zero progress.
- The execa option is named `timeout` (not `timeoutMs`); the public parameter keeps the codebase's `timeoutMs` naming and maps onto it.
- Alternative considered: relying on callers to always pass `signal` — rejected, because the optionality of `signal` is exactly what allowed the hang; a default deadline is the fail-safe.

## User Impact

- **Before**: a stuck SSH endpoint hangs sandbox setup commands forever with no error.
- **After**: the command fails with a clear timeout error after 60s.

## Evidence

- **Before** (upstream/main): `outcome after 3.4s: WATCHDOG-3s` — **FAIL**: sandbox command hung with no timeout after the ssh child stalled
- **After** (with fix): `outcome after 0.9s: REJECTED: Command timed out after 500 milliseconds: ... hang-ssh.mjs -F ... host true` — **PASS**: stalled sandbox command rejected by timeout

## Real Behavior Proof

Proof runs the real `runSshSandboxCommand` against a stub `ssh` executable that accepts the connection and never exits, with `timeoutMs: 500` and a 3s watchdog.

### Before (on main)

```bash
$ node --import tsx proof.mjs
outcome after 3.4s: WATCHDOG-3s
FAIL: sandbox command hung with no timeout after the ssh child stalled
```

### After (with fix)

```bash
$ node --import tsx proof.mjs
outcome after 0.9s: REJECTED: Command timed out after 500 milliseconds: /tmp/ssh-cmd-proof-XXX/hang-ssh.mjs -F /tmp/ssh-cmd-proof-XXX/config -T -o 'RequestTTY=no' host true
PASS: stalled sandbox command rejected by timeout
```

## Tests and Validation

- `npx vitest run src/agents/sandbox/ssh.test.ts` — 58 passed (57 existing + 1 new)
- New regression test: `rejects a sandbox command that stalls past the timeout`
- `tsgo:core` typecheck passed; `oxlint` and `oxfmt --check` clean on the changed files
