### PR TITLE
fix(tls): bound openssl certificate generation with a timeout

### DIFF
--- a/src/infra/tls/gateway.test.ts
+++ b/src/infra/tls/gateway.test.ts
@@ -3,10 +3,16 @@
 import { X509Certificate } from "node:crypto";
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createTrackedTempDirs } from "../../test-utils/tracked-temp-dirs.js";
 import { normalizeFingerprint } from "./fingerprint.js";
 import { loadGatewayTlsRuntime } from "./gateway.js";
+
+const { runExecMock } = vi.hoisted(() => ({ runExecMock: vi.fn() }));
+vi.mock("../../process/exec.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../process/exec.js")>();
+  return { ...actual, runExec: runExecMock };
+});
 
 const tempDirs = createTrackedTempDirs();
 const createTempDir = () => tempDirs.make("openclaw-gateway-tls-test-");
@@ -177,6 +183,20 @@ describe("loadGatewayTlsRuntime", () => {
     expect(result.certPath).not.toBe("   ");
     expect(result.keyPath).toBeTruthy();
     expect(result.keyPath).not.toBe("\t");
+  });
+
+  it("bounds openssl certificate generation with a timeout", async () => {
+    runExecMock.mockResolvedValue({ stdout: "", stderr: "" });
+    const dir = await createTempDir();
+    const certPath = path.join(dir, "gateway-cert.pem");
+    const keyPath = path.join(dir, "gateway-key.pem");
+
+    await loadGatewayTlsRuntime({ enabled: true, certPath, keyPath });
+
+    expect(runExecMock).toHaveBeenCalledOnce();
+    expect(runExecMock.mock.calls[0]?.[0]).toMatch(/openssl$/);
+    expect(runExecMock.mock.calls[0]?.[1]).toContain("req");
+    expect(runExecMock.mock.calls[0]?.[2]).toMatchObject({ timeoutMs: 30_000 });
   });
 
   it("does not fall back for non-empty paths with leading/trailing spaces", async () => {

--- a/src/infra/tls/gateway.ts
+++ b/src/infra/tls/gateway.ts
@@ -61,7 +61,9 @@ async function generateSelfSignedCert(params: {
       "-subj",
       "/CN=openclaw-gateway",
     ],
-    { logOutput: false },
+    // runExec object options carry no implicit deadline; a wedged openssl must
+    // not block gateway TLS initialization (and the doctor flow) forever.
+    { logOutput: false, timeoutMs: 30_000 },
   );
   await fs.chmod(params.keyPath, 0o600).catch(() => {});
   await fs.chmod(params.certPath, 0o600).catch(() => {});


### PR DESCRIPTION
## Summary

Bound the `openssl req` invocation used for gateway TLS self-signed certificate generation with `timeoutMs: 30_000`, so a wedged openssl can no longer block gateway TLS initialization (and the doctor flow) forever.

## What Problem This Solves

`generateSelfSignedCert` (in `src/infra/tls/gateway.ts`) shells out to the system `openssl` to generate the gateway's self-signed certificate when TLS is enabled and no cert exists.

- The call uses `runExec`'s object options form (`{ logOutput: false }`), which — unlike the numeric shorthand — carries **no implicit deadline**: `timeout` is only set when `timeoutMs` is provided.
- openssl can block indefinitely under pathological conditions (entropy exhaustion, broken PKI configuration, a suspended process on a loaded host).
- Since TLS initialization happens inline in gateway startup and doctor flows, a stuck openssl hangs the whole flow with no error.

**Code evidence**: at [gateway.ts:46-62](src/infra/tls/gateway.ts#L46-L62), `runExec(opensslBin, ["req", ...], { logOutput: false })` passes no `timeoutMs`.

## Root Cause

- `runExec(command, args, opts)` only computes a deadline from `opts.timeoutMs` (or the numeric shorthand); the object form without `timeoutMs` means "wait forever".
- The call site passed the object form (to silence output logging) and thereby silently dropped the deadline the numeric form would have had.
- Invariant violated: "every spawned helper settles" — not guaranteed for a blocking system binary.

## Why This Fix

Add `timeoutMs: 30_000` to the existing options object:

- On expiry, execa kills the child and `runExec` rethrows a clear `Command timed out after ...` error, which `loadGatewayTlsRuntime` already surfaces as `gateway tls: failed to generate cert (...)` — no new error-handling logic.
- 30s is generous for a local `rsa:2048` self-signed generation (sub-second on a healthy host) while still bounding the pathological block.
- Alternative considered: switching to the numeric shorthand — rejected, because it would drop `logOutput: false` and still not state the intent explicitly at the call site.

## User Impact

- **Before**: a wedged openssl hangs gateway TLS setup (and doctor) forever with no error.
- **After**: certificate generation fails with a clear timeout error after 30s.

## Evidence

- **Before** (upstream/main): `runExec option objects recorded: [{"logOutput":false}]` — **FAIL**: openssl invocation has no deadline (timeoutMs missing)
- **After** (with fix): `runExec option objects recorded: [{"logOutput":false,"timeoutMs":30000}]` — **PASS**: openssl invocation bounded with timeoutMs=30000

## Real Behavior Proof

Proof drives the real `loadGatewayTlsRuntime` generation path (real `runExec`, real `openssl` writing a real certificate into a temp dir) and records the options object handed to `runExec` via a module boundary hook.

### Before (on main)

```bash
$ node --import tsx proof.mjs
runExec option objects recorded: [{"logOutput":false}]
generated cert exists: true
FAIL: openssl invocation has no deadline (timeoutMs missing)
```

### After (with fix)

```bash
$ node --import tsx proof.mjs
runExec option objects recorded: [{"logOutput":false,"timeoutMs":30000}]
generated cert exists: true
PASS: openssl invocation bounded with timeoutMs=30000
```

## Tests and Validation

- `npx vitest run src/infra/tls/gateway.test.ts` — 8 passed (7 existing + 1 new)
- New regression test: `bounds openssl certificate generation with a timeout`
- `tsgo:core` typecheck passed; `oxlint` and `oxfmt --check` clean on the changed files
