### PR TITLE
fix(mattermost): probe hangs past deadline when DNS preflight stalls

### DIFF
--- a/extensions/mattermost/src/mattermost/probe.preflight-timeout.test.ts
+++ b/extensions/mattermost/src/mattermost/probe.preflight-timeout.test.ts
@@ -1,0 +1,35 @@
+// Real guarded-fetch path: no fetchWithSsrFGuard mock.
+// Locks guard-owned timeoutMs at the probeMattermost entry point.
+// Shared SSRF suites cover stalled DNS; this asserts Mattermost still forwards
+// timeoutMs into that owner so preflight abort happens before HTTP dispatch.
+// Do not rewrite this to AbortSignal.timeout() / init.signal — that would
+// regress the guard-owned contract (#105549).
+import type { LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
+import { describe, expect, it, vi } from "vitest";
+import { probeMattermost } from "./probe.js";
+
+describe("probeMattermost preflight timeout", () => {
+  it("times out when preflight lookup stalls before HTTP dispatch", async () => {
+    const stalledLookup: LookupFn = (() => new Promise<never>(() => {})) as LookupFn;
+    const fetchSpy = vi.fn(async () => new Response("should not run"));
+
+    const started = Date.now();
+    const result = await probeMattermost("https://mm.example.com", "bot-token", 80, false, {
+      fetchImpl: fetchSpy,
+      lookupFn: stalledLookup,
+    });
+    const elapsedMs = Date.now() - started;
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBeNull();
+    expect(result.error).toBe("request timed out");
+    expect(elapsedMs).toBeGreaterThanOrEqual(60);
+    expect(elapsedMs).toBeLessThan(2_000);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    console.log(
+      `[mattermost probe preflight stall proof] timed_out=${!result.ok} error=${
+        result.error ?? "n/a"
+      } elapsed_ms=${elapsedMs} fetch_called=${fetchSpy.mock.calls.length}`,
+    );
+  });
+});

--- a/extensions/mattermost/src/mattermost/probe.preflight-timeout.test.ts
+++ b/extensions/mattermost/src/mattermost/probe.preflight-timeout.test.ts
@@ -1,10 +1,15 @@
 // Exercise the real guard: its timeout owns DNS/proxy preflight as well as fetch.
 import type { LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { probeMattermost } from "./probe.js";
 
 describe("probeMattermost preflight timeout", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("times out when preflight lookup stalls before HTTP dispatch", async () => {
+    vi.stubEnv("OPENCLAW_PROXY_ACTIVE", "0");
     const stalledLookup: LookupFn = (() => new Promise<never>(() => {})) as LookupFn;
     const fetchSpy = vi.fn(async () => new Response("should not run"));
 

--- a/extensions/mattermost/src/mattermost/probe.preflight-timeout.test.ts
+++ b/extensions/mattermost/src/mattermost/probe.preflight-timeout.test.ts
@@ -1,9 +1,4 @@
-// Real guarded-fetch path: no fetchWithSsrFGuard mock.
-// Locks guard-owned timeoutMs at the probeMattermost entry point.
-// Shared SSRF suites cover stalled DNS; this asserts Mattermost still forwards
-// timeoutMs into that owner so preflight abort happens before HTTP dispatch.
-// Do not rewrite this to AbortSignal.timeout() / init.signal — that would
-// regress the guard-owned contract (#105549).
+// Exercise the real guard: its timeout owns DNS/proxy preflight as well as fetch.
 import type { LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
 import { describe, expect, it, vi } from "vitest";
 import { probeMattermost } from "./probe.js";
@@ -26,10 +21,5 @@ describe("probeMattermost preflight timeout", () => {
     expect(elapsedMs).toBeGreaterThanOrEqual(60);
     expect(elapsedMs).toBeLessThan(2_000);
     expect(fetchSpy).not.toHaveBeenCalled();
-    console.log(
-      `[mattermost probe preflight stall proof] timed_out=${!result.ok} error=${
-        result.error ?? "n/a"
-      } elapsed_ms=${elapsedMs} fetch_called=${fetchSpy.mock.calls.length}`,
-    );
   });
 });

--- a/extensions/mattermost/src/mattermost/probe.test.ts
+++ b/extensions/mattermost/src/mattermost/probe.test.ts
@@ -26,6 +26,7 @@ function requireFirstFetchCall() {
     init?: { headers?: unknown; signal?: unknown };
     auditContext?: string;
     policy?: unknown;
+    timeoutMs?: number;
   };
 }
 
@@ -61,7 +62,8 @@ describe("probeMattermost", () => {
     const fetchCall = requireFirstFetchCall();
     expect(fetchCall?.url).toBe("https://mm.example.com/api/v4/users/me");
     expect(fetchCall?.init?.headers).toStrictEqual({ Authorization: "Bearer bot-token" });
-    expect(fetchCall?.init?.signal).toBeInstanceOf(AbortSignal);
+    expect(fetchCall?.timeoutMs).toBe(2500);
+    expect(fetchCall?.init?.signal).toBeUndefined();
     expect(fetchCall?.auditContext).toBe("mattermost-probe");
     expect(fetchCall?.policy).toBeUndefined();
     const { elapsedMs, ...stableResult } = result;
@@ -120,7 +122,7 @@ describe("probeMattermost", () => {
     expect(fetchCall?.policy).toStrictEqual({ allowPrivateNetwork: true });
   });
 
-  it("clamps oversized probe timeouts before scheduling", async () => {
+  it("clamps oversized probe timeouts before the guard-owned deadline", async () => {
     mockFetchGuard.mockResolvedValueOnce({
       response: new Response(JSON.stringify({ id: "bot-1" }), {
         status: 200,
@@ -128,14 +130,10 @@ describe("probeMattermost", () => {
       }),
       release: mockRelease,
     });
-    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
-    try {
-      await probeMattermost("https://mm.example.com", "bot-token", Number.MAX_SAFE_INTEGER);
 
-      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
-    } finally {
-      setTimeoutSpy.mockRestore();
-    }
+    await probeMattermost("https://mm.example.com", "bot-token", Number.MAX_SAFE_INTEGER);
+
+    expect(requireFirstFetchCall().timeoutMs).toBe(MAX_TIMER_TIMEOUT_MS);
   });
 
   it("returns API error details from JSON response", async () => {

--- a/extensions/mattermost/src/mattermost/probe.ts
+++ b/extensions/mattermost/src/mattermost/probe.ts
@@ -5,6 +5,7 @@ import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import {
   fetchWithSsrFGuard,
   ssrfPolicyFromPrivateNetworkOptIn,
+  type LookupFn,
 } from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeMattermostBaseUrl, readMattermostError, type MattermostUser } from "./client.js";
 import type { BaseProbeResult } from "./runtime-api.js";
@@ -15,11 +16,20 @@ type MattermostProbe = BaseProbeResult & {
   bot?: MattermostUser;
 };
 
+type MattermostProbeFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+/** Optional test hooks so probe can exercise the real guarded-fetch owner. */
+type ProbeMattermostDeps = {
+  fetchImpl?: MattermostProbeFetch;
+  lookupFn?: LookupFn;
+};
+
 export async function probeMattermost(
   baseUrl: string,
   botToken: string,
   timeoutMs = 2500,
   allowPrivateNetwork = false,
+  deps?: ProbeMattermostDeps,
 ): Promise<MattermostProbe> {
   const normalized = normalizeMattermostBaseUrl(baseUrl);
   if (!normalized) {
@@ -27,21 +37,19 @@ export async function probeMattermost(
   }
   const url = `${normalized}/api/v4/users/me`;
   const start = Date.now();
-  const resolvedTimeoutMs = timeoutMs > 0 ? resolveTimerTimeoutMs(timeoutMs, 2500) : 0;
-  const controller = resolvedTimeoutMs > 0 ? new AbortController() : undefined;
-  let timer: NodeJS.Timeout | null = null;
-  if (controller) {
-    timer = setTimeout(() => controller.abort(), resolvedTimeoutMs);
-  }
+  // Guard-owned timeoutMs covers DNS/proxy preflight; init.signal alone does not.
+  const resolvedTimeoutMs = timeoutMs > 0 ? resolveTimerTimeoutMs(timeoutMs, 2500) : undefined;
   try {
     const { response: res, release } = await fetchWithSsrFGuard({
       url,
       init: {
         headers: { Authorization: `Bearer ${botToken}` },
-        signal: controller?.signal,
       },
       auditContext: "mattermost-probe",
       policy: ssrfPolicyFromPrivateNetworkOptIn(allowPrivateNetwork),
+      ...(resolvedTimeoutMs !== undefined ? { timeoutMs: resolvedTimeoutMs } : {}),
+      ...(deps?.fetchImpl ? { fetchImpl: deps.fetchImpl } : {}),
+      ...(deps?.lookupFn ? { lookupFn: deps.lookupFn } : {}),
     });
     try {
       const elapsedMs = Date.now() - start;
@@ -72,9 +80,5 @@ export async function probeMattermost(
       error: message,
       elapsedMs: Date.now() - start,
     };
-  } finally {
-    if (timer) {
-      clearTimeout(timer);
-    }
   }
 }

--- a/extensions/mattermost/src/mattermost/probe.ts
+++ b/extensions/mattermost/src/mattermost/probe.ts
@@ -16,11 +16,9 @@ type MattermostProbe = BaseProbeResult & {
   bot?: MattermostUser;
 };
 
-type MattermostProbeFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
-
 /** Optional test hooks so probe can exercise the real guarded-fetch owner. */
 type ProbeMattermostDeps = {
-  fetchImpl?: MattermostProbeFetch;
+  fetchImpl?: typeof fetch;
   lookupFn?: LookupFn;
 };
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Mattermost channel probe / doctor checks could hang past the configured probe deadline when SSRF DNS/proxy preflight never completes. `probeMattermost` only aborted via `AbortController` on `init.signal`, which does not cover guarded-fetch preflight, so a stalled lookup could leave setup/doctor stuck before HTTP dispatch.

## Why This Change Was Made

Pass the resolved probe deadline as top-level `fetchWithSsrFGuard({ timeoutMs })`, matching the Mattermost API client path and the post-#105549 guard-owned timeout contract. Remove the local `AbortController`/`setTimeout` deadline that only wrapped `RequestInit.signal`. Optional test-only `fetchImpl` / `lookupFn` hooks let the entry point exercise the real guarded-fetch owner without mocking it away.

## User Impact

**Before:** Mattermost probe could hang indefinitely during DNS/proxy preflight despite a 2.5s (or caller) timeout.

**After:** Probe returns `ok: false` with `error: "request timed out"` when preflight stalls, and HTTP `fetch` is never called.

## Evidence

- Exact head: `3c04fdcdcf1f4e3b43627fdd77c4d730e222d457`
- Changed: `extensions/mattermost/src/mattermost/probe.ts`
- Production caller under test: `probeMattermost` → `fetchWithSsrFGuard({ timeoutMs })` with never-resolving `lookupFn`
- Regression: `extensions/mattermost/src/mattermost/probe.preflight-timeout.test.ts` + updated `probe.test.ts`
- Sibling contract: Mattermost `client.ts` already forwards guard `timeoutMs`; shared SSRF suite covers stalled DNS for the guard itself

### Unit + preflight proof (exit 0)

```bash
node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/probe.preflight-timeout.test.ts extensions/mattermost/src/mattermost/probe.test.ts --reporter=verbose
```

```text
 ✓ |extension-mattermost| extensions/mattermost/src/mattermost/probe.test.ts > probeMattermost > returns baseUrl missing for empty base URL
 ✓ |extension-mattermost| extensions/mattermost/src/mattermost/probe.test.ts > probeMattermost > normalizes base URL and returns bot info
 ✓ |extension-mattermost| extensions/mattermost/src/mattermost/probe.test.ts > probeMattermost > bounds and cancels oversized probe success JSON bodies
 ✓ |extension-mattermost| extensions/mattermost/src/mattermost/probe.test.ts > probeMattermost > forwards allowPrivateNetwork to the SSRF guard policy
 ✓ |extension-mattermost| extensions/mattermost/src/mattermost/probe.test.ts > probeMattermost > clamps oversized probe timeouts before the guard-owned deadline
 ✓ |extension-mattermost| extensions/mattermost/src/mattermost/probe.test.ts > probeMattermost > returns API error details from JSON response
 ✓ |extension-mattermost| extensions/mattermost/src/mattermost/probe.test.ts > probeMattermost > falls back to statusText when error body is empty
 ✓ |extension-mattermost| extensions/mattermost/src/mattermost/probe.test.ts > probeMattermost > returns fetch error when request throws
stdout | extensions/mattermost/src/mattermost/probe.preflight-timeout.test.ts > probeMattermost preflight timeout > times out when preflight lookup stalls before HTTP dispatch
[mattermost probe preflight stall proof] timed_out=true error=request timed out elapsed_ms=82 fetch_called=0

 ✓ |extension-mattermost| extensions/mattermost/src/mattermost/probe.preflight-timeout.test.ts > probeMattermost preflight timeout > times out when preflight lookup stalls before HTTP dispatch

 Test Files  2 passed (2)
      Tests  9 passed (9)
```

### Standalone exact-head runtime proof (exit 0, non-Vitest)

```bash
PROOF_ROOT=. PROOF_HEAD=$(git rev-parse HEAD) PROOF_TIMEOUT_MS=80 \
  node --import tsx /tmp/mattermost-probe-preflight-timeout-proof.mjs
```

```text
[standalone] exact_head=3c04fdcdcf1f4e3b43627fdd77c4d730e222d457 caller=probeMattermost→fetchWithSsrFGuard timeoutMs=80
[fetch-timeout] fetch timeout after 80ms (elapsed 81ms) operation=fetchWithSsrFGuard url=https://mm.example.com/api/v4/users/me
[standalone] RESULT timed_out=true ok=false error=request timed out elapsed_ms=130 fetch_called=0
[standalone] PASS
```

## Real behavior proof

- **Behavior or issue addressed:** Mattermost probe no longer hangs when SSRF DNS/proxy preflight never completes; deadline is owned by `fetchWithSsrFGuard` `timeoutMs`.
- **Canonical reachability path:** channel/doctor probe → `probeMattermost` → `fetchWithSsrFGuard({ timeoutMs: resolvedTimeoutMs })` → preflight lookup abort before HTTP dispatch.
- **Boundary crossed:** Operator Mattermost base URL DNS/proxy preflight → local guarded-fetch timeout → probe `{ ok: false, error: "request timed out" }`.
- **Shared helper / provider constraint check:** Reuses `fetchWithSsrFGuard` top-level `timeoutMs` (not `init.signal` / `AbortSignal.timeout()`). Aligns with Mattermost `client.ts` and #105549. No new config/env.
- **Real environment tested:** macOS, Node via `node --import tsx` standalone harness on exact head `3c04fdcdcf1f4e3b43627fdd77c4d730e222d457` (plus Vitest regression).
- **Exact steps or command run after this patch:** `PROOF_ROOT=. PROOF_HEAD=$(git rev-parse HEAD) PROOF_TIMEOUT_MS=80 node --import tsx /tmp/mattermost-probe-preflight-timeout-proof.mjs`
- **Evidence after fix:** Standalone transcript above: `timed_out=true error=request timed out elapsed_ms=130 fetch_called=0` then `PASS`.
- **Observed result after fix:** Stalled preflight returns `request timed out` before HTTP dispatch (`fetch_called=0`).
- **What was not tested:** Live Mattermost server probe with real credentials; full 2.5s production-floor duration (proof uses an 80ms stand-in).
- **Fix classification:** Root cause fix

- [x] AI-assisted (Cursor)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
