### PR TITLE
fix(media): gate inbound audio on structured media facts

### DIFF
--- a/extensions/discord/src/monitor/message-media.ts
+++ b/extensions/discord/src/monitor/message-media.ts
@@ -1,6 +1,6 @@
 // Discord plugin module implements message media behavior.
 import { StickerFormatType, type APIAttachment, type APIStickerItem } from "discord-api-types/v10";
-import { getFileExtension } from "openclaw/plugin-sdk/media-mime";
+import { getFileExtension, normalizeMimeType } from "openclaw/plugin-sdk/media-mime";
 import { saveRemoteMedia, type FetchLike } from "openclaw/plugin-sdk/media-runtime";
 import { buildMediaPayload } from "openclaw/plugin-sdk/reply-payload";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
@@ -49,6 +49,7 @@ const DISCORD_STICKER_ASSET_BASE_URL = "https://media.discordapp.net/stickers";
 export type DiscordMediaInfo = {
   path: string;
   contentType?: string;
+  kind?: "audio";
   placeholder: string;
 };
 
@@ -72,6 +73,56 @@ function isDiscordAudioAttachmentFileName(fileName?: string | null): boolean {
 
 function hasDiscordVoiceAttachmentFields(attachment: APIAttachment): boolean {
   return typeof attachment.duration_secs === "number" || typeof attachment.waveform === "string";
+}
+
+const NON_DEFINITIVE_MEDIA_TYPES = new Set([
+  "application/octet-stream",
+  "binary/octet-stream",
+  // Discord can report this container type without identifying whether it holds audio or video.
+  "application/ogg",
+]);
+
+function isDefinitiveMediaType(contentType: string | null | undefined): boolean {
+  const normalized = normalizeMimeType(contentType);
+  return Boolean(normalized && !NON_DEFINITIVE_MEDIA_TYPES.has(normalized));
+}
+
+function resolveEffectiveMediaType(params: {
+  declaredContentType?: string | null;
+  fetchedContentType?: string | null;
+}): string | undefined {
+  if (isDefinitiveMediaType(params.fetchedContentType)) {
+    return params.fetchedContentType ?? undefined;
+  }
+  if (isDefinitiveMediaType(params.declaredContentType)) {
+    return params.declaredContentType ?? undefined;
+  }
+  return params.fetchedContentType ?? params.declaredContentType ?? undefined;
+}
+
+function resolveDiscordMediaClassification(params: {
+  attachment: APIAttachment;
+  fetchedContentType?: string | null;
+}): { contentType?: string; kind?: "audio" } {
+  const contentType = resolveEffectiveMediaType({
+    declaredContentType: params.attachment.content_type,
+    fetchedContentType: params.fetchedContentType,
+  });
+  const mime = normalizeMimeType(contentType);
+  const kind =
+    mime?.startsWith("audio/") ||
+    hasDiscordVoiceAttachmentFields(params.attachment) ||
+    (isDiscordAudioAttachmentFileName(params.attachment.filename ?? params.attachment.url) &&
+      !isDefinitiveMediaType(contentType))
+      ? "audio"
+      : undefined;
+
+  return {
+    // Inbound projection prefers MIME over kind. A native voice classification
+    // must therefore replace a non-audio MIME rather than be masked by it.
+    contentType: kind === "audio" && !mime?.startsWith("audio/") ? undefined : contentType,
+    ...(kind ? { kind } : {}),
+  };
 }
 
 function mergeHostnameList(...lists: Array<string[] | undefined>): string[] | undefined {
@@ -331,18 +382,23 @@ async function appendResolvedMediaFromAttachments(params: {
         fallbackContentType: attachment.content_type,
         originalFilename: attachment.filename,
       });
+      const classification = resolveDiscordMediaClassification({
+        attachment,
+        fetchedContentType: saved.contentType,
+      });
       params.out.push({
         path: saved.path,
-        contentType: saved.contentType,
-        placeholder: inferPlaceholder(attachment),
+        ...classification,
+        placeholder: inferPlaceholder(classification),
       });
     } catch (err) {
       const id = attachment.id ?? attachmentUrl;
       logVerbose(`${params.errorPrefix} ${id}: ${String(err)}`);
+      const classification = resolveDiscordMediaClassification({ attachment });
       params.out.push({
         path: attachmentUrl,
-        contentType: attachment.content_type,
-        placeholder: inferPlaceholder(attachment),
+        ...classification,
+        placeholder: inferPlaceholder(classification),
       });
     }
   }
@@ -457,8 +513,11 @@ async function appendResolvedMediaFromStickers(params: {
   }
 }
 
-function inferPlaceholder(attachment: APIAttachment): string {
-  const mime = attachment.content_type ?? "";
+function inferPlaceholder(media: Pick<DiscordMediaInfo, "contentType" | "kind">): string {
+  if (media.kind === "audio") {
+    return "<media:audio>";
+  }
+  const mime = normalizeMimeType(media.contentType) ?? "";
   if (mime.startsWith("image/")) {
     return "<media:image>";
   }
@@ -466,12 +525,6 @@ function inferPlaceholder(attachment: APIAttachment): string {
     return "<media:video>";
   }
   if (mime.startsWith("audio/")) {
-    return "<media:audio>";
-  }
-  if (hasDiscordVoiceAttachmentFields(attachment)) {
-    return "<media:audio>";
-  }
-  if (isDiscordAudioAttachmentFileName(attachment.filename ?? attachment.url)) {
     return "<media:audio>";
   }
   return "<media:document>";

--- a/extensions/discord/src/monitor/message-utils.test.ts
+++ b/extensions/discord/src/monitor/message-utils.test.ts
@@ -656,6 +656,7 @@ describe("resolveMediaList", () => {
       {
         path: attachment.url,
         contentType: undefined,
+        kind: "audio",
         placeholder: "<media:audio>",
       },
     ]);
@@ -682,6 +683,205 @@ describe("resolveMediaList", () => {
       {
         path: attachment.url,
         contentType: undefined,
+        kind: "audio",
+        placeholder: "<media:audio>",
+      },
+    ]);
+  });
+
+  it.each(["application/octet-stream", "application/ogg"])(
+    "prefers the structured audio kind over non-audio MIME %s",
+    async (contentType) => {
+      const attachment = {
+        id: "att-audio-conflicting-mime",
+        url: "https://cdn.discordapp.com/attachments/1/voice.ogg",
+        filename: "voice.ogg",
+        content_type: contentType,
+      };
+      readRemoteMediaBuffer.mockResolvedValueOnce({
+        buffer: Buffer.from("audio"),
+        contentType,
+      });
+      saveMediaBuffer.mockResolvedValueOnce({
+        path: "/tmp/voice.ogg",
+        contentType,
+      });
+
+      const result = await resolveMediaList(asMessage({ attachments: [attachment] }), 512);
+
+      expect(result).toEqual([
+        {
+          path: "/tmp/voice.ogg",
+          contentType: undefined,
+          kind: "audio",
+          placeholder: "<media:audio>",
+        },
+      ]);
+    },
+  );
+
+  it("normalizes MIME case before classifying audio", async () => {
+    const attachment = {
+      id: "att-audio-mime-case",
+      url: "https://cdn.discordapp.com/attachments/1/voice.bin",
+      filename: "voice.bin",
+      content_type: "Audio/OGG",
+    };
+    readRemoteMediaBuffer.mockRejectedValueOnce(new Error("blocked by ssrf guard"));
+
+    const result = await resolveMediaList(asMessage({ attachments: [attachment] }), 512);
+
+    expect(result).toEqual([
+      {
+        path: attachment.url,
+        contentType: "Audio/OGG",
+        kind: "audio",
+        placeholder: "<media:audio>",
+      },
+    ]);
+  });
+
+  it("does not let an audio-looking filename override video MIME", async () => {
+    const attachment = {
+      id: "att-video-audio-extension",
+      url: "https://cdn.discordapp.com/attachments/1/clip.ogg",
+      filename: "clip.ogg",
+      content_type: "video/ogg",
+    };
+    readRemoteMediaBuffer.mockRejectedValueOnce(new Error("blocked by ssrf guard"));
+
+    const result = await resolveMediaList(asMessage({ attachments: [attachment] }), 512);
+
+    expect(result).toEqual([
+      {
+        path: attachment.url,
+        contentType: "video/ogg",
+        placeholder: "<media:video>",
+      },
+    ]);
+  });
+
+  it("does not let an audio-looking filename override fetched image MIME", async () => {
+    const attachment = {
+      id: "att-image-audio-extension",
+      url: "https://cdn.discordapp.com/attachments/1/image.ogg",
+      filename: "image.ogg",
+    };
+    readRemoteMediaBuffer.mockResolvedValueOnce({
+      buffer: Buffer.from("image"),
+      contentType: "image/png",
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/image.png",
+      contentType: "image/png",
+    });
+
+    const result = await resolveMediaList(asMessage({ attachments: [attachment] }), 512);
+
+    expect(result).toEqual([
+      {
+        path: "/tmp/image.png",
+        contentType: "image/png",
+        placeholder: "<media:image>",
+      },
+    ]);
+  });
+
+  it("keeps declared audio when the fetched MIME is generic", async () => {
+    const attachment = {
+      id: "att-declared-audio-fetched-generic",
+      url: "https://cdn.discordapp.com/attachments/1/voice",
+      filename: "voice",
+      content_type: "audio/ogg",
+    };
+    readRemoteMediaBuffer.mockResolvedValueOnce({
+      buffer: Buffer.from("audio"),
+      contentType: "application/octet-stream",
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/voice",
+      contentType: "application/octet-stream",
+    });
+
+    const result = await resolveMediaList(asMessage({ attachments: [attachment] }), 512);
+
+    expect(result).toEqual([
+      {
+        path: "/tmp/voice",
+        contentType: "audio/ogg",
+        kind: "audio",
+        placeholder: "<media:audio>",
+      },
+    ]);
+  });
+
+  it.each(["application/pdf", "text/plain"])(
+    "does not infer audio from an .ogg filename with definitive MIME %s",
+    async (contentType) => {
+      const attachment = {
+        id: `att-definitive-${contentType}`,
+        url: "https://cdn.discordapp.com/attachments/1/document.ogg",
+        filename: "document.ogg",
+        content_type: contentType,
+      };
+      readRemoteMediaBuffer.mockRejectedValueOnce(new Error("blocked by ssrf guard"));
+
+      const result = await resolveMediaList(asMessage({ attachments: [attachment] }), 512);
+
+      expect(result).toEqual([
+        {
+          path: attachment.url,
+          contentType,
+          placeholder: "<media:document>",
+        },
+      ]);
+    },
+  );
+
+  it("uses fetched image MIME over declared audio", async () => {
+    const attachment = {
+      id: "att-declared-audio-fetched-image",
+      url: "https://cdn.discordapp.com/attachments/1/voice.ogg",
+      filename: "voice.ogg",
+      content_type: "audio/ogg",
+    };
+    readRemoteMediaBuffer.mockResolvedValueOnce({
+      buffer: Buffer.from("image"),
+      contentType: "image/png",
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/image.png",
+      contentType: "image/png",
+    });
+
+    const result = await resolveMediaList(asMessage({ attachments: [attachment] }), 512);
+
+    expect(result).toEqual([
+      {
+        path: "/tmp/image.png",
+        contentType: "image/png",
+        placeholder: "<media:image>",
+      },
+    ]);
+  });
+
+  it("classifies extensionless Discord voice attachments from native fields", async () => {
+    const attachment = {
+      id: "att-voice-native-fields",
+      url: "https://cdn.discordapp.com/attachments/1/voice",
+      filename: "voice",
+      duration_secs: 1.5,
+      waveform: "AAAA",
+    };
+    readRemoteMediaBuffer.mockRejectedValueOnce(new Error("blocked by ssrf guard"));
+
+    const result = await resolveMediaList(asMessage({ attachments: [attachment] }), 512);
+
+    expect(result).toEqual([
+      {
+        path: attachment.url,
+        contentType: undefined,
+        kind: "audio",
         placeholder: "<media:audio>",
       },
     ]);

--- a/src/auto-reply/reply/get-reply.message-hooks.test.ts
+++ b/src/auto-reply/reply/get-reply.message-hooks.test.ts
@@ -318,7 +318,7 @@ describe("getReplyFromConfig message hooks", () => {
     );
   });
 
-  it("recognizes locked-harness audio from its filename when MIME metadata is missing", async () => {
+  it("does not infer locked-harness audio from its filename when MIME metadata is missing", async () => {
     const sessionKey = "agent:main:harness:claude-cli:locked-audio-filename";
     mocks.resolveReplySessionPreprocessingState.mockReturnValueOnce({
       sessionEntry: {
@@ -340,15 +340,13 @@ describe("getReplyFromConfig message hooks", () => {
         RawBody: "<media:file>",
         CommandBody: "<media:file>",
         MediaType: undefined,
+        MediaTypes: undefined,
       }),
       undefined,
       buildConfiguredAudioCfg(),
     );
 
-    expect(mocks.applyMediaUnderstanding).toHaveBeenCalledOnce();
-    expect(mocks.applyMediaUnderstanding.mock.calls[0]?.[0]).toEqual(
-      expect.objectContaining({ processingMode: "audio-only" }),
-    );
+    expect(mocks.applyMediaUnderstanding).not.toHaveBeenCalled();
   });
 
   it("runs normal media understanding for an unlocked voice note", async () => {

--- a/src/auto-reply/reply/inbound-media.test.ts
+++ b/src/auto-reply/reply/inbound-media.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { hasInboundAudio } from "./inbound-media.js";
+
+describe("hasInboundAudio", () => {
+  it("detects audio from the singular structured media type without a placeholder body", () => {
+    expect(hasInboundAudio({ MediaType: " Audio/Ogg ; codecs=opus " })).toBe(true);
+  });
+
+  it("detects audio in aligned structured media types", () => {
+    expect(hasInboundAudio({ MediaTypes: ["image/png", "audio/mpeg"] })).toBe(true);
+  });
+
+  it("accepts the structured audio kind when a MIME subtype is unavailable", () => {
+    expect(hasInboundAudio({ MediaTypes: ["audio"] })).toBe(true);
+  });
+
+  it("does not infer audio from placeholder or transcript text", () => {
+    expect(hasInboundAudio({ Body: "<media:audio>" })).toBe(false);
+    expect(hasInboundAudio({ Body: "[Audio]\nTranscript:\nhello" })).toBe(false);
+  });
+
+  it("does not rederive audio from a media filename", () => {
+    expect(hasInboundAudio({ MediaPath: "/tmp/voice.ogg" })).toBe(false);
+  });
+
+  it("does not treat non-audio media as audio", () => {
+    expect(hasInboundAudio({ MediaType: "image/png", MediaTypes: ["video/mp4"] })).toBe(false);
+  });
+});

--- a/src/auto-reply/reply/inbound-media.ts
+++ b/src/auto-reply/reply/inbound-media.ts
@@ -1,12 +1,9 @@
-/** Detects inbound media and audio markers in channel message context. */
-import { isAudioFileName } from "@openclaw/media-core/mime";
+/** Detects inbound media and audio facts in channel message context. */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 
 /** Minimal inbound media fields used by media/audio detection. */
 type InboundMediaContext = {
   Body?: unknown;
-  BodyForCommands?: unknown;
-  CommandBody?: unknown;
   MediaType?: unknown;
   StickerMediaIncluded?: unknown;
   SkipStickerMediaUnderstanding?: unknown;
@@ -16,7 +13,6 @@ type InboundMediaContext = {
   MediaPaths?: readonly unknown[];
   MediaUrls?: readonly unknown[];
   MediaTypes?: readonly unknown[];
-  RawBody?: unknown;
 };
 
 function hasNormalizedStringEntry(values: readonly unknown[] | undefined): boolean {
@@ -46,15 +42,12 @@ export function hasInboundMediaForUnderstanding(ctx: InboundMediaContext): boole
   );
 }
 
-const AUDIO_PLACEHOLDER_RE = /^<media:audio>(\s*\([^)]*\))?$/i;
-const AUDIO_HEADER_RE = /^\[Audio\b/i;
-
 function normalizeMediaType(value: unknown): string | undefined {
   const normalized = normalizeOptionalString(value);
-  return normalized?.split(";", 1)[0]?.toLowerCase();
+  return normalized?.split(";", 1)[0]?.trim().toLowerCase() || undefined;
 }
 
-/** Returns true when media fields or body placeholders indicate inbound audio. */
+/** Returns true when the current turn carries structured audio media facts. */
 export function hasInboundAudio(ctx: InboundMediaContext): boolean {
   const mediaTypes = [
     normalizeMediaType(ctx.MediaType),
@@ -62,31 +55,5 @@ export function hasInboundAudio(ctx: InboundMediaContext): boolean {
       ? ctx.MediaTypes.map((type) => normalizeMediaType(type))
       : []),
   ].filter((type): type is string => Boolean(type));
-  if (mediaTypes.some((type) => type === "audio" || type.startsWith("audio/"))) {
-    return true;
-  }
-
-  // Keep the locked-session gate aligned with media-understanding attachment
-  // classification when a channel omits MIME metadata.
-  const mediaLocations = [
-    ctx.MediaPath,
-    ctx.MediaUrl,
-    ...(Array.isArray(ctx.MediaPaths) ? ctx.MediaPaths : []),
-    ...(Array.isArray(ctx.MediaUrls) ? ctx.MediaUrls : []),
-  ];
-  if (mediaLocations.some((value) => isAudioFileName(normalizeOptionalString(value)))) {
-    return true;
-  }
-
-  const body =
-    normalizeOptionalString(ctx.BodyForCommands) ??
-    normalizeOptionalString(ctx.CommandBody) ??
-    normalizeOptionalString(ctx.RawBody) ??
-    normalizeOptionalString(ctx.Body) ??
-    "";
-  const trimmed = body.trim();
-  if (!trimmed) {
-    return false;
-  }
-  return AUDIO_PLACEHOLDER_RE.test(trimmed) || AUDIO_HEADER_RE.test(trimmed);
+  return mediaTypes.some((type) => type === "audio" || type.startsWith("audio/"));
 }


### PR DESCRIPTION
## What Problem This Solves

`hasInboundAudio` — the gate that decides whether an inbound message carries audio for transcription/voice handling — reverse-engineered presentation text: it matched `<media:audio>` placeholder bodies, `[Audio` transcript headers, and audio-looking filenames in addition to the structured `MediaType`/`MediaTypes` fields. This is PR1 of the `<media:kind>` placeholder-elimination program: before channels stop minting placeholder bodies, nothing in core may depend on them for behavior.

## Why This Change Was Made

- `hasInboundAudio` now consumes only structured facts: normalized `MediaType`/`MediaTypes` accepting the structured kind `audio` or `audio/*` MIME (case-insensitive, parameters stripped). The placeholder regex, header regex, and filename inference are deleted (net −10 prod LOC in core).
- A full producer/consumer audit (11 bundled channel plugins mint `<media:` strings; table with file:line cites in the audit summary below) proved every audio-capable channel populates structured media types — except one hole: Discord, when a download fails, could leave a voice-classified attachment with a usable remote URL but no MIME. Discord now carries its native audio classification as structured `kind: "audio"` with deliberate precedence: definitive fetched MIME > definitive declared MIME > generic container types (`application/octet-stream`, `binary/octet-stream`, `application/ogg`); filename inference applies only when the effective MIME is absent/non-definitive; definitive non-audio MIME is never dropped or overridden. The rendered placeholder now derives from the same classification, so text and structured facts cannot diverge.
- Deliberate contract change, frozen by tests: a placeholder body without structured media no longer counts as audio. Such a message has no materialized media and cannot be sent to STT anyway; the old string match only produced a doomed transcription attempt.

## User Impact

Voice-message transcription now triggers on the same prepared facts channel ingress already carries, for every bundled channel. Discord voice messages with failed downloads or generic container MIME are now correctly classified as audio (previously possible false negative), and documents misnamed `*.ogg` are no longer routed into audio-only understanding (previously possible false positive).

## Evidence

- Audit: 11 producers (not ~15 — Matrix and Slack use different conventions), 5 regex consumers plus 6 exact-string consumers enumerated with file:line; per-channel structured audio coverage proof for Discord, Feishu, iMessage, LINE, Mattermost, Signal, Telegram, WhatsApp. Program plan: 4 producer-migration batches, shared formatter API frozen (structured facts only), deletion sweep last.
- Tests via `node scripts/run-vitest.mjs`: new `inbound-media.test.ts` 6/6 (structured detection, placeholder/filename non-inference), `get-reply.message-hooks.test.ts` 18/18 (filename-inference contract flip), Discord `message-utils.test.ts` 59/59 (MIME-conflict, generic-container, native-voice, fetched-override, pdf-named-.ogg cases); reran post-rebase onto origin/main.
- Autoreview (Codex gpt-5.6-sol): first pass found two real P2 precedence defects (generic fetched MIME erasing declared audio; filename hints deleting definitive non-audio MIME) — both fixed; final review clean, "patch is correct (0.87)".
