### PR TITLE
fix(msteams): token refresh hangs past deadline when DNS preflight stalls

### DIFF
--- a/extensions/msteams/src/oauth.test.ts
+++ b/extensions/msteams/src/oauth.test.ts
@@ -7,6 +7,7 @@ const fetchWithSsrFGuardMock = vi.hoisted(() =>
     async (params: {
       url: string;
       init?: RequestInit;
+      timeoutMs?: number;
       fetchImpl?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
     }) => {
       const fetchImpl = params.fetchImpl ?? globalThis.fetch;
@@ -32,6 +33,7 @@ import {
 } from "./oauth.flow.js";
 import {
   MSTEAMS_DEFAULT_DELEGATED_SCOPES,
+  MSTEAMS_DEFAULT_TOKEN_FETCH_TIMEOUT_MS,
   MSTEAMS_OAUTH_REDIRECT_URI,
   buildMSTeamsAuthEndpoint,
   buildMSTeamsTokenEndpoint,
@@ -215,7 +217,10 @@ describe("exchangeMSTeamsCodeForTokens", () => {
     expect(body.get("code")).toBe("auth-code");
     expect(body.get("code_verifier")).toBe("pkce-verifier");
     expect(body.get("redirect_uri")).toBe(MSTEAMS_OAUTH_REDIRECT_URI);
-    expect(fetchWithSsrFGuardMock.mock.calls[0]?.[0]).not.toHaveProperty("fetchImpl");
+    const guardCall = fetchWithSsrFGuardMock.mock.calls[0]?.[0];
+    expect(guardCall).not.toHaveProperty("fetchImpl");
+    expect(guardCall?.timeoutMs).toBe(MSTEAMS_DEFAULT_TOKEN_FETCH_TIMEOUT_MS);
+    expect(guardCall?.init?.signal).toBeUndefined();
   });
 
   it("throws on a 400 error response", async () => {
@@ -318,6 +323,9 @@ describe("refreshMSTeamsDelegatedTokens", () => {
     expect(body.get("grant_type")).toBe("refresh_token");
     expect(body.get("refresh_token")).toBe("original-rt");
     expect(body.get("client_secret")).toBe("secret-1");
+    const guardCall = fetchWithSsrFGuardMock.mock.calls.at(-1)?.[0];
+    expect(guardCall?.timeoutMs).toBe(MSTEAMS_DEFAULT_TOKEN_FETCH_TIMEOUT_MS);
+    expect(guardCall?.init?.signal).toBeUndefined();
   });
 
   it("uses new refresh token when Azure returns one", async () => {

--- a/extensions/msteams/src/oauth.token.preflight-timeout.test.ts
+++ b/extensions/msteams/src/oauth.token.preflight-timeout.test.ts
@@ -1,0 +1,50 @@
+// Real guarded-fetch path: no fetchWithSsrFGuard mock.
+// Locks guard-owned timeoutMs at the refreshMSTeamsDelegatedTokens entry point.
+// Shared SSRF suites cover stalled DNS; this asserts Teams token refresh still
+// forwards timeoutMs into that owner so preflight abort happens before HTTP
+// dispatch. Do not rewrite this to AbortSignal.timeout() / init.signal — that
+// would regress the guard-owned contract (#105549). Sibling graph.ts already
+// passes top-level timeoutMs.
+import type { LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
+import { describe, expect, it, vi } from "vitest";
+import { refreshMSTeamsDelegatedTokens } from "./oauth.token.js";
+
+describe("refreshMSTeamsDelegatedTokens preflight timeout", () => {
+  it("times out when preflight lookup stalls before HTTP dispatch", async () => {
+    const stalledLookup: LookupFn = (() => new Promise<never>(() => {})) as LookupFn;
+    const fetchSpy = vi.fn(async () => new Response("should not run"));
+
+    const started = Date.now();
+    const outcome = await refreshMSTeamsDelegatedTokens({
+      tenantId: "tenant-1",
+      clientId: "client-1",
+      clientSecret: "secret-1", // pragma: allowlist secret
+      refreshToken: "original-rt",
+      fetchImpl: fetchSpy,
+      lookupFn: stalledLookup,
+      timeoutMs: 80,
+    }).then(
+      (value) => ({ ok: true as const, value }),
+      (error: unknown) => ({ ok: false as const, error }),
+    );
+    const elapsedMs = Date.now() - started;
+
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.error).toMatchObject({
+        name: "TimeoutError",
+        message: "request timed out",
+      });
+    }
+    expect(elapsedMs).toBeGreaterThanOrEqual(60);
+    expect(elapsedMs).toBeLessThan(2_000);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    console.log(
+      `[msteams token refresh preflight stall proof] timed_out=${!outcome.ok} name=${
+        outcome.ok ? "n/a" : (outcome.error as Error).name
+      } message=${
+        outcome.ok ? "n/a" : (outcome.error as Error).message
+      } elapsed_ms=${elapsedMs} fetch_called=${fetchSpy.mock.calls.length}`,
+    );
+  });
+});

--- a/extensions/msteams/src/oauth.token.ts
+++ b/extensions/msteams/src/oauth.token.ts
@@ -1,7 +1,7 @@
 // Msteams plugin module implements oauth.token behavior.
 import { resolveExpiresAtMsFromDurationSeconds } from "openclaw/plugin-sdk/number-runtime";
 import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
-import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { fetchWithSsrFGuard, type LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
 import { createMSTeamsHttpError } from "./http-error.js";
 import {
   MSTEAMS_DEFAULT_DELEGATED_SCOPES,
@@ -19,6 +19,15 @@ type MSTeamsTokenResponse = {
   refresh_token?: string;
   expiresAt: number;
   scope?: string;
+};
+
+type MSTeamsTokenFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+/** Optional test hooks so token fetch can exercise the real guarded-fetch owner. */
+type MSTeamsTokenFetchDeps = {
+  fetchImpl?: MSTeamsTokenFetch;
+  lookupFn?: LookupFn;
+  timeoutMs?: number;
 };
 
 function createMSTeamsTokenBody(params: {
@@ -74,7 +83,13 @@ async function fetchMSTeamsTokens(params: {
   body: URLSearchParams;
   auditContext: string;
   failureLabel: string;
+  fetchImpl?: MSTeamsTokenFetch;
+  lookupFn?: LookupFn;
+  timeoutMs?: number;
 }): Promise<MSTeamsTokenResponse> {
+  // Guard-owned timeoutMs covers DNS/proxy preflight; init.signal alone does not.
+  // Sibling graph.ts already passes top-level timeoutMs into fetchWithSsrFGuard.
+  const timeoutMs = params.timeoutMs ?? MSTEAMS_DEFAULT_TOKEN_FETCH_TIMEOUT_MS;
   const { response, release } = await fetchWithSsrFGuard({
     url: params.tokenUrl,
     init: {
@@ -84,9 +99,11 @@ async function fetchMSTeamsTokens(params: {
         Accept: "application/json",
       },
       body: params.body,
-      signal: AbortSignal.timeout(MSTEAMS_DEFAULT_TOKEN_FETCH_TIMEOUT_MS),
     },
     auditContext: params.auditContext,
+    timeoutMs,
+    ...(params.fetchImpl ? { fetchImpl: params.fetchImpl } : {}),
+    ...(params.lookupFn ? { lookupFn: params.lookupFn } : {}),
   });
 
   try {
@@ -113,6 +130,9 @@ async function requestMSTeamsDelegatedTokens(params: {
   auditContext: string;
   failureLabel: string;
   resolveRefreshToken: (data: MSTeamsTokenResponse) => string;
+  fetchImpl?: MSTeamsTokenFetch;
+  lookupFn?: LookupFn;
+  timeoutMs?: number;
 }): Promise<MSTeamsDelegatedTokens> {
   const scopes = params.scopes ?? MSTEAMS_DEFAULT_DELEGATED_SCOPES;
   const body = createMSTeamsTokenBody({
@@ -127,6 +147,9 @@ async function requestMSTeamsDelegatedTokens(params: {
     body,
     auditContext: params.auditContext,
     failureLabel: params.failureLabel,
+    fetchImpl: params.fetchImpl,
+    lookupFn: params.lookupFn,
+    timeoutMs: params.timeoutMs,
   });
 
   return {
@@ -137,14 +160,16 @@ async function requestMSTeamsDelegatedTokens(params: {
   };
 }
 
-export async function exchangeMSTeamsCodeForTokens(params: {
-  tenantId: string;
-  clientId: string;
-  clientSecret: string;
-  code: string;
-  verifier: string;
-  scopes?: readonly string[];
-}): Promise<MSTeamsDelegatedTokens> {
+export async function exchangeMSTeamsCodeForTokens(
+  params: {
+    tenantId: string;
+    clientId: string;
+    clientSecret: string;
+    code: string;
+    verifier: string;
+    scopes?: readonly string[];
+  } & MSTeamsTokenFetchDeps,
+): Promise<MSTeamsDelegatedTokens> {
   return await requestMSTeamsDelegatedTokens({
     tenantId: params.tenantId,
     clientId: params.clientId,
@@ -164,16 +189,21 @@ export async function exchangeMSTeamsCodeForTokens(params: {
       }
       return data.refresh_token;
     },
+    fetchImpl: params.fetchImpl,
+    lookupFn: params.lookupFn,
+    timeoutMs: params.timeoutMs,
   });
 }
 
-export async function refreshMSTeamsDelegatedTokens(params: {
-  tenantId: string;
-  clientId: string;
-  clientSecret: string;
-  refreshToken: string;
-  scopes?: readonly string[];
-}): Promise<MSTeamsDelegatedTokens> {
+export async function refreshMSTeamsDelegatedTokens(
+  params: {
+    tenantId: string;
+    clientId: string;
+    clientSecret: string;
+    refreshToken: string;
+    scopes?: readonly string[];
+  } & MSTeamsTokenFetchDeps,
+): Promise<MSTeamsDelegatedTokens> {
   return await requestMSTeamsDelegatedTokens({
     tenantId: params.tenantId,
     clientId: params.clientId,
@@ -186,5 +216,8 @@ export async function refreshMSTeamsDelegatedTokens(params: {
     auditContext: "msteams-oauth-token-refresh",
     failureLabel: "token refresh",
     resolveRefreshToken: (data) => data.refresh_token ?? params.refreshToken,
+    fetchImpl: params.fetchImpl,
+    lookupFn: params.lookupFn,
+    timeoutMs: params.timeoutMs,
   });
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Microsoft Teams delegated token refresh / exchange could hang past the 10s token-fetch deadline when SSRF DNS/proxy preflight never completes. `fetchMSTeamsTokens` only aborted via `AbortSignal.timeout()` on `init.signal`, which does not cover guarded-fetch preflight, so a stalled lookup can leave the Teams channel unable to refresh auth and stay connected.

## Why This Change Was Made

Pass `MSTEAMS_DEFAULT_TOKEN_FETCH_TIMEOUT_MS` as top-level `fetchWithSsrFGuard({ timeoutMs })`, matching sibling `graph.ts` / Graph attachment callers and the post-#105549 guard-owned timeout contract. Remove `AbortSignal.timeout()` from `RequestInit`. Optional test-only `fetchImpl` / `lookupFn` / `timeoutMs` hooks let the refresh entry point exercise the real guarded-fetch owner without mocking it away.

## User Impact

**Before:** Teams token refresh could hang indefinitely during DNS/proxy preflight despite the 10s token-fetch budget, leaving the channel disconnected after token expiry.

**After:** Refresh/exchange rejects with `TimeoutError` / `request timed out` when preflight stalls, and HTTP `fetch` is never called.

## Evidence

- Exact head: `bb797ba40c8751caaa17bc6aa7e23d2e13da1949`
- Changed: `extensions/msteams/src/oauth.token.ts`
- Production caller under test: `refreshMSTeamsDelegatedTokens` → `fetchMSTeamsTokens` → `fetchWithSsrFGuard({ timeoutMs })` with never-resolving `lookupFn`
- Regression: `extensions/msteams/src/oauth.token.preflight-timeout.test.ts` + updated `oauth.test.ts` (asserts top-level `timeoutMs`, no `init.signal`)
- Sibling on same plugin: `graph.ts` already forwards guard `timeoutMs`

### Unit + preflight proof (exit 0)

```bash
node scripts/run-vitest.mjs extensions/msteams/src/oauth.token.preflight-timeout.test.ts extensions/msteams/src/oauth.test.ts --reporter=verbose
```

```text
 ✓ |extension-msteams| extensions/msteams/src/oauth.test.ts > exchangeMSTeamsCodeForTokens > exchanges an authorization code for delegated tokens
 ✓ |extension-msteams| extensions/msteams/src/oauth.test.ts > refreshMSTeamsDelegatedTokens > refreshes tokens using refresh_token grant and keeps old refresh token when Azure omits it
stdout | extensions/msteams/src/oauth.token.preflight-timeout.test.ts > refreshMSTeamsDelegatedTokens preflight timeout > times out when preflight lookup stalls before HTTP dispatch
[msteams token refresh preflight stall proof] timed_out=true name=TimeoutError message=request timed out elapsed_ms=82 fetch_called=0

 ✓ |extension-msteams| extensions/msteams/src/oauth.token.preflight-timeout.test.ts > refreshMSTeamsDelegatedTokens preflight timeout > times out when preflight lookup stalls before HTTP dispatch

 Test Files  2 passed (2)
      Tests  20 passed (20)
```

### Standalone exact-head runtime proof (exit 0, non-Vitest)

```bash
PROOF_ROOT=. PROOF_HEAD=$(git rev-parse HEAD) PROOF_TIMEOUT_MS=80 \
  node --import tsx /tmp/msteams-token-preflight-timeout-proof.mjs
```

```text
[standalone] exact_head=bb797ba40c8751caaa17bc6aa7e23d2e13da1949 caller=refreshMSTeamsDelegatedTokens→fetchMSTeamsTokens→fetchWithSsrFGuard timeoutMs=80
[fetch-timeout] fetch timeout after 80ms (elapsed 82ms) operation=fetchWithSsrFGuard url=https://login.microsoftonline.com/tenant-1/oauth2/v2.0/token
[standalone] RESULT timed_out=true name=TimeoutError message=request timed out elapsed_ms=112 fetch_called=0
[standalone] PASS
```

## Real behavior proof

- **Behavior or issue addressed:** MS Teams token refresh/exchange no longer hangs when SSRF DNS/proxy preflight never completes; deadline is owned by `fetchWithSsrFGuard` `timeoutMs`.
- **Canonical reachability path:** Teams auth refresh → `refreshMSTeamsDelegatedTokens` → `fetchMSTeamsTokens` → `fetchWithSsrFGuard({ timeoutMs: MSTEAMS_DEFAULT_TOKEN_FETCH_TIMEOUT_MS })` → preflight lookup abort before HTTP dispatch.
- **Boundary crossed:** Azure AD token endpoint DNS/proxy preflight → local guarded-fetch timeout → `TimeoutError` (`request timed out`).
- **Shared helper / provider constraint check:** Reuses `fetchWithSsrFGuard` top-level `timeoutMs` (not `init.signal` / `AbortSignal.timeout()`). Aligns with `extensions/msteams/src/graph.ts` and #105549. Default remains `MSTEAMS_DEFAULT_TOKEN_FETCH_TIMEOUT_MS` (10s). No new config/env.
- **Real environment tested:** macOS, Node via `node --import tsx` standalone harness on exact head `bb797ba40c8751caaa17bc6aa7e23d2e13da1949` (plus Vitest regression).
- **Exact steps or command run after this patch:** `PROOF_ROOT=. PROOF_HEAD=$(git rev-parse HEAD) PROOF_TIMEOUT_MS=80 node --import tsx /tmp/msteams-token-preflight-timeout-proof.mjs`
- **Evidence after fix:** Standalone transcript above: `timed_out=true name=TimeoutError message=request timed out elapsed_ms=112 fetch_called=0` then `PASS`.
- **Observed result after fix:** Stalled preflight rejects with `TimeoutError` / `request timed out` before HTTP dispatch (`fetch_called=0`).
- **What was not tested:** Live Azure AD token refresh with real tenant credentials; full 10s production-floor duration (proof uses an 80ms stand-in).
- **Fix classification:** Root cause fix

- [x] AI-assisted (Cursor)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
