### PR TITLE
fix(mcp): bound probe initialize and honor --connect-timeout

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -11,7 +11,6 @@ import type { ServerCapabilities } from "@modelcontextprotocol/sdk/types.js";
 import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { toErrorObject } from "../infra/errors.js";
 import { logWarn } from "../logger.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { runTasksWithConcurrency } from "../utils/run-with-concurrency.js";
@@ -110,27 +109,53 @@ type McpServerBackoffState = {
 
 export { createMcpJsonSchemaValidator as createBundleMcpJsonSchemaValidator };
 
-function connectWithTimeout(
+async function connectWithTimeout(
+  serverName: string,
   client: Client,
   transport: Transport,
   timeoutMs: number,
 ): Promise<void> {
-  return new Promise<void>((resolve, reject) => {
-    const timer = setTimeout(
-      () => reject(new Error(`MCP server connection timed out after ${timeoutMs}ms`)),
-      timeoutMs,
-    );
-    client.connect(transport).then(
-      (value) => {
-        clearTimeout(timer);
-        resolve(value);
-      },
-      (error: unknown) => {
-        clearTimeout(timer);
-        reject(toErrorObject(error, "Non-Error rejection"));
-      },
-    );
-  });
+  const abortController = new AbortController();
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  let deadlineExpired = false;
+  try {
+    // Client.connect() owns both transport startup and the initialize round trip.
+    // Give the SDK the deadline so initialize is cancelled, while the outer race
+    // also bounds transports whose start() has not reached initialize yet.
+    await Promise.race([
+      client.connect(transport, {
+        signal: abortController.signal,
+        timeout: timeoutMs,
+        maxTotalTimeout: timeoutMs,
+      }),
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => {
+          deadlineExpired = true;
+          abortController.abort();
+          reject(new Error("MCP connect deadline expired"));
+        }, timeoutMs);
+      }),
+    ]);
+  } catch (error) {
+    if (deadlineExpired || (isMcpConfigRecord(error) && error.code === ErrorCode.RequestTimeout)) {
+      if (transport instanceof OpenClawStdioClientTransport) {
+        await transport.forceClose();
+      }
+      // Closing the SDK client settles its pending initialize request. Without
+      // this, later runtime disposal waits its full teardown timeout even though
+      // the stdio child is already dead.
+      await settleWithin(client.close(), Math.min(timeoutMs, 1_000));
+      throw new Error(
+        `MCP server "${serverName}" timed out: did not complete initialize within ${timeoutMs / 1_000}s`,
+        { cause: error },
+      );
+    }
+    throw error;
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
 }
 
 function redactErrorUrls(error: unknown): string {
@@ -456,6 +481,7 @@ export function createSessionMcpRuntime(params: {
       return;
     }
     session.connectPromise ??= connectWithTimeout(
+      session.serverName,
       session.client,
       session.transport,
       connectionTimeoutMs,

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-submit.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-submit.test.ts
@@ -132,4 +132,72 @@ describe("submitEmbeddedAttemptPrompt", () => {
     expect(activeSession.agent.streamFn).toBe(baseStreamFn);
     expect(activeSession.agent.transformContext).toBe(originalTransformContext);
   });
+
+  it("caps oversized MCP tool results at the provider boundary", async () => {
+    const { activeSession } = createSession();
+    const input = createBaseInput();
+    const oversized = "x".repeat(5 * 1024 * 1024);
+    const small = "small MCP result";
+    activeSession.agent.state.messages = [
+      { role: "user", content: "call MCP tools", timestamp: 1 },
+      {
+        role: "toolResult",
+        toolCallId: "mcp-huge-call",
+        toolName: "huge__return_text",
+        content: [{ type: "text", text: oversized }],
+        isError: false,
+        details: { mcpServer: "huge", mcpTool: "return_text" },
+        timestamp: 2,
+      },
+      {
+        role: "toolResult",
+        toolCallId: "mcp-small-call",
+        toolName: "huge__small_text",
+        content: [{ type: "text", text: small }],
+        isError: false,
+        details: { mcpServer: "huge", mcpTool: "small_text" },
+        timestamp: 3,
+      },
+    ] as AgentMessage[];
+    let providerMessages: AgentMessage[] = [];
+    activeSession.agent.streamFn = ((_model, context) => {
+      providerMessages = (context as { messages: AgentMessage[] }).messages;
+      return undefined as never;
+    }) as StreamFn;
+
+    await submitEmbeddedAttemptPrompt({
+      ...input,
+      activeSession,
+      promptActiveSession: async () => {
+        await activeSession.agent.streamFn(
+          {} as never,
+          { messages: activeSession.messages } as never,
+          {} as never,
+        );
+      },
+    });
+
+    type ToolResultMessage = Extract<AgentMessage, { role: "toolResult" }>;
+    const hugeResult = providerMessages.find(
+      (message): message is ToolResultMessage =>
+        message.role === "toolResult" && message.toolCallId === "mcp-huge-call",
+    );
+    const smallResult = providerMessages.find(
+      (message): message is ToolResultMessage =>
+        message.role === "toolResult" && message.toolCallId === "mcp-small-call",
+    );
+    expect(hugeResult?.content[0]).toMatchObject({
+      type: "text",
+      text: expect.stringMatching(/more characters truncated/),
+    });
+    expect(hugeResult?.content[0]?.type === "text" ? hugeResult.content[0].text.length : 0).toBe(
+      input.toolResultMaxChars,
+    );
+    expect(smallResult?.content).toEqual([{ type: "text", text: small }]);
+    const originalHugeResult = activeSession.messages[1];
+    expect(originalHugeResult?.role).toBe("toolResult");
+    expect(
+      originalHugeResult?.role === "toolResult" ? originalHugeResult.content : undefined,
+    ).toEqual([{ type: "text", text: oversized }]);
+  });
 });

--- a/src/cli/mcp-cli.test.ts
+++ b/src/cli/mcp-cli.test.ts
@@ -59,6 +59,64 @@ async function createWorkspace(): Promise<string> {
   return dir;
 }
 
+async function writeProbeMcpServer(filePath: string): Promise<void> {
+  await fs.writeFile(
+    filePath,
+    `let buffer = "";
+const mode = process.env.MCP_MODE ?? "normal";
+if (mode === "crash") {
+  process.exit(1);
+}
+function send(message) {
+  process.stdout.write(JSON.stringify(message) + "\\n");
+}
+function handle(message) {
+  if (message.method === "initialize") {
+    if (mode === "hang-start") {
+      return;
+    }
+    send({
+      jsonrpc: "2.0",
+      id: message.id,
+      result: {
+        protocolVersion: message.params?.protocolVersion ?? "2025-03-26",
+        capabilities: { tools: {} },
+        serverInfo: { name: "cli-probe-test", version: "1.0.0" },
+      },
+    });
+    return;
+  }
+  if (message.method === "tools/list") {
+    send({
+      jsonrpc: "2.0",
+      id: message.id,
+      result: { tools: [{ name: "ping", inputSchema: { type: "object" } }] },
+    });
+  }
+}
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  while (true) {
+    const newline = buffer.indexOf("\\n");
+    if (newline < 0) {
+      return;
+    }
+    const line = buffer.slice(0, newline).replace(/\\r$/, "");
+    buffer = buffer.slice(newline + 1);
+    if (line.trim()) {
+      handle(JSON.parse(line));
+    }
+  }
+});
+process.stdin.on("end", () => process.exit(0));
+process.on("SIGTERM", () => process.exit(0));
+process.on("SIGINT", () => process.exit(0));
+`,
+    "utf8",
+  );
+}
+
 let sharedProgram: Command;
 
 async function runMcpCommand(args: string[]) {
@@ -206,6 +264,114 @@ describe("mcp cli", () => {
       });
     });
   });
+
+  it(
+    "requires initialize to finish within the configured probe timeout before saving",
+    { timeout: 10_000 },
+    async () => {
+      await withTempHome("openclaw-cli-mcp-home-", async (home) => {
+        const workspaceDir = await createWorkspace();
+        const serverPath = path.join(workspaceDir, "probe-server.mjs");
+        const configPath = path.join(home, ".openclaw", "openclaw.json");
+        await writeProbeMcpServer(serverPath);
+        vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+
+        const startedAt = performance.now();
+        await expect(
+          runMcpCommand([
+            "mcp",
+            "add",
+            "hung",
+            "--command",
+            process.execPath,
+            "--arg",
+            serverPath,
+            "--env",
+            "MCP_MODE=hang-start",
+            "--connect-timeout",
+            "0.2",
+          ]),
+        ).rejects.toThrow("__exit__:1");
+        const elapsedMs = performance.now() - startedAt;
+
+        expect(elapsedMs).toBeGreaterThanOrEqual(100);
+        expect(elapsedMs).toBeLessThan(1_500);
+        expect(lastErrorLine()).toContain(
+          'MCP server "hung" timed out: did not complete initialize within 0.2s',
+        );
+        await expect(fs.readFile(configPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+
+        await runMcpCommand([
+          "mcp",
+          "add",
+          "ok",
+          "--command",
+          process.execPath,
+          "--arg",
+          serverPath,
+          "--env",
+          "MCP_MODE=normal",
+        ]);
+        expect(lastLogLine()).toBe(`Saved MCP server "ok" to ${configPath}.`);
+
+        await expect(
+          runMcpCommand([
+            "mcp",
+            "add",
+            "crash",
+            "--command",
+            process.execPath,
+            "--arg",
+            serverPath,
+            "--env",
+            "MCP_MODE=crash",
+          ]),
+        ).rejects.toThrow("__exit__:1");
+
+        mockLog.mockClear();
+        await runMcpCommand(["mcp", "list", "--json"]);
+        const saved = JSON.parse(lastLogLine()) as Record<string, unknown>;
+        expect(Object.keys(saved)).toEqual(["ok"]);
+      });
+    },
+  );
+
+  it(
+    "bounds initialize with a five-second probe timeout when no flag is supplied",
+    { timeout: 8_000 },
+    async () => {
+      await withTempHome("openclaw-cli-mcp-home-", async (home) => {
+        const workspaceDir = await createWorkspace();
+        const serverPath = path.join(workspaceDir, "probe-server.mjs");
+        const configPath = path.join(home, ".openclaw", "openclaw.json");
+        await writeProbeMcpServer(serverPath);
+        vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+
+        const startedAt = performance.now();
+        await expect(
+          runMcpCommand([
+            "mcp",
+            "add",
+            "hung-default",
+            "--command",
+            process.execPath,
+            "--arg",
+            serverPath,
+            "--env",
+            "MCP_MODE=hang-start",
+          ]),
+        ).rejects.toThrow("__exit__:1");
+        const elapsedMs = performance.now() - startedAt;
+
+        expect(elapsedMs).toBeGreaterThanOrEqual(4_500);
+        expect(elapsedMs).toBeLessThan(6_500);
+        expect(lastErrorLine()).toContain(
+          'MCP server "hung-default" timed out: did not complete initialize within 5s',
+        );
+        await expect(fs.readFile(configPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+      });
+    },
+  );
 
   it("labels listed MCP servers as OpenClaw-managed", async () => {
     await withTempHome("openclaw-cli-mcp-home-", async () => {

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -547,15 +547,37 @@ function buildMcpProbeConfig(params: {
   };
 }
 
+const DEFAULT_MCP_PROBE_INITIALIZE_TIMEOUT_MS = 5_000;
+
+function applyMcpProbeInitializeTimeout(server: Record<string, unknown>): Record<string, unknown> {
+  if (
+    typeof server.connectionTimeoutMs === "number" &&
+    Number.isFinite(server.connectionTimeoutMs) &&
+    server.connectionTimeoutMs > 0
+  ) {
+    return server;
+  }
+  return {
+    ...server,
+    connectionTimeoutMs: DEFAULT_MCP_PROBE_INITIALIZE_TIMEOUT_MS,
+  };
+}
+
 async function probeMcpServersOrFail(params: {
   config: OpenClawConfig;
   servers: Record<string, Record<string, unknown>>;
   path: string;
 }): Promise<ReturnType<typeof formatMcpProbeResult>> {
+  const probeServers = Object.fromEntries(
+    Object.entries(params.servers).map(([name, server]) => [
+      name,
+      applyMcpProbeInitializeTimeout(server),
+    ]),
+  );
   const runtime = createSessionMcpRuntime({
     sessionId: "openclaw-cli-mcp-probe",
     workspaceDir: process.cwd(),
-    cfg: buildMcpProbeConfig({ config: params.config, servers: params.servers }),
+    cfg: buildMcpProbeConfig({ config: params.config, servers: probeServers }),
     manifestRegistry: { plugins: [] },
   });
   try {


### PR DESCRIPTION
## What Problem This Solves

`openclaw mcp add` silently SAVED a stdio MCP server that accepts the connection but never answers `initialize` (after ~10-15s, exit 0, no warning) — indistinguishable from success. And `--connect-timeout` was parsed and persisted but IGNORED by the probe (2→15s, 6→11s), so it never bounded the initialize handshake. Found by the R8 QA campaign.

## Why This Change Was Made

A probe should confirm a *completed* initialize, not merely a live connection, and it must honor the operator's `--connect-timeout` (with a sane default) so a hung server fails fast instead of being saved.

## User Impact

The MCP probe now bounds both transport startup and the `initialize` handshake: a server that connects but doesn't complete `initialize` within the timeout FAILS the probe with a clear diagnostic and is NOT saved (same as a crash-on-start). `--connect-timeout` is honored, and CLI probes get a sane 5s default applied at probe time WITHOUT mutating the persisted server config. Timed-out connections are aborted and closed.

Also verified (no change needed): oversized MCP tool results ARE truncated at the provider boundary (~16k chars with a truncation note) before reaching the model — an earlier QA observation of an "uncapped 5MB result" was a pre-truncation measurement; added a regression test to lock this in.

## Evidence

- Live: a 3s-timeout probe of a hung-on-initialize server FAILS in ~3.1s and is NOT saved; a normal server saves and returns `pong`; a 5,242,880-char MCP result is truncated to 16,000 chars with `[... N more characters truncated ...]`.
- Tests: 29 MCP CLI + 150 MCP runtime/truncation tests pass (configured/default timeouts + provider-boundary truncation).
- Autoreview (codex gpt-5.6-sol, xhigh): clean — "patch is correct (0.9)". +293/−19 across 4 files (test-heavy).
