### PR TITLE
fix(scripts): bound merge-head-diff-base git operations

### DIFF
--- a/scripts/lib/merge-head-diff-base.mjs
+++ b/scripts/lib/merge-head-diff-base.mjs
@@ -3,6 +3,7 @@ import { execFileSync } from "node:child_process";
 import { pathToFileURL } from "node:url";
 
 const DEFAULT_GIT_OUTPUT_MAX_BUFFER = 16 * 1024 * 1024;
+const MERGE_DIFF_GIT_TIMEOUT_MS = 30_000;
 
 /** Resolve the git base ref to use when diffing a merge head. */
 export function resolveMergeHeadDiffBase({
@@ -40,6 +41,8 @@ function listCommitParents({ ref, cwd, maxBuffer }) {
       stdio: ["ignore", "pipe", "ignore"],
       encoding: "utf8",
       maxBuffer,
+      timeout: MERGE_DIFF_GIT_TIMEOUT_MS,
+      killSignal: "SIGKILL",
     }).trim();
     return output.split(/\s+/u).slice(1);
   } catch {
@@ -54,6 +57,8 @@ function resolveCommit({ ref, cwd, maxBuffer }) {
       stdio: ["ignore", "pipe", "ignore"],
       encoding: "utf8",
       maxBuffer,
+      timeout: MERGE_DIFF_GIT_TIMEOUT_MS,
+      killSignal: "SIGKILL",
     }).trim();
   } catch {
     return "";


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where git operations in the merge-head-diff-base helper could hang indefinitely during CI change detection. The execFileSync("git", ...) calls in listCommitParents and esolveCommit would block without any timeout, stalling automated workflows when git commands encounter network issues or repository corruption.

## Why This Change Was Made

All execFileSync calls to external commands must include a timeout and kill signal. Without these, transient git issues cause resource leaks and indefinite stalls. This follows the same bounding pattern applied in #110600 (full-release-validation-at-sha).

## User Impact

Change detection can complete or fail-fast within a bounded deadline instead of blocking indefinitely when git operations are unresponsive.

## Evidence

- The change adds a MERGE_DIFF_GIT_TIMEOUT_MS = 30_000 constant and applies 	imeout + killSignal: "SIGKILL" to both execFileSync("git", ...) call sites in listCommitParents and esolveCommit.
- pnpm exec oxfmt --check scripts/lib/merge-head-diff-base.mjs passed.
- git diff --check passed.
- Pattern consistency: matches the bounding approach in scripts/full-release-validation-at-sha.mjs (#110600).

AI-assisted: built with Codex

---

### Real behavior proof

Probe on PR head: extracted the production execFileSync pattern, injected a command shim that blocks forever, and verified the script exits with a timeout error instead of hanging.

```text
$ node proof-timeout.mjs
entrypoint: execFileSync(cmd, [...])
fixture: command waits forever
timeout: TIMEOUT_MS=500ms (scaled down for proof)
status: 1
stderr: spawnSync powershell ETIMEDOUT
```

The production deadline is 30 s; the proof scales it to 500 ms to keep the test fast. The `killSignal: "SIGKILL"` ensures the process is terminated, not just detached.