### PR TITLE
fix(cli): keep plugin help exit-clean by lazily loading node runtime

### DIFF
--- a/src/cli/help-exit.process.test.ts
+++ b/src/cli/help-exit.process.test.ts
@@ -1,0 +1,74 @@
+// Process coverage for help rendering without loading live Gateway transports.
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+
+const execFileAsync = promisify(execFile);
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const CHILD_PROCESS_TIMEOUT_MS = 30_000;
+
+describe("CLI help process exit", () => {
+  it.each([
+    { args: ["--help"], usage: "Usage: openclaw [options] [command]" },
+    { args: ["path", "--help"], usage: "Usage: openclaw path [options] [command]" },
+  ])("exits promptly after $args", async ({ args, usage }) => {
+    const root = tempDirs.make("openclaw-help-exit-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
+    const tlsImportGuardPath = path.join(root, "forbid-tls-import.mjs");
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({ plugins: { entries: { "oc-path": { enabled: true } } } }),
+    );
+    await fs.writeFile(
+      tlsImportGuardPath,
+      `import { registerHooks } from "node:module";
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier === "node:tls" || specifier === "tls") {
+      throw new Error(\`CLI help imported TLS from \${context.parentURL ?? "unknown"}\`);
+    }
+    return nextResolve(specifier, context);
+  },
+});
+`,
+    );
+
+    const result = await execFileAsync(
+      process.execPath,
+      [
+        "--import",
+        pathToFileURL(tlsImportGuardPath).href,
+        "--import",
+        "tsx",
+        "src/entry.ts",
+        ...args,
+      ],
+      {
+        cwd: path.resolve("."),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          HOME: root,
+          NODE_ENV: undefined,
+          NODE_OPTIONS: undefined,
+          NODE_USE_SYSTEM_CA: "1",
+          OPENCLAW_CONFIG_PATH: configPath,
+          OPENCLAW_NO_RESPAWN: "1",
+          OPENCLAW_STATE_DIR: stateDir,
+          VITEST: undefined,
+        },
+        killSignal: "SIGKILL",
+        timeout: CHILD_PROCESS_TIMEOUT_MS,
+      },
+    );
+
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain(usage);
+  });
+});

--- a/src/plugins/cli-gateway-nodes-runtime.ts
+++ b/src/plugins/cli-gateway-nodes-runtime.ts
@@ -5,10 +5,14 @@ import {
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
 } from "../../packages/gateway-protocol/src/client-info.js";
-import { callGateway } from "../gateway/call.js";
 import { normalizeOperatorScopeList } from "../gateway/operator-scopes.js";
+import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { getPluginRuntimeGatewayRequestScope } from "./runtime/gateway-request-scope.js";
 import type { PluginRuntime } from "./runtime/types.js";
+
+// Help builds plugin CLI registrations but never calls runtime.nodes. Keep the
+// live Gateway/TLS graph behind the first node RPC so one-shot help stays inert.
+const gatewayCallModuleLoader = createLazyImportLoader(() => import("../gateway/call.js"));
 
 /** Adds Gateway timer grace for plugin CLI node invoke calls. */
 function resolvePluginCliNodeInvokeGatewayTimeoutMs(
@@ -36,6 +40,7 @@ function resolvePluginCliRuntimeNodeInvokeScopes(scopes: string[] | undefined) {
 export function createPluginCliGatewayNodesRuntime(): PluginRuntime["nodes"] {
   return {
     async list(params) {
+      const { callGateway } = await gatewayCallModuleLoader.load();
       const payload = await callGateway({
         method: "node.list",
         params: {},
@@ -57,6 +62,7 @@ export function createPluginCliGatewayNodesRuntime(): PluginRuntime["nodes"] {
       };
     },
     async invoke(params) {
+      const { callGateway } = await gatewayCallModuleLoader.load();
       const scopes = resolvePluginCliRuntimeNodeInvokeScopes(params.scopes);
       return await callGateway({
         method: "node.invoke",


### PR DESCRIPTION
## What Problem This Solves

`openclaw --help` (the single most common command) and any plugin-provided command's help (e.g. `path --help`) printed their output and then HUNG indefinitely, never exiting (must be killed). It was deterministic and gateway-independent. Commands that don't resolve the plugin-command-alias registry (`--version`, `plugins list --json`, `plugins doctor`, `mcp --help`, etc.) exited cleanly. Found by the R8 QA campaign and independently reproduced.

## Why This Change Was Made

Rendering top-level `--help` (and dispatching plugin commands) resolves the plugin-command-alias registry, which eagerly imported the node plugin's runtime — pulling in the Gateway/TLS dependency graph. That graph opens a handle (the macOS system-CA / TLS machinery) that is never closed for a pure help invocation, so the event loop never drains and the process hangs. This is a fourth distinct CLI-exit-hang root (after the system-CA worker join, the acp module import, and TUI teardown), all in the same "an eagerly-loaded dependency opens a handle a one-shot command never needs" family.

## User Impact

The node plugin's Gateway/TLS dependency graph is now loaded LAZILY — only when a node RPC is actually invoked, not at command registration / help rendering. So `openclaw --help` and plugin-command `--help` render and exit promptly (rc 0). `nodes list`/`nodes invoke` behavior is unchanged.

## Evidence

- Before: both help paths hit the 5s deadline (hang). After: `--help`, `path --help`, `--version`, `plugins list --json` all `CHILD_EXIT code=0`.
- New process-level tests (`src/cli/help-exit.process.test.ts`) cover root + plugin help execution, verify expected output, and guard against the TLS import + the process hang.
- Autoreview (codex gpt-5.6-sol, xhigh): clean — "patch is correct (0.91)". Prod change is +7/−1 in `src/plugins/cli-gateway-nodes-runtime.ts`.
