### PR TITLE
fix(gateway): keep xdg-open stderr truncation surrogate-safe

### DIFF
--- a/src/gateway/server-methods/open-path.test.ts
+++ b/src/gateway/server-methods/open-path.test.ts
@@ -157,6 +157,8 @@ describe("execOpenPath", () => {
       },
       (error: unknown) => (error instanceof Error ? error.message : String(error)),
     );
-    expect(message.endsWith("x")).toBe(true);
+    const expectedMessage = `Command failed with exit code 3: xdg-open: ${"x".repeat(4_095)}`;
+    expect(message).toBe(expectedMessage);
+    expect(message).toHaveLength(expectedMessage.length);
   });
 });

--- a/src/gateway/server-methods/open-path.test.ts
+++ b/src/gateway/server-methods/open-path.test.ts
@@ -135,4 +135,28 @@ describe("execOpenPath", () => {
 
     await expect(execution).rejects.toThrow("xdg-open: no method available");
   });
+
+  it("keeps xdg-open stderr truncation surrogate-safe", async () => {
+    let rejectChild: (error: Error) => void = () => {};
+    const spawned = fakeChild(
+      new Promise((_, reject) => {
+        rejectChild = reject;
+      }),
+    );
+    spawnCommandMock.mockReturnValue(spawned.child);
+
+    const execution = execOpenPath({ command: "xdg-open", args: ["/tmp/workspace"] }, "linux");
+    // 4095 ASCII chars plus one emoji: a plain slice for the final slot would
+    // keep only the emoji's high surrogate half.
+    spawned.stderr.write(`${"x".repeat(4095)}🤖`);
+    rejectChild(new Error("Command failed with exit code 3: xdg-open"));
+
+    const message = await execution.then(
+      () => {
+        throw new Error("expected rejection");
+      },
+      (error: unknown) => (error instanceof Error ? error.message : String(error)),
+    );
+    expect(message.endsWith("x")).toBe(true);
+  });
 });

--- a/src/gateway/server-methods/open-path.ts
+++ b/src/gateway/server-methods/open-path.ts
@@ -54,7 +54,7 @@ async function observeXdgOpenStartup(command: OpenPathCommand): Promise<void> {
     if (stderrText.length >= XDG_OPEN_STDERR_MAX_CHARS) {
       return;
     }
-    stderrText += String(chunk).slice(0, XDG_OPEN_STDERR_MAX_CHARS - stderrText.length);
+    stderrText += truncateUtf16Safe(String(chunk), XDG_OPEN_STDERR_MAX_CHARS - stderrText.length);
   };
   stderr?.on("data", onStderr);
 


### PR DESCRIPTION
## Summary

Truncate the accumulated `xdg-open` stderr text with the surrogate-safe helper instead of a plain `slice`, so a supplementary character at the UTF-16 code-unit cap can no longer leave a dangling lone surrogate in the launcher error diagnostic.

## What Problem This Solves

`observeXdgOpenStartup` (in `src/gateway/server-methods/open-path.ts`) accumulates launcher stderr into a bounded string; on failure, that text becomes the diagnostic suffix of the thrown error.

- The accumulation used `String(chunk).slice(0, remaining)` — a UTF-16 code-unit cut that can land in the middle of a surrogate pair (emoji, non-BMP characters).
- When stderr content at the cap boundary contains such a character, the accumulated text ends with a lone high surrogate, which then propagates into the error message shown to the user/log.
- The file already imports `truncateUtf16Safe` from `@openclaw/normalization-core` — it just wasn't used at this site.

**Code evidence**: at [open-path.ts:57](src/gateway/server-methods/open-path.ts#L57), `stderrText += String(chunk).slice(0, ...)` truncates without surrogate awareness.

## Root Cause

- `String.prototype.slice` counts UTF-16 code units, not code points; a cut between a high and low surrogate leaves the dangling half in the accumulated text.
- Invariant violated: "bounded diagnostic text is always well-formed UTF-16" — not true when the cut crosses a surrogate pair.

## Why This Fix

Replace the plain `slice` with the already-imported `truncateUtf16Safe`:

- When the cap would split a surrogate pair, the helper drops the dangling high-surrogate half instead of emitting it — the diagnostic stays well-formed, and the cap is still enforced (at most one code point shorter).
- One-line change using the codebase's canonical helper (`packages/normalization-core/src/utf16-slice.ts`), consistent with how other bounded text paths handle this (e.g. startup memory truncation).
- Alternative considered: accumulating with `Array.from` and rejoining — equivalent, but allocates per chunk and duplicates what the shared helper already does.

## User Impact

- **Before**: a failing `xdg-open` whose stderr hits the cap mid-emoji produces an error diagnostic ending in a lone surrogate (mojibake in logs/UI).
- **After**: the diagnostic is truncated at a clean character boundary.

## Evidence

- **Before** (upstream/main): `diagnostic tail: "xxxxxxxxxxx\ud83e"` (last code point U+D83E) — **FAIL**: stderr truncation left a lone high surrogate at the cut boundary
- **After** (with fix): `diagnostic tail: "xxxxxxxxxxxx"` (last code point U+78) — **PASS**: stderr truncation dropped the dangling surrogate half

## Real Behavior Proof

Proof spawns a real `xdg-open`-style child that writes 4095 ASCII chars plus one emoji to stderr and exits nonzero, then inspects the thrown diagnostic from the real `execOpenPath`.

### Before (on main)

```bash
$ node --import tsx proof.mjs
diagnostic length: 4176, last code point: U+d83e
diagnostic tail: "xxxxxxxxxxx\ud83e"
FAIL: stderr truncation left a lone high surrogate at the cut boundary
```

### After (with fix)

```bash
$ node --import tsx proof.mjs
diagnostic length: 4175, last code point: U+78
diagnostic tail: "xxxxxxxxxxxx"
PASS: stderr truncation dropped the dangling surrogate half
```

## Tests and Validation

- `node scripts/run-vitest.mjs src/gateway/server-methods/open-path.test.ts` — 9 passed (8 existing + 1 new)
- New regression test: `keeps xdg-open stderr truncation surrogate-safe`
- `tsgo:core` typecheck passed; `oxlint` and `oxfmt --check` clean on the changed files
