### PR TITLE
fix(workboard): avoid duplicate proof entries on completion

### DIFF
--- a/docs/cli/workboard.md
+++ b/docs/cli/workboard.md
@@ -83,6 +83,10 @@ openclaw workboard show 7f4a2c10 --json
 
 Text output prints the compact card line and notes. JSON output returns the full card record, including execution metadata, attempts, comments, links, proof, artifacts, worker logs, protocol state, diagnostics, and automation metadata.
 
+Proof statuses in JSON are worker-reported outcomes. `passed` records the worker's
+self-assessment of the attached command or check; it is not an independent verification
+result.
+
 ## `move`
 
 ```bash

--- a/docs/plugins/workboard.md
+++ b/docs/plugins/workboard.md
@@ -164,9 +164,11 @@ rule as linked sessions (see [Session lifecycle sync](#session-lifecycle-sync)).
 Proof statuses are worker-reported outcomes, not independent verification. A `passed`
 entry means the worker reports that its command or check succeeded; consumers that need
 an independent quality gate should inspect the attached command, URL, or artifact and
-run their own verifier. If the latest proof contains identical evidence with an `unknown`
-status, `workboard_complete` resolves that record in place when reporting `passed`,
-`failed`, or `skipped`, instead of retaining duplicate unresolved and terminal entries.
+run their own verifier. `workboard_proof` returns the new record's `proofId`. When
+`workboard_complete` reports that same proof's terminal status, pass `proofId` so the
+pending record is resolved in place without losing its identity or timestamp. Completion
+proof without `proofId` remains append-only, so a later retry cannot rewrite older history
+merely because its command or note is identical.
 
 Claimed cards reject agent-tool mutations from other agents unless the caller
 holds the claim token returned by `workboard_claim`. Every card returned by an

--- a/docs/plugins/workboard.md
+++ b/docs/plugins/workboard.md
@@ -166,9 +166,10 @@ entry means the worker reports that its command or check succeeded; consumers th
 an independent quality gate should inspect the attached command, URL, or artifact and
 run their own verifier. `workboard_proof` returns the new record's `proofId`. When
 `workboard_complete` reports that same proof's terminal status, pass `proofId` so the
-pending record is resolved in place without losing its identity or timestamp. Completion
-proof without `proofId` remains append-only, so a later retry cannot rewrite older history
-merely because its command or note is identical.
+pending record is resolved in place without losing its identity or timestamp. A proof that
+already has the same terminal status is reused unchanged. Completion proof without
+`proofId` remains append-only, so a later retry cannot rewrite older history merely because
+its command or note is identical.
 
 Claimed cards reject agent-tool mutations from other agents unless the caller
 holds the claim token returned by `workboard_claim`. Every card returned by an

--- a/docs/plugins/workboard.md
+++ b/docs/plugins/workboard.md
@@ -161,6 +161,13 @@ rule as linked sessions (see [Session lifecycle sync](#session-lifecycle-sync)).
 | `workboard_move`                                                                                                                                 | Move a card to another status; claimed cards require the caller's agent claim scope.                                                                                                      |
 | `workboard_dispatch`                                                                                                                             | Nudge dependency promotion or stale-claim cleanup without launching workers; worker launch uses Gateway or slash-command dispatch.                                                        |
 
+Proof statuses are worker-reported outcomes, not independent verification. A `passed`
+entry means the worker reports that its command or check succeeded; consumers that need
+an independent quality gate should inspect the attached command, URL, or artifact and
+run their own verifier. If the latest proof contains identical evidence with an `unknown`
+status, `workboard_complete` resolves that record in place when reporting `passed`,
+`failed`, or `skipped`, instead of retaining duplicate unresolved and terminal entries.
+
 Claimed cards reject agent-tool mutations from other agents unless the caller
 holds the claim token returned by `workboard_claim`. Every card returned by an
 agent tool or Gateway RPC call redacts `metadata.claim.token` to `[redacted]`

--- a/extensions/workboard/src/dispatcher.test.ts
+++ b/extensions/workboard/src/dispatcher.test.ts
@@ -824,6 +824,7 @@ describe("dispatchAndStartWorkboardCards", () => {
     });
     expect(run.mock.calls[0]?.[0]?.message).toContain("Claim token:");
     expect(run.mock.calls[0]?.[0]?.message).toContain("workboard_complete with the card id");
+    expect(run.mock.calls[0]?.[0]?.message).toContain("returned proofId");
     expect(run.mock.calls[0]?.[0]?.message).not.toContain("ownerId and token");
     await expect(store.get(first.id)).resolves.toMatchObject({
       status: "running",

--- a/extensions/workboard/src/dispatcher.ts
+++ b/extensions/workboard/src/dispatcher.ts
@@ -203,6 +203,7 @@ function buildWorkerPrompt(params: {
     "",
     "Heartbeat with workboard_heartbeat using the card id and token while working.",
     "When done, call workboard_complete with the card id, token, summary, and proof.",
+    "If you called workboard_proof separately, pass its returned proofId to workboard_complete.",
     "If blocked, call workboard_block with the card id, token, and reason.",
     "",
     params.context,

--- a/extensions/workboard/src/store-core.ts
+++ b/extensions/workboard/src/store-core.ts
@@ -122,13 +122,14 @@ export class WorkboardCoreStore {
   protected async updateMetadata(
     id: string,
     mutate: (existing: WorkboardCard) => WorkboardMetadata,
+    options: { preserveProofId?: string } = {},
   ): Promise<WorkboardCard> {
     return await this.enqueueMutation(async () => {
       const existing = await this.get(id);
       if (!existing) {
         throw new Error(`card not found: ${id}`);
       }
-      return await this.updateCard(id, { metadata: mutate(existing) });
+      return await this.updateCard(id, { metadata: mutate(existing) }, options);
     });
   }
 
@@ -461,7 +462,11 @@ export class WorkboardCoreStore {
   protected async updateCard(
     id: string,
     patch: WorkboardCardPatch,
-    options: { allowMetadataDependencyLinks?: boolean; enforceStatusHolds?: boolean } = {},
+    options: {
+      allowMetadataDependencyLinks?: boolean;
+      enforceStatusHolds?: boolean;
+      preserveProofId?: string;
+    } = {},
   ): Promise<WorkboardCard> {
     const existing = await this.get(id);
     if (!existing) {
@@ -519,6 +524,7 @@ export class WorkboardCoreStore {
         : normalizeExecution(effectivePatch.execution);
     let metadata = normalizeMetadata(effectivePatch.metadata, existing.metadata, {
       allowDependencyLinks: options.allowMetadataDependencyLinks !== false,
+      preserveProofId: options.preserveProofId,
     });
     if (status !== existing.status && !hasFreshLifecycleStatusSource) {
       // Status patches often spread existing metadata. Only a newly supplied
@@ -543,10 +549,13 @@ export class WorkboardCoreStore {
       }
     }
     if (Object.keys(automationPatch).length > 0) {
-      metadata = trimMetadataToBudget({
-        ...metadata,
-        automation: normalizeAutomationPatch(automationPatch, metadata.automation),
-      });
+      metadata = trimMetadataToBudget(
+        {
+          ...metadata,
+          automation: normalizeAutomationPatch(automationPatch, metadata.automation),
+        },
+        options,
+      );
     }
     const next = removeUndefinedCardFields({
       ...existing,
@@ -595,6 +604,7 @@ export class WorkboardCoreStore {
     });
     next.metadata = trimMetadataToBudget(
       syncExecutionAttemptMetadata(next.metadata ?? {}, execution, now),
+      options,
     );
     next.events = appendEvent(next, updateEvent(existing, next), now);
     if (options.enforceStatusHolds && effectivePatch.status !== undefined) {

--- a/extensions/workboard/src/store-enrichment.ts
+++ b/extensions/workboard/src/store-enrichment.ts
@@ -45,14 +45,18 @@ export class WorkboardEnrichmentStore extends WorkboardCoreStore {
   ): Promise<WorkboardCard> {
     const now = Date.now();
     const proof = normalizeProofInput(input, now);
-    return await this.updateMetadata(id, (existing) => {
-      assertCanMutateClaimedCard(existing, scope);
-      const metadata = clearDiagnostics(existing.metadata, ["missing_proof"]);
-      return {
-        ...metadata,
-        proof: [...(metadata.proof ?? []), proof].slice(-MAX_CARD_PROOF),
-      };
-    });
+    return await this.updateMetadata(
+      id,
+      (existing) => {
+        assertCanMutateClaimedCard(existing, scope);
+        const metadata = clearDiagnostics(existing.metadata, ["missing_proof"]);
+        return {
+          ...metadata,
+          proof: [...(metadata.proof ?? []), proof].slice(-MAX_CARD_PROOF),
+        };
+      },
+      { preserveProofId: proof.id },
+    );
   }
 
   async addProofWithArtifact(
@@ -67,15 +71,19 @@ export class WorkboardEnrichmentStore extends WorkboardCoreStore {
     if (!artifact) {
       throw new Error("artifact url or path is required.");
     }
-    return await this.updateMetadata(id, (existing) => {
-      assertCanMutateClaimedCard(existing, scope);
-      const metadata = clearDiagnostics(existing.metadata, ["missing_proof"]);
-      return {
-        ...metadata,
-        proof: [...(metadata.proof ?? []), proof].slice(-MAX_CARD_PROOF),
-        artifacts: [...(metadata.artifacts ?? []), artifact].slice(-MAX_CARD_ARTIFACTS),
-      };
-    });
+    return await this.updateMetadata(
+      id,
+      (existing) => {
+        assertCanMutateClaimedCard(existing, scope);
+        const metadata = clearDiagnostics(existing.metadata, ["missing_proof"]);
+        return {
+          ...metadata,
+          proof: [...(metadata.proof ?? []), proof].slice(-MAX_CARD_PROOF),
+          artifacts: [...(metadata.artifacts ?? []), artifact].slice(-MAX_CARD_ARTIFACTS),
+        };
+      },
+      { preserveProofId: proof.id },
+    );
   }
 
   async addArtifact(

--- a/extensions/workboard/src/store-enrichment.ts
+++ b/extensions/workboard/src/store-enrichment.ts
@@ -7,6 +7,7 @@ import type {
 } from "@openclaw/workboard-contract";
 import type { PersistedWorkboardAttachment } from "./persistence-types.js";
 import {
+  MAX_CARD_PROOF,
   assertCanMutateClaimedCard,
   capText,
   cardRunId,
@@ -17,7 +18,6 @@ import {
   MAX_CARD_ARTIFACTS,
   MAX_CARD_ATTACHMENTS,
   MAX_CARD_NOTIFICATIONS,
-  MAX_CARD_PROOF,
   MAX_CARD_WORKER_LOGS,
 } from "./store-constants.js";
 import { WorkboardCoreStore } from "./store-core.js";

--- a/extensions/workboard/src/store-enrichment.ts
+++ b/extensions/workboard/src/store-enrichment.ts
@@ -7,7 +7,6 @@ import type {
 } from "@openclaw/workboard-contract";
 import type { PersistedWorkboardAttachment } from "./persistence-types.js";
 import {
-  MAX_CARD_PROOF,
   assertCanMutateClaimedCard,
   capText,
   cardRunId,
@@ -18,6 +17,7 @@ import {
   MAX_CARD_ARTIFACTS,
   MAX_CARD_ATTACHMENTS,
   MAX_CARD_NOTIFICATIONS,
+  MAX_CARD_PROOF,
   MAX_CARD_WORKER_LOGS,
 } from "./store-constants.js";
 import { WorkboardCoreStore } from "./store-core.js";

--- a/extensions/workboard/src/store-inputs.ts
+++ b/extensions/workboard/src/store-inputs.ts
@@ -110,6 +110,7 @@ export type WorkboardCompleteInput = {
   token?: unknown;
   summary?: unknown;
   proof?: unknown;
+  proofId?: unknown;
   artifacts?: unknown;
   createdCardIds?: unknown;
 };

--- a/extensions/workboard/src/store-normalizers.ts
+++ b/extensions/workboard/src/store-normalizers.ts
@@ -1024,10 +1024,10 @@ export function appendCompletionProof(
 export function normalizeMetadata(
   value: unknown,
   fallback: WorkboardMetadata = {},
-  options: { allowDependencyLinks?: boolean } = {},
+  options: { allowDependencyLinks?: boolean; preserveProofId?: string } = {},
 ): WorkboardMetadata {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return trimMetadataToBudget(fallback);
+    return trimMetadataToBudget(fallback, options);
   }
   const record = value as Record<string, unknown>;
   const stale =
@@ -1055,7 +1055,7 @@ export function normalizeMetadata(
             ];
           })()
         : links.slice(-MAX_CARD_LINKS);
-  return trimMetadataToBudget({
+  const normalized = {
     attempts: Array.isArray(record.attempts)
       ? record.attempts
           .map(normalizeAttempt)
@@ -1140,7 +1140,8 @@ export function normalizeMetadata(
       typeof record.failureCount === "number" && Number.isFinite(record.failureCount)
         ? Math.max(0, Math.trunc(record.failureCount))
         : fallback.failureCount,
-  });
+  };
+  return trimMetadataToBudget(normalized, options);
 }
 
 export function normalizeExecution(value: unknown): WorkboardExecution | undefined {
@@ -1298,6 +1299,21 @@ function dropFirst<T>(items: readonly T[] | undefined): T[] | undefined {
   return next.length ? next : undefined;
 }
 
+function dropFirstProofExcept(
+  items: readonly WorkboardProof[] | undefined,
+  preserveProofId: string | undefined,
+): WorkboardProof[] | undefined {
+  if (!items?.length) {
+    return undefined;
+  }
+  const index = preserveProofId ? items.findIndex((proof) => proof.id !== preserveProofId) : 0;
+  if (index < 0) {
+    return items.slice();
+  }
+  const next = items.filter((_, itemIndex) => itemIndex !== index);
+  return next.length ? next : undefined;
+}
+
 function dropFirstNonDependencyLink(
   items: readonly WorkboardLink[] | undefined,
 ): WorkboardLink[] | undefined {
@@ -1327,7 +1343,10 @@ export function appendLinkPreservingDependencies(
   return next.filter((_, index) => index !== dropIndex);
 }
 
-export function trimMetadataToBudget(metadata: WorkboardMetadata): WorkboardMetadata {
+export function trimMetadataToBudget(
+  metadata: WorkboardMetadata,
+  options: { preserveProofId?: string } = {},
+): WorkboardMetadata {
   let next = removeUndefinedMetadataFields(metadata);
   while (metadataByteSize(next) > MAX_CARD_METADATA_BYTES) {
     const currentSize = metadataByteSize(next);
@@ -1340,8 +1359,13 @@ export function trimMetadataToBudget(metadata: WorkboardMetadata): WorkboardMeta
         ...next,
         notifications: dropFirst(next.notifications),
       });
-    } else if (next.proof?.length) {
-      next = removeUndefinedMetadataFields({ ...next, proof: dropFirst(next.proof) });
+    } else if (
+      next.proof?.some((proof) => !options.preserveProofId || proof.id !== options.preserveProofId)
+    ) {
+      next = removeUndefinedMetadataFields({
+        ...next,
+        proof: dropFirstProofExcept(next.proof, options.preserveProofId),
+      });
     } else if (next.artifacts?.length) {
       next = removeUndefinedMetadataFields({ ...next, artifacts: dropFirst(next.artifacts) });
     } else if (next.attachments?.length) {
@@ -1360,8 +1384,13 @@ export function trimMetadataToBudget(metadata: WorkboardMetadata): WorkboardMeta
       }
     } else if (next.comments?.length) {
       next = removeUndefinedMetadataFields({ ...next, comments: dropFirst(next.comments) });
+    } else if (options.preserveProofId) {
+      throw new Error(`card metadata cannot retain proof: ${options.preserveProofId}`);
     }
     if (metadataByteSize(next) >= currentSize) {
+      if (options.preserveProofId) {
+        throw new Error(`card metadata cannot retain proof: ${options.preserveProofId}`);
+      }
       break;
     }
   }

--- a/extensions/workboard/src/store-normalizers.ts
+++ b/extensions/workboard/src/store-normalizers.ts
@@ -983,6 +983,34 @@ export function normalizeProofInput(input: WorkboardProofInput, now: number): Wo
   };
 }
 
+function proofContentMatches(left: WorkboardProof, right: WorkboardProof): boolean {
+  return (
+    left.label === right.label &&
+    left.command === right.command &&
+    left.url === right.url &&
+    left.note === right.note
+  );
+}
+
+export function appendCompletionProof(
+  existing: readonly WorkboardProof[] | undefined,
+  proof: WorkboardProof,
+): WorkboardProof[] {
+  const entries = [...(existing ?? [])];
+  const latest = entries.at(-1);
+  // Completion may refine only the immediately preceding unresolved record; older proof has no
+  // correlation id, so scanning backward could rewrite evidence from a different run.
+  if (
+    proof.status !== "unknown" &&
+    latest?.status === "unknown" &&
+    proofContentMatches(latest, proof)
+  ) {
+    entries[entries.length - 1] = { ...latest, status: proof.status };
+    return entries.slice(-MAX_CARD_PROOF);
+  }
+  return [...entries, proof].slice(-MAX_CARD_PROOF);
+}
+
 export function normalizeMetadata(
   value: unknown,
   fallback: WorkboardMetadata = {},

--- a/extensions/workboard/src/store-normalizers.ts
+++ b/extensions/workboard/src/store-normalizers.ts
@@ -1003,14 +1003,17 @@ export function appendCompletionProof(
   if (!pending) {
     throw new Error(`proof not found: ${proofId}`);
   }
-  if (pending.status !== "unknown") {
-    throw new Error(`proof is already terminal: ${proofId}`);
-  }
   if (proof.status === "unknown") {
     throw new Error("completion proof status must be passed, failed, or skipped.");
   }
   if (completionProofConflicts(pending, proof)) {
     throw new Error(`completion proof does not match pending proof: ${proofId}`);
+  }
+  if (pending.status !== "unknown") {
+    if (pending.status !== proof.status) {
+      throw new Error(`completion proof status does not match existing proof: ${proofId}`);
+    }
+    return entries.slice(-MAX_CARD_PROOF);
   }
   // A proof id is the durable correlation boundary between a separately recorded check and its
   // completion. Preserve the original evidence identity and timestamp while resolving its status.

--- a/extensions/workboard/src/store-normalizers.ts
+++ b/extensions/workboard/src/store-normalizers.ts
@@ -983,32 +983,39 @@ export function normalizeProofInput(input: WorkboardProofInput, now: number): Wo
   };
 }
 
-function proofContentMatches(left: WorkboardProof, right: WorkboardProof): boolean {
-  return (
-    left.label === right.label &&
-    left.command === right.command &&
-    left.url === right.url &&
-    left.note === right.note
+function completionProofConflicts(existing: WorkboardProof, completion: WorkboardProof): boolean {
+  return (["label", "command", "url", "note"] as const).some(
+    (field) => completion[field] !== undefined && completion[field] !== existing[field],
   );
 }
 
 export function appendCompletionProof(
   existing: readonly WorkboardProof[] | undefined,
   proof: WorkboardProof,
+  proofId?: string,
 ): WorkboardProof[] {
   const entries = [...(existing ?? [])];
-  const latest = entries.at(-1);
-  // Completion may refine only the immediately preceding unresolved record; older proof has no
-  // correlation id, so scanning backward could rewrite evidence from a different run.
-  if (
-    proof.status !== "unknown" &&
-    latest?.status === "unknown" &&
-    proofContentMatches(latest, proof)
-  ) {
-    entries[entries.length - 1] = { ...latest, status: proof.status };
-    return entries.slice(-MAX_CARD_PROOF);
+  if (!proofId) {
+    return [...entries, proof].slice(-MAX_CARD_PROOF);
   }
-  return [...entries, proof].slice(-MAX_CARD_PROOF);
+  const index = entries.findIndex((entry) => entry.id === proofId);
+  const pending = index >= 0 ? entries[index] : undefined;
+  if (!pending) {
+    throw new Error(`proof not found: ${proofId}`);
+  }
+  if (pending.status !== "unknown") {
+    throw new Error(`proof is already terminal: ${proofId}`);
+  }
+  if (proof.status === "unknown") {
+    throw new Error("completion proof status must be passed, failed, or skipped.");
+  }
+  if (completionProofConflicts(pending, proof)) {
+    throw new Error(`completion proof does not match pending proof: ${proofId}`);
+  }
+  // A proof id is the durable correlation boundary between a separately recorded check and its
+  // completion. Preserve the original evidence identity and timestamp while resolving its status.
+  entries[index] = { ...pending, status: proof.status };
+  return entries.slice(-MAX_CARD_PROOF);
 }
 
 export function normalizeMetadata(

--- a/extensions/workboard/src/store-workflow.ts
+++ b/extensions/workboard/src/store-workflow.ts
@@ -26,7 +26,6 @@ import {
   MAX_CARD_ARTIFACTS,
   MAX_CARD_COMMENTS,
   MAX_CARD_NOTIFICATIONS,
-  MAX_CARD_PROOF,
   secondsToDurationMs,
 } from "./store-constants.js";
 import type {
@@ -44,6 +43,7 @@ import type {
   WorkboardSpecifyInput,
 } from "./store-inputs.js";
 import {
+  appendCompletionProof,
   clearDiagnostics,
   deriveChildIdempotencyKey,
   normalizeArtifact,
@@ -293,7 +293,7 @@ export class WorkboardWorkflowStore extends WorkboardPromoteStore {
                 { id: randomUUID(), body: summary, createdAt: now },
               ].slice(-MAX_CARD_COMMENTS)
             : metadata.comments,
-          proof: proof ? [...(metadata.proof ?? []), proof].slice(-MAX_CARD_PROOF) : metadata.proof,
+          proof: proof ? appendCompletionProof(metadata.proof, proof) : metadata.proof,
           artifacts: artifacts.length
             ? [...(metadata.artifacts ?? []), ...artifacts].slice(-MAX_CARD_ARTIFACTS)
             : metadata.artifacts,

--- a/extensions/workboard/src/store-workflow.ts
+++ b/extensions/workboard/src/store-workflow.ts
@@ -309,7 +309,10 @@ export class WorkboardWorkflowStore extends WorkboardPromoteStore {
           ),
         },
       },
-      { enforceStatusHolds: true },
+      {
+        enforceStatusHolds: true,
+        ...(proof ? { preserveProofId: proofId ?? proof.id } : {}),
+      },
     );
   }
 

--- a/extensions/workboard/src/store-workflow.ts
+++ b/extensions/workboard/src/store-workflow.ts
@@ -248,6 +248,13 @@ export class WorkboardWorkflowStore extends WorkboardPromoteStore {
       input.proof && typeof input.proof === "object" && !Array.isArray(input.proof)
         ? (input.proof as WorkboardProofInput)
         : undefined;
+    const proofId = normalizeBoundedString(input.proofId, undefined, 120, "proof id");
+    if (input.proofId !== undefined && !proofId) {
+      throw new Error("proofId must be a non-empty string.");
+    }
+    if (proofId && !proofInput) {
+      throw new Error("proof is required when proofId is provided.");
+    }
     const proof = proofInput ? normalizeProofInput(proofInput, now) : undefined;
     const artifacts = Array.isArray(input.artifacts)
       ? input.artifacts
@@ -293,7 +300,7 @@ export class WorkboardWorkflowStore extends WorkboardPromoteStore {
                 { id: randomUUID(), body: summary, createdAt: now },
               ].slice(-MAX_CARD_COMMENTS)
             : metadata.comments,
-          proof: proof ? appendCompletionProof(metadata.proof, proof) : metadata.proof,
+          proof: proof ? appendCompletionProof(metadata.proof, proof, proofId) : metadata.proof,
           artifacts: artifacts.length
             ? [...(metadata.artifacts ?? []), ...artifacts].slice(-MAX_CARD_ARTIFACTS)
             : metadata.artifacts,

--- a/extensions/workboard/src/store.test.ts
+++ b/extensions/workboard/src/store.test.ts
@@ -1047,6 +1047,52 @@ describe("WorkboardStore", () => {
     }
   });
 
+  it("retains the correlated proof when metadata budget trimming is required", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const card = await store.create({
+      title: "Keep proof under metadata pressure",
+      status: "running",
+      metadata: {
+        artifacts: Array.from({ length: 12 }, (_, index) => ({
+          id: `artifact-${index}`,
+          createdAt: index + 1,
+          url: `https://example.com/${index}/${"x".repeat(1900)}`,
+        })),
+      },
+    });
+    const claimed = await store.claim(card.id, { ownerId: "main", token: "token-1" });
+    const artifactCountBefore = claimed.card.metadata?.artifacts?.length ?? 0;
+    expect(artifactCountBefore).toBeGreaterThan(5);
+
+    const proofInput = {
+      command: "pnpm test extensions/workboard",
+      note: "y".repeat(1800),
+    };
+    const pending = await store.addProof(card.id, proofInput, {
+      ownerId: "main",
+      token: "token-1",
+    });
+    const pendingProof = pending.metadata?.proof?.at(-1);
+    expect(pendingProof).toMatchObject({ status: "unknown", command: proofInput.command });
+    expect(pending.metadata?.artifacts?.length ?? 0).toBeLessThan(artifactCountBefore);
+    expect(Buffer.byteLength(JSON.stringify(pending.metadata), "utf8")).toBeLessThanOrEqual(
+      24 * 1024,
+    );
+
+    const completed = await store.complete(card.id, {
+      ownerId: "main",
+      token: "token-1",
+      summary: "Proof survived metadata trimming.",
+      proofId: pendingProof?.id,
+      proof: { ...proofInput, status: "passed" },
+    });
+
+    expect(completed.metadata?.proof).toEqual([{ ...pendingProof, status: "passed" }]);
+    expect(Buffer.byteLength(JSON.stringify(completed.metadata), "utf8")).toBeLessThanOrEqual(
+      24 * 1024,
+    );
+  });
+
   it("keeps identical completion proof append-only without an explicit proof id", async () => {
     const store = new WorkboardStore(createMemoryStore());
     const proofInput = { command: "pnpm test extensions/workboard", note: "94 tests" };

--- a/extensions/workboard/src/store.test.ts
+++ b/extensions/workboard/src/store.test.ts
@@ -1010,6 +1010,91 @@ describe("WorkboardStore", () => {
     expect(restored.events?.at(-1)).toMatchObject({ kind: "unarchived" });
   });
 
+  it("resolves matching unknown proof on completion without duplicating it", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(1_000);
+      const store = new WorkboardStore(createMemoryStore());
+      const card = await store.create({ title: "Resolve worker proof", status: "running" });
+      const claimed = await store.claim(card.id, { ownerId: "main", token: "token-1" });
+      const proofInput = {
+        label: "Haiku syllable check",
+        command: "review poem",
+        note: "Checked each line.",
+      };
+      const pending = await store.addProof(claimed.card.id, proofInput, {
+        ownerId: "main",
+        token: "token-1",
+      });
+
+      vi.setSystemTime(6_000);
+      const completed = await store.complete(claimed.card.id, {
+        ownerId: "main",
+        token: "token-1",
+        summary: "Poem complete.",
+        proof: { ...proofInput, status: "passed" },
+      });
+
+      expect(completed.metadata?.proof).toEqual([
+        {
+          ...pending.metadata?.proof?.[0],
+          status: "passed",
+        },
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not rewrite legacy unknown proof behind a terminal completion match", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const proofInput = { command: "pnpm test extensions/workboard", note: "94 tests" };
+    const card = await store.create({
+      title: "Preserve historical proof",
+      metadata: {
+        proof: [
+          { id: "proof-unknown", status: "unknown", createdAt: 1_000, ...proofInput },
+          { id: "proof-passed", status: "passed", createdAt: 2_000, ...proofInput },
+        ],
+      },
+    });
+
+    const failed = await store.complete(card.id, {
+      summary: "A later run failed.",
+      proof: { ...proofInput, status: "failed" },
+    });
+
+    expect(failed.metadata?.proof?.map((entry) => [entry.id, entry.status])).toEqual([
+      ["proof-unknown", "unknown"],
+      ["proof-passed", "passed"],
+      [expect.any(String), "failed"],
+    ]);
+  });
+
+  it("resolves only the latest identical unknown proof on completion", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const proofInput = { command: "review poem", note: "Checked each line." };
+    const card = await store.create({
+      title: "Keep unresolved proof history",
+      metadata: {
+        proof: [
+          { id: "proof-older", status: "unknown", createdAt: 1_000, ...proofInput },
+          { id: "proof-latest", status: "unknown", createdAt: 2_000, ...proofInput },
+        ],
+      },
+    });
+
+    const completed = await store.complete(card.id, {
+      summary: "Latest check passed.",
+      proof: { ...proofInput, status: "passed" },
+    });
+
+    expect(completed.metadata?.proof?.map((entry) => [entry.id, entry.status])).toEqual([
+      ["proof-older", "unknown"],
+      ["proof-latest", "passed"],
+    ]);
+  });
+
   it("stores attachments in the plugin kv namespace and adds worker context", async () => {
     const attachments = createMemoryStore<PersistedWorkboardAttachment>();
     const store = new WorkboardStore(createMemoryStore(), { attachments });

--- a/extensions/workboard/src/store.test.ts
+++ b/extensions/workboard/src/store.test.ts
@@ -1093,6 +1093,49 @@ describe("WorkboardStore", () => {
     ]);
   });
 
+  it("reuses an explicitly correlated terminal proof with the same status", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const proof = {
+      id: "proof-passed",
+      status: "passed" as const,
+      createdAt: 1_000,
+      command: "pnpm test extensions/workboard",
+    };
+    const card = await store.create({
+      title: "Reuse terminal proof",
+      metadata: { proof: [proof] },
+    });
+
+    const completed = await store.complete(card.id, {
+      summary: "Already passed.",
+      proofId: proof.id,
+      proof: { status: "passed", command: proof.command },
+    });
+
+    expect(completed.metadata?.proof).toEqual([proof]);
+  });
+
+  it("rejects an explicitly correlated terminal proof with a different status", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const card = await store.create({
+      title: "Reject terminal status rewrite",
+      metadata: {
+        proof: [{ id: "proof-passed", status: "passed", createdAt: 1_000 }],
+      },
+    });
+
+    await expect(
+      store.complete(card.id, {
+        proofId: "proof-passed",
+        proof: { status: "failed" },
+      }),
+    ).rejects.toThrow("completion proof status does not match existing proof: proof-passed");
+    await expect(store.get(card.id)).resolves.toMatchObject({
+      status: "todo",
+      metadata: { proof: [{ id: "proof-passed", status: "passed" }] },
+    });
+  });
+
   it("rejects a completion proof id when its evidence does not match", async () => {
     const store = new WorkboardStore(createMemoryStore());
     const card = await store.create({

--- a/extensions/workboard/src/store.test.ts
+++ b/extensions/workboard/src/store.test.ts
@@ -1032,6 +1032,7 @@ describe("WorkboardStore", () => {
         ownerId: "main",
         token: "token-1",
         summary: "Poem complete.",
+        proofId: pending.metadata?.proof?.[0]?.id,
         proof: { ...proofInput, status: "passed" },
       });
 
@@ -1046,16 +1047,13 @@ describe("WorkboardStore", () => {
     }
   });
 
-  it("does not rewrite legacy unknown proof behind a terminal completion match", async () => {
+  it("keeps identical completion proof append-only without an explicit proof id", async () => {
     const store = new WorkboardStore(createMemoryStore());
     const proofInput = { command: "pnpm test extensions/workboard", note: "94 tests" };
     const card = await store.create({
       title: "Preserve historical proof",
       metadata: {
-        proof: [
-          { id: "proof-unknown", status: "unknown", createdAt: 1_000, ...proofInput },
-          { id: "proof-passed", status: "passed", createdAt: 2_000, ...proofInput },
-        ],
+        proof: [{ id: "proof-unknown", status: "unknown", createdAt: 1_000, ...proofInput }],
       },
     });
 
@@ -1066,12 +1064,11 @@ describe("WorkboardStore", () => {
 
     expect(failed.metadata?.proof?.map((entry) => [entry.id, entry.status])).toEqual([
       ["proof-unknown", "unknown"],
-      ["proof-passed", "passed"],
       [expect.any(String), "failed"],
     ]);
   });
 
-  it("resolves only the latest identical unknown proof on completion", async () => {
+  it("resolves only the explicitly correlated proof across identical retries", async () => {
     const store = new WorkboardStore(createMemoryStore());
     const proofInput = { command: "review poem", note: "Checked each line." };
     const card = await store.create({
@@ -1086,6 +1083,7 @@ describe("WorkboardStore", () => {
 
     const completed = await store.complete(card.id, {
       summary: "Latest check passed.",
+      proofId: "proof-latest",
       proof: { ...proofInput, status: "passed" },
     });
 
@@ -1093,6 +1091,34 @@ describe("WorkboardStore", () => {
       ["proof-older", "unknown"],
       ["proof-latest", "passed"],
     ]);
+  });
+
+  it("rejects a completion proof id when its evidence does not match", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const card = await store.create({
+      title: "Reject mismatched proof",
+      metadata: {
+        proof: [
+          {
+            id: "proof-pending",
+            status: "unknown",
+            createdAt: 1_000,
+            command: "pnpm test extensions/workboard",
+          },
+        ],
+      },
+    });
+
+    await expect(
+      store.complete(card.id, {
+        proofId: "proof-pending",
+        proof: { status: "passed", command: "pnpm test extensions/other" },
+      }),
+    ).rejects.toThrow("completion proof does not match pending proof: proof-pending");
+    await expect(store.get(card.id)).resolves.toMatchObject({
+      status: "todo",
+      metadata: { proof: [{ id: "proof-pending", status: "unknown" }] },
+    });
   });
 
   it("stores attachments in the plugin kv namespace and adds worker context", async () => {

--- a/extensions/workboard/src/tools.test.ts
+++ b/extensions/workboard/src/tools.test.ts
@@ -409,16 +409,28 @@ describe("workboard tools", () => {
       await tools.get("workboard_claim")?.execute("call-3", { id: parent.id }),
     );
     const token = claimed.token as string;
+    const pendingProof = readPayload(
+      await tools.get("workboard_proof")?.execute("call-proof", {
+        id: parent.id,
+        token,
+        command: "pnpm test extensions/workboard",
+      }),
+    );
+    expect(pendingProof.proofId).toEqual(expect.any(String));
     const completed = readPayload(
       await tools.get("workboard_complete")?.execute("call-4", {
         id: parent.id,
         token,
         summary: "Done.",
         createdCardIds: [child.id],
+        proofId: pendingProof.proofId,
         proof: { status: "passed", command: "pnpm test extensions/workboard" },
       }),
     );
-    expect(completed.card).toMatchObject({ status: "done" });
+    expect(completed.card).toMatchObject({
+      status: "done",
+      metadata: { proof: [{ id: pendingProof.proofId, status: "passed" }] },
+    });
 
     const dispatch = readPayload(await tools.get("workboard_dispatch")?.execute("call-5", {}));
     expect(dispatch.promoted).toEqual([expect.objectContaining({ id: child.id, status: "ready" })]);

--- a/extensions/workboard/src/tools.ts
+++ b/extensions/workboard/src/tools.ts
@@ -168,6 +168,13 @@ function redactedRawCardResult(card: WorkboardCard) {
   return jsonResult(redactClaimToken(card));
 }
 
+function redactedProofResult(card: WorkboardCard) {
+  return jsonResult({
+    card: redactClaimToken(card),
+    proofId: card.metadata?.proof?.at(-1)?.id,
+  });
+}
+
 const CardIdSchema = Type.Object(
   {
     id: cardIdField(),
@@ -439,7 +446,7 @@ export function createWorkboardTools(params: {
       name: "workboard_proof",
       label: "Workboard Proof",
       description:
-        "Attach proof or artifact metadata to a Workboard card after running tests, checks, or producing screenshots/logs.",
+        "Attach proof or artifact metadata to a Workboard card after running tests, checks, or producing screenshots/logs. Returns proofId; pass it to workboard_complete when that call reports the terminal status for this proof.",
       parameters: Type.Object(
         {
           id: cardIdField(),
@@ -474,7 +481,7 @@ export function createWorkboardTools(params: {
               scope,
             )
           : await store.addProof(id, record, scope);
-        return redactedCardResult(card);
+        return redactedProofResult(card);
       },
     },
     {
@@ -487,6 +494,12 @@ export function createWorkboardTools(params: {
           id: cardIdField(),
           token: claimTokenField(),
           summary: Type.Optional(Type.String({ description: "Completion summary." })),
+          proofId: Type.Optional(
+            Type.String({
+              description:
+                "Proof id returned by workboard_proof when resolving that pending proof.",
+            }),
+          ),
           proof: Type.Optional(
             Type.Object(
               {

--- a/extensions/workboard/src/tools.ts
+++ b/extensions/workboard/src/tools.ts
@@ -169,9 +169,13 @@ function redactedRawCardResult(card: WorkboardCard) {
 }
 
 function redactedProofResult(card: WorkboardCard) {
+  const proofId = card.metadata?.proof?.at(-1)?.id;
+  if (!proofId) {
+    throw new Error("proof was not retained in card metadata.");
+  }
   return jsonResult({
     card: redactClaimToken(card),
-    proofId: card.metadata?.proof?.at(-1)?.id,
+    proofId,
   });
 }
 


### PR DESCRIPTION
Closes #110201

## What Problem This Solves

Fixes an issue where autonomous Workboard completion could retain two copies of the same proof: an unresolved `unknown` record followed seconds later by a new `passed` record. It also clarifies that Workboard proof statuses are worker-reported outcomes rather than independent verification.

## Why This Change Was Made

`workboard_proof` now returns the new record's `proofId`. When `workboard_complete` reports the terminal result for that same check, it can pass `proofId` to resolve exactly that pending record while preserving its id, timestamp, and evidence.

The correlation is explicit rather than inferred from matching command or note text. Completion without `proofId` remains append-only, a same-status terminal proof is reused idempotently, and an unknown result, conflicting terminal status, or conflicting evidence fails closed. The correlated proof is protected while Workboard trims metadata to its 24 KiB cap; other eligible metadata is evicted first, and the mutation fails before persistence if the proof itself cannot fit. That keeps identical retries from silently rewriting an earlier attempt or returning an id for a proof that was not retained. Historical duplicate pairs are not rewritten or migrated.

The public Workboard and CLI docs now define `passed` as worker self-attestation. An independent verifier hook is intentionally not introduced here because that would require a separate persisted/public contract decision.

AI-assisted: yes.

## User Impact

Workers that record proof before completion can carry the returned proof id into `workboard_complete`, avoiding the orphaned `unknown` copy without losing retry history. Operators and API consumers also have explicit guidance that `passed` does not itself prove independent verification.

## Evidence

- Before the fix, the focused regression reproduced two records with identical label, command, and note: `unknown` at 1000 ms and `passed` at 6000 ms.
- `node scripts/run-vitest.mjs extensions/workboard/src/store.test.ts extensions/workboard/src/tools.test.ts extensions/workboard/src/dispatcher.test.ts` — 3 files, 135 tests passed.
- Targeted `oxfmt --check` across the touched Workboard source, tests, and docs — passed; `git diff --check` passed.
- Iterative review caught and fixed three edge cases: unsafe content-based correlation across retries, rejection of an already-terminal matching proof, and loss of the promised proof id during metadata-budget trimming. Fresh autoreview after the retention fix reported no accepted/actionable findings and `patch is correct` (0.93).
- Blacksmith Testbox lease `tbx_01kxww7nzcd0wtbkpm6sqr4wa9` built exact head `4530a2e6a6d339aa3525bf9208fbc39751c8a3dd` with `pnpm build` — passed: https://github.com/openclaw/openclaw/actions/runs/29682128768.
- Hosted exact-head CI is required and checked by the repository prepare gate.
- Exact-head black-box run used the built Gateway RPC surface and `openclaw workboard show --json`. Redacted terminal result:

```json
{
  "head": "4530a2e6a6d339aa3525bf9208fbc39751c8a3dd",
  "correlated": {
    "proofId": "7c2ff266-ff98-466b-a7ba-0310b30b3b9b",
    "createdAt": 1784454772676,
    "count": 1,
    "status": "passed"
  },
  "appendOnly": {
    "count": 2,
    "statuses": ["unknown", "passed"]
  },
  "idempotentTerminal": {
    "count": 1,
    "status": "passed"
  },
  "budget": {
    "artifactsBefore": 12,
    "artifactsAfterProof": 11,
    "artifactsFinal": 11,
    "proofId": "6f1e8178-a906-43f6-b656-c1ec702ce1d9",
    "proofCount": 1,
    "proofStatus": "passed",
    "metadataBytes": 23895
  }
}
```

No UI surface changed, so screenshots are not applicable.
