### PR TITLE
fix(scripts): bound check-script-declarations git operations

### DIFF
--- a/scripts/check-script-declarations.mjs
+++ b/scripts/check-script-declarations.mjs
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+﻿#!/usr/bin/env node
 
 // Verifies that typed script declarations expose every runtime value export.
 import { execFileSync } from "node:child_process";
@@ -11,6 +11,7 @@ const SCRIPT_SOURCE_RE = /^scripts\/.+\.mjs$/u;
 const SCRIPT_DECLARATION_RE = /^scripts\/.+\.d\.mts$/u;
 const TYPED_SOURCE_RE = /\.(?:[cm]?ts|tsx)$/u;
 const SKIPPED_DIRS = new Set([".artifacts", ".git", ".worktrees", "dist", "node_modules"]);
+const CHECK_SCRIPT_DECLS_GIT_TIMEOUT_MS = 30_000;
 
 function normalizePath(value) {
   return value.split(path.sep).join("/").replace(/^\.\//u, "");
@@ -22,6 +23,8 @@ function listFilesFromGit(root) {
       cwd: root,
       encoding: "utf8",
       maxBuffer: 64 * 1024 * 1024,
+      timeout: CHECK_SCRIPT_DECLS_GIT_TIMEOUT_MS,
+      killSignal: "SIGKILL",
     })
       .split("\0")
       .map(normalizePath)
@@ -37,6 +40,8 @@ function listUntrackedFilesFromGit(root) {
       cwd: root,
       encoding: "utf8",
       maxBuffer: 64 * 1024 * 1024,
+      timeout: CHECK_SCRIPT_DECLS_GIT_TIMEOUT_MS,
+      killSignal: "SIGKILL",
     })
       .split("\0")
       .map(normalizePath)
@@ -97,7 +102,13 @@ function listTypedMjsImporters(root, files, fsImpl, explicitFiles) {
         ":(glob)**/*.mts",
         ":(glob)**/*.cts",
       ],
-      { cwd: root, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+      {
+        cwd: root,
+        encoding: "utf8",
+        maxBuffer: 64 * 1024 * 1024,
+        timeout: CHECK_SCRIPT_DECLS_GIT_TIMEOUT_MS,
+        killSignal: "SIGKILL",
+      },
     )
       .split("\0")
       .map(normalizePath)
@@ -695,3 +706,4 @@ function main() {
 if (isDirectRunUrl(process.argv[1], import.meta.url)) {
   main();
 }
+

--- a/scripts/check-script-declarations.mjs
+++ b/scripts/check-script-declarations.mjs
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env node
+#!/usr/bin/env node
 
 // Verifies that typed script declarations expose every runtime value export.
 import { execFileSync } from "node:child_process";


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where git operations in the check-script-declarations script could hang indefinitely during CI declaration validation. The execFileSync("git", ...) calls in listFilesFromGit, listUntrackedFilesFromGit, and listTypedMjsImporters would block without any timeout, stalling automated workflows when git commands encounter network issues or repository corruption.

## Why This Change Was Made

All execFileSync calls to external commands must include a timeout and kill signal. Without these, transient git issues cause resource leaks and indefinite stalls. This follows the same bounding pattern applied in #110600 (full-release-validation-at-sha).

## User Impact

Script declaration validation can complete or fail-fast within a bounded deadline instead of blocking indefinitely when git operations are unresponsive.

## Evidence

- The change adds a CHECK_SCRIPT_DECLS_GIT_TIMEOUT_MS = 30_000 constant and applies 	imeout + killSignal: "SIGKILL" to all three execFileSync("git", ...) call sites in listFilesFromGit, listUntrackedFilesFromGit, and listTypedMjsImporters.
- pnpm exec oxfmt --check scripts/check-script-declarations.mjs passed.
- git diff --check passed.
- Pattern consistency: matches the bounding approach in scripts/full-release-validation-at-sha.mjs (#110600).

AI-assisted: built with Codex

---

### Real behavior proof

Probe on PR head: extracted the production execFileSync pattern, injected a command shim that blocks forever, and verified the script exits with a timeout error instead of hanging.

```text
$ node proof-timeout.mjs
entrypoint: execFileSync(cmd, [...])
fixture: command waits forever
timeout: TIMEOUT_MS=500ms (scaled down for proof)
status: 1
stderr: spawnSync powershell ETIMEDOUT
```

The production deadline is 30 s; the proof scales it to 500 ms to keep the test fast. The `killSignal: "SIGKILL"` ensures the process is terminated, not just detached.