### PR TITLE
fix(agents): keep web search error serialization surrogate-safe

### DIFF
--- a/src/agents/tools/web-search-output.ts
+++ b/src/agents/tools/web-search-output.ts
@@ -212,7 +212,7 @@ export function normalizeWebSearchOutput(params: {
     const rawError =
       typeof result.error === "string"
         ? result.error
-        : truncateUtf16Safe(JSON.stringify(result.error) ?? "", 2_000) || "provider_error";
+        : truncateUtf16Safe(JSON.stringify(result.error) ?? "provider_error", 2_000);
     const rawMessage = typeof result.message === "string" ? result.message : rawError;
     const docs = typeof result.docs === "string" ? toHttpUrl(result.docs) : undefined;
     return {

--- a/src/agents/tools/web-search-output.ts
+++ b/src/agents/tools/web-search-output.ts
@@ -8,6 +8,7 @@
  * spoof the trust marker and transport-specific extras never reach the model.
  */
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { Static } from "typebox";
 import { Type } from "typebox";
 import { wrapWebContent } from "../../security/external-content.js";
@@ -211,7 +212,7 @@ export function normalizeWebSearchOutput(params: {
     const rawError =
       typeof result.error === "string"
         ? result.error
-        : (JSON.stringify(result.error)?.slice(0, 2_000) ?? "provider_error");
+        : truncateUtf16Safe(JSON.stringify(result.error) ?? "", 2_000) || "provider_error";
     const rawMessage = typeof result.message === "string" ? result.message : rawError;
     const docs = typeof result.docs === "string" ? toHttpUrl(result.docs) : undefined;
     return {

--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -721,6 +721,25 @@ describe("web_search normalized output contract", () => {
     expect(normalized.message).toContain("quota exceeded");
   });
 
+  it("keeps structured provider error serialization surrogate-safe at the cap", () => {
+    const normalized = normalizeWebSearchOutput({
+      provider: "external-demo",
+      query: "emoji error",
+      // The emoji straddles the 2000-unit cut: a plain slice would keep only
+      // its high surrogate half.
+      result: { error: { message: `${"x".repeat(1_987)}🤖` } },
+    });
+
+    if (normalized.kind !== "error") {
+      throw new Error("expected error branch");
+    }
+    expect(
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u.test(
+        normalized.message,
+      ),
+    ).toBe(false);
+  });
+
   it("keeps ordinary Source attribution lines in answer content", () => {
     const normalized = normalizeWebSearchOutput({
       provider: "external-answer",

--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -733,11 +733,9 @@ describe("web_search normalized output contract", () => {
     if (normalized.kind !== "error") {
       throw new Error("expected error branch");
     }
-    expect(
-      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u.test(
-        normalized.message,
-      ),
-    ).toBe(false);
+    const expectedPrefix = `{"message":"${"x".repeat(1_987)}`;
+    expect(stripWrapMarkers(normalized.message)).toBe(expectedPrefix);
+    expect(expectedPrefix).toHaveLength(1_999);
   });
 
   it("keeps ordinary Source attribution lines in answer content", () => {


### PR DESCRIPTION
## Summary

Truncate serialized provider error payloads with the surrogate-safe helper instead of a plain `slice`, so a multi-byte character at the 2000-unit cap can no longer leave a dangling lone surrogate in the model-facing error message.

## What Problem This Solves

`normalizeWebSearchOutput` (in `src/agents/tools/web-search-output.ts`) normalizes untrusted web-search provider output. Non-string `error` payloads are serialized (`JSON.stringify`) and capped at 2000 UTF-16 units before being wrapped into the model-facing error message.

- The cap used `.slice(0, 2_000)` — a UTF-16 code-unit cut that can land in the middle of a surrogate pair (emoji, non-BMP characters) inside the provider's error text.
- The wrapped error message then carries a lone high surrogate into the agent transcript — silently malformed content presented as the provider's error.

**Code evidence**: at [web-search-output.ts:214](src/agents/tools/web-search-output.ts#L214), `JSON.stringify(result.error)?.slice(0, 2_000)` truncates without surrogate awareness.

## Root Cause

- `String.prototype.slice` counts UTF-16 code units, not code points; a cut between a high and low surrogate leaves the dangling half in the serialized payload.
- Invariant violated: "capped diagnostic text is always well-formed UTF-16" — not true when the cut crosses a surrogate pair.

## Why This Fix

Replace the plain `slice` with `truncateUtf16Safe` (the codebase's canonical helper in `@openclaw/normalization-core/utf16-slice`):

- When the cap would split a surrogate pair, the helper drops the dangling high-surrogate half instead of emitting it — the message stays well-formed, and the cap is still enforced (at most one code point shorter).
- The `?? "provider_error"` fallback semantics for unserializable payloads are preserved (`JSON.stringify` returning `undefined` still degrades to the literal).
- Alternative considered: `Array.from(...).slice(0, N).join("")` — equivalent, but allocates and duplicates what the shared helper already does.

## User Impact

- **Before**: a provider error containing an emoji at the cap boundary produces a wrapped error message containing a lone surrogate in the agent transcript.
- **After**: the serialized error is truncated at a clean character boundary.

## Evidence

- **Before** (upstream/main): `lone surrogate found at index 2078: U+d83e` — **FAIL**: serialization cap split a surrogate pair into the wrapped error message
- **After** (with fix): `PASS: no lone surrogate in the wrapped error message`

## Real Behavior Proof

Proof feeds the real `normalizeWebSearchOutput` a structured provider error whose message is 1987 ASCII chars plus one emoji, so the emoji straddles the 2000-unit cap, and scans the wrapped message for unpaired surrogates.

### Before (on main)

```bash
$ node --import tsx proof.mjs
message length: 2138
lone surrogate found at index 2078: U+d83e
FAIL: serialization cap split a surrogate pair into the wrapped error message
```

### After (with fix)

```bash
$ node --import tsx proof.mjs
message length: 2137
PASS: no lone surrogate in the wrapped error message
```

## Tests and Validation

- `npx vitest run src/agents/tools/web-search.test.ts` — 54 passed (53 existing + 1 new)
- New regression test: `keeps structured provider error serialization surrogate-safe at the cap`
- `tsgo:core` typecheck passed; `oxlint` and `oxfmt --check` clean on the changed files

## Packaged Resolution Proof (review follow-up)

The review flagged `@openclaw/normalization-core/utf16-slice` as an un-emitted subpath. Verification on this branch shows the subpath **is** part of the published package contract:

- `packages/normalization-core/package.json` has exported `"./utf16-slice" -> ./dist/utf16-slice.mjs` since #99059 (present on current `main` and on the reviewed base).
- The package build script lists `src/utf16-slice.ts` as an explicit entry, and the root tsdown config also derives dist entries from the exports map (`buildPackageDistEntriesFromExports`).
- Proof against the packed artifact (no workspace aliases): `pnpm build && npm pack` emits `dist/utf16-slice.mjs` + `dist/utf16-slice.d.mts`; a clean `npm install` of the tarball in an empty directory resolves the subpath and the helper truncates surrogate-safely:

```text
resolved: @openclaw/normalization-core/utf16-slice
truncateUtf16Safe type: function
output length: 1999 lone surrogate present: false
PASS: packaged install resolves the subpath and truncates surrogate-safely
```

## Review Findings Addressed

- [P1] *Import the helper from an emitted package entry* (`web-search-output.ts:11`) → verified the subpath is an emitted, published entry: exports-map entry present on `main`, explicit build entry in the package build script, and a packed-artifact resolution proof (above) succeeds in a clean install. No import change required; the flag was a false positive.
- [P2] *Run the focused web-search test and a packaged build/import-resolution check* → focused `web-search.test.ts` run is green (54 cases incl. the new cap-boundary regression), and the packaged build/import-resolution check is documented above.
