### PR TITLE
fix(scripts): bound gh-read GitHub CLI execution

### DIFF
--- a/docs/help/scripts.md
+++ b/docs/help/scripts.md
@@ -37,7 +37,7 @@ Optional env:
 
 - `OPENCLAW_GH_READ_INSTALLATION_ID` when you want to skip repo-based installation lookup
 - `OPENCLAW_GH_READ_PERMISSIONS` as a comma-separated override for the read permission subset to request
-- `OPENCLAW_GH_READ_COMMAND_TIMEOUT_MS` as a positive integer deadline for the delegated `gh` command. Ordinary finite reads default to `120000`; the documented long-lived `gh run watch` path preserves its unbounded default unless this variable selects a finite budget.
+- `OPENCLAW_GH_READ_COMMAND_TIMEOUT_MS` as a positive integer deadline for the delegated `gh` command. Ordinary finite reads default to `120000`; explicit GitHub CLI watch/follow modes such as `gh run watch` and `gh pr checks --watch` preserve their unbounded default unless this variable selects a finite budget.
 
 Repo resolution order:
 

--- a/docs/help/scripts.md
+++ b/docs/help/scripts.md
@@ -37,7 +37,7 @@ Optional env:
 
 - `OPENCLAW_GH_READ_INSTALLATION_ID` when you want to skip repo-based installation lookup
 - `OPENCLAW_GH_READ_PERMISSIONS` as a comma-separated override for the read permission subset to request
-- `OPENCLAW_GH_READ_COMMAND_TIMEOUT_MS` as a positive integer deadline for the delegated `gh` command (default: `120000`); set a larger finite value for intentionally long-lived reads such as `gh run watch`
+- `OPENCLAW_GH_READ_COMMAND_TIMEOUT_MS` as a positive integer deadline for the delegated `gh` command. Ordinary finite reads default to `120000`; known long-lived commands such as `gh run watch` preserve their unbounded default unless this variable selects a finite budget.
 
 Repo resolution order:
 

--- a/docs/help/scripts.md
+++ b/docs/help/scripts.md
@@ -37,6 +37,7 @@ Optional env:
 
 - `OPENCLAW_GH_READ_INSTALLATION_ID` when you want to skip repo-based installation lookup
 - `OPENCLAW_GH_READ_PERMISSIONS` as a comma-separated override for the read permission subset to request
+- `OPENCLAW_GH_READ_COMMAND_TIMEOUT_MS` as a positive integer deadline for the delegated `gh` command (default: `120000`); set a larger finite value for intentionally long-lived reads such as `gh run watch`
 
 Repo resolution order:
 

--- a/docs/help/scripts.md
+++ b/docs/help/scripts.md
@@ -37,7 +37,7 @@ Optional env:
 
 - `OPENCLAW_GH_READ_INSTALLATION_ID` when you want to skip repo-based installation lookup
 - `OPENCLAW_GH_READ_PERMISSIONS` as a comma-separated override for the read permission subset to request
-- `OPENCLAW_GH_READ_COMMAND_TIMEOUT_MS` as a positive integer deadline for the delegated `gh` command. Ordinary finite reads default to `120000`; known long-lived commands such as `gh run watch` preserve their unbounded default unless this variable selects a finite budget.
+- `OPENCLAW_GH_READ_COMMAND_TIMEOUT_MS` as a positive integer deadline for the delegated `gh` command. Ordinary finite reads default to `120000`; the documented long-lived `gh run watch` path preserves its unbounded default unless this variable selects a finite budget.
 
 Repo resolution order:
 

--- a/scripts/gh-read.ts
+++ b/scripts/gh-read.ts
@@ -130,14 +130,23 @@ function isLongLivedGitHubCommand(ghArgs: readonly string[]): boolean {
   const commandPath: string[] = [];
   for (let index = 0; index < ghArgs.length && commandPath.length < 2; index += 1) {
     const arg = expectDefined(ghArgs[index], `GitHub CLI argument at index ${index}`);
-    if (arg === "-R" || arg === "--repo" || arg === "--hostname") {
+    const isCodespaceSelector =
+      commandPath[0] === "codespace" &&
+      (arg === "-c" || arg === "--codespace" || arg === "--repo-owner");
+    if (arg === "-R" || arg === "--repo" || arg === "--hostname" || isCodespaceSelector) {
       index += 1;
       continue;
     }
+    const isAttachedCodespaceSelector =
+      commandPath[0] === "codespace" &&
+      ((arg.startsWith("-c") && arg.length > 2) ||
+        arg.startsWith("--codespace=") ||
+        arg.startsWith("--repo-owner="));
     if (
       arg.startsWith("-R") ||
       arg.startsWith("--repo=") ||
       arg.startsWith("--hostname=") ||
+      isAttachedCodespaceSelector ||
       arg.startsWith("-")
     ) {
       continue;
@@ -165,7 +174,11 @@ function isLongLivedGitHubCommand(ghArgs: readonly string[]): boolean {
 
   // `-f` is ambiguous across gh commands, but for `codespace logs` it is the
   // documented short form of `--follow`.
-  return commandPath[0] === "codespace" && commandPath[1] === "logs" && ghArgs.includes("-f");
+  return (
+    commandPath[0] === "codespace" &&
+    commandPath[1] === "logs" &&
+    ghArgs.some((arg) => arg === "-f" || arg === "-f=true")
+  );
 }
 
 function resolveGitHubCommandTimeoutMs(

--- a/scripts/gh-read.ts
+++ b/scripts/gh-read.ts
@@ -21,8 +21,8 @@ const PERMISSIONS_ENV = "OPENCLAW_GH_READ_PERMISSIONS";
 const COMMAND_TIMEOUT_ENV = "OPENCLAW_GH_READ_COMMAND_TIMEOUT_MS";
 const API_VERSION = "2022-11-28";
 const DEFAULT_GITHUB_FETCH_TIMEOUT_MS = 30_000;
-// Use the measured script-family budget for ordinary broad reads. Intentionally
-// long-lived commands can select a larger finite deadline through COMMAND_TIMEOUT_ENV.
+// Use the measured script-family budget for ordinary broad reads. Explicit CLI
+// watch/follow modes keep their unbounded default unless COMMAND_TIMEOUT_ENV is set.
 const DEFAULT_GH_COMMAND_TIMEOUT_MS = 120_000;
 const GITHUB_ERROR_BODY_MAX_CHARS = 4096;
 const GITHUB_JSON_BODY_MAX_BYTES = 1024 * 1024;
@@ -145,9 +145,27 @@ function isLongLivedGitHubCommand(ghArgs: readonly string[]): boolean {
     commandPath.push(arg);
   }
 
-  // `gh run watch` streams until the workflow completes, so preserving its
-  // historical unbounded default avoids surprising existing automation.
-  return commandPath[0] === "run" && commandPath[1] === "watch";
+  if (commandPath[0] === "run" && commandPath[1] === "watch") {
+    return true;
+  }
+
+  // GitHub CLI also exposes long-lived behavior through explicit watch/follow
+  // flags (for example `pr checks --watch` and `agent-task view --follow`).
+  if (
+    ghArgs.some(
+      (arg) =>
+        arg === "--watch" ||
+        arg === "--watch=true" ||
+        arg === "--follow" ||
+        arg === "--follow=true",
+    )
+  ) {
+    return true;
+  }
+
+  // `-f` is ambiguous across gh commands, but for `codespace logs` it is the
+  // documented short form of `--follow`.
+  return commandPath[0] === "codespace" && commandPath[1] === "logs" && ghArgs.includes("-f");
 }
 
 function resolveGitHubCommandTimeoutMs(

--- a/scripts/gh-read.ts
+++ b/scripts/gh-read.ts
@@ -18,10 +18,11 @@ const APP_ID_ENV = "OPENCLAW_GH_READ_APP_ID";
 const KEY_FILE_ENV = "OPENCLAW_GH_READ_PRIVATE_KEY_FILE";
 const INSTALLATION_ID_ENV = "OPENCLAW_GH_READ_INSTALLATION_ID";
 const PERMISSIONS_ENV = "OPENCLAW_GH_READ_PERMISSIONS";
+const COMMAND_TIMEOUT_ENV = "OPENCLAW_GH_READ_COMMAND_TIMEOUT_MS";
 const API_VERSION = "2022-11-28";
 const DEFAULT_GITHUB_FETCH_TIMEOUT_MS = 30_000;
-// gh-read accepts broad read commands, including pagination. Match the measured
-// script-family budget while preventing a stalled gh child from blocking forever.
+// Use the measured script-family budget for ordinary broad reads. Intentionally
+// long-lived commands can select a larger finite deadline through COMMAND_TIMEOUT_ENV.
 const DEFAULT_GH_COMMAND_TIMEOUT_MS = 120_000;
 const GITHUB_ERROR_BODY_MAX_CHARS = 4096;
 const GITHUB_JSON_BODY_MAX_BYTES = 1024 * 1024;
@@ -120,6 +121,15 @@ export function resolveGitHubFetchTimeoutMs(raw = process.env.OPENCLAW_GH_READ_F
   return parseStrictIntegerOption({
     fallback: DEFAULT_GITHUB_FETCH_TIMEOUT_MS,
     label: "OPENCLAW_GH_READ_FETCH_TIMEOUT_MS",
+    min: 1,
+    raw,
+  });
+}
+
+function resolveGitHubCommandTimeoutMs(raw = process.env[COMMAND_TIMEOUT_ENV]) {
+  return parseStrictIntegerOption({
+    fallback: DEFAULT_GH_COMMAND_TIMEOUT_MS,
+    label: COMMAND_TIMEOUT_ENV,
     min: 1,
     raw,
   });
@@ -395,7 +405,7 @@ export function runGitHubCli(
       GITHUB_TOKEN: token,
     },
     killSignal: "SIGKILL",
-    timeout: options.timeoutMs ?? DEFAULT_GH_COMMAND_TIMEOUT_MS,
+    timeout: options.timeoutMs ?? resolveGitHubCommandTimeoutMs(),
   });
 
   if (child.error) {

--- a/scripts/gh-read.ts
+++ b/scripts/gh-read.ts
@@ -68,7 +68,7 @@ type GitHubCliSpawn = (
     env: NodeJS.ProcessEnv;
     killSignal: "SIGKILL";
     stdio: "inherit";
-    timeout: number;
+    timeout?: number;
   },
 ) => {
   error?: Error;
@@ -126,7 +126,37 @@ export function resolveGitHubFetchTimeoutMs(raw = process.env.OPENCLAW_GH_READ_F
   });
 }
 
-function resolveGitHubCommandTimeoutMs(raw = process.env[COMMAND_TIMEOUT_ENV]) {
+function isLongLivedGitHubCommand(ghArgs: readonly string[]): boolean {
+  const commandPath: string[] = [];
+  for (let index = 0; index < ghArgs.length && commandPath.length < 2; index += 1) {
+    const arg = expectDefined(ghArgs[index], `GitHub CLI argument at index ${index}`);
+    if (arg === "-R" || arg === "--repo" || arg === "--hostname") {
+      index += 1;
+      continue;
+    }
+    if (
+      arg.startsWith("-R") ||
+      arg.startsWith("--repo=") ||
+      arg.startsWith("--hostname=") ||
+      arg.startsWith("-")
+    ) {
+      continue;
+    }
+    commandPath.push(arg);
+  }
+
+  // `gh run watch` streams until the workflow completes, so preserving its
+  // historical unbounded default avoids surprising existing automation.
+  return commandPath[0] === "run" && commandPath[1] === "watch";
+}
+
+function resolveGitHubCommandTimeoutMs(
+  ghArgs: readonly string[],
+  raw = process.env[COMMAND_TIMEOUT_ENV],
+): number | undefined {
+  if (!raw?.trim()) {
+    return isLongLivedGitHubCommand(ghArgs) ? undefined : DEFAULT_GH_COMMAND_TIMEOUT_MS;
+  }
   return parseStrictIntegerOption({
     fallback: DEFAULT_GH_COMMAND_TIMEOUT_MS,
     label: COMMAND_TIMEOUT_ENV,
@@ -397,7 +427,8 @@ export function runGitHubCli(
   } = {},
 ): number {
   const spawnSyncImpl = options.spawnSyncImpl ?? spawnSync;
-  const child = spawnSyncImpl("gh", ghArgs, {
+  const timeoutMs = options.timeoutMs ?? resolveGitHubCommandTimeoutMs(ghArgs);
+  const spawnOptions: Parameters<GitHubCliSpawn>[2] = {
     stdio: "inherit",
     env: {
       ...process.env,
@@ -405,8 +436,11 @@ export function runGitHubCli(
       GITHUB_TOKEN: token,
     },
     killSignal: "SIGKILL",
-    timeout: options.timeoutMs ?? resolveGitHubCommandTimeoutMs(),
-  });
+  };
+  if (timeoutMs !== undefined) {
+    spawnOptions.timeout = timeoutMs;
+  }
+  const child = spawnSyncImpl("gh", ghArgs, spawnOptions);
 
   if (child.error) {
     throw child.error;

--- a/scripts/gh-read.ts
+++ b/scripts/gh-read.ts
@@ -24,6 +24,8 @@ const DEFAULT_GITHUB_FETCH_TIMEOUT_MS = 30_000;
 // Use the measured script-family budget for ordinary broad reads. Explicit CLI
 // watch/follow modes keep their unbounded default unless COMMAND_TIMEOUT_ENV is set.
 const DEFAULT_GH_COMMAND_TIMEOUT_MS = 120_000;
+const GITHUB_CLI_TRUE_BOOLEAN_VALUES = new Set(["1", "t", "T", "true", "TRUE", "True"]);
+const GITHUB_CLI_FALSE_BOOLEAN_VALUES = new Set(["0", "f", "F", "false", "FALSE", "False"]);
 const GITHUB_ERROR_BODY_MAX_CHARS = 4096;
 const GITHUB_JSON_BODY_MAX_BYTES = 1024 * 1024;
 const GITHUB_APP_PRIVATE_KEY_MAX_BYTES = 64 * 1024;
@@ -126,6 +128,32 @@ export function resolveGitHubFetchTimeoutMs(raw = process.env.OPENCLAW_GH_READ_F
   });
 }
 
+function isEnabledGitHubBooleanFlag(ghArgs: readonly string[], flag: string): boolean {
+  let enabled = false;
+  const valuePrefix = `${flag}=`;
+  for (const arg of ghArgs) {
+    if (arg === flag) {
+      enabled = true;
+      continue;
+    }
+    if (!arg.startsWith(valuePrefix)) {
+      continue;
+    }
+
+    const value = arg.slice(valuePrefix.length);
+    if (GITHUB_CLI_TRUE_BOOLEAN_VALUES.has(value)) {
+      enabled = true;
+    } else if (GITHUB_CLI_FALSE_BOOLEAN_VALUES.has(value)) {
+      enabled = false;
+    } else {
+      // GitHub CLI rejects values outside Go's strconv.ParseBool grammar, so
+      // an invalid command cannot enter a long-lived watch/follow operation.
+      return false;
+    }
+  }
+  return enabled;
+}
+
 function isLongLivedGitHubCommand(ghArgs: readonly string[]): boolean {
   const commandPath: string[] = [];
   for (let index = 0; index < ghArgs.length && commandPath.length < 2; index += 1) {
@@ -161,13 +189,8 @@ function isLongLivedGitHubCommand(ghArgs: readonly string[]): boolean {
   // GitHub CLI also exposes long-lived behavior through explicit watch/follow
   // flags (for example `pr checks --watch` and `agent-task view --follow`).
   if (
-    ghArgs.some(
-      (arg) =>
-        arg === "--watch" ||
-        arg === "--watch=true" ||
-        arg === "--follow" ||
-        arg === "--follow=true",
-    )
+    isEnabledGitHubBooleanFlag(ghArgs, "--watch") ||
+    isEnabledGitHubBooleanFlag(ghArgs, "--follow")
   ) {
     return true;
   }
@@ -177,7 +200,7 @@ function isLongLivedGitHubCommand(ghArgs: readonly string[]): boolean {
   return (
     commandPath[0] === "codespace" &&
     commandPath[1] === "logs" &&
-    ghArgs.some((arg) => arg === "-f" || arg === "-f=true")
+    isEnabledGitHubBooleanFlag(ghArgs, "-f")
   );
 }
 

--- a/scripts/gh-read.ts
+++ b/scripts/gh-read.ts
@@ -151,7 +151,7 @@ function isLongLivedGitHubCommand(ghArgs: readonly string[]): boolean {
     ) {
       continue;
     }
-    commandPath.push(arg);
+    commandPath.push(commandPath.length === 0 && arg === "cs" ? "codespace" : arg);
   }
 
   if (commandPath[0] === "run" && commandPath[1] === "watch") {

--- a/scripts/gh-read.ts
+++ b/scripts/gh-read.ts
@@ -20,6 +20,9 @@ const INSTALLATION_ID_ENV = "OPENCLAW_GH_READ_INSTALLATION_ID";
 const PERMISSIONS_ENV = "OPENCLAW_GH_READ_PERMISSIONS";
 const API_VERSION = "2022-11-28";
 const DEFAULT_GITHUB_FETCH_TIMEOUT_MS = 30_000;
+// gh-read accepts broad read commands, including pagination. Match the measured
+// script-family budget while preventing a stalled gh child from blocking forever.
+const DEFAULT_GH_COMMAND_TIMEOUT_MS = 120_000;
 const GITHUB_ERROR_BODY_MAX_CHARS = 4096;
 const GITHUB_JSON_BODY_MAX_BYTES = 1024 * 1024;
 const GITHUB_APP_PRIVATE_KEY_MAX_BYTES = 64 * 1024;
@@ -55,6 +58,20 @@ type GitHubJsonOptions = {
 type GitHubBodyReadOptions = {
   signal?: AbortSignal;
   timeoutPromise?: Promise<never>;
+};
+
+type GitHubCliSpawn = (
+  command: string,
+  args: string[],
+  options: {
+    env: NodeJS.ProcessEnv;
+    killSignal: "SIGKILL";
+    stdio: "inherit";
+    timeout: number;
+  },
+) => {
+  error?: Error;
+  status: number | null;
 };
 
 export function parseRepoArg(args: string[]): string | null {
@@ -361,6 +378,32 @@ export function readGitHubAppPrivateKey(filePath: string): string {
   });
 }
 
+export function runGitHubCli(
+  ghArgs: string[],
+  token: string,
+  options: {
+    spawnSyncImpl?: GitHubCliSpawn;
+    timeoutMs?: number;
+  } = {},
+): number {
+  const spawnSyncImpl = options.spawnSyncImpl ?? spawnSync;
+  const child = spawnSyncImpl("gh", ghArgs, {
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      GH_TOKEN: token,
+      GITHUB_TOKEN: token,
+    },
+    killSignal: "SIGKILL",
+    timeout: options.timeoutMs ?? DEFAULT_GH_COMMAND_TIMEOUT_MS,
+  });
+
+  if (child.error) {
+    throw child.error;
+  }
+  return child.status ?? 1;
+}
+
 async function main() {
   if (process.argv.length <= 2) {
     fail(
@@ -376,20 +419,11 @@ async function main() {
   const appJwt = createAppJwt(appId, privateKeyPem);
   const installation = await resolveInstallation(appJwt, repo);
   const token = await createInstallationToken(appJwt, installation, repo);
-  const child = spawnSync("gh", ghArgs, {
-    stdio: "inherit",
-    env: {
-      ...process.env,
-      GH_TOKEN: token,
-      GITHUB_TOKEN: token,
-    },
-  });
-
-  if (child.error) {
-    fail(child.error.message);
+  try {
+    process.exit(runGitHubCli(ghArgs, token));
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error));
   }
-
-  process.exit(child.status ?? 1);
 }
 
 if (isMainModule()) {

--- a/scripts/gh-read.ts
+++ b/scripts/gh-read.ts
@@ -128,26 +128,170 @@ export function resolveGitHubFetchTimeoutMs(raw = process.env.OPENCLAW_GH_READ_F
   });
 }
 
-function isEnabledGitHubBooleanFlag(ghArgs: readonly string[], flag: string): boolean {
+type GitHubCommandPath = {
+  argsStart: number;
+  command: string;
+  subcommand: string;
+};
+
+function parseGitHubBooleanValue(raw: string): boolean | undefined {
+  if (GITHUB_CLI_TRUE_BOOLEAN_VALUES.has(raw)) {
+    return true;
+  }
+  if (GITHUB_CLI_FALSE_BOOLEAN_VALUES.has(raw)) {
+    return false;
+  }
+  return undefined;
+}
+
+function parseGitHubCommandPath(ghArgs: readonly string[]): GitHubCommandPath | null {
+  let command: string | undefined;
+  for (let index = 0; index < ghArgs.length; index += 1) {
+    const arg = expectDefined(ghArgs[index], `GitHub CLI argument at index ${index}`);
+    if (arg === "--") {
+      return null;
+    }
+
+    const isCodespaceCommand = command === "codespace";
+    const isSeparateValueFlag =
+      arg === "-R" ||
+      arg === "--repo" ||
+      arg === "--hostname" ||
+      (isCodespaceCommand && (arg === "-c" || arg === "--codespace" || arg === "--repo-owner"));
+    if (isSeparateValueFlag) {
+      index += 1;
+      continue;
+    }
+
+    const isAttachedValueFlag =
+      (arg.startsWith("-R") && arg.length > 2) ||
+      arg.startsWith("--repo=") ||
+      arg.startsWith("--hostname=") ||
+      (isCodespaceCommand &&
+        ((arg.startsWith("-c") && arg.length > 2) ||
+          arg.startsWith("--codespace=") ||
+          arg.startsWith("--repo-owner=")));
+    if (isAttachedValueFlag || arg.startsWith("-")) {
+      continue;
+    }
+
+    if (!command) {
+      command = arg === "cs" ? "codespace" : arg;
+      continue;
+    }
+    return { argsStart: index + 1, command, subcommand: arg };
+  }
+  return null;
+}
+
+function resolveLongGitHubBooleanFlag(
+  args: readonly string[],
+  flag: string,
+  valueFlags: { long: readonly string[]; short: readonly string[] },
+): boolean {
   let enabled = false;
   const valuePrefix = `${flag}=`;
-  for (const arg of ghArgs) {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = expectDefined(args[index], `GitHub CLI argument at index ${index}`);
+    if (arg === "--") {
+      break;
+    }
     if (arg === flag) {
       enabled = true;
       continue;
     }
-    if (!arg.startsWith(valuePrefix)) {
+    if (arg.startsWith(valuePrefix)) {
+      const value = parseGitHubBooleanValue(arg.slice(valuePrefix.length));
+      if (value === undefined) {
+        return false;
+      }
+      enabled = value;
+      continue;
+    }
+    if (valueFlags.long.includes(arg) || valueFlags.short.includes(arg)) {
+      if (index + 1 >= args.length) {
+        return false;
+      }
+      index += 1;
+      continue;
+    }
+    if (
+      valueFlags.long.some((valueFlag) => arg.startsWith(`${valueFlag}=`)) ||
+      valueFlags.short.some(
+        (valueFlag) => arg.startsWith(valueFlag) && arg.length > valueFlag.length,
+      )
+    ) {
+      continue;
+    }
+  }
+  return enabled;
+}
+
+function resolveCodespaceLogsFollow(args: readonly string[]): boolean {
+  let enabled = false;
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = expectDefined(args[index], `GitHub CLI argument at index ${index}`);
+    if (arg === "--") {
+      break;
+    }
+    if (arg === "--follow") {
+      enabled = true;
+      continue;
+    }
+    if (arg.startsWith("--follow=")) {
+      const value = parseGitHubBooleanValue(arg.slice("--follow=".length));
+      if (value === undefined) {
+        return false;
+      }
+      enabled = value;
+      continue;
+    }
+    if (arg === "--codespace" || arg === "--repo" || arg === "--repo-owner") {
+      if (index + 1 >= args.length) {
+        return false;
+      }
+      index += 1;
+      continue;
+    }
+    if (
+      arg.startsWith("--codespace=") ||
+      arg.startsWith("--repo=") ||
+      arg.startsWith("--repo-owner=")
+    ) {
+      continue;
+    }
+    if (!arg.startsWith("-") || arg.startsWith("--") || arg === "-") {
       continue;
     }
 
-    const value = arg.slice(valuePrefix.length);
-    if (GITHUB_CLI_TRUE_BOOLEAN_VALUES.has(value)) {
-      enabled = true;
-    } else if (GITHUB_CLI_FALSE_BOOLEAN_VALUES.has(value)) {
-      enabled = false;
-    } else {
-      // GitHub CLI rejects values outside Go's strconv.ParseBool grammar, so
-      // an invalid command cannot enter a long-lived watch/follow operation.
+    const shorthand = arg.slice(1);
+    for (let shorthandIndex = 0; shorthandIndex < shorthand.length; shorthandIndex += 1) {
+      const flag = expectDefined(
+        shorthand[shorthandIndex],
+        `GitHub CLI shorthand at index ${shorthandIndex}`,
+      );
+      const remainder = shorthand.slice(shorthandIndex + 1);
+      if (flag === "f") {
+        if (remainder.startsWith("=")) {
+          const value = parseGitHubBooleanValue(remainder.slice(1));
+          if (value === undefined) {
+            return false;
+          }
+          enabled = value;
+          break;
+        }
+        enabled = true;
+        continue;
+      }
+      if (flag === "c" || flag === "R") {
+        if (!remainder && index + 1 >= args.length) {
+          return false;
+        }
+        if (!remainder) {
+          index += 1;
+        }
+        break;
+      }
       return false;
     }
   }
@@ -155,53 +299,31 @@ function isEnabledGitHubBooleanFlag(ghArgs: readonly string[], flag: string): bo
 }
 
 function isLongLivedGitHubCommand(ghArgs: readonly string[]): boolean {
-  const commandPath: string[] = [];
-  for (let index = 0; index < ghArgs.length && commandPath.length < 2; index += 1) {
-    const arg = expectDefined(ghArgs[index], `GitHub CLI argument at index ${index}`);
-    const isCodespaceSelector =
-      commandPath[0] === "codespace" &&
-      (arg === "-c" || arg === "--codespace" || arg === "--repo-owner");
-    if (arg === "-R" || arg === "--repo" || arg === "--hostname" || isCodespaceSelector) {
-      index += 1;
-      continue;
-    }
-    const isAttachedCodespaceSelector =
-      commandPath[0] === "codespace" &&
-      ((arg.startsWith("-c") && arg.length > 2) ||
-        arg.startsWith("--codespace=") ||
-        arg.startsWith("--repo-owner="));
-    if (
-      arg.startsWith("-R") ||
-      arg.startsWith("--repo=") ||
-      arg.startsWith("--hostname=") ||
-      isAttachedCodespaceSelector ||
-      arg.startsWith("-")
-    ) {
-      continue;
-    }
-    commandPath.push(commandPath.length === 0 && arg === "cs" ? "codespace" : arg);
+  const commandPath = parseGitHubCommandPath(ghArgs);
+  if (!commandPath) {
+    return false;
   }
-
-  if (commandPath[0] === "run" && commandPath[1] === "watch") {
+  if (commandPath.command === "run" && commandPath.subcommand === "watch") {
     return true;
   }
 
-  // GitHub CLI also exposes long-lived behavior through explicit watch/follow
-  // flags (for example `pr checks --watch` and `agent-task view --follow`).
-  if (
-    isEnabledGitHubBooleanFlag(ghArgs, "--watch") ||
-    isEnabledGitHubBooleanFlag(ghArgs, "--follow")
-  ) {
-    return true;
+  const commandArgs = ghArgs.slice(commandPath.argsStart);
+  if (commandPath.command === "pr" && commandPath.subcommand === "checks") {
+    return resolveLongGitHubBooleanFlag(commandArgs, "--watch", {
+      long: ["--interval", "--jq", "--json", "--repo", "--template"],
+      short: ["-i", "-q", "-R", "-t"],
+    });
   }
-
-  // `-f` is ambiguous across gh commands, but for `codespace logs` it is the
-  // documented short form of `--follow`.
-  return (
-    commandPath[0] === "codespace" &&
-    commandPath[1] === "logs" &&
-    isEnabledGitHubBooleanFlag(ghArgs, "-f")
-  );
+  if (commandPath.command === "agent-task" && commandPath.subcommand === "view") {
+    return resolveLongGitHubBooleanFlag(commandArgs, "--follow", {
+      long: ["--repo"],
+      short: ["-R"],
+    });
+  }
+  if (commandPath.command === "codespace" && commandPath.subcommand === "logs") {
+    return resolveCodespaceLogsFollow(commandArgs);
+  }
+  return false;
 }
 
 function resolveGitHubCommandTimeoutMs(

--- a/test/scripts/gh-read.test.ts
+++ b/test/scripts/gh-read.test.ts
@@ -126,6 +126,14 @@ describe("gh-read helpers", () => {
       args: ["codespace", "logs", "-f=true"],
       mode: "codespace log true-valued short follow mode",
     },
+    {
+      args: ["cs", "logs", "-f"],
+      mode: "codespace alias log short follow mode",
+    },
+    {
+      args: ["cs", "-c", "example", "logs", "-f=true"],
+      mode: "codespace alias selected log true-valued short follow mode",
+    },
   ])("preserves the unbounded default for $mode", ({ args }) => {
     const received = { args: [] as string[], command: "", timeout: 120_000 as number | undefined };
     const spawnSyncImpl = vi.fn(

--- a/test/scripts/gh-read.test.ts
+++ b/test/scripts/gh-read.test.ts
@@ -114,6 +114,18 @@ describe("gh-read helpers", () => {
       args: ["codespace", "logs", "-f"],
       mode: "codespace log short follow mode",
     },
+    {
+      args: ["codespace", "-c", "example", "logs", "-f"],
+      mode: "codespace log follow mode with a selected codespace",
+    },
+    {
+      args: ["codespace", "--repo-owner", "openclaw", "logs", "-f"],
+      mode: "codespace log follow mode with a selected repository owner",
+    },
+    {
+      args: ["codespace", "logs", "-f=true"],
+      mode: "codespace log true-valued short follow mode",
+    },
   ])("preserves the unbounded default for $mode", ({ args }) => {
     const received = { args: [] as string[], command: "", timeout: 120_000 as number | undefined };
     const spawnSyncImpl = vi.fn(

--- a/test/scripts/gh-read.test.ts
+++ b/test/scripts/gh-read.test.ts
@@ -107,8 +107,24 @@ describe("gh-read helpers", () => {
       mode: "pull request check watch mode",
     },
     {
+      args: ["pr", "checks", "111328", "--watch=1"],
+      mode: "numeric pull request check watch mode",
+    },
+    {
+      args: ["pr", "checks", "111328", "--watch=True"],
+      mode: "mixed-case pull request check watch mode",
+    },
+    {
+      args: ["pr", "checks", "111328", "--watch=false", "--watch=TRUE"],
+      mode: "final enabled pull request check watch mode",
+    },
+    {
       args: ["agent-task", "view", "111328", "--follow"],
       mode: "agent task follow mode",
+    },
+    {
+      args: ["agent-task", "view", "111328", "--follow=T"],
+      mode: "uppercase agent task follow mode",
     },
     {
       args: ["codespace", "logs", "-f"],
@@ -127,12 +143,20 @@ describe("gh-read helpers", () => {
       mode: "codespace log true-valued short follow mode",
     },
     {
+      args: ["codespace", "logs", "-f=1"],
+      mode: "codespace log numeric short follow mode",
+    },
+    {
       args: ["cs", "logs", "-f"],
       mode: "codespace alias log short follow mode",
     },
     {
       args: ["cs", "-c", "example", "logs", "-f=true"],
       mode: "codespace alias selected log true-valued short follow mode",
+    },
+    {
+      args: ["cs", "-c", "example", "logs", "-f=TRUE"],
+      mode: "codespace alias selected log uppercase short follow mode",
     },
   ])("preserves the unbounded default for $mode", ({ args }) => {
     const received = { args: [] as string[], command: "", timeout: 120_000 as number | undefined };
@@ -152,6 +176,33 @@ describe("gh-read helpers", () => {
       command: "gh",
       timeout: undefined,
     });
+  });
+
+  it.each([
+    {
+      args: ["pr", "checks", "111328", "--watch=1", "--watch=false"],
+      mode: "finally disabled pull request check watch mode",
+    },
+    {
+      args: ["agent-task", "view", "111328", "--follow=True", "--follow=0"],
+      mode: "finally disabled agent task follow mode",
+    },
+    {
+      args: ["cs", "logs", "-f=TRUE", "-f=false"],
+      mode: "finally disabled codespace alias log follow mode",
+    },
+  ])("uses the ordinary timeout for $mode", ({ args }) => {
+    const received = { timeout: undefined as number | undefined };
+    const spawnSyncImpl = vi.fn(
+      (_command: string, _childArgs: string[], options: { timeout?: number }) => {
+        received.timeout = options.timeout;
+        return { status: 0 };
+      },
+    );
+
+    expect(runGitHubCli(args, "test-fixture-credential", { spawnSyncImpl })).toBe(0);
+    expect(spawnSyncImpl).toHaveBeenCalledOnce();
+    expect(received.timeout).toBe(120_000);
   });
 
   it("rejects invalid operator-selected GitHub CLI timeouts", () => {

--- a/test/scripts/gh-read.test.ts
+++ b/test/scripts/gh-read.test.ts
@@ -67,7 +67,33 @@ describe("gh-read helpers", () => {
     expect(
       runGitHubCli(["run", "watch", "123"], "test-fixture-credential", { spawnSyncImpl }),
     ).toBe(0);
-    expect(spawnSyncImpl.mock.calls[0]?.[2].timeout).toBe(900_000);
+    expect(spawnSyncImpl).toHaveBeenCalledWith("gh", ["run", "watch", "123"], {
+      env: expect.any(Object),
+      killSignal: "SIGKILL",
+      stdio: "inherit",
+      timeout: 900_000,
+    });
+  });
+
+  it("preserves the unbounded default for long-lived GitHub CLI commands", () => {
+    const spawnSyncImpl = vi.fn(() => ({ status: 0 }));
+
+    expect(
+      runGitHubCli(
+        ["--repo", "openclaw/openclaw", "run", "watch", "123"],
+        "test-fixture-credential",
+        { spawnSyncImpl },
+      ),
+    ).toBe(0);
+    expect(spawnSyncImpl).toHaveBeenCalledWith(
+      "gh",
+      ["--repo", "openclaw/openclaw", "run", "watch", "123"],
+      {
+        env: expect.any(Object),
+        killSignal: "SIGKILL",
+        stdio: "inherit",
+      },
+    );
   });
 
   it("rejects invalid operator-selected GitHub CLI timeouts", () => {

--- a/test/scripts/gh-read.test.ts
+++ b/test/scripts/gh-read.test.ts
@@ -20,6 +20,7 @@ import {
 describe("gh-read helpers", () => {
   afterEach(() => {
     vi.useRealTimers();
+    vi.unstubAllEnvs();
   });
 
   it("prints wrapper usage before reading auth env", () => {
@@ -57,6 +58,26 @@ describe("gh-read helpers", () => {
       stdio: "inherit",
       timeout: 120_000,
     });
+  });
+
+  it("accepts a longer operator-selected GitHub CLI timeout", () => {
+    vi.stubEnv("OPENCLAW_GH_READ_COMMAND_TIMEOUT_MS", "900000");
+    const spawnSyncImpl = vi.fn(() => ({ status: 0 }));
+
+    expect(
+      runGitHubCli(["run", "watch", "123"], "test-fixture-credential", { spawnSyncImpl }),
+    ).toBe(0);
+    expect(spawnSyncImpl.mock.calls[0]?.[2].timeout).toBe(900_000);
+  });
+
+  it("rejects invalid operator-selected GitHub CLI timeouts", () => {
+    vi.stubEnv("OPENCLAW_GH_READ_COMMAND_TIMEOUT_MS", "15m");
+    const spawnSyncImpl = vi.fn(() => ({ status: 0 }));
+
+    expect(() =>
+      runGitHubCli(["run", "watch", "123"], "test-fixture-credential", { spawnSyncImpl }),
+    ).toThrow(/OPENCLAW_GH_READ_COMMAND_TIMEOUT_MS must be an integer/u);
+    expect(spawnSyncImpl).not.toHaveBeenCalled();
   });
 
   it("finds repo from gh args", () => {

--- a/test/scripts/gh-read.test.ts
+++ b/test/scripts/gh-read.test.ts
@@ -76,7 +76,15 @@ describe("gh-read helpers", () => {
   });
 
   it("preserves the unbounded default for long-lived GitHub CLI commands", () => {
-    const spawnSyncImpl = vi.fn(() => ({ status: 0 }));
+    const received = { args: [] as string[], command: "", timeout: 120_000 as number | undefined };
+    const spawnSyncImpl = vi.fn(
+      (command: string, childArgs: string[], options: { timeout?: number }) => {
+        received.command = command;
+        received.args = childArgs;
+        received.timeout = options.timeout;
+        return { status: 0 };
+      },
+    );
 
     expect(
       runGitHubCli(
@@ -85,15 +93,45 @@ describe("gh-read helpers", () => {
         { spawnSyncImpl },
       ),
     ).toBe(0);
-    expect(spawnSyncImpl).toHaveBeenCalledWith(
-      "gh",
-      ["--repo", "openclaw/openclaw", "run", "watch", "123"],
-      {
-        env: expect.any(Object),
-        killSignal: "SIGKILL",
-        stdio: "inherit",
+    expect(spawnSyncImpl).toHaveBeenCalledOnce();
+    expect(received).toEqual({
+      args: ["--repo", "openclaw/openclaw", "run", "watch", "123"],
+      command: "gh",
+      timeout: undefined,
+    });
+  });
+
+  it.each([
+    {
+      args: ["--hostname=github.com", "pr", "checks", "111328", "--watch"],
+      mode: "pull request check watch mode",
+    },
+    {
+      args: ["agent-task", "view", "111328", "--follow"],
+      mode: "agent task follow mode",
+    },
+    {
+      args: ["codespace", "logs", "-f"],
+      mode: "codespace log short follow mode",
+    },
+  ])("preserves the unbounded default for $mode", ({ args }) => {
+    const received = { args: [] as string[], command: "", timeout: 120_000 as number | undefined };
+    const spawnSyncImpl = vi.fn(
+      (command: string, childArgs: string[], options: { timeout?: number }) => {
+        received.command = command;
+        received.args = childArgs;
+        received.timeout = options.timeout;
+        return { status: 0 };
       },
     );
+
+    expect(runGitHubCli(args, "test-fixture-credential", { spawnSyncImpl })).toBe(0);
+    expect(spawnSyncImpl).toHaveBeenCalledOnce();
+    expect(received).toEqual({
+      args,
+      command: "gh",
+      timeout: undefined,
+    });
   });
 
   it("rejects invalid operator-selected GitHub CLI timeouts", () => {

--- a/test/scripts/gh-read.test.ts
+++ b/test/scripts/gh-read.test.ts
@@ -14,6 +14,7 @@ import {
   readBoundedGitHubErrorText,
   readBoundedGitHubJson,
   resolveGitHubFetchTimeoutMs,
+  runGitHubCli,
 } from "../../scripts/gh-read.js";
 
 describe("gh-read helpers", () => {
@@ -35,6 +36,27 @@ describe("gh-read helpers", () => {
 
     expect(stderr).toContain("usage: scripts/gh-read <gh args...>");
     expect(stderr).toContain("OPENCLAW_GH_READ_APP_ID");
+  });
+
+  it("bounds delegated GitHub CLI execution", () => {
+    const fixtureCredential = "test-fixture-credential";
+    const timeoutError = Object.assign(new Error("spawnSync gh ETIMEDOUT"), {
+      code: "ETIMEDOUT",
+    });
+    const spawnSyncImpl = vi.fn(() => ({
+      error: timeoutError,
+      status: null,
+    }));
+
+    expect(() =>
+      runGitHubCli(["api", "repos/openclaw/openclaw"], fixtureCredential, { spawnSyncImpl }),
+    ).toThrow(timeoutError);
+    expect(spawnSyncImpl).toHaveBeenCalledWith("gh", ["api", "repos/openclaw/openclaw"], {
+      env: expect.any(Object),
+      killSignal: "SIGKILL",
+      stdio: "inherit",
+      timeout: 120_000,
+    });
   });
 
   it("finds repo from gh args", () => {

--- a/test/scripts/gh-read.test.ts
+++ b/test/scripts/gh-read.test.ts
@@ -158,6 +158,18 @@ describe("gh-read helpers", () => {
       args: ["cs", "-c", "example", "logs", "-f=TRUE"],
       mode: "codespace alias selected log uppercase short follow mode",
     },
+    {
+      args: ["codespace", "logs", "-fc=example"],
+      mode: "codespace grouped short follow mode with an attached selector",
+    },
+    {
+      args: ["cs", "logs", "-fcexample"],
+      mode: "codespace alias grouped short follow mode",
+    },
+    {
+      args: ["codespace", "logs", "-f=false", "--follow=1"],
+      mode: "codespace mixed-alias finally enabled follow mode",
+    },
   ])("preserves the unbounded default for $mode", ({ args }) => {
     const received = { args: [] as string[], command: "", timeout: 120_000 as number | undefined };
     const spawnSyncImpl = vi.fn(
@@ -190,6 +202,26 @@ describe("gh-read helpers", () => {
     {
       args: ["cs", "logs", "-f=TRUE", "-f=false"],
       mode: "finally disabled codespace alias log follow mode",
+    },
+    {
+      args: ["codespace", "logs", "--follow=TRUE", "-f=false"],
+      mode: "mixed-alias finally disabled codespace log follow mode",
+    },
+    {
+      args: ["codespace", "logs", "-cf"],
+      mode: "codespace selector value that resembles a follow shorthand",
+    },
+    {
+      args: ["codespace", "logs", "-c", "-f"],
+      mode: "separate codespace selector value that resembles a follow flag",
+    },
+    {
+      args: ["agent-task", "view", "111328", "-R", "--follow"],
+      mode: "repository value that resembles an agent task follow flag",
+    },
+    {
+      args: ["search", "code", "--", "--watch"],
+      mode: "positional watch text after the flag terminator",
     },
   ])("uses the ordinary timeout for $mode", ({ args }) => {
     const received = { timeout: undefined as number | undefined };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers and repository automation using `scripts/gh-read` for ordinary finite reads could hang indefinitely when the delegated GitHub CLI process stopped responding. A stalled read could therefore block the surrounding workflow without returning an actionable failure.

- **Root cause:** `scripts/gh-read` owns the lifetime of each delegated `gh` child, but its canonical `runGitHubCli` boundary previously supplied no deadline for ordinary reads.
- **Compatibility boundary:** Explicit GitHub CLI watch/follow workflows historically had no fixed deadline. They remain unbounded by default, while operators can opt them or any other command into a validated finite budget.

## Why This Change Was Made

`runGitHubCli` now applies a 120,000 ms default to ordinary finite reads at the shared child-process boundary. It preserves the unbounded default for the inherent `gh run watch` command and explicit true-valued `--watch`/`--follow` modes, including codespace selector forms such as `gh codespace -c NAME logs -f`, the official `gh cs` alias, and grouped PFlag shorthand such as `gh cs logs -fc=NAME`. The classifier parses only supported command paths, stops at `--`, consumes value-taking flags, shares final precedence between codespace `-f` and `--follow`, and accepts GitHub CLI's Go Boolean grammar. `OPENCLAW_GH_READ_COMMAND_TIMEOUT_MS` explicitly selects a positive safe-integer timeout for any command, including those long-running modes.

This keeps the hang protection at the canonical process owner while resolving the compatibility finding caused by applying the initial finite default to a documented long-lived command.

- **Timeout selection:** A live 5,000-PR pagination read completed in 47.770 seconds. The two-minute ordinary-read default leaves 72.230 seconds of observed margin and follows the broad-pagination owner pattern used in #109968.
- **Contract surface:** This changes only the repository `scripts/gh-read` wrapper and its documented optional environment control. It does not change an OpenClaw product API, schema, protocol, or migration.
- **Long-lived mode audit:** GitHub CLI 2.86.0's command reference exposes long-running behavior through `gh run watch`, `gh pr checks --watch`, agent-task `--follow`, and codespace logs `--follow`/`-f`. The classifier covers these semantic forms, including the official `gh cs` alias, selectors before or after `logs`, grouped shorthand, the `--` terminator, value-taking short flags, and all `strconv.ParseBool` true spellings such as `1`, `T`, `True`, and `TRUE`. Repeated `-f`/`--follow` aliases use their final effective value, while flag-like values and positional text do not enable a long-lived mode.
- **Related open PR scan:** #110601 is a sibling timeout pattern for distinct scripts and call sites, not a competing implementation of this `gh-read` owner fix.
- **Out of scope:** The unchanged GitHub App token bootstrap, GitHub API fetch handling, and other direct `execPlainGh` or `execFileSync` call sites are intentionally unchanged.
- **Risk and guardrail:** A legitimate ordinary command exceeding the selected finite budget is terminated, and an operator can choose an override that is unnecessarily short or long. Tests cover global-option parsing, GitHub CLI Boolean grammar and repeated-flag precedence, default selection, explicit override validation, inherited stdio, token propagation, successful exits, ordinary nonzero statuses, and timeout propagation.

## User Impact

Maintainers and repository automation now receive an actionable `ETIMEDOUT` failure instead of waiting forever when an ordinary delegated GitHub CLI read stalls. Existing GitHub CLI watch/follow usage keeps its unbounded default, and operators can set `OPENCLAW_GH_READ_COMMAND_TIMEOUT_MS` when they want any command to use a finite budget.

## Evidence

- Exact verified candidate tree was committed unchanged at `c2d72a4251887e41174dd27ecd4acac3b6ef1778`.
- A real stalled ordinary child exercised the production `runGitHubCli` boundary and was terminated after 120,104 ms:

  ```json
  {"timeout":120000,"killSignal":"SIGKILL","error":"ETIMEDOUT","status":null,"signal":"SIGKILL"}
  ```

- A real `gh run watch` child used no timeout option by default and completed with status 0 after 2,032 ms.
- The same `gh run watch` path with `OPENCLAW_GH_READ_COMMAND_TIMEOUT_MS=5000` received a 5,000 ms timeout and completed with status 0 after 2,035 ms.
- A live `gh pr checks 111328 -R openclaw/openclaw --watch=1 --interval 1` command received no timeout option and returned the hosted failing-check status after 2,495 ms.
- A real `gh cs logs -fc=example` child exercised grouped `-f` plus `-c`, received no timeout option, and completed with status 0 after 2,021 ms.
- A live broad-pagination command returned `5000` with status 0 in 47,770 ms through the same production owner with the 120,000 ms ordinary-read default.
- `pnpm exec vitest run test/scripts/gh-read.test.ts` — 44/44 passed, including grouped shorthand, mixed-alias precedence, value-taking flags, and `--` termination.
- Targeted Oxlint, formatter check, documentation discovery, and diff whitespace checks passed.
- The runtime proofs exercised the changed delegated-command boundary with real children and a live GitHub query. The unchanged outer GitHub App installation-token bootstrap was not repeated because App credentials were unavailable in this environment.
- Local test TypeScript compilation was not repeated because this host could not provide the required attested resource guard. Remote `check-test-types` CI is authoritative for that lane; the previously reported unsafe mock tuple access has been removed.
