### PR TITLE
fix(agents): web_fetch leaves body open after provider fallback

### DIFF
--- a/src/agents/tools/web-fetch.provider-fallback.test.ts
+++ b/src/agents/tools/web-fetch.provider-fallback.test.ts
@@ -1,12 +1,14 @@
 // Provider fallback tests verify web_fetch normalizes third-party fetch output
 // before exposing it to agents or cache entries.
 import { rm } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import { setActiveDegradedSecretOwners } from "../../secrets/runtime-degraded-state.js";
 import { wrapExternalContent } from "../../security/external-content.js";
 import { withFetchPreconnect } from "../../test-utils/fetch-mock.js";
 import { createWebFetchTool } from "./web-fetch.js";
+import * as webGuardedFetch from "./web-guarded-fetch.js";
 
 const { resolveWebFetchDefinitionMock } = vi.hoisted(() => ({
   resolveWebFetchDefinitionMock: vi.fn(),
@@ -358,5 +360,292 @@ describe("web_fetch provider fallback normalization", () => {
     expect(secondDetails.externalContent?.provider).toBe("perplexity-fetch");
     expect(secondDetails.text).toContain("perplexity-fetch fallback body");
     expect(secondDetails.cached).toBeUndefined();
+  });
+
+  it("cancels an unread non-OK response body when provider fallback succeeds", async () => {
+    let cancelled = false;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.enqueue(new TextEncoder().encode("upstream error body"));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    global.fetch = withFetchPreconnect(
+      vi.fn(
+        async () =>
+          new Response(stream, {
+            status: 503,
+            statusText: "Service Unavailable",
+            headers: { "content-type": "text/plain" },
+          }),
+      ),
+    );
+    resolveWebFetchDefinitionMock.mockReturnValue({
+      provider: { id: "firecrawl" },
+      definition: {
+        description: "firecrawl",
+        parameters: {},
+        execute: async () => ({
+          text: "provider rescued body",
+          status: 200,
+          contentType: "text/plain",
+          extractor: "custom-provider",
+        }),
+      },
+    });
+
+    const tool = createWebFetchTool({
+      config: {} as OpenClawConfig,
+      sandboxed: false,
+    });
+    const result = await tool?.execute?.("call-provider-fallback", {
+      url: "https://example.com/non-ok-fallback",
+    });
+    const details = result?.details as { text?: string; extractor?: string };
+
+    expect(details.extractor).toBe("custom-provider");
+    expect(details.text).toContain("provider rescued body");
+    expect(cancelled).toBe(true);
+    console.log(
+      `[web-fetch non-ok fallback cancel proof] cancelled=${cancelled} extractor=${details.extractor ?? "n/a"}`,
+    );
+  });
+
+  it("cancels the response body when readability-disabled fallback succeeds", async () => {
+    let cancelInvoked = false;
+    global.fetch = withFetchPreconnect(
+      vi.fn(async () => {
+        const stream = new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(
+              new TextEncoder().encode("<html><body><p>direct html</p></body></html>"),
+            );
+            controller.close();
+          },
+        });
+        const response = new Response(stream, {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        });
+        const body = response.body;
+        if (!body) {
+          throw new Error("expected response body");
+        }
+        const originalCancel = body.cancel.bind(body);
+        body.cancel = ((reason?: unknown) => {
+          cancelInvoked = true;
+          return originalCancel(reason);
+        }) as typeof body.cancel;
+        return response;
+      }),
+    );
+    resolveWebFetchDefinitionMock.mockReturnValue({
+      provider: { id: "firecrawl" },
+      definition: {
+        description: "firecrawl",
+        parameters: {},
+        execute: async () => ({
+          text: "provider html rescue",
+          status: 200,
+          contentType: "text/plain",
+          extractor: "custom-provider",
+        }),
+      },
+    });
+
+    const tool = createWebFetchTool({
+      config: {
+        tools: { web: { fetch: { readability: false } } },
+      } as OpenClawConfig,
+      sandboxed: false,
+    });
+    const result = await tool?.execute?.("call-provider-fallback", {
+      url: "https://example.com/readability-off-fallback",
+    });
+    const details = result?.details as { text?: string; extractor?: string };
+
+    expect(details.extractor).toBe("custom-provider");
+    expect(details.text).toContain("provider html rescue");
+    expect(cancelInvoked).toBe(true);
+    console.log(
+      `[web-fetch readability-off fallback cancel proof] cancel_invoked=${cancelInvoked} extractor=${details.extractor ?? "n/a"}`,
+    );
+  });
+
+  it("does not block provider fallback when body cancel never settles", async () => {
+    // cancel() must stay fire-and-forget; awaiting it can hang a successful fallback.
+    global.fetch = withFetchPreconnect(
+      vi.fn(async () => {
+        const stream = new ReadableStream<Uint8Array>({
+          pull(controller) {
+            controller.enqueue(new TextEncoder().encode("never-settling-cancel body"));
+          },
+          cancel() {
+            return new Promise(() => {
+              // Intentionally never settles.
+            });
+          },
+        });
+        return new Response(stream, {
+          status: 503,
+          statusText: "Service Unavailable",
+          headers: { "content-type": "text/plain" },
+        });
+      }),
+    );
+    resolveWebFetchDefinitionMock.mockReturnValue({
+      provider: { id: "firecrawl" },
+      definition: {
+        description: "firecrawl",
+        parameters: {},
+        execute: async () => ({
+          text: "provider rescued despite hung cancel",
+          status: 200,
+          contentType: "text/plain",
+          extractor: "custom-provider",
+        }),
+      },
+    });
+
+    const tool = createWebFetchTool({
+      config: {
+        tools: { web: { fetch: { cacheTtlMinutes: 0 } } },
+      } as OpenClawConfig,
+      sandboxed: false,
+    });
+    const started = Date.now();
+    const result = await Promise.race([
+      tool?.execute?.("call-provider-fallback", {
+        url: "https://example.com/hung-cancel-fallback",
+      }),
+      new Promise((_, reject) => {
+        setTimeout(() => reject(new Error("fallback blocked on never-settling cancel")), 1500);
+      }),
+    ]);
+    const elapsedMs = Date.now() - started;
+    const details = (result as { details?: { text?: string; extractor?: string } })?.details;
+
+    expect(details?.extractor).toBe("custom-provider");
+    expect(details?.text).toContain("provider rescued despite hung cancel");
+    expect(elapsedMs).toBeLessThan(1500);
+    console.log(
+      `[web-fetch never-settling cancel proof] returned=true elapsed_ms=${elapsedMs} extractor=${details?.extractor ?? "n/a"}`,
+    );
+  });
+
+  it("cancels unread non-OK body over real guarded HTTP when provider fallback succeeds", async () => {
+    // Real node:http upstream + production guarded fetch path (private-network allow
+    // only for this loopback proof). Provider fallback is configured; cancel must run
+    // before the early return so the abandoned body is closed.
+    const realGuarded = webGuardedFetch.fetchWithWebToolsNetworkGuard;
+    const guardedSpy = vi
+      .spyOn(webGuardedFetch, "fetchWithWebToolsNetworkGuard")
+      .mockImplementation((params) =>
+        realGuarded({
+          ...params,
+          policy: {
+            ...params.policy,
+            dangerouslyAllowPrivateNetwork: true,
+          },
+        }),
+      );
+
+    let cancelInvoked = 0;
+    const originalCancel = ReadableStream.prototype.cancel;
+    ReadableStream.prototype.cancel = function cancel(
+      this: ReadableStream,
+      reason?: unknown,
+    ): Promise<void> {
+      cancelInvoked += 1;
+      return originalCancel.call(this, reason);
+    };
+
+    let serverSawClose = false;
+    let server: Server | undefined;
+    try {
+      server = createServer((req, res) => {
+        res.writeHead(503, {
+          "Content-Type": "text/plain; charset=utf-8",
+          "Content-Length": "1048576",
+        });
+        res.write("upstream-error-body-chunk\n");
+        const timer = setInterval(() => {
+          try {
+            res.write("x".repeat(2048));
+          } catch {
+            clearInterval(timer);
+          }
+        }, 10);
+        const markClosed = () => {
+          serverSawClose = true;
+          clearInterval(timer);
+          try {
+            res.end();
+          } catch {
+            // already closed
+          }
+        };
+        req.on("aborted", markClosed);
+        req.on("close", markClosed);
+        res.on("close", markClosed);
+      });
+      await new Promise<void>((resolve) => {
+        server?.listen(0, "127.0.0.1", () => resolve());
+      });
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("expected TCP listen address");
+      }
+      const url = `http://127.0.0.1:${address.port}/non-ok-fallback`;
+
+      resolveWebFetchDefinitionMock.mockReturnValue({
+        provider: { id: "firecrawl" },
+        definition: {
+          description: "firecrawl",
+          parameters: {},
+          execute: async () => ({
+            text: "provider rescued from real upstream",
+            status: 200,
+            contentType: "text/plain",
+            extractor: "custom-provider",
+          }),
+        },
+      });
+
+      const tool = createWebFetchTool({
+        config: {
+          tools: { web: { fetch: { cacheTtlMinutes: 0 } } },
+        } as OpenClawConfig,
+        sandboxed: false,
+      });
+      const started = Date.now();
+      const result = await tool?.execute?.("call-provider-fallback", { url });
+      const elapsedMs = Date.now() - started;
+      const details = result?.details as { text?: string; extractor?: string };
+
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 150);
+      });
+
+      expect(details.extractor).toBe("custom-provider");
+      expect(details.text).toContain("provider rescued from real upstream");
+      expect(cancelInvoked).toBeGreaterThan(0);
+      expect(serverSawClose).toBe(true);
+      console.log(
+        `[web-fetch live guarded HTTP cancel proof] url_host=127.0.0.1 cancel_invoked=${cancelInvoked} server_closed=${serverSawClose} extractor=${details.extractor ?? "n/a"} elapsed_ms=${elapsedMs}`,
+      );
+    } finally {
+      ReadableStream.prototype.cancel = originalCancel;
+      guardedSpy.mockRestore();
+      await new Promise<void>((resolve) => {
+        if (!server) {
+          resolve();
+          return;
+        }
+        server.close(() => resolve());
+      });
+    }
   });
 });

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -562,6 +562,13 @@ async function normalizeProviderWebFetchPayload(params: {
   };
 }
 
+function cancelUnreadWebFetchBody(response: Response): void {
+  // Provider fallback may return early without reading the upstream body; cancel
+  // so release() does not leave the stream open. Do not await cancel() — mocked or
+  // non-compliant streams can leave it unsettled and hang a successful fallback.
+  void response.body?.cancel().catch(() => undefined);
+}
+
 async function maybeFetchProviderWebFetchPayload(
   params: WebFetchRuntimeParams & {
     urlToFetch: string;
@@ -683,6 +690,7 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
         tookMs: Date.now() - start,
       });
       if (payload) {
+        cancelUnreadWebFetchBody(res);
         return payload;
       }
       const rawDetailResult = await readResponseText(res, { maxBytes: DEFAULT_ERROR_MAX_BYTES });
@@ -740,6 +748,7 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
             payload = null;
           }
           if (payload) {
+            cancelUnreadWebFetchBody(res);
             return payload;
           }
           const basic = await extractBasicHtmlContent({
@@ -766,6 +775,7 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
           tookMs: Date.now() - start,
         });
         if (payload) {
+          cancelUnreadWebFetchBody(res);
           return payload;
         }
         throw new Error(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `web_fetch` could leave an upstream response body open when a non-OK (or extraction-failed) response was abandoned after a successful provider fallback return. `finally` only called `release()`; the unread (or abandoned) body was never cancelled.

## Why This Change Was Made

Before returning a provider-fallback payload that abandons the direct fetch response, cancel the response body best-effort (`void body?.cancel().catch(...)`), matching the cancel-before-release campaign used elsewhere in core. Cancellation is fire-and-forget so a never-settling `cancel()` cannot hang a successful fallback. Covers both the non-OK early-return path and the readability-disabled HTML fallback return path.

## User Impact

**Before:** Successful provider fallback after a non-OK upstream (or after skipping local HTML extraction) could retain an abandoned response stream until GC. An awaited cancel could also stall the fallback return.

**After:** The abandoned upstream body is cancelled without awaiting before returning the fallback payload; dispatcher release still runs in `finally`.

## Evidence

### Proof (exit 0)

```bash
node scripts/run-vitest.mjs src/agents/tools/web-fetch.provider-fallback.test.ts -t "cancels an unread non-OK|cancels the response body when readability|does not block provider fallback|cancels unread non-OK body over real" --reporter=verbose
```

```text
[web-fetch non-ok fallback cancel proof] cancelled=true extractor=custom-provider
[web-fetch readability-off fallback cancel proof] cancel_invoked=true extractor=custom-provider
[web-fetch never-settling cancel proof] returned=true elapsed_ms=1 extractor=custom-provider
[web-fetch live guarded HTTP cancel proof] url_host=127.0.0.1 cancel_invoked=1 server_closed=true extractor=custom-provider elapsed_ms=192

 ✓ cancels an unread non-OK response body when provider fallback succeeds
 ✓ cancels the response body when readability-disabled fallback succeeds
 ✓ does not block provider fallback when body cancel never settles
 ✓ cancels unread non-OK body over real guarded HTTP when provider fallback succeeds

 Test Files  2 passed (2)
 Tests  8 passed | 10 skipped (18)
```

Live log: `/tmp/proof-111332-live.txt`

## Real behavior proof

- **Behavior or issue addressed:** Non-OK and readability-disabled HTML upstream bodies are cancelled when provider fallback succeeds and returns early; never-settling `cancel()` cannot block the return.
- **Canonical reachability path:** `createWebFetchTool` → guarded fetch → `maybeFetchProviderWebFetchPayload` success → `cancelUnreadWebFetchBody(res)` (fire-and-forget) → return payload → `release()`.
- **Boundary crossed:** Abandoned upstream HTTP body stream → `body.cancel()` before fallback return; real `node:http` 503 upstream closed (`server_closed=true`) after cancel.
- **Shared helper / provider constraint check:** Local `cancelUnreadWebFetchBody` uses `void body?.cancel().catch(() => undefined)` (same best-effort pattern as `readResponseText` in `web-shared.ts`).
- **Observed result after fix:** `cancel_invoked=1 server_closed=true extractor=custom-provider` on real guarded loopback HTTP; never-settling cancel returns in ~1ms.
- **Fix classification:** Root cause fix

- [x] AI-assisted (Cursor)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
