### PR TITLE
fix(zalouser): probe timeout reported as Not authenticated

### DIFF
--- a/extensions/zalouser/src/probe.test.ts
+++ b/extensions/zalouser/src/probe.test.ts
@@ -32,13 +32,15 @@ describe("probeZalouser", () => {
     });
   });
 
-  it("returns not authenticated when no user info is returned", async () => {
+  it("returns not authenticated when no user info is returned before the timeout", async () => {
+    vi.useFakeTimers();
     mockGetUserInfo.mockResolvedValueOnce(null);
-    await expect(probeZalouser("default")).resolves.toEqual({
+    await expect(probeZalouser("default", 10)).resolves.toEqual({
       ok: false,
       error: "Not authenticated",
       elapsedMs: expect.any(Number),
     });
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it("returns error when user lookup throws", async () => {
@@ -59,7 +61,7 @@ describe("probeZalouser", () => {
 
     await expect(pending).resolves.toEqual({
       ok: false,
-      error: "Not authenticated",
+      error: "timeout",
       elapsedMs: expect.any(Number),
     });
   });

--- a/extensions/zalouser/src/probe.ts
+++ b/extensions/zalouser/src/probe.ts
@@ -18,13 +18,9 @@ export async function probeZalouser(
   return await runChannelProbe(
     timeoutMs ? resolveTimerTimeoutMs(timeoutMs, 1000, 1000) : undefined,
     async () => {
-      try {
-        const user = await getZaloUserInfo(profile);
-        return user ? { ok: true, user } : { ok: false, error: "Not authenticated" };
-      } catch (error) {
-        return { ok: false, error: formatErrorMessage(error) };
-      }
+      const user = await getZaloUserInfo(profile);
+      return user ? { ok: true, user } : { ok: false, error: "Not authenticated" };
     },
-    () => ({ ok: false, error: "Not authenticated" }),
+    (error) => ({ ok: false, error: formatErrorMessage(error) }),
   );
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a slow or stalled Zalouser account lookup was reported as `Not authenticated` in channel status, even though the saved session could still be valid.

## Why This Change Was Made

The rewritten head keeps timeout ownership in the shared `runChannelProbe` helper. A lookup that completes with no user still reports `Not authenticated`; a deadline now reports the shared `timeout` error, and ordinary lookup failures retain their real error text. The stale branch's private `Promise.race` and duplicate timeout policy were removed.

No config, Plugin SDK surface, authentication flow, or message-delivery behavior changes.

## User Impact

Operators can distinguish a transient or stalled Zalo lookup from a missing login instead of being told to authenticate again incorrectly.

## Evidence

Exact rewritten head: `0483663520cc76e77dc87443baa937b75398d600`

- Focused probe and shared-helper tests: 2 files, 10 tests passed.
- Zalouser channel neighborhood: 3 files, 26 tests passed.
- Timeout-focused probe suite repeated 5 times: 30/30 assertions passed.
- Actual plugin status projection: a stalled lookup produced `{ ok: false, error: "timeout", elapsedMs }`, and `zalouserPlugin.status.buildChannelSummary` preserved that result.
- Completed null lookup with a deadline still reports `Not authenticated` and clears its timer.
- Scoped `oxfmt`, `oxlint`, and `git diff --check`: clean.
- Blacksmith Testbox changed gate: `tbx_01kz3yapfm9yy0jqpafkx723e1`, exit 0. Actions: https://github.com/openclaw/openclaw/actions/runs/30819945116
- Autoreview: no accepted P0/P1 findings; patch confidence `0.94`.

Production delta is `+3/-7`; total delta is `+8/-10`.
