### PR TITLE
fix(plugins): cancel discarded TTS contract response bodies

### DIFF
--- a/src/plugins/contracts/tts-contract-suites.ts
+++ b/src/plugins/contracts/tts-contract-suites.ts
@@ -1165,7 +1165,10 @@ export function describeTtsProviderRuntimeContract() {
                 messages: {
                   tts: {
                     provider: "openai",
-                    openai: { baseUrl: `http://127.0.0.1:${port}/v1`, apiKey: "test-key" },
+                    openai: {
+                      baseUrl: `http://127.0.0.1:${port}/v1`,
+                      apiKey: "fixture-api-key",
+                    },
                   },
                 },
               }),

--- a/src/plugins/contracts/tts-contract-suites.ts
+++ b/src/plugins/contracts/tts-contract-suites.ts
@@ -1,4 +1,5 @@
 // TTS contract suites provide reusable text-to-speech plugin contract assertions.
+import http from "node:http";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   createEmptyPluginRegistry,
@@ -269,14 +270,20 @@ function buildTestOpenAISpeechProvider(): SpeechProviderPlugin {
       typeof process.env.OPENAI_API_KEY === "string",
     synthesize: async ({ text, providerConfig, providerOverrides }) => {
       const config = providerConfig as Record<string, unknown> | undefined;
-      await fetch(`${resolveBaseUrl(config?.baseUrl, "https://api.openai.com/v1")}/audio/speech`, {
-        method: "POST",
-        body: JSON.stringify({
-          input: text,
-          model: providerOverrides?.model ?? config?.model ?? "gpt-4o-mini-tts",
-          voice: providerOverrides?.voice ?? config?.voice ?? "alloy",
-        }),
-      });
+      const res = await fetch(
+        `${resolveBaseUrl(config?.baseUrl, "https://api.openai.com/v1")}/audio/speech`,
+        {
+          method: "POST",
+          body: JSON.stringify({
+            input: text,
+            model: providerOverrides?.model ?? config?.model ?? "gpt-4o-mini-tts",
+            voice: providerOverrides?.voice ?? config?.voice ?? "alloy",
+          }),
+        },
+      );
+      // The contract only asserts the request, but an unread audio body pins the
+      // connection-pool socket — release it instead of leaking fds across calls.
+      await res.body?.cancel().catch(() => {});
       return {
         audioBuffer: createAudioBuffer(1),
         outputFormat: "mp3",
@@ -292,15 +299,19 @@ function buildTestOpenAISpeechProvider(): SpeechProviderPlugin {
         typeof config?.instructions === "string" ? config.instructions : undefined;
       const instructions =
         model === "gpt-4o-mini-tts" ? configuredInstructions || undefined : undefined;
-      await fetch(`${resolveBaseUrl(config?.baseUrl, "https://api.openai.com/v1")}/audio/speech`, {
-        method: "POST",
-        body: JSON.stringify({
-          input: text,
-          model,
-          voice: config?.voice ?? "alloy",
-          instructions,
-        }),
-      });
+      const res = await fetch(
+        `${resolveBaseUrl(config?.baseUrl, "https://api.openai.com/v1")}/audio/speech`,
+        {
+          method: "POST",
+          body: JSON.stringify({
+            input: text,
+            model,
+            voice: config?.voice ?? "alloy",
+            instructions,
+          }),
+        },
+      );
+      await res.body?.cancel().catch(() => {});
       return {
         audioBuffer: createAudioBuffer(2),
         outputFormat: "mp3",
@@ -1126,6 +1137,47 @@ export function describeTtsProviderRuntimeContract() {
           expect(result.attempts?.[1]?.personaBinding).toBe("none");
           expect(typeof result.attempts?.[1]?.latencyMs).toBe("number");
           expect(result.attempts?.[1]?.error).toBeUndefined();
+        });
+      });
+
+      it("cancels the discarded speech response body after synthesize", async () => {
+        await withIsolatedSpeechProviderEnvAsync({}, async () => {
+          let sawConnectionClose = false;
+          const server = http.createServer((_req, res) => {
+            res.writeHead(200, { "content-type": "audio/mpeg" });
+            res.write(Buffer.alloc(16));
+            res.on("close", () => {
+              sawConnectionClose = true;
+            });
+            // Intentionally never res.end(): an unread body must still be
+            // released by the caller, not left pinning the connection.
+          });
+          await new Promise<void>((resolve) => {
+            server.listen(0, "127.0.0.1", resolve);
+          });
+          const address = server.address();
+          const port = typeof address === "object" && address ? address.port : 0;
+          try {
+            const result = await ttsRuntime.synthesizeSpeech({
+              text: "hello cancel",
+              cfg: asLegacyOpenClawConfig({
+                agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
+                messages: {
+                  tts: {
+                    provider: "openai",
+                    openai: { baseUrl: `http://127.0.0.1:${port}/v1`, apiKey: "test-key" },
+                  },
+                },
+              }),
+            });
+            expect(result.success).toBe(true);
+            await vi.waitFor(() => expect(sawConnectionClose).toBe(true), { timeout: 5_000 });
+          } finally {
+            server.closeAllConnections();
+            await new Promise((resolve) => {
+              server.close(resolve);
+            });
+          }
         });
       });
 


### PR DESCRIPTION
## Summary

Cancel the discarded response bodies in the OpenAI TTS contract provider's `synthesize`/`synthesizeTelephony`, so repeated contract runs no longer pin connection-pool sockets and leak file descriptors.

## What Problem This Solves

The OpenAI TTS contract provider fixture (in `src/plugins/contracts/tts-contract-suites.ts`) POSTs to `/audio/speech` and awaits only the fetch promise — which resolves as soon as response headers arrive.

- The audio response body is never consumed and never cancelled.
- An unread body keeps its connection-pool socket occupied; repeated `synthesize` calls (contract suites run them in loops) accumulate open sockets — visible as steady `/proc/self/fd` growth and, at scale, connection-pool exhaustion.

**Code evidence**: at [tts-contract-suites.ts:272](src/plugins/contracts/tts-contract-suites.ts#L272) and [:295](src/plugins/contracts/tts-contract-suites.ts#L295), `await fetch(...)` discards the response without touching `res.body`.

## Root Cause

- `fetch` resolves on headers; the body stream must be consumed or explicitly cancelled for the connection to return to the pool.
- The fixture only needs the request side-effect (the contract asserts the request, not the audio), so the body was simply never released.
- Invariant violated: "every response body is consumed or cancelled" — not held at either call site.

## Why This Fix

Capture the response and `await res.body?.cancel().catch(() => {})` at both call sites:

- Cancelling the body tells the HTTP client to release the socket immediately instead of waiting for a body that will never be read — the pool socket is freed on every call.
- The `.catch(() => {})` mirrors the codebase's established cleanup idiom (e.g. `cancelUnreadResponseBody` in provider discovery) so a non-compliant stream can never turn cleanup into a new failure mode.
- Both `synthesize` and `synthesizeTelephony` are fixed; no other call sites in the file share the pattern.
- Alternative considered: draining the body (`await res.arrayBuffer()`) — rejected, because it downloads audio bytes the contract never uses; cancelling is strictly cheaper.

## User Impact

- **Before**: repeated contract `synthesize` calls leak pool sockets (fd growth per call), risking connection exhaustion in long suite runs.
- **After**: connections are released after each call; fd usage stays flat.

## Evidence

- **Before** (upstream/main): `server saw connection close: false`, `fds before=49 after=55 (delta=6)` — **FAIL**: discarded response bodies pinned connection-pool sockets
- **After** (with fix): `server saw connection close: true`, `fds before=49 after=49 (delta=0)` — **PASS**: discarded response bodies cancelled, connections released

## Real Behavior Proof

Proof drives the real OpenAI contract provider's `synthesize` (loaded unmodified) three times against a real local HTTP server whose response body never ends, tracking server-side connection close and `/proc/self/fd`.

### Before (on main)

```bash
$ node --import tsx proof.mjs
server saw connection close: false
fds before=49 after=55 (delta=6)
FAIL: discarded response bodies pinned connection-pool sockets
```

### After (with fix)

```bash
$ node --import tsx proof.mjs
server saw connection close: true
fds before=49 after=49 (delta=0)
PASS: discarded response bodies cancelled, connections released
```

## Tests and Validation

- `npx vitest run src/plugins/contracts/tts.contract.test.ts` — 42 passed (41 existing + 1 new)
- New regression test: `cancels the discarded speech response body after synthesize`
- `tsgo:core` typecheck passed; `oxlint` and `oxfmt --check` clean on the changed files
