### PR TITLE
fix(ci): bound mantis-discord-smoke git fetch with timeout

### DIFF
--- a/.github/workflows/mantis-discord-smoke.yml
+++ b/.github/workflows/mantis-discord-smoke.yml
@@ -1,4 +1,4 @@
-﻿name: Mantis Discord Smoke
+name: Mantis Discord Smoke
 
 on:
   workflow_dispatch:
@@ -172,4 +172,3 @@ jobs:
           path: .artifacts/qa-e2e/mantis/
           retention-days: 14
           if-no-files-found: error
-

--- a/.github/workflows/mantis-discord-smoke.yml
+++ b/.github/workflows/mantis-discord-smoke.yml
@@ -1,4 +1,4 @@
-name: Mantis Discord Smoke
+﻿name: Mantis Discord Smoke
 
 on:
   workflow_dispatch:
@@ -85,14 +85,14 @@ jobs:
           selected_revision="$(git rev-parse HEAD)"
           trusted_reason=""
 
-          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          timeout --signal=TERM --kill-after=10s 120s git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
 
           if git merge-base --is-ancestor "$selected_revision" refs/remotes/origin/main; then
             trusted_reason="main-ancestor"
           elif git tag --points-at "$selected_revision" | grep -Eq '^v'; then
             trusted_reason="release-tag"
           elif [[ "$INPUT_REF" =~ ^release/[0-9]{4}\.[0-9]+\.[0-9]+$ ]]; then
-            git fetch --no-tags origin "+refs/heads/${INPUT_REF}:refs/remotes/origin/${INPUT_REF}"
+            timeout --signal=TERM --kill-after=10s 120s git fetch --no-tags origin "+refs/heads/${INPUT_REF}:refs/remotes/origin/${INPUT_REF}"
             release_branch_sha="$(git rev-parse "refs/remotes/origin/${INPUT_REF}")"
             if [[ "$selected_revision" == "$release_branch_sha" ]]; then
               trusted_reason="release-branch-head"
@@ -172,3 +172,4 @@ jobs:
           path: .artifacts/qa-e2e/mantis/
           retention-days: 14
           if-no-files-found: error
+


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the mantis-discord-smoke workflow could remain stuck in its `git fetch` steps until the job timeout when the Git transport stalls. This blocks Mantis Discord smoke testing and wastes runner time.

## Why This Change Was Made

The two `git fetch` commands (trusted-revision main fetch L88, release-branch fetch L95) now run through the `timeout --signal=TERM --kill-after=10s 120s` bounded process pattern. This matches the pattern already applied to linux-app-release in #110027 and macos-release workflows. All tag validation, merge-base checks, and smoke operations are unchanged.

## User Impact

Maintainers get a prompt, actionable fetch failure instead of losing a smoke-test runner for the full job timeout before the Mantis Discord verification begins.

## Evidence

- Two one-line additions prepending `timeout --signal=TERM --kill-after=10s 120s` to existing `git fetch` commands on lines 88 and 95.
- `git diff --check` passed.
- Pattern consistency: matches the bounding approach in `.github/workflows/linux-app-release.yml` (#110027).

AI-assisted: built with Codex