### PR TITLE
fix(channels): preserve terminal ingress outcomes when stop abort races delivery return

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2276,7 +2276,7 @@ src/channels/message/adapter.ts	1
 src/channels/message/capabilities.ts	2
 src/channels/message/ingress-claim-owner.ts	1
 src/channels/message/ingress-drain.ts	1
-src/channels/message/ingress-monitor.ts	6
+src/channels/message/ingress-monitor.ts	4
 src/channels/message/ingress-queue.ts	6
 src/channels/message/outbound-bridge.ts	2
 src/channels/message/outbound-echo-state.ts	2

--- a/src/channels/message/ingress-errors.ts
+++ b/src/channels/message/ingress-errors.ts
@@ -1,0 +1,38 @@
+/** Named ingress error factory shared by channel payload and admission failures. */
+type ChannelIngressErrorClass<TError extends Error, TArgs extends unknown[]> = {
+  new (...args: TArgs): TError;
+  readonly name: string;
+  readonly prototype: TError;
+};
+
+export function createChannelIngressError(
+  name: string,
+): ChannelIngressErrorClass<Error, [message: string, options?: ErrorOptions]>;
+export function createChannelIngressError<TReason extends string>(
+  name: string,
+  options: { withReason: true },
+): ChannelIngressErrorClass<
+  Error & { readonly reason: TReason },
+  [reason: TReason, message: string, errorOptions?: ErrorOptions]
+>;
+export function createChannelIngressError(
+  name: string,
+  options?: { withReason?: boolean },
+): unknown {
+  const IngressError = class extends Error {
+    declare readonly reason?: string;
+
+    constructor(first: string, second?: string | ErrorOptions, third?: ErrorOptions) {
+      const reasoned = options?.withReason === true;
+      const message = reasoned && typeof second === "string" ? second : first;
+      const errorOptions = reasoned ? third : typeof second === "string" ? undefined : second;
+      super(message, errorOptions);
+      this.name = name;
+      if (reasoned) {
+        this.reason = first;
+      }
+    }
+  };
+  Object.defineProperty(IngressError, "name", { configurable: true, value: name });
+  return IngressError;
+}

--- a/src/channels/message/ingress-monitor.test.ts
+++ b/src/channels/message/ingress-monitor.test.ts
@@ -10,9 +10,9 @@ import {
 } from "../../process/gateway-work-admission.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import { sleep } from "../../utils/sleep.js";
+import { createChannelIngressError } from "./ingress-errors.js";
 import {
   CHANNEL_INGRESS_RETENTION_DEFAULTS,
-  createChannelIngressError,
   createChannelIngressMonitor,
   type ChannelIngressMonitorDeliveryResult,
   type ChannelIngressMonitorLifecycle,

--- a/src/channels/message/ingress-monitor.test.ts
+++ b/src/channels/message/ingress-monitor.test.ts
@@ -802,6 +802,82 @@ describe("channel ingress monitor", () => {
     });
   });
 
+  it("completes deliveries whose terminal result races a stop abort", async () => {
+    await withQueue(async (queue) => {
+      const deliver = vi.fn(async (_raw: RawEvent, lifecycle: ChannelIngressMonitorLifecycle) => {
+        await new Promise<void>((resolve) => {
+          if (lifecycle.abortSignal.aborted) {
+            resolve();
+            return;
+          }
+          lifecycle.abortSignal.addEventListener("abort", () => resolve(), { once: true });
+        });
+        return { kind: "completed" as const };
+      });
+      const monitor = createMonitor(queue, deliver);
+      monitor.start();
+      await monitor.admit({ id: "event-stop-completed", lane: "a", text: "hello" });
+      await vi.waitFor(() => expect(deliver).toHaveBeenCalledOnce());
+
+      await monitor.stop();
+
+      // Side effects finished and the channel reported completed; settling the
+      // claim for retry would replay already-delivered work on restart.
+      await expect(queue.listPending()).resolves.toEqual([]);
+      await expect(queue.listClaims()).resolves.toEqual([]);
+    });
+  });
+
+  it("keeps deferred handoffs with their owner when a stop abort races the return", async () => {
+    await withQueue(async (queue) => {
+      const deliver = vi.fn(async (_raw: RawEvent, lifecycle: ChannelIngressMonitorLifecycle) => {
+        lifecycle.onDeferred();
+        await new Promise<void>((resolve) => {
+          if (lifecycle.abortSignal.aborted) {
+            resolve();
+            return;
+          }
+          lifecycle.abortSignal.addEventListener("abort", () => resolve(), { once: true });
+        });
+        return { kind: "deferred" as const };
+      });
+      const monitor = createMonitor(queue, deliver);
+      monitor.start();
+      await monitor.admit({ id: "event-stop-deferred-race", lane: "a", text: "hello" });
+      await vi.waitFor(() => expect(deliver).toHaveBeenCalledOnce());
+
+      await monitor.stop();
+
+      // The deferred owner still owns the claim; releasing it for retry would
+      // replay work the owner is completing.
+      await expect(queue.listPending()).resolves.toEqual([]);
+      await expect(queue.listClaims()).resolves.toHaveLength(1);
+    });
+  });
+
+  it("keeps a deferred handoff authoritative when delivery then returns completed", async () => {
+    await withQueue(async (queue) => {
+      const deliver = vi.fn(async (_raw: RawEvent, lifecycle: ChannelIngressMonitorLifecycle) => {
+        lifecycle.onDeferred();
+        return { kind: "completed" as const };
+      });
+      const monitor = createMonitor(queue, deliver);
+      monitor.start();
+      await monitor.admit({ id: "event-deferred-then-completed", lane: "a", text: "hello" });
+      await vi.waitFor(() => expect(deliver).toHaveBeenCalledOnce());
+
+      await monitor.stop();
+
+      // Contract pin: a deferred handoff owns the claim, so a conflicting
+      // completed return must surface as deferred. Through today's drain both
+      // outcomes leave the row held (the drain only completes from
+      // dispatching); this locks the claim with its owner rather than letting
+      // a sibling drain release or replay it.
+      await expect(queue.listPending()).resolves.toEqual([]);
+      await expect(queue.listClaims()).resolves.toHaveLength(1);
+    });
+  });
+
   it("clears a queued drain request when abort wins an active pump", async () => {
     await withQueue(async (queue) => {
       let markPruneStarted = () => {};

--- a/src/channels/message/ingress-monitor.test.ts
+++ b/src/channels/message/ingress-monitor.test.ts
@@ -110,6 +110,15 @@ function createMonitor(
   });
 }
 
+async function waitForAbort(signal: AbortSignal): Promise<void> {
+  if (signal.aborted) {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    signal.addEventListener("abort", () => resolve(), { once: true });
+  });
+}
+
 afterEach(() => {
   resetGatewayWorkAdmission();
   closeOpenClawStateDatabaseForTest();
@@ -635,13 +644,7 @@ describe("channel ingress monitor", () => {
   it("releases a pre-adoption delivery for retry before disposing on stop", async () => {
     await withQueue(async (queue) => {
       const deliver = vi.fn(async (_raw: RawEvent, lifecycle: ChannelIngressMonitorLifecycle) => {
-        await new Promise<void>((resolve) => {
-          if (lifecycle.abortSignal.aborted) {
-            resolve();
-            return;
-          }
-          lifecycle.abortSignal.addEventListener("abort", () => resolve(), { once: true });
-        });
+        await waitForAbort(lifecycle.abortSignal);
       });
       const monitor = createMonitor(queue, deliver);
       monitor.start();
@@ -805,13 +808,7 @@ describe("channel ingress monitor", () => {
   it("completes deliveries whose terminal result races a stop abort", async () => {
     await withQueue(async (queue) => {
       const deliver = vi.fn(async (_raw: RawEvent, lifecycle: ChannelIngressMonitorLifecycle) => {
-        await new Promise<void>((resolve) => {
-          if (lifecycle.abortSignal.aborted) {
-            resolve();
-            return;
-          }
-          lifecycle.abortSignal.addEventListener("abort", () => resolve(), { once: true });
-        });
+        await waitForAbort(lifecycle.abortSignal);
         return { kind: "completed" as const };
       });
       const monitor = createMonitor(queue, deliver);
@@ -832,13 +829,7 @@ describe("channel ingress monitor", () => {
     await withQueue(async (queue) => {
       const deliver = vi.fn(async (_raw: RawEvent, lifecycle: ChannelIngressMonitorLifecycle) => {
         lifecycle.onDeferred();
-        await new Promise<void>((resolve) => {
-          if (lifecycle.abortSignal.aborted) {
-            resolve();
-            return;
-          }
-          lifecycle.abortSignal.addEventListener("abort", () => resolve(), { once: true });
-        });
+        await waitForAbort(lifecycle.abortSignal);
         return { kind: "deferred" as const };
       });
       const monitor = createMonitor(queue, deliver);
@@ -855,10 +846,11 @@ describe("channel ingress monitor", () => {
     });
   });
 
-  it("keeps a deferred handoff authoritative when delivery then returns completed", async () => {
+  it("keeps a deferred handoff when stop abort races a conflicting completed return", async () => {
     await withQueue(async (queue) => {
       const deliver = vi.fn(async (_raw: RawEvent, lifecycle: ChannelIngressMonitorLifecycle) => {
         lifecycle.onDeferred();
+        await waitForAbort(lifecycle.abortSignal);
         return { kind: "completed" as const };
       });
       const monitor = createMonitor(queue, deliver);
@@ -868,11 +860,8 @@ describe("channel ingress monitor", () => {
 
       await monitor.stop();
 
-      // Contract pin: a deferred handoff owns the claim, so a conflicting
-      // completed return must surface as deferred. Through today's drain both
-      // outcomes leave the row held (the drain only completes from
-      // dispatching); this locks the claim with its owner rather than letting
-      // a sibling drain release or replay it.
+      // A recorded handoff owns the claim, so stop cannot rewrite the
+      // conflicting terminal return and release the row for replay.
       await expect(queue.listPending()).resolves.toEqual([]);
       await expect(queue.listClaims()).resolves.toHaveLength(1);
     });

--- a/src/channels/message/ingress-monitor.ts
+++ b/src/channels/message/ingress-monitor.ts
@@ -432,10 +432,19 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
         if (result?.kind === "failed-retryable") {
           return result;
         }
-        if (isAborted() || lifecycle.abortSignal.aborted) {
-          return { kind: "failed-retryable", error: createStoppedError() };
-        }
+        // Terminal and handoff outcomes must reach the drain even when stop
+        // races the return: the drain settles terminal results under abort and
+        // keeps deferred claims for their owner. Rewriting them to
+        // failed-retryable here would release claims whose side effects already
+        // ran, replaying delivered work on restart.
         if (result?.kind === "completed") {
+          // A deferred handoff recorded during delivery stays authoritative:
+          // the drain already placed the claim in deferred and only settles a
+          // completed result from dispatching, so a conflicting terminal return
+          // would strand the claim until later recovery.
+          if (deferredHandoff) {
+            return { kind: "deferred" };
+          }
           return result;
         }
         if (result?.kind === "deferred") {
@@ -444,11 +453,17 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
           }
           return { kind: "deferred" };
         }
+        if (deferredHandoff) {
+          return { kind: "deferred" };
+        }
+        if (isAborted() || lifecycle.abortSignal.aborted) {
+          return { kind: "failed-retryable", error: createStoppedError() };
+        }
         if (!handedOff) {
           // A policy gate or deliberate no-dispatch is terminal for transport replay.
           await wrappedLifecycle.onAdopted();
         }
-        return deferredHandoff ? { kind: "deferred" } : { kind: "completed" };
+        return { kind: "completed" };
       },
     });
     return drain;

--- a/src/channels/message/ingress-monitor.ts
+++ b/src/channels/message/ingress-monitor.ts
@@ -16,42 +16,6 @@ import { ChannelIngressUnavailableError } from "./ingress-unavailable.js";
 
 const DEFAULT_APPEND_RETRY_DELAYS_MS = [0, 100, 300] as const;
 
-type ChannelIngressErrorClass<TError extends Error, TArgs extends unknown[]> = {
-  new (...args: TArgs): TError;
-  readonly name: string;
-  readonly prototype: TError;
-};
-
-export function createChannelIngressError(
-  name: string,
-): ChannelIngressErrorClass<Error, [message: string, options?: ErrorOptions]>;
-export function createChannelIngressError<TReason extends string>(
-  name: string,
-  options: { withReason: true },
-): ChannelIngressErrorClass<
-  Error & { readonly reason: TReason },
-  [reason: TReason, message: string, errorOptions?: ErrorOptions]
->;
-export function createChannelIngressError(
-  name: string,
-  options?: { withReason?: boolean },
-): unknown {
-  const IngressError = class extends Error {
-    declare readonly reason?: string;
-
-    constructor(first: string, second?: string | ErrorOptions, third?: ErrorOptions) {
-      const reasoned = options?.withReason === true;
-      super(reasoned ? (second as string) : first, reasoned ? third : (second as ErrorOptions));
-      this.name = name;
-      if (reasoned) {
-        this.reason = first;
-      }
-    }
-  };
-  Object.defineProperty(IngressError, "name", { configurable: true, value: name });
-  return IngressError;
-}
-
 /** Stable identity and serialization lane extracted before durable admission. */
 export type ChannelIngressMonitorFacts = { eventId: string; laneKey: string };
 

--- a/src/plugin-sdk/channel-outbound.ts
+++ b/src/plugin-sdk/channel-outbound.ts
@@ -34,9 +34,9 @@ export {
 } from "../channels/message/ingress-drain.js";
 export {
   CHANNEL_INGRESS_RETENTION_DEFAULTS,
-  createChannelIngressError,
   createChannelIngressMonitor,
 } from "../channels/message/ingress-monitor.js";
+export { createChannelIngressError } from "../channels/message/ingress-errors.js";
 export {
   DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
   DEFAULT_INGRESS_RETRY_MAX_ATTEMPTS,


### PR DESCRIPTION
## What Problem This Solves

`createChannelIngressMonitor` rewrote a delivery result to `failed-retryable` when `stop()` aborted the monitor before the delivery returned. The rewrite ran before the monitor inspected `completed` or `deferred`.

That released the SQLite claim after the channel side effect had already run. A successor monitor could replay the row and duplicate the message.

## Root cause

The monitor discarded the authoritative delivery result. This contradicted the ingress drain contract, which settles terminal results after an abort race and leaves deferred work with its owner.

## Fix

- Preserve explicit `completed`, `failed-retryable`, and `deferred` results before the abort fallback.
- Preserve a recorded deferred handoff when a callback later returns a conflicting `completed` result.
- Use abort-to-retry only for a void return with no recorded handoff.
- Keep the Plugin SDK export stable after moving the ingress error factory to its own module.

## Evidence

A local stop/restart driver used the real shared monitor, drain, and SQLite queue.

- Current main replayed each completed, deferred, and conflicting outcome once after restart.
- Exact head replayed none of the three outcomes after restart.
- Exact head settled completed work and preserved deferred ownership until its owner completed it.
- The conflicting regression fails on pre-fix code because the row becomes pending with a stopped-monitor error.

Focused tests:

```sh
node scripts/run-vitest.mjs src/channels/message/
```

- Shared channel message suite: 22 files and 237 tests passed.
- Monitor-backed channel sweep: 20 files and 281 tests passed.
- Recorded Telegram direct-message smoke: one reply, one provider request, and clean teardown.
- Local ClawSweeper review: patch correct, zero findings, security cleared, and zero rank-up moves.

## Change size

- Production: +17 lines.
- Tests: +65 lines.
- Config: 0 net lines.

Fixes #130567
