### PR TITLE
fix(auto-reply): defer rollover for legacy pending-reset tombstones with active runs

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -578,7 +578,9 @@ async function agentCommandInternal(
               terminalRunId: runId,
               terminalDeliveryEvidence: restartRecoveryTerminalDeliveryEvidence,
             }),
-            updatedAt: Date.now(),
+            // Bookkeeping: keep the legacy updatedAt=0 pending-reset marker
+            // (resolveBookkeepingUpdatedAt inlined; this file is at the max-lines budget).
+            updatedAt: entry.updatedAt === 0 ? 0 : Date.now(),
           };
           const persisted = await persistAgentSession({
             sessionStore,

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -7,7 +7,7 @@ import {
 import { resolveAgentModelFallbackValues } from "../config/model-input.js";
 import { resolveSessionAuthProfileOverrideSource } from "../config/sessions/auth-profile-override-provenance.js";
 import { hasSessionAutoModelFallbackProvenance } from "../config/sessions/model-override-provenance.js";
-import { resolveBookkeepingUpdatedAt } from "../config/sessions/reset.js";
+import { resolveBookkeepingUpdatedAt } from "../config/sessions/reset-policy.js";
 import { resolvePersistedSessionStoreOwnerForKey } from "../config/sessions/session-store-owner.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { AgentDefaultsConfig } from "../config/types.agent-defaults.js";

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -7,6 +7,7 @@ import {
 import { resolveAgentModelFallbackValues } from "../config/model-input.js";
 import { resolveSessionAuthProfileOverrideSource } from "../config/sessions/auth-profile-override-provenance.js";
 import { hasSessionAutoModelFallbackProvenance } from "../config/sessions/model-override-provenance.js";
+import { resolveBookkeepingUpdatedAt } from "../config/sessions/reset.js";
 import { resolvePersistedSessionStoreOwnerForKey } from "../config/sessions/session-store-owner.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { AgentDefaultsConfig } from "../config/types.agent-defaults.js";
@@ -296,7 +297,7 @@ export function clearAutoFallbackPrimaryProbeSelection(
     delete entry.authProfileOverrideCompactionCount;
   }
   delete entry.fallbackNotice;
-  entry.updatedAt = now;
+  entry.updatedAt = resolveBookkeepingUpdatedAt(entry.updatedAt, now);
 }
 
 export { resolveAgentIdFromSessionKey };

--- a/src/agents/auth-profiles/session-override.ts
+++ b/src/agents/auth-profiles/session-override.ts
@@ -1,5 +1,6 @@
 /** Keeps automatic auth profiles stable within sessions while rotating at lifecycle boundaries. */
 import { resolveSessionAuthProfileOverrideSource } from "../../config/sessions/auth-profile-override-provenance.js";
+import { resolveBookkeepingUpdatedAt } from "../../config/sessions/reset.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ProviderModelRouteAuthRequirement } from "../../plugin-sdk/provider-model-types.js";
@@ -72,7 +73,10 @@ function applySessionAuthProfileOverrideState(
   } else {
     entry.authProfileOverrideCompactionCount = state.authProfileOverrideCompactionCount;
   }
-  entry.updatedAt = Math.max(entry.updatedAt ?? 0, updatedAt);
+  entry.updatedAt = Math.max(
+    entry.updatedAt ?? 0,
+    resolveBookkeepingUpdatedAt(entry.updatedAt, updatedAt),
+  );
 }
 
 function matchesSessionAuthProfileOverrideSnapshot(

--- a/src/agents/command/assistant-transcript-repair.ts
+++ b/src/agents/command/assistant-transcript-repair.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { resolveBookkeepingUpdatedAt } from "../../config/sessions/reset.js";
 import type { SessionEntry, PendingTranscriptRepairState } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -66,7 +67,7 @@ export async function persistAssistantTranscriptRepairRecord(params: {
       entry: {
         ...existing,
         pendingTranscriptRepair: [...(existing.pendingTranscriptRepair ?? []), nextRepair],
-        updatedAt: now,
+        updatedAt: resolveBookkeepingUpdatedAt(existing.updatedAt, now),
       },
       shouldPersist: (current) =>
         current?.sessionId === runOwnedSessionId && current.abortedLastRun !== true,
@@ -153,7 +154,11 @@ export async function repairPendingAssistantTranscriptTurns(params: {
       sessionKey: context.sessionKey,
       storePath: context.storePath,
       initialEntry: current,
-      entry: { ...current, pendingTranscriptRepair: undefined, updatedAt: Date.now() },
+      entry: {
+        ...current,
+        pendingTranscriptRepair: undefined,
+        updatedAt: resolveBookkeepingUpdatedAt(current.updatedAt),
+      },
       shouldPersist: (latest) => latest?.sessionId === entry.sessionId,
     });
   } catch (error) {

--- a/src/agents/command/post-run.ts
+++ b/src/agents/command/post-run.ts
@@ -3,6 +3,7 @@ import type { FollowupRun } from "../../auto-reply/reply/queue.js";
 import type { CliDeps } from "../../cli/deps.types.js";
 import { resolveSessionAuthProfileOverrideSource } from "../../config/sessions/auth-profile-override-provenance.js";
 import { formatSqliteSessionFileMarker } from "../../config/sessions/legacy-sqlite-marker.js";
+import { resolveBookkeepingUpdatedAt } from "../../config/sessions/reset.js";
 import { buildRestartRecoveryClaimCleanupPatch } from "../../config/sessions/restart-recovery-state.js";
 import type { RestartRecoveryTerminalDeliveryEvidenceResult } from "../../config/sessions/restart-recovery-types.js";
 import { resolveFreshSessionTotalTokens, type SessionEntry } from "../../config/sessions/types.js";
@@ -574,7 +575,7 @@ export async function finalizeEmbeddedAgentCommand(params: {
           entry: {
             ...(clearOwnedPendingFinal || clearStaleTransportOnly
               ? clearPendingFinalDelivery(entry, now)
-              : { ...entry, updatedAt: now }),
+              : { ...entry, updatedAt: resolveBookkeepingUpdatedAt(entry.updatedAt, now) }),
             ...(recoveryClaimEntry
               ? buildRestartRecoveryClaimCleanupPatch({
                   entry: {

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -8,6 +8,7 @@ import {
   setSessionRuntimeModel,
   type SessionEntry,
 } from "../../config/sessions.js";
+import { resolveBookkeepingUpdatedAt } from "../../config/sessions/reset.js";
 import { patchSessionEntryCore } from "../../config/sessions/session-accessor.js";
 import { projectSessionSnapshotChanges } from "../../config/sessions/session-snapshot-merge.js";
 import { resolveMaintenanceConfigFromInput } from "../../config/sessions/store-maintenance.js";
@@ -357,7 +358,7 @@ export async function clearCliSessionInStore(params: {
       }
       const next = { ...currentEntry };
       clearCliSession(next, provider);
-      next.updatedAt = Date.now();
+      next.updatedAt = resolveBookkeepingUpdatedAt(currentEntry.updatedAt);
       didClear = true;
       return next;
     },
@@ -512,11 +513,12 @@ export async function recordCliCompactionInStore(params: {
     clearAllCliSessions(next);
   }
   next.compactionCount = (entry.compactionCount ?? 0) + 1;
-  next.updatedAt = Date.now();
+  next.updatedAt = resolveBookkeepingUpdatedAt(entry.updatedAt);
   const newSessionId = normalizeOptionalString(params.newSessionId);
   if (newSessionId && newSessionId !== entry.sessionId) {
     delete (next as { sessionFile?: unknown }).sessionFile;
     next.sessionId = newSessionId;
+    next.updatedAt = Date.now();
     next.usageFamilyKey = entry.usageFamilyKey ?? sessionKey;
     next.usageFamilySessionIds = Array.from(
       new Set([...(entry.usageFamilySessionIds ?? []), entry.sessionId, newSessionId]),

--- a/src/agents/embedded-agent-subscribe.handlers.compaction.runtime.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.compaction.runtime.ts
@@ -2,6 +2,7 @@
  * Runtime helpers for reconciling compaction counts after subscribe events.
  */
 import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
+import { resolveBookkeepingUpdatedAt } from "../config/sessions/reset.js";
 import { updateSessionEntry } from "../config/sessions/session-accessor.js";
 
 /** Persist the highest observed compaction count after a successful subscribed run. */
@@ -27,7 +28,7 @@ export default async function reconcileSessionStoreCompactionCountAfterSuccess(p
     }
     return {
       compactionCount: nextCount,
-      updatedAt: Math.max(entry.updatedAt ?? 0, now),
+      updatedAt: Math.max(entry.updatedAt ?? 0, resolveBookkeepingUpdatedAt(entry.updatedAt, now)),
     };
   });
   return nextEntry?.compactionCount;

--- a/src/agents/main-session-recovery/main-session-recovery-state.ts
+++ b/src/agents/main-session-recovery/main-session-recovery-state.ts
@@ -7,6 +7,7 @@ import type {
   MainRestartRecoveryState,
   RestartRecoveryRun,
 } from "../../config/sessions.js";
+import { resolveBookkeepingUpdatedAt } from "../../config/sessions/reset.js";
 import { hasRestartRecoveryTerminalRun } from "../../config/sessions/restart-recovery-state.js";
 import {
   isAcpSessionKey,
@@ -347,7 +348,7 @@ export function transitionMainSessionRecovery(
       for (const run of command.runs ?? []) {
         recordLifecycleFence(entry, run);
       }
-      entry.updatedAt = command.now;
+      entry.updatedAt = resolveBookkeepingUpdatedAt(entry.updatedAt, command.now);
       return { kind: "applied" };
     }
     case "inspect": {
@@ -441,7 +442,7 @@ export function transitionMainSessionRecovery(
           lifecycleGeneration: command.lifecycleGeneration,
         },
       });
-      entry.updatedAt = command.now;
+      entry.updatedAt = resolveBookkeepingUpdatedAt(entry.updatedAt, command.now);
       return {
         kind: "reserved",
         reservation: {
@@ -563,7 +564,7 @@ export function transitionMainSessionRecovery(
         // or the dedupe cache replays that terminal pre-dispatch failure.
         entry.restartRecoveryDeliveryRunId = undefined;
       }
-      entry.updatedAt = command.now;
+      entry.updatedAt = resolveBookkeepingUpdatedAt(entry.updatedAt, command.now);
       return { kind: "applied" };
     }
     case "claim_foreground": {
@@ -708,7 +709,7 @@ export function transitionMainSessionRecovery(
       entry.lastRunId = resolveRestartRecoveryTerminalClientRunId(entry);
       entry.endedAt = command.now;
       entry.runtimeMs = Math.max(0, command.now - (entry.startedAt ?? command.now));
-      entry.updatedAt = command.now;
+      entry.updatedAt = resolveBookkeepingUpdatedAt(entry.updatedAt, command.now);
       return { kind: "tombstoned" };
     }
     case "doctor_repair": {
@@ -716,7 +717,7 @@ export function transitionMainSessionRecovery(
         return { kind: "no_change" };
       }
       entry.abortedLastRun = false;
-      entry.updatedAt = command.now;
+      entry.updatedAt = resolveBookkeepingUpdatedAt(entry.updatedAt, command.now);
       return { kind: "doctor_repaired" };
     }
     case "clear": {

--- a/src/agents/main-session-recovery/main-session-restart-dispatch.ts
+++ b/src/agents/main-session-recovery/main-session-restart-dispatch.ts
@@ -4,6 +4,7 @@ import { GatewayClientRequestError } from "../../../packages/gateway-client/src/
 import { isExecutionIdentityCollectionEnabled } from "../../audit/audit-config.js";
 import { sanitizePendingFinalDeliveryText } from "../../auto-reply/reply/pending-final-delivery.js";
 import type { SessionEntry } from "../../config/sessions.js";
+import { resolveBookkeepingUpdatedAt } from "../../config/sessions/reset.js";
 import {
   buildRestartRecoveryClaimCleanupPatch,
   hasRestartRecoveryTerminalRun,
@@ -200,7 +201,7 @@ async function settleRestartRecoveryDispatch(params: {
       } else {
         entry.abortedLastRun = false;
       }
-      entry.updatedAt = now;
+      entry.updatedAt = resolveBookkeepingUpdatedAt(entry.updatedAt, now);
       return {
         result: undefined,
         replacements: [{ sessionKey: current.sessionKey, entry }],
@@ -493,7 +494,7 @@ export async function resumeMainSession(params: {
         if (params.forceRestartSafeTools) {
           entry.restartRecoveryForceSafeTools = true;
         }
-        entry.updatedAt = Date.now();
+        entry.updatedAt = resolveBookkeepingUpdatedAt(entry.updatedAt);
         return {
           result: true,
           replacements: [{ sessionKey: params.sessionKey, entry }],

--- a/src/agents/pending-final-delivery-marker.ts
+++ b/src/agents/pending-final-delivery-marker.ts
@@ -6,6 +6,7 @@ import {
   normalizePendingFinalDeliveryPayloads,
   normalizePendingFinalRecoveryPayloads,
 } from "../auto-reply/reply/pending-final-delivery.js";
+import { resolveBookkeepingUpdatedAt } from "../config/sessions/reset-policy.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import { isSubagentSessionKey } from "../routing/session-key.js";
 import type { DeliveryContext } from "../utils/delivery-context.shared.js";
@@ -89,7 +90,7 @@ export async function persistPendingFinalDeliveryMarker(
         createdAt: now,
         context: params.deliveryContext,
       },
-      updatedAt: now,
+      updatedAt: resolveBookkeepingUpdatedAt(entry.updatedAt, now),
     },
     shouldPersist: (current) =>
       current?.sessionId === params.runOwnedSessionId && current.abortedLastRun !== true,

--- a/src/agents/subagents/registry/subagent-control-kill-runtime.ts
+++ b/src/agents/subagents/registry/subagent-control-kill-runtime.ts
@@ -1,5 +1,6 @@
 /** Session-lifecycle mutation and persistence for subagent kills. */
 import type { ClearSessionQueueResult } from "../../../auto-reply/reply/queue.js";
+import { resolveBookkeepingUpdatedAt } from "../../../config/sessions/reset-policy.js";
 import {
   loadSessionEntry,
   patchSessionEntryCore,
@@ -153,7 +154,7 @@ export async function persistSubagentAbortedLastRun(params: {
           : {
               ...current,
               abortedLastRun: params.abortedLastRun,
-              updatedAt: Date.now(),
+              updatedAt: resolveBookkeepingUpdatedAt(current.updatedAt),
             },
       {
         assertCommitAllowed: params.assertCommitAllowed,

--- a/src/agents/subagents/registry/subagent-recovery-state.ts
+++ b/src/agents/subagents/registry/subagent-recovery-state.ts
@@ -1,4 +1,5 @@
 import type { SessionEntry } from "../../../config/sessions.js";
+import { resolveBookkeepingUpdatedAt } from "../../../config/sessions/reset.js";
 import { isAgentEventLifecycleGenerationCurrent } from "../../../infra/agent-events.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
@@ -44,6 +45,6 @@ export function clearWedgedSubagentRecoveryAbort(entry: SessionEntry, now: numbe
     return false;
   }
   entry.abortedLastRun = false;
-  entry.updatedAt = now;
+  entry.updatedAt = resolveBookkeepingUpdatedAt(entry.updatedAt, now);
   return true;
 }

--- a/src/agents/subagents/registry/subagent-registry-restart-recovery-session.ts
+++ b/src/agents/subagents/registry/subagent-registry-restart-recovery-session.ts
@@ -1,3 +1,4 @@
+import { resolveBookkeepingUpdatedAt } from "../../../config/sessions/reset.js";
 import { patchSessionEntryCore } from "../../../config/sessions/session-accessor.js";
 
 export async function settleAcceptedRecoverySession(params: {
@@ -35,7 +36,7 @@ export async function settleAcceptedRecoverySession(params: {
         lastAttemptAt: params.now,
         lastRunId: params.runId,
       };
-      current.updatedAt = params.now;
+      current.updatedAt = resolveBookkeepingUpdatedAt(current.updatedAt, params.now);
       settled = true;
       return current;
     },

--- a/src/agents/subagents/registry/subagent-registry-restart-recovery.ts
+++ b/src/agents/subagents/registry/subagent-registry-restart-recovery.ts
@@ -3,6 +3,7 @@ import {
   resolveAgentIdFromSessionKey,
   resolveSessionStorePathCore,
 } from "../../../config/sessions.js";
+import { resolveBookkeepingUpdatedAt } from "../../../config/sessions/reset.js";
 import {
   loadSessionEntry,
   patchSessionEntryCore,
@@ -424,7 +425,7 @@ export async function recoverInterruptedSubagentRow(
                 wedgedAt: params.now,
                 wedgedReason: blockedReason,
               };
-              current.updatedAt = params.now;
+              current.updatedAt = resolveBookkeepingUpdatedAt(current.updatedAt, params.now);
               return current;
             },
             {

--- a/src/auto-reply/reply/abort-cutoff.runtime.ts
+++ b/src/auto-reply/reply/abort-cutoff.runtime.ts
@@ -1,3 +1,4 @@
+import { resolveBookkeepingUpdatedAt } from "../../config/sessions/reset.js";
 /** Runtime persistence helper for clearing abort-cutoff state from sessions. */
 import { patchSessionEntryCore } from "../../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
@@ -16,17 +17,18 @@ export async function clearAbortCutoffInSessionRuntime(params: {
   }
 
   applyAbortCutoffToSessionEntry(sessionEntry, undefined);
-  const updatedAt = Date.now();
+  // Bookkeeping clear must not consume the legacy updatedAt=0 pending-reset marker.
+  const updatedAt = resolveBookkeepingUpdatedAt(sessionEntry.updatedAt);
   sessionEntry.updatedAt = updatedAt;
   sessionStore[sessionKey] = sessionEntry;
 
   if (storePath) {
     await patchSessionEntryCore(
       { storePath, sessionKey },
-      () => ({
+      (entry) => ({
         abortCutoffMessageSid: undefined,
         abortCutoffTimestamp: undefined,
-        updatedAt,
+        updatedAt: resolveBookkeepingUpdatedAt(entry.updatedAt),
       }),
       { fallbackEntry: sessionEntry },
     );

--- a/src/auto-reply/reply/agent-runner-cli-dispatch.ts
+++ b/src/auto-reply/reply/agent-runner-cli-dispatch.ts
@@ -21,6 +21,7 @@ import {
 import { inferToolMetaFromArgsCore, isCommandBearingToolCall } from "../../agents/tool-display.js";
 import { normalizeAgentPlanSteps } from "../../channels/streaming.js";
 import type { SessionEntry } from "../../config/sessions.js";
+import { resolveBookkeepingUpdatedAt } from "../../config/sessions/reset.js";
 import { updateSessionEntry } from "../../config/sessions/session-accessor.js";
 import type { AgentEventPayload } from "../../infra/agent-events.js";
 import { emitAgentEvent, withAgentRunLifecycleGeneration } from "../../infra/agent-events.js";
@@ -245,7 +246,8 @@ export async function clearCliSessionBindingForRun(params: {
       return;
     }
     clearCliSession(entry, params.provider);
-    entry.updatedAt = updatedAt;
+    // Bookkeeping clear must not consume the legacy updatedAt=0 pending-reset marker.
+    entry.updatedAt = resolveBookkeepingUpdatedAt(entry.updatedAt, updatedAt);
   };
   clearEntry(params.activeSessionEntry);
   clearEntry(params.sessionKey ? params.sessionStore?.[params.sessionKey] : undefined);

--- a/src/auto-reply/reply/agent-runner-result-accounting.ts
+++ b/src/auto-reply/reply/agent-runner-result-accounting.ts
@@ -5,6 +5,7 @@ import { resolveFastModeState } from "../../agents/fast-mode.js";
 import { consolidateLiveModelSwitchAfterRun } from "../../agents/live-model-switch.js";
 import { isCliProvider } from "../../agents/model-selection.js";
 import { resolveSessionAuthProfileOverrideSource } from "../../config/sessions/auth-profile-override-provenance.js";
+import { resolveBookkeepingUpdatedAt } from "../../config/sessions/reset.js";
 import { updateSessionEntry } from "../../config/sessions/session-accessor.js";
 import { logVerbose } from "../../globals.js";
 import { shouldPreserveUserFacingSessionStateForInputProvenance } from "../../sessions/input-provenance.js";
@@ -79,7 +80,7 @@ export async function accountAgentTurn(context: AgentTurnAccountingContext) {
     sessionKey &&
     activeSessionEntry.groupActivationNeedsSystemIntro
   ) {
-    const updatedAt = Date.now();
+    const updatedAt = resolveBookkeepingUpdatedAt(activeSessionEntry.updatedAt);
     activeSessionEntry.groupActivationNeedsSystemIntro = false;
     activeSessionEntry.updatedAt = updatedAt;
     activeSessionStore[sessionKey] = activeSessionEntry;
@@ -202,7 +203,7 @@ export async function accountAgentTurn(context: AgentTurnAccountingContext) {
       : undefined;
     if (fallbackStateEntry) {
       fallbackStateEntry.fallbackNotice = fallbackNotice;
-      fallbackStateEntry.updatedAt = Date.now();
+      fallbackStateEntry.updatedAt = resolveBookkeepingUpdatedAt(fallbackStateEntry.updatedAt);
       activeSessionEntry = fallbackStateEntry;
     }
     if (sessionKey && fallbackStateEntry && activeSessionStore) {

--- a/src/auto-reply/reply/agent-runner-result-complete.ts
+++ b/src/auto-reply/reply/agent-runner-result-complete.ts
@@ -3,6 +3,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { hasConfiguredModelFallbacks } from "../../agents/agent-scope.js";
 import { resolveModelAuthMode } from "../../agents/model-auth.js";
 import type { SessionEntry } from "../../config/sessions.js";
+import { resolveBookkeepingUpdatedAt } from "../../config/sessions/reset.js";
 import { updateSessionEntry } from "../../config/sessions/session-accessor.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { sessionDeliveryChannel } from "../../utils/delivery-context.shared.js";
@@ -404,7 +405,7 @@ export async function completeReplyAgentRun(input: {
                   context: pendingFinalDeliveryContext,
                   createdAt: Date.now(),
                 },
-                updatedAt: Date.now(),
+                updatedAt: resolveBookkeepingUpdatedAt(entry.updatedAt),
               }
             : null,
         {

--- a/src/auto-reply/reply/agent-runner-run.ts
+++ b/src/auto-reply/reply/agent-runner-run.ts
@@ -1,5 +1,6 @@
 import { resolveDefaultAgentId } from "../../agents/agent-scope-config.js";
 import { settleProgressVisibilityCallbackResult } from "../../channels/progress-visibility.js";
+import { resolveBookkeepingUpdatedAt } from "../../config/sessions/reset.js";
 import { hasRestartRecoverySourceClaim } from "../../config/sessions/restart-recovery-state.js";
 import { loadSessionEntry, updateSessionEntry } from "../../config/sessions/session-accessor.js";
 import { logVerbose } from "../../globals.js";
@@ -229,7 +230,9 @@ export async function runReplyAgent(
     if (!activeSessionEntry || !activeSessionStore || !sessionKey) {
       return;
     }
-    const updatedAt = Date.now();
+    // Bookkeeping touches must not consume the legacy updatedAt=0 pending-reset
+    // marker while the owning run is still active.
+    const updatedAt = resolveBookkeepingUpdatedAt(activeSessionEntry.updatedAt);
     activeSessionEntry.updatedAt = updatedAt;
     activeSessionStore[sessionKey] = activeSessionEntry;
     if (storePath) {

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -779,6 +779,97 @@ describe("runReplyAgent auto-compaction token update", () => {
     }
   });
 
+  it("retains the legacy pending-reset marker when a followup queues behind the active run", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-queued-tombstone-"));
+    const storePath = path.join(tmp, "sessions.json");
+    const sessionKey = "main";
+    const sessionEntry = {
+      sessionId: "session",
+      updatedAt: 0,
+    };
+    await seedSessionStore({ storePath, sessionKey, entry: sessionEntry });
+    vi.mocked(enqueueFollowupRun).mockReturnValueOnce(true);
+
+    const { typing, sessionCtx, resolvedQueue, followupRun } = createBaseRun({
+      storePath,
+      sessionEntry,
+    });
+
+    const result = await runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: sessionKey,
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: true,
+      isActive: true,
+      typing,
+      sessionCtx,
+      sessionEntry,
+      sessionStore: { [sessionKey]: sessionEntry },
+      sessionKey,
+      storePath,
+      defaultModel: "anthropic/claude-opus-4-6",
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    // The queued turn's bookkeeping touch must leave the updatedAt=0
+    // pending-reset marker intact for the deferred rollover.
+    expect(result).toBeUndefined();
+    expect(enqueueFollowupRun).toHaveBeenCalledTimes(1);
+    expect(sessionEntry.updatedAt).toBe(0);
+    expect(loadSessionEntry({ storePath, sessionKey })?.updatedAt).toBe(0);
+  });
+
+  it("stamps a fresh updatedAt for ordinary entries when a followup queues behind the active run", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-queued-ordinary-"));
+    const storePath = path.join(tmp, "sessions.json");
+    const sessionKey = "main";
+    const sessionEntry = {
+      sessionId: "session",
+      updatedAt: 1_000,
+    };
+    await seedSessionStore({ storePath, sessionKey, entry: sessionEntry });
+    vi.mocked(enqueueFollowupRun).mockReturnValueOnce(true);
+
+    const { typing, sessionCtx, resolvedQueue, followupRun } = createBaseRun({
+      storePath,
+      sessionEntry,
+    });
+
+    const result = await runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: sessionKey,
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: true,
+      isActive: true,
+      typing,
+      sessionCtx,
+      sessionEntry,
+      sessionStore: { [sessionKey]: sessionEntry },
+      sessionKey,
+      storePath,
+      defaultModel: "anthropic/claude-opus-4-6",
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    expect(result).toBeUndefined();
+    expect(sessionEntry.updatedAt).toBeGreaterThan(1_000);
+    expect(loadSessionEntry({ storePath, sessionKey })?.updatedAt).toBeGreaterThan(1_000);
+  });
+
   it("keeps a provided reply operation active until final delivery completes", async () => {
     const sessionKey = "main";
     const sessionEntry = {

--- a/src/auto-reply/reply/body.ts
+++ b/src/auto-reply/reply/body.ts
@@ -1,4 +1,5 @@
 // Builds message body text from session state and reply metadata.
+import { resolveBookkeepingUpdatedAt } from "../../config/sessions/reset.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { setAbortMemory } from "./abort-primitives.js";
@@ -32,7 +33,9 @@ export async function applySessionHints(params: {
     // The abort hint is one-shot; clear durable state once it is added.
     const sessionEntry = params.sessionEntryHandle?.getCurrent() ?? params.sessionEntry;
     if (sessionEntry && params.sessionEntryHandle && params.sessionKey) {
-      const updatedAt = Date.now();
+      // Clearing the one-shot hint is bookkeeping: it must not consume the
+      // legacy updatedAt=0 pending-reset marker.
+      const updatedAt = resolveBookkeepingUpdatedAt(sessionEntry.updatedAt);
       params.sessionEntryHandle.patchCurrent({
         abortedLastRun: false,
         updatedAt,
@@ -45,15 +48,15 @@ export async function applySessionHints(params: {
             storePath: params.storePath,
             sessionKey,
           },
-          () => ({
+          (entry) => ({
             abortedLastRun: false,
-            updatedAt,
+            updatedAt: resolveBookkeepingUpdatedAt(entry.updatedAt),
           }),
           { fallbackEntry: params.sessionEntryHandle.getCurrent() ?? sessionEntry },
         );
       }
     } else if (sessionEntry && params.sessionStore && params.sessionKey) {
-      const updatedAt = Date.now();
+      const updatedAt = resolveBookkeepingUpdatedAt(sessionEntry.updatedAt);
       sessionEntry.abortedLastRun = false;
       sessionEntry.updatedAt = updatedAt;
       params.sessionStore[params.sessionKey] = sessionEntry;
@@ -65,9 +68,9 @@ export async function applySessionHints(params: {
             storePath: params.storePath,
             sessionKey,
           },
-          () => ({
+          (entry) => ({
             abortedLastRun: false,
-            updatedAt,
+            updatedAt: resolveBookkeepingUpdatedAt(entry.updatedAt),
           }),
           { fallbackEntry: sessionEntry },
         );

--- a/src/auto-reply/reply/commands-acp/lifecycle.ts
+++ b/src/auto-reply/reply/commands-acp/lifecycle.ts
@@ -29,6 +29,7 @@ import {
   readChannelContextAdmissionEvidence,
   type ChannelAdmissionEvidence,
 } from "../../../channels/message-access/admission-evidence.js";
+import { resolveBookkeepingUpdatedAt } from "../../../config/sessions/reset.js";
 import { updateSessionEntry } from "../../../config/sessions/session-accessor.js";
 import type { SessionAcpMeta } from "../../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
@@ -97,7 +98,7 @@ async function persistSpawnedSessionLabel(params: {
       params.commandParams.sessionStore[params.sessionKey] = {
         ...existing,
         label,
-        updatedAt: now,
+        updatedAt: resolveBookkeepingUpdatedAt(existing.updatedAt, now),
       };
     }
   }

--- a/src/auto-reply/reply/commands-name.test.ts
+++ b/src/auto-reply/reply/commands-name.test.ts
@@ -122,6 +122,22 @@ describe("name command", () => {
     expect(takeCommandSessionMetadataChanges(params.ctx)).toBeUndefined();
   });
 
+  it("keeps the legacy updatedAt=0 pending-reset marker when renaming", async () => {
+    const storePath = await createStorePath();
+    await upsertSessionEntryCore(
+      { storePath, sessionKey },
+      { sessionId: "sess-main", updatedAt: 0, totalTokens: 0, totalTokensFresh: true },
+    );
+
+    const params = buildNameParams("/name Billing rework", storePath);
+    const result = await handleNameCommand(params, true);
+
+    expect(result?.shouldContinue).toBe(false);
+    const persisted = loadSessionEntry({ storePath, sessionKey });
+    expect(persisted?.label).toBe("Billing rework");
+    expect(persisted?.updatedAt).toBe(0);
+  });
+
   it("rejects a label already used by another session", async () => {
     const storePath = await createStorePath();
     const now = Date.now();

--- a/src/auto-reply/reply/commands-name.ts
+++ b/src/auto-reply/reply/commands-name.ts
@@ -2,6 +2,7 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
+import { resolveBookkeepingUpdatedAt } from "../../config/sessions/reset.js";
 import {
   applySessionPatchProjection,
   loadSessionEntryReadOnly,
@@ -94,7 +95,9 @@ export const handleNameCommand: CommandHandler = defineAuthorizedTextCommand(
           return { ok: false, error: `label already in use: ${validated.label}` };
         }
         entry.label = validated.label;
-        entry.updatedAt = Math.max(entry.updatedAt ?? 0, Date.now());
+        // Renaming is bookkeeping: it must not consume the legacy updatedAt=0
+        // pending-reset marker while a rollover is deferred.
+        entry.updatedAt = resolveBookkeepingUpdatedAt(entry.updatedAt);
         return {
           ok: true,
           entry,

--- a/src/auto-reply/reply/commands-session-store.test.ts
+++ b/src/auto-reply/reply/commands-session-store.test.ts
@@ -301,6 +301,70 @@ describe("commands session store persistence", () => {
     });
   });
 
+  it("preserves the legacy pending-reset marker through command persistence", async () => {
+    await withTempStore(async (storePath) => {
+      const sessionKey = "agent:main:command";
+      const tombstoned: SessionEntry = {
+        sessionId: "command-session",
+        updatedAt: 0,
+        responseUsage: "tokens",
+      };
+      await replaceSessionEntry({ storePath, sessionKey }, { ...tombstoned });
+      const entry: SessionEntry = { ...tombstoned, responseUsage: "off" };
+      const sessionStore: Record<string, SessionEntry> = { [sessionKey]: entry };
+
+      await expect(
+        persistCommandSession({
+          initialSessionEntry: { ...tombstoned },
+          sessionEntry: entry,
+          sessionStore,
+          sessionKey,
+          storePath,
+          touchedFields: ["responseUsage"],
+        }),
+      ).resolves.toBe(true);
+
+      expect(entry.updatedAt).toBe(0);
+      expect(sessionStore[sessionKey]?.updatedAt).toBe(0);
+      expect(loadSessionEntry({ storePath, sessionKey })).toMatchObject({
+        sessionId: "command-session",
+        responseUsage: "off",
+        updatedAt: 0,
+      });
+    });
+  });
+
+  it("preserves the legacy pending-reset marker through abort target persistence", async () => {
+    await withTempStore(async (storePath) => {
+      const sessionKey = "agent:main:abort-target";
+      const tombstoned: SessionEntry = {
+        sessionId: "abort-session",
+        updatedAt: 0,
+      };
+      await replaceSessionEntry({ storePath, sessionKey }, { ...tombstoned });
+      const entry: SessionEntry = { ...tombstoned };
+      const sessionStore: Record<string, SessionEntry> = { [sessionKey]: entry };
+
+      await expect(
+        persistAbortTargetEntry({
+          entry,
+          key: sessionKey,
+          sessionStore,
+          storePath,
+        }),
+      ).resolves.toBe(true);
+
+      expect(entry.abortedLastRun).toBe(true);
+      expect(entry.updatedAt).toBe(0);
+      expect(sessionStore[sessionKey]?.updatedAt).toBe(0);
+      expect(loadSessionEntry({ storePath, sessionKey })).toMatchObject({
+        sessionId: "abort-session",
+        abortedLastRun: true,
+        updatedAt: 0,
+      });
+    });
+  });
+
   it("falls back to the supplied abort target when the persisted row is missing", async () => {
     await withTempStore(async (storePath) => {
       const sessionKey = "agent:main:abort-target";

--- a/src/auto-reply/reply/commands-session-store.ts
+++ b/src/auto-reply/reply/commands-session-store.ts
@@ -1,5 +1,6 @@
 // Shared session-store helpers for command handlers that mutate sessions.
 import { resolveSessionStoreEntryCore, type SessionEntry } from "../../config/sessions.js";
+import { resolveBookkeepingUpdatedAt } from "../../config/sessions/reset.js";
 import { patchSessionEntryCore } from "../../config/sessions/session-accessor.js";
 import { sessionSnapshotChangesApplied } from "../../config/sessions/session-snapshot-merge.js";
 import { applyAbortCutoffToSessionEntry, type AbortCutoff } from "./abort-cutoff.js";
@@ -42,7 +43,9 @@ export async function persistCommandSession(params: PersistSessionEntryParams): 
   const sessionEntry = params.sessionEntry;
   const creatingSession = params.allowCreateSessionEntry === true;
   const initialEntry = params.initialSessionEntry ?? { ...sessionEntry };
-  sessionEntry.updatedAt = Date.now();
+  // Command persistence is bookkeeping: it must not consume the legacy
+  // updatedAt=0 pending-reset marker, or the deferred rollover never runs.
+  sessionEntry.updatedAt = resolveBookkeepingUpdatedAt(sessionEntry.updatedAt);
   params.sessionStore[params.sessionKey] = sessionEntry;
   if (params.storePath) {
     // Slash commands mutate one known session entry; skipping global session
@@ -95,7 +98,9 @@ export async function persistAbortTargetEntry(params: {
 
   entry.abortedLastRun = true;
   applyAbortCutoffToSessionEntry(entry, abortCutoff);
-  entry.updatedAt = Date.now();
+  // Abort persistence is bookkeeping: it must not consume the legacy
+  // updatedAt=0 pending-reset marker, in memory or in the replacement write.
+  entry.updatedAt = resolveBookkeepingUpdatedAt(entry.updatedAt);
   sessionStore[key] = entry;
 
   if (storePath) {
@@ -104,7 +109,7 @@ export async function persistAbortTargetEntry(params: {
       (nextEntry) => {
         nextEntry.abortedLastRun = true;
         applyAbortCutoffToSessionEntry(nextEntry, abortCutoff);
-        nextEntry.updatedAt = Date.now();
+        nextEntry.updatedAt = resolveBookkeepingUpdatedAt(nextEntry.updatedAt);
         return nextEntry;
       },
       {

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -11,6 +11,7 @@ import {
 import { persistStickyModelSelectionBestEffort } from "../../agents/sticky-model-selection.js";
 import { resolveEffectiveAgentRuntime } from "../../agents/thinking-runtime.js";
 import { resolveSessionAuthProfileOverrideSource } from "../../config/sessions/auth-profile-override-provenance.js";
+import { resolveBookkeepingUpdatedAt } from "../../config/sessions/reset.js";
 import { triggerSessionPatchHook } from "../../gateway/session-patch-hooks.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { applyModelOverrideWithAuthProfileCompatibility } from "../../sessions/auth-profile-preservation.js";
@@ -489,7 +490,9 @@ export async function handleDirectiveOnly(
       const appliedRuntime = applyModelRuntimeDirective(sessionEntry, modelRuntimeResolution);
       modelSelectionUpdated = applied.updated || appliedRuntime.updated;
     }
-    sessionEntry.updatedAt = Date.now();
+    // Directive persistence is bookkeeping: it must not consume the legacy
+    // updatedAt=0 pending-reset marker while a rollover is deferred.
+    sessionEntry.updatedAt = resolveBookkeepingUpdatedAt(sessionEntry.updatedAt);
     sessionStore[sessionKey] = sessionEntry;
     if (storePath) {
       const persistence = await persistSessionDirectiveSnapshot({

--- a/src/auto-reply/reply/dispatch-from-config.pending-final.ts
+++ b/src/auto-reply/reply/dispatch-from-config.pending-final.ts
@@ -1,4 +1,5 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { resolveBookkeepingUpdatedAt } from "../../config/sessions/reset.js";
 import { buildRestartRecoveryClaimCleanupPatch } from "../../config/sessions/restart-recovery-state.js";
 import { updateSessionEntry } from "../../config/sessions/session-accessor.js";
 import { settlePendingFinalDelivery } from "../../infra/outbound/delivery-completion.js";
@@ -68,7 +69,7 @@ export async function clearPendingFinalDeliveryAfterSuccess(
                   : undefined,
               status: "done" as const,
             }),
-        updatedAt: Date.now(),
+        updatedAt: resolveBookkeepingUpdatedAt(entry.updatedAt),
       };
     },
     { skipMaintenance: true, takeCacheOwnership: true },

--- a/src/auto-reply/reply/restart-recovery-claim.ts
+++ b/src/auto-reply/reply/restart-recovery-claim.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { resolveBookkeepingUpdatedAt } from "../../config/sessions/reset.js";
 import {
   buildRestartRecoveryClaimCleanupPatch,
   hasRestartRecoverySourceClaim,
@@ -76,7 +77,7 @@ export async function retireTerminalRestartRecoverySourceClaim(params: {
           recordTerminalSource: true,
           terminalSourceRunId: params.sourceTurnId,
         }),
-        updatedAt: Date.now(),
+        updatedAt: resolveBookkeepingUpdatedAt(current.updatedAt),
       };
     },
     { skipMaintenance: true, takeCacheOwnership: true },
@@ -256,7 +257,7 @@ export function createReplyRestartRecoveryClaimController(params: {
                 restartRecoveryDeliveryRequestFingerprint: undefined,
               }),
           restartRecoverySourceIngress: entry.restartRecoverySourceIngress ?? "control-ui",
-          updatedAt: Date.now(),
+          updatedAt: resolveBookkeepingUpdatedAt(entry.updatedAt),
         },
         recorder,
         sessionId,
@@ -329,9 +330,9 @@ export function createReplyRestartRecoveryClaimController(params: {
           runtimeMs: undefined,
           startedAt: updatedAt,
           status: "running",
-          updatedAt,
+          updatedAt: resolveBookkeepingUpdatedAt(entry.updatedAt, updatedAt),
         }
-      : { ...retiredClaim, updatedAt };
+      : { ...retiredClaim, updatedAt: resolveBookkeepingUpdatedAt(entry.updatedAt, updatedAt) };
     const persisted = await persistAdmissionPatch({
       entry,
       patch,
@@ -381,7 +382,7 @@ export function createReplyRestartRecoveryClaimController(params: {
                       restartRecoveryForceSafeTools: true,
                     }
                   : {}),
-                updatedAt,
+                updatedAt: resolveBookkeepingUpdatedAt(current.updatedAt, updatedAt),
               }
             : null,
         { skipMaintenance: true, takeCacheOwnership: true },
@@ -407,7 +408,10 @@ export function createReplyRestartRecoveryClaimController(params: {
           persistedCurrent.restartRecoveryDeliveryRunId === recoveryRunId &&
           persistedCurrent.restartRecoveryDeliverySourceRunId === recoverySourceRunId &&
           persistedCurrent.restartRecoveryBeforeAgentReplyState === undefined
-            ? { restartRecoveryBeforeAgentReplyState: "pending", updatedAt }
+            ? {
+                restartRecoveryBeforeAgentReplyState: "pending",
+                updatedAt: resolveBookkeepingUpdatedAt(persistedCurrent.updatedAt, updatedAt),
+              }
             : null,
         { skipMaintenance: true, takeCacheOwnership: true },
       );
@@ -451,7 +455,7 @@ export function createReplyRestartRecoveryClaimController(params: {
                 ? Math.max(0, endedAt - current.startedAt)
                 : undefined,
             status: "failed" as const,
-            updatedAt: endedAt,
+            updatedAt: resolveBookkeepingUpdatedAt(current.updatedAt, endedAt),
           };
         }
         const preservesPendingFinal = current.pendingFinalDelivery !== undefined;
@@ -486,7 +490,7 @@ export function createReplyRestartRecoveryClaimController(params: {
                 status: "done" as const,
               }
             : {}),
-          updatedAt: endedAt ?? Date.now(),
+          updatedAt: resolveBookkeepingUpdatedAt(current.updatedAt, endedAt ?? Date.now()),
         };
       },
     );

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -9,6 +9,7 @@ import {
 } from "../../agents/exec-defaults.js";
 import { SESSION_TOTAL_TOKENS_VERSION, type SessionEntry } from "../../config/sessions.js";
 import { formatSqliteSessionFileMarker } from "../../config/sessions/legacy-sqlite-marker.js";
+import { resolveBookkeepingUpdatedAt } from "../../config/sessions/reset.js";
 import {
   patchSessionEntryCore,
   updateSessionEntry,
@@ -249,7 +250,7 @@ export async function ensureSkillSnapshot(params: {
     nextEntry = {
       ...current,
       sessionId: sessionId ?? current.sessionId ?? crypto.randomUUID(),
-      updatedAt: Date.now(),
+      updatedAt: resolveBookkeepingUpdatedAt(current.updatedAt),
       systemSent: true,
       skillsSnapshot: skillSnapshot,
     };
@@ -294,7 +295,7 @@ export async function ensureSkillSnapshot(params: {
     nextEntry = {
       ...current,
       sessionId: sessionId ?? current.sessionId ?? crypto.randomUUID(),
-      updatedAt: Date.now(),
+      updatedAt: resolveBookkeepingUpdatedAt(current.updatedAt),
       skillsSnapshot,
     };
     nextEntry = await persistSessionEntryUpdate({
@@ -367,7 +368,7 @@ export async function incrementCompactionCount(params: {
   const nextCount = (entry.compactionCount ?? 0) + incrementBy;
   const updates: Partial<SessionEntry> = {
     compactionCount: nextCount,
-    updatedAt: now,
+    updatedAt: resolveBookkeepingUpdatedAt(entry.updatedAt, now),
     ...(incrementBy > 0 ? { contextBudgetStatus: undefined } : {}),
   };
   if (compactionKind === "context-engine") {

--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -18,6 +18,7 @@ import {
   type SessionSystemPromptReport,
   type SessionEntry,
 } from "../../config/sessions.js";
+import { resolveBookkeepingUpdatedAt } from "../../config/sessions/reset.js";
 import { updateSessionEntry } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
@@ -152,7 +153,7 @@ export async function persistSessionUsageUpdate(params: {
           sessionKey,
         },
         async (entry) => {
-          const updatedAt = Date.now();
+          const updatedAt = resolveBookkeepingUpdatedAt(entry.updatedAt);
           const preserveSessionModelState =
             params.isHeartbeat === true ||
             params.preserveRuntimeModel === true ||
@@ -288,7 +289,7 @@ export async function persistSessionUsageUpdate(params: {
             systemPromptReport: preserveUserFacingRunState
               ? entry.systemPromptReport
               : (params.systemPromptReport ?? entry.systemPromptReport),
-            updatedAt: Date.now(),
+            updatedAt: resolveBookkeepingUpdatedAt(entry.updatedAt),
           };
           if (
             !preserveUserFacingRunState &&

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -4444,6 +4444,77 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
     }
   });
 
+  it("retains the pending-reset marker through owner usage accounting until the rollover", async () => {
+    vi.useFakeTimers();
+    const existingSessionId = "accounting-tombstone-session";
+    let operation: ReturnType<typeof replyRunRegistry.begin> | undefined;
+    try {
+      vi.setSystemTime(new Date(2026, 0, 18, 5, 0, 0));
+      const storePath = await createStorePath("openclaw-accounting-tombstone-");
+      const sessionKey = "agent:main:telegram:dm:accounting-tombstone-user";
+      const transcriptPath = path.join(path.dirname(storePath), `${existingSessionId}.jsonl`);
+
+      await writeSessionStoreFast(storePath, {
+        [sessionKey]: {
+          sessionId: existingSessionId,
+          updatedAt: 0,
+        },
+      });
+      await fs.writeFile(transcriptPath, '{"type":"message"}\n', "utf8");
+      operation = replyRunRegistry.begin({
+        sessionKey,
+        sessionId: existingSessionId,
+        resetTriggered: false,
+      });
+      operation.setPhase("running");
+
+      const cfg = {
+        session: { store: storePath, reset: { mode: "daily", atHour: 4 } },
+      } as OpenClawConfig;
+      const initTurn = (body: string) =>
+        initSessionState({
+          ctx: {
+            Body: body,
+            RawBody: body,
+            CommandBody: body,
+            From: "user-accounting-tombstone",
+            To: "bot",
+            ChatType: "direct",
+            SessionKey: sessionKey,
+            Provider: "telegram",
+            Surface: "telegram",
+          },
+          cfg,
+          commandAuthorized: true,
+        });
+
+      const deferred = await initTurn("hello while active");
+      expect(deferred.isNewSession).toBe(false);
+      expect(readSessionStoreFast(storePath)[sessionKey]?.updatedAt).toBe(0);
+
+      // The active owner's final usage accounting is bookkeeping: it must not
+      // consume the retained pending-reset marker before the deferred rollover.
+      await persistSessionUsageUpdate({
+        storePath,
+        sessionKey,
+        cfg,
+        usage: { input: 12, output: 4 },
+        modelUsed: "claude",
+        providerUsed: "anthropic",
+      });
+      expect(readSessionStoreFast(storePath)[sessionKey]?.updatedAt).toBe(0);
+
+      operation.complete();
+      const rolledOver = await initTurn("hello after run finished");
+      expect(rolledOver.isNewSession).toBe(true);
+      expect(rolledOver.previousSessionEntry?.sessionId).toBe(existingSessionId);
+      expect(readSessionStoreFast(storePath)[sessionKey]?.updatedAt).toBeGreaterThan(0);
+    } finally {
+      operation?.complete();
+      vi.useRealTimers();
+    }
+  });
+
   it("does not re-arm the pending-reset marker when an explicit reset lands during an active run", async () => {
     vi.useFakeTimers();
     const existingSessionId = "explicit-reset-tombstone-session";

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -4378,6 +4378,136 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
     }
   });
 
+  it("retains the legacy pending-reset marker through deferral until the active run completes", async () => {
+    vi.useFakeTimers();
+    const existingSessionId = "deferred-then-completed-tombstone-session";
+    let operation: ReturnType<typeof replyRunRegistry.begin> | undefined;
+    try {
+      vi.setSystemTime(new Date(2026, 0, 18, 5, 0, 0));
+      const storePath = await createStorePath("openclaw-deferred-tombstone-sequence-");
+      const sessionKey = "agent:main:telegram:dm:deferred-tombstone-sequence-user";
+      const transcriptPath = path.join(path.dirname(storePath), `${existingSessionId}.jsonl`);
+
+      await writeSessionStoreFast(storePath, {
+        [sessionKey]: {
+          sessionId: existingSessionId,
+          updatedAt: 0,
+        },
+      });
+      await fs.writeFile(transcriptPath, '{"type":"message"}\n', "utf8");
+      operation = replyRunRegistry.begin({
+        sessionKey,
+        sessionId: existingSessionId,
+        resetTriggered: false,
+      });
+      operation.setPhase("running");
+
+      const cfg = {
+        session: { store: storePath, reset: { mode: "daily", atHour: 4 } },
+      } as OpenClawConfig;
+      const initTurn = (body: string) =>
+        initSessionState({
+          ctx: {
+            Body: body,
+            RawBody: body,
+            CommandBody: body,
+            From: "user-deferred-tombstone-sequence",
+            To: "bot",
+            ChatType: "direct",
+            SessionKey: sessionKey,
+            Provider: "telegram",
+            Surface: "telegram",
+          },
+          cfg,
+          commandAuthorized: true,
+        });
+
+      // While the run is active the rollover is deferred, and the persisted
+      // entry must keep updatedAt=0 so the pending reset is not silently consumed.
+      const deferred = await initTurn("hello while active");
+      expect(deferred.isNewSession).toBe(false);
+      expect(deferred.previousSessionEntry).toBeUndefined();
+      expect(readSessionStoreFast(storePath)[sessionKey]?.updatedAt).toBe(0);
+
+      // Once the run completes, the next initialization observes the retained
+      // tombstone and performs the required one-time reset.
+      operation.complete();
+      const rolledOver = await initTurn("hello after run finished");
+      expect(rolledOver.isNewSession).toBe(true);
+      expect(rolledOver.resetTriggered).toBe(false);
+      expect(rolledOver.previousSessionEntry?.sessionId).toBe(existingSessionId);
+      const storedUpdatedAt = readSessionStoreFast(storePath)[sessionKey]?.updatedAt;
+      expect(storedUpdatedAt).toBeGreaterThan(0);
+    } finally {
+      operation?.complete();
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not re-arm the pending-reset marker when an explicit reset lands during an active run", async () => {
+    vi.useFakeTimers();
+    const existingSessionId = "explicit-reset-tombstone-session";
+    let operation: ReturnType<typeof replyRunRegistry.begin> | undefined;
+    try {
+      vi.setSystemTime(new Date(2026, 0, 18, 5, 0, 0));
+      const storePath = await createStorePath("openclaw-explicit-reset-tombstone-");
+      const sessionKey = "agent:main:telegram:dm:explicit-reset-tombstone-user";
+      const transcriptPath = path.join(path.dirname(storePath), `${existingSessionId}.jsonl`);
+
+      await writeSessionStoreFast(storePath, {
+        [sessionKey]: {
+          sessionId: existingSessionId,
+          updatedAt: 0,
+        },
+      });
+      await fs.writeFile(transcriptPath, '{"type":"message"}\n', "utf8");
+      operation = replyRunRegistry.begin({
+        sessionKey,
+        sessionId: existingSessionId,
+        resetTriggered: false,
+      });
+      operation.setPhase("running");
+
+      const cfg = {
+        session: { store: storePath, reset: { mode: "daily", atHour: 4 } },
+      } as OpenClawConfig;
+      const initTurn = (body: string) =>
+        initSessionState({
+          ctx: {
+            Body: body,
+            RawBody: body,
+            CommandBody: body,
+            From: "user-explicit-reset-tombstone",
+            To: "bot",
+            ChatType: "direct",
+            SessionKey: sessionKey,
+            Provider: "telegram",
+            Surface: "telegram",
+          },
+          cfg,
+          commandAuthorized: true,
+        });
+
+      // An explicit /new is not an implicit rollover: it proceeds even while the
+      // old run is active, and the fresh session must not be persisted with the
+      // legacy updatedAt=0 marker.
+      const explicitReset = await initTurn("/new");
+      expect(explicitReset.isNewSession).toBe(true);
+      expect(explicitReset.resetTriggered).toBe(true);
+      expect(readSessionStoreFast(storePath)[sessionKey]?.updatedAt).toBeGreaterThan(0);
+
+      // After the old run completes, the next init must not perform a spurious
+      // rollover of the session the explicit reset just created.
+      operation.complete();
+      const nextTurn = await initTurn("hello after explicit reset");
+      expect(nextTurn.isNewSession).toBe(false);
+      expect(nextTurn.previousSessionEntry).toBeUndefined();
+    } finally {
+      operation?.complete();
+      vi.useRealTimers();
+    }
+  });
+
   it("does not defer stale boundary append for the current turn's queued reservation", async () => {
     vi.useFakeTimers();
     let operation: ReturnType<typeof replyRunRegistry.begin> | undefined;

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -4261,6 +4261,123 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
     }
   });
 
+  it("defers rollover of a legacy pending-reset tombstone while the same session has an active run", async () => {
+    vi.useFakeTimers();
+    const existingSessionId = "active-tombstone-session";
+    let operation: ReturnType<typeof replyRunRegistry.begin> | undefined;
+    try {
+      vi.setSystemTime(new Date(2026, 0, 18, 5, 0, 0));
+      const storePath = await createStorePath("openclaw-active-tombstone-archive-");
+      const sessionKey = "agent:main:telegram:dm:active-tombstone-user";
+      const transcriptPath = path.join(path.dirname(storePath), `${existingSessionId}.jsonl`);
+
+      // Older releases persisted updatedAt=0 as an explicit pending reset marker;
+      // evaluateSessionFreshness reports it as { fresh: false } with no staleReason.
+      await writeSessionStoreFast(storePath, {
+        [sessionKey]: {
+          sessionId: existingSessionId,
+          updatedAt: 0,
+        },
+      });
+      await fs.writeFile(transcriptPath, '{"type":"message"}\n', "utf8");
+      operation = replyRunRegistry.begin({
+        sessionKey,
+        sessionId: existingSessionId,
+        resetTriggered: false,
+      });
+      operation.setPhase("running");
+
+      const cfg = {
+        session: { store: storePath, reset: { mode: "daily", atHour: 4 } },
+      } as OpenClawConfig;
+      const result = await initSessionState({
+        ctx: {
+          Body: "hello while active",
+          RawBody: "hello while active",
+          CommandBody: "hello while active",
+          From: "user-active-tombstone",
+          To: "bot",
+          ChatType: "direct",
+          SessionKey: sessionKey,
+          Provider: "telegram",
+          Surface: "telegram",
+        },
+        cfg,
+        commandAuthorized: true,
+      });
+
+      expect(result.isNewSession).toBe(false);
+      expect(result.sessionId).toBe(existingSessionId);
+      expect(result.previousSessionEntry).toBeUndefined();
+      const archived = (await fs.readdir(path.dirname(storePath))).filter((entry) =>
+        entry.startsWith(`${existingSessionId}.jsonl.reset.`),
+      );
+      expect(archived).toHaveLength(0);
+    } finally {
+      operation?.complete();
+      vi.useRealTimers();
+    }
+  });
+
+  it("rolls over a legacy pending-reset tombstone normally once the active run completes", async () => {
+    vi.useFakeTimers();
+    const existingSessionId = "completed-tombstone-session";
+    try {
+      vi.setSystemTime(new Date(2026, 0, 18, 5, 0, 0));
+      const storePath = await createStorePath("openclaw-completed-tombstone-archive-");
+      const sessionKey = "agent:main:telegram:dm:completed-tombstone-user";
+      const transcriptPath = path.join(path.dirname(storePath), `${existingSessionId}.jsonl`);
+
+      await writeSessionStoreFast(storePath, {
+        [sessionKey]: {
+          sessionId: existingSessionId,
+          updatedAt: 0,
+        },
+      });
+      await fs.writeFile(transcriptPath, '{"type":"message"}\n', "utf8");
+      // The previous run already exited; complete() releases the session lane so
+      // the registry no longer reports an active operation for this session.
+      replyRunRegistry
+        .begin({
+          sessionKey,
+          sessionId: existingSessionId,
+          resetTriggered: false,
+        })
+        .complete();
+
+      const cfg = {
+        session: { store: storePath, reset: { mode: "daily", atHour: 4 } },
+      } as OpenClawConfig;
+      const result = await initSessionState({
+        ctx: {
+          Body: "hello after run finished",
+          RawBody: "hello after run finished",
+          CommandBody: "hello after run finished",
+          From: "user-completed-tombstone",
+          To: "bot",
+          ChatType: "direct",
+          SessionKey: sessionKey,
+          Provider: "telegram",
+          Surface: "telegram",
+        },
+        cfg,
+        commandAuthorized: true,
+      });
+
+      expect(result.isNewSession).toBe(true);
+      expect(result.resetTriggered).toBe(false);
+      expect(result.sessionId).toBe(existingSessionId);
+      expect(result.previousSessionEntry?.sessionId).toBe(existingSessionId);
+      expect(await fs.stat(transcriptPath).catch(() => null)).not.toBeNull();
+      const archived = (await fs.readdir(path.dirname(storePath))).filter((entry) =>
+        entry.startsWith(`${existingSessionId}.jsonl.reset.`),
+      );
+      expect(archived).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not defer stale boundary append for the current turn's queued reservation", async () => {
     vi.useFakeTimers();
     let operation: ReturnType<typeof replyRunRegistry.begin> | undefined;

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -722,12 +722,13 @@ async function initSessionStateAttemptLocked(
     !freshEntry &&
     canReuseExistingEntry &&
     entryFreshness?.fresh === false &&
-    entryFreshness.staleReason != null &&
     activeReplyOperation?.phase !== "queued" &&
     activeReplyOperation?.sessionId === entry?.sessionId;
   // Implicit daily/idle rollover must not rename a transcript while that exact
   // session's active writer is still running. Admission will steer/wait/queue;
   // queued pre-dispatch reservations still let the current turn roll over.
+  // fresh === false without a staleReason is the legacy updatedAt=0 pending-reset
+  // tombstone, which carries the same live-transcript invariant.
   const effectiveFreshEntry = deferImplicitRolloverForActiveRun ? true : freshEntry;
   // Capture the current session entry before any reset so its transcript can be
   // archived afterward.  We need to do this for both explicit resets (/new, /reset)

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -730,6 +730,13 @@ async function initSessionStateAttemptLocked(
   // fresh === false without a staleReason is the legacy updatedAt=0 pending-reset
   // tombstone, which carries the same live-transcript invariant.
   const effectiveFreshEntry = deferImplicitRolloverForActiveRun ? true : freshEntry;
+  // Deferral must not consume the legacy pending-reset marker: persisting a
+  // current updatedAt here would erase the tombstone, so the required one-time
+  // reset would never run once the active run completes. Explicit resets already
+  // exclude deferral via resetTriggered; the isNewSession guard keeps retention
+  // tied to calls that actually defer the rollover.
+  const retainPendingResetMarker =
+    deferImplicitRolloverForActiveRun && !isNewSession && entry?.updatedAt === 0;
   // Capture the current session entry before any reset so its transcript can be
   // archived afterward.  We need to do this for both explicit resets (/new, /reset)
   // and for scheduled/daily resets where the session has become stale (!freshEntry).
@@ -880,7 +887,7 @@ async function initSessionStateAttemptLocked(
     ...preservedState,
     sessionId,
     lifecycleRevision: isNewSession ? crypto.randomUUID() : baseEntry?.lifecycleRevision,
-    updatedAt: Date.now(),
+    updatedAt: retainPendingResetMarker ? 0 : Date.now(),
     sessionStartedAt: isNewSession
       ? now
       : (baseEntry?.sessionStartedAt ?? lifecycleTimestamps.sessionStartedAt),

--- a/src/channels/turn/pending-delivery-notice.ts
+++ b/src/channels/turn/pending-delivery-notice.ts
@@ -1,3 +1,4 @@
+import { resolveBookkeepingUpdatedAt } from "../../config/sessions/reset-policy.js";
 import {
   loadSessionEntryReadOnly,
   updateSessionEntry,
@@ -43,7 +44,10 @@ async function acknowledgePendingDeliveryNotice(params: {
     (current) =>
       current.sessionId === params.sessionId &&
       current.pendingDeliveryNotice?.intentId === params.intentId
-        ? { pendingDeliveryNotice: undefined, updatedAt: Date.now() }
+        ? {
+            pendingDeliveryNotice: undefined,
+            updatedAt: resolveBookkeepingUpdatedAt(current.updatedAt),
+          }
         : null,
     { skipMaintenance: true, takeCacheOwnership: true },
   );
@@ -91,7 +95,7 @@ export async function deliverPendingDeliveryNotice(
         current.pendingDeliveryNotice?.intentId === notice.intentId
           ? {
               pendingDeliveryNotice: { ...notice, state: "unresolved" as const },
-              updatedAt: Date.now(),
+              updatedAt: resolveBookkeepingUpdatedAt(current.updatedAt),
             }
           : null,
       );
@@ -113,7 +117,7 @@ export async function deliverPendingDeliveryNotice(
         current.pendingDeliveryNotice?.intentId === notice.intentId
           ? {
               pendingDeliveryNotice: { ...notice, state: "unresolved" as const },
-              updatedAt: Date.now(),
+              updatedAt: resolveBookkeepingUpdatedAt(current.updatedAt),
             }
           : null,
       );

--- a/src/commands/doctor-main-session-recovery.test.ts
+++ b/src/commands/doctor-main-session-recovery.test.ts
@@ -96,7 +96,9 @@ describe("doctor main-session recovery integrity", () => {
       | InternalSessionEntry
       | undefined;
     expect(persisted?.abortedLastRun).toBe(false);
-    expect(persisted?.updatedAt).toBeGreaterThan(0);
+    // The repair is bookkeeping: it preserves the legacy updatedAt=0
+    // pending-reset marker instead of stamping a fresh timestamp.
+    expect(persisted?.updatedAt).toBe(0);
     expect(persisted?.mainRestartRecovery?.tombstone?.reason).toBe(reason);
     expect(changes).toEqual([
       "- Cleared aborted restart-recovery flags for 1 wedged main session.",

--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -481,7 +481,9 @@ describe("doctor state integrity oauth dir checks", () => {
       { abortedLastRun?: boolean; updatedAt?: number }
     >;
     expect(persisted[sessionKey]?.abortedLastRun).toBe(false);
-    expect(persisted[sessionKey]?.updatedAt).toBeGreaterThan(0);
+    // The repair is bookkeeping: it preserves the legacy updatedAt=0
+    // pending-reset marker instead of stamping a fresh timestamp.
+    expect(persisted[sessionKey]?.updatedAt).toBe(0);
     expect(doctorChangesText()).toContain("Cleared aborted restart-recovery flags");
   });
 

--- a/src/commands/doctor/shared/codex-route-session-repair.ts
+++ b/src/commands/doctor/shared/codex-route-session-repair.ts
@@ -11,6 +11,7 @@ import {
   loadPersistedSharedAuthProfileStore,
   parseLegacyCredentialEntry,
 } from "../../../agents/auth-profiles/persisted.js";
+import { resolveBookkeepingUpdatedAt } from "../../../config/sessions/reset-policy.js";
 import {
   applySessionEntryReplacements,
   iterateDoctorSessionKeyBatches,
@@ -245,7 +246,7 @@ function repairCodexSessionStoreRoutes(params: {
     ) {
       continue;
     }
-    entry.updatedAt = now;
+    entry.updatedAt = resolveBookkeepingUpdatedAt(entry.updatedAt, now);
     sessionKeys.push(sessionKey);
   }
   return {

--- a/src/config/sessions/reset-policy.ts
+++ b/src/config/sessions/reset-policy.ts
@@ -145,6 +145,34 @@ export function resolveBookkeepingUpdatedAt(
   return currentUpdatedAt === 0 ? 0 : now;
 }
 
+type PendingResetMarkerIdentity = {
+  lifecycleRevision?: string | undefined;
+  sessionId?: string | undefined;
+  updatedAt?: number | undefined;
+};
+
+/**
+ * Retains the legacy `updatedAt === 0` pending-reset marker (see
+ * resolveBookkeepingUpdatedAt) through a same-identity canonical replacement.
+ * Replacement choke points call this before persisting so any writer — present
+ * or future — cannot consume the marker by stamping a fresh timestamp. A
+ * rollover that performs the pending reset rotates `sessionId` or
+ * `lifecycleRevision` and therefore still mints a fresh `updatedAt`.
+ */
+export function retainPendingResetMarker(
+  previous: PendingResetMarkerIdentity | undefined,
+  next: PendingResetMarkerIdentity,
+): void {
+  if (
+    previous?.updatedAt === 0 &&
+    next.updatedAt !== 0 &&
+    next.sessionId === previous.sessionId &&
+    next.lifecycleRevision === previous.lifecycleRevision
+  ) {
+    next.updatedAt = 0;
+  }
+}
+
 function normalizeResetAtHour(value: number | undefined): number {
   if (typeof value !== "number" || !Number.isFinite(value)) {
     return DEFAULT_RESET_AT_HOUR;

--- a/src/config/sessions/reset-policy.ts
+++ b/src/config/sessions/reset-policy.ts
@@ -131,6 +131,20 @@ function resolveTimestamp(value: number | undefined, now?: number): number | und
   return value;
 }
 
+/**
+ * Resolves the `updatedAt` a bookkeeping write may persist. The legacy
+ * `updatedAt === 0` pending-reset marker (see evaluateSessionFreshness) is a
+ * one-time reset contract: generic bookkeeping timestamps must not consume it,
+ * or the required reset is silently skipped once the active run completes.
+ * Only a rollover that performs the pending reset mints a fresh `updatedAt`.
+ */
+export function resolveBookkeepingUpdatedAt(
+  currentUpdatedAt: number | undefined,
+  now: number = Date.now(),
+): number {
+  return currentUpdatedAt === 0 ? 0 : now;
+}
+
 function normalizeResetAtHour(value: number | undefined): number {
   if (typeof value !== "number" || !Number.isFinite(value)) {
     return DEFAULT_RESET_AT_HOUR;

--- a/src/config/sessions/reset-policy.ts
+++ b/src/config/sessions/reset-policy.ts
@@ -152,6 +152,22 @@ type PendingResetMarkerIdentity = {
 };
 
 /**
+ * The full lifecycle identity used by the pending-reset marker contract: both
+ * the session id and the lifecycle revision. A rollover that performs the
+ * pending reset may retain the session id, but it always rotates the lifecycle
+ * revision, so matching on the session id alone would wrongly preserve the
+ * marker into the new lifecycle.
+ */
+export function isSameLifecycleIdentity(
+  left: PendingResetMarkerIdentity | undefined,
+  right: PendingResetMarkerIdentity | undefined,
+): boolean {
+  return (
+    left?.sessionId === right?.sessionId && left?.lifecycleRevision === right?.lifecycleRevision
+  );
+}
+
+/**
  * Retains the legacy `updatedAt === 0` pending-reset marker (see
  * resolveBookkeepingUpdatedAt) through a same-identity canonical replacement.
  * Replacement choke points call this before persisting so any writer — present
@@ -166,8 +182,7 @@ export function retainPendingResetMarker(
   if (
     previous?.updatedAt === 0 &&
     next.updatedAt !== 0 &&
-    next.sessionId === previous.sessionId &&
-    next.lifecycleRevision === previous.lifecycleRevision
+    isSameLifecycleIdentity(previous, next)
   ) {
     next.updatedAt = 0;
   }

--- a/src/config/sessions/reset.ts
+++ b/src/config/sessions/reset.ts
@@ -10,6 +10,7 @@ import type { SessionResetType } from "./reset-policy.js";
 /** Public reset policy exports plus helpers that classify direct, group, and thread sessions. */
 export {
   evaluateSessionFreshness,
+  resolveBookkeepingUpdatedAt,
   resolveSessionResetPolicy,
   type SessionFreshness,
   type SessionResetMode,

--- a/src/config/sessions/reset.ts
+++ b/src/config/sessions/reset.ts
@@ -12,6 +12,7 @@ export {
   evaluateSessionFreshness,
   resolveBookkeepingUpdatedAt,
   resolveSessionResetPolicy,
+  retainPendingResetMarker,
   type SessionFreshness,
   type SessionResetMode,
   type SessionResetPolicy,

--- a/src/config/sessions/restart-recovery-receipt.ts
+++ b/src/config/sessions/restart-recovery-receipt.ts
@@ -1,4 +1,5 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { resolveBookkeepingUpdatedAt } from "./reset.js";
 import {
   hasActiveRestartRecoverySourceClaim,
   hasRestartRecoveryTerminalRun,
@@ -70,7 +71,7 @@ export async function beginRestartRecoveryTerminalDelivery(
       return {
         restartRecoveryDeliveryReceiptState: "terminal-pending",
         restartRecoveryDeliveryToolCallId: scope.toolCallId,
-        updatedAt: Date.now(),
+        updatedAt: resolveBookkeepingUpdatedAt(entry.updatedAt),
       };
     },
     { skipMaintenance: true, takeCacheOwnership: true },
@@ -123,7 +124,7 @@ export async function completeRestartRecoveryTerminalDelivery(
       }
       return {
         restartRecoveryDeliveryReceiptState: "delivered-terminal",
-        updatedAt: Date.now(),
+        updatedAt: resolveBookkeepingUpdatedAt(entry.updatedAt),
       };
     },
     { skipMaintenance: true, takeCacheOwnership: true },
@@ -164,7 +165,7 @@ export async function cancelRestartRecoveryTerminalDelivery(
       return {
         restartRecoveryDeliveryReceiptState: undefined,
         restartRecoveryDeliveryToolCallId: undefined,
-        updatedAt: Date.now(),
+        updatedAt: resolveBookkeepingUpdatedAt(entry.updatedAt),
       };
     },
     { skipMaintenance: true, takeCacheOwnership: true },

--- a/src/config/sessions/session-accessor.entry-mutation.ts
+++ b/src/config/sessions/session-accessor.entry-mutation.ts
@@ -4,6 +4,7 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import type { ChannelRouteRef } from "../../plugin-sdk/channel-route.js";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
+import { resolveBookkeepingUpdatedAt } from "./reset-policy.js";
 import {
   resolveAccessStorePath,
   loadSessionEntry,
@@ -325,7 +326,12 @@ export async function markSessionAbortTarget(params: {
         const entry = {
           ...currentEntry,
           abortedLastRun: true,
-          updatedAt: params.now?.() ?? Date.now(),
+          // Marking an abort is bookkeeping: it must not consume the legacy
+          // updatedAt=0 pending-reset marker.
+          updatedAt: resolveBookkeepingUpdatedAt(
+            currentEntry.updatedAt,
+            params.now?.() ?? Date.now(),
+          ),
         };
         applySessionAbortCutoff(
           entry,

--- a/src/config/sessions/session-accessor.lifecycle.ts
+++ b/src/config/sessions/session-accessor.lifecycle.ts
@@ -8,7 +8,7 @@ import {
   shouldSkipPluginHostCleanupStore,
   type PluginHostSessionCleanupStoreParams,
 } from "./plugin-host-cleanup.js";
-import { resolveBookkeepingUpdatedAt } from "./reset.js";
+import { resolveBookkeepingUpdatedAt, retainPendingResetMarker } from "./reset.js";
 import {
   resolveAccessStorePath,
   loadSessionEntry,
@@ -252,6 +252,10 @@ export async function applySessionPatchProjections<
           const previousSessionKeys = candidateKeys.filter(
             (sessionKey) => sessionKey !== target.primaryKey && workingStore[sessionKey],
           );
+          // Canonical replacement boundary: a same-identity projection must not
+          // consume the legacy updatedAt=0 pending-reset marker, regardless of
+          // what the projecting caller stamped.
+          retainPendingResetMarker(existingEntry, projected.entry);
           mutations.push({
             entry: projected.entry,
             ...(previousSessionKeys.length > 0 ? { previousSessionKeys } : {}),

--- a/src/config/sessions/session-accessor.lifecycle.ts
+++ b/src/config/sessions/session-accessor.lifecycle.ts
@@ -8,6 +8,7 @@ import {
   shouldSkipPluginHostCleanupStore,
   type PluginHostSessionCleanupStoreParams,
 } from "./plugin-host-cleanup.js";
+import { resolveBookkeepingUpdatedAt } from "./reset.js";
 import {
   resolveAccessStorePath,
   loadSessionEntry,
@@ -384,7 +385,7 @@ export async function cleanupPluginHostSessionStore(
           return null;
         }
         clearPluginHostCleanupTarget(currentEntry, params);
-        currentEntry.updatedAt = now;
+        currentEntry.updatedAt = resolveBookkeepingUpdatedAt(currentEntry.updatedAt, now);
         return currentEntry;
       },
       {

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -14,6 +14,7 @@ import {
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
 import { isInternalSessionEffectsKey } from "./internal-session-key.js";
 import { deriveLastRoutePatch, deriveSessionMetaPatch } from "./metadata.js";
+import { retainPendingResetMarker } from "./reset.js";
 import type {
   ExactSessionEntry,
   SessionAccessScope,
@@ -625,6 +626,10 @@ async function patchSqliteSessionEntrySnapshot<TSnapshot>(
           ];
           previousIdentity = createSessionIdentitySnapshot(snapshotRows);
           const selectedPreviousEntry = params.existingEntry(fresh) ?? writeBase;
+          // Canonical replacement boundary: replaceEntry writers stamp their own
+          // timestamps; keep the legacy updatedAt=0 pending-reset marker through
+          // same-identity replacements (merge modes already preserve it).
+          retainPendingResetMarker(selectedPreviousEntry, next);
           writeSessionEntry(writeDatabase, sessionKey, next, {
             previousEntry: selectedPreviousEntry,
           });

--- a/src/config/sessions/session-accessor.sqlite-replacement-projection.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-replacement-projection.test.ts
@@ -129,3 +129,101 @@ describe("session entry replacement compare-and-swap", () => {
     });
   });
 });
+
+describe("pending-reset marker retention through canonical replacements", () => {
+  const tempDirs: string[] = [];
+  let storePath: string;
+  let scope: { sessionKey: string; storePath: string };
+
+  beforeEach(async () => {
+    readExactSessionEntryRowMock.mockImplementation(
+      actualSessionEntryStore.readExactSessionEntryRow,
+    );
+    storePath = `${makeTempDir(tempDirs, "marker-retention")}/openclaw-agent.sqlite`;
+    scope = { sessionKey: "agent:main:marker-row", storePath };
+    await upsertSessionEntryCore(scope, {
+      model: "base",
+      sessionId: "marker-row",
+      updatedAt: 0,
+    });
+  });
+
+  afterEach(() => {
+    readExactSessionEntryRowMock.mockReset();
+    cleanupTempDirs(tempDirs);
+  });
+
+  it("keeps the legacy updatedAt=0 marker through same-identity replacements", async () => {
+    await applySessionEntryReplacements({
+      sessionKeys: [scope.sessionKey],
+      storePath,
+      update: (entries) => ({
+        replacements: entries.map(({ entry, sessionKey }) => ({
+          entry: { ...entry, label: "renamed", updatedAt: Date.now() },
+          sessionKey,
+        })),
+        result: undefined,
+      }),
+    });
+
+    expect(loadSessionEntry({ ...scope, readConsistency: "latest" })).toMatchObject({
+      label: "renamed",
+      sessionId: "marker-row",
+      updatedAt: 0,
+    });
+  });
+
+  it("mints a fresh updatedAt when the replacement rotates identity", async () => {
+    const rotatedAt = Date.now();
+    await applySessionEntryReplacements({
+      sessionKeys: [scope.sessionKey],
+      storePath,
+      update: (entries) => ({
+        replacements: entries.map(({ entry, sessionKey }) => ({
+          entry: { ...entry, lifecycleRevision: "rotated", updatedAt: rotatedAt },
+          sessionKey,
+        })),
+        result: undefined,
+      }),
+    });
+
+    expect(loadSessionEntry({ ...scope, readConsistency: "latest" })?.updatedAt).toBe(rotatedAt);
+  });
+
+  it("keeps the marker through patchSessionEntryCore replaceEntry", async () => {
+    const { patchSessionEntryCore } = await import("./session-accessor.js");
+    await patchSessionEntryCore(
+      scope,
+      (current) => ({ ...current, label: "patched", updatedAt: Date.now() }),
+      { replaceEntry: true, skipMaintenance: true },
+    );
+
+    expect(loadSessionEntry({ ...scope, readConsistency: "latest" })).toMatchObject({
+      label: "patched",
+      updatedAt: 0,
+    });
+  });
+
+  it("keeps the marker through applySessionPatchProjection", async () => {
+    const { applySessionPatchProjection } = await import("./session-accessor.js");
+    const result = await applySessionPatchProjection<{ ok: false; error: string }>({
+      storePath,
+      resolveTarget: () => ({ primaryKey: scope.sessionKey, candidateKeys: [scope.sessionKey] }),
+      project: ({ existingEntry }) => {
+        if (!existingEntry) {
+          return { ok: false, error: "missing" };
+        }
+        return {
+          ok: true,
+          entry: { ...existingEntry, label: "projected", updatedAt: Date.now() },
+        };
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(loadSessionEntry({ ...scope, readConsistency: "latest" })).toMatchObject({
+      label: "projected",
+      updatedAt: 0,
+    });
+  });
+});

--- a/src/config/sessions/session-accessor.sqlite-replacement-projection.ts
+++ b/src/config/sessions/session-accessor.sqlite-replacement-projection.ts
@@ -1,6 +1,7 @@
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import { isInternalSessionEffectsKey } from "./internal-session-key.js";
+import { retainPendingResetMarker } from "./reset.js";
 import type {
   SessionEntryReplacementSnapshot,
   SessionEntryReplacementUpdate,
@@ -201,19 +202,20 @@ async function applySqliteSessionEntryReplacementProjection<T, TReplacement>(
               for (const { entry, sessionKey } of sourceEntries) {
                 previous.set(sessionKey, entry);
               }
-              writeSessionEntry(
-                transactionDb,
-                replacement.sessionKey,
-                cloneSessionEntry(replacement.entry),
-                { previousEntry: selectedBefore ?? null },
-              );
+              const nextEntry = cloneSessionEntry(replacement.entry);
+              // Canonical replacement boundary: keep the legacy updatedAt=0
+              // pending-reset marker through same-identity replacements.
+              retainPendingResetMarker(selectedBefore, nextEntry);
+              writeSessionEntry(transactionDb, replacement.sessionKey, nextEntry, {
+                previousEntry: selectedBefore ?? null,
+              });
               deleteLegacySessionEntryRows(
                 transactionDb,
                 [...(replacement.previousSessionKeys ?? [])],
                 replacement.sessionKey,
                 { rehomeMembers: selectedBefore?.sessionId === replacement.entry.sessionId },
               );
-              current.set(replacement.sessionKey, replacement.entry);
+              current.set(replacement.sessionKey, nextEntry);
             }
             maintenancePlans.push(
               applySessionEntryMaintenance(transactionDb, {

--- a/src/config/sessions/session-accessor.sqlite-transcript-write.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-write.ts
@@ -5,6 +5,7 @@ import {
   type OpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
 import { clearAllCliSessions } from "./cli-session-binding.js";
+import { resolveBookkeepingUpdatedAt } from "./reset.js";
 import type {
   SessionTranscriptAccessScope,
   SessionTranscriptTurnMessageAppend,
@@ -232,7 +233,10 @@ export async function trimTranscriptForManualCompact(
       delete nextEntry.totalTokensFresh;
       delete nextEntry.totalTokensVersion;
       clearAllCliSessions(nextEntry);
-      nextEntry.updatedAt = options.nowMs ?? Date.now();
+      nextEntry.updatedAt = resolveBookkeepingUpdatedAt(
+        freshEntry.updatedAt,
+        options.nowMs ?? Date.now(),
+      );
       // The transcript rewrite, binding clear, and token invalidation describe one generation.
       // Keep them in this transaction so either both become visible or neither does.
       writeSessionEntry(writeDatabase, resolved.sessionKey, nextEntry, {

--- a/src/config/sessions/session-accessor.transcript-turn.ts
+++ b/src/config/sessions/session-accessor.transcript-turn.ts
@@ -13,6 +13,7 @@ import { getRuntimeConfig } from "../io.js";
 import { tryResolveLegacyCompatibilityAgentId } from "../legacy.default-agent-owner.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 import { resolveSessionStorePathCore } from "./paths.js";
+import { resolveBookkeepingUpdatedAt } from "./reset.js";
 import { updateSessionEntry } from "./session-accessor.entry-mutation.js";
 import {
   loadSessionEntryReadOnly,
@@ -487,7 +488,12 @@ async function touchTranscriptTurnSessionEntry(params: {
     },
     (current) =>
       current.sessionId === params.target.sessionId
-        ? { updatedAt: Math.max(current.updatedAt ?? 0, updatedAt) }
+        ? {
+            updatedAt: Math.max(
+              current.updatedAt ?? 0,
+              resolveBookkeepingUpdatedAt(current.updatedAt, updatedAt),
+            ),
+          }
         : null,
     { skipMaintenance: true },
   );

--- a/src/config/sessions/session-snapshot-merge.test.ts
+++ b/src/config/sessions/session-snapshot-merge.test.ts
@@ -652,3 +652,20 @@ describe("session snapshot merge", () => {
     expect(merged.mainRestartRecovery?.reservation).toBeUndefined();
   });
 });
+
+describe("pending-reset marker retention", () => {
+  it("keeps the legacy updatedAt=0 marker through bookkeeping patches", () => {
+    const tombstoned: SessionEntry = { sessionId: "session-1", updatedAt: 0 };
+    const next = mergeSessionEntry(tombstoned, { label: "touched", updatedAt: Date.now() });
+    expect(next.updatedAt).toBe(0);
+  });
+
+  it("mints a fresh updatedAt when a patch rotates the session identity", () => {
+    const tombstoned: SessionEntry = { sessionId: "session-1", updatedAt: 0 };
+    const next = mergeSessionEntry(tombstoned, {
+      sessionId: "session-2",
+      updatedAt: Date.now(),
+    });
+    expect(next.updatedAt).toBeGreaterThan(0);
+  });
+});

--- a/src/config/sessions/session-snapshot-merge.test.ts
+++ b/src/config/sessions/session-snapshot-merge.test.ts
@@ -668,4 +668,27 @@ describe("pending-reset marker retention", () => {
     });
     expect(next.updatedAt).toBeGreaterThan(0);
   });
+
+  it("keeps the legacy updatedAt=0 marker through same-identity snapshot merges", () => {
+    const tombstoned: SessionEntry = { sessionId: "session-1", updatedAt: 0 };
+    const next: SessionEntry = { sessionId: "session-1", updatedAt: Date.now(), label: "touched" };
+    const merged = mergeSessionSnapshotChanges({
+      initial: tombstoned,
+      next,
+      current: { ...tombstoned },
+    });
+    expect(merged.updatedAt).toBe(0);
+    expect(merged.label).toBe("touched");
+  });
+
+  it("mints a fresh updatedAt when a snapshot merge rotates the session identity", () => {
+    const tombstoned: SessionEntry = { sessionId: "session-1", updatedAt: 0 };
+    const next: SessionEntry = { sessionId: "session-2", updatedAt: Date.now() };
+    const merged = mergeSessionSnapshotChanges({
+      initial: tombstoned,
+      next,
+      current: { ...tombstoned },
+    });
+    expect(merged.updatedAt).toBeGreaterThan(0);
+  });
 });

--- a/src/config/sessions/session-snapshot-merge.test.ts
+++ b/src/config/sessions/session-snapshot-merge.test.ts
@@ -691,4 +691,23 @@ describe("pending-reset marker retention", () => {
     });
     expect(merged.updatedAt).toBeGreaterThan(0);
   });
+
+  it("mints a fresh updatedAt when a snapshot merge keeps the session id but rotates the lifecycle revision", () => {
+    const tombstoned: SessionEntry = {
+      sessionId: "session-1",
+      updatedAt: 0,
+      lifecycleRevision: "rev-1",
+    };
+    const next: SessionEntry = {
+      sessionId: "session-1",
+      updatedAt: Date.now(),
+      lifecycleRevision: "rev-2",
+    };
+    const merged = mergeSessionSnapshotChanges({
+      initial: tombstoned,
+      next,
+      current: { ...tombstoned },
+    });
+    expect(merged.updatedAt).toBeGreaterThan(0);
+  });
 });

--- a/src/config/sessions/session-snapshot-merge.ts
+++ b/src/config/sessions/session-snapshot-merge.ts
@@ -1,4 +1,5 @@
 import { isDeepStrictEqual } from "node:util";
+import { isSameLifecycleIdentity } from "./reset-policy.js";
 import type { InternalSessionEntry as SessionEntry } from "./types.js";
 
 type SessionEntryRecord = Partial<Record<keyof SessionEntry, unknown>>;
@@ -254,10 +255,12 @@ export function projectSessionSnapshotChanges(params: {
       // The legacy updatedAt=0 pending-reset marker (see evaluateSessionFreshness)
       // is a one-time reset contract: a same-identity snapshot merge must not
       // lift it, or the required reset is silently skipped once the active run
-      // completes. Only the rollover that performs the reset mints a fresh
-      // updatedAt (see resolveBookkeepingUpdatedAt).
+      // completes. Identity is the full lifecycle identity (session id and
+      // lifecycle revision): a rollover may retain the session id, but it
+      // rotates the revision when it performs the reset and mints fresh
+      // (see resolveBookkeepingUpdatedAt, isSameLifecycleIdentity).
       patch.updatedAt =
-        params.current.updatedAt === 0 && params.current.sessionId === params.next.sessionId
+        params.current.updatedAt === 0 && isSameLifecycleIdentity(params.current, params.next)
           ? 0
           : Math.max(params.current.updatedAt, params.next.updatedAt);
       continue;

--- a/src/config/sessions/session-snapshot-merge.ts
+++ b/src/config/sessions/session-snapshot-merge.ts
@@ -251,7 +251,15 @@ export function projectSessionSnapshotChanges(params: {
       continue;
     }
     if (field === "updatedAt") {
-      patch.updatedAt = Math.max(params.current.updatedAt, params.next.updatedAt);
+      // The legacy updatedAt=0 pending-reset marker (see evaluateSessionFreshness)
+      // is a one-time reset contract: a same-identity snapshot merge must not
+      // lift it, or the required reset is silently skipped once the active run
+      // completes. Only the rollover that performs the reset mints a fresh
+      // updatedAt (see resolveBookkeepingUpdatedAt).
+      patch.updatedAt =
+        params.current.updatedAt === 0 && params.current.sessionId === params.next.sessionId
+          ? 0
+          : Math.max(params.current.updatedAt, params.next.updatedAt);
       continue;
     }
     if (

--- a/src/config/sessions/session-transcript-turn-state.ts
+++ b/src/config/sessions/session-transcript-turn-state.ts
@@ -1,3 +1,4 @@
+import { resolveBookkeepingUpdatedAt } from "./reset.js";
 import {
   mergeRestartRecoveryTerminalRunIds,
   sameRestartRecoveryTerminalRunIds,
@@ -85,10 +86,13 @@ export function buildExpectedTranscriptTurnSessionPatch(params: {
     ...(acceptedMessage && restartRecoveryTerminalRunIds ? { restartRecoveryTerminalRunIds } : {}),
     ...(touchUpdatedAt > 0
       ? {
-          updatedAt: Math.max(
-            params.currentEntry.updatedAt ?? 0,
-            params.sessionLifecyclePatch?.updatedAt ?? 0,
-            touchUpdatedAt,
+          updatedAt: resolveBookkeepingUpdatedAt(
+            params.currentEntry.updatedAt,
+            Math.max(
+              params.currentEntry.updatedAt ?? 0,
+              params.sessionLifecyclePatch?.updatedAt ?? 0,
+              touchUpdatedAt,
+            ),
           ),
         }
       : {}),

--- a/src/config/sessions/store-maintenance-recent-preservation.test.ts
+++ b/src/config/sessions/store-maintenance-recent-preservation.test.ts
@@ -84,6 +84,21 @@ describe("recent session maintenance preservation", () => {
     },
   );
 
+  it("keeps the legacy updatedAt=0 pending-reset marker entry through prune", () => {
+    const now = Date.now();
+    const markerKey = "agent:main:web:legacy-pending-reset";
+    const staleKey = "agent:main:dashboard:stale";
+    const store: Record<string, SessionEntry> = {
+      [markerKey]: { sessionId: "legacy", updatedAt: 0 },
+      [staleKey]: { sessionId: "stale", updatedAt: now - 60 * DAY_MS },
+    };
+
+    expect(pruneStaleEntries(store, 30 * DAY_MS)).toBe(1);
+    expect(store).toHaveProperty(markerKey);
+    expect(store[markerKey]?.updatedAt).toBe(0);
+    expect(store).not.toHaveProperty(staleKey);
+  });
+
   it("is opt-in and keeps recent interactive sessions through prune and cap pressure", () => {
     const now = Date.now();
     const recentKey = "agent:main:dashboard:recent";

--- a/src/config/sessions/store-maintenance.ts
+++ b/src/config/sessions/store-maintenance.ts
@@ -284,7 +284,10 @@ function isGatewayModelRunSessionKey(sessionKey: string): boolean {
 
 /**
  * Remove entries whose `updatedAt` is older than the configured threshold.
- * Entries without `updatedAt` are kept (cannot determine staleness).
+ * Entries without `updatedAt` are kept (cannot determine staleness). The
+ * legacy `updatedAt === 0` pending-reset marker (see evaluateSessionFreshness)
+ * is not a real timestamp either: it carries no staleness signal, so the entry
+ * is kept until the pending reset performs its one-time rollover.
  * Mutates `store` in-place.
  */
 export function pruneStaleEntries(
@@ -314,7 +317,7 @@ export function pruneStaleEntries(
     ) {
       continue;
     }
-    if (entry?.updatedAt != null && entry.updatedAt < cutoffMs) {
+    if (entry?.updatedAt != null && entry.updatedAt !== 0 && entry.updatedAt < cutoffMs) {
       opts.onPruned?.({ key, entry });
       delete store[key];
       pruned++;

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -26,6 +26,7 @@ import {
   type SqliteSessionFileMarker,
 } from "./legacy-sqlite-marker.js";
 import { resolveDefaultSessionStorePath, resolveSessionStorePathCore } from "./paths.js";
+import { resolveBookkeepingUpdatedAt } from "./reset.js";
 import {
   loadSessionEntryReadOnly,
   loadTranscriptEvents,
@@ -686,7 +687,7 @@ async function touchSqliteAssistantAppendSessionEntry(params: {
 }): Promise<void> {
   const now = Date.now();
   const buildPatch = (entry: SessionEntry | undefined): Partial<SessionEntry> => ({
-    updatedAt: Math.max(entry?.updatedAt ?? 0, now),
+    updatedAt: Math.max(entry?.updatedAt ?? 0, resolveBookkeepingUpdatedAt(entry?.updatedAt, now)),
     sessionStartedAt: entry?.sessionStartedAt ?? params.currentEntry.sessionStartedAt ?? now,
   });
   await updateSessionEntry(

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -753,6 +753,13 @@ function resolveMergedUpdatedAt(
   if (options?.policy === "preserve-activity" && existing) {
     return existingUpdatedAt ?? patchUpdatedAt ?? now;
   }
+  // The legacy updatedAt=0 pending-reset marker (see evaluateSessionFreshness)
+  // is a one-time reset contract: bookkeeping activity touches must not lift it,
+  // or the required reset is silently skipped. Only identity-changing writes
+  // (the rollover that performs the reset) mint a fresh updatedAt.
+  if (existingUpdatedAt === 0 && (!patch.sessionId || patch.sessionId === existing?.sessionId)) {
+    return 0;
+  }
   return Math.max(existingUpdatedAt ?? 0, patchUpdatedAt ?? 0, now);
 }
 

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -755,9 +755,14 @@ function resolveMergedUpdatedAt(
   }
   // The legacy updatedAt=0 pending-reset marker (see evaluateSessionFreshness)
   // is a one-time reset contract: bookkeeping activity touches must not lift it,
-  // or the required reset is silently skipped. Only identity-changing writes
-  // (the rollover that performs the reset) mint a fresh updatedAt.
-  if (existingUpdatedAt === 0 && (!patch.sessionId || patch.sessionId === existing?.sessionId)) {
+  // or the required reset is silently skipped. Only writes that change the full
+  // lifecycle identity (session id or lifecycle revision — the rollover that
+  // performs the reset) mint a fresh updatedAt.
+  if (
+    existingUpdatedAt === 0 &&
+    (!patch.sessionId || patch.sessionId === existing?.sessionId) &&
+    (!patch.lifecycleRevision || patch.lifecycleRevision === existing?.lifecycleRevision)
+  ) {
     return 0;
   }
   return Math.max(existingUpdatedAt ?? 0, patchUpdatedAt ?? 0, now);

--- a/src/gateway/server-methods/agent-cron-continuation.ts
+++ b/src/gateway/server-methods/agent-cron-continuation.ts
@@ -1,5 +1,6 @@
 import type { AgentRunTerminalOutcome } from "../../agents/agent-run-terminal-outcome.js";
 import type { SessionEntry } from "../../config/sessions.js";
+import { resolveBookkeepingUpdatedAt } from "../../config/sessions/reset.js";
 import { applySessionEntryReplacements } from "../../config/sessions/session-accessor.js";
 import { mergeSessionSnapshotChanges } from "../../config/sessions/session-snapshot-merge.js";
 import { getAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
@@ -108,7 +109,7 @@ export function createCronContinuationController(params: {
               basePersisted:
                 releasedMarker.basePersisted === true || canPersistToBase || baseWasSuperseded,
             };
-            current.updatedAt = Date.now();
+            current.updatedAt = resolveBookkeepingUpdatedAt(current.updatedAt);
             replacements.push({ sessionKey: activeClaim.sessionKey, entry: current });
             return { replacements, result: true };
           },

--- a/src/gateway/server-methods/agent-run-model-selection.ts
+++ b/src/gateway/server-methods/agent-run-model-selection.ts
@@ -1,6 +1,7 @@
 import { resolveCliRuntimeExecutionProvider } from "../../agents/model-runtime-aliases.js";
 import { isCliProvider } from "../../agents/model-selection.js";
 import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
+import { resolveBookkeepingUpdatedAt } from "../../config/sessions/reset.js";
 import { applySessionEntryReplacements } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { AgentTurnContext } from "../agent-turn/types.js";
@@ -74,7 +75,7 @@ export function createAgentRunModelSelectionHandler(params: {
                 cronRunContinuation,
                 modelProvider: provider,
                 model,
-                updatedAt: Date.now(),
+                updatedAt: resolveBookkeepingUpdatedAt(current.updatedAt),
               },
             },
           ],

--- a/src/gateway/server-methods/agent-session-patch.test.ts
+++ b/src/gateway/server-methods/agent-session-patch.test.ts
@@ -70,6 +70,43 @@ function buildCreationPatch(opts: {
 }
 
 describe("agent session patch", () => {
+  it("consumes the pending-reset marker when a new lifecycle keeps the session id", () => {
+    const now = 5_000;
+    const tombstone: SessionEntry = { sessionId: "tombstoned-session", updatedAt: 0 };
+    const built = buildAgentSessionPatch({
+      freshEntry: tombstone,
+      initialEntry: tombstone,
+      cfg: {},
+      sessionAgentId: "main",
+      canonicalSessionKey: "agent:main:main",
+      storePath: "/tmp/openclaw-agent-tombstone-test.json",
+      normalizedSpawned: {},
+      requestDeliveryHint: undefined,
+      hasRestoredCronContinuation: false,
+      resetPolicy: resolveSessionResetPolicy({ resetType: "direct" }),
+      now,
+      isSystemGatewayRun: false,
+      visibleRequest: true,
+      fallbackSessionId: "tombstoned-session",
+      touchInteraction: false,
+      failedSessionTranscriptMissing: () => false,
+    });
+
+    expect(built.isNewSession).toBe(true);
+    expect(built.patch.sessionId).toBe("tombstoned-session");
+    expect(built.patch.lifecycleRevision).toEqual(expect.any(String));
+
+    const merged = mergeSessionEntry(tombstone, built.patch);
+    expect(merged.updatedAt).toBeGreaterThan(0);
+    expect(merged.lifecycleRevision).toBe(built.patch.lifecycleRevision);
+  });
+
+  it("keeps the pending-reset marker for bookkeeping patches without identity rotation", () => {
+    const tombstone: SessionEntry = { sessionId: "tombstoned-session", updatedAt: 0 };
+    const merged = mergeSessionEntry(tombstone, { label: "renamed", updatedAt: 5_000 });
+    expect(merged.updatedAt).toBe(0);
+  });
+
   it("clears agent status at the next human interaction boundary", () => {
     const patch = buildPatch(true);
     expect(Object.hasOwn(patch, "agentStatus")).toBe(true);

--- a/src/gateway/server-methods/agent-session-patch.ts
+++ b/src/gateway/server-methods/agent-session-patch.ts
@@ -238,6 +238,12 @@ export function buildAgentSessionPatch(params: {
     sessionId: patchSessionId,
     updatedAt: params.now,
     ...(freshIsNewSession && !freshSessionRotatedSinceLoad ? { sessionStartedAt: params.now } : {}),
+    // A new lifecycle on a previously occupied slot must advance the lifecycle
+    // identity: the merge then consumes the legacy updatedAt=0 pending-reset
+    // marker exactly once instead of re-detecting the tombstone on every turn.
+    ...(freshIsNewSession && params.freshEntry && !freshSessionRotatedSinceLoad
+      ? { lifecycleRevision: crypto.randomUUID() }
+      : {}),
     ...(params.touchInteraction
       ? {
           lastInteractionAt: params.now,

--- a/src/gateway/server-methods/chat-send-message-injection.ts
+++ b/src/gateway/server-methods/chat-send-message-injection.ts
@@ -14,6 +14,7 @@ import {
 } from "../../auto-reply/reply/reply-run-registry.js";
 import { resolveInboundReplyToolAuthorityOverlay } from "../../auto-reply/reply/reply-tool-authority.js";
 import type { RuntimeMsgContext } from "../../auto-reply/templating.js";
+import { resolveBookkeepingUpdatedAt } from "../../config/sessions/reset.js";
 import { updateSessionEntry } from "../../config/sessions/session-accessor.js";
 import { isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import { logMessageProcessed, logMessageReceived } from "../../logging/diagnostic.js";
@@ -187,7 +188,7 @@ export async function finalizeAcceptedChatSendMessageInjection(params: {
       ? { outcome: "skipped", options: { reason: "reply_operation_aborted" } }
       : { outcome: "completed", options: { reason: "active_run_injected" } },
   });
-  const updatedAt = Date.now();
+  const updatedAt = entry ? resolveBookkeepingUpdatedAt(entry.updatedAt) : Date.now();
   if (entry) {
     entry.updatedAt = updatedAt;
   }

--- a/src/gateway/server-methods/sessions-compact.ts
+++ b/src/gateway/server-methods/sessions-compact.ts
@@ -14,6 +14,7 @@ import {
   SESSION_LIFECYCLE_CHANGED_ERROR_REASON,
   type SessionEntry,
 } from "../../config/sessions.js";
+import { resolveBookkeepingUpdatedAt } from "../../config/sessions/reset.js";
 import {
   applySessionPatchProjection,
   preflightSessionTranscriptForManualCompact,
@@ -420,7 +421,7 @@ export const sessionCompactHandlers: GatewayRequestHandlers = {
                     return { ok: false };
                   }
                   const entryToUpdate = existingEntry;
-                  entryToUpdate.updatedAt = Date.now();
+                  entryToUpdate.updatedAt = resolveBookkeepingUpdatedAt(entryToUpdate.updatedAt);
                   entryToUpdate.compactionCount =
                     Math.max(0, entryToUpdate.compactionCount ?? 0) + 1;
                   if (result.compactionKind === "context-engine") {

--- a/src/gateway/session-compaction-checkpoints.ts
+++ b/src/gateway/session-compaction-checkpoints.ts
@@ -17,6 +17,7 @@ import {
 import { isCompactionCheckpointTranscriptFileName } from "../config/sessions/artifacts.js";
 import { readFileRangeAsync } from "../config/sessions/file-range.js";
 import { parseSqliteSessionFileMarker } from "../config/sessions/legacy-sqlite-marker.js";
+import { resolveBookkeepingUpdatedAt } from "../config/sessions/reset.js";
 import {
   loadSessionEntry,
   loadTranscriptEventsSync,
@@ -775,7 +776,10 @@ async function persistSessionCompactionCheckpoint(
       trimmedCheckpoints = trimSessionCheckpoints(checkpoints, snapshotBytesByPath);
       stored = true;
       return {
-        updatedAt: Math.max(existing.updatedAt ?? 0, createdAt),
+        updatedAt: Math.max(
+          existing.updatedAt ?? 0,
+          resolveBookkeepingUpdatedAt(existing.updatedAt, createdAt),
+        ),
         compactionCheckpoints: trimmedCheckpoints.kept,
       };
     },

--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -359,6 +359,45 @@ describe("gateway sessions patch", () => {
     });
   });
 
+  test("preserves the legacy updatedAt=0 pending-reset marker on metadata patches", async () => {
+    const store: Record<string, SessionEntry> = {
+      [MAIN_SESSION_KEY]: {
+        sessionId: "sess-main",
+        updatedAt: 0,
+      },
+    };
+
+    const entry = expectPatchOk(
+      await runPatch({
+        store,
+        patch: { key: MAIN_SESSION_KEY, label: "kept" },
+      }),
+    );
+
+    expect(entry.label).toBe("kept");
+    expect(entry.updatedAt).toBe(0);
+    expect(store[MAIN_SESSION_KEY]?.updatedAt).toBe(0);
+  });
+
+  test("stamps a fresh updatedAt for same-identity patches on live entries", async () => {
+    const store: Record<string, SessionEntry> = {
+      [MAIN_SESSION_KEY]: {
+        sessionId: "sess-main",
+        updatedAt: 1,
+      },
+    };
+
+    const entry = expectPatchOk(
+      await runPatch({
+        store,
+        patch: { key: MAIN_SESSION_KEY, label: "kept" },
+      }),
+    );
+
+    expect(entry.label).toBe("kept");
+    expect(entry.updatedAt).toBeGreaterThan(1);
+  });
+
   test("attributes the archive transition and clears attribution on restore", async () => {
     const archivedBy = { type: "human" as const, id: "profile-ada", label: "Ada" };
     const archived = expectPatchOk(

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -252,7 +252,11 @@ export async function projectSessionsPatchEntry(params: {
   const next: SessionEntry = {
     ...existing,
     sessionId: existing?.sessionId || randomUUID(),
-    updatedAt: Math.max(existing?.updatedAt ?? 0, now),
+    // Bookkeeping write on an existing session: preserve the legacy updatedAt=0
+    // pending-reset marker (resolveBookkeepingUpdatedAt inlined; this file is at
+    // the max-lines budget). New rows always mint a fresh timestamp.
+    updatedAt:
+      existing?.sessionId && existing.updatedAt === 0 ? 0 : Math.max(existing?.updatedAt ?? 0, now),
     ...(params.preparedSessionRoot ? { sessionRoot: params.preparedSessionRoot } : {}),
     // Stamp only genuinely new rows; existing placeholder aliases must not be restamped.
     ...(creation && params.existingEntry === undefined ? buildSessionCreationStamp(creation) : {}),

--- a/src/gateway/worker-environments/transcript-commit.ts
+++ b/src/gateway/worker-environments/transcript-commit.ts
@@ -7,6 +7,7 @@ import type {
 import type { AgentMessage } from "../../agents/runtime/index.js";
 import { SessionManager } from "../../agents/sessions/session-manager.js";
 import { redactTranscriptMessage } from "../../agents/transcript-redact.js";
+import { resolveBookkeepingUpdatedAt } from "../../config/sessions/reset.js";
 import {
   loadSessionEntry,
   publishTranscriptUpdate,
@@ -400,7 +401,12 @@ async function applyWorkerTranscriptCommit(params: {
       const nextEntry = {
         ...freshEntry,
         ...(appendedCount > 0
-          ? { updatedAt: Math.max(freshEntry.updatedAt ?? 0, Date.now()) }
+          ? {
+              updatedAt: Math.max(
+                freshEntry.updatedAt ?? 0,
+                resolveBookkeepingUpdatedAt(freshEntry.updatedAt),
+              ),
+            }
           : {}),
       };
       replaceSessionEntrySync(params.target, nextEntry);

--- a/src/infra/outbound/delivery-completion.ts
+++ b/src/infra/outbound/delivery-completion.ts
@@ -7,6 +7,7 @@ import {
   markConversationDeliveryUnknown,
   type ConversationDeliveryRecord,
 } from "../../config/sessions/conversation-delivery-store.js";
+import { resolveBookkeepingUpdatedAt } from "../../config/sessions/reset-policy.js";
 import { updateSessionEntry } from "../../config/sessions/session-accessor.js";
 import type { InternalSessionEntry } from "../../config/sessions/types.js";
 import type { OutboundDeliveryResult } from "./deliver-types.js";
@@ -141,7 +142,7 @@ export async function settlePendingFinalDelivery(
           deliveries: deliveries.with(index, { id: completion.deliveryId, state: settled }),
         },
         ...(clearsNotice ? { pendingDeliveryNotice: undefined } : owedNotice),
-        updatedAt: Date.now(),
+        updatedAt: resolveBookkeepingUpdatedAt(internalEntry.updatedAt),
       };
     },
     { skipMaintenance: true, takeCacheOwnership: true },

--- a/src/model-picker/apply-session-model-selection.ts
+++ b/src/model-picker/apply-session-model-selection.ts
@@ -22,6 +22,7 @@ import { persistReplySessionEntry } from "../auto-reply/reply/session-entry-pers
 import { isThinkingLevelSupported, resolveSupportedThinkingLevel } from "../auto-reply/thinking.js";
 import type { ThinkLevel } from "../auto-reply/thinking.shared.js";
 import { resolveSessionAuthProfileOverrideSource } from "../config/sessions/auth-profile-override-provenance.js";
+import { resolveBookkeepingUpdatedAt } from "../config/sessions/reset.js";
 import {
   adoptPersistedSessionSnapshot,
   SESSION_MODEL_OVERRIDE_TRANSACTION_FIELDS,
@@ -271,7 +272,7 @@ export async function applySessionModelSelection(
     }
   }
   // An explicit selection retains the existing persistence and conflict semantics even when idempotent.
-  nextEntry.updatedAt = Date.now();
+  nextEntry.updatedAt = resolveBookkeepingUpdatedAt(nextEntry.updatedAt);
   let persistedEntry: SessionEntry;
   if (params.storePath) {
     const persistence = await persistReplySessionEntry({

--- a/src/plugins/host-hook-state.ts
+++ b/src/plugins/host-hook-state.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { isPromiseLike } from "@openclaw/normalization-core/promise-like";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { SessionEntry } from "../config/sessions.js";
+import { resolveBookkeepingUpdatedAt } from "../config/sessions/reset.js";
 import {
   resolveSessionEntryAccessTarget,
   updateResolvedSessionEntry,
@@ -177,7 +178,7 @@ export async function enqueuePluginNextTurnInjection(params: {
     }
     injections[params.pluginId] = [...existing, record];
     entry.pluginNextTurnInjections = injections;
-    entry.updatedAt = now;
+    entry.updatedAt = resolveBookkeepingUpdatedAt(entry.updatedAt, now);
     enqueued = true;
     return { enqueued, id: resultId };
   });
@@ -240,7 +241,7 @@ async function drainPluginNextTurnInjections(params: {
     // records are stale owner state and are discarded with expired records.
     delete entry.pluginNextTurnInjections;
     if (drained.length > 0) {
-      entry.updatedAt = now;
+      entry.updatedAt = resolveBookkeepingUpdatedAt(entry.updatedAt, now);
     }
     return drained;
   });
@@ -380,7 +381,7 @@ export async function patchPluginSessionExtension(params: {
           entryRecord[slotKey] = projected;
         }
       }
-      entry.updatedAt = Date.now();
+      entry.updatedAt = resolveBookkeepingUpdatedAt(entry.updatedAt);
       return pluginState[namespace] as PluginJsonValue | undefined;
     },
   );

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -1,6 +1,7 @@
 // Session model override helpers normalize per-session provider model choices.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { SessionEntry } from "../config/sessions.js";
+import { resolveBookkeepingUpdatedAt } from "../config/sessions/reset.js";
 
 /** User or automatic model/provider override selection for a session entry. */
 type ModelOverrideSelection = {
@@ -193,7 +194,7 @@ export function applyModelOverrideToSessionEntry(params: {
       entry.liveModelSwitchPending = true;
     }
     delete entry.fallbackNotice;
-    entry.updatedAt = Date.now();
+    entry.updatedAt = resolveBookkeepingUpdatedAt(entry.updatedAt);
   }
 
   return { updated };


### PR DESCRIPTION
## What Problem This Solves

`initSessionState` protects live transcripts from implicit rollover with `deferImplicitRolloverForActiveRun` (`src/auto-reply/reply/session.ts:698`): when a stale session still has an active reply run, the rollover is deferred so the reset boundary is never written into the transcript while that exact session's writer is still running ("Implicit daily/idle rollover must not rename a transcript while that exact session's active writer is still running").

#111140 (disable automatic session resets by default) added an early return to `evaluateSessionFreshness` for the legacy `updatedAt === 0` pending-reset tombstone (`src/config/sessions/reset-policy.ts:88-91`), yielding `{ fresh: false }` **without** a `staleReason`. The deferral guard additionally required `entryFreshness.staleReason != null` — a condition that was always true before #111140, when `updatedAt: 0` flowed through the daily/idle evaluation and came out stale with `staleReason: "daily"` under the old default. Post-#111140 the condition is never true for tombstoned entries, so the active-run deferral is silently skipped for exactly those sessions.

Failure scenario: a user on a prior release has a session with the `updatedAt: 0` pending-reset marker (acknowledged shipped state — the reset-policy comment says "Older releases persisted updatedAt=0 as an explicit pending reset marker") and a reply run still active in that session. The next inbound message evaluates freshness → tombstone → `fresh: false`, no `staleReason` → deferral skipped → the session rolls over mid-run: `isNewSession=true` and a reset boundary is committed while the run is still writing, so the run's remaining output lands after a rollover boundary in a session the reset policy already considered rolled over. This regresses both the new `none` default and explicitly configured `daily`/`idle` policies.

## Why This Change Was Made

Four commits, one invariant — the legacy pending-reset tombstone must behave like any other stale entry under active-run deferral, and no write inside the active-run window may consume the one-time reset:

1. **Defer the tombstone rollover while the run is active.** The `staleReason != null` condition encoded a pre-#111140 invariant (`fresh === false` ⇒ a stale reason exists) that the tombstone branch broke. Removing the condition restores the guard for every `fresh === false` entry; the tombstone carries the same live-transcript invariant the guard exists to protect. The alternative (inventing a `staleReason` for the tombstone) would mislabel the reset end reason downstream, and #111140's own test codifies the bare `{ fresh: false }` shape, so the guard site is the right place to fix.
2. **Retain the pending-reset marker through deferral.** Deferral reuses the entry and the shared persist write stamps `updatedAt: Date.now()` — which would erase the `updatedAt === 0` tombstone, so the required one-time reset would never fire after the run completes (found in review). When — and only when — a call actually defers a tombstone (`retainPendingResetMarker = deferImplicitRolloverForActiveRun && !isNewSession && entry?.updatedAt === 0`), the entry is persisted with `updatedAt: 0` retained, so the next initialization after the run completes observes the marker and performs the reset exactly once. Explicit resets (`/new`, `/reset`) are excluded twice over: they set `resetTriggered`, which already disables deferral, and the `!isNewSession` guard ties retention to deferral-only calls.
3. **Preserve the marker through active-run bookkeeping writes.** Retention at the initializer alone is insufficient (found in review): the same inbound turn can queue or steer behind the active owner (`touchActiveSessionEntry`), and the owner's final result accounting (`persistSessionUsageUpdate`) also timestamps the entry before cleanup — and the touch-activity merge (`resolveMergedUpdatedAt`) forced `Math.max(existing, patch, now)`, so no patch could persist `0` at all. The canonical write lane now keeps an existing `updatedAt === 0` on same-identity patches (`src/config/sessions/types.ts`); identity-changing patches (the rollover that performs the reset) still mint a fresh `updatedAt`. In-memory bookkeeping stamps in the reply-run boundary go through a shared `resolveBookkeepingUpdatedAt` (`src/config/sessions/reset-policy.ts`): queue/steer touch, group-intro and fallback-notice accounting, CLI binding cleanup, abort-cutoff/abort-hint clears, and abort target marking (`replaceEntry` path).
4. **Preserve the marker through command, abort, and directive persistence (found in review).** Command persistence (`persistCommandSession`), abort target persistence (`persistAbortTargetEntry`), and directive snapshots still stamped `Date.now()` before persisting, and the snapshot merger (`projectSessionSnapshotChanges`) kept `Math.max(current, next)` for `updatedAt` — so `/send`, `/activation`, `/dock`, TTS, or `/stop` during an active-run deferral lifted the tombstone in memory and in the durable row, silently skipping the required one-time rollover. These writers now resolve their stamp through `resolveBookkeepingUpdatedAt`, and the snapshot merger retains `updatedAt === 0` on same-identity merges, mirroring the `mergeSessionEntry` rule; identity-rotating rollovers still mint a fresh `updatedAt`.

## User Impact

Before: upgrading users with legacy pending-reset tombstones can have an active session rolled over mid-run when the next message arrives — the rollover boundary is committed while the model is still writing, splitting remaining output across the boundary. After: tombstoned sessions with an active run defer rollover exactly like daily/idle-stale sessions; the pending-reset marker survives the deferral, and the rollover happens exactly once when the first initialization after the run completes observes it.

## Evidence

Head `6e699d32bbb` (rebased onto `main` `6669872a95f`; deferral, marker-retention, active-run bookkeeping preservation, plus the command/abort, /name, and the full same-identity write-surface convergence commits (34 writers routed through the bookkeeping rule; complete inventory in the latest comment); also dropped a stale `agentCfgContextTokens` test param that no longer exists in `RunReplyAgentParams`, fixing the `check-test-types-core-4` lane).

- Regression test ① `defers rollover of a legacy pending-reset tombstone while the same session has an active run` in `src/auto-reply/reply/session.test.ts` — `updatedAt: 0` tombstone + active run ⇒ `isNewSession=false`, `previousSessionEntry` undefined, no reset archives.
- Regression test ② `rolls over a legacy pending-reset tombstone normally once the active run completes` — same tombstone with the run completed (registry lane released) ⇒ `isNewSession=true`, `previousSessionEntry.sessionId` set, transcript intact.
- Regression test ③ `retains the legacy pending-reset marker through deferral until the active run completes` — one store, full sequence: deferred init keeps `updatedAt: 0` persisted; after the run completes the next init rolls over (`isNewSession=true`, `previousSessionEntry` set) and the stored entry carries a current `updatedAt` — marker consumed exactly once.
- Regression test ④ `does not re-arm the pending-reset marker when an explicit reset lands during an active run` — `/new` during an active run on a tombstone proceeds (`resetTriggered=true`), persists a current `updatedAt`, and the post-completion init does not perform a spurious rollover.
- Regression test ⑤ `retains the pending-reset marker through owner usage accounting until the rollover` — deferred init → real `persistSessionUsageUpdate` (final accounting) → persisted `updatedAt` stays `0` → run completes → next init rolls over exactly once.
- Regression test ⑥⑦ in `src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts` — a followup queued behind the active run leaves the tombstoned entry at `updatedAt: 0` in memory and persisted; an ordinary entry still gets stamped (control arm).
- Merge-rule units in `src/config/sessions/session-snapshot-merge.test.ts` — same-identity patches keep `updatedAt: 0`; identity-rotating patches mint fresh.
- Regression tests ⑧⑨ in `src/auto-reply/reply/commands-session-store.test.ts` against a real on-disk store (no mocks of the changed surface) — a tombstoned entry keeps `updatedAt: 0` in memory and in the durable row through command persistence (touched-field write) and through abort target persistence (`replaceEntry` path); a same-identity snapshot merge keeps `0`, an identity-rotating merge mints fresh.
- Red-green proof on this head: with the three production files stashed, the two new command-store tests and the same-identity merge test fail exactly as predicted (timestamps lifted to `Date.now()`); with the fix restored all pass.
- Before-run on the rebase base: the identical tombstone + active-run scenario against `main` `886e5c04900` (the base of this head; final base `5f561999a9d` differs only in `scripts/check-changed.mts`) reproduces the defect — `isNewSession=true`, `previousSessionEntry` set: the rollover proceeds while the session's own reply run is still active.
- Full file suite: `node scripts/run-vitest.mjs src/auto-reply/reply/session.test.ts` → 175/175 pass on `3e5439ab7b3`, including the pre-existing deferral tests (daily stale, queued-reservation exclusion) and #112988's boundary-append tests, confirming the guard's other behaviors are unchanged.
- Sibling suites on `3e5439ab7b3`: `reset-policy.test.ts` (#111140's codified `{ fresh: false }` tombstone contract untouched), `session-snapshot-merge.test.ts` 20/20, `session-accessor.test.ts` 108/108, `session-accessor.conformance.test.ts` 45/45, `agent-runner.misc.runreplyagent.test.ts` 84/84, `reply-turn-admission` + `body` + `abort-cutoff.runtime` + `agent-runner-cli-dispatch` + `agent-runner-result-accounting` + `dispatch-from-config.pending-final` 82/82, other merge users (`acp/runtime/session-meta*`, `agents/openclaw-tools.session-status`, `agents/agent-command.live-model-switch`) 214/214. `pnpm tsgo:core`, `oxlint`, `oxfmt` clean.
- Introduced-by: #111140; pre-change behavior verified at `git show e23dde3de5^:src/config/sessions/reset-policy.ts` (no tombstone early return; `updatedAt: 0` evaluated stale with `staleReason: "daily"`).

## Real behavior proof (refreshed on current head)

Live runs of the real `initSessionState` (no mocks of the changed surface) with a real on-disk store/transcript and a real `replyRunRegistry` run, refreshed on the submitted head `3e5439ab7b3`:

- **Deferral keeps the marker**: tombstone + active run → `isNewSession=false`, `previousSessionEntry=none`, and the persisted store entry still has `updatedAt=0` — the pending reset is deferred, not consumed.
- **Retained marker fires exactly once**: same store, run completed → next init rolls over (`isNewSession=true`, `resetTriggered=false`, `previousSessionEntry` set) and the stored entry now carries a current `updatedAt`.
- **Before** (rebase base `886e5c04900`, the identical integration path minus this fix): tombstone + active run → `isNewSession=true`, `previousSessionEntry=live-tombstone-session` — the session rolls over while its own reply run is still active (on current main rollover is boundary-append per #112988, so the race manifests as the rollover decision committed mid-run, not an archive rename).

Full transcript: https://github.com/openclaw/openclaw/pull/111351#issuecomment-5307793275 (before/after on `9ae123e7e1`) and the deferred-then-completed sequence on `39d27bf9237` in the latest proof comment.

Focused suites on head `6e699d32bbb`: `commands-session-store.test.ts` 11/11, `session-snapshot-merge.test.ts` 22/22, `session.test.ts` + `commands-stop-target.test.ts` + `commands-abort-trigger.test.ts` + `agent-runner.misc.runreplyagent.test.ts` 265/265 pass. `pnpm tsgo:core`, `oxlint`, `oxfmt` clean. Owner-path proof through queued-admission and final-accounting writes on the previous head: see the latest proof comment.













Fixes #130568


## Exact-head proof (2026-08-27, head 1939967ee3a)

Rebased onto current `origin/main` (no behavior change; conflict resolutions preserved main's newer safeguards — see the re-review comment for the per-file adaptation list). Fresh REAL on-disk proof on the exact head: production modules (`initSessionState`, `replyRunRegistry`, `persistSessionUsageUpdate`, session-accessor store, `evaluateSessionFreshness`) driven by a plain Node/tsx script against a real temp state dir (isolated `OPENCLAW_STATE_DIR`), no vitest, no mocks.

Transcript (verbatim, machine paths redacted to `/tmp/...`):

```
state dir: /tmp/pr111351-proof-yGOn5W
PASS  seed: tombstone persisted with updatedAt=0  {"sessionId":"proof-tombstone-session","updatedAt":0}
PASS  freshness: { fresh: false } with no staleReason (tombstone shape)  {"fresh":false}
PASS  (i) rollover deferred while run active: isNewSession=false  {"isNewSession":false,"sessionId":"proof-tombstone-session","previousSessionEntry":null}
PASS  (i) marker survives deferral write: updatedAt still 0  {"updatedAt":0}
PASS  (i) no transcript archive/reset artifacts while deferred  {"archived":[]}
PASS  (ii) marker survives bookkeeping usage write: updatedAt still 0  {"updatedAt":0,"inputTokens":12,"outputTokens":4}
PASS  (iii) rollover proceeds after run completes: isNewSession=true  {"isNewSession":true,"resetTriggered":false,"previousSessionEntrySessionId":"proof-tombstone-session"}
PASS  (iii) marker consumed by true reset: updatedAt > 0  {"updatedAt":1787838361364,"sessionId":"proof-tombstone-session","lifecycleRevision":"3454bc58-f4df-44f0-9d36-64c5b65cbcb0"}
PASS  (d) lifecycle identity rotated on rollover  {"after":"3454bc58-f4df-44f0-9d36-64c5b65cbcb0"}
PASS  live transcript file preserved on disk  {"path":"/tmp/pr111351-proof-yGOn5W/proof-tombstone-session.jsonl"}
PROOF RESULT: ALL CHECKS PASSED
```

Exact-head test results (all green): `session.test.ts` 179/179, `reset-policy.test.ts` + `reset.test.ts` green, plus the PR-touched suites `sessions-patch.test.ts`, `session-snapshot-merge.test.ts`, `session-accessor.sqlite-replacement-projection.test.ts`, `store-maintenance-recent-preservation.test.ts`, `commands-session-store.test.ts`, `commands-name.test.ts`, `agent-session-patch.test.ts`, `doctor-main-session-recovery.test.ts`, `doctor-state-integrity.test.ts` — 6 Vitest shards passed total. `oxlint` 0 errors on all 68 changed files; `pnpm tsgo:core` clean. Net diff vs `origin/main` touches exactly the original 68 files.
