### PR TITLE
docs: link macOS onboarding to app download

### DIFF
--- a/docs/start/onboarding.md
+++ b/docs/start/onboarding.md
@@ -12,6 +12,12 @@ verified AI backend, grant permissions, and hand off to the agent's own
 bootstrap ritual.
 For CLI onboarding and a comparison of both paths, see [Onboarding Overview](/start/onboarding-overview).
 
+<Tip>
+Don't have the app yet? Follow the
+[macOS app download instructions](/platforms/macos#download), then return here
+for first-run setup.
+</Tip>
+
 <Steps>
 <Step title="Approve macOS warning">
 <Frame>


### PR DESCRIPTION
Closes #111338

AI-assisted: Codex. I reviewed the change and understand its behavior and scope.

## What Problem This Solves

Fixes an issue where first-time macOS app users would reach the onboarding guide without a route to download the app first.

## Why This Change Was Made

The onboarding page now includes a short preflight tip linking to the canonical macOS download section. Release asset details remain centralized on the macOS platform page instead of being duplicated.

## User Impact

Readers can move directly from onboarding to the supported macOS app download guidance, then return to the first-run steps.

## Evidence

- Confirmed the current English and Chinese onboarding pages have no app-download handoff before the first-run steps.
- Confirmed `/platforms/macos#download` is the canonical page and anchor for `.dmg` and `.zip` guidance.
- `pnpm docs:list` — passed.
- `pnpm docs:check-mdx` — passed for 744 files.
- `pnpm docs:check-links:anchors` — passed under Node 24.15.0. The first attempt under Node 25.9.0 was rejected because Mintlify does not support Node 25+.
- `pnpm docs:check-i18n-glossary` — passed.
- `./node_modules/.bin/oxfmt --check docs/start/onboarding.md` — passed.
- `git diff --check origin/main...HEAD` — passed.

Localized output was not generated in this checkout because repository policy keeps translated docs in the separate publish repository; this PR changes the English source consumed by that pipeline.
