### PR TITLE
fix(ai): honor Retry-After when retry-after-ms is unparseable

### DIFF
--- a/packages/ai/src/providers/openai-chatgpt-responses.retry.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.retry.test.ts
@@ -98,38 +98,28 @@ describe("streamOpenAICodexResponses retry classification", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  function stubRetryThenFail(headers: Record<string, string>): {
-    fetchMock: ReturnType<typeof vi.fn<typeof fetch>>;
-    delays: number[];
-  } {
-    const fetchMock = vi
-      .fn<typeof fetch>()
-      .mockResolvedValueOnce(new Response("rate limited", { status: 429, headers }))
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ error: { message: "Invalid credentials" } }), {
-          status: 401,
-        }),
-      );
-    vi.stubGlobal("fetch", fetchMock);
-    const delays: number[] = [];
-    vi.spyOn(globalThis, "setTimeout").mockImplementation((callback: TimerHandler, ms?: number) => {
-      delays.push(ms ?? 0);
-      if (typeof callback === "function") {
-        callback();
-      }
-      return 0 as unknown as ReturnType<typeof setTimeout>;
-    });
-    return { fetchMock, delays };
-  }
-
   it.each([
     { label: "unparseable", retryAfterMs: "not-a-number" },
     { label: "empty", retryAfterMs: "" },
   ])("honors retry-after when retry-after-ms is $label", async ({ retryAfterMs }) => {
-    const { fetchMock, delays } = stubRetryThenFail({
-      "retry-after-ms": retryAfterMs,
-      "retry-after": "7",
-    });
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response("rate limited", {
+          status: 429,
+          headers: { "retry-after-ms": retryAfterMs, "retry-after": "7" },
+        }),
+      )
+      .mockRejectedValueOnce(new Error("usage limit: stop after retry delay"));
+    vi.stubGlobal("fetch", fetchMock);
+    const setTimeoutSpy = vi
+      .spyOn(globalThis, "setTimeout")
+      .mockImplementation((callback: TimerHandler) => {
+        if (typeof callback === "function") {
+          callback();
+        }
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      });
 
     await streamOpenAICodexResponses(model, context, {
       apiKey: jwt,
@@ -137,23 +127,7 @@ describe("streamOpenAICodexResponses retry classification", () => {
     }).result();
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(delays).toContain(7_000);
-  });
-
-  it("prefers a parseable retry-after-ms over retry-after", async () => {
-    const { fetchMock, delays } = stubRetryThenFail({
-      "retry-after-ms": "2500",
-      "retry-after": "7",
-    });
-
-    await streamOpenAICodexResponses(model, context, {
-      apiKey: jwt,
-      transport: "sse",
-    }).result();
-
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(delays).toContain(2_500);
-    expect(delays).not.toContain(7_000);
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 7_000);
   });
 
   it("does not retry a bodyless 304 response", async () => {

--- a/packages/ai/src/providers/openai-chatgpt-responses.retry.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.retry.test.ts
@@ -98,6 +98,64 @@ describe("streamOpenAICodexResponses retry classification", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  function stubRetryThenFail(headers: Record<string, string>): {
+    fetchMock: ReturnType<typeof vi.fn<typeof fetch>>;
+    delays: number[];
+  } {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response("rate limited", { status: 429, headers }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: { message: "Invalid credentials" } }), {
+          status: 401,
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    const delays: number[] = [];
+    vi.spyOn(globalThis, "setTimeout").mockImplementation((callback: TimerHandler, ms?: number) => {
+      delays.push(ms ?? 0);
+      if (typeof callback === "function") {
+        callback();
+      }
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    });
+    return { fetchMock, delays };
+  }
+
+  it.each([
+    { label: "unparseable", retryAfterMs: "not-a-number" },
+    { label: "empty", retryAfterMs: "" },
+  ])("honors retry-after when retry-after-ms is $label", async ({ retryAfterMs }) => {
+    const { fetchMock, delays } = stubRetryThenFail({
+      "retry-after-ms": retryAfterMs,
+      "retry-after": "7",
+    });
+
+    await streamOpenAICodexResponses(model, context, {
+      apiKey: jwt,
+      transport: "sse",
+    }).result();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(delays).toContain(7_000);
+  });
+
+  it("prefers a parseable retry-after-ms over retry-after", async () => {
+    const { fetchMock, delays } = stubRetryThenFail({
+      "retry-after-ms": "2500",
+      "retry-after": "7",
+    });
+
+    await streamOpenAICodexResponses(model, context, {
+      apiKey: jwt,
+      transport: "sse",
+    }).result();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(delays).toContain(2_500);
+    expect(delays).not.toContain(7_000);
+  });
+
   it("does not retry a bodyless 304 response", async () => {
     const fetchMock = vi
       .fn<typeof fetch>()

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -147,12 +147,12 @@ function isRetryableError(status: number, errorText: string): boolean {
 function resolveHttpRetryDelayMs(response: Response, attempt: number): number {
   const fallbackMs = BASE_DELAY_MS * 2 ** attempt;
   const retryAfterMs = response.headers.get("retry-after-ms");
-  if (retryAfterMs !== null) {
+  if (retryAfterMs) {
     const trimmed = retryAfterMs.trim();
     const millis = Number(trimmed);
-    return /^\d+(?:\.\d+)?$/.test(trimmed) && Number.isFinite(millis)
-      ? (clampTimerTimeoutMs(millis, 0) ?? fallbackMs)
-      : fallbackMs;
+    if (/^\d+(?:\.\d+)?$/.test(trimmed) && Number.isFinite(millis)) {
+      return clampTimerTimeoutMs(millis, 0) ?? fallbackMs;
+    }
   }
 
   const retryAfter = response.headers.get("retry-after");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users on ChatGPT (Codex) models would hit repeated rate-limit
failures when the server asked them to wait a specific amount of time. When a 429
response carries a `retry-after-ms` value the client cannot parse, the server's
valid `Retry-After` header sitting next to it is discarded, and the client retries
on its own short exponential schedule instead. It gets rate-limited again, burns
its remaining attempts well inside the server's cooldown window, and surfaces a
rate-limit error for a turn the server had told it to simply wait out.

## Why This Change Was Made

`retry-after-ms` and `Retry-After` are ordered preferences, not exclusive
alternatives: the millisecond header is preferred when usable, otherwise the
seconds header applies. The retry path treated the mere *presence* of
`retry-after-ms` as the decision point and returned before ever reading
`Retry-After`, so an unparseable value — or an empty string, which is present but
carries no information — silently downgraded the wait to blind backoff.

This aligns the path with `parseRetryAfterSeconds` in
`src/agents/provider-transport-fetch.ts:465`, which handles the same two-header
protocol and falls through to `Retry-After` when `retry-after-ms` fails to parse.
The fix adopts that shape exactly: return only on a successful parse.

Scope is deliberately narrow. Precedence is unchanged, a parseable
`retry-after-ms` still wins, and the existing clamp and HTTP-date handling are
untouched. The behavior predates the extraction of this helper in #110655; the
refactor preserved it faithfully rather than introducing it.

## User Impact

On rate-limited ChatGPT Responses turns, the client now waits as long as the
server asked whenever the server communicated that in either header. Sessions
that previously failed with a rate-limit error during a provider cooldown now
recover on their own. Users who never receive a malformed `retry-after-ms` see no
change.

## Evidence

**Real-behavior proof — no mocks, no fake timers, real socket, real wall clock.**

A genuine `node:http` server answers the first request with `429`,
`retry-after-ms: not-a-number`, `retry-after: 3`, and the real
`streamOpenAICodexResponses` is driven against it via `tsx`. The measured gap is
the actual elapsed time between the two inbound requests observed by the server:

Before (this branch with the source change reverted):

```
server requests observed : 2
measured retry gap (ms)  : 1016
stopReason               : error

FAIL - ignored Retry-After, used blind backoff (gap 1016ms)
```

After:

```
server requests observed : 2
measured retry gap (ms)  : 3018
stopReason               : error

PASS - honored the server's Retry-After: 3 (gap 3018ms)
```

1016 ms is `BASE_DELAY_MS * 2 ** 0` — the blind fallback. 3018 ms is the server's
instruction.

**Regression tests.** Three cases added to the existing suite: an unparseable
`retry-after-ms`, an empty one, and a guard that a parseable `retry-after-ms`
still takes precedence over a conflicting `Retry-After`.

The new tests are load-bearing. Reverting only the source change (test file
untouched) turns them red with exactly the symptom described above:

```
× honors retry-after when retry-after-ms is 'unparseable'
× honors retry-after when retry-after-ms is 'empty'

AssertionError: expected [ 1000 ] to include 7000
```

**Local checks.** `openai-chatgpt-responses.retry.test.ts` and
`openai-chatgpt-responses.test.ts`: 42 passed. `oxlint` clean, `oxfmt --check`
clean, `check-max-lines-ratchet` clean (the helper's line count is unchanged).

AI-assisted.