### PR TITLE
docs: link macOS onboarding pages to app download

### DIFF
--- a/docs/start/onboarding-overview.md
+++ b/docs/start/onboarding-overview.md
@@ -16,13 +16,13 @@ detailed setup.
 
 ## Which path should I use?
 
-|                | CLI onboarding                         | macOS app onboarding           |
-| -------------- | -------------------------------------- | ------------------------------ |
-| **Platforms**  | macOS, Linux, Windows (native or WSL2) | macOS only                     |
-| **Interface**  | Inference setup, then OpenClaw         | Inference setup, then OpenClaw |
-| **Best for**   | Servers, headless, full control        | Desktop Mac, visual setup      |
-| **Automation** | `--non-interactive` for scripts        | Manual only                    |
-| **Command**    | `openclaw onboard`                     | Launch the app                 |
+|                | CLI onboarding                         | macOS app onboarding                                          |
+| -------------- | -------------------------------------- | ------------------------------------------------------------- |
+| **Platforms**  | macOS, Linux, Windows (native or WSL2) | macOS only                                                    |
+| **Interface**  | Inference setup, then OpenClaw         | Inference setup, then OpenClaw                                |
+| **Best for**   | Servers, headless, full control        | Desktop Mac, visual setup                                     |
+| **Automation** | `--non-interactive` for scripts        | Manual only                                                   |
+| **Command**    | `openclaw onboard`                     | [Download the app](/platforms/macos#download), then launch it |
 
 Most users should start with **CLI onboarding** — it works everywhere and gives
 you the most control.
@@ -81,7 +81,7 @@ CLI command docs: [`openclaw onboard`](/cli/onboard)
 
 ## macOS app onboarding
 
-Open the OpenClaw app. If its configured local or remote Gateway is reachable
+Download the macOS app from the [macOS app download page](/platforms/macos#download), then open it. If its configured local or remote Gateway is reachable
 and the default agent already has a configured model, the app skips onboarding
 and OpenClaw and opens the normal agent UI immediately.
 

--- a/docs/start/onboarding-overview.md
+++ b/docs/start/onboarding-overview.md
@@ -81,7 +81,8 @@ CLI command docs: [`openclaw onboard`](/cli/onboard)
 
 ## macOS app onboarding
 
-Download the macOS app from the [macOS app download page](/platforms/macos#download), then open it. If its configured local or remote Gateway is reachable
+[Download the macOS app](/platforms/macos#download), then open it. If its
+configured local or remote Gateway is reachable
 and the default agent already has a configured model, the app skips onboarding
 and OpenClaw and opens the normal agent UI immediately.
 

--- a/docs/start/onboarding.md
+++ b/docs/start/onboarding.md
@@ -12,6 +12,12 @@ verified AI backend, grant permissions, and hand off to the agent's own
 bootstrap ritual.
 For CLI onboarding and a comparison of both paths, see [Onboarding Overview](/start/onboarding-overview).
 
+<Tip>
+Don't have the app yet? Follow the
+[macOS app download instructions](/platforms/macos#download), then return here
+for first-run setup.
+</Tip>
+
 <Steps>
 <Step title="Approve macOS warning">
 <Frame>

--- a/docs/start/onboarding.md
+++ b/docs/start/onboarding.md
@@ -13,9 +13,8 @@ bootstrap ritual.
 For CLI onboarding and a comparison of both paths, see [Onboarding Overview](/start/onboarding-overview).
 
 <Tip>
-Don't have the app yet? Follow the
-[macOS app download instructions](/platforms/macos#download), then return here
-for first-run setup.
+Need the app first? [Download OpenClaw for macOS](/platforms/macos#download),
+then return here for first-run setup.
 </Tip>
 
 <Steps>


### PR DESCRIPTION
## What Problem This Solves

Closes #111338
First-time macOS users reaching the onboarding guide cannot find where to download the app. Both entry points (`/start/onboarding` and `/start/onboarding-overview`) assume the app is already installed without providing a download route.

## Why This Change Was Made

The macOS platform page (`/platforms/macos#download`) already contains canonical download instructions (GitHub Releases `.dmg`/`.zip` guidance). The onboarding pages should link to it rather than duplicate release-asset details. This aligns with the Codex review verdict: "Add a concise, localized preface or callout in `docs/start/onboarding.md` that links first-time macOS users to the canonical macOS download instructions, then keep release-asset details centralized in `docs/platforms/macos.md`."

Changes:

- **`docs/start/onboarding.md`**: Added a `<Tip>` before the `<Steps>` component linking to `/platforms/macos#download`, matching the `<Tip>` pattern used in `getting-started.md` and other `docs/start/` pages.
- **`docs/start/onboarding-overview.md`**: Updated the comparison table's macOS "Command" row from "Launch the app" to include a download link, and added the same download link to the macOS section opening sentence. This fixes the same gap at the overview entry point, which PR #111352 leaves unaddressed.

## User Impact

Readers of either the macOS onboarding page or the onboarding overview page can now navigate directly to the supported macOS app download guidance before following first-run steps. Chinese-language users at `/zh-CN/start/onboarding` will receive the same handoff once the publish pipeline syncs the English source.

## Evidence

- Confirmed the current English and Chinese onboarding pages have no app-download handoff before the first-run steps.
- Confirmed `/platforms/macos#download` is the canonical page and anchor for download guidance (`docs/platforms/macos.md:18` has `## Download`).
- `pnpm docs:list` — passed.
- `pnpm docs:check-mdx` — passed (744 files).
- `pnpm docs:check-i18n-glossary` — passed.
- `oxfmt --check docs/start/onboarding.md docs/start/onboarding-overview.md` — passed.
- `git diff --check` — passed.
Localized output is not generated in this checkout; translated docs live in the separate publish repo and sync from this English source.
