### PR TITLE
fix: unblock main CI — duplicate instanceId getter + pr-ci-sweeper lookback time-bomb

### DIFF
--- a/scripts/github/pr-ci-sweeper.d.mts
+++ b/scripts/github/pr-ci-sweeper.d.mts
@@ -16,4 +16,5 @@ export function runPrCiSweeper(params: {
   core: Pick<Console, "info"> & { setFailed: (message: string) => void };
   dryRun?: boolean;
   appSlug?: string;
+  now?: number;
 }): Promise<Array<{ number: number; sha: string; action: "refire" | "skip"; reason: string }>>;

--- a/scripts/github/pr-ci-sweeper.mjs
+++ b/scripts/github/pr-ci-sweeper.mjs
@@ -131,13 +131,19 @@ async function reopenWithRetry({ github, core, owner, repo, pullNumber }) {
   return false;
 }
 
-export async function runPrCiSweeper({ github, context, core, dryRun = false, appSlug = "" }) {
+export async function runPrCiSweeper({
+  github,
+  context,
+  core,
+  dryRun = false,
+  appSlug = "",
+  now = Date.now(),
+}) {
   const sweeperLogins = new Set(KNOWN_SWEEPER_LOGINS);
   if (appSlug) {
     sweeperLogins.add(`${appSlug}[bot]`);
   }
   const { owner, repo } = context.repo;
-  const now = Date.now();
   const results = [];
   let refires = 0;
   const openPrs = await github.paginate(github.rest.pulls.list, {

--- a/test/scripts/pr-ci-sweeper.test.ts
+++ b/test/scripts/pr-ci-sweeper.test.ts
@@ -210,6 +210,7 @@ describe("runPrCiSweeper", () => {
       core: core as never,
       dryRun: true,
       appSlug: "openclaw-barnacle",
+      now: NOW,
     });
     expect(results).toEqual([
       { number: 7, sha: "a".repeat(12), action: "refire", reason: "ci-startup-failure" },
@@ -230,6 +231,7 @@ describe("runPrCiSweeper", () => {
       context: context as never,
       core: core as never,
       appSlug: "openclaw-barnacle",
+      now: NOW,
     });
     expect(results).toEqual([
       { number: 9, sha: "c".repeat(12), action: "refire", reason: "ci-run-missing" },


### PR DESCRIPTION
## What Problem This Solves

`main` CI is fully red. `ui/src/api/gateway.ts` declares the `instanceId` getter **twice** (`TS2300: Duplicate identifier`), failing `check-prod-types`, `check-test-types`, `check-lint`, `check-additional-boundaries-a`, `QA Smoke CI`, and the compact shards — i.e. every downstream job that typechecks/builds the UI. This blocks all PR landings.

## Why This Change Was Made

Two independently-merged PRs each added an identical `get instanceId()` to `GatewayApi`:
- #111225 (watched-sessions presence / facepiles)
- #110831 (iOS clients: model controls, session management)

Git merged them without a textual conflict (the getters sit in different spots), but the result declares the same class member twice. Both bodies are identical (`return this.opts.instanceId`), so this is a pure duplicate — remove one. The earlier declaration carries the explicit `: string | undefined` return type, so that one is kept.

## User Impact

None functional — restores green CI so PRs can land again. No behavior change; the getter returns the same value.

## Evidence

- Root error (main run [29682581701](https://github.com/openclaw/openclaw/actions/runs/29682581701)): `ui/src/api/gateway.ts(364,7): error TS2300: Duplicate identifier 'instanceId'` and oxlint `Identifier 'instanceId' has already been declared` at 364:7.
- main was green at `cfe4096db` and went red at `5c9916950` (#111225), staying red through #110831 — the two PRs that added the getter.
- Fix: delete the untyped duplicate getter (4-line deletion), keep the typed one.

---

## Second breakage (same red main): pr-ci-sweeper lookback time-bomb

After the duplicate-getter fix, `checks-node-compact-large-6` still failed on `test/scripts/pr-ci-sweeper.test.ts` — independent and also pre-existing. `runPrCiSweeper` hardcoded `Date.now()` for its 24h lookback, but the tests build PR fixtures at `NOW - 2h` with `NOW` pinned to `2026-07-18T12:00:00Z`. Once real wall-clock crossed ~24h past that pin (today, 2026-07-19), the fixtures aged out of the lookback window and two assertions flipped from `refire` to `skip / outside-lookback`.

Fix: thread an injectable `now` (default `Date.now()`) into `runPrCiSweeper` — exactly the seam `classifyPrForSweep` already has — and pin the two `runPrCiSweeper` tests to `NOW`. Behavior in production is unchanged (defaults to real time). `test/scripts/pr-ci-sweeper.test.ts` now 14/14 green (`node scripts/run-vitest.mjs`).
