### PR TITLE
fix(infra): release exec-approvals locks across VirtioFS identity drift

### DIFF
--- a/src/infra/exec-approvals-lock.ts
+++ b/src/infra/exec-approvals-lock.ts
@@ -87,17 +87,83 @@ function sleepExecApprovalsSyncLockRetry(): void {
   }
 }
 
+function syncLockPayloadMatchesStablePath(lock: ExecApprovalsSyncLock): boolean {
+  const expected = Buffer.from(lock.raw, "utf8");
+  let descriptor: number | undefined;
+  try {
+    const before = fs.lstatSync(lock.lockPath);
+    if (!before.isFile() || before.size !== expected.byteLength) {
+      return false;
+    }
+    const openFlags =
+      fs.constants.O_RDONLY |
+      (process.platform !== "win32" && typeof fs.constants.O_NOFOLLOW === "number"
+        ? fs.constants.O_NOFOLLOW
+        : 0) |
+      (typeof fs.constants.O_NONBLOCK === "number" ? fs.constants.O_NONBLOCK : 0);
+    descriptor = fs.openSync(lock.lockPath, openFlags);
+    const opened = fs.fstatSync(descriptor);
+    if (!opened.isFile() || opened.size !== expected.byteLength) {
+      return false;
+    }
+
+    // Read at most one byte beyond the owned payload so a raced replacement
+    // cannot force an unbounded allocation before ownership fails closed.
+    const current = Buffer.allocUnsafe(expected.byteLength + 1);
+    let bytesRead = 0;
+    while (bytesRead < current.byteLength) {
+      const count = fs.readSync(
+        descriptor,
+        current,
+        bytesRead,
+        current.byteLength - bytesRead,
+        bytesRead,
+      );
+      if (count === 0) {
+        break;
+      }
+      bytesRead += count;
+    }
+
+    const after = fs.lstatSync(lock.lockPath);
+    return (
+      after.isFile() &&
+      before.dev === after.dev &&
+      before.ino === after.ino &&
+      after.size === expected.byteLength &&
+      bytesRead === expected.byteLength &&
+      expected.equals(current.subarray(0, bytesRead))
+    );
+  } catch {
+    return false;
+  } finally {
+    if (descriptor !== undefined) {
+      try {
+        fs.closeSync(descriptor);
+      } catch {
+        // Best-effort verification cleanup; retaining the sidecar fails closed.
+      }
+    }
+  }
+}
+
 function removeOwnedExecApprovalsLock(
   lock: ExecApprovalsSyncLock,
   options: { requirePayloadMatch: boolean },
 ): void {
   try {
-    const current = fs.lstatSync(lock.lockPath);
-    if (
-      current.dev === lock.device &&
-      current.ino === lock.inode &&
-      (!options.requirePayloadMatch || fs.readFileSync(lock.lockPath, "utf8") === lock.raw)
-    ) {
+    // Normal release uses the per-acquisition nonce in the exact payload, so
+    // acquisition-fd/path drift cannot strand a lock. Pin the current pathname
+    // during its bounded read; failed-write cleanup keeps the acquisition
+    // identity check because the expected payload may be partial.
+    let stillOwned: boolean;
+    if (options.requirePayloadMatch) {
+      stillOwned = syncLockPayloadMatchesStablePath(lock);
+    } else {
+      const current = fs.lstatSync(lock.lockPath);
+      stillOwned = current.dev === lock.device && current.ino === lock.inode;
+    }
+    if (stillOwned) {
       fs.rmSync(lock.lockPath, { force: true });
     }
   } catch {

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { once } from "node:events";
 // Covers exec approvals store socket interactions.
 import fs from "node:fs";
+import fsp from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -96,6 +97,18 @@ function createHomeDir(): string {
   deleteTestEnvValue("OPENCLAW_PROFILE");
   deleteTestEnvValue("OPENCLAW_STATE_DIR");
   return dir;
+}
+
+function differentInode(inode: number): number;
+function differentInode(inode: bigint): bigint;
+function differentInode(inode: number | bigint): number | bigint;
+function differentInode(inode: number | bigint): number | bigint {
+  // Windows file indexes can exceed Number.MAX_SAFE_INTEGER, so `inode + 1`
+  // is not guaranteed to produce an observable identity change.
+  if (typeof inode === "bigint") {
+    return inode === 1n ? 2n : 1n;
+  }
+  return inode === 1 ? 2 : 1;
 }
 
 function approvalsFilePath(homeDir: string): string {
@@ -300,6 +313,271 @@ describe("exec approvals store helpers", () => {
         await once(child, "exit");
       }
     }
+  });
+
+  it("releases sync locks across descriptor and pathname identity drift", () => {
+    const dir = createHomeDir();
+    ensureExecApprovals();
+    const lockPath = `${approvalsFilePath(dir)}.lock`;
+    const realLstatSync = fs.lstatSync.bind(fs);
+    let identityDriftObserved = false;
+    vi.spyOn(fs, "lstatSync").mockImplementation((...args) => {
+      const stat = realLstatSync(...args) as fs.Stats;
+      if (String(args[0]) !== lockPath) {
+        return stat;
+      }
+      const inode = differentInode(stat.ino);
+      identityDriftObserved = inode !== stat.ino;
+      return Object.assign(Object.create(Object.getPrototypeOf(stat)), stat, {
+        ino: inode,
+      }) as fs.Stats;
+    });
+
+    saveExecApprovals({
+      version: 1,
+      defaults: { security: "allowlist" },
+      agents: {},
+    });
+
+    expect(identityDriftObserved).toBe(true);
+    expect(fs.existsSync(lockPath)).toBe(false);
+    expect(loadExecApprovals().defaults?.security).toBe("allowlist");
+    expect(fs.existsSync(lockPath)).toBe(false);
+    expect(loadExecApprovals().defaults?.security).toBe("allowlist");
+    expect(fs.existsSync(lockPath)).toBe(false);
+  });
+
+  it("keeps a replacement sync sidecar after the owner descriptor closes", () => {
+    const dir = createHomeDir();
+    ensureExecApprovals();
+    const lockPath = `${approvalsFilePath(dir)}.lock`;
+    let lockDescriptor: number | undefined;
+    let replacementRaw: string | undefined;
+    const realWriteFileSync = fs.writeFileSync.bind(fs);
+    vi.spyOn(fs, "writeFileSync").mockImplementation(
+      (...args: Parameters<typeof fs.writeFileSync>) => {
+        const [target, contents] = args;
+        if (
+          typeof target === "number" &&
+          typeof contents === "string" &&
+          contents.includes('"nonce"')
+        ) {
+          lockDescriptor = target;
+        }
+        return realWriteFileSync(...args);
+      },
+    );
+    const realCloseSync = fs.closeSync.bind(fs);
+    vi.spyOn(fs, "closeSync").mockImplementation((descriptor) => {
+      realCloseSync(descriptor);
+      if (descriptor === lockDescriptor && replacementRaw === undefined) {
+        const current = JSON.parse(fs.readFileSync(lockPath, "utf8")) as Record<string, unknown>;
+        replacementRaw = `${JSON.stringify({ ...current, nonce: crypto.randomUUID() }, null, 2)}\n`;
+        fs.rmSync(lockPath, { force: true });
+        fs.writeFileSync(lockPath, replacementRaw, "utf8");
+      }
+    });
+
+    saveExecApprovals({
+      version: 1,
+      defaults: { security: "allowlist" },
+      agents: {},
+    });
+
+    expect(lockDescriptor).toBeDefined();
+    expect(replacementRaw).toBeDefined();
+    expect(fs.readFileSync(lockPath, "utf8")).toBe(replacementRaw);
+    fs.rmSync(lockPath, { force: true });
+  });
+
+  it("retains a sync sidecar when its pathname changes during release verification", () => {
+    const dir = createHomeDir();
+    ensureExecApprovals();
+    const lockPath = `${approvalsFilePath(dir)}.lock`;
+    const realLstatSync = fs.lstatSync.bind(fs);
+    let lockPathReads = 0;
+    let identityDriftObserved = false;
+    vi.spyOn(fs, "lstatSync").mockImplementation((...args) => {
+      const stat = realLstatSync(...args) as fs.Stats;
+      if (String(args[0]) !== lockPath) {
+        return stat;
+      }
+      lockPathReads += 1;
+      if (lockPathReads === 1) {
+        return stat;
+      }
+      const inode = differentInode(stat.ino);
+      identityDriftObserved = inode !== stat.ino;
+      return Object.assign(Object.create(Object.getPrototypeOf(stat)), stat, {
+        ino: inode,
+      }) as fs.Stats;
+    });
+
+    saveExecApprovals({
+      version: 1,
+      defaults: { security: "allowlist" },
+      agents: {},
+    });
+
+    expect(lockPathReads).toBe(2);
+    expect(identityDriftObserved).toBe(true);
+    expect(fs.existsSync(lockPath)).toBe(true);
+    expect(loadExecApprovals().defaults?.security).toBe("deny");
+    fs.rmSync(lockPath, { force: true });
+  });
+
+  it("bounds sync release reads when the sidecar grows after verification opens it", () => {
+    const dir = createHomeDir();
+    ensureExecApprovals();
+    const lockPath = `${approvalsFilePath(dir)}.lock`;
+    let expectedBytes: number | undefined;
+    let verificationDescriptor: number | undefined;
+    let sidecarGrew = false;
+    const verificationReadLengths: number[] = [];
+    const realWriteFileSync = fs.writeFileSync.bind(fs);
+    vi.spyOn(fs, "writeFileSync").mockImplementation(
+      (...args: Parameters<typeof fs.writeFileSync>) => {
+        const [target, contents] = args;
+        if (
+          typeof target === "number" &&
+          typeof contents === "string" &&
+          contents.includes('"nonce"')
+        ) {
+          expectedBytes = Buffer.byteLength(contents, "utf8");
+        }
+        return realWriteFileSync(...args);
+      },
+    );
+    const realOpenSync = fs.openSync.bind(fs);
+    vi.spyOn(fs, "openSync").mockImplementation((...args) => {
+      const descriptor = realOpenSync(...args);
+      if (String(args[0]) === lockPath && typeof args[1] === "number") {
+        verificationDescriptor = descriptor;
+      }
+      return descriptor;
+    });
+    const realFstatSync = fs.fstatSync.bind(fs);
+    vi.spyOn(fs, "fstatSync").mockImplementation((...args) => {
+      const stat = realFstatSync(...args) as fs.Stats;
+      if (args[0] === verificationDescriptor && !sidecarGrew) {
+        fs.appendFileSync(lockPath, " ".repeat(1024 * 1024), "utf8");
+        sidecarGrew = true;
+      }
+      return stat;
+    });
+    const realReadSync = fs.readSync.bind(fs);
+    vi.spyOn(fs, "readSync").mockImplementation(((
+      descriptor: number,
+      buffer: NodeJS.ArrayBufferView,
+      offset: number,
+      length: number,
+      position: number | null,
+    ) => {
+      if (descriptor === verificationDescriptor) {
+        verificationReadLengths.push(length);
+      }
+      return realReadSync(descriptor, buffer, offset, length, position);
+    }) as typeof fs.readSync);
+
+    saveExecApprovals({
+      version: 1,
+      defaults: { security: "allowlist" },
+      agents: {},
+    });
+
+    expect(expectedBytes).toBeDefined();
+    expect(verificationDescriptor).toBeDefined();
+    expect(sidecarGrew).toBe(true);
+    expect(verificationReadLengths.length).toBeGreaterThan(0);
+    expect(Math.max(...verificationReadLengths)).toBeLessThanOrEqual((expectedBytes ?? 0) + 1);
+    expect(fs.statSync(lockPath).size).toBeGreaterThan(expectedBytes ?? 0);
+    fs.rmSync(lockPath, { force: true });
+  });
+
+  it("retains a partial sync sidecar when failed-write identity cannot be proven", () => {
+    const dir = createHomeDir();
+    ensureExecApprovals();
+    const lockPath = `${approvalsFilePath(dir)}.lock`;
+    const realLstatSync = fs.lstatSync.bind(fs);
+    let identityDriftObserved = false;
+    vi.spyOn(fs, "lstatSync").mockImplementation((...args) => {
+      const stat = realLstatSync(...args) as fs.Stats;
+      if (String(args[0]) !== lockPath) {
+        return stat;
+      }
+      const inode = differentInode(stat.ino);
+      identityDriftObserved = inode !== stat.ino;
+      return Object.assign(Object.create(Object.getPrototypeOf(stat)), stat, {
+        ino: inode,
+      }) as fs.Stats;
+    });
+    const realWriteFileSync = fs.writeFileSync.bind(fs);
+    let failedLockWrite = false;
+    vi.spyOn(fs, "writeFileSync").mockImplementation(
+      (...args: Parameters<typeof fs.writeFileSync>) => {
+        const [target, contents] = args;
+        if (
+          !failedLockWrite &&
+          typeof target === "number" &&
+          typeof contents === "string" &&
+          contents.includes('"nonce"')
+        ) {
+          failedLockWrite = true;
+          realWriteFileSync(target, '{"pid":', "utf8");
+          throw Object.assign(new Error("injected partial lock write"), { code: "EIO" });
+        }
+        return realWriteFileSync(...args);
+      },
+    );
+
+    expect(() =>
+      saveExecApprovals({
+        version: 1,
+        defaults: { security: "allowlist" },
+        agents: {},
+      }),
+    ).toThrow("injected partial lock write");
+
+    expect(failedLockWrite).toBe(true);
+    expect(identityDriftObserved).toBe(true);
+    expect(fs.readFileSync(lockPath, "utf8")).toBe('{"pid":');
+    expect(loadExecApprovals().defaults?.security).toBe("deny");
+    expect(fs.existsSync(lockPath)).toBe(true);
+    fs.rmSync(lockPath, { force: true });
+  });
+
+  it("releases async locks across descriptor and pathname identity drift", async () => {
+    const dir = createHomeDir();
+    ensureExecApprovals();
+    const lockPath = `${approvalsFilePath(dir)}.lock`;
+    const realLstat = fsp.lstat.bind(fsp);
+    let identityDriftObserved = false;
+    const lstatSpy = vi.spyOn(fsp, "lstat").mockImplementation(async (...args) => {
+      const stat = await realLstat(...args);
+      if (String(args[0]) !== lockPath) {
+        return stat;
+      }
+      const inode = differentInode(stat.ino);
+      identityDriftObserved = inode !== stat.ino;
+      return Object.assign(Object.create(Object.getPrototypeOf(stat)), stat, {
+        ino: inode,
+      });
+    });
+
+    try {
+      await updateExecApprovals({
+        update: (file) => ({
+          ...file,
+          defaults: { ...file.defaults, security: "allowlist" },
+        }),
+      });
+    } finally {
+      lstatSpy.mockRestore();
+    }
+
+    expect(identityDriftObserved).toBe(true);
+    expect(fs.existsSync(lockPath)).toBe(false);
+    expect(loadExecApprovals().defaults?.security).toBe("allowlist");
   });
 
   it("keeps custom-state approvals independent from the default state", async () => {


### PR DESCRIPTION
<!-- submission-timestamps:start -->
First submitted: July 19, 2026, 6:22 AM (US Eastern Time) / 10:22 UTC.
Last body edit: July 25, 2026, 10:16 AM (US Eastern Time) / 14:16 UTC.
Latest head commit: July 25, 2026, 10:11 AM (US Eastern Time) / 14:11 UTC.
<!-- submission-timestamps:end -->

## Summary

Fixes #106777 for the remaining synchronous exec-approvals lock path.

Current `main` already pins `@openclaw/fs-safe@0.4.7`, whose asynchronous sidecar release tolerates descriptor/path identity drift. This contribution keeps that shared async owner boundary intact and hardens the separate synchronous lock in `src/infra/exec-approvals-lock.ts`:

- persist a unique nonce in every synchronous sidecar;
- verify the exact nonce-bearing bytes through a bounded descriptor read before normal release;
- require a stable regular-file pathname across verification;
- retain changed, oversized, partial, or otherwise unprovable sidecars so authorization fails closed; and
- preserve acquisition `dev`/`ino` checks only for failed-write cleanup, where the expected payload may be incomplete.

The refreshed diff has one commit, two files, and no dependency, config, schema, API, or policy-format change.

## What Problem This Solves

On Docker Desktop VirtioFS and similar virtual filesystems, `fstat(fd)` and `lstat(path)` can report different identities for the same file. The old synchronous release treated that disagreement as loss of ownership and silently retained the live `exec-approvals.json.lock` sidecar. A later policy read then timed out and resolved to the fail-closed `security=deny` fallback, including for otherwise allowlisted commands.

Current `main` already fixes the asynchronous package-owned path. Without this contribution, synchronous reads and compatibility writes still depend on acquisition inode equality and can strand the same authorization store.

## User Impact

Completed synchronous policy reads and writes release their own sidecars after filesystem identity drift. Later reads return the configured policy instead of falling back to `deny` because of a stranded lock.

There is no configuration, command, policy-data, socket, or public TypeScript API migration.

## Implementation

- `src/infra/exec-approvals-lock.ts`
  - Stores the exact serialized nonce-bearing payload on the lock handle.
  - Uses `lstat -> open(O_NOFOLLOW | O_NONBLOCK) -> fstat -> bounded read -> lstat` for normal release verification.
  - Reads at most the expected payload length plus one byte.
  - Requires exact bytes and stable pathname identity before unlinking.
  - Keeps acquisition identity checks for partial or failed writes.
- `src/infra/exec-approvals-store.test.ts`
  - Covers descriptor/path identity drift without a stranded sync sidecar.
  - Covers exact-payload and nonce-changing replacements.
  - Covers pathname drift during release verification.
  - Grows a sidecar after the verification `fstat` gate and proves every read request is capped at `expected + 1`.
  - Covers ambiguous partial-write cleanup.
  - Uses deterministic `number`/`bigint` inode deltas so Windows precision cannot create false proof.
  - Retains asynchronous identity-drift coverage through `@openclaw/fs-safe@0.4.7`.

## Code-Path Analysis

- Runtime entries: `loadExecApprovals`, `saveExecApprovals`, `updateExecApprovals`, and `commitExecAuthorizationLocked` in `src/infra/exec-approvals-store.ts` and `src/infra/exec-approvals-authorization.ts`.
- Lock owner boundary: `src/infra/exec-approvals-lock.ts`.
- Policy file I/O boundary: `src/infra/exec-approvals-file-io.ts`.
- Async adapter: `src/plugin-sdk/file-lock.ts`, backed by `@openclaw/fs-safe/file-lock`.
- Key callers: `src/agents/bash-tools.exec.ts`, `src/gateway/server-methods/exec-approvals.ts`, and `src/security/audit.ts`.
- Stale-owner policy: `src/infra/stale-lock-file.ts`.
- Adjacent coverage: `src/infra/exec-approvals-store.test.ts`, `src/infra/file-lock.test.ts`, and `src/plugin-sdk/file-lock.test.ts`.

The synchronous and async paths intentionally remain separate because synchronous policy consumers cannot await the shared async lock manager. The change is scoped to the synchronous release contract instead of duplicating the current async implementation.

## Mainline And Branch Provenance

- Official default branch: `OpenClaw/OpenClaw:main`.
- Exact proof base: `cb628df1993a538129bcf0223ab86593b14bdb0f`.
- Exact proof head: `snowzlmbot/OpenClaw:fix/exec-approvals-async-lock@1ab4776051d71385dcd15f88786dd3fbf994a1d3`.
- The head is one commit directly on that recorded base.
- Latest upstream checked before this body update: `main@97c57585a1001552eb61060e36cb150fc958fb5f`.
- The one newer upstream commit does not touch either changed file; exact-base/head behavior and the focused test surface remain patch-identical.
- The fork default branch contains no contribution-specific commit.

## Dependency And Contract Verification

The locked [`@openclaw/fs-safe@0.4.7`](https://www.npmjs.com/package/@openclaw/fs-safe/v/0.4.7) source was inspected directly. Its async sidecar release verifies exact ownership bytes through bounded descriptor reads and stable pathname checks. This contribution applies the same ownership principle to OpenClaw's separate synchronous lock while retaining stricter acquisition-identity checks for incomplete writes.

Related shared implementation and evidence: [openclaw/fs-safe#45](https://github.com/openclaw/fs-safe/pull/45), [CI](https://github.com/openclaw/fs-safe/actions/runs/29793313095), and [coverage](https://github.com/openclaw/fs-safe/actions/runs/29793313003).

## Evidence

[Exact-SHA real FUSE before/after proof](https://github.com/snowzlmbot/openclaw/actions/runs/30161197719) completed successfully on a GitHub-hosted `ubuntu-24.04` runner with a real `fuse-overlayfs` mount (`fuseblk`). Both jobs checked out and verified immutable target SHAs.

- Before lane: `OpenClaw/OpenClaw@cb628df1993a538129bcf0223ab86593b14bdb0f`.
  - Async identity changed, its owned sidecar was removed, and the subsequent policy remained `allowlist`.
  - Sync identity changed, its sidecar remained after release, and the subsequent policy resolved to `deny`.
  - Proof job: [before - real FUSE consumer proof](https://github.com/snowzlmbot/openclaw/actions/runs/30161197719/job/89686684385).
- After lane: `snowzlmbot/OpenClaw@1ab4776051d71385dcd15f88786dd3fbf994a1d3`.
  - Async and sync identities changed, both owned sidecars were removed, and subsequent policy reads remained `allowlist`.
  - The focused `exec-approvals-store` regression suite passed on this exact head.
  - Proof job: [after - real FUSE consumer proof](https://github.com/snowzlmbot/openclaw/actions/runs/30161197719/job/89686684354).

Sanitized artifact excerpt:

```text
before: filesystem=fuseblk identity_changed=true sync_lock_present_after_release=true subsequent_read_security=deny result=passed
after:  filesystem=fuseblk identity_changed=true sync_lock_present_after_release=false subsequent_read_security=allowlist result=passed
```

The run uploads compact `before` and `after` proof logs named with their immutable target SHAs. No screenshot or video is necessary because the defect is a filesystem/state transition fully captured by the exact-SHA logs.

## Validation

- Exact-head focused regression suite in the FUSE workflow: passed.
- `oxfmt --check src/infra/exec-approvals-lock.ts src/infra/exec-approvals-store.test.ts`: passed.
- `oxlint src/infra/exec-approvals-lock.ts src/infra/exec-approvals-store.test.ts`: zero warnings and errors.
- `git diff --check`: passed.
- Independent final source review: no accepted or actionable finding remained after the bounded-growth, cross-platform inode, and union-type fixes.
- Upstream exact-head checks: in progress at the time of this body update; completed results remain authoritative on the Checks tab.

## Risk

- Authorization and availability: a false ownership decision can delete another owner's lock or strand a live lock. Exact payload equality plus stable-path verification keeps uncertain cases fail closed.
- Race handling: pathname, type, size, open/read, and byte-count changes retain the sidecar.
- Memory: the verifier allocates and reads at most the expected payload length plus one byte.
- Compatibility: `O_NOFOLLOW` is used only off Windows; failed or unsupported verification retains the lock.
- Performance: the payload is small, and the added synchronous metadata calls occur once during release.

## Rollback

Revert the single implementation/test commit. No configuration, schema, migration, dependency graph, or irreversible state change is involved. Existing sidecars are not rewritten.

## Docs Updated

No user documentation change is needed because there is no API, configuration, schema, or operator workflow change. Code comments, deterministic regressions, and exact-SHA proof cover the changed behavior.

## Related Issue / PR

- Fixes #106777.
- Builds on the nonce-based synchronous ownership design in #108971 while tightening release verification against path races and oversized replacements.
- Accounts for the async-path investigation in #111028; current `main` already carries the shared dependency fix.

## Labels Considered

`bug`, `P1`, and `impact:security` may be relevant because a stranded authorization lock turns later policy reads into fail-closed denials. Label assignment remains maintainer-owned.

## Not Tested / Limitations

- The public proof uses `fuse-overlayfs` on a GitHub-hosted Linux runner, not Docker Desktop VirtioFS on macOS.
- Windows behavior is covered by platform guards, deterministic number/bigint regressions, and repository CI rather than the FUSE lane.
- Non-cooperating same-directory writers remain outside the cooperative lock protocol; raced changes are retained fail closed.
