### PR TITLE
fix(browser): report final URL when opening managed Chrome tabs

### DIFF
--- a/extensions/browser/src/browser/cdp-page-session.test.ts
+++ b/extensions/browser/src/browser/cdp-page-session.test.ts
@@ -1,0 +1,32 @@
+// Browser tests cover CDP committed page-session URL observation.
+import { describe, expect, it } from "vitest";
+import { prepareCdpTargetSession } from "./cdp-page-session.js";
+import type { CdpSendFn } from "./cdp.helpers.js";
+
+describe("prepareCdpTargetSession", () => {
+  it("ignores Chrome's transient colon URL while navigation is settling", async () => {
+    let frameReadCount = 0;
+    const send: CdpSendFn = async (method) => {
+      if (method === "Target.attachToTarget") {
+        return { sessionId: "SESSION" };
+      }
+      if (method === "Page.getFrameTree") {
+        frameReadCount += 1;
+        return {
+          frameTree: {
+            frame:
+              frameReadCount <= 8
+                ? { loaderId: "LOADER_TRANSIENT", url: ":" }
+                : { loaderId: "LOADER_FINAL", url: "https://example.com/final" },
+          },
+        };
+      }
+      return {};
+    };
+
+    await expect(
+      prepareCdpTargetSession(send, "TARGET", "https://example.com/start"),
+    ).resolves.toBe("https://example.com/final");
+    expect(frameReadCount).toBeGreaterThan(8);
+  });
+});

--- a/extensions/browser/src/browser/cdp-page-session.ts
+++ b/extensions/browser/src/browser/cdp-page-session.ts
@@ -34,6 +34,10 @@ function readCommittedFrameUrl(
     return unreachableUrl;
   }
   const url = typeof frame?.url === "string" ? frame.url.trim() : "";
+  // Chrome reports ":" for the initial empty document before navigation commits.
+  if (url === ":") {
+    return undefined;
+  }
   const fragment = typeof frame?.urlFragment === "string" ? frame.urlFragment.trim() : "";
   return url ? `${url}${fragment}` : undefined;
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening a public URL with `openclaw browser open` and OpenClaw-managed Chrome could receive `opened: :` (or `"url": ":"` in JSON) even though the new tab successfully navigated to the requested page.

## Why This Change Was Made

Chrome can briefly expose `:` as the main-frame URL while a newly created target is still settling. The CDP navigation observer now treats only that exact transient value as unsettled and continues its existing polling for a committed URL. Existing handling for unreachable URLs, `about:blank`, timeouts, SSRF policy, and navigation failures is unchanged.

## User Impact

The immediate CLI and JSON result now reports the opened page URL for managed Chrome tabs, so users and automation no longer receive invalid URL metadata for a tab that opened successfully. No public API, configuration, or security boundary changes.

## Evidence

Live third-party end-to-end proof used a fresh isolated OpenClaw Gateway on loopback, an OpenClaw-managed headless Chrome instance, and temporary credentials. All browser actions were exercised with the OpenClaw CLI; coclaw was not used.

| Case | Before on main | After this change |
| --- | --- | --- |
| `https://example.com` (`--json`) | `"url": ":"`; `browser tabs` later showed `https://example.com/` | Immediate `"url": "https://example.com"` |
| `https://www.iana.org/domains/reserved` (`--json`) | `"url": ":"`; the tab later showed the requested URL | Immediate requested URL; `browser tabs` matched |
| `https://example.org` (text output) | `opened: :` | `opened: https://example.org` |
| `about:blank` control | `"url": "about:blank"` | Unchanged |

The regression test was confirmed RED before the production change (`:` was returned after the stability window), then GREEN after the fix.

- Focused Vitest: 2 files, 52/52 tests passed.
- `oxfmt --check`: passed for both changed files.
- Focused Oxlint: passed for both changed files.
- Extension production TypeScript check: passed.
- Extension test TypeScript check: passed.
- `git diff --check`: passed.
- Full repository `pnpm build && pnpm check && pnpm test` was not run locally; CI remains authoritative for the wider repository lanes.
