### PR TITLE
test(browser): add cross-operation tab reference parity contract

### DIFF
--- a/extensions/browser/src/browser/server-context.tab-reference-parity.contract.test.ts
+++ b/extensions/browser/src/browser/server-context.tab-reference-parity.contract.test.ts
@@ -1,0 +1,172 @@
+// Browser contract test: agent-facing tab references must resolve to the
+// same raw CDP targetId across every operation that accepts a tab handle.
+// snapshot/act/navigate/screenshot/pdf routes all enter through
+// ensureTabAvailable, so covering listTabs + ensureTabAvailable + focusTab +
+// closeTab fixes the cross-operation handle-resolution contract in one place.
+// If a future change lets one operation bypass the shared resolver in
+// server-context.selection.ts / server-context.tab-ops.ts, this table catches
+// the drift before agents see silent mis-targeting.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { withBrowserFetchPreconnect } from "../../test-fetch.js";
+import "../test-support/browser-security.mock.js";
+import "./server-context.chrome-test-harness.js";
+import { BrowserTargetAmbiguousError } from "./errors.js";
+import {
+  createTestBrowserRouteContext,
+  makeState,
+  originalFetch,
+} from "./server-context.remote-tab-ops.harness.js";
+
+afterEach(async () => {
+  const { closePlaywrightBrowserConnection } = await import("./pw-session.js");
+  await closePlaywrightBrowserConnection().catch(() => {});
+  globalThis.fetch = originalFetch;
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+type JsonListEntry = {
+  id: string;
+  title: string;
+  url: string;
+  webSocketDebuggerUrl: string;
+  type: string;
+};
+
+// Fixture mirrors target-id.test.ts so the resolver-level priority and the
+// operation-level parity share one canonical example.
+//   tab A: raw "ABCDEF123456", label "docs", tabId "t1"
+//   tab B: raw "ABC999",        label "app",  tabId "t2"
+// "ABCDEF" is a unique prefix of A; "ABC" is an ambiguous prefix of both.
+const FIXTURE_TABS: JsonListEntry[] = [
+  {
+    id: "ABCDEF123456",
+    title: "Docs",
+    url: "https://docs.example.com",
+    webSocketDebuggerUrl: "ws://127.0.0.1/devtools/page/ABCDEF123456",
+    type: "page",
+  },
+  {
+    id: "ABC999",
+    title: "App",
+    url: "https://app.example.com",
+    webSocketDebuggerUrl: "ws://127.0.0.1/devtools/page/ABC999",
+    type: "page",
+  },
+];
+
+function createParityFetchMock(): ReturnType<typeof vi.fn> {
+  return vi.fn(async (url: unknown) => {
+    const value = String(url);
+    if (value.includes("/json/list")) {
+      return { ok: true, json: async () => FIXTURE_TABS } as unknown as Response;
+    }
+    if (value.includes("/json/activate/") || value.includes("/json/close/")) {
+      return { ok: true } as unknown as Response;
+    }
+    throw new Error(`unexpected fetch: ${value}`);
+  });
+}
+
+function setupProfile() {
+  const fetchMock = createParityFetchMock();
+  global.fetch = withBrowserFetchPreconnect(fetchMock);
+  const state = makeState("openclaw");
+  const ctx = createTestBrowserRouteContext({ getState: () => state });
+  return { fetchMock, openclaw: ctx.forProfile("openclaw") };
+}
+
+// Labels are agent-assigned via labelTab, not returned by /json/list, so seed
+// them once per profile before asserting label-based resolution.
+async function setupProfileWithLabels() {
+  const ctx = setupProfile();
+  await ctx.openclaw.labelTab("ABCDEF123456", "docs");
+  await ctx.openclaw.labelTab("ABC999", "app");
+  return ctx;
+}
+
+function backendTargetIds(
+  fetchMock: ReturnType<typeof vi.fn>,
+  endpoint: "/json/activate/" | "/json/close/",
+): string[] {
+  return fetchMock.mock.calls
+    .map(([url]) => String(url))
+    .filter((url) => url.includes(endpoint))
+    .map((url) => url.slice(url.lastIndexOf(endpoint) + endpoint.length));
+}
+
+describe("tab reference parity contract", () => {
+  it("listTabs attaches tabId, label, and suggestedTargetId for every fixture tab", async () => {
+    const { openclaw } = await setupProfileWithLabels();
+    const tabs = await openclaw.listTabs();
+    expect(tabs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          targetId: "ABCDEF123456",
+          tabId: "t1",
+          label: "docs",
+          suggestedTargetId: "docs",
+        }),
+        expect.objectContaining({
+          targetId: "ABC999",
+          tabId: "t2",
+          label: "app",
+          suggestedTargetId: "app",
+        }),
+      ]),
+    );
+  });
+
+  // Cross-operation parity: every agent-facing handle resolves to the same raw
+  // targetId across labelTab, ensureTabAvailable (snapshot/act/navigate route
+  // entry), focusTab, and closeTab. Each operation gets an isolated profile so
+  // sticky lastTargetId state cannot mask a divergence.
+  const resolveCases: Array<{ name: string; input: string; expected: string }> = [
+    { name: "tabId t1", input: "t1", expected: "ABCDEF123456" },
+    { name: "tabId t2", input: "t2", expected: "ABC999" },
+    { name: "label docs", input: "docs", expected: "ABCDEF123456" },
+    { name: "label app", input: "app", expected: "ABC999" },
+    { name: "raw targetId A", input: "ABCDEF123456", expected: "ABCDEF123456" },
+    { name: "raw targetId B", input: "ABC999", expected: "ABC999" },
+    { name: "unique raw prefix ABCDEF", input: "ABCDEF", expected: "ABCDEF123456" },
+  ];
+
+  for (const { name, input, expected } of resolveCases) {
+    it(`resolves "${name}" to ${expected} across label/ensure/focus/close`, async () => {
+      const labelCtx = await setupProfileWithLabels();
+      const labeled = await labelCtx.openclaw.labelTab(input, "parity");
+      expect(labeled.targetId).toBe(expected);
+
+      const ensureCtx = await setupProfileWithLabels();
+      const ensured = await ensureCtx.openclaw.ensureTabAvailable(input);
+      expect(ensured.targetId).toBe(expected);
+
+      const focusCtx = await setupProfileWithLabels();
+      await focusCtx.openclaw.focusTab(input);
+      expect(backendTargetIds(focusCtx.fetchMock, "/json/activate/")).toContain(expected);
+
+      const closeCtx = await setupProfileWithLabels();
+      await closeCtx.openclaw.closeTab(input);
+      expect(backendTargetIds(closeCtx.fetchMock, "/json/close/")).toContain(expected);
+    });
+  }
+
+  it("rejects an ambiguous raw prefix consistently across label/ensure/focus/close", async () => {
+    const labelCtx = await setupProfileWithLabels();
+    await expect(labelCtx.openclaw.labelTab("ABC", "parity")).rejects.toBeInstanceOf(
+      BrowserTargetAmbiguousError,
+    );
+    const ensureCtx = await setupProfileWithLabels();
+    await expect(ensureCtx.openclaw.ensureTabAvailable("ABC")).rejects.toBeInstanceOf(
+      BrowserTargetAmbiguousError,
+    );
+    const focusCtx = await setupProfileWithLabels();
+    await expect(focusCtx.openclaw.focusTab("ABC")).rejects.toBeInstanceOf(
+      BrowserTargetAmbiguousError,
+    );
+    const closeCtx = await setupProfileWithLabels();
+    await expect(closeCtx.openclaw.closeTab("ABC")).rejects.toBeInstanceOf(
+      BrowserTargetAmbiguousError,
+    );
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

OpenClaw browser's agent-facing tab handles (`suggestedTargetId` / label / `tabId` / raw `targetId` / unique prefix) all funnel through a single `resolveTargetIdFromTabs` resolver across five operations: `listTabs`, `labelTab`, `ensureTabAvailable`, `focusTab`, and `closeTab`. That cross-operation parity contract had no dedicated contract test pinning it down. Existing coverage is spread per-operation (`target-id.test.ts` covers the resolver unit layer; `server-context.tab-selection-state.test.ts` covers list/focus/close/label friendly references and alias migration; `agent.act.normalize.test.ts` covers act-path canonicalization). If a future change lets one operation bypass the shared resolver and parse handles itself, the scattered tests might not catch the parity drift.

## Why This Change Was Made

Add `server-context.tab-reference-parity.contract.test.ts`, a table-driven contract test using fixture tabs matching `target-id.test.ts`. It asserts that the same handle resolves to the same raw `targetId` across all five operations, and that an ambiguous prefix consistently throws `BrowserTargetAmbiguousError` across all five. snapshot/act/navigate/screenshot/pdf routes all enter through `ensureTabAvailable`, so covering `ensureTabAvailable` covers those routes' handle-resolution entry. Each operation gets an isolated profile so sticky `lastTargetId` state cannot mask a divergence.

Non-goals: no production behavior change, no CLI/schema/skills/docs wording changes, no decision on deprecating CLI `tab select <index>` or tightening label rules — those two stay open questions.

## User Impact

No user-visible behavior change. This is a pure test addition that locks down the existing cross-operation handle-resolution parity contract to prevent future regressions.

## Evidence

### Live terminal capture (HEAD `a27c40b3dce2b61e1882a869f502141cfaac0db1`)

Command:

```
node scripts/run-vitest.mjs extensions/browser/src/browser/server-context.tab-reference-parity.contract.test.ts -- --reporter=verbose
```

Output (exit code 0):

```
[test] starting test/vitest/vitest.extension-browser.config.ts

 RUN  v4.1.10 /root/openclaw

 ✓ |extension-browser| extensions/browser/src/browser/server-context.tab-reference-parity.contract.test.ts > tab reference parity contract > listTabs attaches tabId, label, and suggestedTargetId for every fixture tab 1049ms
 ✓ |extension-browser| extensions/browser/src/browser/server-context.tab-reference-parity.contract.test.ts > tab reference parity contract > resolves "tabId t1" to ABCDEF123456 across label/ensure/focus/close 10ms
 ✓ |extension-browser| extensions/browser/src/browser/server-context.tab-reference-parity.contract.test.ts > tab reference parity contract > resolves "tabId t2" to ABC999 across label/ensure/focus/close 6ms
 ✓ |extension-browser| extensions/browser/src/browser/server-context.tab-reference-parity.contract.test.ts > tab reference parity contract > resolves "label docs" to ABCDEF123456 across label/ensure/focus/close 5ms
 ✓ |extension-browser| extensions/browser/src/browser/server-context.tab-reference-parity.contract.test.ts > tab reference parity contract > resolves "label app" to ABC999 across label/ensure/focus/close 5ms
 ✓ |extension-browser| extensions/browser/src/browser/server-context.tab-reference-parity.contract.test.ts > tab reference parity contract > resolves "raw targetId A" to ABCDEF123456 across label/ensure/focus/close 5ms
 ✓ |extension-browser| extensions/browser/src/browser/server-context.tab-reference-parity.contract.test.ts > tab reference parity contract > resolves "raw targetId B" to ABC999 across label/ensure/focus/close 4ms
 ✓ |extension-browser| extensions/browser/src/browser/server-context.tab-reference-parity.contract.test.ts > tab reference parity contract > resolves "unique raw prefix ABCDEF" to ABCDEF123456 across label/ensure/focus/close 5ms
 ✓ |extension-browser| extensions/browser/src/browser/server-context.tab-reference-parity.contract.test.ts > tab reference parity contract > rejects an ambiguous raw prefix consistently across label/ensure/focus/close 6ms

 Test Files  1 passed (1)
      Tests  9 passed (9)
   Start at  19:34:02
   Duration  4.43s (transform 1.94s, setup 319ms, import 2.79s, tests 1.11s, environment 0ms)

[test] passed 1 Vitest shard in 9.74s
```

### Shared resolver + operation entry points inspection

The contract test encodes a real invariant, not an accidental shared behavior. Every agent-facing handle path converges on one resolver:

- **Shared resolver**: `resolveTargetIdFromTabs` in `extensions/browser/src/browser/target-id.ts:126` is the single function that turns any agent-facing handle (`tabId`, label, raw `targetId`, unique prefix) into a canonical `targetId`. Its priority / collision / ambiguity / dedup rules are unit-tested in `target-id.test.ts`.
- **`listTabs`** (`server-context.tab-ops.ts`, `createProfileTabOps`): produces the `tabId` / `label` / `suggestedTargetId` handles that the other operations resolve. It does not take a handle input; its role in the parity contract is to be the handle producer the other four operations agree with.
- **`labelTab`** (`server-context.tab-ops.ts:476`): resolves the input handle by calling `resolveTargetIdFromTabs` directly (line 483), then assigns the label.
- **`ensureTabAvailable` / `focusTab` / `closeTab`** (`server-context.selection.ts`, `createProfileSelectionOps`): resolve the input handle via the shared helper `resolveTargetIdOrThrow` (`server-context.selection.ts:226`), which calls `resolveTargetIdFromTabs` (line 238). `ensureTabAvailable` is the route entry for `snapshot` / `act` / `navigate` / `screenshot` / `pdf` via `withRouteTabContext` in `routes/agent.shared.ts`, so those routes inherit the same resolver.
- **Sibling tests** already cover per-operation behavior: `target-id.test.ts` (resolver unit), `server-context.tab-selection-state.test.ts` (list/focus/close/label friendly refs + alias migration), `agent.act.normalize.test.ts` (act-path canonicalization), `browser-utils.test.ts` (resolver edge cases). This PR adds the missing cross-operation parity layer that catches drift if any operation ever bypasses the shared resolver.
- **Feature history**: `resolveTargetIdFromTabs` is the current-main canonical resolver for agent-facing tab handles; no shipped fallback or alias path exists, so the parity contract is the invariant the runtime already relies on.

### Static checks

- `pnpm format:check` (new file): passed
- `pnpm tsgo:extensions:test` (covers `extensions/**/*.test.ts`, including the new file): passed
- `oxlint` on the new file: passed
- `git diff --check`: passed

### Proof environment

- Head SHA: `a27c40b3dce2b61e1882a869f502141cfaac0db1`
- `pnpm check:changed` intended to delegate to Blacksmith Testbox, but the local crabbox binary was unavailable, so per root `AGENTS.md` trusted-source fallback the above local proof was run. Pre-commit autoreview could not run because no codex/claude/pi reviewer CLI is available locally; the owner opted out (scope is a pure test addition with no production behavior change).

AI-assisted; I reviewed the implementation and understand the contract being locked down.
