### PR TITLE
fix(gateway): stop reports success without stopping a foreground gateway

### DIFF
--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -249,6 +249,19 @@ describe("runDaemonRestart health checks", () => {
     );
   }
 
+  async function runUnmanagedStop(opts: { json?: boolean; force?: boolean } = { json: true }) {
+    let outcome: unknown;
+    runServiceStop.mockImplementation(
+      async (params: {
+        onNotLoaded?: (ctx: { stdout: NodeJS.WritableStream }) => Promise<unknown>;
+      }) => {
+        outcome = await params.onNotLoaded?.({ stdout: process.stdout });
+      },
+    );
+    await runDaemonStop(opts);
+    return outcome;
+  }
+
   beforeAll(async () => {
     ({ runDaemonStart, runDaemonRestart, runDaemonStop } = await import("./lifecycle.js"));
   });
@@ -707,25 +720,20 @@ describe("runDaemonRestart health checks", () => {
   });
 
   it("signals an unmanaged gateway process on stop", async () => {
-    findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4200, 4200, 4300]);
-    runServiceStop.mockImplementation(
-      async (params: {
-        onNotLoaded?: (ctx: { stdout: NodeJS.WritableStream }) => Promise<unknown>;
-      }) => {
-        await params.onNotLoaded?.({ stdout: process.stdout });
-      },
-    );
+    findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4300, 4300, 4400]);
 
-    await runDaemonStop({ json: true });
+    await runUnmanagedStop();
 
     expect(findVerifiedGatewayListenerPidsOnPortSync).toHaveBeenCalledWith(18789);
-    expect(signalVerifiedGatewayPidSync).toHaveBeenCalledWith(4200, "SIGTERM");
     expect(signalVerifiedGatewayPidSync).toHaveBeenCalledWith(4300, "SIGTERM");
+    expect(signalVerifiedGatewayPidSync).toHaveBeenCalledWith(4400, "SIGTERM");
+    // Verified listeners win over the lock owner (pid 4200) when lsof can see them.
+    expect(signalVerifiedGatewayPidSync).not.toHaveBeenCalledWith(4200, "SIGTERM");
     expect(appendGatewayLifecycleAudit).toHaveBeenCalledWith({
       action: "stop",
       source: "cli",
       mode: "sigterm",
-      pid: 4200,
+      pid: 4300,
     });
   });
 
@@ -760,15 +768,8 @@ describe("runDaemonRestart health checks", () => {
   it("allows forced non-interactive unmanaged stop fallback", async () => {
     isTerminalInteractive.mockReturnValue(false);
     findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4200]);
-    runServiceStop.mockImplementation(
-      async (params: {
-        onNotLoaded?: (ctx: { stdout: NodeJS.WritableStream }) => Promise<unknown>;
-      }) => {
-        await params.onNotLoaded?.({ stdout: process.stdout });
-      },
-    );
 
-    await runDaemonStop({ json: true, force: true });
+    await runUnmanagedStop({ json: true, force: true });
 
     expect(signalVerifiedGatewayPidSync).toHaveBeenCalledWith(4200, "SIGTERM");
   });
@@ -789,15 +790,8 @@ describe("runDaemonRestart health checks", () => {
   it("stops a running disabled systemd unit through the service manager", async () => {
     vi.spyOn(process, "platform", "get").mockReturnValue("linux");
     service.readRuntime.mockResolvedValue({ status: "running" });
-    runServiceStop.mockImplementation(
-      async (params: {
-        onNotLoaded?: (ctx: { stdout: NodeJS.WritableStream }) => Promise<unknown>;
-      }) => {
-        await params.onNotLoaded?.({ stdout: process.stdout });
-      },
-    );
 
-    await runDaemonStop({ json: true });
+    await runUnmanagedStop();
 
     expect(service.stop).toHaveBeenCalledWith(
       expect.objectContaining({ env: process.env, stdout: process.stdout }),
@@ -811,6 +805,37 @@ describe("runDaemonRestart health checks", () => {
     expect(service.readCommand).not.toHaveBeenCalled();
     expect(loadConfig).not.toHaveBeenCalled();
     expect(resolveGatewayPort).not.toHaveBeenCalled();
+  });
+
+  it("stops the locked gateway owner when listener discovery finds nothing", async () => {
+    findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([]);
+    formatGatewayPidList.mockImplementation((pids) => pids.join(", "));
+
+    const outcome = await runUnmanagedStop();
+
+    expect(signalVerifiedGatewayPidSync).toHaveBeenCalledWith(4200, "SIGTERM");
+    expect(appendGatewayLifecycleAudit).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "stop", mode: "sigterm", pid: 4200 }),
+    );
+    expect(outcome).toEqual({
+      result: "stopped",
+      message: "Gateway stop signal sent to unmanaged process on port 18789: 4200.",
+    });
+  });
+
+  it("stops the active lock port when the configured port has drifted", async () => {
+    findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([]);
+    readActiveGatewayLockIdentity.mockResolvedValue({
+      pid: 4300,
+      createdAt: "2026-07-16T12:00:00.000Z",
+      port: 39_471,
+    });
+
+    await runUnmanagedStop();
+
+    expect(findVerifiedGatewayListenerPidsOnPortSync).toHaveBeenCalledWith(39_471);
+    expect(signalVerifiedGatewayPidSync).toHaveBeenCalledWith(4300, "SIGTERM");
+    expect(service.readCommand).not.toHaveBeenCalled();
   });
 
   it("signals a single unmanaged gateway process on restart", async () => {
@@ -1071,15 +1096,9 @@ describe("runDaemonRestart health checks", () => {
     });
     stopSystemdService.mockResolvedValue(undefined);
     findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4200]);
-    runServiceStop.mockImplementation(
-      async (params: {
-        onNotLoaded?: (ctx: { stdout: NodeJS.WritableStream }) => Promise<unknown>;
-      }) => {
-        await params.onNotLoaded?.({ stdout: process.stdout });
-      },
+    await expect(runUnmanagedStop()).resolves.toEqual(
+      expect.objectContaining({ result: "stopped" }),
     );
-
-    await expect(runDaemonStop({ json: true })).resolves.toBeUndefined();
     expect(stopSystemdService).toHaveBeenCalled();
     expect(signalVerifiedGatewayPidSync).not.toHaveBeenCalled();
   });
@@ -1097,15 +1116,7 @@ describe("runDaemonRestart health checks", () => {
       ),
     );
     findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4200]);
-    runServiceStop.mockImplementation(
-      async (params: {
-        onNotLoaded?: (ctx: { stdout: NodeJS.WritableStream }) => Promise<unknown>;
-      }) => {
-        await params.onNotLoaded?.({ stdout: process.stdout });
-      },
-    );
-
-    await expect(runDaemonStop({ json: true })).rejects.toThrow(
+    await expect(runUnmanagedStop()).rejects.toThrow(
       /sudo systemctl stop openclaw-gateway\.service/,
     );
     expect(stopSystemdService).toHaveBeenCalled();
@@ -1114,16 +1125,12 @@ describe("runDaemonRestart health checks", () => {
 
   it("skips unmanaged signaling for pids that are not live gateway processes", async () => {
     findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([]);
-    runServiceStop.mockImplementation(
-      async (params: {
-        onNotLoaded?: (ctx: { stdout: NodeJS.WritableStream }) => Promise<unknown>;
-      }) => {
-        await params.onNotLoaded?.({ stdout: process.stdout });
-      },
-    );
+    readActiveGatewayLockIdentity.mockResolvedValue(undefined);
 
-    await runDaemonStop({ json: true });
+    const outcome = await runUnmanagedStop();
 
     expect(signalVerifiedGatewayPidSync).not.toHaveBeenCalled();
+    expect(appendGatewayLifecycleAudit).not.toHaveBeenCalled();
+    expect(outcome).toBeNull();
   });
 });

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -206,12 +206,16 @@ async function handleSystemScopeSystemdGateway(
   };
 }
 
-async function stopGatewayWithoutServiceManager(port: number) {
+async function stopGatewayWithoutServiceManager(port: number, lockOwnerPid: number | undefined) {
   const managed = await handleSystemScopeSystemdGateway("stop");
   if (managed) {
     return managed;
   }
-  const pids = resolveVerifiedGatewayListenerPids(port);
+  const listenerPids = resolveVerifiedGatewayListenerPids(port);
+  // Listener discovery needs lsof, which minimal containers omit. The gateway
+  // lock already names the verified owner of this port, so signal it instead of
+  // reporting the gateway as not running while it keeps serving.
+  const pids = listenerPids.length > 0 ? listenerPids : lockOwnerPid ? [lockOwnerPid] : [];
   if (pids.length === 0) {
     return null;
   }
@@ -517,7 +521,6 @@ export async function runDaemonStop(opts: DaemonLifecycleOptions = {}) {
   }
   assertGatewayServiceMutationAllowed("stop the gateway");
   const service = resolveGatewayService();
-  let gatewayPortPromise: Promise<number> | undefined;
   return await runServiceStop({
     serviceNoun: "Gateway",
     service,
@@ -537,10 +540,14 @@ export async function runDaemonStop(opts: DaemonLifecycleOptions = {}) {
           return { result: "stopped" };
         }
       }
-      gatewayPortPromise ??= resolveGatewayLifecyclePort(service).catch(() =>
-        resolveGatewayPortFallback(),
-      );
-      return await stopGatewayWithoutServiceManager(await gatewayPortPromise);
+      // An unmanaged run loop keeps its lock port across config edits, so use it
+      // for discovery the way restart already does; otherwise a valid port
+      // override makes the running gateway look like it is already stopped.
+      const lockIdentity = await readActiveGatewayLockIdentity().catch(() => undefined);
+      const port =
+        lockIdentity?.port ??
+        (await resolveGatewayLifecyclePort(service).catch(() => resolveGatewayPortFallback()));
+      return await stopGatewayWithoutServiceManager(port, lockIdentity?.pid);
     },
   });
 }


### PR DESCRIPTION
Closes #72948

## What Problem This Solves

`openclaw gateway stop --force` could report `ok: true` / `result: "not-loaded"` while a foreground gateway kept serving. The unmanaged fallback scanned only the configured port through `lsof`; it therefore found nothing when `lsof` was absent or the running gateway used an overridden port.

## Why This Change Was Made

The gateway lock already records the validated owner PID and actual port. The not-loaded stop path now reads that identity once, scans its port, and uses the lock owner only when verified listener discovery returns no PIDs. Listener discovery retains precedence.

The safety boundary remains centralized: `readActiveGatewayLockIdentity` rejects dead, recycled, port-less, or non-gateway owners, and `signalVerifiedGatewayPidSync` re-reads argv immediately before `SIGTERM`. Managed-service ownership, the non-interactive force guard, restart cleanup, and the no-verified-owner no-op remain unchanged. This is deliberately narrower than adding another process-discovery implementation.

No config, UI, capability, or public API surface is added.

## User Impact

Foreground gateways can now be stopped on hosts without `lsof` and when their runtime port differs from configuration. JSON callers receive `result: "stopped"` only after a verified target is signalled.

## Evidence

Reviewed and rebased by a maintainer onto current `origin/main`; exact pushed head: `62c07c041b92bb53c9b27ca3ffe738a0cece7a03`.

- `node scripts/run-vitest.mjs src/cli/daemon-cli/lifecycle.test.ts` — 1 file, 40 tests passed after the final rebase.
- `node scripts/check-changed.mjs -- src/cli/daemon-cli/lifecycle.ts src/cli/daemon-cli/lifecycle.test.ts` — passed all core/core-test changed-surface gates on the immediately preceding diff-equivalent rebased head, including typechecks, changed-file lint, import cycles, database-first, SDK, and plugin-boundary guards. [Hosted run](https://github.com/openclaw/openclaw/actions/runs/29695925758).
- Real foreground gateway, configured-port drift with `lsof` available — stop returned `stopped`; process gone; runtime port free.
- Real foreground gateway in a private mount namespace with `/usr/bin/lsof` masked — stop used the active lock owner, returned `stopped`; process gone; port free.
- Full-branch autoreview after the final rebase — no actionable findings, correctness confidence 0.95.

The regression matrix also proves listener PIDs retain precedence, a validated lock owner is used only when discovery is empty, the lock port handles config drift, managed/disabled-service cleanup is preserved, and inactive lock identities remain `not-loaded`.

Credit: @mayank6136 reported #72948 with the sandbox reproduction and manual `kill -TERM` workaround. #72224 explores a broader `/proc` discovery approach; this PR fixes stop at the existing verified lock-owner boundary instead.
