### PR TITLE
fix(swarm): live agents.run fan-outs launch collectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Swarm collector launches:** preserve the host-owned backend identity for in-process code-mode child launches so live `agents.run(...)` fan-outs pass the collector spoofing guard without weakening external-client rejection. (#110325)
 - **Channel outbound echo suppression:** drop recently emitted platform message and source identities at shared inbound admission and migrate Discord thread unbinds off channel-local expiry state, preventing delayed webhook copies from re-entering agents.
 - **Reef startup reconciliation:** contain retryable relay failures during startup without supervisor restart loops, while preserving definitive-error and cancellation handling. Thanks @Yigtwxx.
 - **Codex stale-session replies:** stop model fallback after another gateway supersedes a Codex session generation and deliver a safe retry notice instead of abandoning the message silently.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Swarm collector launches:** preserve the host-owned backend identity for in-process code-mode child launches so live `agents.run(...)` fan-outs pass the collector spoofing guard without weakening external-client rejection. (#110325)
 - **Channel outbound echo suppression:** drop recently emitted platform message and source identities at shared inbound admission and migrate Discord thread unbinds off channel-local expiry state, preventing delayed webhook copies from re-entering agents.
 - **Reef startup reconciliation:** contain retryable relay failures during startup without supervisor restart loops, while preserving definitive-error and cancellation handling. Thanks @Yigtwxx.
 - **Codex stale-session replies:** stop model fallback after another gateway supersedes a Codex session generation and deliver a safe retry notice instead of abandoning the message silently.

--- a/src/agents/subagent-spawn.in-process-gateway.test.ts
+++ b/src/agents/subagent-spawn.in-process-gateway.test.ts
@@ -81,7 +81,9 @@ async function waitForAssertion(assertion: () => void, timeoutMs = 2_000): Promi
     } catch (error) {
       lastError = error;
     }
-    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 10);
+    });
   }
   throw lastError;
 }

--- a/src/agents/subagent-spawn.in-process-gateway.test.ts
+++ b/src/agents/subagent-spawn.in-process-gateway.test.ts
@@ -1,0 +1,219 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearConfigCache,
+  clearRuntimeConfigSnapshot,
+  getRuntimeConfig,
+} from "../config/config.js";
+import { prepareAgentRequestPreflight } from "../gateway/server-methods/agent-request-preflight.js";
+import type {
+  GatewayRequestContext,
+  GatewayRequestOptions,
+} from "../gateway/server-methods/types.js";
+import { createSyntheticPluginRuntimeClient } from "../gateway/server-plugin-runtime-client.js";
+import { clearFallbackGatewayContext } from "../gateway/server-plugins.js";
+import { withPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
+import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import { subagentRuns } from "./subagent-registry-memory.js";
+import {
+  resetSubagentRegistryForTests,
+  testing as subagentRegistryTesting,
+} from "./subagent-registry.test-helpers.js";
+import { spawnSubagentDirect } from "./subagent-spawn.js";
+import { testing as subagentSpawnTesting } from "./subagent-spawn.test-support.js";
+import { testing as swarmSchedulerTesting } from "./swarm-scheduler.test-support.js";
+
+const envSnapshot = captureEnv(["OPENCLAW_CONFIG_PATH", "OPENCLAW_STATE_DIR"]);
+let stateDir = "";
+
+function makeGatewayContext(): GatewayRequestContext {
+  return {
+    dedupe: new Map(),
+    addChatRun: vi.fn(),
+    removeChatRun: vi.fn(),
+    chatAbortControllers: new Map(),
+    chatQueuedTurns: new Map(),
+    chatRunBuffers: new Map(),
+    chatDeltaSentAt: new Map(),
+    chatDeltaLastBroadcastLen: new Map(),
+    chatDeltaLastBroadcastText: new Map(),
+    agentDeltaSentAt: new Map(),
+    bufferedAgentEvents: new Map(),
+    chatAbortedRuns: new Map(),
+    clearChatRunState: vi.fn(),
+    agentRunSeq: new Map(),
+    broadcast: vi.fn(),
+    nodeSendToSession: vi.fn(),
+    logGateway: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    broadcastToConnIds: vi.fn(),
+    getSessionEventSubscriberConnIds: () => new Set(),
+    getRuntimeConfig,
+  } as unknown as GatewayRequestContext;
+}
+
+function externalCliClient(): GatewayRequestOptions["client"] {
+  return {
+    connect: {
+      minProtocol: 1,
+      maxProtocol: 1,
+      client: {
+        id: "cli",
+        version: "test",
+        platform: "test",
+        mode: "cli",
+      },
+      scopes: ["operator.write"],
+    },
+  } as GatewayRequestOptions["client"];
+}
+
+async function waitForAssertion(assertion: () => void, timeoutMs = 2_000): Promise<void> {
+  let lastError: unknown;
+  for (let elapsed = 0; elapsed <= timeoutMs; elapsed += 10) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+  }
+  throw lastError;
+}
+
+describe("spawnSubagentDirect in-process Gateway collector launch", () => {
+  beforeEach(async () => {
+    swarmSchedulerTesting.reset();
+    resetSubagentRegistryForTests({ persist: false });
+    clearFallbackGatewayContext();
+    clearRuntimeConfigSnapshot();
+    clearConfigCache();
+    subagentRegistryTesting.setDepsForTest({
+      persistSubagentRunsToDisk: () => {},
+      persistSubagentRunsToDiskOrThrow: () => {},
+      restoreSubagentRunsFromDisk: () => 0,
+      ensureRuntimePluginsLoaded: () => {},
+    });
+
+    stateDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-swarm-gateway-"));
+    setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+    setTestEnvValue("OPENCLAW_CONFIG_PATH", path.join(stateDir, "openclaw.json"));
+    await writeFile(
+      path.join(stateDir, "openclaw.json"),
+      `${JSON.stringify({
+        session: { mainKey: "main", scope: "per-sender" },
+        tools: { swarm: true },
+        agents: {
+          defaults: { workspace: stateDir },
+          list: [{ id: "main", workspace: stateDir }],
+        },
+      })}\n`,
+    );
+    clearConfigCache();
+  });
+
+  afterEach(async () => {
+    clearFallbackGatewayContext();
+    swarmSchedulerTesting.reset();
+    resetSubagentRegistryForTests({ persist: false });
+    subagentRegistryTesting.setDepsForTest();
+    subagentSpawnTesting.setDepsForTest();
+    clearRuntimeConfigSnapshot();
+    clearConfigCache();
+    envSnapshot.restore();
+    if (stateDir) {
+      await rm(stateDir, { recursive: true, force: true });
+      stateDir = "";
+    }
+  });
+
+  it("hands a registered collector launch to Gateway as the host", async () => {
+    const gatewayContext = makeGatewayContext();
+    const dispatchOptions: Array<{ method: string; forceSyntheticClient?: boolean }> = [];
+    const preflightResults: Array<{
+      externalAccepted: boolean;
+      externalError?: string;
+      hostAccepted: boolean;
+      hostResponded: boolean;
+    }> = [];
+    subagentSpawnTesting.setDepsForTest({
+      dispatchGatewayMethodInProcess: async (method, params, options) => {
+        dispatchOptions.push({ method, forceSyntheticClient: options?.forceSyntheticClient });
+
+        const externalRespond = vi.fn();
+        const externalPreflight = prepareAgentRequestPreflight({
+          params,
+          respond: externalRespond,
+          context: gatewayContext,
+          client: externalCliClient(),
+        } as never);
+
+        const hostRespond = vi.fn();
+        const client = options?.forceSyntheticClient
+          ? createSyntheticPluginRuntimeClient({ scopes: options.syntheticScopes })
+          : externalCliClient();
+        const hostPreflight = prepareAgentRequestPreflight({
+          params,
+          respond: hostRespond,
+          context: gatewayContext,
+          client,
+        } as never);
+        preflightResults.push({
+          externalAccepted: externalPreflight !== undefined,
+          externalError: (externalRespond.mock.calls[0]?.[2] as { message?: string } | undefined)
+            ?.message,
+          hostAccepted: hostPreflight !== undefined,
+          hostResponded: hostRespond.mock.calls.length > 0,
+        });
+        return {
+          runId: params.idempotencyKey as string,
+          status: "accepted",
+        };
+      },
+    });
+    const result = await withPluginRuntimeGatewayRequestScope(
+      {
+        context: gatewayContext,
+        client: externalCliClient(),
+        isWebchatConnect: () => false,
+      },
+      () =>
+        spawnSubagentDirect(
+          {
+            task: "return a collector result",
+            collect: true,
+            context: "isolated",
+            lightContext: true,
+            groupId: "swarm-live-launch",
+            swarmLaunchReplayKey: "code-mode:agentSpawn:1",
+          },
+          {
+            agentSessionKey: "agent:main:main",
+            requesterRunId: "parent-run",
+          },
+        ),
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(result.runId).toBeTruthy();
+    await waitForAssertion(() => {
+      expect(dispatchOptions).toEqual([{ method: "agent", forceSyntheticClient: true }]);
+      expect(preflightResults).toEqual([
+        {
+          externalAccepted: false,
+          externalError: "swarm collector fields require an enabled, host-registered collector run",
+          hostAccepted: true,
+          hostResponded: false,
+        },
+      ]);
+      expect(subagentRuns.get(result.runId!)).toMatchObject({
+        childSessionKey: result.childSessionKey,
+        collect: true,
+        swarmLaunchIdempotencyKey: result.runId,
+        swarmLaunchPending: false,
+      });
+    });
+  });
+});

--- a/src/agents/subagent-spawn.in-process-gateway.test.ts
+++ b/src/agents/subagent-spawn.in-process-gateway.test.ts
@@ -13,7 +13,10 @@ import type {
   GatewayRequestOptions,
 } from "../gateway/server-methods/types.js";
 import { createSyntheticPluginRuntimeClient } from "../gateway/server-plugin-runtime-client.js";
-import { clearFallbackGatewayContext } from "../gateway/server-plugins.js";
+import {
+  clearFallbackGatewayContext,
+  type dispatchGatewayMethodInProcess,
+} from "../gateway/server-plugins.js";
 import { withPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { subagentRuns } from "./subagent-registry-memory.js";
@@ -139,7 +142,11 @@ describe("spawnSubagentDirect in-process Gateway collector launch", () => {
       hostResponded: boolean;
     }> = [];
     subagentSpawnTesting.setDepsForTest({
-      dispatchGatewayMethodInProcess: async (method, params, options) => {
+      dispatchGatewayMethodInProcess: async <T>(
+        method: string,
+        params: Record<string, unknown>,
+        options?: NonNullable<Parameters<typeof dispatchGatewayMethodInProcess>[2]>,
+      ) => {
         dispatchOptions.push({ method, forceSyntheticClient: options?.forceSyntheticClient });
 
         const externalRespond = vi.fn();
@@ -170,7 +177,7 @@ describe("spawnSubagentDirect in-process Gateway collector launch", () => {
         return {
           runId: params.idempotencyKey as string,
           status: "accepted",
-        };
+        } as T;
       },
     });
     const result = await withPluginRuntimeGatewayRequestScope(

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -264,12 +264,15 @@ async function callSubagentGateway(
   ) {
     // Spawn is already running in the gateway process for channel/tool calls.
     // Direct dispatch avoids self-connecting over WS while the same event loop is busy.
+    // Agent launches are host-owned even when the parent request came from CLI/HTTP.
+    // Reusing that external identity makes collector preflight treat the launch as spoofed.
+    const forceSyntheticClient = request.method === "agent" || scopes != null;
     return await subagentSpawnDeps.dispatchGatewayMethodInProcess(
       request.method,
       request.params as Record<string, unknown>,
       {
         expectFinal: request.expectFinal,
-        ...(scopes != null ? { forceSyntheticClient: true } : {}),
+        ...(forceSyntheticClient ? { forceSyntheticClient: true } : {}),
         ...(typeof request.timeoutMs === "number" ? { timeoutMs: request.timeoutMs } : {}),
         ...(scopes != null ? { syntheticScopes: scopes } : {}),
       },


### PR DESCRIPTION
Related: #110325

## What Problem This Solves

Fixes an issue where users running a live code-mode `agents.run(...)` fan-out through a real gateway would see every collector child launch rejected as requiring a host-registered collector, even though the gateway had registered all children correctly.

## Why This Change Was Made

In-process agent launches are now dispatched with the gateway's synthetic backend identity even when the parent turn arrived from the CLI or HTTP. The collector preflight remains unchanged: external client identities still cannot spoof collector fields, while the legitimate host-owned launch carries the identity that the existing guard requires. A regression test exercises the actual spawn request, registry, and preflight wiring and proves both sides of that boundary.

## User Impact

Live Swarm fan-outs can launch and collect child agents successfully. Remote clients still cannot bypass the collector registration guard.

## Evidence

- Before the fix, the isolated live gateway rejected the registered children with `swarm collector fields require an enabled, host-registered collector run`.
- After the fix, the same isolated gateway/CLI path launched and completed the three collector children. The persisted `agentWait` settlement returned `[1, 2, 3, "SWARM-OK"]`; all three final child rows ended as `subagent-complete` with swarm status `done`. No credentials or operator gateway state were used.
- Focused swarm, code-mode, spawn, and preflight coverage: 8 files / 98 tests passed.
- `pnpm check:test-types`: passed in a fresh Testbox after the test dispatcher was typed against the production generic contract ([run](https://github.com/openclaw/openclaw/actions/runs/29686007196)).
- `pnpm ui:build`: passed; 2,373 modules transformed and bundle budgets passed.
- `pnpm deadcode:exports`: passed; all scans reported 0 entries.
- `pnpm format`: passed.
- Autoreview: no accepted/actionable findings on either commit.
- UI/dead-export heavy proof: https://github.com/openclaw/openclaw/actions/runs/29685537419
- Pull-request CI at `54df4ce0442` completed with seven failures, all in the unrelated `net-policy`/SSRF surface. The exact base SHA `c95a8e3df1e` is already red on `main` ([base run](https://github.com/openclaw/openclaw/actions/runs/29684768425)); no branch-path diagnostic remains.

AI-assisted; I reviewed the implementation, live behavior, and security boundary.
