### PR TITLE
fix(discord): activity widgets recover from stalled gateway responses

### DIFF
--- a/extensions/discord/src/activities/shell.test.ts
+++ b/extensions/discord/src/activities/shell.test.ts
@@ -9,19 +9,9 @@ const WIDGET_REQUEST_TIMEOUT_MS = 20_000;
 class TestElement {
   className = "";
   textContent = "";
-  title = "";
-  referrerPolicy = "";
-  src = "";
   readonly children: TestElement[] = [];
-  readonly attributes = new Map<string, string>();
-  private html = "";
-
-  get innerHTML() {
-    return this.html;
-  }
 
   set innerHTML(value: string) {
-    this.html = value;
     if (value === "") {
       this.children.length = 0;
     }
@@ -29,10 +19,6 @@ class TestElement {
 
   append(...children: TestElement[]) {
     this.children.push(...children);
-  }
-
-  setAttribute(name: string, value: string) {
-    this.attributes.set(name, value);
   }
 }
 
@@ -68,16 +54,18 @@ async function executeShellWithHungRequest(hung: HungRequest) {
     async ready() {}
   }
 
-  let nextTimeoutId = 0;
-  const timeoutCallbacks = new Map<number, () => void>();
-  const clearTimeoutMock = vi.fn((timeoutId: number) => {
-    timeoutCallbacks.delete(timeoutId);
+  let timeoutCallback: (() => void) | undefined;
+  const clearTimeoutMock = vi.fn(() => {
+    timeoutCallback = undefined;
   });
-  const setTimeoutMock = vi.fn((callback: () => void, _timeoutMs: number) => {
-    nextTimeoutId += 1;
-    timeoutCallbacks.set(nextTimeoutId, callback);
-    return nextTimeoutId;
+  const setTimeoutMock = vi.fn((callback: () => void) => {
+    timeoutCallback = callback;
+    return 1;
   });
+  const stallUntilAbort = (signal: AbortSignal | null | undefined, message: string) =>
+    new Promise<never>((_resolve, reject) => {
+      signal?.addEventListener("abort", () => reject(new Error(message)), { once: true });
+    });
   let fetchCall = 0;
   const fetchMock = vi.fn<typeof fetch>(async (_input, init) => {
     fetchCall += 1;
@@ -86,22 +74,11 @@ async function executeShellWithHungRequest(hung: HungRequest) {
     }
     const signal = init?.signal;
     if (hung.phase === "fetch") {
-      return await new Promise<Response>((_resolve, reject) => {
-        signal?.addEventListener("abort", () => reject(new Error("request aborted")), {
-          once: true,
-        });
-      });
+      return await stallUntilAbort(signal, "request aborted");
     }
-    return {
-      ok: true,
-      status: 200,
-      json: async () =>
-        await new Promise((_resolve, reject) => {
-          signal?.addEventListener("abort", () => reject(new Error("body aborted")), {
-            once: true,
-          });
-        }),
-    } as Response;
+    const response = Response.json({});
+    response.json = async () => await stallUntilAbort(signal, "body aborted");
+    return response;
   });
 
   const source = DISCORD_ACTIVITY_SHELL_JS.replace(
@@ -125,8 +102,8 @@ async function executeShellWithHungRequest(hung: HungRequest) {
 
   const expectedRequestCount = hung.request === "token" ? 1 : 2;
   await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(expectedRequestCount));
-  expect(timeoutCallbacks.size).toBe(1);
-  timeoutCallbacks.values().next().value?.();
+  expect(timeoutCallback).toBeTypeOf("function");
+  timeoutCallback?.();
   await vi.waitFor(() => expect(readStatusHeading(app)).toBe("Gateway offline"));
   return { clearTimeoutMock, fetchMock, setTimeoutMock };
 }

--- a/extensions/discord/src/activities/shell.test.ts
+++ b/extensions/discord/src/activities/shell.test.ts
@@ -1,0 +1,152 @@
+// Discord Activity shell tests execute the generated browser script against controlled fetches.
+import { runInNewContext } from "node:vm";
+import { describe, expect, it, vi } from "vitest";
+import { DISCORD_ACTIVITY_SHELL_JS } from "./shell.js";
+
+const TOKEN_REQUEST_TIMEOUT_MS = 35_000;
+const WIDGET_REQUEST_TIMEOUT_MS = 20_000;
+
+class TestElement {
+  className = "";
+  textContent = "";
+  title = "";
+  referrerPolicy = "";
+  src = "";
+  readonly children: TestElement[] = [];
+  readonly attributes = new Map<string, string>();
+  private html = "";
+
+  get innerHTML() {
+    return this.html;
+  }
+
+  set innerHTML(value: string) {
+    this.html = value;
+    if (value === "") {
+      this.children.length = 0;
+    }
+  }
+
+  append(...children: TestElement[]) {
+    this.children.push(...children);
+  }
+
+  setAttribute(name: string, value: string) {
+    this.attributes.set(name, value);
+  }
+}
+
+function readStatusHeading(app: TestElement): string | undefined {
+  return app.children[0]?.children[0]?.textContent;
+}
+
+type HungRequest = {
+  request: "token" | "widget";
+  phase: "fetch" | "body";
+};
+
+async function executeShellWithHungRequest(hung: HungRequest) {
+  const app = new TestElement();
+  const document = {
+    querySelector: (selector: string) => (selector === "#app" ? app : null),
+    createElement: () => new TestElement(),
+  };
+  const window = {
+    location: {
+      hostname: "123456.discordsays.com",
+      origin: "https://123456.discordsays.com",
+    },
+  };
+  class DiscordSDK {
+    customId = "widget-1";
+    instanceId = "instance-1";
+    commands = {
+      authorize: async () => ({ code: "discord-code" }),
+      authenticate: async () => ({}),
+    };
+
+    async ready() {}
+  }
+
+  let nextTimeoutId = 0;
+  const timeoutCallbacks = new Map<number, () => void>();
+  const clearTimeoutMock = vi.fn((timeoutId: number) => {
+    timeoutCallbacks.delete(timeoutId);
+  });
+  const setTimeoutMock = vi.fn((callback: () => void, _timeoutMs: number) => {
+    nextTimeoutId += 1;
+    timeoutCallbacks.set(nextTimeoutId, callback);
+    return nextTimeoutId;
+  });
+  let fetchCall = 0;
+  const fetchMock = vi.fn<typeof fetch>(async (_input, init) => {
+    fetchCall += 1;
+    if (hung.request === "widget" && fetchCall === 1) {
+      return Response.json({ access_token: "access", session_token: "session" });
+    }
+    const signal = init?.signal;
+    if (hung.phase === "fetch") {
+      return await new Promise<Response>((_resolve, reject) => {
+        signal?.addEventListener("abort", () => reject(new Error("request aborted")), {
+          once: true,
+        });
+      });
+    }
+    return {
+      ok: true,
+      status: 200,
+      json: async () =>
+        await new Promise((_resolve, reject) => {
+          signal?.addEventListener("abort", () => reject(new Error("body aborted")), {
+            once: true,
+          });
+        }),
+    } as Response;
+  });
+
+  const source = DISCORD_ACTIVITY_SHELL_JS.replace(
+    'import { DiscordSDK } from "./vendor/embedded-app-sdk.mjs";\n\n',
+    "",
+  );
+  runInNewContext(source, {
+    AbortController,
+    // Discord mobile/web clients may not expose the Baseline 2024 static helper.
+    AbortSignal: {},
+    DiscordSDK,
+    Response,
+    URL,
+    URLSearchParams,
+    clearTimeout: clearTimeoutMock,
+    document,
+    fetch: fetchMock,
+    setTimeout: setTimeoutMock,
+    window,
+  });
+
+  const expectedRequestCount = hung.request === "token" ? 1 : 2;
+  await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(expectedRequestCount));
+  expect(timeoutCallbacks.size).toBe(1);
+  timeoutCallbacks.values().next().value?.();
+  await vi.waitFor(() => expect(readStatusHeading(app)).toBe("Gateway offline"));
+  return { clearTimeoutMock, fetchMock, setTimeoutMock };
+}
+
+describe("Discord Activity shell request deadlines", () => {
+  it.each([
+    { request: "token", phase: "fetch", timeoutMs: TOKEN_REQUEST_TIMEOUT_MS },
+    { request: "token", phase: "body", timeoutMs: TOKEN_REQUEST_TIMEOUT_MS },
+    { request: "widget", phase: "fetch", timeoutMs: WIDGET_REQUEST_TIMEOUT_MS },
+    { request: "widget", phase: "body", timeoutMs: WIDGET_REQUEST_TIMEOUT_MS },
+  ] as const)("bounds a hung $request $phase", async ({ request, phase, timeoutMs }) => {
+    const { clearTimeoutMock, fetchMock, setTimeoutMock } = await executeShellWithHungRequest({
+      request,
+      phase,
+    });
+    const expectedRequestCount = request === "token" ? 1 : 2;
+
+    expect(fetchMock).toHaveBeenCalledTimes(expectedRequestCount);
+    expect(setTimeoutMock).toHaveBeenCalledTimes(expectedRequestCount);
+    expect(setTimeoutMock).toHaveBeenLastCalledWith(expect.any(Function), timeoutMs);
+    expect(clearTimeoutMock).toHaveBeenCalledTimes(expectedRequestCount);
+  });
+});

--- a/extensions/discord/src/activities/shell.ts
+++ b/extensions/discord/src/activities/shell.ts
@@ -1,5 +1,10 @@
 export const DISCORD_ACTIVITY_ROUTE_PREFIX = "/discord/activity";
 
+// The token route makes two sequential 15-second Discord API calls; the widget route makes one.
+// Keep the browser deadline outside those server budgets so valid slow responses are not aborted.
+const DISCORD_ACTIVITY_TOKEN_REQUEST_TIMEOUT_MS = 35_000;
+const DISCORD_ACTIVITY_WIDGET_REQUEST_TIMEOUT_MS = 20_000;
+
 export const DISCORD_ACTIVITY_SHELL_CSP =
   "default-src 'none'; script-src 'self'; style-src 'unsafe-inline'; " +
   "connect-src 'self'; frame-src 'self'; img-src data:; base-uri 'none'; frame-ancestors *";
@@ -16,6 +21,8 @@ h1{font-size:18px;margin:0 0 8px;color:#f2f3f5}p{margin:0;color:#b5bac1;line-hei
 
 export const DISCORD_ACTIVITY_SHELL_JS = `import { DiscordSDK } from "./vendor/embedded-app-sdk.mjs";
 
+const tokenRequestTimeoutMs = ${DISCORD_ACTIVITY_TOKEN_REQUEST_TIMEOUT_MS};
+const widgetRequestTimeoutMs = ${DISCORD_ACTIVITY_WIDGET_REQUEST_TIMEOUT_MS};
 const app = document.querySelector("#app");
 function show(message, detail) {
   app.className = "";
@@ -41,13 +48,32 @@ function proxiedDocUrl(value) {
   return url.pathname + url.search;
 }
 async function readJson(response) {
-  const body = await response.json().catch(() => ({}));
+  let body;
+  try {
+    body = await response.json();
+  } catch (error) {
+    // Error responses may legitimately omit JSON details; successful responses must not
+    // turn an aborted or malformed body into an apparently valid empty payload.
+    if (response.ok) throw error;
+    body = {};
+  }
   if (!response.ok) {
     const error = new Error(typeof body.error === "string" ? body.error : "request failed");
     error.status = response.status;
     throw error;
   }
   return body;
+}
+async function fetchJsonWithDeadline(input, init, timeoutMs) {
+  // Activities also run in mobile webviews; avoid requiring the newer
+  // AbortSignal.timeout() static API just to enforce this request boundary.
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await readJson(await fetch(input, { ...init, signal: controller.signal }));
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 async function run() {
   const match = window.location.hostname.match(/^(\\d+)\\.discordsays\\.com$/i);
@@ -65,19 +91,25 @@ async function run() {
     prompt: "none",
     scope: ["identify"],
   });
-  const auth = await readJson(await fetch("./api/token", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ code }),
-  }));
+  const auth = await fetchJsonWithDeadline(
+    "./api/token",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ code }),
+    },
+    tokenRequestTimeoutMs,
+  );
   await sdk.commands.authenticate({ access_token: auth.access_token });
   const query = new URLSearchParams({
     custom_id: sdk.customId ?? "",
     instance_id: sdk.instanceId,
   });
-  const widget = await readJson(await fetch("./api/widget?" + query, {
-    headers: { Authorization: "Bearer " + auth.session_token },
-  }));
+  const widget = await fetchJsonWithDeadline(
+    "./api/widget?" + query,
+    { headers: { Authorization: "Bearer " + auth.session_token } },
+    widgetRequestTimeoutMs,
+  );
   app.className = "widget";
   app.innerHTML = "";
   const bar = document.createElement("div");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening a Discord Activity widget could remain stuck indefinitely when the OpenClaw Gateway request connected but either the fetch or successful response body stopped making progress. The Activity shell never reached its existing "Gateway offline" recovery state in that condition.

## Why This Change Was Made

The Activity shell now applies one deadline across both `fetch()` and response-body parsing. Token exchange receives a 35-second budget because its server path can make two sequential Discord API calls with 15-second limits; widget loading receives 20 seconds for its single 15-second upstream call. Both retain five seconds for local HTTP and response parsing, and successful responses no longer hide aborted or malformed JSON bodies as empty objects.

This intentionally bounds only the Activity-to-Gateway request boundary. It does not change Discord SDK `ready`, `authorize`, or `authenticate` behavior.

The regression harness keeps the four relevant cases (token/widget crossed with fetch/body stall) while removing unused fake-DOM and multi-timer machinery.

## User Impact

Discord Activity users now see the existing Gateway-offline recovery screen instead of an indefinitely loading widget when a Gateway response stalls. Valid slow Discord API responses remain within the outer browser deadlines.

## Evidence

Exact head: `0018608fc0642601ff67b1b88893a58c8bf22c54`

Focused Activity suite:

```text
node scripts/run-vitest.mjs extensions/discord/src/activities/shell.test.ts extensions/discord/src/activities/http.test.ts extensions/discord/src/activities/discord-api.test.ts
3 files passed, 38 tests passed
```

Real HTTP response-body stall probe:

```json
{"elapsedMs":35110,"heading":"Gateway offline","responseClosed":true}
```

The probe used a real local HTTP response that sent success headers and a partial JSON body, then stopped. The exact head aborted the body read near the configured token deadline, closed the response, and rendered the recovery state.

Changed-surface gate:

```text
node scripts/check-changed.mjs -- extensions/discord/src/activities/shell.ts extensions/discord/src/activities/shell.test.ts
passed (format, lint, production/test type checks, package and architecture boundaries)
```

Hosted gate: https://github.com/openclaw/openclaw/actions/runs/29694352330

Fresh uncommitted and full-branch autoreviews reported no accepted/actionable findings. `git diff --check` passed.
