### PR TITLE
fix(gateway): preserve explicit approval ids byte-for-byte for validation

### DIFF
--- a/src/gateway/exec-approval-manager.test.ts
+++ b/src/gateway/exec-approval-manager.test.ts
@@ -586,22 +586,34 @@ describe("ExecApprovalManager", () => {
   });
 
   it.each([
-    ["UUID", "12345678-1234-1234-1234-123456789abc"],
-    ["plugin UUID", "plugin:12345678-1234-1234-1234-123456789abc"],
-    ["system-agent UUID", "system-agent:12345678-1234-1234-1234-123456789abc"],
-    ["node id", "node:mac-studio_1.local"],
+    ["two-phase exec UUID", "12345678-1234-1234-1234-123456789abc"],
+    ["plugin approval UUID", "plugin:12345678-1234-1234-1234-123456789abc"],
+    ["system-agent approval UUID", "system-agent:12345678-1234-1234-1234-123456789abc"],
+    ["node system.run replay UUID", "abcdefab-1234-5678-9abc-123456789abc"],
+    ["leading dash", "-approval-123"],
+    ["128-character id", "a".repeat(128)],
   ])("preserves a safe explicit %s byte-for-byte", (_label, id) => {
     const manager = new ExecApprovalManager();
 
     expect(manager.create({ command: "echo exact" }, 60_000, id).id).toBe(id);
   });
 
+  it.each([[undefined], [null], [""]])("generates an id for an empty id sentinel (%s)", (id) => {
+    const manager = new ExecApprovalManager();
+
+    expect(manager.create({ command: "echo generated" }, 60_000, id).id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  });
+
   it.each([
-    ["empty value", ""],
     ["URL dot segment", "."],
     ["URL parent segment", ".."],
     ["ANSI escape", "approval-\u001b[31mred"],
+    ["ASCII control", "approval-\u0000hidden"],
     ["Unicode control", "approval-\u202Ehidden"],
+    ["lone surrogate", "approval-\ud800hidden"],
+    ["whitespace", "approval unsafe"],
     ["trailing line feed", "approval-safe\n"],
     ["trailing carriage return", "approval-safe\r"],
     ["trailing line separator", "approval-safe\u2028"],

--- a/src/gateway/exec-approval-manager.ts
+++ b/src/gateway/exec-approval-manager.ts
@@ -57,6 +57,7 @@ const EXPLICIT_APPROVAL_ID_INVALID_CHAR_PATTERN = /[^A-Za-z0-9._:-]/;
 
 /** Typed creation failure for an explicit approval id outside the shared safe format. */
 export class InvalidApprovalIdError extends Error {
+  readonly code = "EXEC_APPROVAL_ID_INVALID";
   readonly reason = "INVALID_APPROVAL_ID";
 
   constructor() {
@@ -237,11 +238,11 @@ export class ExecApprovalManager<TPayload = ExecApprovalRequestPayload> {
     if (expiresAtMs === undefined) {
       throw new Error("approval expiry is unavailable");
     }
-    const hasExplicitId = id !== null && id !== undefined;
+    // Empty remains the caller-facing sentinel for manager-generated ids.
+    const hasExplicitId = id !== null && id !== undefined && id.length > 0;
     if (
       hasExplicitId &&
-      (id.length === 0 ||
-        id.length > 128 ||
+      (id.length > 128 ||
         id === "." ||
         id === ".." ||
         EXPLICIT_APPROVAL_ID_INVALID_CHAR_PATTERN.test(id))

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -195,7 +195,9 @@ export function createExecApprovalHandlers(
       const twoPhase = p.twoPhase === true;
       const timeoutMs =
         typeof p.timeoutMs === "number" ? p.timeoutMs : DEFAULT_EXEC_APPROVAL_TIMEOUT_MS;
-      const explicitId = normalizeOptionalString(p.id) ?? null;
+      // IDs are opaque cross-surface handles. Preserve every supplied byte so
+      // the manager can reject unsafe values instead of silently normalizing them.
+      const explicitId = p.id ?? null;
       const host = normalizeOptionalString(p.host) ?? "";
       const nodeId = normalizeOptionalString(p.nodeId) ?? "";
       const approvalContext = resolveSystemRunApprovalRequestContext({
@@ -365,7 +367,7 @@ export function createExecApprovalHandlers(
             false,
             undefined,
             errorShape(ErrorCodes.INVALID_REQUEST, error.message, {
-              details: { reason: error.reason },
+              details: { code: error.code, reason: error.reason },
             }),
           );
           return;

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -4405,7 +4405,12 @@ describe("exec approval handlers", () => {
   it.each([
     ["URL dot segment", ".."],
     ["ANSI escape", "approval-\u001b[31mred"],
+    ["ASCII control", "approval-\u0000hidden"],
     ["Unicode control", "approval-\u202Ehidden"],
+    ["lone surrogate", "approval-\ud800hidden"],
+    ["whitespace", "approval unsafe"],
+    ["surrounding whitespace", " approval-safe "],
+    ["whitespace-only value", " "],
     ["embedded line feed", "approval-\nunsafe"],
     ["overlong value", "a".repeat(129)],
   ])("rejects an unsafe explicit approval id containing an %s", async (_label, id) => {
@@ -4422,10 +4427,30 @@ describe("exec approval handlers", () => {
     expect(mockCallArg(respond, 0, 1)).toBeUndefined();
     expect(mockCallArg(respond, 0, 2)).toMatchObject({
       code: "INVALID_REQUEST",
-      details: { reason: "INVALID_APPROVAL_ID" },
+      details: {
+        code: "EXEC_APPROVAL_ID_INVALID",
+        reason: "INVALID_APPROVAL_ID",
+      },
     });
     expect(manager.getSnapshot(id)).toBeNull();
     expect(broadcasts).toEqual([]);
+  });
+
+  it("accepts an explicit approval id with a leading dash", async () => {
+    const { manager, handlers, broadcasts, respond, context } = createExecApprovalFixture();
+
+    const requestPromise = requestExecApproval({
+      handlers,
+      respond,
+      context,
+      params: { id: "-approval-123", host: "gateway", twoPhase: true },
+    });
+
+    const { id } = await waitForRequestedExecApprovalPayload(broadcasts);
+    await requestPromise;
+    expect(id).toBe("-approval-123");
+    expect(manager.getSnapshot(id)).not.toBeNull();
+    expect(mockCallArg(respond)).toBe(true);
   });
 
   it("rejects explicit approval ids with the reserved plugin prefix", async () => {


### PR DESCRIPTION
## What Problem This Solves
The exec-approval RPC ingress normalized (trimmed) caller-supplied approval ids before the manager's validity guard ran, so ids differing only in surrounding whitespace collapsed into one identity before rejection could see them — undermining the opaque-id contract that downstream surfaces (approvals CLI #111060) rely on. The guard's error also lacked a machine-readable code.

## Why This Change Was Made
Explicit ids now reach `ExecApprovalManager.create()` byte-for-byte; empty stays the caller-facing sentinel for manager-generated UUIDs; invalid ids reject with INVALID_REQUEST plus additive `details.code = EXEC_APPROVAL_ID_INVALID`. Producer inventory (two-phase exec UUIDs, plugin:<uuid>, system-agent:<uuid>, node system.run replay) all fit the existing safe charset unchanged.

## User Impact
No behavior change for legitimate clients; hostile or malformed ids are rejected deterministically with a typed code instead of being silently altered.

## Evidence
- 244 tests green across exec-approval-manager + server-methods suites (UUID/prefixed producers, 128-char boundary, ANSI/controls, lone surrogate, whitespace regressions, overlength).
- Structured autoreview clean (0.97).
