### PR TITLE
fix(usage): price usage rows with the owning agent's model registry

### DIFF
--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -171,6 +171,88 @@ describe("session cost usage", () => {
     });
   });
 
+  it("prices and aggregates usage with each row's agent-local registry", async () => {
+    const root = await makeSessionCostRoot("agent-scoped-pricing");
+    const provider = "demo-agent-scope";
+    const model = "demo-model";
+    const now = new Date().toISOString();
+    const writeAgentUsage = async (agentId: string, inputPrice: number, inputs: number[]) => {
+      const agentRoot = path.join(root, "agents", agentId);
+      const agentDir = path.join(agentRoot, "agent");
+      const sessionsDir = path.join(agentRoot, "sessions");
+      await fs.mkdir(agentDir, { recursive: true });
+      await fs.mkdir(sessionsDir, { recursive: true });
+      await fs.writeFile(
+        path.join(agentDir, "models.json"),
+        JSON.stringify({
+          providers: {
+            [provider]: {
+              models: [
+                {
+                  id: model,
+                  cost: { input: inputPrice, output: 0, cacheRead: 0, cacheWrite: 0 },
+                },
+              ],
+            },
+          },
+        }),
+        "utf8",
+      );
+      await fs.writeFile(
+        path.join(sessionsDir, `${agentId}-session.jsonl`),
+        [
+          JSON.stringify({ type: "session", version: 1, id: `${agentId}-session` }),
+          ...inputs.map((input) =>
+            JSON.stringify({
+              type: "message",
+              timestamp: now,
+              message: {
+                role: "assistant",
+                provider,
+                model,
+                usage: { input, output: 0, totalTokens: input },
+              },
+            }),
+          ),
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+    };
+
+    await writeAgentUsage("main", 9, [250_000]);
+    await writeAgentUsage("alpha", 1, [1_000_000, 500_000]);
+    await writeAgentUsage("beta", 2, [1_000_000]);
+    const config = {
+      models: {
+        providers: {
+          [provider]: {
+            models: [
+              {
+                id: model,
+                cost: { input: 7, output: 0, cacheRead: 0, cacheWrite: 0 },
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    await withStateDir(root, async () => {
+      const alpha = await loadCostUsageSummary({ agentId: "alpha", config });
+      const beta = await loadCostUsageSummary({ agentId: "beta", config });
+      const unscoped = await loadCostUsageSummary({ config });
+
+      expect(alpha.totals.totalTokens).toBe(1_500_000);
+      expect(alpha.totals.totalCost).toBeCloseTo(1.5, 8);
+      expect(beta.totals.totalTokens).toBe(1_000_000);
+      expect(beta.totals.totalCost).toBeCloseTo(2, 8);
+      expect(alpha.totals.totalCost + beta.totals.totalCost).toBeCloseTo(3.5, 8);
+      expect(unscoped.totals.totalTokens).toBe(250_000);
+      expect(unscoped.totals.totalCost).toBeCloseTo(2.25, 8);
+    });
+  });
+
   it("does not fall back from empty SQLite transcripts to stale JSONL usage files", async () => {
     const root = await makeSessionCostRoot("sqlite-cost-empty");
     const storePath = path.join(root, "agents", "main", "sessions", "sessions.json");

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -6,6 +6,7 @@ import readline from "node:readline";
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { resolveAgentDir } from "../agents/agent-scope-config.js";
 import type { NormalizedUsage, UsageLike } from "../agents/usage.js";
 import { normalizeUsage } from "../agents/usage.js";
 import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
@@ -179,8 +180,18 @@ type UsageCostTranscriptFile = {
   maxSeq?: number;
 };
 
-function resolveUsageCostPricingFingerprint(config?: OpenClawConfig): string {
-  return resolveModelCostConfigFingerprint(config);
+function resolveUsageCostAgentDir(
+  config: OpenClawConfig | undefined,
+  agentId: string | undefined,
+): string | undefined {
+  return agentId === undefined ? undefined : resolveAgentDir(config ?? {}, agentId);
+}
+
+function resolveUsageCostPricingFingerprint(
+  config?: OpenClawConfig,
+  agentDir?: string,
+): string {
+  return resolveModelCostConfigFingerprint(config, agentDir);
 }
 
 function resolveUsageCostSessionStorePath(params?: {
@@ -858,14 +869,22 @@ type UsageCostResolver = (params: {
   model?: string;
 }) => ReturnType<typeof resolveModelCostConfig>;
 
-function createUsageCostResolver(config?: OpenClawConfig): UsageCostResolver {
+function createUsageCostResolver(params?: {
+  config?: OpenClawConfig;
+  agentDir?: string;
+}): UsageCostResolver {
   const cache = new Map<string, ReturnType<typeof resolveModelCostConfig>>();
   return ({ provider, model }) => {
     const key = `${provider ?? ""}\0${model ?? ""}`;
     if (cache.has(key)) {
       return cache.get(key);
     }
-    const cost = resolveModelCostConfig({ provider, model, config });
+    const cost = resolveModelCostConfig({
+      provider,
+      model,
+      config: params?.config,
+      agentDir: params?.agentDir,
+    });
     cache.set(key, cost);
     return cost;
   };
@@ -1087,7 +1106,7 @@ async function scanTranscriptFile(params: {
   endOffset?: number;
   onEntry: (entry: ParsedTranscriptEntry) => void;
 }): Promise<void> {
-  const resolveCost = params.resolveCost ?? createUsageCostResolver(params.config);
+  const resolveCost = params.resolveCost ?? createUsageCostResolver({ config: params.config });
   for await (const parsed of readTranscriptRecords(
     params.filePath,
     params.startOffset,
@@ -1215,13 +1234,15 @@ export async function loadCostUsageSummary(params?: {
   defaultStart.setDate(defaultStart.getDate() - 29);
   const startMs = params?.startMs ?? defaultStart.getTime();
   const endMs = params?.endMs ?? now;
+  const agentDir = resolveUsageCostAgentDir(params?.config, params?.agentId);
   const databasePath = resolveUsageCostCacheDatabasePath(params?.agentId);
   const result = await refreshCostUsageCacheForAgent({
     config: params?.config,
     agentId: params?.agentId,
+    agentDir,
     databasePath,
   });
-  const pricingFingerprint = resolveUsageCostPricingFingerprint(params?.config);
+  const pricingFingerprint = resolveUsageCostPricingFingerprint(params?.config, agentDir);
   const rollups = readUsageCostRollups(params?.agentId, pricingFingerprint, databasePath);
   const files = await listUsageCountedTranscriptFiles(params?.agentId);
   return buildCostUsageSummaryFromRollups({
@@ -1512,6 +1533,7 @@ async function scanUsageFileForRollup(params: {
 async function refreshCostUsageCacheForAgent(params?: {
   config?: OpenClawConfig;
   agentId?: string;
+  agentDir?: string;
   databasePath?: string;
   maxFiles?: number;
   sessionsDir?: string;
@@ -1524,7 +1546,9 @@ async function refreshCostUsageCacheForAgent(params?: {
     return "busy";
   }
   try {
-    const pricingFingerprint = resolveUsageCostPricingFingerprint(params?.config);
+    const agentDir =
+      params?.agentDir ?? resolveUsageCostAgentDir(params?.config, params?.agentId);
+    const pricingFingerprint = resolveUsageCostPricingFingerprint(params?.config, agentDir);
     const rows = readSessionCostUsageRollupRows(params?.agentId, databasePath);
     const rawValues = new Map(rows.map((row) => [row.key, row.valueJson]));
     const rollups = readUsageCostRollups(params?.agentId, pricingFingerprint, databasePath);
@@ -1567,7 +1591,7 @@ async function refreshCostUsageCacheForAgent(params?: {
     const staleFiles = getUsageCostStaleRollupFiles({ rollups, files: refreshFiles })
       .toSorted((a, b) => a.size - b.size || a.filePath.localeCompare(b.filePath))
       .slice(0, maxFiles);
-    const resolveCost = createUsageCostResolver(params?.config);
+    const resolveCost = createUsageCostResolver({ config: params?.config, agentDir });
 
     for (const file of staleFiles) {
       const previous = rollups.get(file.filePath);
@@ -1601,6 +1625,7 @@ async function refreshCostUsageCacheForAgent(params?: {
 async function refreshCostUsageCache(params?: {
   config?: OpenClawConfig;
   agentId?: string;
+  agentDir?: string;
   maxFiles?: number;
   sessionFiles?: string[];
   startMs?: number;
@@ -1617,8 +1642,9 @@ export async function loadCostUsageSummaryFromCache(params: {
   requestRefresh?: boolean;
   refreshMode?: "background" | "sync-when-empty";
 }): Promise<CostUsageSummary> {
+  const agentDir = resolveUsageCostAgentDir(params.config, params.agentId);
   const databasePath = resolveUsageCostCacheDatabasePath(params.agentId);
-  const pricingFingerprint = resolveUsageCostPricingFingerprint(params.config);
+  const pricingFingerprint = resolveUsageCostPricingFingerprint(params.config, agentDir);
   let rollups = readUsageCostRollups(params.agentId, pricingFingerprint, databasePath);
   let files = await listUsageCountedTranscriptFiles(params.agentId);
   const staleFiles = getUsageCostStaleRollupFiles({ rollups, files });
@@ -1628,6 +1654,7 @@ export async function loadCostUsageSummaryFromCache(params: {
       const result = await refreshCostUsageCache({
         config: params.config,
         agentId: params.agentId,
+        agentDir,
         startMs: params.startMs,
       });
       rollups = readUsageCostRollups(params.agentId, pricingFingerprint, databasePath);
@@ -1661,8 +1688,9 @@ export async function loadSessionCostSummariesFromCache(params: {
   dayBucket?: UsageDailyBucket;
   requestRefresh?: boolean;
 }): Promise<{ summaries: Array<SessionCostSummary | null>; cacheStatus: UsageCacheStatus }> {
+  const agentDir = resolveUsageCostAgentDir(params.config, params.agentId);
   const databasePath = resolveUsageCostCacheDatabasePath(params.agentId);
-  const pricingFingerprint = resolveUsageCostPricingFingerprint(params.config);
+  const pricingFingerprint = resolveUsageCostPricingFingerprint(params.config, agentDir);
   const rollups = readUsageCostRollups(params.agentId, pricingFingerprint, databasePath);
   const fileTasks = params.sessions.map(
     (session) => async () => await resolveUsageCostTranscriptFile(session.sessionFile),
@@ -1947,11 +1975,13 @@ export async function loadSessionCostSummary(params: {
   if (!file) {
     return null;
   }
+  const agentDir = resolveUsageCostAgentDir(params.config, params.agentId);
   const databasePath = resolveUsageCostCacheDatabasePath(params.agentId);
   while (
     (await refreshCostUsageCacheForAgent({
       config: params.config,
       agentId: params.agentId,
+      agentDir,
       databasePath,
       sessionFiles: [sessionFile],
     })) === "busy"
@@ -1966,7 +1996,7 @@ export async function loadSessionCostSummary(params: {
   if (!currentFile) {
     return null;
   }
-  const pricingFingerprint = resolveUsageCostPricingFingerprint(params.config);
+  const pricingFingerprint = resolveUsageCostPricingFingerprint(params.config, agentDir);
   const stored = readUsageCostRollups(params.agentId, pricingFingerprint, databasePath).get(
     currentFile.filePath,
   );
@@ -2008,7 +2038,8 @@ export async function loadSessionUsageTimeSeries(params: {
   }
 
   const points: Array<Omit<SessionUsageTimePoint, "cumulativeTokens" | "cumulativeCost">> = [];
-  const resolveCost = createUsageCostResolver(params.config);
+  const agentDir = resolveUsageCostAgentDir(params.config, params.agentId);
+  const resolveCost = createUsageCostResolver({ config: params.config, agentDir });
 
   await scanUsageFile({
     filePath: sessionFile,
@@ -2123,7 +2154,8 @@ export async function loadSessionLogs(params: {
   const limit = params.limit ?? 50;
   const boundedLimit = Number.isInteger(limit);
   const retentionLimit = limit * 2;
-  const resolveCost = createUsageCostResolver(params.config);
+  const agentDir = resolveUsageCostAgentDir(params.config, params.agentId);
+  const resolveCost = createUsageCostResolver({ config: params.config, agentDir });
 
   for await (const parsed of readTranscriptRecordsBestEffort(sessionFile)) {
     try {

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -187,10 +187,7 @@ function resolveUsageCostAgentDir(
   return agentId === undefined ? undefined : resolveAgentDir(config ?? {}, agentId);
 }
 
-function resolveUsageCostPricingFingerprint(
-  config?: OpenClawConfig,
-  agentDir?: string,
-): string {
+function resolveUsageCostPricingFingerprint(config?: OpenClawConfig, agentDir?: string): string {
   return resolveModelCostConfigFingerprint(config, agentDir);
 }
 
@@ -1546,8 +1543,7 @@ async function refreshCostUsageCacheForAgent(params?: {
     return "busy";
   }
   try {
-    const agentDir =
-      params?.agentDir ?? resolveUsageCostAgentDir(params?.config, params?.agentId);
+    const agentDir = params?.agentDir ?? resolveUsageCostAgentDir(params?.config, params?.agentId);
     const pricingFingerprint = resolveUsageCostPricingFingerprint(params?.config, agentDir);
     const rows = readSessionCostUsageRollupRows(params?.agentId, databasePath);
     const rawValues = new Map(rows.map((row) => [row.key, row.valueJson]));

--- a/src/utils/usage-format.test.ts
+++ b/src/utils/usage-format.test.ts
@@ -238,6 +238,105 @@ describe("usage-format", () => {
     });
   });
 
+  it("scopes models.json pricing by agent directory before configured and default pricing", async () => {
+    const secondAgentDir = path.join(stateDir, "agents", "second", "agent");
+    const configuredOnlyAgentDir = path.join(stateDir, "agents", "configured-only", "agent");
+    const writePricing = async (targetAgentDir: string, input: number) => {
+      await fs.mkdir(targetAgentDir, { recursive: true });
+      await fs.writeFile(
+        path.join(targetAgentDir, "models.json"),
+        JSON.stringify({
+          providers: {
+            "demo-scoped": {
+              models: [
+                {
+                  id: "demo-model",
+                  cost: { input, output: 0, cacheRead: 0, cacheWrite: 0 },
+                },
+              ],
+            },
+          },
+        }),
+        "utf8",
+      );
+    };
+    await writePricing(agentDir, 10);
+    await writePricing(secondAgentDir, 20);
+    await fs.mkdir(configuredOnlyAgentDir, { recursive: true });
+
+    const config = {
+      models: {
+        providers: {
+          "demo-scoped": {
+            models: [
+              {
+                id: "demo-model",
+                cost: { input: 30, output: 0, cacheRead: 0, cacheWrite: 0 },
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const resolveInputPrice = (scopedAgentDir?: string) =>
+      resolveModelCostConfig({
+        provider: "demo-scoped",
+        model: "demo-model",
+        config,
+        agentDir: scopedAgentDir,
+      })?.input;
+
+    expect(resolveInputPrice(agentDir)).toBe(10);
+    expect(resolveInputPrice(secondAgentDir)).toBe(20);
+    expect(resolveInputPrice(configuredOnlyAgentDir)).toBe(30);
+    expect(resolveInputPrice()).toBe(10);
+  });
+
+  it("bounds the agent-directory models.json pricing cache", async () => {
+    const writePricing = async (targetAgentDir: string, input: number) => {
+      await fs.mkdir(targetAgentDir, { recursive: true });
+      await fs.writeFile(
+        path.join(targetAgentDir, "models.json"),
+        JSON.stringify({
+          providers: {
+            "demo-bounded": {
+              models: [
+                {
+                  id: "demo-model",
+                  cost: { input, output: 0, cacheRead: 0, cacheWrite: 0 },
+                },
+              ],
+            },
+          },
+        }),
+        "utf8",
+      );
+    };
+    const agentDirs = Array.from({ length: 129 }, (_, index) =>
+      path.join(stateDir, "agents", `bounded-${index}`, "agent"),
+    );
+    for (const [index, targetAgentDir] of agentDirs.entries()) {
+      await writePricing(targetAgentDir, index + 1);
+      expect(
+        resolveModelCostConfig({
+          provider: "demo-bounded",
+          model: "demo-model",
+          agentDir: targetAgentDir,
+        })?.input,
+      ).toBe(index + 1);
+    }
+
+    const firstAgentDir = expectDefined(agentDirs[0]);
+    await writePricing(firstAgentDir, 999);
+    expect(
+      resolveModelCostConfig({
+        provider: "demo-bounded",
+        model: "demo-model",
+        agentDir: firstAgentDir,
+      })?.input,
+    ).toBe(999);
+  });
+
   it("falls back to openclaw config pricing when models.json is absent", () => {
     const config = {
       models: {

--- a/src/utils/usage-format.test.ts
+++ b/src/utils/usage-format.test.ts
@@ -326,7 +326,7 @@ describe("usage-format", () => {
       ).toBe(index + 1);
     }
 
-    const firstAgentDir = expectDefined(agentDirs[0]);
+    const firstAgentDir = expectDefined(agentDirs[0], "first bounded agent directory");
     await writePricing(firstAgentDir, 999);
     expect(
       resolveModelCostConfig({

--- a/src/utils/usage-format.ts
+++ b/src/utils/usage-format.ts
@@ -91,9 +91,10 @@ type RawModelCostConfig = Omit<ModelCostConfig, "tieredPricing"> & {
 };
 
 const EMPTY_PROVIDER_COST_INDEX = new Map<string, ModelCostConfig>();
+const MODELS_JSON_COST_CACHE_LIMIT = 128;
 const MODEL_KEY_CACHE_LIMIT = 4096;
 
-let modelsJsonCostCache: ModelsJsonCostCache | null = null;
+let modelsJsonCostCacheByAgentDir = new Map<string, ModelsJsonCostCache>();
 let providerCostIndexByConfig = new WeakMap<
   Record<string, ModelProviderConfig>,
   ProviderCostIndexCacheEntry
@@ -345,12 +346,15 @@ function getProviderCostIndex(
 }
 
 function loadModelsJsonCostIndex(options?: {
+  agentDir?: string;
   allowPluginNormalization?: boolean;
 }): Map<string, ModelCostConfig> {
   const useRawEntries = options?.allowPluginNormalization === false;
-  const modelsPath = path.join(resolveDefaultAgentDir({}), "models.json");
+  const agentDir = options?.agentDir ?? resolveDefaultAgentDir({});
+  const modelsPath = path.join(agentDir, "models.json");
   try {
-    if (!modelsJsonCostCache || modelsJsonCostCache.path !== modelsPath) {
+    let modelsJsonCostCache = modelsJsonCostCacheByAgentDir.get(agentDir);
+    if (!modelsJsonCostCache) {
       const parsed = tryReadJsonSync<{
         providers?: Record<string, ModelProviderConfig>;
       }>(modelsPath);
@@ -363,6 +367,13 @@ function loadModelsJsonCostIndex(options?: {
         normalizedEntries: null,
         rawEntries: null,
       };
+      if (modelsJsonCostCacheByAgentDir.size >= MODELS_JSON_COST_CACHE_LIMIT) {
+        const oldestAgentDir = modelsJsonCostCacheByAgentDir.keys().next().value;
+        if (oldestAgentDir !== undefined) {
+          modelsJsonCostCacheByAgentDir.delete(oldestAgentDir);
+        }
+      }
+      modelsJsonCostCacheByAgentDir.set(agentDir, modelsJsonCostCache);
     }
 
     if (useRawEntries) {
@@ -576,14 +587,19 @@ function serializeCostIndex(
  * Fingerprints all model-pricing sources that can affect usage cost estimates.
  * Consumers cache this value to know when resolved cost entries need recomputation.
  */
-export function resolveModelCostConfigFingerprint(config?: OpenClawConfig): string {
+export function resolveModelCostConfigFingerprint(
+  config?: OpenClawConfig,
+  agentDir?: string,
+): string {
   return stableCostFingerprintValue({
     configuredRaw: serializeCostIndex(
       getProviderCostIndex(config?.models?.providers, { allowPluginNormalization: false }),
     ),
     configuredNormalized: serializeCostIndex(getProviderCostIndex(config?.models?.providers)),
-    modelsJsonRaw: serializeCostIndex(loadModelsJsonCostIndex({ allowPluginNormalization: false })),
-    modelsJsonNormalized: serializeCostIndex(loadModelsJsonCostIndex()),
+    modelsJsonRaw: serializeCostIndex(
+      loadModelsJsonCostIndex({ agentDir, allowPluginNormalization: false }),
+    ),
+    modelsJsonNormalized: serializeCostIndex(loadModelsJsonCostIndex({ agentDir })),
     gatewayPricing: getGatewayModelPricingCacheFingerprint(),
   });
 }
@@ -596,6 +612,7 @@ export function resolveModelCostConfig(params: {
   provider?: string;
   model?: string;
   config?: OpenClawConfig;
+  agentDir?: string;
   allowPluginNormalization?: boolean;
 }): ModelCostConfig | undefined {
   const rawKey = toDirectModelKey(params);
@@ -606,6 +623,7 @@ export function resolveModelCostConfig(params: {
   // Favor direct configured keys first so local pricing/status lookups stay
   // synchronous and do not drag plugin/provider discovery into the hot path.
   const rawModelsJsonCost = loadModelsJsonCostIndex({
+    agentDir: params.agentDir,
     allowPluginNormalization: false,
   }).get(rawKey);
   if (rawModelsJsonCost) {
@@ -627,7 +645,7 @@ export function resolveModelCostConfig(params: {
   if (shouldUseNormalizedCostLookup(params)) {
     const key = toResolvedModelKey(params);
     if (key && key !== rawKey) {
-      const modelsJsonCost = loadModelsJsonCostIndex().get(key);
+      const modelsJsonCost = loadModelsJsonCostIndex({ agentDir: params.agentDir }).get(key);
       if (modelsJsonCost) {
         return modelsJsonCost;
       }
@@ -737,7 +755,7 @@ export function estimateUsageCost(params: {
 }
 
 export function resetUsageFormatCachesForTest(): void {
-  modelsJsonCostCache = null;
+  modelsJsonCostCacheByAgentDir = new Map();
   providerCostIndexByConfig = new WeakMap();
   modelKeyCache = new Map();
   sortedPricingTiersByInput = new WeakMap();


### PR DESCRIPTION
## What Problem This Solves
Usage-cost pricing always loaded models.json from the physical default agent's directory regardless of which agent produced the usage, so non-main agents' local pricing was ignored and main-local pricing was silently applied fleet-wide, corrupting per-agent cost totals and budgets (single-agent-era assumption; audit P1).

## Why This Change Was Made
Usage loaders resolve the effective agent's directory once per computation and thread it through pricing resolution and the rollup pricing fingerprint. Resolution order per row: agent-local models.json → configured pricing → existing default fallback for genuinely unscoped rows. models.json indexes are cached per agent directory in a bounded (128-entry) process-lifecycle cache; stale rollups invalidate when agent-local pricing differs.

## User Impact
Fleet cost summaries, per-session costs, and budgets now reflect each agent's actual pricing. Unscoped usage keeps today's behavior; no UI or config changes.

## Evidence
- 94 tests green across usage-format + session-cost-usage suites: two agents with different registry prices, multi-row aggregation, configured fallback, unscoped default behavior, cache isolation, bounded eviction.
- Structured autoreview clean (0.94).
