### PR TITLE
fix: warn before retrying timed-out exec commands

### DIFF
--- a/src/agents/bash-tools.exec-foreground-failures.test.ts
+++ b/src/agents/bash-tools.exec-foreground-failures.test.ts
@@ -196,7 +196,10 @@ describe("exec foreground failures", () => {
     expect(supervisorMock.spawn.mock.calls[0]?.[0]?.timeoutMs).toBe(1_000);
     const text = requireTextContent(result);
     expect(text).toMatch(/timed out/i);
-    expect(text).toMatch(/re-run with a higher timeout/i);
+    expect(text).toContain("external side effects may already have completed");
+    expect(text).toContain("Verify the resulting state before retrying");
+    expect(text).toContain("Do not automatically rerun non-idempotent commands");
+    expect(text).toContain("known to be safe to retry");
     const details = requireFailedDetails(result.details);
     expect(details.exitCode).toBeNull();
     expect(details.exitSignal).toBe("SIGKILL");

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -2320,6 +2320,42 @@ EOF`,
     expect(runExecProcessMock).toHaveBeenCalledTimes(1);
   });
 
+  it("warns detached approval followups after a supervisor timeout", async () => {
+    resolveApprovalDecisionOrUndefinedMock.mockResolvedValue("allow-once");
+    createExecApprovalDecisionStateMock.mockReturnValue({
+      baseDecision: { timedOut: false },
+      approvedByAsk: true,
+      deniedReason: null,
+    });
+    const outcome = {
+      status: "failed" as const,
+      exitCode: null,
+      exitReason: "overall-timeout" as const,
+      timedOut: true,
+      aggregated: "",
+      reason: "Command timed out.",
+    } satisfies ExecApprovalFollowupOutcome;
+    runExecProcessMock.mockResolvedValue({
+      session: { id: "sess-timeout" },
+      promise: Promise.resolve(outcome),
+    });
+    buildExecApprovalFollowupTargetMock.mockImplementation((value) => value);
+
+    const result = await runGatewayAllowlist({
+      command: "side-effecting-command",
+      turnSourceChannel: "feishu",
+    });
+
+    expect(result.pendingResult?.details.status).toBe("approval-pending");
+    await vi.waitFor(() => {
+      expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledOnce();
+    });
+    expect(requireSentFollowupText(0)).toContain(
+      "external side effects may already have completed",
+    );
+    expect(requireSentFollowupText(0)).toContain("Verify the resulting state before retrying");
+  });
+
   it("drops detached execution and follow-up when the owning run is aborted", async () => {
     resolveApprovalDecisionOrUndefinedMock.mockRejectedValue(runAbortedApprovalError);
     buildExecApprovalFollowupTargetMock.mockImplementation((value) => value);

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -65,6 +65,7 @@ import {
   sendExecApprovalFollowupResult,
   shouldResolveExecApprovalUnavailableInline,
 } from "./bash-tools.exec-host-shared.js";
+import { appendExecTimeoutRetryGuidance } from "./bash-tools.exec-output.js";
 import {
   DEFAULT_NOTIFY_TAIL_CHARS,
   createApprovalSlug,
@@ -390,6 +391,7 @@ function buildGatewayExecApprovalFollowupSummary(params: {
   approvalFollowupText?: string;
 }): string {
   const exitLabel = formatOutcomeExitLabel(params.outcome);
+  let summary: string;
   if (params.trigger === "diagnostics") {
     const diagnosticsText =
       params.outcome.status === "completed" && params.outcome.exitCode === 0
@@ -397,15 +399,16 @@ function buildGatewayExecApprovalFollowupSummary(params: {
         : formatDiagnosticsExportFailure({ outcome: params.outcome, exitLabel });
     const followupText = params.approvalFollowupText?.trim();
     const body = [diagnosticsText, followupText].filter(Boolean).join("\n\n");
-    return `Exec finished (gateway id=${params.approvalId}, session=${params.sessionId}, ${exitLabel})\n${body}`;
+    summary = `Exec finished (gateway id=${params.approvalId}, session=${params.sessionId}, ${exitLabel})\n${body}`;
+  } else {
+    const output = normalizeNotifyOutput(
+      tail(params.outcome.aggregated || "", DEFAULT_NOTIFY_TAIL_CHARS),
+    );
+    summary = output
+      ? `Exec finished (gateway id=${params.approvalId}, session=${params.sessionId}, ${exitLabel})\n${output}`
+      : `Exec finished (gateway id=${params.approvalId}, session=${params.sessionId}, ${exitLabel})`;
   }
-
-  const output = normalizeNotifyOutput(
-    tail(params.outcome.aggregated || "", DEFAULT_NOTIFY_TAIL_CHARS),
-  );
-  return output
-    ? `Exec finished (gateway id=${params.approvalId}, session=${params.sessionId}, ${exitLabel})\n${output}`
-    : `Exec finished (gateway id=${params.approvalId}, session=${params.sessionId}, ${exitLabel})`;
+  return appendExecTimeoutRetryGuidance(summary, params.outcome.exitReason);
 }
 
 function shouldAwaitGatewayApprovalInline(params: {

--- a/src/agents/bash-tools.exec-output.test.ts
+++ b/src/agents/bash-tools.exec-output.test.ts
@@ -7,7 +7,7 @@ import {
 } from "./bash-tools.exec-output.js";
 
 describe("appendExecTimeoutRetryGuidance", () => {
-  it.each(["overall-timeout", "no-output-timeout"])(
+  it.each(["overall-timeout", "no-output-timeout"] as const)(
     "warns that %s may already have produced side effects",
     (exitReason) => {
       const text = appendExecTimeoutRetryGuidance("Command timed out.", exitReason);

--- a/src/agents/bash-tools.exec-output.test.ts
+++ b/src/agents/bash-tools.exec-output.test.ts
@@ -1,6 +1,28 @@
 // Tests for exec output rendering helpers.
 import { describe, expect, it } from "vitest";
-import { renderExecOutputText, renderExecUpdateText } from "./bash-tools.exec-output.js";
+import {
+  appendExecTimeoutRetryGuidance,
+  renderExecOutputText,
+  renderExecUpdateText,
+} from "./bash-tools.exec-output.js";
+
+describe("appendExecTimeoutRetryGuidance", () => {
+  it.each(["overall-timeout", "no-output-timeout"])(
+    "warns that %s may already have produced side effects",
+    (exitReason) => {
+      const text = appendExecTimeoutRetryGuidance("Command timed out.", exitReason);
+
+      expect(text).toContain("external side effects may already have completed");
+      expect(text).toContain("Verify the resulting state before retrying");
+      expect(text).toContain("Do not automatically rerun non-idempotent commands");
+      expect(text).toContain("known to be safe to retry");
+    },
+  );
+
+  it("leaves non-timeout exits unchanged", () => {
+    expect(appendExecTimeoutRetryGuidance("Command failed.", "signal")).toBe("Command failed.");
+  });
+});
 
 describe("renderExecOutputText", () => {
   it("returns placeholder for undefined input", () => {

--- a/src/agents/bash-tools.exec-output.ts
+++ b/src/agents/bash-tools.exec-output.ts
@@ -4,6 +4,8 @@
  * progress, polling, and completion surfaces.
  */
 const EXEC_NO_OUTPUT_PLACEHOLDER = "(no output)";
+const EXEC_TIMEOUT_RETRY_GUIDANCE =
+  "The command was terminated, but external side effects may already have completed. Verify the resulting state before retrying. Do not automatically rerun non-idempotent commands. Use a higher timeout only when the command is known to be safe to retry.";
 
 /** Render command output with a stable placeholder for empty output. */
 export function renderExecOutputText(value: string | undefined): string {
@@ -14,4 +16,15 @@ export function renderExecOutputText(value: string | undefined): string {
 export function renderExecUpdateText(params: { tailText?: string; warnings: string[] }): string {
   const warningText = params.warnings.length ? `${params.warnings.join("\n")}\n\n` : "";
   return warningText + renderExecOutputText(params.tailText);
+}
+
+/** Add retry-safety guidance only for supervisor timeout exits. */
+export function appendExecTimeoutRetryGuidance(
+  text: string,
+  exitReason: string | undefined,
+): string {
+  if (exitReason !== "overall-timeout" && exitReason !== "no-output-timeout") {
+    return text;
+  }
+  return `${text}\n\n${EXEC_TIMEOUT_RETRY_GUIDANCE}`;
 }

--- a/src/agents/bash-tools.exec-output.ts
+++ b/src/agents/bash-tools.exec-output.ts
@@ -3,6 +3,8 @@
  * Keeps no-output placeholders and warning placement consistent across exec
  * progress, polling, and completion surfaces.
  */
+import type { TerminationReason } from "../process/supervisor/types.js";
+
 const EXEC_NO_OUTPUT_PLACEHOLDER = "(no output)";
 const EXEC_TIMEOUT_RETRY_GUIDANCE =
   "The command was terminated, but external side effects may already have completed. Verify the resulting state before retrying. Do not automatically rerun non-idempotent commands. Use a higher timeout only when the command is known to be safe to retry.";
@@ -21,7 +23,7 @@ export function renderExecUpdateText(params: { tailText?: string; warnings: stri
 /** Add retry-safety guidance only for supervisor timeout exits. */
 export function appendExecTimeoutRetryGuidance(
   text: string,
-  exitReason: string | undefined,
+  exitReason: TerminationReason | undefined,
 ): string {
   if (exitReason !== "overall-timeout" && exitReason !== "no-output-timeout") {
     return text;

--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -520,6 +520,9 @@ describe("exec notifyOnExit suppression", () => {
 
     const [message, options] = requireSystemEventCall();
     expect(message).toContain("Exec failed");
+    expect(message).toContain("external side effects may already have completed");
+    expect(message).toContain("Verify the resulting state before retrying");
+    expect(message).toContain("Do not automatically rerun non-idempotent commands");
     expect(options.sessionKey).toBe("agent:main:main");
     expect(requestHeartbeatMock).toHaveBeenCalledTimes(1);
     const heartbeat = requireHeartbeatCall();
@@ -731,6 +734,10 @@ describe("runExecProcess exit outcomes", () => {
     expect(outcome.failureKind).toBe("overall-timeout");
     expect(outcome.timedOut).toBe(true);
     expect(outcome.reason).toContain("30 seconds");
+    expect(outcome.reason).toContain("external side effects may already have completed");
+    expect(outcome.reason).toContain("Verify the resulting state before retrying");
+    expect(outcome.reason).toContain("Do not automatically rerun non-idempotent commands");
+    expect(outcome.reason).toContain("known to be safe to retry");
     expect(outcome.reason).toContain("background=true");
     expect(outcome.reason).toContain("yieldMs");
     expect(outcome.reason).toContain("Do not rely on shell backgrounding");

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -45,7 +45,7 @@ import {
   markExited,
   tail,
 } from "./bash-process-registry.js";
-import { renderExecUpdateText } from "./bash-tools.exec-output.js";
+import { appendExecTimeoutRetryGuidance, renderExecUpdateText } from "./bash-tools.exec-output.js";
 import {
   buildDockerExecArgs,
   chunkString,
@@ -331,11 +331,12 @@ function maybeNotifyOnExit(session: ProcessSession, status: "completed" | "faile
   const summary = output
     ? `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel}) :: ${output}`
     : `Exec ${status} (${session.id.slice(0, 8)}, ${exitLabel})`;
+  const eventText = appendExecTimeoutRetryGuidance(summary, session.exitReason);
   const eventRouting = session.eventRouting ?? {
     mainKey: session.mainKey,
     sessionScope: session.sessionScope,
   };
-  enqueueSystemEvent(summary, {
+  enqueueSystemEvent(eventText, {
     sessionKey: resolveEventSessionKeyForPolicy(sessionKey, eventRouting),
     deliveryContext: session.notifyDeliveryContext,
   });
@@ -450,12 +451,18 @@ function formatExecFailureReason(params: {
       return "Command not found";
     case "shell-not-executable":
       return "Command not executable (permission denied)";
-    case "overall-timeout":
-      return typeof params.timeoutSec === "number" && params.timeoutSec > 0
-        ? `Command timed out after ${params.timeoutSec} seconds. If this command is expected to take longer, re-run with a higher timeout (e.g., exec timeout=300). If it should keep running, start it with exec background=true or yieldMs so OpenClaw can register a pollable process session. Do not rely on shell backgrounding with a trailing &.`
-        : "Command timed out. If this command is expected to take longer, re-run with a higher timeout (e.g., exec timeout=300). If it should keep running, start it with exec background=true or yieldMs so OpenClaw can register a pollable process session. Do not rely on shell backgrounding with a trailing &.";
+    case "overall-timeout": {
+      const timeoutText =
+        typeof params.timeoutSec === "number" && params.timeoutSec > 0
+          ? `Command timed out after ${params.timeoutSec} seconds.`
+          : "Command timed out.";
+      return `${appendExecTimeoutRetryGuidance(timeoutText, params.failureKind)}\n\nIf it should keep running, start it with exec background=true or yieldMs so OpenClaw can register a pollable process session. Do not rely on shell backgrounding with a trailing &.`;
+    }
     case "no-output-timeout":
-      return "Command timed out waiting for output";
+      return appendExecTimeoutRetryGuidance(
+        "Command timed out waiting for output.",
+        params.failureKind,
+      );
     case "signal":
       return `Command aborted by signal ${params.exitSignal}`;
     case "aborted":

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -92,6 +92,7 @@ export type ExecToolDefaults = {
 export type ExecApprovalFollowupOutcome = {
   status: "completed" | "failed";
   exitCode: number | null;
+  exitReason?: TerminationReason;
   timedOut: boolean;
   aggregated: string;
   reason?: string;

--- a/src/agents/bash-tools.process.poll-timeout.test.ts
+++ b/src/agents/bash-tools.process.poll-timeout.test.ts
@@ -104,6 +104,30 @@ test("process poll accepts string timeout values", async () => {
   });
 });
 
+test("process poll warns when the session times out while poll is waiting", async () => {
+  vi.useFakeTimers();
+  try {
+    const sessionId = "sess-timeout-while-polling";
+    const { processTool, session } = createProcessSessionHarness(sessionId);
+
+    setTimeout(() => {
+      markExited(session, null, "SIGKILL", "failed", "overall-timeout", false);
+    }, 10);
+
+    const pollPromise = pollSession(processTool, "toolcall", sessionId, 2000);
+    await vi.advanceTimersByTimeAsync(250);
+    const poll = await pollPromise;
+
+    expect(pollStatus(poll)).toBe("failed");
+    expect(poll.content[0]).toMatchObject({
+      type: "text",
+      text: expect.stringContaining("Verify the resulting state before retrying"),
+    });
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
 test("process poll clamps long waits to 30 seconds", async () => {
   vi.useFakeTimers();
   try {
@@ -223,4 +247,16 @@ test("process poll exposes finished-session termination metadata", async () => {
   expect(details.timedOut).toBe(true);
   expect(details.noOutputTimedOut).toBe(true);
   expect(details.aggregated).toContain("terminated");
+  expect(poll.content[0]).toMatchObject({
+    type: "text",
+    text: expect.stringContaining("external side effects may already have completed"),
+  });
+  expect(poll.content[0]).toMatchObject({
+    type: "text",
+    text: expect.stringContaining("Verify the resulting state before retrying"),
+  });
+  expect(poll.content[0]).toMatchObject({
+    type: "text",
+    text: expect.stringContaining("Do not automatically rerun non-idempotent commands"),
+  });
 });

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -20,6 +20,7 @@ import {
   setJobTtlMs,
 } from "./bash-process-registry.js";
 import { describeProcessTool } from "./bash-tools.descriptions.js";
+import { appendExecTimeoutRetryGuidance } from "./bash-tools.exec-output.js";
 import {
   handleProcessSendKeys,
   type WritableStdin,
@@ -394,16 +395,18 @@ export function createProcessTool(
                 content: [
                   {
                     type: "text",
-                    text:
+                    text: appendExecTimeoutRetryGuidance(
                       (scopedFinished.tail ||
                         `(no output recorded${
                           scopedFinished.truncated ? " — truncated to cap" : ""
                         })`) +
-                      `\n\nProcess exited with ${
-                        scopedFinished.exitSignal
-                          ? `signal ${scopedFinished.exitSignal}`
-                          : `code ${scopedFinished.exitCode ?? 0}`
-                      }.`,
+                        `\n\nProcess exited with ${
+                          scopedFinished.exitSignal
+                            ? `signal ${scopedFinished.exitSignal}`
+                            : `code ${scopedFinished.exitCode ?? 0}`
+                        }.`,
+                      scopedFinished.exitReason,
+                    ),
                   },
                 ],
                 details: {
@@ -475,13 +478,15 @@ export function createProcessTool(
             content: [
               {
                 type: "text",
-                text:
+                text: appendExecTimeoutRetryGuidance(
                   (output || "(no new output)") +
-                  (exited
-                    ? `\n\nProcess exited with ${
-                        exitSignal ? `signal ${exitSignal}` : `code ${exitCode}`
-                      }.`
-                    : buildInputWaitHint(runtime) || "\n\nProcess still running."),
+                    (exited
+                      ? `\n\nProcess exited with ${
+                          exitSignal ? `signal ${exitSignal}` : `code ${exitCode}`
+                        }.`
+                      : buildInputWaitHint(runtime) || "\n\nProcess still running."),
+                  exited ? scopedSession.exitReason : undefined,
+                ),
               },
             ],
             details: {

--- a/src/agents/embedded-agent-runner/run/payloads.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.test.ts
@@ -595,7 +595,7 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
         toolName: "exec",
         timedOut: true,
         error:
-          "Command timed out after 1800 seconds. If this command is expected to take longer, re-run with a higher timeout (e.g., exec timeout=300).",
+          "Command timed out after 1800 seconds. The command was terminated, but external side effects may already have completed. Verify the resulting state before retrying. Do not automatically rerun non-idempotent commands. Use a higher timeout only when the command is known to be safe to retry.",
       },
       sessionKey: "agent:main:cron:job-1",
       verboseLevel: "off",
@@ -604,7 +604,7 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     expectSingleToolErrorPayload(payloads, {
       title: "Exec",
       detail:
-        "Command timed out after 1800 seconds. If this command is expected to take longer, re-run with a higher timeout (e.g., exec timeout=300).",
+        "Command timed out after 1800 seconds. The command was terminated, but external side effects may already have completed. Verify the resulting state before retrying. Do not automatically rerun non-idempotent commands. Use a higher timeout only when the command is known to be safe to retry.",
     });
   });
 


### PR DESCRIPTION
Closes #111387
Related: #88206

## What Problem This Solves

Fixes an issue where scheduled tasks could send the same external notification twice when a side-effecting `exec` command completed its send but was terminated by the tool timeout. The timeout result previously told the agent to rerun with a higher timeout without warning that external side effects might already have completed.

## Why This Change Was Made

Timeout results now tell the agent to verify external state before retrying, never automatically rerun non-idempotent commands, and use a higher timeout only when retry safety is known. The guidance is shared by foreground exec failures, background completion events, and `process poll` results for both overall and no-output timeouts.

This intentionally does not deduplicate identical shell commands or change cron scheduling. Identical calls can be intentional, and the redacted run history in #111387 shows the duplicate occurred inside one agent run after a timeout.

## User Impact

Agents handling scheduled work are less likely to repeat email, chat, webhook, or other external side effects after an ambiguous timeout. Safe long-running commands can still be retried with a larger timeout or started as a registered background process.

## Evidence

- Redacted main-agent evidence and cron-history analysis are recorded in #111387.
- After-fix runtime proof used the production process supervisor to terminate a benign command after one second, then read the real terminal result through the production `process poll` tool:

  <details>
  <summary>Redacted runtime transcript</summary>

  ```text
  supervisorExit: reason=overall-timeout, exitSignal=SIGTERM, timedOut=true
  processPollDetails: status=failed, exitReason=overall-timeout, timedOut=true

  (no output recorded)

  Process exited with signal SIGTERM.

  The command was terminated, but external side effects may already have completed. Verify the resulting state before retrying. Do not automatically rerun non-idempotent commands. Use a higher timeout only when the command is known to be safe to retry.
  ```

  </details>

- `node scripts/run-vitest.mjs src/agents/bash-tools.exec-output.test.ts src/agents/bash-tools.exec-runtime.test.ts src/agents/bash-tools.exec-foreground-failures.test.ts src/agents/bash-tools.process.poll-timeout.test.ts src/agents/embedded-agent-runner/run/payloads.test.ts` (127 tests passed across 2 shards)
- Targeted `oxlint` on all 8 changed files
- `git diff --check`
- `autoreview --mode uncommitted`: clean, no accepted/actionable findings
- PR CI run `29687974442`: all selected typecheck, lint, test, build, and guard jobs passed (81 successful checks in the current rollup; no failures).

AI-assisted with Codex. I reviewed the implementation and understand the timeout and retry-safety behavior.
