### PR TITLE
fix: local lint works in dependency-less worktrees

### DIFF
--- a/scripts/lib/local-heavy-check-runtime.d.mts
+++ b/scripts/lib/local-heavy-check-runtime.d.mts
@@ -6,6 +6,15 @@ export type LocalHostResources = {
 export function isLocalCheckEnabled(env: NodeJS.ProcessEnv): boolean;
 /** Ensure local check runs opt into safeguard environment outside CI. */
 export function resolveLocalHeavyCheckEnv(env?: NodeJS.ProcessEnv): NodeJS.ProcessEnv;
+/** Resolve a repo tool from this worktree or the primary checkout's installed toolchain. */
+export function resolveRepoToolBinPath(
+  toolName: string,
+  options?: {
+    cwd?: string;
+    fileExists?: (candidate: string) => boolean;
+    resolveCommonDir?: (cwd: string) => string | null;
+  },
+): string;
 /** Apply local tsgo defaults for declaration skipping, caching, throttling, and profiling. */
 export function applyLocalTsgoPolicy(
   args: string[],

--- a/scripts/lib/local-heavy-check-runtime.mjs
+++ b/scripts/lib/local-heavy-check-runtime.mjs
@@ -38,6 +38,27 @@ export function resolveLocalHeavyCheckEnv(env = process.env) {
   };
 }
 
+/** Resolve a repo tool from this worktree or the primary checkout's installed toolchain. */
+export function resolveRepoToolBinPath(
+  toolName,
+  { cwd = process.cwd(), fileExists = fs.existsSync, resolveCommonDir = resolveGitCommonDir } = {},
+) {
+  const localPath = path.resolve(cwd, "node_modules", ".bin", toolName);
+  if (fileExists(localPath)) {
+    return localPath;
+  }
+
+  const commonDir = resolveCommonDir(cwd);
+  if (!commonDir || path.basename(commonDir) !== ".git") {
+    return localPath;
+  }
+
+  // Linked worktrees share the primary checkout's .git directory. Its parent
+  // owns the installed toolchain that dependency-less worktrees can reuse.
+  const primaryPath = path.join(path.dirname(commonDir), "node_modules", ".bin", toolName);
+  return fileExists(primaryPath) ? primaryPath : localPath;
+}
+
 function hasFlag(args, name) {
   return args.some((arg) => arg === name || arg.startsWith(`${name}=`));
 }

--- a/scripts/run-oxlint.mjs
+++ b/scripts/run-oxlint.mjs
@@ -7,11 +7,12 @@ import {
   acquireLocalHeavyCheckLockSync,
   applyLocalOxlintPolicy,
   resolveLocalHeavyCheckEnv,
+  resolveRepoToolBinPath,
   shouldAcquireLocalHeavyCheckLockForOxlint,
 } from "./lib/local-heavy-check-runtime.mjs";
 import { createManagedCommandInvocation, runManagedCommand } from "./lib/managed-child-process.mjs";
+import { resolvePathEnvKey } from "./windows-cmd-helpers.mjs";
 
-const oxlintPath = path.resolve("node_modules", ".bin", "oxlint");
 const PREPARE_EXTENSION_BOUNDARY_ARGS = [
   path.resolve("scripts", "prepare-extension-package-boundary-artifacts.mjs"),
 ];
@@ -178,6 +179,18 @@ function hasTrackedPath({ cwd, target }) {
   return result.status === 0 && result.stdout.trim().length > 0;
 }
 
+function resolveOxlintToolchainEnv(oxlintPath, env, platform = process.platform) {
+  const pathKey = platform === "win32" ? resolvePathEnvKey(env) : "PATH";
+  const delimiter = platform === "win32" ? ";" : path.delimiter;
+  const currentPath = env[pathKey]?.trim();
+  return {
+    ...env,
+    // Type-aware oxlint resolves its optional tsgolint peer through PATH, so
+    // keep the selected checkout's toolchain together in dependency-less worktrees.
+    [pathKey]: [path.dirname(oxlintPath), currentPath].filter(Boolean).join(delimiter),
+  };
+}
+
 async function prepareExtensionPackageBoundaryArtifacts(env) {
   const releaseArtifactsLock = acquireLocalHeavyCheckLockSync({
     cwd: process.cwd(),
@@ -256,10 +269,11 @@ export async function main(argv = process.argv.slice(2), runtimeEnv = process.en
       await prepareExtensionPackageBoundaryArtifacts(env);
     }
 
+    const oxlintPath = resolveRepoToolBinPath("oxlint");
     const status = await runManagedCommand({
       bin: oxlintPath,
       args: finalArgs,
-      env,
+      env: resolveOxlintToolchainEnv(oxlintPath, env),
     });
     process.exitCode = status;
   } finally {

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -1287,6 +1287,10 @@ const TOOLING_SOURCE_TEST_TARGETS = new Map([
   ["scripts/lib/format-generated-module.mjs", ["test/scripts/format-generated-module.test.ts"]],
   ["scripts/lib/ios-version.ts", ["test/scripts/ios-version.test.ts"]],
   ["scripts/lib/live-docker-stage.sh", ["test/scripts/live-docker-stage.test.ts"]],
+  [
+    "scripts/lib/local-heavy-check-runtime.d.mts",
+    ["test/scripts/local-heavy-check-runtime.test.ts"],
+  ],
   ["scripts/lib/local-heavy-check-runtime.mjs", ["test/scripts/local-heavy-check-runtime.test.ts"]],
   ["scripts/lib/kova-report-gate.mjs", ["test/scripts/kova-report-gate.test.ts"]],
   ["scripts/lib/kova-report-publish-files.mjs", ["test/scripts/kova-report-publish-files.test.ts"]],

--- a/test/scripts/local-heavy-check-runtime.test.ts
+++ b/test/scripts/local-heavy-check-runtime.test.ts
@@ -8,6 +8,7 @@ import {
   applyLocalOxlintPolicy,
   applyLocalTsgoPolicy,
   resolveLocalHeavyCheckEnv,
+  resolveRepoToolBinPath,
   shouldAcquireLocalHeavyCheckLockForOxlint,
   shouldAcquireLocalHeavyCheckLockForTsgo,
 } from "../../scripts/lib/local-heavy-check-runtime.mjs";
@@ -40,6 +41,29 @@ function makeEnv(overrides: Record<string, string | undefined> = {}) {
 }
 
 describe("local-heavy-check-runtime", () => {
+  it("resolves repo tools from the primary checkout for dependency-less worktrees", () => {
+    const primaryRoot = createTempDir("openclaw-primary-checkout-");
+    const cwd = path.join(primaryRoot, ".codex", "worktrees", "task", "openclaw");
+    const commonDir = path.join(primaryRoot, ".git");
+    const localPath = path.resolve(cwd, "node_modules", ".bin", "oxlint");
+    const primaryPath = path.join(primaryRoot, "node_modules", ".bin", "oxlint");
+
+    expect(
+      resolveRepoToolBinPath("oxlint", {
+        cwd,
+        fileExists: (candidate) => candidate === primaryPath,
+        resolveCommonDir: () => commonDir,
+      }),
+    ).toBe(primaryPath);
+    expect(
+      resolveRepoToolBinPath("oxlint", {
+        cwd,
+        fileExists: (candidate) => candidate === localPath || candidate === primaryPath,
+        resolveCommonDir: () => commonDir,
+      }),
+    ).toBe(localPath);
+  });
+
   it("reenables local heavy-check policy for local wrapper entrypoints", () => {
     expect(resolveLocalHeavyCheckEnv({ OPENCLAW_LOCAL_CHECK: "0", PATH: "/usr/bin" })).toEqual({
       OPENCLAW_LOCAL_CHECK: "1",

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -1773,6 +1773,10 @@ describe("scripts/test-projects changed-target routing", () => {
   it("keeps shared script library edits on owner tests", () => {
     const expectedTargets = new Map([
       [
+        "scripts/lib/local-heavy-check-runtime.d.mts",
+        ["test/scripts/local-heavy-check-runtime.test.ts"],
+      ],
+      [
         "scripts/lib/local-heavy-check-runtime.mjs",
         ["test/scripts/local-heavy-check-runtime.test.ts"],
       ],


### PR DESCRIPTION
Related: #111293

## What Problem This Solves

Fixes an issue where developers and agents running local lint from a dependency-less linked, Claude, or Codex worktree would fail with `ENOENT` because `scripts/run-oxlint.mjs` only looked for oxlint in that worktree's `node_modules/.bin`. This forced avoidable hosted-CI feedback cycles for lint findings even when the primary checkout already had the repository toolchain installed.

## Why This Change Was Made

The local-check runtime now resolves repository tool binaries from the current worktree first, then falls back to the checkout that owns Git's shared common directory. The oxlint wrapper also places the selected toolchain's `.bin` directory on the child PATH so type-aware lint can find its `tsgolint` peer. The shared `.d.mts` contract and changed-test routing cover the new resolver. Sharded lint needs no duplicate resolver because every shard already delegates through `run-oxlint.mjs`; its lock, sparse-checkout, preparation, timeout, and process-group policies are unchanged.

## User Impact

Developers and agents can run focused oxlint checks from dependency-less linked worktrees while reusing the primary checkout's installed toolchain, catching lint failures before opening or updating a PR.

## Evidence

- Before: `node scripts/run-oxlint.mjs --version` failed with `spawn <worktree>/node_modules/.bin/oxlint ENOENT` while the primary checkout had oxlint installed.
- After: the same dependency-less worktree resolves `/Users/steipete/Projects/openclaw/node_modules/.bin/oxlint` and reports oxlint 1.73.0.
- Type-aware focused lint passes with the worktree's `node_modules` absent and the selected primary toolchain on PATH.
- `node scripts/check-script-declarations.mjs` — 237 declaration contracts match.
- `node scripts/run-vitest.mjs test/scripts/local-heavy-check-runtime.test.ts test/scripts/run-oxlint.test.ts test/scripts/test-projects.test.ts` — 274/274 tests passed.
- `git diff --check` passed.
- AutoReview: both implementation passes clean, with no accepted/actionable findings.

AI-assisted by Codex. I reviewed the implementation and validation evidence.
