### PR TITLE
fix(gateway): keep mixed-role trusted-proxy pairings pending

### DIFF
--- a/src/gateway/server.auth.trusted-proxy-device-autoapprove.test.ts
+++ b/src/gateway/server.auth.trusted-proxy-device-autoapprove.test.ts
@@ -12,7 +12,7 @@ import {
 } from "../infra/device-identity.js";
 import { getPairedDevice, listDevicePairing } from "../infra/device-pairing.js";
 import { buildDeviceAuthPayloadV3 } from "./device-auth.js";
-import { CONTROL_UI_CLIENT } from "./server.auth.test-helpers.js";
+import { CONTROL_UI_CLIENT, NODE_CLIENT } from "./server.auth.test-helpers.js";
 import {
   connectReq,
   installGatewayTestHooks,
@@ -228,6 +228,43 @@ describe("trusted-proxy browser device auto-approval", () => {
       "operator.approvals",
       "operator.read",
     ]);
+  });
+
+  test("leaves mixed node and operator requests pending for manual approval", async () => {
+    await writeGatewayAuthConfig({
+      mode: "trusted-proxy",
+      deviceAutoApprove: { enabled: true, scopes: ["operator.read"] },
+    });
+    const identityPath = deviceIdentityPath("trusted-proxy-mixed-role");
+    const identity = loadOrCreateDeviceIdentity({ path: identityPath });
+
+    await withGatewayServer(async ({ port }) => {
+      const nodeWs = await openBrowserWs(port, trustedProxyHeaders());
+      try {
+        const nodeRes = await connectReq(nodeWs, {
+          skipDefaultAuth: true,
+          client: NODE_CLIENT,
+          role: "node",
+          scopes: [],
+          deviceIdentityPath: identityPath,
+        });
+        expect(nodeRes.ok).toBe(false);
+      } finally {
+        nodeWs.close();
+      }
+
+      const browserRes = await connectBrowser({
+        port,
+        identityPath,
+        scopes: ["operator.read"],
+      });
+      expect(browserRes.ok).toBe(false);
+    });
+
+    await expect(getPairedDevice(identity.deviceId)).resolves.toBeNull();
+    expect(
+      (await listDevicePairing()).pending.find((entry) => entry.deviceId === identity.deviceId),
+    ).toMatchObject({ roles: ["node", "operator"] });
   });
 
   test("caps omitted scopes to the declared proxy scopes", async () => {

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -552,6 +552,49 @@ describe("device pairing tokens", () => {
     ]);
   });
 
+  test("refuses trusted-proxy auto-approval for a merged node and operator request", async () => {
+    const baseDir = await makeDevicePairingDir();
+    await requestDevicePairing(
+      {
+        deviceId: "mixed-role-device-1",
+        publicKey: "public-key-mixed-role-1",
+        role: "node",
+        scopes: [],
+      },
+      baseDir,
+    );
+    const browser = await requestDevicePairing(
+      {
+        deviceId: "mixed-role-device-1",
+        publicKey: "public-key-mixed-role-1",
+        role: "operator",
+        scopes: ["operator.read"],
+      },
+      baseDir,
+    );
+    expect(browser.request.roles).toEqual(["node", "operator"]);
+
+    await expect(
+      approveDevicePairing(
+        browser.request.requestId,
+        {
+          callerScopes: ["operator.read"],
+          approvedVia: "trusted-proxy",
+          autoApproveNewDeviceScopes: ["operator.read"],
+        },
+        baseDir,
+      ),
+    ).resolves.toBeNull();
+
+    await expect(getPairedDevice("mixed-role-device-1", baseDir)).resolves.toBeNull();
+    expect((await listDevicePairing(baseDir)).pending).toContainEqual(
+      expect.objectContaining({
+        requestId: browser.request.requestId,
+        roles: ["node", "operator"],
+      }),
+    );
+  });
+
   test.each([
     {
       name: "node custom scope",

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -792,9 +792,9 @@ export async function approveDevicePairing(
       "owner" | "silent" | "trusted-cidr" | "trusted-proxy" | "ssh-verified"
     >;
     /**
-     * Replace the pending scopes only if this is still a brand-new device.
-     * Used by trusted-proxy auto-approval to cap grants without ever approving
-     * an existing-device repair or upgrade request.
+     * Replace the pending scopes only if this is still a brand-new operator device.
+     * The live role set is rechecked under the pairing lock so a merged request
+     * cannot inherit non-operator access through browser auto-approval.
      */
     autoApproveNewDeviceScopes?: readonly string[];
   },
@@ -826,16 +826,19 @@ export async function approveDevicePairing(
     if (!pendingRecord) {
       return null;
     }
+    const autoApproveScopes = options?.autoApproveNewDeviceScopes;
+    const requestedRoles = resolveRequestedRoles(pendingRecord);
     if (
-      options?.autoApproveNewDeviceScopes &&
-      (pendingRecord.isRepair || state.pairedByDeviceId[pendingRecord.deviceId])
+      autoApproveScopes &&
+      (pendingRecord.isRepair ||
+        state.pairedByDeviceId[pendingRecord.deviceId] ||
+        !sameStringSet(requestedRoles, [OPERATOR_ROLE]))
     ) {
       return null;
     }
-    const pending = options?.autoApproveNewDeviceScopes
-      ? { ...pendingRecord, scopes: [...options.autoApproveNewDeviceScopes] }
+    const pending = autoApproveScopes
+      ? { ...pendingRecord, scopes: [...autoApproveScopes] }
       : pendingRecord;
-    const requestedRoles = mergeRoles(pending.roles, pending.role) ?? [];
     const requestedScopes = normalizeDeviceAuthScopes(pending.scopes);
     const roleMismatchScope = resolveScopeOutsideRequestedRoles({
       requestedRoles,


### PR DESCRIPTION
Related: #111189

## What Problem This Solves

Fixes an issue where a trusted-proxy browser login could auto-approve a pending device request that also contained a non-operator role. That mixed-role request should require explicit owner approval instead of inheriting browser auto-approval.

## Why This Change Was Made

The pairing store now rechecks the complete live role set under its existing lock and allows new-browser auto-approval only when that set is exactly `operator`. This keeps role and scope authorization bounded at the same atomic owner boundary without changing the existing Plugin SDK declaration.

## User Impact

Normal first-time browser login through a trusted proxy remains automatic. A device identity with a mixed-role pending request stays pending for manual approval and receives no persistent device grant.

## Evidence

- Blacksmith Testbox `tbx_01kxx73a9c071zggttwn4a3v3z`: 60 pairing-store tests and 9 trusted-proxy Gateway tests passed.
- Focused real Gateway handshake proof passed both the normal browser auto-approval case and the mixed-role fail-closed case.
- `pnpm check:changed` passed, including formatting, Plugin SDK API baseline, production/test typechecks, focused lint, pairing guards, database-first checks, and import-cycle checks.
- Autoreview: clean, no accepted/actionable findings, confidence 0.96.

AI-assisted with Codex; the implementation and proof were reviewed before submission.
