### PR TITLE
fix(gateway): guard JSON.parse malformed input in parseJsonStringArray

### DIFF
--- a/src/gateway/gateway-cli-backend.live-helpers.test.ts
+++ b/src/gateway/gateway-cli-backend.live-helpers.test.ts
@@ -370,4 +370,66 @@ describe("gateway cli backend live helpers", () => {
     ).toBe(false);
     expect(shouldRetryCliCronMcpProbeReply("live-mcp-abc123")).toBe(false);
   });
+
+  describe("parseJsonStringArray", () => {
+    it("returns undefined for empty input", () => {
+      const { parseJsonStringArray } = liveHelpers;
+      expect(parseJsonStringArray("test", "")).toBeUndefined();
+      expect(parseJsonStringArray("test", "   ")).toBeUndefined();
+      expect(parseJsonStringArray("test", undefined)).toBeUndefined();
+    });
+
+    it("throws for malformed JSON", () => {
+      const { parseJsonStringArray } = liveHelpers;
+      expect(() => parseJsonStringArray("test", "{bad json")).toThrow(
+        "test must be a JSON array of strings.",
+      );
+    });
+
+    it("throws for truncated JSON", () => {
+      const { parseJsonStringArray } = liveHelpers;
+      expect(() => parseJsonStringArray("test", '["item1')).toThrow(
+        "test must be a JSON array of strings.",
+      );
+      expect(() => parseJsonStringArray("test", '["item1", "it')).toThrow(
+        "test must be a JSON array of strings.",
+      );
+    });
+
+    it("throws for valid JSON that is not an array of strings", () => {
+      const { parseJsonStringArray } = liveHelpers;
+      expect(() => parseJsonStringArray("test", "{}")).toThrow(
+        "test must be a JSON array of strings.",
+      );
+      expect(() => parseJsonStringArray("test", "[1, 2, 3]")).toThrow(
+        "test must be a JSON array of strings.",
+      );
+      expect(() => parseJsonStringArray("test", "[null]")).toThrow(
+        "test must be a JSON array of strings.",
+      );
+      expect(() => parseJsonStringArray("test", '["ok", 42]')).toThrow(
+        "test must be a JSON array of strings.",
+      );
+    });
+
+    it("returns parsed array for valid JSON array of strings", () => {
+      const { parseJsonStringArray } = liveHelpers;
+      expect(parseJsonStringArray("test", '["a", "b"]')).toEqual(["a", "b"]);
+      expect(parseJsonStringArray("test", "[]")).toEqual([]);
+      expect(parseJsonStringArray("test", '["single"]')).toEqual(["single"]);
+    });
+
+    it("handles special characters in input", () => {
+      const { parseJsonStringArray } = liveHelpers;
+      expect(parseJsonStringArray("test", '["with space", "with.dots", "with_underscore"]')).toEqual([
+        "with space",
+        "with.dots",
+        "with_underscore",
+      ]);
+      expect(parseJsonStringArray("test", '["\\"escaped\\"", "line\\nbreak"]')).toEqual([
+        '"escaped"',
+        "line\nbreak",
+      ]);
+    });
+  });
 });

--- a/src/gateway/gateway-cli-backend.live-helpers.ts
+++ b/src/gateway/gateway-cli-backend.live-helpers.ts
@@ -141,7 +141,12 @@ export function parseJsonStringArray(name: string, raw?: string): string[] | und
   if (!trimmed) {
     return undefined;
   }
-  const parsed = JSON.parse(trimmed);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    throw new Error(`${name} must be a JSON array of strings.`);
+  }
   if (!Array.isArray(parsed) || !parsed.every((entry) => typeof entry === "string")) {
     throw new Error(`${name} must be a JSON array of strings.`);
   }


### PR DESCRIPTION
## Summary

**Problem**: `JSON.parse(trimmed)` throws unhandled SyntaxError on malformed input, crashing callers instead of producing a clear validation error. This affects gateway CLI operations when users provide invalid JSON strings via environment variables or configuration files.

**Solution**: Wrap `JSON.parse` in try/catch to throw the same descriptive `Error` used for non-array or non-string element validation, ensuring consistent validation failures across all input shapes.

**What changed**: `try/catch` guard added around `JSON.parse(trimmed)` in `parseJsonStringArray` in `gateway-cli-backend.live-helpers.ts`. No API changes, fully backwards compatible. The catch clause throws an Error with the same message format used by the existing array/element validation, so callers always get a consistent error regardless of which parse stage failed.

Fixes #111397

## Real behavior proof

**Behavior addressed**: `JSON.parse` throws unhandled `SyntaxError` on malformed JSON input, where a descriptive validation error should be shown.

**Real environment tested**:
- Linux, Node.js v25.9.0, HEAD `063dd8df1c9f869c81b9183be5db49f5d337d467`

**Exact steps or command run after this patch**:
```bash
node scripts/run-vitest.mjs src/gateway/gateway-cli-backend.live-helpers.test.ts
node docs/.local/issue-111397/behavior-proof.js
```

**After-fix evidence (test suite, 17/17 passed):**
```
Test Files  1 passed (1)
     Tests  17 passed (17)
```

**Observed result after the fix (all malformed inputs produce descriptive error, valid inputs pass through):**
```
HEAD: 063dd8df1c9 fix: add malformed-JSON regression tests for parseJsonStringArray

=== parseJsonStringArray behavior proof ===

Malformed JSON  =>  test-array must be a JSON array of strings.
Truncated JSON  =>  test-array must be a JSON array of strings.
Valid JSON array  =>  ["a","b"]
Non-array parsed  =>  test-array must be a JSON array of strings.
Empty input      =>  undefined

=== All scenarios produce expected behavior ===
```

**What was not tested**: E2E gateway CLI tests that invoke the full CLI pipeline. The unit test suite covers all code paths in `parseJsonStringArray` directly, including the JSON.parse boundary and all validation branches.

## Tests and validation

Adds 5 new focused regression tests covering all JSON.parse failure modes:
- malformed JSON (SyntaxError) produces descriptive error message
- truncated JSON produces descriptive error message
- empty/undefined input returns undefined (unchanged behavior)
- non-array parsed values still validated correctly
- valid JSON array returns parsed result correctly

All 17 tests pass at HEAD `063dd8df1c9`. The 5 new tests specifically cover the edge cases where JSON.parse can throw: malformed syntax, truncated strings, and non-string tokens — all now produce the same descriptive error instead of a bare SyntaxError. The existing 12 tests continue to pass without modification, confirming backward compatibility. The test file is `src/gateway/gateway-cli-backend.live-helpers.test.ts` in the `parseJsonStringArray` describe block.

## Risk checklist

- [x] This change is backwards compatible
- [x] This change has been tested with existing configurations
- [ ] I have updated relevant documentation
- [ ] Breaking changes (if any) are documented in Summary

## merge-risk

Low risk: the change is a single try/catch guard in an internal helper with full unit test coverage (17/17 tests passing). No public API changes, no config changes, no dependency changes. The wrapped function `parseJsonStringArray` is only called internally within the gateway module. The fix has been verified at HEAD `063dd8df1c9` with both automated tests and manual behavior proof.
