### PR TITLE
fix(schemas): tighten offset/limit to Type.Integer in bashTools schemas

### DIFF
--- a/src/agents/bash-tools.schemas.ts
+++ b/src/agents/bash-tools.schemas.ts
@@ -90,8 +90,8 @@ export const processSchema = Type.Object({
   text: Type.Optional(Type.String({ description: "Text to paste for paste" })),
   bracketed: Type.Optional(Type.Boolean({ description: "Wrap paste in bracketed mode" })),
   eof: Type.Optional(Type.Boolean({ description: "Close stdin after write" })),
-  offset: Type.Optional(Type.Number({ description: "Log offset" })),
-  limit: Type.Optional(Type.Number({ description: "Log length" })),
+  offset: Type.Optional(Type.Integer({ description: "Log offset", minimum: 0 })),
+  limit: Type.Optional(Type.Integer({ description: "Log length", minimum: 1 })),
   timeout: Type.Optional(
     Type.Number({
       description:


### PR DESCRIPTION
offset and limit in processSchema represent log row offsets and line counts — integers, not floats.

Using Type.Number() allows LLM tools to pass fractional values that are silently floor'd at runtime, creating a gap between schema contract and behavior. Tighten to Type.Integer() with appropriate minimum bounds.