### PR TITLE
fix(message): ignore populated location on text sends

### DIFF
--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -1593,6 +1593,17 @@ describe("handleTelegramAction", () => {
       expectedContent: "",
       expectedOptions: { mediaUrl: "https://example.com/note.ogg" },
     },
+    {
+      name: "image alias",
+      params: {
+        action: "sendMessage",
+        to: "123456",
+        image: "https://example.com/photo.jpg",
+      },
+      expectedTo: "123456",
+      expectedContent: "",
+      expectedOptions: { mediaUrl: "https://example.com/photo.jpg" },
+    },
   ] as const)("maps sendMessage params for $name", async (testCase) => {
     await handleTelegramAction(testCase.params, telegramConfig());
     const call = mockCall(sendMessageTelegram, 0, `sendMessage params ${testCase.name}`);

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -191,6 +191,7 @@ function readTelegramSendMediaUrls(params: Record<string, unknown>) {
   const seen = new Set<string>();
   pushTelegramMediaUrl(mediaUrls, seen, params.mediaUrl);
   pushTelegramMediaUrl(mediaUrls, seen, params.media);
+  pushTelegramMediaUrl(mediaUrls, seen, params.image);
   pushTelegramMediaUrl(mediaUrls, seen, params.path);
   pushTelegramMediaUrl(mediaUrls, seen, params.filePath);
   pushTelegramMediaUrl(mediaUrls, seen, params.fileUrl);

--- a/extensions/telegram/src/channel-actions.contract.test.ts
+++ b/extensions/telegram/src/channel-actions.contract.test.ts
@@ -122,6 +122,13 @@ describe("telegram actions contract", () => {
     expect(discovery?.actions).not.toContain("sendLocation");
     expect(properties).toHaveProperty("asVideoNote");
     expect(properties).toHaveProperty("location");
+    expect(contributions.find((entry) => entry.properties.asVideoNote)?.visibility).toBe(
+      "all-configured",
+    );
+    expect(contributions.find((entry) => entry.properties.location)?.actions).toEqual(["send"]);
+    expect(contributions.find((entry) => entry.properties.location)?.visibility).toBe(
+      "current-channel",
+    );
   });
 
   it("does not advertise inline buttons for non-empty legacy Telegram capabilities without inlineButtons", () => {

--- a/extensions/telegram/src/channel-actions.ts
+++ b/extensions/telegram/src/channel-actions.ts
@@ -23,6 +23,7 @@ import {
 } from "./accounts.js";
 import { isTelegramInlineButtonsEnabled } from "./inline-buttons.js";
 import {
+  createTelegramLocationToolSchema,
   createTelegramPollExtraToolSchemas,
   createTelegramRichSendExtraToolSchemas,
 } from "./message-tool-schema.js";
@@ -204,6 +205,11 @@ function describeTelegramMessageTool({
     schema.push({
       properties: createTelegramRichSendExtraToolSchemas(),
       visibility: "all-configured",
+    });
+    schema.push({
+      properties: createTelegramLocationToolSchema(),
+      actions: ["send"],
+      visibility: "current-channel",
     });
   }
   return {

--- a/extensions/telegram/src/message-tool-schema.ts
+++ b/extensions/telegram/src/message-tool-schema.ts
@@ -19,6 +19,12 @@ export function createTelegramRichSendExtraToolSchemas() {
           "Send one video attachment as a round Telegram video note. Captions are delivered separately.",
       }),
     ),
+  };
+}
+
+/** Schema for Telegram's standalone location payload on the existing send action. */
+export function createTelegramLocationToolSchema() {
+  return {
     location: Type.Optional(
       Type.Object(
         {
@@ -40,7 +46,7 @@ export function createTelegramRichSendExtraToolSchemas() {
         },
         {
           description:
-            "Standalone Telegram location. Coordinates send a pin; name plus address sends a venue. Do not combine with message or media.",
+            'Standalone Telegram location for action="send". Coordinates send a pin; name plus address sends a venue. Do not combine with message or media.',
         },
       ),
     ),

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -2239,6 +2239,47 @@ describe("message tool schema scoping", () => {
     },
   );
 
+  it("does not merge current-channel schemas into an unscoped message tool", () => {
+    const telegramWithScopedLocation = createChannelPlugin({
+      id: "telegram",
+      label: "Telegram",
+      docsPath: "/channels/telegram",
+      blurb: "Telegram test plugin.",
+      actions: ["send"],
+      toolSchema: () => [
+        {
+          actions: ["send"],
+          properties: {
+            location: Type.Optional(
+              Type.Object({ latitude: Type.Number(), longitude: Type.Number() }),
+            ),
+          },
+          visibility: "current-channel",
+        },
+      ],
+    });
+    setActivePluginRegistry(
+      createTestRegistry([
+        { pluginId: "telegram", source: "test", plugin: telegramWithScopedLocation },
+        { pluginId: "discord", source: "test", plugin: discordPlugin },
+      ]),
+    );
+
+    const unscopedProperties = getToolProperties(createMessageTool({ config: {} as never }));
+    const scopedProperties = getToolProperties(
+      createMessageTool({ config: {} as never, currentChannelProvider: "telegram" }),
+    );
+
+    expect(unscopedProperties.location).toMatchObject({ type: "string" });
+    expect(scopedProperties.location).toMatchObject({
+      type: "object",
+      properties: {
+        latitude: { type: "number" },
+        longitude: { type: "number" },
+      },
+    });
+  });
+
   it("includes poll in the action enum when the current channel supports poll actions", () => {
     setActivePluginRegistry(
       createTestRegistry([{ pluginId: "telegram", source: "test", plugin: telegramPlugin }]),

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -1713,6 +1713,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
           cfg,
           action,
           params: actionParams,
+          actionOrigin: "message-tool",
           defaultAccountId: accountId ?? undefined,
           requesterAccountId: trustedTurnContext?.requesterAccountId,
           requesterSenderId: trustedTurnContext?.requesterSenderId,

--- a/src/channels/plugins/message-action-discovery.ts
+++ b/src/channels/plugins/message-action-discovery.ts
@@ -422,7 +422,9 @@ export function resolveChannelMessageToolSchemaProperties(
         }
         continue;
       }
-      mergeToolSchemaProperties(properties, contribution.properties);
+      if (visibility === "all-configured") {
+        mergeToolSchemaProperties(properties, contribution.properties);
+      }
     }
   }
   if (currentChannel && !seenPluginIds.has(currentChannel)) {

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -10,7 +10,10 @@ import {
   GATEWAY_CLIENT_NAMES,
 } from "../../../packages/gateway-protocol/src/client-info.js";
 import { jsonResult } from "../../agents/tools/common.js";
-import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
+import type {
+  ChannelMessageActionAdapter,
+  ChannelPlugin,
+} from "../../channels/plugins/types.public.js";
 import type { SessionTranscriptAppendResult } from "../../config/sessions/transcript.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { AGENT_HARNESS_SESSION_KEY_RESERVED_MESSAGE } from "../../sessions/agent-harness-session-key.js";
@@ -79,6 +82,11 @@ vi.mock("../../channels/plugins/message-action-dispatch.js", () => ({
 
 const TEST_AGENT_WORKSPACE = "/tmp/openclaw-test-workspace";
 let sendHandlers: typeof import("./send.js").sendHandlers;
+
+const telegramGatewayTestActions: ChannelMessageActionAdapter = {
+  describeMessageTool: () => ({ actions: ["send"] }),
+  handleAction: async () => jsonResult({ ok: true }),
+};
 
 function resolveAgentIdFromSessionKeyForTests(params: { sessionKey?: string }): string {
   if (typeof params.sessionKey === "string") {
@@ -2002,6 +2010,62 @@ describe("gateway send mirroring", () => {
           currentMessagingTarget: "user:15551234567",
         }),
       }),
+    );
+  });
+
+  it("removes incidental model location before Telegram gateway dispatch", async () => {
+    mocks.getChannelPlugin.mockReturnValue({
+      actions: { handleAction: true, ...telegramGatewayTestActions },
+    });
+    mocks.dispatchChannelMessageAction.mockResolvedValueOnce(jsonResult({ ok: true }));
+    const sessionKey = "agent:main:telegram:direct:123";
+
+    const { respond } = await runMessageActionRequest({
+      channel: "telegram",
+      action: "send",
+      params: {
+        to: "123",
+        message: "hello",
+        location: { latitude: 48.858844, longitude: 2.294351 },
+      },
+      sessionKey,
+      agentId: "main",
+      idempotencyKey: "idem-telegram-incidental-location",
+    });
+
+    expect(firstRespondCall(respond)[0]).toBe(true);
+    expect(mocks.dispatchChannelMessageAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "telegram",
+        action: "send",
+        params: { to: "123", message: "hello" },
+      }),
+    );
+  });
+
+  it("keeps direct gateway Telegram sends strict instead of applying model repair", async () => {
+    mocks.getChannelPlugin.mockReturnValue({
+      actions: { handleAction: true, ...telegramGatewayTestActions },
+    });
+    mocks.dispatchChannelMessageAction.mockResolvedValueOnce(jsonResult({ ok: true }));
+    const mixedParams = {
+      to: "123",
+      message: "hello",
+      location: { latitude: 48.858844, longitude: 2.294351 },
+    };
+
+    await runMessageActionRequest(
+      {
+        channel: "telegram",
+        action: "send",
+        params: mixedParams,
+        idempotencyKey: "idem-telegram-direct-mixed",
+      },
+      directCliClient(),
+    );
+
+    expect(mocks.dispatchChannelMessageAction).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "send", params: mixedParams }),
     );
   });
 

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -17,7 +17,10 @@ import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { sendDurableMessageBatch } from "../../channels/message/runtime.js";
 import type { ConversationReadInvocationOrigin } from "../../channels/plugins/conversation-read-origin.js";
 import { dispatchChannelMessageAction } from "../../channels/plugins/message-action-dispatch.js";
-import type { ChannelThreadingToolContext } from "../../channels/plugins/types.public.js";
+import type {
+  ChannelMessageActionName,
+  ChannelThreadingToolContext,
+} from "../../channels/plugins/types.public.js";
 import type { InternalChannelThreadingToolContext } from "../../channels/threading-tool-context-internal.js";
 import { createOutboundSendDeps } from "../../cli/deps.js";
 import {
@@ -49,6 +52,7 @@ import {
 } from "../../infra/outbound/source-reply-mirror.js";
 import { maybeResolveIdLikeTarget } from "../../infra/outbound/target-resolver.js";
 import { resolveOutboundTarget } from "../../infra/outbound/targets.js";
+import { normalizeTelegramMessageActionRequest } from "../../infra/outbound/telegram-message-action-normalization.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
 import { KeyedAsyncQueue } from "../../plugin-sdk/keyed-async-queue.js";
 import { extractToolPayload } from "../../plugin-sdk/tool-payload.js";
@@ -541,12 +545,23 @@ export const sendHandlers: GatewayRequestHandlers = {
           normalizeOptionalString(request.agentId) ??
           (sessionKey ? resolveSessionAgentId({ sessionKey, config: cfg }) : undefined);
         const accountId = normalizeOptionalString(request.accountId) ?? undefined;
-        if (request.action === "send") {
+        const requestedAction = request.action as ChannelMessageActionName;
+        const normalizedRequest = normalizeTelegramMessageActionRequest({
+          channel,
+          action: requestedAction,
+          args: request.params,
+          origin: client?.internal?.agentRuntimeIdentity?.messageActionContext
+            ? "message-tool"
+            : "direct",
+        });
+        const action = normalizedRequest.action;
+        const actionParams = normalizedRequest.args;
+        if (action === "send") {
           await hydrateAttachmentParamsForAction({
             cfg,
             channel,
             accountId,
-            args: request.params,
+            args: actionParams,
             action: "send",
             mediaPolicy: resolveAttachmentMediaPolicy({
               mediaLocalRoots: getAgentScopedMediaLocalRoots(cfg, agentId),
@@ -554,9 +569,9 @@ export const sendHandlers: GatewayRequestHandlers = {
           });
         }
         const sourceReplyMirror = {
-          action: request.action,
+          action,
           channel,
-          actionParams: request.params,
+          actionParams,
           cfg,
           accountId,
           currentAccountId: trustedContext.requesterAccountId,
@@ -577,9 +592,9 @@ export const sendHandlers: GatewayRequestHandlers = {
         const gatewayClientScopes = client?.connect?.scopes ?? [];
         const handled = await dispatchChannelMessageAction({
           channel,
-          action: request.action as never,
+          action,
           cfg,
-          params: request.params,
+          params: actionParams,
           accountId,
           requesterAccountId: trustedContext.requesterAccountId,
           requesterSenderId: trustedContext.requesterSenderId,
@@ -600,7 +615,7 @@ export const sendHandlers: GatewayRequestHandlers = {
           await cancelTerminalSourceReplyDelivery(terminalDeliveryReceipt);
           const error = errorShape(
             ErrorCodes.INVALID_REQUEST,
-            `Message action ${request.action} not supported for channel ${channel}.`,
+            `Message action ${action} not supported for channel ${channel}.`,
           );
           cacheGatewayDedupeFailure({ context, dedupeKey, error });
           return { ok: false, error, meta: { channel } };

--- a/src/infra/outbound/message-action-runner.send-validation.test.ts
+++ b/src/infra/outbound/message-action-runner.send-validation.test.ts
@@ -3,9 +3,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
-import { createTestRegistry } from "../../test-utils/channel-plugins.js";
+import {
+  createChannelTestPluginBase,
+  createTestRegistry,
+} from "../../test-utils/channel-plugins.js";
 import { runMessageAction } from "./message-action-runner.js";
 import {
+  directOutbound,
   forumTestPlugin,
   runDrySend,
   workspaceConfig,
@@ -13,6 +17,32 @@ import {
 } from "./message-action-runner.test-helpers.js";
 
 const emptyConfig = {} as OpenClawConfig;
+const portableLocation = { latitude: 48.858844, longitude: 2.294351 };
+const normalizedSendPlugin = {
+  ...createChannelTestPluginBase({
+    id: "telegram",
+    label: "Telegram",
+    config: {
+      listAccountIds: () => ["default"],
+      resolveAccount: () => ({ enabled: true }),
+      isConfigured: () => true,
+    },
+  }),
+  outbound: directOutbound,
+  messaging: {
+    normalizeTarget: (raw: string) => raw.trim() || undefined,
+    targetResolver: {
+      looksLikeId: (raw: string) => Boolean(raw.trim()),
+      hint: "<chat_id>",
+    },
+  },
+  actions: {
+    describeMessageTool: () => ({ actions: ["send"] as const }),
+  },
+};
+const normalizedSendConfig = {
+  channels: { telegram: { enabled: true } },
+} as OpenClawConfig;
 
 describe("runMessageAction send validation", () => {
   beforeEach(() => {
@@ -27,6 +57,11 @@ describe("runMessageAction send validation", () => {
           pluginId: "forum",
           source: "test",
           plugin: forumTestPlugin,
+        },
+        {
+          pluginId: "telegram",
+          source: "test",
+          plugin: normalizedSendPlugin,
         },
       ]),
     );
@@ -126,6 +161,26 @@ describe("runMessageAction send validation", () => {
       ).rejects.toThrow(/cannot be combined/i);
     },
   );
+
+  it.each([
+    { name: "text", content: { message: "hello" } },
+    { name: "buffer media", content: { buffer: "aGVsbG8=", filename: "hello.txt" } },
+  ])("repairs incidental location for model-authored $name sends", async ({ content }) => {
+    const result = await runMessageAction({
+      cfg: normalizedSendConfig,
+      action: "send",
+      actionOrigin: "message-tool",
+      params: {
+        channel: "telegram",
+        target: "123",
+        ...content,
+        location: portableLocation,
+      },
+      dryRun: true,
+    });
+
+    expect(result).toMatchObject({ kind: "send", action: "send" });
+  });
 
   it("uses the current internal UI source as the message-tool-only send sink", async () => {
     const result = await runMessageAction({

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -119,6 +119,7 @@ import {
 } from "./source-reply-mirror.js";
 import { normalizeTargetForProvider } from "./target-normalization.js";
 import { resolveChannelTarget, type ResolvedMessagingTarget } from "./target-resolver.js";
+import { normalizeTelegramMessageActionRequest } from "./telegram-message-action-normalization.js";
 
 export type MessageActionRunnerGateway = {
   url?: string;
@@ -144,6 +145,8 @@ export type RunMessageActionParams = {
   cfg: OpenClawConfig;
   action: ChannelMessageActionName;
   params: Record<string, unknown>;
+  /** @internal Identifies model-authored message-tool calls for channel-scoped repair. */
+  actionOrigin?: "message-tool";
   defaultAccountId?: string;
   requesterAccountId?: string | null;
   requesterSenderId?: string | null;
@@ -1880,6 +1883,13 @@ export async function runMessageAction(
   }
   const channel = await resolveChannel(cfg, params, input.toolContext, action);
   params.channel = channel;
+  const normalizedRequest = normalizeTelegramMessageActionRequest({
+    channel,
+    action,
+    args: params,
+    origin: input.actionOrigin ?? "direct",
+  });
+  params = { ...normalizedRequest.args, channel };
   const channelPlugin = resolveOutboundChannelPlugin({ channel, cfg });
   const pluginOwnedAction = action !== "send" && action !== "poll";
   if (

--- a/src/infra/outbound/telegram-message-action-normalization.test.ts
+++ b/src/infra/outbound/telegram-message-action-normalization.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { normalizeTelegramMessageActionRequest } from "./telegram-message-action-normalization.js";
+
+const location = { latitude: 48.858844, longitude: 2.294351 };
+
+function normalize(params: {
+  channel?: string;
+  action?: "send";
+  args: Record<string, unknown>;
+  origin?: "message-tool" | "direct";
+}) {
+  return normalizeTelegramMessageActionRequest({
+    channel: params.channel ?? "telegram",
+    action: params.action ?? "send",
+    args: params.args,
+    origin: params.origin ?? "message-tool",
+  });
+}
+
+describe("Telegram message action normalization", () => {
+  it.each([
+    { name: "text", content: { message: "hello" } },
+    { name: "image", content: { image: "https://example.test/photo.jpg" } },
+    { name: "buffer", content: { buffer: "base64-data" } },
+    { name: "attachment path", content: { attachments: [{ filePath: "/tmp/photo.png" }] } },
+    {
+      name: "attachment URL",
+      content: { attachments: [{ mediaUrl: "https://example.test/photo.png" }] },
+    },
+  ])("removes incidental location from model-authored $name sends", ({ content }) => {
+    expect(normalize({ args: { ...content, location } })).toEqual({
+      action: "send",
+      args: content,
+    });
+  });
+
+  it.each([{ presentation: {} }, { interactive: {} }, { attachments: [{}] }, { mediaUrls: [] }])(
+    "preserves location when the apparent content placeholder is empty",
+    (placeholder) => {
+      expect(normalize({ args: { ...placeholder, location } })).toEqual({
+        action: "send",
+        args: { ...placeholder, location },
+      });
+    },
+  );
+
+  it("preserves legacy location-only sends", () => {
+    expect(normalize({ args: { location } })).toEqual({
+      action: "send",
+      args: { location },
+    });
+  });
+
+  it("keeps direct mixed sends strict", () => {
+    expect(normalize({ args: { message: "hello", location }, origin: "direct" })).toEqual({
+      action: "send",
+      args: { message: "hello", location },
+    });
+  });
+
+  it("does not rewrite another channel", () => {
+    expect(normalize({ channel: "slack", args: { message: "hello", location } })).toEqual({
+      action: "send",
+      args: { message: "hello", location },
+    });
+  });
+});

--- a/src/infra/outbound/telegram-message-action-normalization.ts
+++ b/src/infra/outbound/telegram-message-action-normalization.ts
@@ -1,0 +1,87 @@
+import type { ChannelMessageActionName } from "../../channels/plugins/types.public.js";
+// Telegram-specific pre-dispatch repair for the shared message action paths.
+// Keep this host-owned and private: it is not a Channel Plugin SDK contract.
+import {
+  hasLegacyInteractiveReplyBlocks,
+  hasMessagePresentationBlocks,
+} from "../../interactive/payload.js";
+
+const TELEGRAM_SEND_CONTENT_FIELDS = [
+  "message",
+  "text",
+  "content",
+  "SendMessage",
+  "caption",
+  "buffer",
+  "media",
+  "mediaUrl",
+  "mediaUrls",
+  "path",
+  "filePath",
+  "image",
+  "fileUrl",
+] as const;
+
+const TELEGRAM_ATTACHMENT_MEDIA_FIELDS = [
+  "media",
+  "mediaUrl",
+  "path",
+  "filePath",
+  "fileUrl",
+  "url",
+] as const;
+
+function hasTelegramAttachmentMedia(value: unknown): boolean {
+  return (
+    Array.isArray(value) &&
+    value.some((attachment) => {
+      if (!attachment || typeof attachment !== "object" || Array.isArray(attachment)) {
+        return false;
+      }
+      const record = attachment as Record<string, unknown>;
+      return TELEGRAM_ATTACHMENT_MEDIA_FIELDS.some((field) => {
+        const media = record[field];
+        return typeof media === "string" && Boolean(media.trim());
+      });
+    })
+  );
+}
+
+function hasTelegramSendContent(args: Record<string, unknown>): boolean {
+  return (
+    TELEGRAM_SEND_CONTENT_FIELDS.some((field) => {
+      const value = args[field];
+      if (typeof value === "string") {
+        return Boolean(value.trim());
+      }
+      if (Array.isArray(value)) {
+        return value.some((entry) => typeof entry === "string" && Boolean(entry.trim()));
+      }
+      return value != null && value !== false;
+    }) ||
+    hasTelegramAttachmentMedia(args.attachments) ||
+    hasMessagePresentationBlocks(args.presentation) ||
+    hasLegacyInteractiveReplyBlocks(args.interactive)
+  );
+}
+
+export function normalizeTelegramMessageActionRequest(params: {
+  channel: string;
+  action: ChannelMessageActionName;
+  args: Record<string, unknown>;
+  origin: "message-tool" | "direct";
+}): { action: ChannelMessageActionName; args: Record<string, unknown> } {
+  if (params.channel !== "telegram") {
+    return { action: params.action, args: params.args };
+  }
+  if (
+    params.origin !== "message-tool" ||
+    params.action !== "send" ||
+    !Object.hasOwn(params.args, "location") ||
+    !hasTelegramSendContent(params.args)
+  ) {
+    return { action: params.action, args: params.args };
+  }
+  const { location: _ignoredActionScopedLocation, ...args } = params.args;
+  return { action: "send", args };
+}


### PR DESCRIPTION
## What Problem This Solves

Current `main` includes #112013, which correctly treats a blank string `location: ""` as omitted. A separate failure remains when a model-generated Telegram `message(action="send")` call populates a **non-empty location object** alongside ordinary text or media. Shared outbound validation correctly rejects mixed location + content payloads, so the visible reply is otherwise dropped.

## Scope After #112013

This PR now covers only the remaining populated-object case:

- **model-authored Telegram send with real content:** remove incidental `location` and deliver the content;
- **direct/API mixed send:** preserve the payload so existing strict validation still rejects it;
- **location-only send:** preserve and deliver the native Telegram pin/venue;
- **Telegram `image` alias:** recognize it as media in the direct Telegram action path.

It does not add a shared message action or weaken the public mixed-payload contract.

## Design

- Marks agent message-tool calls with a private internal origin.
- Uses one host-owned Telegram normalizer in both local `runMessageAction` and Gateway `message.action` paths.
- Removes `location` only for trusted model-authored Telegram `send` calls that also contain real text, media, attachments, presentation, or interactive content.
- Leaves direct/API requests and every non-Telegram channel untouched.
- Keeps Telegram's location object schema scoped to the current Telegram channel, avoiding collision with the generic string `location` used by other actions.
- Recognizes the Telegram `image` alias in delivery.

## Rebase and Trim

Rebuilt as **one commit on latest `main`**, reducing the previous PR head from 33 commits / 17 files to **1 commit / 14 files**. Removed obsolete documentation, source-reply changes, generated/budget churn, merge commits, and the superseded blank-string work now supplied by #112013.

The remaining files cover distinct required boundaries: Telegram schema/action mapping, message-tool origin, local runner normalization, Gateway normalization, strict direct-call behavior, and focused regressions.

## Evidence

Existing live Bot API proof remains applicable to the retained behavior:

- Redacted transcript: https://gist.github.com/snotty/d3ca4e6b5d473b8513570bb7dab007ea
- Native Telegram Desktop proof: https://github.com/openclaw/openclaw/actions/runs/29691948840

Observed behavior:

```text
model text + incidental location  -> text delivered; location removed
model image + incidental location -> image delivered; location removed
standalone location               -> native location delivered
 direct mixed content + location  -> existing strict rejection
```

## Validation

On the rebuilt patch:

- focused Telegram/message/Gateway suites: **8 files / 540 tests passed**;
- production TypeScript: passed;
- test TypeScript: passed;
- focused type-aware lint: **0 warnings / 0 errors**;
- focused formatting: passed;
- full build: passed, including Control UI performance budgets;
- `git diff --check`: passed.

Repository-wide `pnpm check` reaches the shrinkwrap guard and reports stale root/extension shrinkwrap files already present on current `main`; this PR changes no dependency manifests or shrinkwrap files.
