### PR TITLE
fix: reject unknown non-interactive auth choices

### DIFF
--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -208,6 +208,7 @@ export async function runNonInteractiveLocalSetup(params: {
       opts,
       runtime,
       baseConfig,
+      workspaceDir,
     });
     if (!nextConfigAfterAuth) {
       return;

--- a/src/commands/onboard-non-interactive/local/auth-choice.test.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.test.ts
@@ -4,6 +4,13 @@ import type { OpenClawConfig } from "../../../config/config.js";
 import { resolveAgentModelPrimaryValue } from "../../../config/model-input.js";
 import { applyNonInteractiveAuthChoice } from "./auth-choice.js";
 
+const formatAuthChoiceChoicesForCli = vi.hoisted(() =>
+  vi.fn(() => "custom-api-key|skip|demo-provider-api-key"),
+);
+vi.mock("../../auth-choice-options.js", () => ({
+  formatAuthChoiceChoicesForCli,
+}));
+
 const applyNonInteractivePluginProviderChoice = vi.hoisted(() => vi.fn(async () => undefined));
 vi.mock("./auth-choice.plugin-providers.js", () => ({
   applyNonInteractivePluginProviderChoice,
@@ -20,6 +27,10 @@ vi.mock("../../../plugins/provider-auth-choices.js", () => ({
   resolveManifestDeprecatedProviderAuthChoice,
   resolveManifestProviderAuthChoices,
 }));
+const resolveDeprecatedProviderInstallCatalogEntry = vi.hoisted(() => vi.fn(() => undefined));
+vi.mock("../../../plugins/provider-install-catalog.js", () => ({
+  resolveDeprecatedProviderInstallCatalogEntry,
+}));
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -30,6 +41,8 @@ beforeEach(() => {
   resolveManifestDeprecatedProviderAuthChoice.mockReturnValue(undefined);
   resolveManifestProviderAuthChoices.mockReset();
   resolveManifestProviderAuthChoices.mockReturnValue([]);
+  resolveDeprecatedProviderInstallCatalogEntry.mockReset();
+  resolveDeprecatedProviderInstallCatalogEntry.mockReturnValue(undefined);
 });
 
 function createRuntime() {
@@ -41,6 +54,44 @@ function createRuntime() {
 }
 
 describe("applyNonInteractiveAuthChoice", () => {
+  it("rejects an unknown auth choice and lists the valid choices", async () => {
+    const runtime = createRuntime();
+    const nextConfig = { agents: { defaults: {} } } as OpenClawConfig;
+
+    const result = await applyNonInteractiveAuthChoice({
+      nextConfig,
+      authChoice: "definitely-not-a-provider",
+      opts: {} as never,
+      runtime: runtime as never,
+      baseConfig: nextConfig,
+    });
+
+    expect(result).toBeNull();
+    expect(runtime.error).toHaveBeenCalledWith(
+      'Unknown --auth-choice "definitely-not-a-provider". Valid choices: custom-api-key, skip, demo-provider-api-key, oauth, setup-token, token, apiKey.',
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("continues to apply an enumerated provider auth choice", async () => {
+    const runtime = createRuntime();
+    const nextConfig = { agents: { defaults: {} } } as OpenClawConfig;
+    const resolvedConfig = { auth: { profiles: { "demo-provider:default": { mode: "api_key" } } } };
+    applyNonInteractivePluginProviderChoice.mockResolvedValueOnce(resolvedConfig as never);
+
+    const result = await applyNonInteractiveAuthChoice({
+      nextConfig,
+      authChoice: "demo-provider-api-key",
+      opts: {} as never,
+      runtime: runtime as never,
+      baseConfig: nextConfig,
+    });
+
+    expect(result).toBe(resolvedConfig);
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(runtime.exit).not.toHaveBeenCalled();
+  });
+
   it("resolves plugin provider auth before builtin custom-provider handling", async () => {
     const runtime = createRuntime();
     const nextConfig = { agents: { defaults: {} } } as OpenClawConfig;
@@ -79,7 +130,7 @@ describe("applyNonInteractiveAuthChoice", () => {
       '"demo-provider-legacy" is no longer supported. Use --auth-choice "demo-provider-modern-api" instead.',
     );
     expect(runtime.exit).toHaveBeenCalledWith(1);
-    expect(applyNonInteractivePluginProviderChoice).toHaveBeenCalledOnce();
+    expect(applyNonInteractivePluginProviderChoice).not.toHaveBeenCalled();
   });
 
   it("escapes deprecated auth choice guidance for terminal output", async () => {
@@ -102,7 +153,30 @@ describe("applyNonInteractiveAuthChoice", () => {
       '"legacy\\u001b[31mchoice" is no longer supported. Use --auth-choice "modern\\nchoice" instead.',
     );
     expect(runtime.exit).toHaveBeenCalledWith(1);
-    expect(applyNonInteractivePluginProviderChoice).toHaveBeenCalledOnce();
+    expect(applyNonInteractivePluginProviderChoice).not.toHaveBeenCalled();
+  });
+
+  it("keeps replacement guidance for deprecated install-catalog choices", async () => {
+    const runtime = createRuntime();
+    const nextConfig = { agents: { defaults: {} } } as OpenClawConfig;
+    resolveDeprecatedProviderInstallCatalogEntry.mockReturnValueOnce({
+      choiceId: "qwen-api-key",
+    } as never);
+
+    const result = await applyNonInteractiveAuthChoice({
+      nextConfig,
+      authChoice: "modelstudio-api-key",
+      opts: {} as never,
+      runtime: runtime as never,
+      baseConfig: nextConfig,
+    });
+
+    expect(result).toBeNull();
+    expect(runtime.error).toHaveBeenCalledWith(
+      '"modelstudio-api-key" is no longer supported. Use --auth-choice "qwen-api-key" instead.',
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(applyNonInteractivePluginProviderChoice).not.toHaveBeenCalled();
   });
 
   it("stores custom provider env refs through the local auth-choice seam", async () => {

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -10,6 +10,7 @@ import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { SecretInput } from "../../../config/types.secrets.js";
 import { formatErrorMessage } from "../../../infra/errors.js";
 import { resolveManifestDeprecatedProviderAuthChoice } from "../../../plugins/provider-auth-choices.js";
+import { resolveDeprecatedProviderInstallCatalogEntry } from "../../../plugins/provider-install-catalog.js";
 import type { RuntimeEnv } from "../../../runtime.js";
 import { resolveDefaultSecretProviderAlias } from "../../../secrets/ref-contract.js";
 import {
@@ -17,6 +18,7 @@ import {
   isDeprecatedAuthChoice,
   resolveDeprecatedAuthChoiceReplacement,
 } from "../../auth-choice-legacy.js";
+import { formatAuthChoiceChoicesForCli } from "../../auth-choice-options.js";
 import { normalizeSecretInputModeInput } from "../../auth-choice.apply-helpers.js";
 import { normalizeApiKeyTokenProviderAuthChoice } from "../../auth-choice.apply.api-providers.js";
 import {
@@ -33,6 +35,8 @@ type ResolvedNonInteractiveApiKey = NonNullable<
   Awaited<ReturnType<typeof resolveNonInteractiveApiKey>>
 >;
 
+const GENERIC_NON_INTERACTIVE_AUTH_CHOICES = ["oauth", "setup-token", "token", "apiKey"];
+
 /** Applies a local non-interactive auth choice to the pending OpenClaw config. */
 export async function applyNonInteractiveAuthChoice(params: {
   nextConfig: OpenClawConfig;
@@ -40,6 +44,7 @@ export async function applyNonInteractiveAuthChoice(params: {
   opts: OnboardOptions;
   runtime: RuntimeEnv;
   baseConfig: OpenClawConfig;
+  workspaceDir?: string;
 }): Promise<OpenClawConfig | null> {
   const { opts, runtime, baseConfig } = params;
   let authChoice = normalizeApiKeyTokenProviderAuthChoice({
@@ -133,11 +138,18 @@ export async function applyNonInteractiveAuthChoice(params: {
       ...(paramsLocal.metadata ? { metadata: paramsLocal.metadata } : {}),
     };
   };
-  if (isDeprecatedAuthChoice(authChoice, { config: nextConfig, env: process.env })) {
+  if (
+    isDeprecatedAuthChoice(authChoice, {
+      config: nextConfig,
+      workspaceDir: params.workspaceDir,
+      env: process.env,
+    })
+  ) {
     // Keep deprecated aliases out of the config by normalizing them before
     // either plugin dispatch or built-in setup handling.
     const replacement = resolveDeprecatedAuthChoiceReplacement(authChoice, {
       config: nextConfig,
+      workspaceDir: params.workspaceDir,
       env: process.env,
     });
     if (replacement) {
@@ -147,12 +159,55 @@ export async function applyNonInteractiveAuthChoice(params: {
       runtime.error(
         formatDeprecatedNonInteractiveAuthChoiceError(authChoice, {
           config: nextConfig,
+          workspaceDir: params.workspaceDir,
           env: process.env,
         })!,
       );
       runtime.exit(1);
       return null;
     }
+  }
+
+  const deprecatedChoice = resolveManifestDeprecatedProviderAuthChoice(authChoice as string, {
+    config: nextConfig,
+    workspaceDir: params.workspaceDir,
+    env: process.env,
+  });
+  const deprecatedInstallChoice = deprecatedChoice
+    ? undefined
+    : resolveDeprecatedProviderInstallCatalogEntry(authChoice as string, {
+        config: nextConfig,
+        workspaceDir: params.workspaceDir,
+        env: process.env,
+        includeUntrustedWorkspacePlugins: false,
+      });
+  const replacementChoiceId = deprecatedChoice?.choiceId ?? deprecatedInstallChoice?.choiceId;
+  if (replacementChoiceId) {
+    runtime.error(
+      `${JSON.stringify(authChoice as string)} is no longer supported. Use --auth-choice ${JSON.stringify(replacementChoiceId)} instead.`,
+    );
+    runtime.exit(1);
+    return null;
+  }
+
+  const validAuthChoices = Array.from(
+    new Set([
+      ...formatAuthChoiceChoicesForCli({
+        includeLegacyAliases: false,
+        includeSkip: true,
+        config: nextConfig,
+        workspaceDir: params.workspaceDir,
+        env: process.env,
+      }).split("|"),
+      ...GENERIC_NON_INTERACTIVE_AUTH_CHOICES,
+    ]),
+  );
+  if (!validAuthChoices.includes(authChoice) && !authChoice.startsWith("provider-plugin:")) {
+    runtime.error(
+      `Unknown --auth-choice ${JSON.stringify(authChoice)}. Valid choices: ${validAuthChoices.join(", ")}.`,
+    );
+    runtime.exit(1);
+    return null;
   }
 
   const pluginProviderChoice = await applyNonInteractivePluginProviderChoice({
@@ -181,18 +236,6 @@ export async function applyNonInteractiveAuthChoice(params: {
         `Auth choice "${params.authChoice}" was not matched to a provider setup flow.`,
         'For Anthropic legacy token auth, use "--auth-choice setup-token --token-provider anthropic --token <token>" or pass "--auth-choice token --token-provider anthropic".',
       ].join("\n"),
-    );
-    runtime.exit(1);
-    return null;
-  }
-
-  const deprecatedChoice = resolveManifestDeprecatedProviderAuthChoice(authChoice as string, {
-    config: nextConfig,
-    env: process.env,
-  });
-  if (deprecatedChoice) {
-    runtime.error(
-      `${JSON.stringify(authChoice as string)} is no longer supported. Use --auth-choice ${JSON.stringify(deprecatedChoice.choiceId)} instead.`,
     );
     runtime.exit(1);
     return null;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running non-interactive onboarding with an unknown `--auth-choice` would see onboarding succeed and write configuration even though no provider or usable inference route was configured.

Before, this deterministic repro exited 0 and wrote `openclaw.json`:

```shell
openclaw onboard --non-interactive --accept-risk --auth-choice definitely-not-a-provider --skip-health --skip-skills --skip-bootstrap
```

## Why This Change Was Made

Non-interactive onboarding now validates the requested choice against the same provider-aware choice catalog used by the interactive picker before loading provider runtimes. The validation preserves generic CLI choices, direct provider-plugin choices, trusted workspace discovery, and replacement guidance for deprecated manifest and install-catalog aliases.

## User Impact

Automation now fails clearly and safely for misspelled or unsupported auth choices: the CLI names the invalid value, lists valid choices, exits 1, and does not write configuration. Valid choices continue through the existing setup path unchanged.

## Evidence

- Before: the repro exited 0 and wrote `openclaw.json` without configuring inference.
- After: the repro and a second unknown-value probe each exited 1, named the invalid value, listed valid choices, and left `openclaw.json` absent.
- Valid-path black box: `--auth-choice skip` exited 0 and wrote `openclaw.json` in an isolated state directory.
- Focused tests: 57/57 passed across onboarding dispatch, non-interactive auth-choice, and plugin-provider coverage.
- Blacksmith Testbox `tbx_01kxx86gnvwc5zts781j06t5k6`: `pnpm tsgo`, `pnpm check:test-types`, and `pnpm deadcode:exports` passed. Run: https://github.com/openclaw/openclaw/actions/runs/29688492921
- Targeted `run-oxlint`, formatting, and `git diff --check` passed.
- Fresh autoreview passed twice with no accepted/actionable findings, including the requested branch review against `origin/main`.

AI-assisted: yes. I understand the change and validated the observable CLI behavior plus the touched source and type surfaces.
