### PR TITLE
fix(qa): prevent burst events from being dropped

### DIFF
--- a/extensions/qa-lab/src/bus-queries.ts
+++ b/extensions/qa-lab/src/bus-queries.ts
@@ -176,12 +176,15 @@ export function pollQaBusEvents(params: {
     requestedCursor: params.input?.cursor,
   });
   const limit = Math.max(1, Math.min(params.input?.limit ?? 100, 500));
-  const matches = params.events
-    .filter((event) => event.accountId === accountId && event.cursor > effectiveStartCursor)
-    .slice(0, limit)
-    .map((event) => cloneEvent(event));
+  const matchingEvents = params.events.filter(
+    (event) => event.accountId === accountId && event.cursor > effectiveStartCursor,
+  );
+  const page = matchingEvents.slice(0, limit);
+  // A limited page may advance only through events it returns. Jumping to the
+  // bus-wide cursor would make every remaining account event unreachable.
+  const nextCursor = matchingEvents.length > page.length ? page.at(-1)?.cursor : params.cursor;
   return {
-    cursor: params.cursor,
-    events: matches,
+    cursor: nextCursor ?? params.cursor,
+    events: page.map((event) => cloneEvent(event)),
   };
 }

--- a/extensions/qa-lab/src/bus-server.test.ts
+++ b/extensions/qa-lab/src/bus-server.test.ts
@@ -200,6 +200,40 @@ describe("qa-bus server", () => {
     ).toEqual([queuedAfterReset.id]);
   });
 
+  it("paginates a burst without advancing past events omitted by the poll limit", async () => {
+    const state = createQaBusState();
+    const bus = await startQaBusServer({ state });
+    stops.push(bus["stop"]);
+
+    for (let index = 1; index <= 101; index += 1) {
+      state.addInboundMessage({
+        accountId: "acct-a",
+        conversation: { id: "burst", kind: "direct" },
+        senderId: "acct-a-user",
+        text: `burst event ${index}`,
+      });
+    }
+
+    const firstPage = await pollQaBus({
+      baseUrl: bus.baseUrl,
+      accountId: "acct-a",
+      cursor: 0,
+      timeoutMs: 0,
+    });
+    expect(firstPage.events).toHaveLength(100);
+    expect(firstPage.cursor).toBe(100);
+
+    const secondPage = await pollQaBus({
+      baseUrl: bus.baseUrl,
+      accountId: "acct-a",
+      cursor: firstPage.cursor,
+      timeoutMs: 0,
+    });
+    expect(secondPage.events).toHaveLength(1);
+    expect(secondPage.events[0]?.cursor).toBe(101);
+    expect(secondPage.cursor).toBe(101);
+  });
+
   it("rejects malformed poll numeric fields before long-polling", async () => {
     const state = createQaBusState();
     const bus = await startQaBusServer({ state });


### PR DESCRIPTION
Closes #111402

## What Problem This Solves

Fixes an issue where QA Channel consumers could permanently miss inbound messages when more matching bus events were queued than fit in one poll response.

## Why This Change Was Made

Limited poll responses now advance only through the last event actually returned. Once the matching backlog is exhausted, the response can still advance to the bus-wide cursor without replaying unrelated-account traffic.

## User Impact

QA Channel stress runs can process bursts larger than the 100-event default page without silently dropping the remaining messages.

## Evidence

- Before: the new 101-event HTTP bus regression failed because the 100-event first page returned cursor 101 instead of 100.
- After, local: `node scripts/run-vitest.mjs extensions/qa-lab/src/bus-server.test.ts` — 9 tests passed.
- After, Blacksmith Testbox: `pnpm test extensions/qa-lab/src/bus-server.test.ts` — 9 tests passed.
- After, Blacksmith Testbox: `pnpm test extensions/qa-lab` — 139 files and 1,617 tests passed.
- `git diff --check` and targeted oxfmt check passed.
- Autoreview: clean, with no accepted/actionable findings.

AI-assisted: yes. The maintainer reviewed the runtime path, regression, and proof.
