### PR TITLE
test(sessions): isolate store pruning integration test

### DIFF
--- a/src/config/sessions/session-history-eviction.test.ts
+++ b/src/config/sessions/session-history-eviction.test.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { executeSqliteQuerySync } from "../../infra/kysely-sync.js";
@@ -8,6 +7,11 @@ import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+  withOpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
 import { appendSqliteTrajectoryRuntimeEvents } from "../../trajectory/runtime-store.sqlite.js";
 import type { TrajectoryEvent } from "../../trajectory/types.js";
 import { measureSessionPhysicalDiskUsage } from "./disk-budget.js";
@@ -25,17 +29,28 @@ import {
 import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
 
 describe("SQLite historical session disk budget", () => {
+  let testState: OpenClawTestState;
   let tempDir: string;
   let storePath: string;
 
-  beforeEach(() => {
-    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-session-history-budget-"));
+  beforeEach(async () => {
+    testState = await createOpenClawTestState({
+      prefix: "openclaw-session-history-budget-",
+      layout: "state-only",
+    });
+    tempDir = testState.sessionsDir();
+    fs.mkdirSync(tempDir, { recursive: true });
     storePath = path.join(tempDir, "sessions.json");
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await enforceSqliteSessionHistoryDiskBudget({
+      storePath,
+      mode: "warn",
+      maintenance: { maxDiskBytes: null, highWaterBytes: null },
+    });
     closeOpenClawAgentDatabasesForTest();
-    fs.rmSync(tempDir, { recursive: true, force: true });
+    await testState.cleanup();
   });
 
   it("evicts the oldest historical session and stops after reaching high water", async () => {
@@ -291,41 +306,47 @@ function createTrajectoryEvent(sessionId: string, sessionKey: string): Trajector
 
 describe("kickSessionHistoryDiskBudgetMaintenance", () => {
   it("throttles repeat kicks and skips warn mode entirely", async () => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-session-history-kick-"));
-    const storePath = path.join(tempDir, "sessions.json");
-    const maintenance = {
-      mode: "warn",
-      maxDiskBytes: 1,
-      highWaterBytes: 0,
-    } as never;
-    // Warn mode must not schedule background enforcement at all.
-    kickSessionHistoryDiskBudgetMaintenance({
-      storePath,
-      maintenanceConfig: maintenance,
-    });
-    const enforceMaintenance = {
-      mode: "enforce",
-      maxDiskBytes: Number.MAX_SAFE_INTEGER,
-      highWaterBytes: Number.MAX_SAFE_INTEGER - 1,
-    } as never;
-    const first = Date.now();
-    kickSessionHistoryDiskBudgetMaintenance({
-      storePath,
-      maintenanceConfig: enforceMaintenance,
-      now: first,
-    });
-    // Second kick inside the throttle window is a no-op (single-slot state).
-    kickSessionHistoryDiskBudgetMaintenance({
-      storePath,
-      maintenanceConfig: enforceMaintenance,
-      now: first + 1_000,
-    });
-    // Give the fire-and-forget pass a tick to settle; an under-budget store
-    // must leave every session untouched.
-    await new Promise((resolve) => {
-      setTimeout(resolve, 50);
-    });
-    closeOpenClawAgentDatabasesForTest();
-    fs.rmSync(tempDir, { recursive: true, force: true });
+    await withOpenClawTestState(
+      { prefix: "openclaw-session-history-kick-", layout: "state-only" },
+      async (testState) => {
+        const tempDir = testState.sessionsDir();
+        fs.mkdirSync(tempDir, { recursive: true });
+        const storePath = path.join(tempDir, "sessions.json");
+        const maintenance = {
+          mode: "warn",
+          maxDiskBytes: 1,
+          highWaterBytes: 0,
+        } as never;
+        // Warn mode must not schedule background enforcement at all.
+        kickSessionHistoryDiskBudgetMaintenance({
+          storePath,
+          maintenanceConfig: maintenance,
+        });
+        const enforceMaintenance = {
+          mode: "enforce",
+          maxDiskBytes: Number.MAX_SAFE_INTEGER,
+          highWaterBytes: Number.MAX_SAFE_INTEGER - 1,
+        } as never;
+        const first = Date.now();
+        kickSessionHistoryDiskBudgetMaintenance({
+          storePath,
+          maintenanceConfig: enforceMaintenance,
+          now: first,
+        });
+        // Second kick inside the throttle window is a no-op (single-slot state).
+        kickSessionHistoryDiskBudgetMaintenance({
+          storePath,
+          maintenanceConfig: enforceMaintenance,
+          now: first + 1_000,
+        });
+        // A queued no-op pass is a deterministic barrier behind the fire-and-forget kick.
+        await enforceSqliteSessionHistoryDiskBudget({
+          storePath,
+          mode: "warn",
+          maintenance: { maxDiskBytes: null, highWaterBytes: null },
+        });
+        closeOpenClawAgentDatabasesForTest();
+      },
+    );
   });
 });

--- a/src/config/sessions/store.pruning.integration.test.ts
+++ b/src/config/sessions/store.pruning.integration.test.ts
@@ -3,9 +3,12 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
-import { createSuiteTempRootTracker } from "../../test-helpers/temp-dir.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
 import {
   resolveTrajectoryFilePath,
   resolveTrajectoryPointerFilePath,
@@ -25,7 +28,6 @@ vi.mock("../config.js", async () => ({
 
 import { getRuntimeConfig } from "../config.js";
 import { runSessionsCleanup } from "./cleanup-service.js";
-import { measureSessionPhysicalDiskUsage } from "./disk-budget.js";
 import {
   appendTranscriptMessage,
   listSessionEntries,
@@ -35,6 +37,7 @@ import {
   replaceSessionEntry,
   resetSessionEntryLifecycle,
 } from "./session-accessor.js";
+import { enforceSqliteSessionHistoryDiskBudget } from "./session-history-eviction.js";
 import { registerSessionMaintenancePreserveKeysProvider } from "./store-maintenance-preserve.js";
 import {
   clearSessionStoreCacheForTest,
@@ -62,8 +65,6 @@ function jsonRoundTrip<T>(value: T): T {
 }
 
 const archiveTimestamp = (ms: number) => new Date(ms).toISOString().replaceAll(":", "-");
-
-const suiteRootTracker = createSuiteTempRootTracker({ prefix: "openclaw-pruning-integ-" });
 
 function makeEntry(updatedAt: number): SessionEntry {
   return { sessionId: crypto.randomUUID(), updatedAt };
@@ -93,8 +94,10 @@ function applyCappedMaintenanceConfig(mockLoadConfigLocal: ReturnType<typeof vi.
   });
 }
 
-async function createCaseDir(prefix: string): Promise<string> {
-  return await suiteRootTracker.make(prefix);
+function disableAutomaticDiskBudget(mockLoadConfigValue: ReturnType<typeof vi.fn>) {
+  mockLoadConfigValue.mockReturnValue({
+    session: { maintenance: { maxDiskBytes: false } },
+  });
 }
 
 async function expectPathExists(targetPath: string): Promise<void> {
@@ -186,30 +189,37 @@ async function seedSqliteTrajectoryEvent(params: {
 }
 
 describe("Integration: saveSessionStore with pruning", () => {
+  let testState: OpenClawTestState;
   let testDir: string;
   let storePath: string;
   let savedCacheTtl: string | undefined;
 
-  beforeAll(async () => {
-    await suiteRootTracker.setup();
-  });
-
-  afterAll(async () => {
-    await suiteRootTracker.cleanup();
-  });
-
   beforeEach(async () => {
     mockLoadConfig = vi.mocked(getRuntimeConfig) as ReturnType<typeof vi.fn>;
     mockLoadConfig.mockReset();
-    testDir = await createCaseDir("pruning-integ");
+    disableAutomaticDiskBudget(mockLoadConfig);
+    testState = await createOpenClawTestState({
+      prefix: "openclaw-pruning-integ-",
+      layout: "state-only",
+    });
+    testDir = testState.sessionsDir();
+    await fs.mkdir(testDir, { recursive: true });
     storePath = path.join(testDir, "sessions.json");
     savedCacheTtl = process.env.OPENCLAW_SESSION_CACHE_TTL_MS;
     process.env.OPENCLAW_SESSION_CACHE_TTL_MS = "0";
     clearSessionStoreCacheForTest();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     mockLoadConfig.mockReset();
+    disableAutomaticDiskBudget(mockLoadConfig);
+    // Reset/delete entry lifecycles kick fire-and-forget history maintenance.
+    // Serialize a no-op pass behind them before closing shared SQLite handles.
+    await enforceSqliteSessionHistoryDiskBudget({
+      storePath,
+      mode: "warn",
+      maintenance: { maxDiskBytes: null, highWaterBytes: null },
+    });
     clearSessionStoreCacheForTest();
     closeOpenClawAgentDatabasesForTest();
     if (savedCacheTtl === undefined) {
@@ -217,6 +227,7 @@ describe("Integration: saveSessionStore with pruning", () => {
     } else {
       process.env.OPENCLAW_SESSION_CACHE_TTL_MS = savedCacheTtl;
     }
+    await testState.cleanup();
   });
 
   it("saveSessionStore prunes stale model-run probes before capping real sessions", async () => {
@@ -1134,14 +1145,13 @@ describe("Integration: saveSessionStore with pruning", () => {
       target: { canonicalKey: sessionKey, storeKeys: [sessionKey] },
       buildNextEntry: () => ({ sessionId: "live-budget-session", updatedAt: Date.now() }),
     });
-    const before = await measureSessionPhysicalDiskUsage(storePath);
     mockLoadConfig.mockReturnValue({
       session: {
         maintenance: {
           mode: "enforce",
           pruneAfter: "365d",
           maxEntries: 500,
-          maxDiskBytes: before.totalBytes - 1,
+          maxDiskBytes: 0,
           highWaterBytes: 0,
         },
       },
@@ -1653,7 +1663,8 @@ describe("Integration: saveSessionStore with pruning", () => {
     applyCappedMaintenanceConfig(mockLoadConfig);
 
     const now = Date.now();
-    const externalDir = await createCaseDir("external-cap");
+    const externalDir = testState.path("external-cap");
+    await fs.mkdir(externalDir, { recursive: true });
     const externalTranscript = path.join(externalDir, "outside.jsonl");
     await fs.writeFile(externalTranscript, "external", "utf-8");
     const store: Record<string, SessionEntry> = {
@@ -1828,7 +1839,8 @@ describe("Integration: saveSessionStore with pruning", () => {
     });
 
     const now = Date.now();
-    const externalDir = await createCaseDir("external-session");
+    const externalDir = testState.path("external-session");
+    await fs.mkdir(externalDir, { recursive: true });
     const externalTranscript = path.join(externalDir, "outside.jsonl");
     await fs.writeFile(externalTranscript, "z".repeat(400), "utf-8");
 


### PR DESCRIPTION
## What Problem This Solves

`src/config/sessions/store.pruning.integration.test.ts` flaked inside CI shard runs ("expected +0 to be 1") while passing standalone — it blocked #111371's landing until a rerun and has the classic shard-leakage signature.

## Why This Change Was Made

Root cause (reproduced exactly before fixing): fixture seeding started a *background* disk-budget maintenance check whose module-level `pendingForce` marker survived reset; when that check completed it re-read the tightened config mock and evicted the historical SQLite generation first, leaving the explicitly awaited cleanup pass with `removedEntries: 0`. Fixes: automatic disk-budget maintenance disabled during fixture setup (only the explicit cleanup sees the zero-byte budget), every test gets a fresh realpath-backed state dir, deterministic queue barriers before closing shared SQLite handles, and the sibling `session-history-eviction.test.ts` hardened the same way (its 50 ms sleep replaced with queue synchronization).

## User Impact

None (test-only). CI stops flaking on this shard.

## Evidence

- Exact `0` failure reproduced in the pre-fix repetition loop, then 15/15 green on Testbox.
- Full `vitest.runtime-config` shard portion: 201 files / 2,702 tests green twice.
- Structured autoreview (codex/gpt-5.6-sol, xhigh): clean (0.9).
