### PR TITLE
fix(scripts): resolve remaining repo tools through the worktree-aware helper

### DIFF
--- a/scripts/check-tsgo-core-boundary.mjs
+++ b/scripts/check-tsgo-core-boundary.mjs
@@ -3,10 +3,11 @@
 // Enforces core tsgo project boundaries and sparse-checkout safety.
 import { spawnSync } from "node:child_process";
 import path from "node:path";
+import { resolveRepoToolBinPath } from "./lib/local-heavy-check-runtime.mjs";
 import { createManagedCommandInvocation } from "./lib/managed-child-process.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
-const tsgoPath = path.join(repoRoot, "node_modules", ".bin", "tsgo");
+const tsgoPath = resolveRepoToolBinPath("tsgo", { cwd: repoRoot });
 
 const coreGraphs = [
   { name: "core", config: "tsconfig.core.json" },

--- a/scripts/format-docs.mjs
+++ b/scripts/format-docs.mjs
@@ -6,6 +6,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { resolveRepoToolBinPath } from "./lib/local-heavy-check-runtime.mjs";
 import { repairMintlifyAccordionIndentation } from "./lib/mintlify-accordion.mjs";
 import { buildCmdExeCommandLine, resolveWindowsCmdExePath } from "./windows-cmd-helpers.mjs";
 
@@ -124,7 +125,7 @@ export function resolveOxfmtInvocation(args, params = {}) {
   const platform = params.platform ?? process.platform;
   const existsSync = params.existsSync ?? fs.existsSync;
   const shimName = platform === "win32" ? "oxfmt.cmd" : "oxfmt";
-  const shimPath = path.join(repoRoot, "node_modules", ".bin", shimName);
+  const shimPath = resolveRepoToolBinPath(shimName, { cwd: repoRoot, fileExists: existsSync });
 
   if (existsSync(shimPath)) {
     if (platform === "win32") {

--- a/scripts/profile-tsgo.mjs
+++ b/scripts/profile-tsgo.mjs
@@ -8,13 +8,14 @@ import path from "node:path";
 import {
   acquireLocalHeavyCheckLockSync,
   applyLocalTsgoPolicy,
+  resolveRepoToolBinPath,
   shouldAcquireLocalHeavyCheckLockForTsgo,
 } from "./lib/local-heavy-check-runtime.mjs";
 import { createManagedCommandInvocation } from "./lib/managed-child-process.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 const artifactRoot = path.resolve(repoRoot, ".artifacts/tsgo-profile");
-const tsgoPath = path.resolve(repoRoot, "node_modules", ".bin", "tsgo");
+const tsgoPath = resolveRepoToolBinPath("tsgo", { cwd: repoRoot });
 
 const GRAPH_DEFINITIONS = {
   core: {

--- a/scripts/run-tsgo.mjs
+++ b/scripts/run-tsgo.mjs
@@ -7,6 +7,7 @@ import {
   acquireLocalHeavyCheckLockSync,
   applyLocalTsgoPolicy,
   resolveLocalHeavyCheckEnv,
+  resolveRepoToolBinPath,
   shouldAcquireLocalHeavyCheckLockForTsgo,
 } from "./lib/local-heavy-check-runtime.mjs";
 import { createManagedCommandInvocation } from "./lib/managed-child-process.mjs";
@@ -20,7 +21,7 @@ const { args: finalArgs, env } = applyLocalTsgoPolicy(
   resolveLocalHeavyCheckEnv(process.env),
 );
 
-const tsgoPath = path.resolve("node_modules", ".bin", "tsgo");
+const tsgoPath = resolveRepoToolBinPath("tsgo");
 const tsBuildInfoFile = readFlagValue(finalArgs, "--tsBuildInfoFile");
 if (tsBuildInfoFile) {
   fs.mkdirSync(path.dirname(path.resolve(tsBuildInfoFile)), { recursive: true });


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #111393. Four scripts still resolved `node_modules/.bin` tools from the current checkout only: `run-tsgo.mjs`, `check-tsgo-core-boundary.mjs`, `profile-tsgo.mjs`, and the `format-docs.mjs` oxfmt shim. In dependency-less linked worktrees this made `run-oxlint.mjs` die with `spawnSync .bin/tsgo ENOENT` inside its extension-boundary prep step — so #111393's oxlint fix couldn't actually complete end-to-end — and blocked every local tsgo entry point.

## Why This Change Was Made

All four sites now use the `resolveRepoToolBinPath` helper #111393 introduced (worktree-local first, then the primary checkout owning the shared `.git`). `format-docs` keeps its injectable `existsSync`/`repoRoot` test seams by passing them through to the resolver; platform-specific shim handling (`oxfmt.cmd` via cmd.exe) is unchanged.

## User Impact

Developer tooling only: agents and humans in linked/sparse worktrees can now run the full local lint path (including boundary-dts prep) and tsgo entry points against the primary checkout's toolchain instead of discovering failures through 40-minute PR CI cycles.

## Evidence

- Live before/after in a dependency-less `.claude/worktrees` checkout: `node scripts/run-oxlint.mjs <file>` previously failed `spawnSync .bin/tsgo ENOENT`; with this change tsgo resolves and executes (remaining local failure in that environment is unrelated staleness of the primary checkout's installed `@openclaw/fs-safe`, which a fresh install resolves — CI installs fresh).
- `node scripts/check-script-declarations.mjs`: 237 declaration contracts match.
- `node scripts/run-vitest.mjs test/scripts/local-heavy-check-runtime.test.ts`: 33/33.
- `node scripts/run-vitest.mjs test/scripts/format-docs.test.ts`: 5/5 (exercises the injectable-seam path through the resolver, including the Windows shim invocation).
- Targeted oxlint on the four changed scripts: clean.
- Autoreview (Codex gpt-5.6-sol): clean, "patch is correct (0.89)".
