### PR TITLE
feat(ui): gravatar fallback in shared avatar primitive

### DIFF
--- a/src/gateway/control-ui-csp.test.ts
+++ b/src/gateway/control-ui-csp.test.ts
@@ -36,10 +36,17 @@ describe("buildControlUiCspHeader", () => {
     expect(connectSrc?.split(" ")).not.toContain("https:");
   });
 
-  it("limits image loading to same-origin, data, and managed blob URLs", () => {
+  it("limits image loading to local sources and the Gravatar fallback origin", () => {
     const csp = buildControlUiCspHeader();
-    expect(csp).toContain("img-src 'self' data: blob:");
-    expect(csp).not.toContain("img-src 'self' data: blob: https:");
+    const imgSrc = csp.split("; ").find((directive) => directive.startsWith("img-src "));
+    expect(imgSrc?.split(" ")).toEqual([
+      "img-src",
+      "'self'",
+      "data:",
+      "blob:",
+      "https://gravatar.com",
+    ]);
+    expect(imgSrc?.split(" ")).not.toContain("https:");
   });
 
   it("allows same-origin and inline audio/video playback", () => {

--- a/src/gateway/control-ui-csp.ts
+++ b/src/gateway/control-ui-csp.ts
@@ -72,7 +72,7 @@ export function buildControlUiCspHeader(opts?: {
     "frame-src 'self' http: https:",
     `script-src ${scriptTokens.join(" ")}`,
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-    "img-src 'self' data: blob:",
+    "img-src 'self' data: blob: https://gravatar.com",
     "media-src 'self' data: blob:",
     "font-src 'self' https://fonts.gstatic.com",
     "worker-src 'self'",

--- a/ui/src/components/viewer-facepile.test.ts
+++ b/ui/src/components/viewer-facepile.test.ts
@@ -1,0 +1,98 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PresenceViewer } from "./viewer-facepile.ts";
+import "./viewer-facepile.ts";
+
+type ViewerAvatarElement = HTMLElement & {
+  user: PresenceViewer;
+  updateComplete: Promise<boolean>;
+};
+
+function viewer(overrides: Partial<PresenceViewer> = {}): PresenceViewer {
+  return {
+    id: "profile-1",
+    name: "Test Person",
+    watchedSessions: [],
+    ...overrides,
+  };
+}
+
+async function mountViewer(user: PresenceViewer): Promise<ViewerAvatarElement> {
+  const avatar = document.createElement("openclaw-viewer-avatar") as ViewerAvatarElement;
+  avatar.user = user;
+  document.body.append(avatar);
+  await avatar.updateComplete;
+  return avatar;
+}
+
+async function waitForImage(avatar: ViewerAvatarElement): Promise<HTMLImageElement> {
+  await vi.waitFor(() => expect(avatar.querySelector("img")).not.toBeNull());
+  return avatar.querySelector<HTMLImageElement>("img")!;
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+describe("viewer avatar resolution", () => {
+  it("keeps an uploaded avatar ahead of the email fallback", async () => {
+    const digest = vi.spyOn(globalThis.crypto.subtle, "digest");
+    const avatar = await mountViewer(
+      viewer({ email: "test@example.com", avatarUrl: "/api/users/profile-1/avatar?v=2" }),
+    );
+    const image = await waitForImage(avatar);
+
+    expect(image.getAttribute("src")).toBe("/api/users/profile-1/avatar?v=2");
+    expect(image.getAttribute("referrerpolicy")).toBe("no-referrer");
+    expect(image.getAttribute("loading")).toBe("lazy");
+    expect(digest).not.toHaveBeenCalled();
+  });
+
+  it("normalizes and hashes email with SHA-256 for the Gravatar URL", async () => {
+    const avatar = await mountViewer(viewer({ email: "  TEST@example.com " }));
+
+    expect(avatar.querySelector("img")).toBeNull();
+    expect(avatar.textContent?.trim()).toBe("TP");
+    const image = await waitForImage(avatar);
+    expect(image.getAttribute("src")).toBe(
+      "https://gravatar.com/avatar/973dfe463ec85785f5f95af5ba3906eedb2d931c24e69824a89ea65dba4e813b?d=404&s=128",
+    );
+  });
+
+  it("falls back to initials when the Gravatar image fails", async () => {
+    const avatar = await mountViewer(viewer({ email: "missing-one@example.test" }));
+    const image = await waitForImage(avatar);
+
+    image.dispatchEvent(new Event("error"));
+    await avatar.updateComplete;
+
+    expect(avatar.querySelector("img")).toBeNull();
+    expect(avatar.textContent?.trim()).toBe("TP");
+  });
+
+  it("renders initials without attempting a hash when email is absent", async () => {
+    const digest = vi.spyOn(globalThis.crypto.subtle, "digest");
+    const avatar = await mountViewer(viewer());
+
+    expect(avatar.querySelector("img")).toBeNull();
+    expect(avatar.textContent?.trim()).toBe("TP");
+    expect(digest).not.toHaveBeenCalled();
+  });
+
+  it("caches missing Gravatars by normalized email", async () => {
+    const digest = vi.spyOn(globalThis.crypto.subtle, "digest");
+    const first = await mountViewer(viewer({ email: " Missing-Two@Example.Test " }));
+    const image = await waitForImage(first);
+    image.dispatchEvent(new Event("error"));
+    await first.updateComplete;
+
+    const second = await mountViewer(
+      viewer({ id: "profile-2", email: "missing-two@example.test" }),
+    );
+
+    expect(second.querySelector("img")).toBeNull();
+    expect(digest).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/src/components/viewer-facepile.test.ts
+++ b/ui/src/components/viewer-facepile.test.ts
@@ -50,6 +50,20 @@ describe("viewer avatar resolution", () => {
     expect(digest).not.toHaveBeenCalled();
   });
 
+  it("retries a failed uploaded avatar after the user snapshot updates", async () => {
+    const avatarUrl = "/api/users/profile-1/avatar?v=2";
+    const avatar = await mountViewer(viewer({ avatarUrl }));
+    const failedImage = await waitForImage(avatar);
+
+    failedImage.dispatchEvent(new Event("error"));
+    await avatar.updateComplete;
+    expect(avatar.querySelector("img")).toBeNull();
+
+    avatar.user = viewer({ avatarUrl });
+    await avatar.updateComplete;
+    expect(avatar.querySelector("img")?.getAttribute("src")).toBe(avatarUrl);
+  });
+
   it("normalizes and hashes email with SHA-256 for the Gravatar URL", async () => {
     const avatar = await mountViewer(viewer({ email: "  TEST@example.com " }));
 
@@ -70,6 +84,20 @@ describe("viewer avatar resolution", () => {
 
     expect(avatar.querySelector("img")).toBeNull();
     expect(avatar.textContent?.trim()).toBe("TP");
+  });
+
+  it("does not attribute a stale Gravatar error to the next user", async () => {
+    const avatar = await mountViewer(viewer({ email: "first-stale@example.test" }));
+    const staleImage = await waitForImage(avatar);
+
+    avatar.user = viewer({ id: "profile-2", email: "second-current@example.test" });
+    staleImage.dispatchEvent(new Event("error"));
+    await avatar.updateComplete;
+
+    const image = await waitForImage(avatar);
+    expect(image.getAttribute("src")).toMatch(
+      /^https:\/\/gravatar\.com\/avatar\/[a-f0-9]{64}\?d=404&s=128$/u,
+    );
   });
 
   it("renders initials without attempting a hash when email is absent", async () => {

--- a/ui/src/components/viewer-facepile.ts
+++ b/ui/src/components/viewer-facepile.ts
@@ -177,6 +177,12 @@ class ViewerAvatar extends OpenClawLightDomContentsElement {
   private failedImageUrl: string | null = null;
   private resolutionId = 0;
 
+  protected override willUpdate(changedProperties: PropertyValues<this>) {
+    if (changedProperties.has("user")) {
+      this.failedImageUrl = null;
+    }
+  }
+
   protected override updated(changedProperties: PropertyValues<this>) {
     if (!changedProperties.has("user")) {
       return;
@@ -212,7 +218,12 @@ class ViewerAvatar extends OpenClawLightDomContentsElement {
       return;
     }
     const email = normalizedEmail(user.email);
-    if (!user.avatarUrl && email && imageUrl === this.gravatar?.url) {
+    if (
+      !user.avatarUrl &&
+      email &&
+      imageUrl === this.gravatar?.url &&
+      email === this.gravatar.email
+    ) {
       gravatarUrlCache.set(email, negativeEntry());
       this.gravatar = null;
       return;

--- a/ui/src/components/viewer-facepile.ts
+++ b/ui/src/components/viewer-facepile.ts
@@ -1,5 +1,5 @@
-import { html, nothing } from "lit";
-import { property } from "lit/decorators.js";
+import { html, nothing, type PropertyValues } from "lit";
+import { property, state } from "lit/decorators.js";
 import type { PresenceEntry } from "../api/types.ts";
 import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
 import "./tooltip.ts";
@@ -112,11 +112,98 @@ function avatarColor(userId: string): string {
   return `hsl(${(hash >>> 0) % 360} 48% 42%)`;
 }
 
+type GravatarCacheEntry = string | null | Promise<string | null>;
+
+// Missing images stay missing for this page lifetime, so repeated avatar mounts
+// do not keep sending the same known-404 request to Gravatar.
+const gravatarUrlCache = new Map<string, GravatarCacheEntry>();
+
+function normalizedEmail(email: string | null | undefined): string | undefined {
+  return normalized(email)?.toLowerCase();
+}
+
+function gravatarUrlForEmail(email: string): GravatarCacheEntry {
+  const normalizedValue = normalizedEmail(email);
+  if (!normalizedValue) {
+    return null;
+  }
+  if (gravatarUrlCache.has(normalizedValue)) {
+    return gravatarUrlCache.get(normalizedValue) ?? null;
+  }
+  const pending = Promise.resolve()
+    .then(() =>
+      globalThis.crypto.subtle.digest("SHA-256", new TextEncoder().encode(normalizedValue)),
+    )
+    .then((digest) => {
+      const hash = [...new Uint8Array(digest)]
+        .map((byte) => byte.toString(16).padStart(2, "0"))
+        .join("");
+      const url = `https://gravatar.com/avatar/${hash}?d=404&s=128`;
+      gravatarUrlCache.set(normalizedValue, url);
+      return url;
+    })
+    .catch(() => {
+      gravatarUrlCache.set(normalizedValue, null);
+      return null;
+    });
+  gravatarUrlCache.set(normalizedValue, pending);
+  return pending;
+}
+
 export type ViewerAvatarVariant = "session" | "footer" | "profile";
 
 class ViewerAvatar extends OpenClawLightDomContentsElement {
   @property({ attribute: false }) user: PresenceViewer | null = null;
   @property() variant: ViewerAvatarVariant = "session";
+
+  @state() private gravatar: { email: string; url: string } | null = null;
+
+  private failedImageUrl: string | null = null;
+  private resolutionId = 0;
+
+  protected override updated(changedProperties: PropertyValues<this>) {
+    if (!changedProperties.has("user")) {
+      return;
+    }
+    const resolutionId = ++this.resolutionId;
+    const email = this.user?.avatarUrl ? undefined : normalizedEmail(this.user?.email);
+    if (!email) {
+      return;
+    }
+    const applyResolvedUrl = (url: string | null) => {
+      if (
+        resolutionId === this.resolutionId &&
+        !this.user?.avatarUrl &&
+        normalizedEmail(this.user?.email) === email
+      ) {
+        this.gravatar = url ? { email, url } : null;
+      }
+    };
+    const resolved = gravatarUrlForEmail(email);
+    if (typeof resolved === "string") {
+      applyResolvedUrl(resolved);
+      return;
+    }
+    if (resolved) {
+      void resolved.then(applyResolvedUrl);
+    }
+  }
+
+  private readonly handleImageError = (event: Event) => {
+    const imageUrl = (event.currentTarget as HTMLImageElement).getAttribute("src");
+    const user = this.user;
+    if (!imageUrl || !user) {
+      return;
+    }
+    const email = normalizedEmail(user.email);
+    if (!user.avatarUrl && email && imageUrl === this.gravatar?.url) {
+      gravatarUrlCache.set(email, null);
+      this.gravatar = null;
+      return;
+    }
+    this.failedImageUrl = imageUrl;
+    this.requestUpdate();
+  };
 
   override render() {
     const user = this.user;
@@ -124,13 +211,22 @@ class ViewerAvatar extends OpenClawLightDomContentsElement {
       return nothing;
     }
     const label = presenceViewerLabel(user);
+    const email = normalizedEmail(user.email);
+    const gravatarUrl = this.gravatar && this.gravatar.email === email ? this.gravatar.url : null;
+    const imageUrl = user.avatarUrl ?? gravatarUrl;
     return html`<span
       class="viewer-avatar viewer-avatar--${this.variant}"
       data-viewer-id=${user.id}
       aria-label=${label}
     >
-      ${user.avatarUrl
-        ? html`<img src=${user.avatarUrl} alt="" referrerpolicy="no-referrer" />`
+      ${imageUrl && imageUrl !== this.failedImageUrl
+        ? html`<img
+            src=${imageUrl}
+            alt=""
+            referrerpolicy="no-referrer"
+            loading="lazy"
+            @error=${this.handleImageError}
+          />`
         : html`<span style=${`background: ${avatarColor(user.id)}`}>${initialsFor(user)}</span>`}
     </span>`;
   }

--- a/ui/src/components/viewer-facepile.ts
+++ b/ui/src/components/viewer-facepile.ts
@@ -112,23 +112,36 @@ function avatarColor(userId: string): string {
   return `hsl(${(hash >>> 0) % 360} 48% 42%)`;
 }
 
-type GravatarCacheEntry = string | null | Promise<string | null>;
+type GravatarCacheEntry = string | Promise<string | null> | { failedUntil: number };
 
-// Missing images stay missing for this page lifetime, so repeated avatar mounts
-// do not keep sending the same known-404 request to Gravatar.
+// An <img> error cannot distinguish a Gravatar 404 from a transient network or
+// 5xx failure, so negative entries expire instead of poisoning the page lifetime.
+const GRAVATAR_NEGATIVE_CACHE_MS = 10 * 60 * 1000;
 const gravatarUrlCache = new Map<string, GravatarCacheEntry>();
+
+function negativeEntry(): GravatarCacheEntry {
+  return { failedUntil: Date.now() + GRAVATAR_NEGATIVE_CACHE_MS };
+}
 
 function normalizedEmail(email: string | null | undefined): string | undefined {
   return normalized(email)?.toLowerCase();
 }
 
-function gravatarUrlForEmail(email: string): GravatarCacheEntry {
+function gravatarUrlForEmail(email: string): string | null | Promise<string | null> {
   const normalizedValue = normalizedEmail(email);
   if (!normalizedValue) {
     return null;
   }
-  if (gravatarUrlCache.has(normalizedValue)) {
-    return gravatarUrlCache.get(normalizedValue) ?? null;
+  const cached = gravatarUrlCache.get(normalizedValue);
+  if (cached !== undefined) {
+    if (typeof cached === "object" && cached !== null && "failedUntil" in cached) {
+      if (cached.failedUntil > Date.now()) {
+        return null;
+      }
+      gravatarUrlCache.delete(normalizedValue);
+    } else {
+      return cached;
+    }
   }
   const pending = Promise.resolve()
     .then(() =>
@@ -143,7 +156,7 @@ function gravatarUrlForEmail(email: string): GravatarCacheEntry {
       return url;
     })
     .catch(() => {
-      gravatarUrlCache.set(normalizedValue, null);
+      gravatarUrlCache.set(normalizedValue, negativeEntry());
       return null;
     });
   gravatarUrlCache.set(normalizedValue, pending);
@@ -197,7 +210,7 @@ class ViewerAvatar extends OpenClawLightDomContentsElement {
     }
     const email = normalizedEmail(user.email);
     if (!user.avatarUrl && email && imageUrl === this.gravatar?.url) {
-      gravatarUrlCache.set(email, null);
+      gravatarUrlCache.set(email, negativeEntry());
       this.gravatar = null;
       return;
     }

--- a/ui/src/components/viewer-facepile.ts
+++ b/ui/src/components/viewer-facepile.ts
@@ -116,6 +116,9 @@ type GravatarCacheEntry = string | Promise<string | null> | { failedUntil: numbe
 
 // An <img> error cannot distinguish a Gravatar 404 from a transient network or
 // 5xx failure, so negative entries expire instead of poisoning the page lifetime.
+// Accepted tradeoff: re-resolution happens on the next user-prop update (any
+// presence/snapshot event), not on a timer — a fully idle page keeps initials
+// until activity resumes rather than each avatar owning a retry timer.
 const GRAVATAR_NEGATIVE_CACHE_MS = 10 * 60 * 1000;
 const gravatarUrlCache = new Map<string, GravatarCacheEntry>();
 

--- a/ui/src/e2e/profile-page.e2e.test.ts
+++ b/ui/src/e2e/profile-page.e2e.test.ts
@@ -181,6 +181,64 @@ describeControlUiE2e("Control UI profile page mocked Gateway E2E", () => {
     }
   });
 
+  it("renders the shared Gravatar fallback in the profile preview", async () => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    const gravatarRequests: string[] = [];
+    await page.route("https://gravatar.com/avatar/**", async (route) => {
+      gravatarRequests.push(route.request().url());
+      await route.fulfill({
+        body: '<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"/>',
+        contentType: "image/svg+xml",
+        status: 200,
+      });
+    });
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "usage.cost": usageCostResponse,
+        "sessions.usage": sessionsUsageResponse,
+        "users.self": {
+          profile: {
+            id: "profile-1",
+            displayName: "Test Person",
+            avatarMime: null,
+            mergedInto: null,
+            createdAt: 1,
+            updatedAt: 2,
+            emails: ["test@example.com"],
+            hasAvatar: false,
+          },
+        },
+      },
+    });
+
+    try {
+      const response = await page.goto(`${server.baseUrl}settings/profile`);
+      expect(response?.status()).toBe(200);
+      const connect = await gateway.waitForRequest("connect");
+      const instanceId = (connect.params as { client?: { instanceId?: string } } | undefined)
+        ?.client?.instanceId;
+      expect(instanceId).toBeTruthy();
+      await gateway.emitGatewayEvent("presence", {
+        presence: [
+          {
+            instanceId,
+            user: { id: "profile-1", email: "test@example.com", name: "Test Person" },
+          },
+        ],
+      });
+
+      const expectedUrl =
+        "https://gravatar.com/avatar/973dfe463ec85785f5f95af5ba3906eedb2d931c24e69824a89ea65dba4e813b?d=404&s=128";
+      const profileAvatar = page.locator("#settings-profile-identity openclaw-viewer-avatar img");
+      await profileAvatar.waitFor({ timeout: 10_000 });
+      expect(await profileAvatar.getAttribute("src")).toBe(expectedUrl);
+      await expect.poll(() => gravatarRequests.includes(expectedUrl)).toBe(true);
+    } finally {
+      await context.close();
+    }
+  });
+
   it("keeps the loading note while a cold usage cache is still rebuilding", async () => {
     const context = await browser.newContext();
     const page = await context.newPage();

--- a/ui/src/pages/profile/identity-section.test.ts
+++ b/ui/src/pages/profile/identity-section.test.ts
@@ -56,6 +56,28 @@ describe("renderIdentitySection", () => {
     expect(container.textContent).toContain("ada@example.test, ada@work.test");
   });
 
+  it("uses the linked email fallback when the profile has no upload", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    render(
+      renderIdentitySection(
+        createProps({
+          avatarUrl: null,
+          profile: { ...PROFILE, emails: ["profile-preview@example.test"], hasAvatar: false },
+        }),
+      ),
+      container,
+    );
+    const avatar = container.querySelector<HTMLElement>("openclaw-viewer-avatar") as
+      | (HTMLElement & { updateComplete: Promise<unknown> })
+      | null;
+
+    await vi.waitFor(() => expect(avatar?.querySelector("img")).not.toBeNull());
+    expect(avatar?.querySelector("img")?.getAttribute("src")).toMatch(
+      /^https:\/\/gravatar\.com\/avatar\/[a-f0-9]{64}\?d=404&s=128$/u,
+    );
+  });
+
   it("edits and saves the display name with the standard input pattern", () => {
     const onDisplayNameInput = vi.fn();
     const onSaveDisplayName = vi.fn();

--- a/ui/src/test-helpers/app-sidebar-cases/basics.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/basics.ts
@@ -45,6 +45,34 @@ describe("AppSidebar update card wiring", () => {
 });
 
 describe("AppSidebar viewer presence", () => {
+  it("renders the self user's Gravatar in the footer identity chip", async () => {
+    const client = { instanceId: "self-instance" } as GatewayBrowserClient;
+    const gatewayHarness = createGatewayHarness(client);
+    const { sidebar } = await mountSidebar(
+      gatewayHarness.gateway,
+      createSessions("main", ["agent:main:main"]),
+    );
+    sidebar.connected = true;
+
+    gatewayHarness.publishEvent("presence", {
+      presence: [
+        {
+          instanceId: "self-instance",
+          user: { id: "00-self", email: "test@example.com", name: "Self User" },
+        },
+      ],
+    });
+
+    await vi.waitFor(() => {
+      const avatar = sidebar.querySelector<HTMLImageElement>(
+        ".sidebar-footer-bar__identity openclaw-viewer-avatar img",
+      );
+      expect(avatar?.src).toBe(
+        "https://gravatar.com/avatar/973dfe463ec85785f5f95af5ba3906eedb2d931c24e69824a89ea65dba4e813b?d=404&s=128",
+      );
+    });
+  });
+
   it("groups identified viewers for session rows and the footer", async () => {
     const client = { instanceId: "self-instance" } as GatewayBrowserClient;
     const gatewayHarness = createGatewayHarness(client);


### PR DESCRIPTION
## What Problem This Solves

Teammates without an uploaded avatar render as initials everywhere (facepiles, footer chip, profile page), even when they have a Gravatar — the common internet default. Product owner decision: gravatar fallback, default-on.

## Why This Change Was Made

The shared avatar primitive now resolves: **uploaded avatar → Gravatar-by-email → initials + color hash**, in one code path used by session-row/footer facepiles, the own-identity chip, and the profile preview.

- Gravatar URLs use SHA-256 hashing via Web Crypto per [Gravatar's documented normalization](https://docs.gravatar.com/general/hash/) (no MD5 shipped), with `d=404&s=128` so a missing Gravatar surfaces as an image error → initials, no placeholder flash.
- Email→URL results are cached; image errors negative-cache the email with a 10-minute expiry — an `<img>` error can't distinguish a real 404 from a transient network/5xx failure, so a blip must not poison the page lifetime. Re-resolution rides the next presence/snapshot update (documented tradeoff: no per-avatar retry timers; a fully idle page keeps initials until activity resumes).
- `loading="lazy"` added, `referrerpolicy="no-referrer"` retained; everything stays in the lazy facepile chunk.
- Gateway CSP `img-src` gains exactly `https://gravatar.com` — the test asserts the full directive token list and explicitly rejects broad `https:`.

Identity-less gateways unchanged (no email → initials, as today).

## User Impact

Shared-gateway teammates get real faces without uploading anything; uploaded avatars still win.

## Evidence

- Full Testbox UI suite: 337 files, 4,725 passed / 20 skipped ([run](https://github.com/openclaw/openclaw/actions/runs/29687907211)); focused rounds: 18 CSP + 10 UI + 4 browser tests, plus facepile suite green after the TTL fix.
- `pnpm check:changed`: format, strict types, lint, repo guards green.
- Equal-path startup: 310,751 → 310,731 gzip bytes (−20 B); lazy-path +295 B.
- Structured autoreview (codex/gpt-5.6-sol, xhigh) across three rounds: permanent-negative-cache finding fixed with the TTL; idle-page retry finding consciously rejected as the documented tradeoff above.
