### PR TITLE
fix: prevent flaky SQLite session pruning CI

### DIFF
--- a/src/config/sessions/store.pruning.integration.test.ts
+++ b/src/config/sessions/store.pruning.integration.test.ts
@@ -25,7 +25,6 @@ vi.mock("../config.js", async () => ({
 
 import { getRuntimeConfig } from "../config.js";
 import { runSessionsCleanup } from "./cleanup-service.js";
-import { measureSessionPhysicalDiskUsage } from "./disk-budget.js";
 import {
   appendTranscriptMessage,
   listSessionEntries,
@@ -1119,6 +1118,10 @@ describe("Integration: saveSessionStore with pruning", () => {
   });
 
   it("sessions cleanup extracts and evicts historical SQLite rows under physical pressure", async () => {
+    // Keep ordinary write/reset kicks inert; this test owns the explicit pressure pass below.
+    mockLoadConfig.mockReturnValue({
+      session: { maintenance: { maxDiskBytes: false } },
+    });
     const sessionKey = "agent:main:historical-budget";
     await seedSqliteSessionStore(storePath, {
       [sessionKey]: { sessionId: "historical-budget-session", updatedAt: 1 },
@@ -1134,14 +1137,15 @@ describe("Integration: saveSessionStore with pruning", () => {
       target: { canonicalKey: sessionKey, storeKeys: [sessionKey] },
       buildNextEntry: () => ({ sessionId: "live-budget-session", updatedAt: Date.now() }),
     });
-    const before = await measureSessionPhysicalDiskUsage(storePath);
     mockLoadConfig.mockReturnValue({
       session: {
         maintenance: {
           mode: "enforce",
           pruneAfter: "365d",
           maxEntries: 500,
-          maxDiskBytes: before.totalBytes - 1,
+          // Keep the store unconditionally over budget even if cleanup checkpoints its WAL
+          // between preview and enforcement.
+          maxDiskBytes: 1,
           highWaterBytes: 0,
         },
       },


### PR DESCRIPTION
Related: #111194

## What Problem This Solves

Fixes an issue where unrelated pull requests could fail a Node CI shard when the SQLite session-pruning integration test raced background disk-budget maintenance.

## Why This Change Was Made

The test now disables ordinary write/reset budget kicks during fixture setup, then gives the explicit cleanup pass a deterministic one-byte budget. This keeps pressure invariant across WAL checkpoints and ensures the asserted cleanup owns the eviction.

## User Impact

No product behavior changes. Maintainers and contributors no longer see this timing-sensitive false CI failure.

## Evidence

- The original failure occurred in [run 29688533529, attempt 1](https://github.com/openclaw/openclaw/actions/runs/29688533529/job/88197080447) with `expected +0 to be 1`; the unchanged rerun passed.
- The original test passed 30/30 times in isolation on [Testbox run 29689073015](https://github.com/openclaw/openclaw/actions/runs/29689073015), confirming the failure needs the loaded-shard timing.
- A threshold-only patch reproduced the background-kick race immediately in [Testbox run 29689178491](https://github.com/openclaw/openclaw/actions/runs/29689178491).
- The final patch passed 30/30 bounded-loop repetitions in [Testbox run 29689247378](https://github.com/openclaw/openclaw/actions/runs/29689247378).
- The delegated `coreTests` changed-surface gate passed in [Testbox run 29689343436](https://github.com/openclaw/openclaw/actions/runs/29689343436).
- Fresh branch autoreview reported no accepted or actionable findings; `git diff --check` is clean.

AI-assisted: Codex investigated, implemented, and verified this maintainer-requested fix.
