### PR TITLE
fix: avoid repeated model discovery in configless runs

### DIFF
--- a/src/agents/embedded-agent-runner/run-orchestrator.ts
+++ b/src/agents/embedded-agent-runner/run-orchestrator.ts
@@ -195,6 +195,7 @@ async function runEmbeddedAgentInternal(
       const config = params.config ?? EMPTY_EMBEDDED_AGENT_CONFIG;
       const requestedAgentDir =
         params.agentDir ?? resolveAgentDir(config, requestedWorkspaceResolution.agentId);
+      const retainIdleRunOwner = params.config === undefined;
       const preparedInput = {
         config,
         agentId: requestedWorkspaceResolution.agentId,
@@ -203,9 +204,11 @@ async function runEmbeddedAgentInternal(
         workspaceDir: requestedWorkspaceResolution.workspaceDir,
         preserveWorkspaceDirOnRefresh: !requestedWorkspaceResolution.isCanonicalWorkspace,
       };
-      // Every admitted run leases its exact generation. Non-gateway hosts release dynamic
-      // workspaces after the run so one-off workspace paths cannot accumulate persistent owners.
-      const preparedModelRuntimeLease = await acquireAgentRunPreparedModelRuntime(preparedInput);
+      // Configless direct hosts reuse one bounded idle generation. Gateway and explicitly
+      // configured runs release dynamic workspaces so one-off paths cannot accumulate owners.
+      const preparedModelRuntimeLease = await acquireAgentRunPreparedModelRuntime(preparedInput, {
+        retainIdleRunOwner,
+      });
       const preparedModelRuntime = preparedModelRuntimeLease.snapshot;
       try {
         // A reload may complete while admission waits. The committed generation owns config,

--- a/src/agents/prepared-model-runtime.lifecycle.test.ts
+++ b/src/agents/prepared-model-runtime.lifecycle.test.ts
@@ -171,6 +171,41 @@ describe("prepared model runtime snapshots", () => {
     );
   });
 
+  it("retains only the latest idle direct-run owner", async () => {
+    const firstInput = {
+      config: {},
+      agentId: "default",
+      agentDir: "/tmp/standalone-retained-run-agent",
+      workspaceDir: "/tmp/standalone-retained-run-workspace",
+    };
+    const firstLease = await acquireAgentRunPreparedModelRuntime(firstInput, {
+      retainIdleRunOwner: true,
+    });
+    firstLease.release();
+
+    await expect(prepareModelRuntimeSnapshot(firstInput)).resolves.toBe(firstLease.snapshot);
+    const reusedLease = await acquireAgentRunPreparedModelRuntime(firstInput, {
+      retainIdleRunOwner: true,
+    });
+    reusedLease.release();
+    expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledOnce();
+
+    const secondInput = {
+      ...firstInput,
+      workspaceDir: "/tmp/standalone-retained-run-workspace-2",
+    };
+    const secondLease = await acquireAgentRunPreparedModelRuntime(secondInput, {
+      retainIdleRunOwner: true,
+    });
+    secondLease.release();
+
+    await expect(prepareModelRuntimeSnapshot(firstInput)).rejects.toThrow(
+      "prepared model runtime owner was not published",
+    );
+    await expect(prepareModelRuntimeSnapshot(secondInput)).resolves.toBe(secondLease.snapshot);
+    expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2);
+  });
+
   it("publishes an exact dynamic workspace owner at gateway run admission", async () => {
     mocks.configuredAgentIds = ["default"];
     const config = {};

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -44,6 +44,7 @@ let modelRuntimeBuildTimeoutMs = DEFAULT_MODEL_RUNTIME_BUILD_TIMEOUT_MS;
 const owners = new Map<string, PreparedModelRuntimeOwner>();
 const agentBuildCompletions = new Map<string, Promise<void>>();
 const standaloneActivationTails = new Map<string, Promise<void>>();
+let retainedDirectRunOwner: { key: string; owner: PreparedModelRuntimeOwner } | undefined;
 let gatewayLifecycleActive = false;
 let refreshTail: Promise<void> = Promise.resolve();
 let refreshRequestEpoch = 0;
@@ -244,6 +245,7 @@ async function activateStandalonePreparedModelRuntimeNow(
 async function acquirePreparedModelRuntimeLease(
   rawInput: PreparedModelRuntimeInput,
   provenance: "run" | "ephemeral",
+  options: { retainIdleRunOwner?: boolean } = {},
 ): Promise<PreparedModelRuntimeLease> {
   let input = normalizePreparedModelRuntimeInput({
     ...rawInput,
@@ -322,6 +324,18 @@ async function acquirePreparedModelRuntimeLease(
   if (owner.provenance !== provenance) {
     return { snapshot, release: () => {} };
   }
+  if (provenance === "run" && options.retainIdleRunOwner) {
+    const previous = retainedDirectRunOwner;
+    retainedDirectRunOwner = { key, owner };
+    if (
+      previous &&
+      previous.owner !== owner &&
+      (previous.owner.leaseCount ?? 0) === 0 &&
+      owners.get(previous.key) === previous.owner
+    ) {
+      owners.delete(previous.key);
+    }
+  }
   owner.leaseCount = (owner.leaseCount ?? 0) + 1;
   let released = false;
   return {
@@ -332,10 +346,13 @@ async function acquirePreparedModelRuntimeLease(
       }
       released = true;
       owner.leaseCount = Math.max(0, (owner.leaseCount ?? 1) - 1);
-      // Dynamic generations live exactly as long as their admitted run or metadata read. The
-      // identity check prevents an old lease from deleting a replacement at the same key.
+      // Configless direct runs retain one bounded idle generation; dynamic gateway and metadata
+      // generations live exactly as long as their lease. The identity checks prevent an old
+      // release from deleting a replacement at the same key.
       if (owner.leaseCount === 0 && owners.get(key) === owner) {
-        owners.delete(key);
+        if (retainedDirectRunOwner?.owner !== owner) {
+          owners.delete(key);
+        }
       }
     },
   };
@@ -344,8 +361,9 @@ async function acquirePreparedModelRuntimeLease(
 /** Acquires the exact writable workspace generation at agent-run admission. */
 export async function acquireAgentRunPreparedModelRuntime(
   rawInput: PreparedModelRuntimeInput,
+  options: { retainIdleRunOwner?: boolean } = {},
 ): Promise<PreparedModelRuntimeLease> {
-  return await acquirePreparedModelRuntimeLease(rawInput, "run");
+  return await acquirePreparedModelRuntimeLease(rawInput, "run", options);
 }
 
 /** Acquires a one-read metadata generation without retaining a dynamic workspace owner. */
@@ -692,6 +710,7 @@ function resetPreparedModelRuntimeSnapshotsForTest(): void {
   owners.clear();
   agentBuildCompletions.clear();
   standaloneActivationTails.clear();
+  retainedDirectRunOwner = undefined;
   gatewayLifecycleActive = false;
   refreshTail = Promise.resolve();
   refreshRequestEpoch = 0;


### PR DESCRIPTION
Related: #111173

## What Problem This Solves

Fixes an issue where users running the embedded agent without an explicit config would repeat model discovery for every run after the prepared-runtime lifecycle refactor.

## Why This Change Was Made

Configless direct runs now retain one bounded idle prepared-runtime owner, while gateway and explicitly configured runs keep the existing lease-lifetime cleanup. Switching to another direct-run workspace evicts the previous idle owner, so reuse does not restore unbounded workspace accumulation.

## User Impact

Repeated configless embedded runs reuse their prepared model catalog instead of rebuilding it each time. Gateway reload and dynamic-workspace behavior are unchanged.

## Evidence

- Reproduced the regression twice on current `main`: `src/agents/embedded-agent-runner.e2e.test.ts` expected one model-catalog initialization across two configless runs but observed two.
- Focused lifecycle and embedded-runner suites pass after the fix (55 tests per iteration), repeated three consecutive times on Blacksmith Testbox.
- `pnpm check:changed` passes, including core/core-test typechecks, changed-file lint and format, SDK contract, dependency, import-cycle, and state guards.
- Two independent autoreview passes reported no accepted or actionable findings.
