### PR TITLE
fix(whatsapp): unscoped echo detection silently drops legitimate messages across different chats

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor/echo.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/echo.test.ts
@@ -15,4 +15,35 @@ describe("createEchoTracker", () => {
     );
     expect(tracker.has(text)).toBe(true);
   });
+
+  it("scopes echo detection by conversation so same text in different chats does not collide", () => {
+    const tracker = createEchoTracker({});
+
+    // Bot replies "Done." to Alice's chat (jid: chat-A).
+    tracker.rememberText("Done.", { conversationId: "chat-A" });
+
+    // True same-chat echo detection still works.
+    expect(tracker.has("Done.", "chat-A")).toBe(true);
+
+    // Bob in a different chat (jid: chat-B) sends "Done." — must not match.
+    expect(tracker.has("Done.", "chat-B")).toBe(false);
+
+    // After forgetting for chat-A, the text is no longer tracked.
+    tracker.forget("Done.", "chat-A");
+    expect(tracker.has("Done.", "chat-A")).toBe(false);
+  });
+
+  it("treats absent conversationId as unscoped for backward compatibility", () => {
+    const tracker = createEchoTracker({});
+
+    // Remember without conversation scope.
+    tracker.rememberText("Hello", {});
+    // Check without conversation scope — matches.
+    expect(tracker.has("Hello")).toBe(true);
+    // Check with conversation scope — unscoped text should not match scoped check.
+    expect(tracker.has("Hello", "chat-X")).toBe(false);
+    // A scoped remember also does not pollute the unscoped space.
+    tracker.rememberText("World", { conversationId: "chat-A" });
+    expect(tracker.has("World")).toBe(false);
+  });
 });

--- a/extensions/whatsapp/src/auto-reply/monitor/echo.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/echo.ts
@@ -7,10 +7,12 @@ export type EchoTracker = {
       combinedBody?: string;
       combinedBodySessionKey?: string;
       logVerboseMessage?: boolean;
+      /** WhatsApp JID of the conversation this text was sent to. */
+      conversationId?: string;
     },
   ) => void;
-  has: (key: string) => boolean;
-  forget: (key: string) => void;
+  has: (key: string, conversationId?: string) => boolean;
+  forget: (key: string, conversationId?: string) => void;
   buildCombinedKey: (params: { sessionKey: string; combinedBody: string }) => string;
 };
 
@@ -34,11 +36,15 @@ export function createEchoTracker(params: {
     }
   };
 
+  const scopedKey = (key: string, conversationId?: string) =>
+    conversationId ? `${conversationId}\0${key}` : key;
+
   const rememberText: EchoTracker["rememberText"] = (text, opts) => {
     if (!text) {
       return;
     }
-    recentlySent.add(text);
+    const key = scopedKey(text, opts.conversationId);
+    recentlySent.add(key);
     if (opts.combinedBody && opts.combinedBodySessionKey) {
       recentlySent.add(
         buildCombinedKey({
@@ -57,9 +63,9 @@ export function createEchoTracker(params: {
 
   return {
     rememberText,
-    has: (key) => recentlySent.has(key),
-    forget: (key) => {
-      recentlySent.delete(key);
+    has: (key, conversationId) => recentlySent.has(scopedKey(key, conversationId)),
+    forget: (key, conversationId) => {
+      recentlySent.delete(scopedKey(key, conversationId));
     },
     buildCombinedKey,
   };

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
@@ -521,6 +521,7 @@ export function createWhatsAppReplyPlan(params: {
       combinedBody?: string;
       combinedBodySessionKey?: string;
       logVerboseMessage?: boolean;
+      conversationId?: string;
     },
   ) => void;
   replyLogger: ReturnType<typeof getChildLogger>;
@@ -604,6 +605,7 @@ export function createWhatsAppReplyPlan(params: {
       combinedBody: params.context.Body as string | undefined,
       combinedBodySessionKey: params.route.sessionKey,
       logVerboseMessage: shouldLog,
+      conversationId,
     });
     const fromDisplay = conversationId;
     if (shouldLogVerbose()) {
@@ -689,6 +691,7 @@ export function createWhatsAppReplyPlan(params: {
               combinedBody: params.context.Body as string | undefined,
               combinedBodySessionKey: params.route.sessionKey,
               logVerboseMessage: shouldLog,
+              conversationId,
             });
             return whatsAppReplyDeliveryVisibilityFromDurableResult(durable.delivery);
           }

--- a/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
@@ -175,9 +175,9 @@ export function createWebOnMessageHandler(params: {
     }
 
     // Skip if this is a message we just sent (echo detection)
-    if (params.echoTracker.has(msg.payload.body)) {
+    if (params.echoTracker.has(msg.payload.body, conversationId)) {
       logVerbose("Skipping auto-reply: detected echo (message matches recently sent text)");
-      params.echoTracker.forget(msg.payload.body);
+      params.echoTracker.forget(msg.payload.body, conversationId);
       return;
     }
 

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -33,6 +33,7 @@ import { deliverWebReply } from "../deliver-reply.js";
 import { whatsappInboundLog } from "../loggers.js";
 import { elide } from "../util.js";
 import { maybeSendAckReaction } from "./ack-reaction.js";
+import type { EchoTracker } from "./echo.js";
 import {
   resolveVisibleWhatsAppGroupHistory,
   resolveVisibleWhatsAppReplyContext,
@@ -192,16 +193,9 @@ export async function processMessage(params: {
   replyResolver: typeof getReplyFromConfig;
   replyLogger: ReturnType<typeof getChildLogger>;
   backgroundTasks: Set<Promise<unknown>>;
-  rememberSentText: (
-    text: string | undefined,
-    opts: {
-      combinedBody?: string;
-      combinedBodySessionKey?: string;
-      logVerboseMessage?: boolean;
-    },
-  ) => void;
-  echoHas: (key: string) => boolean;
-  echoForget: (key: string) => void;
+  rememberSentText: EchoTracker["rememberText"];
+  echoHas: EchoTracker["has"];
+  echoForget: EchoTracker["forget"];
   buildCombinedEchoKey: (p: { sessionKey: string; combinedBody: string }) => string;
   maxMediaTextChunkLimit?: number;
   groupHistory?: GroupHistoryEntry[];


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where WhatsApp's echo detection silently drops legitimate inbound messages from any chat when the message text happens to match something the bot recently said in a **different** chat.

The echo tracker stores recently-sent text in an unscoped `Set<string>` keyed by raw text only. When the bot replies "Done." to Alice in chat A, that exact string is remembered. Later, when Bob in chat B (a completely different conversation) sends "Done.", the echo check returns true and Bob's message is silently discarded — no dispatch, no session record, no acknowledgment. The `fromMe` id-keyed dedupe and the combined-body session-keyed key already handle true same-chat echo suppression, so the unscoped text check produces almost exclusively false positives on short common texts ("ok", "yes", "done", single emoji, users echoing the bot's wording).

## Why This Change Was Made

The echo tracker's `has`, `forget`, and `rememberText` now accept an optional `conversationId` parameter (WhatsApp JID). When present, the tracked key is prefixed with `${conversationId}\0`, scoping the echo detection to the conversation where the text was sent.

All three production call sites pass `conversationId`:
- **`on-message.ts`**: `echoTracker.has(msg.payload.body, conversationId)` and `echoTracker.forget(msg.payload.body, conversationId)`
- **`inbound-dispatch.ts`** (two delivery call sites): `rememberSentText` receives the context's `conversationId`

Callers that omit `conversationId` get unscoped keys, preserving backward compatibility.

## User Impact

Short reply texts and common phrases no longer silently block messages from unrelated conversations. True same-chat echo suppression — where WhatsApp re-delivers the bot's own message through the websocket — continues to work. No config, protocol, or persisted-state changes.

## Evidence

### Regression coverage

- `echo.test.ts` (2 new): same text remembered for chat-A only matches chat-A, not chat-B; absent conversationId produces unscoped keys for backward compatibility.
- Against unfixed main, both new tests fail — `"Done."` remembered for chat-A still matches chat-B. The existing UTF-16-safe test passes unchanged.
- `node scripts/run-vitest.mjs extensions/whatsapp/src/auto-reply/monitor/echo.test.ts` → 3 passed.
- `node scripts/run-vitest.mjs extensions/whatsapp/src/auto-reply/monitor/process-message.test.ts extensions/whatsapp/src/auto-reply/monitor/process-message.audio-preflight.test.ts extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts` → 80 passed.

### Sibling-surface context

WhatsApp provides two layers of echo detection: the id-keyed per-account+per-chat dedupe in the durable ingress path, and the from-me gate at the monitor level. The unscoped text key was a third, redundant layer that only removed the conversation scope — restoring that scope brings it into alignment with the other two layers. No other channel uses this text-keyed echo pattern.