### PR TITLE
fix(deepinfra): model list fails when HTTP proxy is required

### DIFF
--- a/extensions/deepinfra/provider-models.proxy.test.ts
+++ b/extensions/deepinfra/provider-models.proxy.test.ts
@@ -1,0 +1,51 @@
+// DeepInfra proxy tests cover the live model discovery transport policy.
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>()),
+  fetchWithSsrFGuard: fetchWithSsrFGuardMock,
+}));
+
+import { discoverDeepInfraModels } from "./provider-models.js";
+
+const ORIGINAL_VITEST = process.env.VITEST;
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+
+function restoreEnv(key: "VITEST" | "NODE_ENV", value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}
+
+afterEach(() => {
+  restoreEnv("VITEST", ORIGINAL_VITEST);
+  restoreEnv("NODE_ENV", ORIGINAL_NODE_ENV);
+  fetchWithSsrFGuardMock.mockReset();
+  vi.restoreAllMocks();
+});
+
+describe("DeepInfra model discovery proxy policy", () => {
+  it("allows the guarded official catalog request to use an eligible HTTP proxy", async () => {
+    delete process.env.VITEST;
+    process.env.NODE_ENV = "development";
+    const release = vi.fn(async () => undefined);
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response("unavailable", { status: 503 }),
+      release,
+    });
+
+    await discoverDeepInfraModels({ hasApiKey: true });
+
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "trusted_env_proxy",
+        url: "https://api.deepinfra.com/v1/openai/models?sort_by=openclaw&filter=with_meta",
+      }),
+    );
+    expect(release).toHaveBeenCalledOnce();
+  });
+});

--- a/extensions/deepinfra/provider-models.ts
+++ b/extensions/deepinfra/provider-models.ts
@@ -1,4 +1,6 @@
 // Deepinfra provider module implements model/runtime integration.
+
+import { withTrustedEnvProxyGuardedFetchMode } from "openclaw/plugin-sdk/fetch-runtime";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import {
   getCachedLiveProviderModelRows,
@@ -8,6 +10,7 @@ import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-c
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { hasConfiguredSecretInput } from "openclaw/plugin-sdk/secret-input";
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { asPositiveSafeInteger } from "openclaw/plugin-sdk/string-coerce-runtime";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 
@@ -413,6 +416,7 @@ export async function discoverDeepInfraSurfaces(options?: {
       buildRequestHeaders: () => ({ Accept: "application/json" }),
       auditContext: "deepinfra-model-discovery",
       shouldCacheRows: hasDeepInfraSurfaceModelRows,
+      fetchGuard: (params) => fetchWithSsrFGuard(withTrustedEnvProxyGuardedFetchMode(params)),
     });
     if (data.length === 0) {
       log.warn("No models found from DeepInfra agent-projection endpoint, using static catalog");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users whose network requires a standard HTTP(S) proxy could not run the DeepInfra model list. The public catalog request timed out after five seconds and consumed the prepared model-runtime publication deadline, so the CLI exited before showing any models.

## Why This Change Was Made

The fixed DeepInfra-owned catalog endpoint now uses OpenClaw's existing trusted-environment-proxy guarded-fetch preset. The change retains the existing hostname policy, SSRF checks, timeout, cache, pagination, redirect handling, response limits, connection release, and offline behavior.

Related implementation pattern: #110924

## User Impact

DeepInfra users behind an eligible HTTP(S) proxy can list the current live catalog instead of seeing the CLI fail during startup. Networks without a working proxy continue to use the existing guarded timeout path.

## Evidence

Live proof used only `pnpm openclaw` for OpenClaw runtime verification, with an isolated state directory and a test-only placeholder `DEEPINFRA_API_KEY`:

- **Before:** `pnpm openclaw models list --provider deepinfra --plain` logged a 5,005 ms timeout for the official catalog and exited with `prepared model runtime publication timed out`.
- **Third-party control:** DeepInfra's public [OpenClaw model projection endpoint](https://api.deepinfra.com/v1/openai/models?sort_by=openclaw&filter=with_meta) returned HTTP 200 with 168 tagged rows; 90 were tagged for the chat surface.
- **After:** the same `pnpm openclaw models list --provider deepinfra --plain` command completed and listed 92 DeepInfra entries, including live models outside the 8 bundled fallback rows. A direct provider projection check reported `live=true` and 90 chat rows.
- **No-proxy control:** after clearing all HTTP(S)/ALL proxy variables, the guarded request timed out after 5,004 ms and retained the pre-fix CLI failure, confirming the patch does not bypass the existing direct-network boundary.

Focused and extension verification:

- Regression test failed before the production change because the guarded request omitted `trusted_env_proxy`.
- `node scripts/run-vitest.mjs extensions/deepinfra/provider-models.proxy.test.ts`: 1/1 passed.
- `pnpm test:extension deepinfra`: 13 files, 73/73 tests passed.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 CI=1 node scripts/check-changed.mjs`: passed, including format, Plugin SDK baseline, extension production/test typechecks, targeted lint, boundary, database-first, sidecar, and import-cycle checks.
- `codex review --base origin/main`: no findings; reviewer independently ran 19 related tests and live proxy/direct controls.

No real inference request was made; the exercised third-party boundary is DeepInfra's public model catalog.
