### PR TITLE
fix(qa): restore ask-user roundtrip coverage

### DIFF
--- a/docs/tools/ask-user.md
+++ b/docs/tools/ask-user.md
@@ -81,9 +81,7 @@ Example answered result:
   "status": "answered",
   "answers": {
     "answers": {
-      "deploy_target": {
-        "answers": ["Staging (Recommended)"]
-      }
+      "deploy_target": ["Staging (Recommended)"]
     }
   }
 }

--- a/qa/scenarios/runtime/tools/ask-user.yaml
+++ b/qa/scenarios/runtime/tools/ask-user.yaml
@@ -86,7 +86,7 @@ flow:
             - expr: liveTurnTimeoutMs(env, 45000)
             - expr: "env.providerMode === 'mock-openai' ? 100 : 250"
         - assert:
-            expr: "pendingQuestion.questions.length === 3 && pendingQuestion.questions[0].id === 'deploy_target' && pendingQuestion.questions[1].multiSelect === true && pendingQuestion.questions.every((question) => question.isOther === true)"
+            expr: "pendingQuestion.questions.length === 3 && pendingQuestion.questions[0].questionId === 'deploy_target' && pendingQuestion.questions[1].multiSelect === true && pendingQuestion.questions.every((question) => question.isOther === true)"
             message:
               expr: "`ask_user question shape drifted: ${JSON.stringify(pendingQuestion.questions)}`"
         - set: resolution
@@ -96,9 +96,9 @@ flow:
                 id: pendingQuestion.id,
                 answers: {
                   answers: {
-                    deploy_target: { answers: ['Production'] },
-                    checks: { answers: ['Unit (Recommended)', 'E2E'] },
-                    release_note: { answers: ['night-shift'] },
+                    deploy_target: ['Production'],
+                    checks: ['Unit (Recommended)', 'E2E'],
+                    release_note: ['night-shift'],
                   },
                 },
                 resolvedBy: 'qa-lab',

--- a/src/agents/tools/ask-user-tool.test.ts
+++ b/src/agents/tools/ask-user-tool.test.ts
@@ -252,7 +252,7 @@ describe("ask_user prompt delivery", () => {
     settleAskUserPromptDelivery(reservation.questionId);
     finishWait?.({
       status: "answered",
-      answers: { answers: { deploy_target: { answers: ["Production"] } } },
+      answers: { answers: { deploy_target: ["Production"] } },
     });
     await expect(pending).resolves.toMatchObject({ details: { status: "answered" } });
   });


### PR DESCRIPTION
Closes #111415

## What Problem This Solves

Fixes an issue where maintainers running the QA suite would see the `ask_user` roundtrip fail on every attempt after the Gateway question protocol was reshaped. The stale scenario stopped before it could prove that a blocked agent receives operator answers and resumes correctly, and the public result example showed the same obsolete answer wrapper.

## Why This Change Was Made

The scenario, its focused fixture, and the public example now use the canonical Gateway contract: question records expose `questionId`, and each answer-map value is a string array. This keeps one protocol shape across executable QA, unit coverage, documentation, the Gateway manager, and clients; it adds no compatibility path for the unreleased pre-flattened shape.

## User Impact

Maintainers regain a truthful end-to-end `ask_user` QA signal, and users reading the tool documentation see the answer payload OpenClaw actually returns. Product runtime behavior is unchanged.

## Evidence

- Before: focused QA failed both the normal attempt and built-in retry on `pendingQuestion.questions[0].id`; after correcting that, `question.resolve` rejected all three nested answer values as `must be array`.
- After: `runtime-tool-ask-user` passed through QA Channel + QA Lab + a real Gateway child + mock OpenAI provider. The blocked run resumed with `ASK-USER-ROUNDTRIP-OK | deploy=Production | checks=Unit,E2E | note=night-shift`.
- Focused protocol/tool tests: 3 files, 52 tests passed.
- Changed-surface gate: full TypeScript build, core/extensions/scripts lint, import-cycle scan, formatting, and repository policy guards passed on Blacksmith Testbox.
- `git diff --check` and docs formatting passed.
- Autoreview: clean, no accepted/actionable findings.

## AI Assistance

This change was implemented and reviewed with Codex assistance under maintainer direction.
