### PR TITLE
fix(ui): prevent unsafe custodian nudge answers

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -7590,6 +7590,7 @@ public struct SystemAgentChatResult: Codable, Sendable {
     public let sessionid: String
     public let reply: String
     public let sensitive: Bool?
+    public let wizardinputpending: Bool?
     public let action: AnyCodable
     public let agentdraft: String?
     public let agentid: String?
@@ -7601,6 +7602,7 @@ public struct SystemAgentChatResult: Codable, Sendable {
         sessionid: String,
         reply: String,
         sensitive: Bool? = nil,
+        wizardinputpending: Bool? = nil,
         action: AnyCodable,
         agentdraft: String? = nil,
         agentid: String? = nil,
@@ -7611,6 +7613,7 @@ public struct SystemAgentChatResult: Codable, Sendable {
         self.sessionid = sessionid
         self.reply = reply
         self.sensitive = sensitive
+        self.wizardinputpending = wizardinputpending
         self.action = action
         self.agentdraft = agentdraft
         self.agentid = agentid
@@ -7623,6 +7626,7 @@ public struct SystemAgentChatResult: Codable, Sendable {
         case sessionid = "sessionId"
         case reply
         case sensitive
+        case wizardinputpending = "wizardInputPending"
         case action
         case agentdraft = "agentDraft"
         case agentid = "agentId"

--- a/packages/gateway-client/src/client.ts
+++ b/packages/gateway-client/src/client.ts
@@ -1189,6 +1189,7 @@ export class GatewayClient {
       expectFinal,
       timeoutMs,
       signal: opts?.signal,
+      onSent: opts?.onSent,
       onAccepted: opts?.onAccepted,
     });
   }

--- a/packages/gateway-client/src/client.watchdog.test.ts
+++ b/packages/gateway-client/src/client.watchdog.test.ts
@@ -466,20 +466,26 @@ describe("GatewayClient", () => {
 
   test("cleans pending request state when websocket send throws", async () => {
     const { client, send } = createOpenGatewayClient(25);
+    const onSent = vi.fn();
     send.mockImplementationOnce(() => {
       throw new Error("synthetic send failure");
     });
 
-    await expect(client.request("status")).rejects.toThrow("synthetic send failure");
+    await expect(client.request("status", undefined, { onSent })).rejects.toThrow(
+      "synthetic send failure",
+    );
+    expect(onSent).not.toHaveBeenCalled();
     expect(getPendingCount(client)).toBe(0);
   });
 
   test("notifies accepted expectFinal requests while continuing to wait for final", async () => {
     const { client, send } = createOpenGatewayClient(25);
 
+    const onSent = vi.fn();
     const onAccepted = vi.fn();
     const requestPromise = client.request<{ status: string }>("agent", undefined, {
       expectFinal: true,
+      onSent,
       onAccepted,
     });
     const frame = JSON.parse(String(send.mock.calls[0]?.[0])) as { id: string };
@@ -491,6 +497,7 @@ describe("GatewayClient", () => {
       payload: { status: "accepted", runId: "run-1" },
     });
 
+    expect(onSent).toHaveBeenCalledOnce();
     expect(onAccepted).toHaveBeenCalledWith({ status: "accepted", runId: "run-1" });
     expect(getPendingCount(client)).toBe(1);
 

--- a/packages/gateway-client/src/protocol-client.ts
+++ b/packages/gateway-client/src/protocol-client.ts
@@ -19,6 +19,7 @@ export type GatewayProtocolSocketHandlers = {
 export type GatewayProtocolRequestOptions = {
   timeoutMs?: number | null;
   expectFinal?: boolean;
+  onSent?: () => void;
   onAccepted?: (payload: unknown) => void;
   signal?: AbortSignal;
 };
@@ -294,6 +295,7 @@ export class GatewayProtocolClient<TPlan> {
       this.pending.set(id, pending);
       try {
         socket.send(JSON.stringify({ type: "req", id, method, params }));
+        this.invoke("sent", () => options?.onSent?.());
       } catch (error) {
         this.pending.delete(id);
         cleanup();

--- a/packages/gateway-protocol/src/schema/openclaw.ts
+++ b/packages/gateway-protocol/src/schema/openclaw.ts
@@ -62,6 +62,8 @@ export const SystemAgentChatResultSchema = closedObject({
   reply: NonEmptyString,
   /** The next reply is a hosted-wizard secret and clients must mask its input/echo. */
   sensitive: Type.Optional(Type.Boolean()),
+  /** The hosted wizard will consume the next message as its current step answer. */
+  wizardInputPending: Type.Optional(Type.Boolean()),
   action: Type.Union([
     Type.Literal("none"),
     // The user asked to talk to their agent; clients should move to their

--- a/src/gateway/server-methods/system-agent.test.ts
+++ b/src/gateway/server-methods/system-agent.test.ts
@@ -688,7 +688,7 @@ describe("openclaw.chat", () => {
     const context = makeContext(sessions);
 
     const prompt = await callChat(context, { sessionId: "s1", message: "connect telegram" });
-    expect(prompt.payload).toMatchObject({ sensitive: true });
+    expect(prompt.payload).toMatchObject({ sensitive: true, wizardInputPending: true });
     transcriptStoreMocks.appendTranscriptTurn.mockClear();
 
     await callChat(context, { sessionId: "s1", message: "raw-secret-value" });

--- a/src/gateway/server-methods/system-agent.ts
+++ b/src/gateway/server-methods/system-agent.ts
@@ -654,6 +654,7 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
               ? { agentId: reply.handoff.agentId }
               : {}),
             ...(reply.sensitive === true ? { sensitive: true } : {}),
+            ...(reply.wizardInputPending === true ? { wizardInputPending: true } : {}),
             ...(reply.question ? { question: reply.question } : {}),
             ...(proposalId ? { needsApproval: true, proposalId } : {}),
           },

--- a/src/system-agent/chat-engine.test.ts
+++ b/src/system-agent/chat-engine.test.ts
@@ -1003,6 +1003,27 @@ describe("SystemAgentChatEngine", () => {
     expect(tokenStep.text).toContain("Before entering the token");
     expect(tokenStep.text).toContain("Bot token");
     expect(tokenStep.sensitive).toBe(true);
+    expect(tokenStep.wizardInputPending).toBe(true);
+  });
+
+  it("marks a non-card hosted-wizard step as pending input", async () => {
+    useTempStateDir();
+    const engine = new SystemAgentChatEngine({
+      surface: "gateway",
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      deps: { loadOverview: fakeOverviewLoader() },
+      runChannelSetupWizard: async (_channel: string, prompter: WizardPrompter) => {
+        await prompter.text({ message: "Bot label" });
+      },
+    });
+
+    const textStep = await engine.handle("connect telegram");
+
+    expect(textStep.text).toContain("Bot label");
+    expect(textStep.question).toBeUndefined();
+    expect(textStep.sensitive).toBeUndefined();
+    expect(textStep.wizardInputPending).toBe(true);
   });
 
   it("routes sensitive CLI wizard prompts to the masked channel setup flow", async () => {

--- a/src/system-agent/chat-engine.ts
+++ b/src/system-agent/chat-engine.ts
@@ -85,6 +85,8 @@ type SystemAgentChatReply = {
   agentDraft?: "hatch";
   /** The next hosted-wizard reply contains a secret and must be masked/redacted by hosts. */
   sensitive?: boolean;
+  /** The hosted wizard will consume the next message as its current step answer. */
+  wizardInputPending?: boolean;
   /** Present when the host must leave chat for an interactive handoff. */
   handoff?: SystemAgentOperation;
   /** Structured choice mirroring the awaited wizard step for card-capable clients. */
@@ -476,6 +478,7 @@ export class SystemAgentChatEngine {
     return {
       ...reply,
       ...(this.wizardBridge?.step?.sensitive === true ? { sensitive: true } : {}),
+      ...(this.wizardBridge ? { wizardInputPending: true } : {}),
       ...(question ? { question } : {}),
     };
   }

--- a/ui/src/e2e/custodian-event-nudge.e2e.test.ts
+++ b/ui/src/e2e/custodian-event-nudge.e2e.test.ts
@@ -113,6 +113,7 @@ describeControlUiE2e("Control UI custodian event nudge mocked Gateway E2E", () =
         });
       }
 
+      await gateway.deferNext("openclaw.chat");
       await nudge.click();
       await expect.poll(async () => (await gateway.getRequests("openclaw.chat")).length).toBe(2);
       const requests = await gateway.getRequests("openclaw.chat");
@@ -121,6 +122,12 @@ describeControlUiE2e("Control UI custodian event nudge mocked Gateway E2E", () =
         sessionId: "e2e-custodian",
       });
       await page.locator(".chat-group.user", { hasText: "what happened with telegram?" }).waitFor();
+      await gateway.resolveDeferred("openclaw.chat", {
+        sessionId: "e2e-custodian",
+        reply: "I'm watching the system.",
+        action: "none",
+      });
+      await expect.poll(() => page.locator(".chat-group.assistant").count()).toBe(2);
       expect(await nudge.count()).toBe(0);
 
       await gateway.emitGatewayEvent("health", {
@@ -135,6 +142,111 @@ describeControlUiE2e("Control UI custodian event nudge mocked Gateway E2E", () =
           path: path.join(uiProofArtifactDir, "03-message-sent.png"),
         });
       }
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("keeps event nudges out of sensitive wizard input", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      featureMethods: ["chat.metadata", "chat.startup", "openclaw.chat"],
+      methodResponses: {
+        "openclaw.chat": {
+          sessionId: "e2e-sensitive-custodian",
+          reply: "Paste your API key.",
+          action: "none",
+          sensitive: true,
+        },
+      },
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}custodian`);
+      await page.getByPlaceholder("Enter sensitive value").waitFor();
+      await gateway.emitGatewayEvent("health", {
+        channelLabels: { discord: "Discord" },
+        channels: { discord: { configured: true, connected: false, running: true } },
+      });
+
+      const nudge = page.getByRole("button", {
+        name: "Discord just disconnected — ask me what happened",
+      });
+      await nudge.waitFor();
+      await expect.poll(() => nudge.isDisabled()).toBe(true);
+      await nudge.evaluate((element) => (element as HTMLButtonElement).click());
+      await settleUi(page);
+
+      expect(await gateway.getRequests("openclaw.chat")).toHaveLength(1);
+      expect(await page.getByText("what happened with discord?").count()).toBe(0);
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("keeps nudges out of a closed question and sends a parseable skip answer", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      featureMethods: ["chat.metadata", "chat.startup", "openclaw.chat"],
+      methodResponses: {
+        "openclaw.chat": {
+          sessionId: "e2e-wizard-custodian",
+          reply: "Choose one.",
+          action: "none",
+          question: {
+            id: "access",
+            header: "Access",
+            question: "How should OpenClaw work?",
+            options: [{ label: "Full access" }, { label: "Ask first" }],
+            isOther: false,
+          },
+        },
+      },
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}custodian`);
+      const skip = page.getByRole("button", { name: "Skip for now" });
+      await skip.waitFor();
+      await gateway.emitGatewayEvent("health", {
+        channelLabels: { discord: "Discord" },
+        channels: { discord: { configured: true, connected: false, running: true } },
+      });
+      const nudge = page.getByRole("button", {
+        name: "Discord just disconnected — ask me what happened",
+      });
+      await nudge.waitFor();
+      await expect.poll(() => nudge.isDisabled()).toBe(true);
+      await nudge.evaluate((element) => (element as HTMLButtonElement).click());
+      await settleUi(page);
+      expect(await gateway.getRequests("openclaw.chat")).toHaveLength(1);
+
+      await gateway.setMethodResponse("openclaw.chat", {
+        sessionId: "e2e-wizard-custodian",
+        reply: "Moving on.",
+        action: "none",
+      });
+      await skip.click();
+
+      await expect.poll(async () => (await gateway.getRequests("openclaw.chat")).length).toBe(2);
+      const requests = await gateway.getRequests("openclaw.chat");
+      expect(requests[1]?.params).toMatchObject({
+        message: "cancel",
+        sessionId: "e2e-wizard-custodian",
+      });
+      await page.locator(".chat-group.user", { hasText: "Skip for now" }).waitFor();
+      await page.getByText("Moving on.").waitFor();
+      expect(await page.locator("openclaw-option-card").count()).toBe(0);
     } finally {
       await context.close();
     }

--- a/ui/src/pages/custodian/custodian-page.nudges.test.ts
+++ b/ui/src/pages/custodian/custodian-page.nudges.test.ts
@@ -71,6 +71,27 @@ describe("custodian page nudges", () => {
     );
   });
 
+  it("shows configuration reload failures from health snapshots", async () => {
+    const request = vi.fn().mockResolvedValue({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "Everything is healthy.",
+      action: "none",
+    });
+    const { context, emitGatewayEvent } = createContext(request);
+    const { page } = await mountPage(context, { onboarding: false });
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+
+    emitGatewayEvent({
+      event: "health",
+      payload: { configReload: { hotReloadStatus: "disabled" }, channels: {} },
+    });
+    await page.updateComplete;
+
+    expect(page.querySelector(".custodian__nudge")?.textContent).toContain(
+      "Configuration reload stopped",
+    );
+  });
+
   it("does not report an intentionally stopped channel as disconnected", async () => {
     const request = vi.fn().mockResolvedValue({
       sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
@@ -352,7 +373,7 @@ describe("custodian page nudges", () => {
     expect(request).toHaveBeenCalledOnce();
   });
 
-  it("replaces a pending nudge only with a more severe event", async () => {
+  it("replaces a pending nudge with the latest health failure", async () => {
     const request = vi.fn().mockResolvedValue({
       sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
       reply: "Everything is healthy.",
@@ -380,7 +401,7 @@ describe("custodian page nudges", () => {
       },
     });
     await page.updateComplete;
-    expect(page.querySelector(".custodian__nudge")?.textContent).toContain("Telegram is degraded");
+    expect(page.querySelector(".custodian__nudge")?.textContent).toContain("Discord is degraded");
 
     emitGatewayEvent({
       event: "health",
@@ -393,6 +414,45 @@ describe("custodian page nudges", () => {
     expect(page.querySelector(".custodian__nudge")?.textContent).toContain(
       "Discord just disconnected",
     );
+
+    emitGatewayEvent({
+      event: "health",
+      payload: {
+        channelLabels: { telegram: "Telegram" },
+        channels: { telegram: { configured: true, healthState: "stale-socket" } },
+      },
+    });
+    await page.updateComplete;
+    expect(page.querySelector(".custodian__nudge")?.textContent).toContain("Telegram is degraded");
+  });
+
+  it("clears a pending nudge when health recovers", async () => {
+    const request = vi.fn().mockResolvedValue({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "Everything is healthy.",
+      action: "none",
+    });
+    const { context, emitGatewayEvent } = createContext(request);
+    const { page } = await mountPage(context, { onboarding: false });
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+
+    emitGatewayEvent({
+      event: "health",
+      payload: {
+        channels: { telegram: { configured: true, running: true, connected: false } },
+      },
+    });
+    await page.updateComplete;
+    expect(page.querySelector(".custodian__nudge")).not.toBeNull();
+
+    emitGatewayEvent({
+      event: "health",
+      payload: {
+        channels: { telegram: { configured: true, running: true, connected: true } },
+      },
+    });
+    await page.updateComplete;
+    expect(page.querySelector(".custodian__nudge")).toBeNull();
   });
 
   it("sends a real message when an event nudge is clicked", async () => {
@@ -408,6 +468,7 @@ describe("custodian page nudges", () => {
     emitGatewayEvent({
       event: "health",
       payload: {
+        channelLabels: { telegram: "Telegram" },
         channels: {
           telegram: { configured: true, tokenStatus: "configured_unavailable" },
         },
@@ -421,6 +482,315 @@ describe("custodian page nudges", () => {
       message: "what happened with telegram authentication?",
     });
     expect(page.textContent).toContain("what happened with telegram authentication?");
+    await waitForFast(() => expect(page.querySelector(".custodian__nudge")).toBeNull());
+  });
+
+  it("does not send an event nudge while a sensitive reply is active", async () => {
+    const request = vi.fn().mockResolvedValue({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "Paste your token.",
+      sensitive: true,
+      action: "none",
+    });
+    const { context, emitGatewayEvent } = createContext(request);
+    const { page } = await mountPage(context, { onboarding: false });
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+
+    emitGatewayEvent({
+      event: "health",
+      payload: {
+        channels: {
+          discord: { configured: true, tokenStatus: "configured_unavailable" },
+        },
+      },
+    });
+    await page.updateComplete;
+    const action = page.querySelector<HTMLButtonElement>(".custodian__nudge-action")!;
+    expect(action.disabled).toBe(true);
+    action.click();
+    await page.updateComplete;
+
+    expect(request).toHaveBeenCalledOnce();
+    expect(page.querySelector(".custodian__nudge")).not.toBeNull();
+  });
+
+  it("does not send an event nudge while a structured question is unresolved", async () => {
+    const request = vi.fn().mockResolvedValue({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "Choose one.",
+      action: "none",
+      question: {
+        id: "access",
+        header: "Access",
+        question: "How should OpenClaw work?",
+        options: [{ label: "Full access" }, { label: "Ask first" }],
+        isOther: false,
+      },
+    });
+    const { context, emitGatewayEvent } = createContext(request);
+    const { page } = await mountPage(context, { onboarding: false });
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+
+    emitGatewayEvent({
+      event: "health",
+      payload: {
+        channels: { discord: { configured: true, tokenStatus: "configured_unavailable" } },
+      },
+    });
+    await page.updateComplete;
+    const action = page.querySelector<HTMLButtonElement>(".custodian__nudge-action")!;
+    expect(action.disabled).toBe(true);
+    action.click();
+    await page.updateComplete;
+
+    expect(request).toHaveBeenCalledOnce();
+    expect(page.querySelector("openclaw-option-card")).not.toBeNull();
+  });
+
+  it("keeps event nudges blocked after a question reply has an uncertain failure", async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({
+        sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+        reply: "Choose one.",
+        action: "none",
+        question: {
+          id: "access",
+          header: "Access",
+          question: "How should OpenClaw work?",
+          options: [{ label: "Full access" }, { label: "Ask first" }],
+          isOther: false,
+        },
+      })
+      .mockRejectedValueOnce(new Error("Request failed"));
+    const { context, emitGatewayEvent } = createContext(request);
+    const { page } = await mountPage(context, { onboarding: false });
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+
+    emitGatewayEvent({
+      event: "health",
+      payload: {
+        channels: { discord: { configured: true, tokenStatus: "configured_unavailable" } },
+      },
+    });
+    await page.updateComplete;
+    page.querySelector<HTMLButtonElement>(".option-card__skip")!.click();
+
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
+    await waitForFast(() => expect(page.querySelector('[role="alert"]')).not.toBeNull());
+    expect(page.querySelector('[role="alert"] button')).toBeNull();
+    const action = page.querySelector<HTMLButtonElement>(".custodian__nudge-action")!;
+    expect(action.disabled).toBe(true);
+    action.click();
+    await page.updateComplete;
+
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps event nudges blocked after a typed question reply has an uncertain failure", async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({
+        sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+        reply: "Choose one.",
+        action: "none",
+        question: {
+          id: "access",
+          header: "Access",
+          question: "How should OpenClaw work?",
+          options: [{ label: "Full access" }, { label: "Ask first" }],
+          isOther: true,
+        },
+      })
+      .mockRejectedValueOnce(new Error("Request failed"));
+    const { context, emitGatewayEvent } = createContext(request);
+    const { page } = await mountPage(context, { onboarding: false });
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+
+    emitGatewayEvent({
+      event: "health",
+      payload: {
+        channels: { discord: { configured: true, tokenStatus: "configured_unavailable" } },
+      },
+    });
+    await page.updateComplete;
+    const input = page.querySelector<HTMLTextAreaElement>(
+      ".agent-chat__composer-combobox textarea",
+    )!;
+    input.value = "Something else";
+    input.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    await page.updateComplete;
+    page.querySelector<HTMLButtonElement>(".chat-send-btn")!.click();
+
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
+    await waitForFast(() => expect(page.querySelector('[role="alert"]')).not.toBeNull());
+    const action = page.querySelector<HTMLButtonElement>(".custodian__nudge-action")!;
+    expect(action.disabled).toBe(true);
+    action.click();
+    await page.updateComplete;
+
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it("restores an event nudge after its request fails", async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({
+        sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+        reply: "Everything is healthy.",
+        action: "none",
+      })
+      .mockRejectedValueOnce(new Error("Request failed"));
+    const { context, emitGatewayEvent } = createContext(request);
+    const { page } = await mountPage(context, { onboarding: false });
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+
+    emitGatewayEvent({
+      event: "health",
+      payload: {
+        channelLabels: { telegram: "Telegram" },
+        channels: {
+          telegram: { configured: true, tokenStatus: "configured_unavailable" },
+        },
+      },
+    });
+    await page.updateComplete;
+    page.querySelector<HTMLButtonElement>(".custodian__nudge-action")!.click();
+
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
+    await waitForFast(() => expect(page.querySelector('[role="alert"]')).not.toBeNull());
+    await page.updateComplete;
+    expect(page.querySelector(".custodian__nudge")?.textContent).toContain(
+      "Telegram authentication degraded",
+    );
+  });
+
+  it("keeps a newer lower-severity failure when an earlier nudge send succeeds", async () => {
+    let resolveNudge!: (value: { sessionId: string; reply: string; action: "none" }) => void;
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({
+        sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+        reply: "Everything is healthy.",
+        action: "none",
+      })
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveNudge = resolve;
+          }),
+      );
+    const { context, emitGatewayEvent } = createContext(request);
+    const { page } = await mountPage(context, { onboarding: false });
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+
+    emitGatewayEvent({
+      event: "health",
+      payload: {
+        channelLabels: { telegram: "Telegram" },
+        channels: {
+          telegram: { configured: true, tokenStatus: "configured_unavailable" },
+        },
+      },
+    });
+    await page.updateComplete;
+    page.querySelector<HTMLButtonElement>(".custodian__nudge-action")!.click();
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
+
+    emitGatewayEvent({
+      event: "health",
+      payload: {
+        channelLabels: { discord: "Discord" },
+        channels: { discord: { configured: true, healthState: "stale-socket" } },
+      },
+    });
+    resolveNudge({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "Telegram checked.",
+      action: "none",
+    });
+
+    await waitForFast(() => expect(page.textContent).toContain("Telegram checked."));
+    await page.updateComplete;
+    expect(page.querySelector(".custodian__nudge")?.textContent).toContain("Discord is degraded");
+  });
+
+  it("consumes a nudge after an unchanged health snapshot arrives while sending", async () => {
+    let resolveNudge!: (value: { sessionId: string; reply: string; action: "none" }) => void;
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({
+        sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+        reply: "Everything is healthy.",
+        action: "none",
+      })
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveNudge = resolve;
+          }),
+      );
+    const { context, emitGatewayEvent } = createContext(request);
+    const { page } = await mountPage(context, { onboarding: false });
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+    const degradedHealth = {
+      channels: { telegram: { configured: true, healthState: "stale-socket" } },
+    };
+
+    emitGatewayEvent({ event: "health", payload: degradedHealth });
+    await page.updateComplete;
+    page.querySelector<HTMLButtonElement>(".custodian__nudge-action")!.click();
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
+
+    emitGatewayEvent({ event: "health", payload: degradedHealth });
+    resolveNudge({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "Telegram checked.",
+      action: "none",
+    });
+
+    await waitForFast(() => expect(page.querySelector(".custodian__nudge")).toBeNull());
+  });
+
+  it("does not restore a failed nudge after health recovers while sending", async () => {
+    let rejectNudge!: (error: Error) => void;
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({
+        sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+        reply: "Everything is healthy.",
+        action: "none",
+      })
+      .mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectNudge = reject;
+          }),
+      );
+    const { context, emitGatewayEvent } = createContext(request);
+    const { page } = await mountPage(context, { onboarding: false });
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+
+    emitGatewayEvent({
+      event: "health",
+      payload: {
+        channels: { telegram: { configured: true, running: true, connected: false } },
+      },
+    });
+    await page.updateComplete;
+    page.querySelector<HTMLButtonElement>(".custodian__nudge-action")!.click();
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
+
+    emitGatewayEvent({
+      event: "health",
+      payload: {
+        channels: { telegram: { configured: true, running: true, connected: true } },
+      },
+    });
+    rejectNudge(new Error("Request failed"));
+
+    await waitForFast(() => expect(page.querySelector('[role="alert"]')).not.toBeNull());
+    await page.updateComplete;
     expect(page.querySelector(".custodian__nudge")).toBeNull();
   });
 

--- a/ui/src/pages/custodian/custodian-page.nudges.test.ts
+++ b/ui/src/pages/custodian/custodian-page.nudges.test.ts
@@ -547,7 +547,7 @@ describe("custodian page nudges", () => {
     expect(page.querySelector("openclaw-option-card")).not.toBeNull();
   });
 
-  it("keeps event nudges blocked after a question reply has an uncertain failure", async () => {
+  it("keeps nudges blocked after an uncertain question reply and rejected retry", async () => {
     const request = vi
       .fn()
       .mockResolvedValueOnce({
@@ -562,7 +562,10 @@ describe("custodian page nudges", () => {
           isOther: false,
         },
       })
-      .mockRejectedValueOnce(new Error("Request failed"));
+      .mockRejectedValueOnce(new Error("Request failed"))
+      .mockRejectedValueOnce(
+        new GatewayRequestError({ code: "INVALID_REQUEST", message: "Request failed" }),
+      );
     const { context, emitGatewayEvent } = createContext(request);
     const { page } = await mountPage(context, { onboarding: false });
     await waitForFast(() => expect(request).toHaveBeenCalledOnce());
@@ -585,6 +588,18 @@ describe("custodian page nudges", () => {
     await page.updateComplete;
 
     expect(request).toHaveBeenCalledTimes(2);
+
+    const input = page.querySelector<HTMLTextAreaElement>(
+      ".agent-chat__composer-combobox textarea",
+    )!;
+    input.value = "Try again";
+    input.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    await page.updateComplete;
+    page.querySelector<HTMLButtonElement>(".chat-send-btn")!.click();
+
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(3));
+    await page.updateComplete;
+    expect(page.querySelector<HTMLButtonElement>(".custodian__nudge-action")!.disabled).toBe(true);
   });
 
   it("restores a closed question after its reply is explicitly rejected", async () => {

--- a/ui/src/pages/custodian/custodian-page.nudges.test.ts
+++ b/ui/src/pages/custodian/custodian-page.nudges.test.ts
@@ -556,6 +556,33 @@ describe("custodian page nudges", () => {
     expect(page.querySelector("openclaw-option-card")).not.toBeNull();
   });
 
+  it("does not send an event nudge while a non-card hosted wizard step awaits input", async () => {
+    const request = vi.fn().mockResolvedValue({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "Type your bot token.",
+      action: "none",
+      wizardInputPending: true,
+    });
+    const { context, emitGatewayEvent } = createContext(request);
+    const { page } = await mountPage(context, { onboarding: false });
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+
+    emitGatewayEvent({
+      event: "health",
+      payload: {
+        channels: { discord: { configured: true, tokenStatus: "configured_unavailable" } },
+      },
+    });
+    await page.updateComplete;
+    const action = page.querySelector<HTMLButtonElement>(".custodian__nudge-action")!;
+    expect(action.disabled).toBe(true);
+    action.click();
+    await page.updateComplete;
+
+    expect(request).toHaveBeenCalledOnce();
+    expect(page.querySelector("openclaw-option-card")).toBeNull();
+  });
+
   it("keeps nudges blocked after an uncertain question reply and rejected retry", async () => {
     const request = vi
       .fn()

--- a/ui/src/pages/custodian/custodian-page.nudges.test.ts
+++ b/ui/src/pages/custodian/custodian-page.nudges.test.ts
@@ -587,6 +587,43 @@ describe("custodian page nudges", () => {
     expect(request).toHaveBeenCalledTimes(2);
   });
 
+  it("restores a closed question after its reply is explicitly rejected", async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({
+        sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+        reply: "Choose one.",
+        action: "none",
+        question: {
+          id: "access",
+          header: "Access",
+          question: "How should OpenClaw work?",
+          options: [{ label: "Full access" }, { label: "Ask first" }],
+          isOther: false,
+        },
+      })
+      .mockRejectedValueOnce(
+        new GatewayRequestError({ code: "INVALID_REQUEST", message: "Request failed" }),
+      );
+    const { context, emitGatewayEvent } = createContext(request);
+    const { page } = await mountPage(context, { onboarding: false });
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+
+    emitGatewayEvent({
+      event: "health",
+      payload: {
+        channels: { discord: { configured: true, tokenStatus: "configured_unavailable" } },
+      },
+    });
+    await page.updateComplete;
+    page.querySelector<HTMLButtonElement>(".option-card__skip")!.click();
+
+    await waitForFast(() => expect(page.querySelector('[role="alert"]')).not.toBeNull());
+    await page.updateComplete;
+    expect(page.querySelector("openclaw-option-card")).not.toBeNull();
+    expect(page.querySelector<HTMLButtonElement>(".custodian__nudge-action")!.disabled).toBe(true);
+  });
+
   it("keeps event nudges blocked after a typed question reply has an uncertain failure", async () => {
     const request = vi
       .fn()

--- a/ui/src/pages/custodian/custodian-page.nudges.test.ts
+++ b/ui/src/pages/custodian/custodian-page.nudges.test.ts
@@ -907,6 +907,53 @@ describe("custodian page nudges", () => {
     expect(page.querySelector(".custodian__nudge")?.textContent).toContain("Discord is degraded");
   });
 
+  it("consumes an in-flight incident that becomes current again before completion", async () => {
+    let resolveNudge!: (value: { sessionId: string; reply: string; action: "none" }) => void;
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({
+        sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+        reply: "Everything is healthy.",
+        action: "none",
+      })
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveNudge = resolve;
+          }),
+      );
+    const { context, emitGatewayEvent } = createContext(request);
+    const { page } = await mountPage(context, { onboarding: false });
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+    const telegramFailure = {
+      channelLabels: { telegram: "Telegram" },
+      channels: { telegram: { configured: true, running: true, connected: false } },
+    };
+
+    emitGatewayEvent({ event: "health", payload: telegramFailure });
+    await page.updateComplete;
+    page.querySelector<HTMLButtonElement>(".custodian__nudge-action")!.click();
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
+
+    emitGatewayEvent({
+      event: "health",
+      payload: {
+        channels: { discord: { configured: true, tokenStatus: "configured_unavailable" } },
+      },
+    });
+    emitGatewayEvent({ event: "health", payload: telegramFailure });
+    resolveNudge({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "Telegram checked.",
+      action: "none",
+    });
+
+    await waitForFast(() => expect(page.querySelector(".custodian__nudge")).toBeNull());
+    emitGatewayEvent({ event: "health", payload: telegramFailure });
+    await page.updateComplete;
+    expect(page.querySelector(".custodian__nudge")).toBeNull();
+  });
+
   it("consumes a nudge after an unchanged health snapshot arrives while sending", async () => {
     let resolveNudge!: (value: { sessionId: string; reply: string; action: "none" }) => void;
     const request = vi

--- a/ui/src/pages/custodian/custodian-page.nudges.test.ts
+++ b/ui/src/pages/custodian/custodian-page.nudges.test.ts
@@ -5,6 +5,15 @@ import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gatewa
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import { createContext, mountPage } from "./custodian-page.test-harness.ts";
 
+function rejectAfterSend(
+  _method: unknown,
+  _params: unknown,
+  options?: { onSent?: () => void },
+): Promise<never> {
+  options?.onSent?.();
+  return Promise.reject(new Error("Request failed"));
+}
+
 describe("custodian page nudges", () => {
   beforeEach(() => {
     vi.spyOn(crypto, "randomUUID").mockReturnValue("00000000-0000-4000-8000-000000000001");
@@ -562,7 +571,7 @@ describe("custodian page nudges", () => {
           isOther: false,
         },
       })
-      .mockRejectedValueOnce(new Error("Request failed"))
+      .mockImplementationOnce(rejectAfterSend)
       .mockRejectedValueOnce(
         new GatewayRequestError({ code: "INVALID_REQUEST", message: "Request failed" }),
       );
@@ -582,6 +591,7 @@ describe("custodian page nudges", () => {
     await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
     await waitForFast(() => expect(page.querySelector('[role="alert"]')).not.toBeNull());
     expect(page.querySelector('[role="alert"] button')).toBeNull();
+    expect(page.querySelector("openclaw-option-card")).toBeNull();
     const action = page.querySelector<HTMLButtonElement>(".custodian__nudge-action")!;
     expect(action.disabled).toBe(true);
     action.click();
@@ -654,7 +664,7 @@ describe("custodian page nudges", () => {
           isOther: true,
         },
       })
-      .mockRejectedValueOnce(new Error("Request failed"));
+      .mockImplementationOnce(rejectAfterSend);
     const { context, emitGatewayEvent } = createContext(request);
     const { page } = await mountPage(context, { onboarding: false });
     await waitForFast(() => expect(request).toHaveBeenCalledOnce());
@@ -676,6 +686,7 @@ describe("custodian page nudges", () => {
 
     await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
     await waitForFast(() => expect(page.querySelector('[role="alert"]')).not.toBeNull());
+    expect(page.querySelector<HTMLButtonElement>(".option-card__skip")?.disabled).toBe(true);
     const action = page.querySelector<HTMLButtonElement>(".custodian__nudge-action")!;
     expect(action.disabled).toBe(true);
     action.click();

--- a/ui/src/pages/custodian/custodian-page.nudges.test.ts
+++ b/ui/src/pages/custodian/custodian-page.nudges.test.ts
@@ -1,7 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import { createContext, mountPage } from "./custodian-page.test-harness.ts";
 
@@ -640,7 +640,9 @@ describe("custodian page nudges", () => {
         reply: "Everything is healthy.",
         action: "none",
       })
-      .mockRejectedValueOnce(new Error("Request failed"));
+      .mockRejectedValueOnce(
+        new GatewayRequestError({ code: "INVALID_REQUEST", message: "Request failed" }),
+      );
     const { context, emitGatewayEvent } = createContext(request);
     const { page } = await mountPage(context, { onboarding: false });
     await waitForFast(() => expect(request).toHaveBeenCalledOnce());
@@ -663,6 +665,79 @@ describe("custodian page nudges", () => {
     expect(page.querySelector(".custodian__nudge")?.textContent).toContain(
       "Telegram authentication degraded",
     );
+  });
+
+  it("consumes a delivered nudge whose reply becomes stale during reconnect", async () => {
+    let resolveNudge!: (value: { sessionId: string; reply: string; action: "none" }) => void;
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({
+        sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+        reply: "Everything is healthy.",
+        action: "none",
+      })
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveNudge = resolve;
+          }),
+      );
+    const { context, emitGatewayEvent, setGatewaySnapshot } = createContext(request);
+    const { page } = await mountPage(context, { onboarding: false });
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+    const degradedHealth = {
+      channels: { telegram: { configured: true, healthState: "stale-socket" } },
+    };
+
+    emitGatewayEvent({ event: "health", payload: degradedHealth });
+    await page.updateComplete;
+    page.querySelector<HTMLButtonElement>(".custodian__nudge-action")!.click();
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
+
+    setGatewaySnapshot({ connected: false, reconnecting: true });
+    await page.updateComplete;
+    setGatewaySnapshot({ connected: true, reconnecting: false });
+    await page.updateComplete;
+    resolveNudge({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "Telegram checked.",
+      action: "none",
+    });
+
+    await waitForFast(() => expect(page.querySelector(".custodian__nudge")).toBeNull());
+    emitGatewayEvent({ event: "health", payload: degradedHealth });
+    await page.updateComplete;
+    expect(page.querySelector(".custodian__nudge")).toBeNull();
+  });
+
+  it("consumes a transmitted nudge when its delivery outcome is unknown", async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({
+        sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+        reply: "Everything is healthy.",
+        action: "none",
+      })
+      .mockImplementationOnce((_method, _params, options?: { onSent?: () => void }) => {
+        options?.onSent?.();
+        return Promise.reject(new Error("gateway closed"));
+      });
+    const { context, emitGatewayEvent } = createContext(request);
+    const { page } = await mountPage(context, { onboarding: false });
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+    const degradedHealth = {
+      channels: { telegram: { configured: true, healthState: "stale-socket" } },
+    };
+
+    emitGatewayEvent({ event: "health", payload: degradedHealth });
+    await page.updateComplete;
+    page.querySelector<HTMLButtonElement>(".custodian__nudge-action")!.click();
+
+    await waitForFast(() => expect(page.querySelector('[role="alert"]')).not.toBeNull());
+    expect(page.querySelector(".custodian__nudge")).toBeNull();
+    emitGatewayEvent({ event: "health", payload: degradedHealth });
+    await page.updateComplete;
+    expect(page.querySelector(".custodian__nudge")).toBeNull();
   });
 
   it("keeps a newer lower-severity failure when an earlier nudge send succeeds", async () => {

--- a/ui/src/pages/custodian/custodian-page.nudges.test.ts
+++ b/ui/src/pages/custodian/custodian-page.nudges.test.ts
@@ -632,6 +632,60 @@ describe("custodian page nudges", () => {
     expect(request).toHaveBeenCalledTimes(2);
   });
 
+  it("ignores a stale question reply outcome after a same-owner reconnect", async () => {
+    let resolveQuestion!: (value: { sessionId: string; reply: string; action: "none" }) => void;
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({
+        sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+        reply: "Choose one.",
+        action: "none",
+        question: {
+          id: "access",
+          header: "Access",
+          question: "How should OpenClaw work?",
+          options: [{ label: "Full access" }, { label: "Ask first" }],
+          isOther: false,
+        },
+      })
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveQuestion = resolve;
+          }),
+      );
+    const { context, emitGatewayEvent, setGatewaySnapshot } = createContext(request);
+    const { page } = await mountPage(context, { onboarding: false });
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+
+    emitGatewayEvent({
+      event: "health",
+      payload: {
+        channels: { discord: { configured: true, tokenStatus: "configured_unavailable" } },
+      },
+    });
+    await page.updateComplete;
+    page.querySelector<HTMLButtonElement>(".option-card__skip")!.click();
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
+
+    setGatewaySnapshot({ connected: false, reconnecting: true });
+    await page.updateComplete;
+    setGatewaySnapshot({ connected: true, reconnecting: false });
+    await page.updateComplete;
+    resolveQuestion({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "Moving on.",
+      action: "none",
+    });
+
+    await Promise.resolve();
+    await page.updateComplete;
+    const action = page.querySelector<HTMLButtonElement>(".custodian__nudge-action")!;
+    expect(action.disabled).toBe(true);
+    action.click();
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
   it("restores an event nudge after its request fails", async () => {
     const request = vi
       .fn()

--- a/ui/src/pages/custodian/custodian-page.test.ts
+++ b/ui/src/pages/custodian/custodian-page.test.ts
@@ -534,7 +534,7 @@ describe("custodian page", () => {
     await page.updateComplete;
     expect(request.mock.calls[1]?.[1]).toMatchObject({ message: "cancel" });
     expect(page.querySelector(".chat-group.user")?.textContent).toContain("Skip for now");
-    expect(page.querySelector("openclaw-option-card")).toBeNull();
+    await waitForFast(() => expect(page.querySelector("openclaw-option-card")).toBeNull());
   });
 
   it("retires a structured question after a freeform reply", async () => {

--- a/ui/src/pages/custodian/custodian-page.test.ts
+++ b/ui/src/pages/custodian/custodian-page.test.ts
@@ -502,7 +502,7 @@ describe("custodian page", () => {
     expect(page.textContent).not.toContain("test-token-placeholder");
   });
 
-  it("sends skip as a reply and dismisses the question", async () => {
+  it("sends a wizard-parseable cancel reply when skipping a closed question", async () => {
     const question = {
       id: "access",
       header: "Access",
@@ -532,7 +532,8 @@ describe("custodian page", () => {
 
     await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
     await page.updateComplete;
-    expect(request.mock.calls[1]?.[1]).toMatchObject({ message: "Skip for now" });
+    expect(request.mock.calls[1]?.[1]).toMatchObject({ message: "cancel" });
+    expect(page.querySelector(".chat-group.user")?.textContent).toContain("Skip for now");
     expect(page.querySelector("openclaw-option-card")).toBeNull();
   });
 

--- a/ui/src/pages/custodian/custodian-page.ts
+++ b/ui/src/pages/custodian/custodian-page.ts
@@ -418,17 +418,20 @@ export class CustodianPage extends OpenClawLightDomElement {
   private async requestReply(
     client: GatewayBrowserClient,
     params: SystemAgentChatParams,
-  ): Promise<boolean> {
+  ): Promise<eventNudgeState.CustodianSendOutcome> {
     const epoch = ++this.requestEpoch;
+    let delivery: eventNudgeState.CustodianSendDelivery = "unsent";
     this.sending = true;
     this.error = null;
     this.retryParams = params;
     try {
       const result = await client.request<SystemAgentChatResult>("openclaw.chat", params, {
         timeoutMs: SYSTEM_AGENT_CHAT_TIMEOUT_MS,
+        onSent: () => (delivery = "sent"),
       });
+      delivery = "received";
       if (epoch !== this.requestEpoch || client !== this.activeClient) {
-        return false;
+        return "sent";
       }
       this.sessionId = result.sessionId;
       this.sensitive = result.sensitive === true;
@@ -439,7 +442,7 @@ export class CustodianPage extends OpenClawLightDomElement {
         if (result.agentId) {
           const roster = await this.context.agents.refreshList();
           if (epoch !== this.requestEpoch || client !== this.activeClient) {
-            return false;
+            return "sent";
           }
           sessionKey = buildAgentMainSessionKey({
             agentId: result.agentId,
@@ -459,7 +462,7 @@ export class CustodianPage extends OpenClawLightDomElement {
       } else if (result.action === "exit") {
         this.exitSetup();
       }
-      return true;
+      return "sent";
     } catch (error) {
       if (epoch === this.requestEpoch && client === this.activeClient) {
         this.error = custodianErrorMessage(error);
@@ -469,7 +472,7 @@ export class CustodianPage extends OpenClawLightDomElement {
       if (params.message !== undefined && this.retryParams === params) {
         this.retryParams = null;
       }
-      return false;
+      return eventNudgeState.classifyCustodianSendFailure(error, delivery);
     } finally {
       if (epoch === this.requestEpoch) {
         this.sending = false;
@@ -481,7 +484,7 @@ export class CustodianPage extends OpenClawLightDomElement {
     text = this.input,
     display?: string,
     questionReply = this.hasUnresolvedQuestion(),
-  ): Promise<boolean> {
+  ): Promise<eventNudgeState.CustodianSendOutcome> {
     // Trim decides emptiness only; sensitive values (credentials) may carry
     // meaningful whitespace and must reach the agent exactly as entered.
     const message = this.sensitive ? text : text.trim();
@@ -493,7 +496,7 @@ export class CustodianPage extends OpenClawLightDomElement {
       this.questionReplyUncertain = true;
     }
     if (!message.trim() || !client || !this.chatAvailable || this.sending) {
-      return false;
+      return "rejected";
     }
     const displayText = this.sensitive ? t("custodian.sensitiveReply") : (display ?? message);
     // A new operator turn supersedes any abandoned-turn unknown-outcome warning.
@@ -510,7 +513,7 @@ export class CustodianPage extends OpenClawLightDomElement {
       },
     ];
     this.input = "";
-    const sent = await this.requestReply(client, {
+    const outcome = await this.requestReply(client, {
       sessionId: this.sessionId,
       ...this.welcomeVariant(),
       message,
@@ -520,9 +523,9 @@ export class CustodianPage extends OpenClawLightDomElement {
       this.sessionVariant === sessionVariant &&
       this.sessionOwnershipKey === sessionOwnershipKey
     ) {
-      this.questionReplyUncertain = !sent;
+      this.questionReplyUncertain = outcome !== "sent";
     }
-    return sent;
+    return outcome;
   }
 
   private async sendEventNudge(): Promise<void> {
@@ -531,16 +534,12 @@ export class CustodianPage extends OpenClawLightDomElement {
       return;
     }
     [this.eventNudge, this.eventNudgePending] = [null, nudge];
-    const sent = await this.send(nudge.message);
+    const outcome = await this.send(nudge.message);
     if (this.eventNudgePending === nudge) {
       this.eventNudgePending = null;
-      this.eventNudgeClosed = sent;
-      this.eventNudge = sent ? null : nudge;
+      this.eventNudgeClosed = outcome !== "rejected";
+      this.eventNudge = outcome === "rejected" ? nudge : null;
     }
-  }
-
-  private dismissEventNudge(): void {
-    [this.eventNudge, this.eventNudgeClosed] = [null, true];
   }
 
   private dismissQuestion(message: CustodianMessage): void {
@@ -650,7 +649,7 @@ export class CustodianPage extends OpenClawLightDomElement {
                   this.sensitive ||
                   this.hasUnresolvedQuestion(),
                 onSend: () => void this.sendEventNudge(),
-                onDismiss: () => this.dismissEventNudge(),
+                onDismiss: () => void ([this.eventNudge, this.eventNudgeClosed] = [null, true]),
               })
             : nothing}
           ${this.messages.map((message) => {

--- a/ui/src/pages/custodian/custodian-page.ts
+++ b/ui/src/pages/custodian/custodian-page.ts
@@ -554,7 +554,7 @@ export class CustodianPage extends OpenClawLightDomElement {
       t("optionCard.skip"),
       true,
     );
-    if (outcome !== "rejected") {
+    if (outcome !== "rejected" && this.messages.includes(message)) {
       this.dismissedQuestions = new Set(this.dismissedQuestions).add(
         `${message.id}:${question.id}`,
       );

--- a/ui/src/pages/custodian/custodian-page.ts
+++ b/ui/src/pages/custodian/custodian-page.ts
@@ -10,7 +10,6 @@ import { property, state } from "lit/decorators.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { icons } from "../../components/icons.ts";
-import "../../components/option-card.ts";
 import { t } from "../../i18n/index.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { searchForSession } from "../../lib/sessions/navigation.ts";
@@ -24,12 +23,14 @@ import "../../styles/custodian.css";
 import { renderChatAvatar } from "../chat/chat-avatar.ts";
 import { renderMessageGroup } from "../chat/components/chat-message.ts";
 import { renderCustodianChangeHistory } from "./custodian-history.ts";
+import { renderCustodianQuestionCard } from "./custodian-question-card.ts";
 import * as eventNudgeState from "./event-nudge.ts";
 import { parseCustodianQuestion, type CustodianStructuredQuestion } from "./structured-question.ts";
 import {
   createCustodianSessionId,
   createCustodianTranscriptMessages,
   custodianErrorMessage,
+  hasUnresolvedCustodianQuestion,
   readCustodianTranscript,
   renderCustodianEarlierDivider,
   toCustodianMessageGroup,
@@ -93,12 +94,11 @@ export class CustodianPage extends OpenClawLightDomElement {
         if (this.onboarding || this.newAgentIntent || this.eventNudgeClosed) {
           return;
         }
-        [this.eventNudge, this.eventNudgePending] =
-          eventNudgeState.reconcileCustodianEventNudge(
-            this.eventNudge,
-            this.eventNudgePending,
-            event,
-          );
+        [this.eventNudge, this.eventNudgePending] = eventNudgeState.reconcileCustodianEventNudge(
+          this.eventNudge,
+          this.eventNudgePending,
+          event,
+        );
       }),
   );
 
@@ -237,8 +237,7 @@ export class CustodianPage extends OpenClawLightDomElement {
     this.sending = false;
     this.chatAvailable = false;
     if (variantChanged || ownershipChanged) {
-      this.eventNudge = null;
-      this.eventNudgePending = null;
+      [this.eventNudge, this.eventNudgePending] = [null, null];
       // A different operator or mode must not inherit the previous context's
       // abandoned-turn warning; same-ownership paths below preserve it.
       this.abandonedTurnOutcomeUnknown = false;
@@ -490,8 +489,7 @@ export class CustodianPage extends OpenClawLightDomElement {
     const sessionVariant = this.sessionVariant;
     const sessionOwnershipKey = this.sessionOwnershipKey;
     if (questionReply) {
-      // A failed structured reply may still have reached the hosted wizard.
-      // Block unrelated nudges until a new wizard session makes the outcome known.
+      // A failed wizard reply may have arrived, so block nudges until the session outcome is known.
       this.questionReplyUncertain = true;
     }
     if (!message.trim() || !client || !this.chatAvailable || this.sending) {
@@ -532,8 +530,7 @@ export class CustodianPage extends OpenClawLightDomElement {
     if (!nudge || this.sensitive || this.hasUnresolvedQuestion()) {
       return;
     }
-    this.eventNudge = null;
-    this.eventNudgePending = nudge;
+    [this.eventNudge, this.eventNudgePending] = [null, nudge];
     const sent = await this.send(nudge.message);
     if (this.eventNudgePending === nudge) {
       this.eventNudgePending = null;
@@ -543,8 +540,7 @@ export class CustodianPage extends OpenClawLightDomElement {
   }
 
   private dismissEventNudge(): void {
-    this.eventNudge = null;
-    this.eventNudgeClosed = true;
+    [this.eventNudge, this.eventNudgeClosed] = [null, true];
   }
 
   private dismissQuestion(message: CustodianMessage): void {
@@ -553,8 +549,7 @@ export class CustodianPage extends OpenClawLightDomElement {
       return;
     }
     this.dismissedQuestions = new Set(this.dismissedQuestions).add(`${message.id}:${question.id}`);
-    // Closed hosted-wizard selects accept the canonical cancel token; open
-    // "other" prompts retain the visible skip label as their free-form reply.
+    // Closed wizard selects accept cancel; open "other" prompts use their visible free-form reply.
     void this.send(question.isOther ? t("optionCard.skip") : "cancel", t("optionCard.skip"), true);
   }
 
@@ -565,8 +560,7 @@ export class CustodianPage extends OpenClawLightDomElement {
     }
     const option = question.options.find((candidate) => candidate.label === label);
     this.answeredQuestions = new Set(this.answeredQuestions).add(`${message.id}:${question.id}`);
-    // The transcript shows the friendly label; the engine receives the reply
-    // text it actually parses (wizard answers, canonical commands).
+    // Show the friendly label while sending the canonical reply that the engine parses.
     void this.send(option?.reply ?? label, label, true);
   }
 
@@ -581,16 +575,12 @@ export class CustodianPage extends OpenClawLightDomElement {
   }
 
   private hasUnresolvedQuestion(): boolean {
-    if (this.questionReplyUncertain) {
-      return true;
-    }
-    return this.messages.some((message) => {
-      if (!message.question) {
-        return false;
-      }
-      const key = `${message.id}:${message.question.id}`;
-      return !this.dismissedQuestions.has(key) && !this.answeredQuestions.has(key);
-    });
+    return hasUnresolvedCustodianQuestion(
+      this.messages,
+      this.dismissedQuestions,
+      this.answeredQuestions,
+      this.questionReplyUncertain,
+    );
   }
 
   private exitSetup(): void {
@@ -651,28 +641,17 @@ export class CustodianPage extends OpenClawLightDomElement {
 
         <div class="custodian__messages" aria-live="polite">
           ${!this.onboarding && this.eventNudge
-            ? html`<div class="custodian__nudge" role="status">
-                <button
-                  class="custodian__nudge-action"
-                  type="button"
-                  ?disabled=${!this.activeClient ||
+            ? eventNudgeState.renderCustodianEventNudge({
+                nudge: this.eventNudge,
+                disabled:
+                  !this.activeClient ||
                   !this.chatAvailable ||
                   this.sending ||
                   this.sensitive ||
-                  this.hasUnresolvedQuestion()}
-                  @click=${() => void this.sendEventNudge()}
-                >
-                  ${eventNudgeState.eventNudgeText(this.eventNudge)}
-                </button>
-                <button
-                  class="custodian__nudge-dismiss"
-                  type="button"
-                  aria-label=${t("custodian.nudge.dismiss")}
-                  @click=${() => this.dismissEventNudge()}
-                >
-                  ×
-                </button>
-              </div>`
+                  this.hasUnresolvedQuestion(),
+                onSend: () => void this.sendEventNudge(),
+                onDismiss: () => this.dismissEventNudge(),
+              })
             : nothing}
           ${this.messages.map((message) => {
             const questionKey = message.question ? `${message.id}:${message.question.id}` : "";
@@ -687,26 +666,15 @@ export class CustodianPage extends OpenClawLightDomElement {
               })}
               ${renderCustodianEarlierDivider(message, this.earlierBoundaryAfterId)}
               ${showQuestion
-                ? html`<div class="custodian__option-card">
-                    <openclaw-option-card
-                      .props=${{
-                        header: message.question!.header,
-                        question: message.question!.question,
-                        options: message.question!.options.map((option) => ({
-                          value: option.label,
-                          label: option.label,
-                          description: option.description,
-                          recommended: option.recommended,
-                        })),
-                        disabled:
-                          this.sending ||
-                          !this.chatAvailable ||
-                          this.answeredQuestions.has(questionKey),
-                        onSelect: (label: string) => this.answerQuestion(message, label),
-                        onSkip: () => this.dismissQuestion(message),
-                      }}
-                    ></openclaw-option-card>
-                  </div>`
+                ? renderCustodianQuestionCard({
+                    question: message.question!,
+                    disabled:
+                      this.sending ||
+                      !this.chatAvailable ||
+                      this.answeredQuestions.has(questionKey),
+                    onSelect: (label) => this.answerQuestion(message, label),
+                    onSkip: () => this.dismissQuestion(message),
+                  })
                 : nothing}
             `;
           })}

--- a/ui/src/pages/custodian/custodian-page.ts
+++ b/ui/src/pages/custodian/custodian-page.ts
@@ -33,6 +33,7 @@ import {
   hasUnresolvedCustodianQuestion,
   readCustodianTranscript,
   renderCustodianEarlierDivider,
+  retireCustodianQuestions,
   toCustodianMessageGroup,
   type CustodianMessage,
 } from "./transcript.ts";
@@ -182,7 +183,7 @@ export class CustodianPage extends OpenClawLightDomElement {
     client: GatewayBrowserClient,
     variant: "onboarding" | "new-agent" | "caretaker",
   ): void {
-    this.retireQuestions();
+    this.answeredQuestions = retireCustodianQuestions(this.messages, this.answeredQuestions);
     this.retryParams = null;
     this.input = "";
     this.sensitive = false;
@@ -499,7 +500,8 @@ export class CustodianPage extends OpenClawLightDomElement {
     const displayText = this.sensitive ? t("custodian.sensitiveReply") : (display ?? message);
     // A new operator turn supersedes any abandoned-turn unknown-outcome warning.
     this.abandonedTurnOutcomeUnknown = false;
-    this.retireQuestions();
+    const answeredQuestions = this.answeredQuestions;
+    this.answeredQuestions = retireCustodianQuestions(this.messages, this.answeredQuestions);
     this.messages = [
       ...this.messages,
       {
@@ -519,7 +521,10 @@ export class CustodianPage extends OpenClawLightDomElement {
     const replyEpoch = this.requestEpoch;
     const outcome = await reply;
     if (questionReply && this.requestEpoch === replyEpoch) {
-      this.questionReplyUncertain = outcome !== "sent";
+      this.questionReplyUncertain = outcome === "unknown";
+      if (outcome === "rejected") {
+        this.answeredQuestions = answeredQuestions;
+      }
     }
     return outcome;
   }
@@ -538,14 +543,22 @@ export class CustodianPage extends OpenClawLightDomElement {
     }
   }
 
-  private dismissQuestion(message: CustodianMessage): void {
+  private async dismissQuestion(message: CustodianMessage): Promise<void> {
     const question = message.question;
     if (!question) {
       return;
     }
-    this.dismissedQuestions = new Set(this.dismissedQuestions).add(`${message.id}:${question.id}`);
     // Closed wizard selects accept cancel; open "other" prompts use their visible free-form reply.
-    void this.send(question.isOther ? t("optionCard.skip") : "cancel", t("optionCard.skip"), true);
+    const outcome = await this.send(
+      question.isOther ? t("optionCard.skip") : "cancel",
+      t("optionCard.skip"),
+      true,
+    );
+    if (outcome !== "rejected") {
+      this.dismissedQuestions = new Set(this.dismissedQuestions).add(
+        `${message.id}:${question.id}`,
+      );
+    }
   }
 
   private answerQuestion(message: CustodianMessage, label: string): void {
@@ -554,19 +567,8 @@ export class CustodianPage extends OpenClawLightDomElement {
       return;
     }
     const option = question.options.find((candidate) => candidate.label === label);
-    this.answeredQuestions = new Set(this.answeredQuestions).add(`${message.id}:${question.id}`);
     // Show the friendly label while sending the canonical reply that the engine parses.
     void this.send(option?.reply ?? label, label, true);
-  }
-
-  private retireQuestions(): void {
-    const answered = new Set(this.answeredQuestions);
-    for (const message of this.messages) {
-      if (message.question) {
-        answered.add(`${message.id}:${message.question.id}`);
-      }
-    }
-    this.answeredQuestions = answered;
   }
 
   private hasUnresolvedQuestion(): boolean {
@@ -668,7 +670,7 @@ export class CustodianPage extends OpenClawLightDomElement {
                       !this.chatAvailable ||
                       this.answeredQuestions.has(questionKey),
                     onSelect: (label) => this.answerQuestion(message, label),
-                    onSkip: () => this.dismissQuestion(message),
+                    onSkip: () => void this.dismissQuestion(message),
                   })
                 : nothing}
             `;

--- a/ui/src/pages/custodian/custodian-page.ts
+++ b/ui/src/pages/custodian/custodian-page.ts
@@ -69,6 +69,7 @@ export class CustodianPage extends OpenClawLightDomElement {
   @state() private historyLoadingMore = false;
   @state() private historyError: string | null = null;
   @state() private eventNudge: eventNudgeState.CustodianEventNudge | null = null;
+  @state() private eventNudgePending: eventNudgeState.CustodianEventNudge | null = null;
 
   private sessionId = createCustodianSessionId();
   private requestEpoch = 0;
@@ -81,7 +82,6 @@ export class CustodianPage extends OpenClawLightDomElement {
   private earlierBoundaryAfterId: number | null = null;
   private lastHelloDeviceToken = "";
   private eventNudgeClosed = false;
-  private eventNudgePending: eventNudgeState.CustodianEventNudge | null = null;
   private abandonedTurnOutcomeUnknown = false;
   private historyLoaded = false;
   private readonly subscriptions = new SubscriptionsController(this).watch(
@@ -534,12 +534,12 @@ export class CustodianPage extends OpenClawLightDomElement {
     if (!nudge || this.sensitive || this.hasUnresolvedQuestion()) {
       return;
     }
-    [this.eventNudge, this.eventNudgePending] = [null, nudge];
+    this.eventNudgePending = nudge;
     const outcome = await this.send(nudge.message);
     if (this.eventNudgePending === nudge) {
       this.eventNudgePending = null;
-      this.eventNudgeClosed = outcome !== "rejected";
-      this.eventNudge = outcome === "rejected" ? nudge : null;
+      const consumed = eventNudgeState.shouldConsumeNudge(this.eventNudge, nudge, outcome);
+      [this.eventNudgeClosed, this.eventNudge] = [consumed, consumed ? null : this.eventNudge];
     }
   }
 
@@ -637,7 +637,7 @@ export class CustodianPage extends OpenClawLightDomElement {
         </header>
 
         <div class="custodian__messages" aria-live="polite">
-          ${!this.onboarding && this.eventNudge
+          ${!this.onboarding && this.eventNudge && !this.eventNudgePending
             ? eventNudgeState.renderCustodianEventNudge({
                 nudge: this.eventNudge,
                 disabled:

--- a/ui/src/pages/custodian/custodian-page.ts
+++ b/ui/src/pages/custodian/custodian-page.ts
@@ -24,7 +24,7 @@ import "../../styles/custodian.css";
 import { renderChatAvatar } from "../chat/chat-avatar.ts";
 import { renderMessageGroup } from "../chat/components/chat-message.ts";
 import { renderCustodianChangeHistory } from "./custodian-history.ts";
-import { classifyCustodianEventNudge, type CustodianEventNudge } from "./event-nudge.ts";
+import * as eventNudgeState from "./event-nudge.ts";
 import { parseCustodianQuestion, type CustodianStructuredQuestion } from "./structured-question.ts";
 import {
   createCustodianSessionId,
@@ -53,6 +53,7 @@ export class CustodianPage extends OpenClawLightDomElement {
   @state() private input = "";
   @state() private sending = false;
   @state() private sensitive = false;
+  @state() private questionReplyUncertain = false;
   @state() private error: string | null = null;
   @state() private dismissedQuestions = new Set<string>();
   @state() private answeredQuestions = new Set<string>();
@@ -65,7 +66,7 @@ export class CustodianPage extends OpenClawLightDomElement {
   @state() private historyLoading = false;
   @state() private historyLoadingMore = false;
   @state() private historyError: string | null = null;
-  @state() private eventNudge: CustodianEventNudge | null = null;
+  @state() private eventNudge: eventNudgeState.CustodianEventNudge | null = null;
 
   private sessionId = createCustodianSessionId();
   private requestEpoch = 0;
@@ -78,6 +79,7 @@ export class CustodianPage extends OpenClawLightDomElement {
   private earlierBoundaryAfterId: number | null = null;
   private lastHelloDeviceToken = "";
   private eventNudgeClosed = false;
+  private eventNudgePending: eventNudgeState.CustodianEventNudge | null = null;
   private abandonedTurnOutcomeUnknown = false;
   private historyLoaded = false;
   private readonly subscriptions = new SubscriptionsController(this).watch(
@@ -91,10 +93,12 @@ export class CustodianPage extends OpenClawLightDomElement {
         if (this.onboarding || this.newAgentIntent || this.eventNudgeClosed) {
           return;
         }
-        const next = classifyCustodianEventNudge(event);
-        if (next && (!this.eventNudge || next.severity > this.eventNudge.severity)) {
-          this.eventNudge = next;
-        }
+        [this.eventNudge, this.eventNudgePending] =
+          eventNudgeState.reconcileCustodianEventNudge(
+            this.eventNudge,
+            this.eventNudgePending,
+            event,
+          );
       }),
   );
 
@@ -182,6 +186,7 @@ export class CustodianPage extends OpenClawLightDomElement {
     this.retryParams = null;
     this.input = "";
     this.sensitive = false;
+    this.questionReplyUncertain = false;
     this.error = null;
     this.earlierBoundaryAfterId = this.messages.at(-1)?.id ?? null;
     this.startSession(client, variant, false);
@@ -233,6 +238,7 @@ export class CustodianPage extends OpenClawLightDomElement {
     this.chatAvailable = false;
     if (variantChanged || ownershipChanged) {
       this.eventNudge = null;
+      this.eventNudgePending = null;
       // A different operator or mode must not inherit the previous context's
       // abandoned-turn warning; same-ownership paths below preserve it.
       this.abandonedTurnOutcomeUnknown = false;
@@ -329,6 +335,7 @@ export class CustodianPage extends OpenClawLightDomElement {
     this.error = null;
     this.input = "";
     this.sensitive = false;
+    this.questionReplyUncertain = false;
     this.earlierBoundaryAfterId = null;
   }
 
@@ -412,7 +419,7 @@ export class CustodianPage extends OpenClawLightDomElement {
   private async requestReply(
     client: GatewayBrowserClient,
     params: SystemAgentChatParams,
-  ): Promise<void> {
+  ): Promise<boolean> {
     const epoch = ++this.requestEpoch;
     this.sending = true;
     this.error = null;
@@ -422,7 +429,7 @@ export class CustodianPage extends OpenClawLightDomElement {
         timeoutMs: SYSTEM_AGENT_CHAT_TIMEOUT_MS,
       });
       if (epoch !== this.requestEpoch || client !== this.activeClient) {
-        return;
+        return false;
       }
       this.sessionId = result.sessionId;
       this.sensitive = result.sensitive === true;
@@ -433,7 +440,7 @@ export class CustodianPage extends OpenClawLightDomElement {
         if (result.agentId) {
           const roster = await this.context.agents.refreshList();
           if (epoch !== this.requestEpoch || client !== this.activeClient) {
-            return;
+            return false;
           }
           sessionKey = buildAgentMainSessionKey({
             agentId: result.agentId,
@@ -453,6 +460,7 @@ export class CustodianPage extends OpenClawLightDomElement {
       } else if (result.action === "exit") {
         this.exitSetup();
       }
+      return true;
     } catch (error) {
       if (epoch === this.requestEpoch && client === this.activeClient) {
         this.error = custodianErrorMessage(error);
@@ -462,6 +470,7 @@ export class CustodianPage extends OpenClawLightDomElement {
       if (params.message !== undefined && this.retryParams === params) {
         this.retryParams = null;
       }
+      return false;
     } finally {
       if (epoch === this.requestEpoch) {
         this.sending = false;
@@ -469,13 +478,24 @@ export class CustodianPage extends OpenClawLightDomElement {
     }
   }
 
-  private send(text = this.input, display?: string): void {
+  private async send(
+    text = this.input,
+    display?: string,
+    questionReply = this.hasUnresolvedQuestion(),
+  ): Promise<boolean> {
     // Trim decides emptiness only; sensitive values (credentials) may carry
     // meaningful whitespace and must reach the agent exactly as entered.
     const message = this.sensitive ? text : text.trim();
     const client = this.activeClient;
+    const sessionVariant = this.sessionVariant;
+    const sessionOwnershipKey = this.sessionOwnershipKey;
+    if (questionReply) {
+      // A failed structured reply may still have reached the hosted wizard.
+      // Block unrelated nudges until a new wizard session makes the outcome known.
+      this.questionReplyUncertain = true;
+    }
     if (!message.trim() || !client || !this.chatAvailable || this.sending) {
-      return;
+      return false;
     }
     const displayText = this.sensitive ? t("custodian.sensitiveReply") : (display ?? message);
     // A new operator turn supersedes any abandoned-turn unknown-outcome warning.
@@ -492,21 +512,34 @@ export class CustodianPage extends OpenClawLightDomElement {
       },
     ];
     this.input = "";
-    void this.requestReply(client, {
+    const sent = await this.requestReply(client, {
       sessionId: this.sessionId,
       ...this.welcomeVariant(),
       message,
     });
+    if (
+      questionReply &&
+      this.sessionVariant === sessionVariant &&
+      this.sessionOwnershipKey === sessionOwnershipKey
+    ) {
+      this.questionReplyUncertain = !sent;
+    }
+    return sent;
   }
 
-  private sendEventNudge(): void {
+  private async sendEventNudge(): Promise<void> {
     const nudge = this.eventNudge;
-    if (!nudge) {
+    if (!nudge || this.sensitive || this.hasUnresolvedQuestion()) {
       return;
     }
     this.eventNudge = null;
-    this.eventNudgeClosed = true;
-    this.send(nudge.message);
+    this.eventNudgePending = nudge;
+    const sent = await this.send(nudge.message);
+    if (this.eventNudgePending === nudge) {
+      this.eventNudgePending = null;
+      this.eventNudgeClosed = sent;
+      this.eventNudge = sent ? null : nudge;
+    }
   }
 
   private dismissEventNudge(): void {
@@ -514,27 +547,15 @@ export class CustodianPage extends OpenClawLightDomElement {
     this.eventNudgeClosed = true;
   }
 
-  private eventNudgeText(nudge: CustodianEventNudge): string {
-    if (nudge.kind === "config-reload") {
-      return t("custodian.nudge.configReload");
-    }
-    const channel = nudge.channelLabel ?? t("custodian.nudge.channelFallback");
-    if (nudge.kind === "channel-auth") {
-      return t("custodian.nudge.channelAuth", { channel });
-    }
-    if (nudge.kind === "channel-disconnected") {
-      return t("custodian.nudge.channelDisconnected", { channel });
-    }
-    return t("custodian.nudge.channelDegraded", { channel });
-  }
-
   private dismissQuestion(message: CustodianMessage): void {
-    const questionId = message.question?.id;
-    if (!questionId) {
+    const question = message.question;
+    if (!question) {
       return;
     }
-    this.dismissedQuestions = new Set(this.dismissedQuestions).add(`${message.id}:${questionId}`);
-    this.send(t("optionCard.skip"));
+    this.dismissedQuestions = new Set(this.dismissedQuestions).add(`${message.id}:${question.id}`);
+    // Closed hosted-wizard selects accept the canonical cancel token; open
+    // "other" prompts retain the visible skip label as their free-form reply.
+    void this.send(question.isOther ? t("optionCard.skip") : "cancel", t("optionCard.skip"), true);
   }
 
   private answerQuestion(message: CustodianMessage, label: string): void {
@@ -546,7 +567,7 @@ export class CustodianPage extends OpenClawLightDomElement {
     this.answeredQuestions = new Set(this.answeredQuestions).add(`${message.id}:${question.id}`);
     // The transcript shows the friendly label; the engine receives the reply
     // text it actually parses (wizard answers, canonical commands).
-    this.send(option?.reply ?? label, label);
+    void this.send(option?.reply ?? label, label, true);
   }
 
   private retireQuestions(): void {
@@ -557,6 +578,19 @@ export class CustodianPage extends OpenClawLightDomElement {
       }
     }
     this.answeredQuestions = answered;
+  }
+
+  private hasUnresolvedQuestion(): boolean {
+    if (this.questionReplyUncertain) {
+      return true;
+    }
+    return this.messages.some((message) => {
+      if (!message.question) {
+        return false;
+      }
+      const key = `${message.id}:${message.question.id}`;
+      return !this.dismissedQuestions.has(key) && !this.answeredQuestions.has(key);
+    });
   }
 
   private exitSetup(): void {
@@ -582,7 +616,7 @@ export class CustodianPage extends OpenClawLightDomElement {
       return;
     }
     event.preventDefault();
-    this.send();
+    void this.send();
   }
 
   override render() {
@@ -621,10 +655,14 @@ export class CustodianPage extends OpenClawLightDomElement {
                 <button
                   class="custodian__nudge-action"
                   type="button"
-                  ?disabled=${!this.activeClient || !this.chatAvailable || this.sending}
-                  @click=${() => this.sendEventNudge()}
+                  ?disabled=${!this.activeClient ||
+                  !this.chatAvailable ||
+                  this.sending ||
+                  this.sensitive ||
+                  this.hasUnresolvedQuestion()}
+                  @click=${() => void this.sendEventNudge()}
                 >
-                  ${this.eventNudgeText(this.eventNudge)}
+                  ${eventNudgeState.eventNudgeText(this.eventNudge)}
                 </button>
                 <button
                   class="custodian__nudge-dismiss"
@@ -750,7 +788,7 @@ export class CustodianPage extends OpenClawLightDomElement {
                   !this.activeClient ||
                   !this.chatAvailable ||
                   this.sending}
-                  @click=${() => this.send()}
+                  @click=${() => void this.send()}
                 >
                   ${icons.arrowUp}
                   <span class="agent-chat__control-label">${t("custodian.send")}</span>

--- a/ui/src/pages/custodian/custodian-page.ts
+++ b/ui/src/pages/custodian/custodian-page.ts
@@ -489,8 +489,6 @@ export class CustodianPage extends OpenClawLightDomElement {
     // meaningful whitespace and must reach the agent exactly as entered.
     const message = this.sensitive ? text : text.trim();
     const client = this.activeClient;
-    const sessionVariant = this.sessionVariant;
-    const sessionOwnershipKey = this.sessionOwnershipKey;
     if (questionReply) {
       // A failed wizard reply may have arrived, so block nudges until the session outcome is known.
       this.questionReplyUncertain = true;
@@ -513,16 +511,14 @@ export class CustodianPage extends OpenClawLightDomElement {
       },
     ];
     this.input = "";
-    const outcome = await this.requestReply(client, {
+    const reply = this.requestReply(client, {
       sessionId: this.sessionId,
       ...this.welcomeVariant(),
       message,
     });
-    if (
-      questionReply &&
-      this.sessionVariant === sessionVariant &&
-      this.sessionOwnershipKey === sessionOwnershipKey
-    ) {
+    const replyEpoch = this.requestEpoch;
+    const outcome = await reply;
+    if (questionReply && this.requestEpoch === replyEpoch) {
       this.questionReplyUncertain = outcome !== "sent";
     }
     return outcome;

--- a/ui/src/pages/custodian/custodian-page.ts
+++ b/ui/src/pages/custodian/custodian-page.ts
@@ -55,6 +55,7 @@ export class CustodianPage extends OpenClawLightDomElement {
   @state() private input = "";
   @state() private sending = false;
   @state() private sensitive = false;
+  @state() private wizardInputPending = false;
   @state() private questionReplyUncertain = false;
   @state() private error: string | null = null;
   @state() private dismissedQuestions = new Set<string>();
@@ -186,8 +187,7 @@ export class CustodianPage extends OpenClawLightDomElement {
     this.answeredQuestions = retireCustodianQuestions(this.messages, this.answeredQuestions);
     this.retryParams = null;
     this.input = "";
-    this.sensitive = false;
-    this.questionReplyUncertain = false;
+    this.sensitive = this.wizardInputPending = this.questionReplyUncertain = false;
     this.error = null;
     this.earlierBoundaryAfterId = this.messages.at(-1)?.id ?? null;
     this.startSession(client, variant, false);
@@ -334,8 +334,7 @@ export class CustodianPage extends OpenClawLightDomElement {
     this.retryParams = null;
     this.error = null;
     this.input = "";
-    this.sensitive = false;
-    this.questionReplyUncertain = false;
+    this.sensitive = this.wizardInputPending = this.questionReplyUncertain = false;
     this.earlierBoundaryAfterId = null;
   }
 
@@ -436,6 +435,7 @@ export class CustodianPage extends OpenClawLightDomElement {
       }
       this.sessionId = result.sessionId;
       this.sensitive = result.sensitive === true;
+      this.wizardInputPending = result.wizardInputPending === true;
       this.retryParams = null;
       this.appendAssistant(result.reply, parseCustodianQuestion(result.question));
       if (result.action === "open-agent") {
@@ -576,6 +576,7 @@ export class CustodianPage extends OpenClawLightDomElement {
       this.messages,
       this.dismissedQuestions,
       this.answeredQuestions,
+      this.wizardInputPending,
       this.questionReplyUncertain,
     );
   }

--- a/ui/src/pages/custodian/custodian-page.ts
+++ b/ui/src/pages/custodian/custodian-page.ts
@@ -490,6 +490,7 @@ export class CustodianPage extends OpenClawLightDomElement {
     // meaningful whitespace and must reach the agent exactly as entered.
     const message = this.sensitive ? text : text.trim();
     const client = this.activeClient;
+    const questionState = [this.answeredQuestions, this.questionReplyUncertain] as const;
     if (questionReply) {
       // A failed wizard reply may have arrived, so block nudges until the session outcome is known.
       this.questionReplyUncertain = true;
@@ -500,7 +501,6 @@ export class CustodianPage extends OpenClawLightDomElement {
     const displayText = this.sensitive ? t("custodian.sensitiveReply") : (display ?? message);
     // A new operator turn supersedes any abandoned-turn unknown-outcome warning.
     this.abandonedTurnOutcomeUnknown = false;
-    const answeredQuestions = this.answeredQuestions;
     this.answeredQuestions = retireCustodianQuestions(this.messages, this.answeredQuestions);
     this.messages = [
       ...this.messages,
@@ -521,9 +521,9 @@ export class CustodianPage extends OpenClawLightDomElement {
     const replyEpoch = this.requestEpoch;
     const outcome = await reply;
     if (questionReply && this.requestEpoch === replyEpoch) {
-      this.questionReplyUncertain = outcome === "unknown";
+      this.questionReplyUncertain = eventNudgeState.questionUncertainty(questionState[1], outcome);
       if (outcome === "rejected") {
-        this.answeredQuestions = answeredQuestions;
+        this.answeredQuestions = questionState[0];
       }
     }
     return outcome;

--- a/ui/src/pages/custodian/custodian-question-card.ts
+++ b/ui/src/pages/custodian/custodian-question-card.ts
@@ -1,0 +1,28 @@
+import { html } from "lit";
+import "../../components/option-card.ts";
+import type { CustodianStructuredQuestion } from "./structured-question.ts";
+
+export function renderCustodianQuestionCard(params: {
+  question: CustodianStructuredQuestion;
+  disabled: boolean;
+  onSelect: (label: string) => void;
+  onSkip: () => void;
+}) {
+  return html`<div class="custodian__option-card">
+    <openclaw-option-card
+      .props=${{
+        header: params.question.header,
+        question: params.question.question,
+        options: params.question.options.map((option) => ({
+          value: option.label,
+          label: option.label,
+          description: option.description,
+          recommended: option.recommended,
+        })),
+        disabled: params.disabled,
+        onSelect: params.onSelect,
+        onSkip: params.onSkip,
+      }}
+    ></openclaw-option-card>
+  </div>`;
+}

--- a/ui/src/pages/custodian/event-nudge.ts
+++ b/ui/src/pages/custodian/event-nudge.ts
@@ -32,6 +32,19 @@ export function questionUncertainty(previous: boolean, outcome: CustodianSendOut
   return outcome === "unknown" ? true : previous;
 }
 
+export function shouldConsumeNudge(
+  current: CustodianEventNudge | null,
+  finished: CustodianEventNudge,
+  outcome: CustodianSendOutcome,
+): boolean {
+  return (
+    outcome !== "rejected" &&
+    current !== null &&
+    current.severity === finished.severity &&
+    current.message === finished.message
+  );
+}
+
 export function reconcileCustodianEventNudge(
   current: CustodianEventNudge | null,
   pending: CustodianEventNudge | null,
@@ -44,9 +57,7 @@ export function reconcileCustodianEventNudge(
   if (!pending) {
     return [next, null];
   }
-  const sameIncident =
-    next !== null && pending.severity === next.severity && pending.message === next.message;
-  return sameIncident ? [current, pending] : [next, null];
+  return [next, pending];
 }
 
 function eventNudgeText(nudge: CustodianEventNudge): string {

--- a/ui/src/pages/custodian/event-nudge.ts
+++ b/ui/src/pages/custodian/event-nudge.ts
@@ -1,4 +1,5 @@
 import type { GatewayEventFrame } from "../../api/gateway.ts";
+import { t } from "../../i18n/index.ts";
 
 export type CustodianEventNudge = {
   severity: 1 | 2 | 3;
@@ -6,6 +7,37 @@ export type CustodianEventNudge = {
   channelLabel?: string;
   message: string;
 };
+
+export function reconcileCustodianEventNudge(
+  current: CustodianEventNudge | null,
+  pending: CustodianEventNudge | null,
+  event: Pick<GatewayEventFrame, "event" | "payload">,
+): [CustodianEventNudge | null, CustodianEventNudge | null] {
+  if (event.event !== "health") {
+    return [current, pending];
+  }
+  const next = classifyCustodianEventNudge(event);
+  if (!pending) {
+    return [next, null];
+  }
+  const sameIncident =
+    next !== null && pending.severity === next.severity && pending.message === next.message;
+  return sameIncident ? [current, pending] : [next, null];
+}
+
+export function eventNudgeText(nudge: CustodianEventNudge): string {
+  if (nudge.kind === "config-reload") {
+    return t("custodian.nudge.configReload");
+  }
+  const channel = nudge.channelLabel ?? t("custodian.nudge.channelFallback");
+  if (nudge.kind === "channel-auth") {
+    return t("custodian.nudge.channelAuth", { channel });
+  }
+  if (nudge.kind === "channel-disconnected") {
+    return t("custodian.nudge.channelDisconnected", { channel });
+  }
+  return t("custodian.nudge.channelDegraded", { channel });
+}
 
 type UnknownRecord = Record<string, unknown>;
 
@@ -164,7 +196,7 @@ function classifyHealth(payload: unknown): CustodianEventNudge | null {
 }
 
 /** Only Gateway health failures produce presence nudges; success/info events stay silent. */
-export function classifyCustodianEventNudge(
+function classifyCustodianEventNudge(
   event: Pick<GatewayEventFrame, "event" | "payload">,
 ): CustodianEventNudge | null {
   return event.event === "health" ? classifyHealth(event.payload) : null;

--- a/ui/src/pages/custodian/event-nudge.ts
+++ b/ui/src/pages/custodian/event-nudge.ts
@@ -1,5 +1,5 @@
 import { html } from "lit";
-import type { GatewayEventFrame } from "../../api/gateway.ts";
+import { GatewayRequestError, type GatewayEventFrame } from "../../api/gateway.ts";
 import { t } from "../../i18n/index.ts";
 
 export type CustodianEventNudge = {
@@ -8,6 +8,22 @@ export type CustodianEventNudge = {
   channelLabel?: string;
   message: string;
 };
+
+export type CustodianSendDelivery = "unsent" | "sent" | "received";
+export type CustodianSendOutcome = "sent" | "rejected" | "unknown";
+
+export function classifyCustodianSendFailure(
+  error: unknown,
+  delivery: CustodianSendDelivery,
+): CustodianSendOutcome {
+  if (delivery === "received") {
+    return "sent";
+  }
+  if (error instanceof GatewayRequestError || delivery === "unsent") {
+    return "rejected";
+  }
+  return "unknown";
+}
 
 export function reconcileCustodianEventNudge(
   current: CustodianEventNudge | null,

--- a/ui/src/pages/custodian/event-nudge.ts
+++ b/ui/src/pages/custodian/event-nudge.ts
@@ -25,6 +25,13 @@ export function classifyCustodianSendFailure(
   return "unknown";
 }
 
+export function questionUncertainty(previous: boolean, outcome: CustodianSendOutcome): boolean {
+  if (outcome === "sent") {
+    return false;
+  }
+  return outcome === "unknown" ? true : previous;
+}
+
 export function reconcileCustodianEventNudge(
   current: CustodianEventNudge | null,
   pending: CustodianEventNudge | null,

--- a/ui/src/pages/custodian/event-nudge.ts
+++ b/ui/src/pages/custodian/event-nudge.ts
@@ -49,7 +49,7 @@ export function reconcileCustodianEventNudge(
   return sameIncident ? [current, pending] : [next, null];
 }
 
-export function eventNudgeText(nudge: CustodianEventNudge): string {
+function eventNudgeText(nudge: CustodianEventNudge): string {
   if (nudge.kind === "config-reload") {
     return t("custodian.nudge.configReload");
   }

--- a/ui/src/pages/custodian/event-nudge.ts
+++ b/ui/src/pages/custodian/event-nudge.ts
@@ -1,3 +1,4 @@
+import { html } from "lit";
 import type { GatewayEventFrame } from "../../api/gateway.ts";
 import { t } from "../../i18n/index.ts";
 
@@ -37,6 +38,32 @@ export function eventNudgeText(nudge: CustodianEventNudge): string {
     return t("custodian.nudge.channelDisconnected", { channel });
   }
   return t("custodian.nudge.channelDegraded", { channel });
+}
+
+export function renderCustodianEventNudge(params: {
+  nudge: CustodianEventNudge;
+  disabled: boolean;
+  onSend: () => void;
+  onDismiss: () => void;
+}) {
+  return html`<div class="custodian__nudge" role="status">
+    <button
+      class="custodian__nudge-action"
+      type="button"
+      ?disabled=${params.disabled}
+      @click=${params.onSend}
+    >
+      ${eventNudgeText(params.nudge)}
+    </button>
+    <button
+      class="custodian__nudge-dismiss"
+      type="button"
+      aria-label=${t("custodian.nudge.dismiss")}
+      @click=${params.onDismiss}
+    >
+      ×
+    </button>
+  </div>`;
 }
 
 type UnknownRecord = Record<string, unknown>;

--- a/ui/src/pages/custodian/transcript.ts
+++ b/ui/src/pages/custodian/transcript.ts
@@ -19,6 +19,23 @@ export type CustodianMessage = {
   question: CustodianStructuredQuestion | null;
 };
 
+export function hasUnresolvedCustodianQuestion(
+  messages: readonly CustodianMessage[],
+  dismissedQuestions: ReadonlySet<string>,
+  answeredQuestions: ReadonlySet<string>,
+  replyUncertain: boolean,
+): boolean {
+  return (
+    replyUncertain ||
+    messages.some(
+      (message) =>
+        message.question !== null &&
+        !dismissedQuestions.has(`${message.id}:${message.question.id}`) &&
+        !answeredQuestions.has(`${message.id}:${message.question.id}`),
+    )
+  );
+}
+
 export function createCustodianSessionId(): string {
   if (typeof crypto.randomUUID === "function") {
     return `control-ui-onboarding-${crypto.randomUUID()}`;

--- a/ui/src/pages/custodian/transcript.ts
+++ b/ui/src/pages/custodian/transcript.ts
@@ -23,9 +23,11 @@ export function hasUnresolvedCustodianQuestion(
   messages: readonly CustodianMessage[],
   dismissedQuestions: ReadonlySet<string>,
   answeredQuestions: ReadonlySet<string>,
+  wizardInputPending: boolean,
   replyUncertain: boolean,
 ): boolean {
   return (
+    wizardInputPending ||
     replyUncertain ||
     messages.some(
       (message) =>

--- a/ui/src/pages/custodian/transcript.ts
+++ b/ui/src/pages/custodian/transcript.ts
@@ -36,6 +36,19 @@ export function hasUnresolvedCustodianQuestion(
   );
 }
 
+export function retireCustodianQuestions(
+  messages: readonly CustodianMessage[],
+  answeredQuestions: ReadonlySet<string>,
+): Set<string> {
+  const answered = new Set(answeredQuestions);
+  for (const message of messages) {
+    if (message.question) {
+      answered.add(`${message.id}:${message.question.id}`);
+    }
+  }
+  return answered;
+}
+
 export function createCustodianSessionId(): string {
   if (typeof crypto.randomUUID === "function") {
     return `control-ui-onboarding-${crypto.randomUUID()}`;


### PR DESCRIPTION
## What Problem This Solves

Fixes issues where Custodian users could accidentally submit a canned diagnostic nudge as the answer to any hosted-wizard prompt, lose all later nudges after a rejected request, keep seeing a stale incident after health recovered, or have a card's Skip action rejected by a closed wizard step and repeated.

Before this change:

1. Open a sensitive hosted-wizard prompt, then click an existing health nudge. The nudge text is masked and sent as the prompt's credential value.
2. Open a non-card hosted-wizard text, multiselect, or large-select step, then click a nudge. The diagnostic text is consumed as that step's answer.
3. Reject a nudge request. The visit is marked as having consumed its nudge even though nothing was dispatched.
4. Publish a healthy snapshot, or a newer equal-severity incident. A stale nudge remains visible.
5. Click Skip for a closed hosted-wizard select question. The UI label is submitted as an unparseable answer and the mandatory question repeats.

## Why This Change Was Made

The hosted-wizard owner now reports an explicit `wizardInputPending` response fact for every step that will consume the next message. The gateway carries that additive protocol field to Custodian, which disables event nudges throughout the full wizard-awaiting state instead of inferring safety from sensitive input or rendered cards.

Custodian also keeps event-nudge delivery separate from wizard answers: nudges are consumed only after successful dispatch and reconciled against the latest authoritative health snapshot without overwriting newer state during an in-flight request. Closed wizard questions submit the bridge's accepted `cancel` token while retaining the user-facing Skip label in the transcript.

## User Impact

Custodian nudges can no longer become credentials, structured-card answers, or non-card hosted-wizard answers. Definitely rejected nudge and wizard sends remain retryable, ambiguous deliveries stay guarded under the existing no-replay contract, recovered or superseded incidents update immediately, and Skip now advances closed hosted-wizard questions instead of repeating them.

## Evidence

- Fail-before regression coverage reproduced the sensitive and non-card nudge dispatches, permanent consumption after rejection, stale health state, and unparseable Skip payload.
- `node scripts/run-vitest.mjs ui/src/pages/custodian` passes all 58 tests across 6 files. `src/system-agent/chat-engine.test.ts` passes 64/64, including a non-sensitive non-card text step with no structured question but `wizardInputPending: true`; `src/gateway/server-methods/system-agent.test.ts` passes 29/29 and proves the gateway response carries the pending-input fact. The Gateway client request-hook suite passes 19/19.
- Exact head `9aae05ce60e` passes a real Chromium/Vite Control UI run against the deterministic Gateway transport: 4/4 scenarios, including no request from sensitive or closed-question nudges and the exact `cancel` payload. Redacted terminal result: `Test Files 1 passed (1)`, `Tests 4 passed (4)`, `blacksmith run summary ... exit=0`. The Testbox provisioning action is visible at https://github.com/openclaw/openclaw/actions/runs/29698034254.
- Earlier in this branch, I also ran the existing Chrome profile against an isolated real Gateway and real Discord channel runtime. The channel failed authentication with HTTP 401 as intended, and Custodian rendered `Discord is degraded — ask me what happened`. The requested live hosted-wizard interaction could not proceed because current main rejected `openclaw.chat` before wizard startup with `OpenClaw requires working inference: prepared model runtime owner was not committed after replacement for [isolated-state]/agents/main/agent`. A bounded Claude CLI fallback was unavailable because its global launcher lacks the native binary. I am therefore explicitly skipping only ClawSweeper's non-mock hosted-wizard proof move: the complete wizard-awaiting contract and its non-card path are now covered at the engine, gateway, and UI boundaries, while repairing that unrelated runtime/toolchain blocker is outside this fix.
- Blacksmith Testbox `tbx_01kxxrr49tr7hz2zw3gc3zypvc` passed `pnpm tsgo`, `pnpm check:test-types`, `pnpm deadcode:exports`, `pnpm protocol:check`, and the 4-scenario Chromium test on the exact final head.
- Targeted oxlint, formatting, and `git diff --check` pass on the final tree.
- Fresh whole-branch autoreview against `origin/main` reported no actionable findings at 0.89 confidence after the full hosted-wizard input state and generated client model were carried through the protocol boundary.
- This PR is AI-assisted. I reviewed the complete implementation, wizard answer contract, and regression tests.
