### PR TITLE
fix(system-agent): keep model changes on the verified route

### DIFF
--- a/src/system-agent/agent-turn.ts
+++ b/src/system-agent/agent-turn.ts
@@ -57,7 +57,7 @@ export type SystemAgentTurnRunner = (params: {
 export type SystemAgentSession = {
   sessionId: string;
   /** Exact live-tested inference owner for this ephemeral conversation. */
-  readonly verifiedInference: SystemAgentVerifiedInferenceBinding;
+  verifiedInference: SystemAgentVerifiedInferenceBinding;
   /** Host-owned pending-proposal fingerprint; see system-agent-tool.ts. */
   proposalRef: { current?: string; operation?: SystemAgentOperation };
   /** Native CLI continuity, bound to the exact configured model/auth owner route. */

--- a/src/system-agent/chat-engine.test.ts
+++ b/src/system-agent/chat-engine.test.ts
@@ -1843,6 +1843,60 @@ describe("SystemAgentChatEngine", () => {
     expect(engine.hasPendingProposal()).toBe(true);
   });
 
+  it("rebinds the live conversation after changing its default model", async () => {
+    useTempStateDir();
+    const baseConfig = structuredClone(sharedVerifiedInferenceConfig);
+    const changedConfig = {
+      ...baseConfig,
+      agents: {
+        ...baseConfig.agents,
+        list: baseConfig.agents.list.map((agent) => ({ ...agent, model: "openai/gpt-5.6-sol" })),
+      },
+    } satisfies OpenClawConfig;
+    const verifiedInference = await createAmbientVerifiedBinding(baseConfig);
+    const reboundInference = await createAmbientVerifiedBinding(changedConfig);
+    let currentConfig: OpenClawConfig = baseConfig;
+    const executeOperation = vi.fn(async (_operation, runtime, options) => {
+      currentConfig = changedConfig;
+      options.onVerifiedInferenceChanged?.(reboundInference);
+      runtime.log("Default model: openai/gpt-5.6-sol");
+      return { applied: true };
+    });
+    const runAgentTurn = vi.fn(async (params) => {
+      if (currentConfig === baseConfig) {
+        return null;
+      }
+      return { text: `using ${params.session.verifiedInference.execution.modelLabel}` };
+    });
+    const engine = new SystemAgentChatEngine({
+      yes: true,
+      verifiedInference,
+      executeOperation,
+      runAgentTurn,
+      planWithAssistant: async () => ({
+        reply: "Switching models.",
+        command: "set default model openai/gpt-5.6-sol",
+        modelLabel: "openai/gpt-5.5",
+      }),
+      deps: {
+        readConfigFileSnapshot: vi.fn(async () => configSnapshot(currentConfig)) as never,
+        loadOverview: fakeOverviewLoader({ defaultModel: "openai/gpt-5.5" }),
+      },
+    });
+
+    const changed = await engine.handle("switch models");
+    const next = await engine.handle("which model is active now?");
+
+    expect(changed.text).toContain("Default model: openai/gpt-5.6-sol");
+    expect(next.text).toBe("using openai/gpt-5.6-sol");
+    expect(executeOperation).toHaveBeenCalledOnce();
+    expect(runAgentTurn).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        session: expect.objectContaining({ verifiedInference: reboundInference }),
+      }),
+    );
+  });
+
   it("keeps a pending proposal when the user asks a question instead of yes/no", async () => {
     const planner = vi.fn(async (_params: { input: string; pendingOperation?: string }) => ({
       reply: "A workspace is where your agent keeps its files.",

--- a/src/system-agent/chat-engine.ts
+++ b/src/system-agent/chat-engine.ts
@@ -61,6 +61,8 @@ export type SystemAgentChatEngineOptions = {
   runAgentTurn?: SystemAgentTurnRunner;
   /** Test seam for the approval-intent classifier. */
   classifyApproval?: SystemAgentApprovalClassifier;
+  /** Test seam for the audited host operation executor. */
+  executeOperation?: typeof executeSystemAgentOperation;
   /** Where side effects run; the gateway surface never manages its own daemon. */
   surface?: "cli" | "gateway";
   /** Test seam for the channel-setup wizard hosted by the chat bridge. */
@@ -369,7 +371,7 @@ export class SystemAgentChatEngine {
   private hostProposalResolution: "approved" | "declined" | undefined;
   private readonly history: SystemAgentAssistantTurn[] = [];
   private readonly agentSession: SystemAgentSession;
-  private readonly verifiedInference: SystemAgentVerifiedInferenceBinding;
+  private verifiedInference: SystemAgentVerifiedInferenceBinding;
   /** Turns run strictly one at a time; interleaved handles corrupt wizard/pending state. */
   private turnQueue: Promise<unknown> = Promise.resolve();
 
@@ -609,7 +611,8 @@ export class SystemAgentChatEngine {
     const capture = createCaptureRuntime();
     let result: SystemAgentOperationResult | undefined;
     try {
-      result = await executeSystemAgentOperation(operation, capture, {
+      const executeOperation = this.opts.executeOperation ?? executeSystemAgentOperation;
+      result = await executeOperation(operation, capture, {
         approved: true,
         deps: this.commandDeps(),
         // The model turn, approval classifier, and operation preflight all
@@ -617,6 +620,7 @@ export class SystemAgentChatEngine {
         beforePersistentApply: async () => {
           await this.requirePersistentApplyInference(capture);
         },
+        onVerifiedInferenceChanged: (binding) => this.rebindVerifiedInference(binding),
       });
     } catch (error) {
       if (isSystemAgentInferenceUnavailableError(error)) {
@@ -933,12 +937,14 @@ export class SystemAgentChatEngine {
 
     let result: SystemAgentOperationResult | undefined;
     try {
-      result = await executeSystemAgentOperation(operation, capture, {
+      const executeOperation = this.opts.executeOperation ?? executeSystemAgentOperation;
+      result = await executeOperation(operation, capture, {
         approved: this.opts.yes === true || !isPersistentSystemAgentOperation(operation),
         deps: this.commandDeps(),
         beforePersistentApply: async () => {
           await this.requirePersistentApplyInference(capture);
         },
+        onVerifiedInferenceChanged: (binding) => this.rebindVerifiedInference(binding),
       });
     } catch (error) {
       if (isSystemAgentInferenceUnavailableError(error)) {
@@ -964,12 +970,8 @@ export class SystemAgentChatEngine {
   }
 
   private async requireVerifiedInference() {
-    const binding = this.opts?.verifiedInference;
-    if (
-      !binding ||
-      binding !== this.verifiedInference ||
-      this.agentSession.verifiedInference !== this.verifiedInference
-    ) {
+    const binding = this.verifiedInference;
+    if (this.agentSession.verifiedInference !== binding) {
       return this.throwInferenceUnavailable();
     }
     try {
@@ -984,12 +986,8 @@ export class SystemAgentChatEngine {
   }
 
   private async requirePersistentApplyInference(runtime: RuntimeEnv) {
-    const binding = this.opts?.verifiedInference;
-    if (
-      !binding ||
-      binding !== this.verifiedInference ||
-      this.agentSession.verifiedInference !== this.verifiedInference
-    ) {
+    const binding = this.verifiedInference;
+    if (this.agentSession.verifiedInference !== binding) {
       return this.throwInferenceUnavailable();
     }
     try {
@@ -1009,6 +1007,17 @@ export class SystemAgentChatEngine {
       return this.throwInferenceUnavailable([error], false);
     }
     return this.throwInferenceUnavailable([], false);
+  }
+
+  private rebindVerifiedInference(binding: SystemAgentVerifiedInferenceBinding): void {
+    if (binding.execution.agentId !== this.verifiedInference.execution.agentId) {
+      return;
+    }
+    // Native CLI continuity is route-owned. Keep the conversation transcript,
+    // but force the next turn to establish a session for the new verified route.
+    delete this.agentSession.cliSession;
+    this.verifiedInference = binding;
+    this.agentSession.verifiedInference = binding;
   }
 
   private throwInferenceUnavailable(failures: readonly unknown[] = [], cancelWizard = true): never {

--- a/src/system-agent/operations-execution-helpers.ts
+++ b/src/system-agent/operations-execution-helpers.ts
@@ -1,4 +1,5 @@
 // Shared execution helpers keep the public dispatcher small and reviewable.
+import type { AgentExecutionAuthBinding } from "../agents/execution-auth-binding.js";
 import type { ConfigSetOptions } from "../cli/config-set-input.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { isSensitiveConfigPath } from "../config/sensitive-paths.js";
@@ -26,6 +27,7 @@ import type {
 import { formatSystemAgentPersistentPlan } from "./operations-parse.js";
 import type { SystemAgentOverview } from "./overview.js";
 import { validateSystemAgentPluginInstallSpec } from "./plugin-install.js";
+import type { SystemAgentVerifiedInferenceBinding } from "./verified-inference.js";
 
 type ConfigModule = typeof import("../config/config.js");
 type ConfigFileSnapshot = Awaited<ReturnType<ConfigModule["readConfigFileSnapshot"]>>;
@@ -219,6 +221,8 @@ export type ExecuteOptions = {
    * immediately followed by the persistent effect it authorizes.
    */
   beforePersistentApply?: () => Promise<void>;
+  /** Adopt the exact final binding after a verified model-route write commits. */
+  onVerifiedInferenceChanged?: (binding: SystemAgentVerifiedInferenceBinding) => void;
 };
 
 /**
@@ -568,6 +572,7 @@ export async function executeSetDefaultModel(
         );
       }
       let persistedVerification = initialVerification;
+      let persistedBinding: SystemAgentVerifiedInferenceBinding | undefined;
       let selectedRouteForCommit = verifiedRoute;
       const selectModel = await createSystemAgentModelSelectionUpdater({
         model: operation.model,
@@ -585,11 +590,22 @@ export async function executeSetDefaultModel(
               );
             }
             await opts.beforePersistentApply?.();
+            let latestBinding: SystemAgentVerifiedInferenceBinding | undefined;
             const latestVerification = await verifyInferenceConfig({
               config: sourceConfig,
               runtime: ctx.runtime,
               requireExecutionOwner: true,
               ...(targetAgentId ? { agentId: targetAgentId } : {}),
+              ...(opts.onVerifiedInferenceChanged
+                ? {
+                    onVerifiedExecution: (
+                      _auth: AgentExecutionAuthBinding,
+                      binding: SystemAgentVerifiedInferenceBinding,
+                    ) => {
+                      latestBinding = binding;
+                    },
+                  }
+                : {}),
             });
             if (!latestVerification.ok) {
               throw new Error(
@@ -601,10 +617,16 @@ export async function executeSetDefaultModel(
                 "The final live inference test did not verify the exact model route at the config commit boundary, so the requested model was not saved. Review model aliases and runtime routing, then retry.",
               );
             }
+            if (opts.onVerifiedInferenceChanged && !latestBinding) {
+              throw new Error(
+                "The final live inference test did not return a reusable session binding, so the requested model was not saved. Retry the model change.",
+              );
+            }
             // The live probe can outlive the original OpenClaw authority.
             // Re-check it last, immediately before the writer crosses to disk.
             await opts.beforePersistentApply?.();
             persistedVerification = latestVerification;
+            persistedBinding = latestBinding;
           },
         },
         mutate: async (cfg) => {
@@ -630,6 +652,9 @@ export async function executeSetDefaultModel(
           cfg.agents = selected.agents;
         },
       });
+      if (persistedBinding) {
+        opts.onVerifiedInferenceChanged?.(persistedBinding);
+      }
       ctx.runtime.log(`Updated ${result.path}`);
       ctx.runtime.log(
         targetAgentId

--- a/src/system-agent/operations.setup.test.ts
+++ b/src/system-agent/operations.setup.test.ts
@@ -7,7 +7,11 @@ import { resetPluginStateStoreForTests } from "../plugin-state/plugin-state-stor
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { listSystemAgentAuditEntriesForTests } from "./audit.test-support.js";
 import { SystemAgentInferenceUnavailableError } from "./inference-error.js";
-import { executeSystemAgentOperation, isPersistentSystemAgentOperation } from "./operations.js";
+import {
+  executeSystemAgentOperation,
+  isPersistentSystemAgentOperation,
+  type SystemAgentCommandDeps,
+} from "./operations.js";
 import { createSystemAgentTestRuntime } from "./system-agent.test-helpers.js";
 
 type TestConfig = Record<string, unknown>;
@@ -450,8 +454,14 @@ describe("parseSystemAgentOperation", () => {
     });
     mockConfig.mutateConfigFile.mockClear();
     const { runtime, lines } = createSystemAgentTestRuntime();
+    const reboundBinding = { execution: { agentId: "main" } } as never;
+    const onVerifiedInferenceChanged = vi.fn();
     let verificationCalls = 0;
-    const verifyInferenceConfig = vi.fn(async ({ config }: { config: TestConfig }) => {
+    type VerifyInferenceParams = Parameters<
+      NonNullable<SystemAgentCommandDeps["verifyInferenceConfig"]>
+    >[0];
+    const verifyInferenceConfig = vi.fn(async (params: VerifyInferenceParams) => {
+      const { config, onVerifiedExecution } = params;
       verificationCalls += 1;
       const stagedDefaults = requireRecord(
         requireRecord(config.agents, "agents").defaults,
@@ -502,6 +512,8 @@ describe("parseSystemAgentOperation", () => {
           },
           channels: { telegram: { enabled: true } },
         });
+      } else {
+        onVerifiedExecution?.({} as never, reboundBinding);
       }
       return { ok: true as const, modelRef: "openai/gpt-5.5", latencyMs: 17 };
     });
@@ -509,7 +521,7 @@ describe("parseSystemAgentOperation", () => {
     const result = await executeSystemAgentOperation(
       { kind: "set-default-model", model: "openai/gpt-5.5" },
       runtime,
-      { approved: true, deps: { verifyInferenceConfig } },
+      { approved: true, deps: { verifyInferenceConfig }, onVerifiedInferenceChanged },
     );
 
     expect(result).toEqual({ applied: true });
@@ -520,8 +532,13 @@ describe("parseSystemAgentOperation", () => {
     );
     expect(verifyInferenceConfig).toHaveBeenNthCalledWith(
       2,
-      expect.objectContaining({ requireExecutionOwner: true }),
+      expect.objectContaining({
+        requireExecutionOwner: true,
+        onVerifiedExecution: expect.any(Function),
+      }),
     );
+    expect(onVerifiedInferenceChanged).toHaveBeenCalledOnce();
+    expect(onVerifiedInferenceChanged).toHaveBeenCalledWith(reboundBinding);
     expect(mockConfig.mutateConfigFile).toHaveBeenCalledOnce();
     expect(mockConfig.mutateConfigFile).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/system-agent/tui-backend.test.ts
+++ b/src/system-agent/tui-backend.test.ts
@@ -237,6 +237,36 @@ describe("runSystemAgentTui", () => {
     );
   });
 
+  it("reports that /model cannot replace the active verified inference route", async () => {
+    const verified = await createVerifiedTuiOptions({ loadOverview: async () => overview });
+
+    await runSystemAgentTui(
+      {
+        ...verified,
+        runTui: async (opts) => {
+          const backend = opts.backend as unknown as {
+            patchSession: (opts: { key: string; model: string }) => Promise<unknown>;
+            listSessions: () => Promise<{
+              sessions: Array<{ model?: string; modelProvider?: string }>;
+            }>;
+          };
+
+          await expect(
+            backend.patchSession({
+              key: "agent:openclaw:main",
+              model: "anthropic/claude-opus-4-8",
+            }),
+          ).rejects.toThrow("cannot change the model inside its active verified session");
+          await expect(backend.listSessions()).resolves.toMatchObject({
+            sessions: [{ model: "gpt-5.5", modelProvider: "openai" }],
+          });
+          return { exitReason: "exit" };
+        },
+      },
+      createRuntime(),
+    );
+  });
+
   it("isolates event consumer failures during sendChat", async () => {
     const verified = await createVerifiedTuiOptions({ loadOverview: async () => overview });
     const backendWithEngine = await new Promise<{

--- a/src/system-agent/tui-backend.ts
+++ b/src/system-agent/tui-backend.ts
@@ -227,7 +227,11 @@ class SystemAgentTuiBackend implements TuiBackend {
   }
 
   async patchSession(opts: SessionsPatchParams): Promise<SessionsPatchResult> {
-    const model = splitModelRef(typeof opts.model === "string" ? opts.model : undefined);
+    if (opts.model !== undefined) {
+      throw new Error(
+        "OpenClaw cannot change the model inside its active verified session. Exit and run `openclaw onboard`, then start OpenClaw again.",
+      );
+    }
     return {
       ok: true,
       path: "openclaw",
@@ -236,13 +240,8 @@ class SystemAgentTuiBackend implements TuiBackend {
         sessionId: "openclaw",
         displayName: "OpenClaw",
         updatedAt: Date.now(),
-        ...(model.model ? { model: model.model } : {}),
-        ...(model.provider ? { modelProvider: model.provider } : {}),
       },
-      resolved: {
-        modelProvider: model.provider,
-        model: model.model,
-      },
+      resolved: {},
     };
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes two model-change failures in the OpenClaw system-agent conversation:

- Running `/model provider/model` in the TUI reported success even though the active verified route and subsequent replies stayed on the original model.
- Applying `set-default-model` successfully changed configuration but left the conversation bound to the old route, so the next message failed the owner check and retired the session.

## Why This Change Was Made

The TUI backend now rejects unsupported session-local model replacement with an honest recovery message. Persisted default-model changes capture the exact binding from the final live verification and, only after the config write commits, adopt that binding in the active chat engine. Native CLI continuity is cleared because it belongs to the old route; the conversation transcript remains intact.

## User Impact

Users no longer see a false “model set” result. A successful default-model change keeps the current OpenClaw conversation alive and routes its next turn through the newly verified model.

## Evidence

Before:

- The TUI regression expected `patchSession` to reject but received a successful response containing the requested, inactive model.
- The chat regression timed out because the real executor retained the original immutable binding; the next-turn path could not use the new verified route.

After:

- `node scripts/run-vitest.mjs src/system-agent/chat-engine.test.ts` — 63 passed
- `node scripts/run-vitest.mjs src/system-agent/tui-backend.test.ts` — 9 passed
- `node scripts/run-vitest.mjs src/system-agent/operations.setup.test.ts` — 27 passed
- `pnpm tsgo` — passed on Blacksmith Testbox
- `pnpm check:test-types` — passed on Blacksmith Testbox
- `pnpm deadcode:exports` — passed with 0 entries on Blacksmith Testbox
- `node scripts/run-oxlint.mjs` on all touched files — passed
- `git diff --check` — passed
- Fresh branch autoreview against `origin/main` — no actionable findings

AI-assisted: yes. I reviewed the implementation and tests and understand the binding handoff and route-ownership behavior.
