### PR TITLE
fix(cli): exit cleanly on subcommand-group --help (lazy register handle leak)

### DIFF
--- a/src/cli/help-exit.process.test.ts
+++ b/src/cli/help-exit.process.test.ts
@@ -10,24 +10,34 @@ import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 const execFileAsync = promisify(execFile);
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const CHILD_PROCESS_TIMEOUT_MS = 30_000;
+const LAZY_GROUP_HELP_CASES = [
+  { group: "backup", usageCommand: "backup" },
+  { group: "capability", usageCommand: "infer|capability" },
+  { group: "channels", usageCommand: "channels" },
+  { group: "clawbot", usageCommand: "clawbot" },
+  { group: "daemon", usageCommand: "daemon" },
+  { group: "hooks", usageCommand: "hooks" },
+  { group: "infer", usageCommand: "infer|capability" },
+  { group: "migrate", usageCommand: "migrate" },
+  { group: "node", usageCommand: "node" },
+  { group: "security", usageCommand: "security" },
+  { group: "update", usageCommand: "update" },
+] as const;
 
-describe("CLI help process exit", () => {
-  it.each([
-    { args: ["--help"], usage: "Usage: openclaw [options] [command]" },
-    { args: ["path", "--help"], usage: "Usage: openclaw path [options] [command]" },
-  ])("exits promptly after $args", async ({ args, usage }) => {
-    const root = tempDirs.make("openclaw-help-exit-");
-    const stateDir = path.join(root, "state");
-    const configPath = path.join(stateDir, "openclaw.json");
-    const tlsImportGuardPath = path.join(root, "forbid-tls-import.mjs");
-    await fs.mkdir(stateDir, { recursive: true });
-    await fs.writeFile(
-      configPath,
-      JSON.stringify({ plugins: { entries: { "oc-path": { enabled: true } } } }),
-    );
-    await fs.writeFile(
-      tlsImportGuardPath,
-      `import { registerHooks } from "node:module";
+async function createHelpProcessFixture() {
+  const root = tempDirs.make("openclaw-help-exit-");
+  const stateDir = path.join(root, "state");
+  const configPath = path.join(stateDir, "openclaw.json");
+  const tlsImportGuardPath = path.join(root, "forbid-tls-import.mjs");
+  const keepAlivePath = path.join(root, "keep-alive.mjs");
+  await fs.mkdir(stateDir, { recursive: true });
+  await fs.writeFile(
+    configPath,
+    JSON.stringify({ plugins: { entries: { "oc-path": { enabled: true } } } }),
+  );
+  await fs.writeFile(
+    tlsImportGuardPath,
+    `import { registerHooks } from "node:module";
 registerHooks({
   resolve(specifier, context, nextResolve) {
     if (specifier === "node:tls" || specifier === "tls") {
@@ -37,38 +47,65 @@ registerHooks({
   },
 });
 `,
-    );
+  );
+  await fs.writeFile(keepAlivePath, "setInterval(() => {}, 60_000);\n");
+  return { root, stateDir, configPath, tlsImportGuardPath, keepAlivePath };
+}
 
-    const result = await execFileAsync(
-      process.execPath,
-      [
-        "--import",
-        pathToFileURL(tlsImportGuardPath).href,
-        "--import",
-        "tsx",
-        "src/entry.ts",
-        ...args,
-      ],
-      {
-        cwd: path.resolve("."),
-        encoding: "utf8",
-        env: {
-          ...process.env,
-          HOME: root,
-          NODE_ENV: undefined,
-          NODE_OPTIONS: undefined,
-          NODE_USE_SYSTEM_CA: "1",
-          OPENCLAW_CONFIG_PATH: configPath,
-          OPENCLAW_NO_RESPAWN: "1",
-          OPENCLAW_STATE_DIR: stateDir,
-          VITEST: undefined,
-        },
-        killSignal: "SIGKILL",
-        timeout: CHILD_PROCESS_TIMEOUT_MS,
+async function runHelpProcess(params: {
+  args: string[];
+  forbidTlsImport?: boolean;
+  keepAlive?: boolean;
+}) {
+  const fixture = await createHelpProcessFixture();
+  return await execFileAsync(
+    process.execPath,
+    [
+      ...(params.forbidTlsImport
+        ? ["--import", pathToFileURL(fixture.tlsImportGuardPath).href]
+        : []),
+      ...(params.keepAlive ? ["--import", pathToFileURL(fixture.keepAlivePath).href] : []),
+      "--import",
+      "tsx",
+      "src/entry.ts",
+      ...params.args,
+    ],
+    {
+      cwd: path.resolve("."),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        HOME: fixture.root,
+        NODE_ENV: undefined,
+        NODE_OPTIONS: undefined,
+        NODE_USE_SYSTEM_CA: "1",
+        OPENCLAW_CONFIG_PATH: fixture.configPath,
+        OPENCLAW_NO_RESPAWN: "1",
+        OPENCLAW_STATE_DIR: fixture.stateDir,
+        VITEST: undefined,
       },
-    );
+      killSignal: "SIGKILL",
+      timeout: CHILD_PROCESS_TIMEOUT_MS,
+    },
+  );
+}
+
+describe("CLI help process exit", () => {
+  it.each([
+    { args: ["--help"], usage: "Usage: openclaw [options] [command]" },
+    { args: ["path", "--help"], usage: "Usage: openclaw path [options] [command]" },
+  ])("exits promptly after $args", async ({ args, usage }) => {
+    const result = await runHelpProcess({ args, forbidTlsImport: true });
 
     expect(result.stderr).toBe("");
     expect(result.stdout).toContain(usage);
+  });
+
+  it.each(LAZY_GROUP_HELP_CASES)("exits promptly after $group --help", async (testCase) => {
+    const { group, usageCommand } = testCase;
+    const result = await runHelpProcess({ args: [group, "--help"], keepAlive: true });
+
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain(`Usage: openclaw ${usageCommand} [options] [command]`);
   });
 });

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -133,6 +133,7 @@ const startProxyMock = vi.hoisted(() =>
 );
 const stopProxyMock = vi.hoisted(() => vi.fn<(handle: unknown) => Promise<void>>(async () => {}));
 const flushExitAfterOneShotOutputMock = vi.hoisted(() => vi.fn());
+const requestExitAfterOneShotOutputMock = vi.hoisted(() => vi.fn());
 const maybeRunCliInContainerMock = vi.hoisted(() =>
   vi.fn<
     (argv: string[]) => { handled: true; exitCode: number } | { handled: false; argv: string[] }
@@ -208,6 +209,7 @@ vi.mock("./dotenv.js", () => ({
 
 vi.mock("./one-shot-exit.js", () => ({
   flushExitAfterOneShotOutput: flushExitAfterOneShotOutputMock,
+  requestExitAfterOneShotOutput: requestExitAfterOneShotOutputMock,
 }));
 
 vi.mock("../infra/env.js", async (importOriginal) => ({
@@ -3769,6 +3771,38 @@ describe("runCli exit behavior", () => {
     ]);
     expect(process.exitCode).toBe(1);
     process.exitCode = exitCode;
+  });
+
+  it("requests a flushed one-shot exit after Commander renders help", async () => {
+    const exitCode = process.exitCode;
+    const program = {
+      commands: [{ name: () => "security" }],
+      parseAsync: vi
+        .fn()
+        .mockRejectedValueOnce(new CommanderError(0, "commander.helpDisplayed", "help displayed")),
+    };
+    buildProgramMock.mockReturnValueOnce(program);
+
+    await runCli(["node", "openclaw", "security", "--help"]);
+
+    expect(requestExitAfterOneShotOutputMock).toHaveBeenCalledOnce();
+    expect(flushExitAfterOneShotOutputMock).toHaveBeenCalledOnce();
+    expect(process.exitCode).toBe(0);
+    process.exitCode = exitCode;
+  });
+
+  it("requests a flushed one-shot exit when plugin group help returns normally", async () => {
+    const program = {
+      commands: [{ name: () => "memory" }],
+      parseAsync: vi.fn().mockResolvedValueOnce(undefined),
+    };
+    buildProgramMock.mockReturnValueOnce(program);
+    resolvePluginCliRootOwnerIdsMock.mockReturnValueOnce(["memory-core"]);
+
+    await runCli(["node", "openclaw", "memory", "--help"]);
+
+    expect(requestExitAfterOneShotOutputMock).toHaveBeenCalledOnce();
+    expect(flushExitAfterOneShotOutputMock).toHaveBeenCalledOnce();
   });
 
   it("loads the real primary command before rendering command help", async () => {

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -35,7 +35,7 @@ import {
   resolveGatewayRunPreBootstrapOptions,
 } from "./gateway-run-argv.js";
 import { hasJsonOutputFlag, withConsoleLogsRoutedToStderrForJson } from "./json-output-mode.js";
-import { flushExitAfterOneShotOutput } from "./one-shot-exit.js";
+import { flushExitAfterOneShotOutput, requestExitAfterOneShotOutput } from "./one-shot-exit.js";
 import { tryOutputPrecomputedCommandHelp } from "./precomputed-help.js";
 import { applyCliProfileEnv, parseCliProfileArgs } from "./profile.js";
 import { formatCliCommandSuggestions } from "./program/command-suggestions.js";
@@ -1116,6 +1116,7 @@ export async function runCli(argv: string[] = process.argv) {
     });
   }
 
+  let flushedHelpExit = false;
   try {
     if (shouldUseRootHelpFastPath(normalizedArgv)) {
       const { loadRootHelpRenderOptionsForConfigSensitivePlugins } =
@@ -1406,13 +1407,23 @@ export async function runCli(argv: string[] = process.argv) {
       );
       stopStartupProgress();
 
+      let completedHelpOrVersion = false;
       try {
         await startupTrace.measure("parse", () => program.parseAsync(parseArgv));
+        completedHelpOrVersion = isHelpOrVersionInvocation;
       } catch (error) {
         if (!isCommanderParseExit(error)) {
           throw error;
         }
         process.exitCode = error.exitCode;
+        completedHelpOrVersion = isHelpOrVersionInvocation && error.exitCode === 0;
+      }
+      if (completedHelpOrVersion) {
+        // Lazy command-group registrars can import native/runtime resources solely to
+        // render complete help. Exit after Commander has rendered and streams flush.
+        requestExitAfterOneShotOutput();
+        flushExitAfterOneShotOutput();
+        flushedHelpExit = true;
       }
     } finally {
       stopStartupProgress();
@@ -1423,7 +1434,9 @@ export async function runCli(argv: string[] = process.argv) {
     await disposeCliAgentHarnesses();
     await closeCliMemoryManagers();
     pauseNonTtyStdinForCliExit();
-    flushExitAfterOneShotOutput();
+    if (!flushedHelpExit) {
+      flushExitAfterOneShotOutput();
+    }
   }
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

`openclaw <group> --help` printed complete help text and then **hung forever** (process alive, had to be killed) for 12 command groups: `memory, backup, capability, channels, clawbot, daemon, hooks, infer, migrate, node, security, update`. Top-level `openclaw --help` and the groups' leaf subcommands (`security audit`, `node status`, `backup sqlite list`, …) all exit cleanly — only the pure group `--help` path hung. This is the same CLI-exit-hang class as the earlier fixes, but on a path they didn't cover.

## Why This Change Was Made

Group help is rendered lazily: a placeholder command's action imports the group's real command tree so Commander can print accurate help. On macOS with `NODE_USE_SYSTEM_CA=1` (the default), those imports start Node's system-CA loader worker; at natural shutdown the process blocks in `CleanupCachedRootCertificates` joining `LoadSystemCACertificates`, so the event loop never drains and the CLI never exits.

The fix requests the existing stream-flushed one-shot exit **immediately after Commander finishes rendering help/version** — covering both the `CommanderError` exit path and the normal-return plugin help path — instead of relying on natural event-loop drain. It is gated strictly on help/version invocations with exit code 0, so real command execution keeps its normal teardown (a `flushedHelpExit` flag prevents a double-flush).

## User Impact

- All 12 group `--help` invocations now print correct help and exit (rc 0) in <1.1s.
- No change to leaf command execution, top-level `--help`, plugin-owned help, or `--version` (all verified).

## Evidence

- Fix: `src/cli/run-main.ts` — flush + one-shot exit after successful help/version parse, gated on help/version + exit 0.
- Timing table (built dist), all 12 groups now exit <1.1s (e.g. `security` 0.74s, `infer` 1.10s, `update` 0.68s); leaf/top-level/plugin help unchanged.
- Tests: `src/cli/help-exit.process.test.ts` extended to cover lazy command groups with a deliberately live event-loop handle (13/13); `src/cli/run-main.exit.test.ts` adds the normal-return plugin-help path.
- `check-changed` green (typecheck/lint 0/0/format/boundaries/import-cycles); AutoReview `--mode branch --base origin/main`: patch is correct (0.90).
