### PR TITLE
fix(vercel-ai-gateway): long-context usage costs are underreported

### DIFF
--- a/extensions/vercel-ai-gateway/models.ts
+++ b/extensions/vercel-ai-gateway/models.ts
@@ -115,10 +115,11 @@ function parsePerMillionCost(value: unknown): number | undefined {
       : typeof value === "string"
         ? parseStrictFiniteNumber(value)
         : undefined;
-  if (numeric === undefined || numeric < 0) {
+  if (numeric === undefined || !Number.isFinite(numeric) || numeric < 0) {
     return undefined;
   }
-  return numeric * 1_000_000;
+  const perMillion = numeric * 1_000_000;
+  return Number.isFinite(perMillion) ? perMillion : undefined;
 }
 
 function toPerMillionCost(value: number | string | undefined): number {

--- a/extensions/vercel-ai-gateway/models.ts
+++ b/extensions/vercel-ai-gateway/models.ts
@@ -26,6 +26,16 @@ type VercelPricingShape = {
   output?: number | string;
   input_cache_read?: number | string;
   input_cache_write?: number | string;
+  input_tiers?: unknown;
+  output_tiers?: unknown;
+  input_cache_read_tiers?: unknown;
+  input_cache_write_tiers?: unknown;
+};
+
+type ParsedVercelPricingTier = {
+  cost: number;
+  min: number;
+  max?: number;
 };
 
 type VercelGatewayModelShape = {
@@ -98,7 +108,7 @@ const STATIC_VERCEL_AI_GATEWAY_MODEL_CATALOG: readonly StaticVercelGatewayModel[
   },
 ] as const;
 
-function toPerMillionCost(value: number | string | undefined): number {
+function parsePerMillionCost(value: unknown): number | undefined {
   const numeric =
     typeof value === "number"
       ? value
@@ -106,9 +116,101 @@ function toPerMillionCost(value: number | string | undefined): number {
         ? parseStrictFiniteNumber(value)
         : undefined;
   if (numeric === undefined || numeric < 0) {
-    return 0;
+    return undefined;
   }
   return numeric * 1_000_000;
+}
+
+function toPerMillionCost(value: number | string | undefined): number {
+  return parsePerMillionCost(value) ?? 0;
+}
+
+function readNonNegativeSafeInteger(value: unknown): number | undefined {
+  const numeric =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim()
+        ? Number(value)
+        : Number.NaN;
+  return Number.isSafeInteger(numeric) && numeric >= 0 ? numeric : undefined;
+}
+
+function parsePricingTierList(value: unknown): ParsedVercelPricingTier[] | undefined {
+  if (!Array.isArray(value) || value.length === 0) {
+    return undefined;
+  }
+  const tiers: ParsedVercelPricingTier[] = [];
+  for (const [index, item] of value.entries()) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) {
+      return undefined;
+    }
+    const entry = item as Record<string, unknown>;
+    const cost = parsePerMillionCost(entry.cost);
+    const min = entry.min === undefined && index === 0 ? 0 : readNonNegativeSafeInteger(entry.min);
+    const max = entry.max === undefined ? undefined : readNonNegativeSafeInteger(entry.max);
+    if (cost === undefined || min === undefined || (entry.max !== undefined && max === undefined)) {
+      return undefined;
+    }
+    if (max !== undefined && max <= min) {
+      return undefined;
+    }
+    tiers.push({ cost, min, ...(max === undefined ? {} : { max }) });
+  }
+  if (tiers[0]?.min !== 0 || tiers.at(-1)?.max !== undefined) {
+    return undefined;
+  }
+  for (let index = 1; index < tiers.length; index += 1) {
+    if (tiers[index - 1]?.max !== tiers[index]?.min) {
+      return undefined;
+    }
+  }
+  return tiers;
+}
+
+function pricingTierRangesMatch(
+  reference: ParsedVercelPricingTier[],
+  candidate: ParsedVercelPricingTier[],
+): boolean {
+  return (
+    reference.length === candidate.length &&
+    reference.every(
+      (tier, index) => tier.min === candidate[index]?.min && tier.max === candidate[index]?.max,
+    )
+  );
+}
+
+function normalizeTieredPricing(
+  pricing: VercelPricingShape | undefined,
+  flatCost: ModelDefinitionConfig["cost"],
+): NonNullable<ModelDefinitionConfig["cost"]["tieredPricing"]> | undefined {
+  const inputTiers = parsePricingTierList(pricing?.input_tiers);
+  const outputTiers = parsePricingTierList(pricing?.output_tiers);
+  if (!inputTiers || !outputTiers || !pricingTierRangesMatch(inputTiers, outputTiers)) {
+    return undefined;
+  }
+
+  const parsedCacheReadTiers = parsePricingTierList(pricing?.input_cache_read_tiers);
+  const parsedCacheWriteTiers = parsePricingTierList(pricing?.input_cache_write_tiers);
+  const cacheReadTiers =
+    parsedCacheReadTiers && pricingTierRangesMatch(inputTiers, parsedCacheReadTiers)
+      ? parsedCacheReadTiers
+      : undefined;
+  const cacheWriteTiers =
+    parsedCacheWriteTiers && pricingTierRangesMatch(inputTiers, parsedCacheWriteTiers)
+      ? parsedCacheWriteTiers
+      : undefined;
+
+  return inputTiers.map((tier, index) => {
+    const range: [number, number] | [number] =
+      tier.max === undefined ? [tier.min] : [tier.min, tier.max];
+    return {
+      input: tier.cost,
+      output: outputTiers[index]?.cost ?? flatCost.output,
+      cacheRead: cacheReadTiers?.[index]?.cost ?? flatCost.cacheRead,
+      cacheWrite: cacheWriteTiers?.[index]?.cost ?? flatCost.cacheWrite,
+      range,
+    };
+  });
 }
 
 function normalizeCost(pricing?: VercelPricingShape): ModelDefinitionConfig["cost"] {
@@ -179,6 +281,13 @@ function buildDiscoveredModelDefinition(value: unknown): ModelDefinitionConfig |
     fallback?.maxTokens ??
     VERCEL_AI_GATEWAY_DEFAULT_MAX_TOKENS;
   const normalizedCost = normalizeCost(model.pricing);
+  const tieredPricing = normalizeTieredPricing(model.pricing, normalizedCost);
+  const hasLiveCost =
+    normalizedCost.input > 0 ||
+    normalizedCost.output > 0 ||
+    normalizedCost.cacheRead > 0 ||
+    normalizedCost.cacheWrite > 0 ||
+    tieredPricing !== undefined;
 
   return {
     id,
@@ -194,13 +303,9 @@ function buildDiscoveredModelDefinition(value: unknown): ModelDefinitionConfig |
       : (fallback?.input ?? ["text"]),
     contextWindow,
     maxTokens,
-    cost:
-      normalizedCost.input > 0 ||
-      normalizedCost.output > 0 ||
-      normalizedCost.cacheRead > 0 ||
-      normalizedCost.cacheWrite > 0
-        ? normalizedCost
-        : (fallback?.cost ?? VERCEL_AI_GATEWAY_DEFAULT_COST),
+    cost: hasLiveCost
+      ? { ...normalizedCost, ...(tieredPricing ? { tieredPricing } : {}) }
+      : (fallback?.cost ?? VERCEL_AI_GATEWAY_DEFAULT_COST),
   };
 }
 

--- a/extensions/vercel-ai-gateway/models.ts
+++ b/extensions/vercel-ai-gateway/models.ts
@@ -136,7 +136,10 @@ function readNonNegativeSafeInteger(value: unknown): number | undefined {
   return Number.isSafeInteger(numeric) && numeric >= 0 ? numeric : undefined;
 }
 
-function parsePricingTierList(value: unknown): ParsedVercelPricingTier[] | undefined {
+function parsePricingTierList(
+  value: unknown,
+  options: { allowSparseStart?: boolean } = {},
+): ParsedVercelPricingTier[] | undefined {
   if (!Array.isArray(value) || value.length === 0) {
     return undefined;
   }
@@ -157,7 +160,7 @@ function parsePricingTierList(value: unknown): ParsedVercelPricingTier[] | undef
     }
     tiers.push({ cost, min, ...(max === undefined ? {} : { max }) });
   }
-  if (tiers[0]?.min !== 0 || tiers.at(-1)?.max !== undefined) {
+  if ((!options.allowSparseStart && tiers[0]?.min !== 0) || tiers.at(-1)?.max !== undefined) {
     return undefined;
   }
   for (let index = 1; index < tiers.length; index += 1) {
@@ -166,6 +169,21 @@ function parsePricingTierList(value: unknown): ParsedVercelPricingTier[] | undef
     }
   }
   return tiers;
+}
+
+function resolveOptionalTierCost(
+  tiers: ParsedVercelPricingTier[] | undefined,
+  range: ParsedVercelPricingTier,
+  fallback: number,
+): number {
+  const matchedTier = tiers?.find(
+    (tier) =>
+      tier.min <= range.min &&
+      (range.max === undefined
+        ? tier.max === undefined
+        : tier.max === undefined || range.max <= tier.max),
+  );
+  return matchedTier?.cost ?? fallback;
 }
 
 function pricingTierRangesMatch(
@@ -190,16 +208,12 @@ function normalizeTieredPricing(
     return undefined;
   }
 
-  const parsedCacheReadTiers = parsePricingTierList(pricing?.input_cache_read_tiers);
-  const parsedCacheWriteTiers = parsePricingTierList(pricing?.input_cache_write_tiers);
-  const cacheReadTiers =
-    parsedCacheReadTiers && pricingTierRangesMatch(inputTiers, parsedCacheReadTiers)
-      ? parsedCacheReadTiers
-      : undefined;
-  const cacheWriteTiers =
-    parsedCacheWriteTiers && pricingTierRangesMatch(inputTiers, parsedCacheWriteTiers)
-      ? parsedCacheWriteTiers
-      : undefined;
+  const cacheReadTiers = parsePricingTierList(pricing?.input_cache_read_tiers, {
+    allowSparseStart: true,
+  });
+  const cacheWriteTiers = parsePricingTierList(pricing?.input_cache_write_tiers, {
+    allowSparseStart: true,
+  });
 
   return inputTiers.map((tier, index) => {
     const range: [number, number] | [number] =
@@ -207,8 +221,8 @@ function normalizeTieredPricing(
     return {
       input: tier.cost,
       output: outputTiers[index]?.cost ?? flatCost.output,
-      cacheRead: cacheReadTiers?.[index]?.cost ?? flatCost.cacheRead,
-      cacheWrite: cacheWriteTiers?.[index]?.cost ?? flatCost.cacheWrite,
+      cacheRead: resolveOptionalTierCost(cacheReadTiers, tier, flatCost.cacheRead),
+      cacheWrite: resolveOptionalTierCost(cacheWriteTiers, tier, flatCost.cacheWrite),
       range,
     };
   });

--- a/extensions/vercel-ai-gateway/models.ts
+++ b/extensions/vercel-ai-gateway/models.ts
@@ -26,6 +26,16 @@ type VercelPricingShape = {
   output?: number | string;
   input_cache_read?: number | string;
   input_cache_write?: number | string;
+  input_tiers?: unknown;
+  output_tiers?: unknown;
+  input_cache_read_tiers?: unknown;
+  input_cache_write_tiers?: unknown;
+};
+
+type ParsedVercelPricingTier = {
+  cost: number;
+  min: number;
+  max?: number;
 };
 
 type VercelGatewayModelShape = {
@@ -97,7 +107,7 @@ const STATIC_VERCEL_AI_GATEWAY_MODEL_CATALOG: readonly StaticVercelGatewayModel[
   },
 ] as const;
 
-function toPerMillionCost(value: number | string | undefined): number {
+function parsePerMillionCost(value: unknown): number | undefined {
   const numeric =
     typeof value === "number"
       ? value
@@ -105,9 +115,101 @@ function toPerMillionCost(value: number | string | undefined): number {
         ? parseStrictFiniteNumber(value)
         : undefined;
   if (numeric === undefined || numeric < 0) {
-    return 0;
+    return undefined;
   }
   return numeric * 1_000_000;
+}
+
+function toPerMillionCost(value: number | string | undefined): number {
+  return parsePerMillionCost(value) ?? 0;
+}
+
+function readNonNegativeSafeInteger(value: unknown): number | undefined {
+  const numeric =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim()
+        ? Number(value)
+        : Number.NaN;
+  return Number.isSafeInteger(numeric) && numeric >= 0 ? numeric : undefined;
+}
+
+function parsePricingTierList(value: unknown): ParsedVercelPricingTier[] | undefined {
+  if (!Array.isArray(value) || value.length === 0) {
+    return undefined;
+  }
+  const tiers: ParsedVercelPricingTier[] = [];
+  for (const [index, item] of value.entries()) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) {
+      return undefined;
+    }
+    const entry = item as Record<string, unknown>;
+    const cost = parsePerMillionCost(entry.cost);
+    const min = entry.min === undefined && index === 0 ? 0 : readNonNegativeSafeInteger(entry.min);
+    const max = entry.max === undefined ? undefined : readNonNegativeSafeInteger(entry.max);
+    if (cost === undefined || min === undefined || (entry.max !== undefined && max === undefined)) {
+      return undefined;
+    }
+    if (max !== undefined && max <= min) {
+      return undefined;
+    }
+    tiers.push({ cost, min, ...(max === undefined ? {} : { max }) });
+  }
+  if (tiers[0]?.min !== 0 || tiers.at(-1)?.max !== undefined) {
+    return undefined;
+  }
+  for (let index = 1; index < tiers.length; index += 1) {
+    if (tiers[index - 1]?.max !== tiers[index]?.min) {
+      return undefined;
+    }
+  }
+  return tiers;
+}
+
+function pricingTierRangesMatch(
+  reference: ParsedVercelPricingTier[],
+  candidate: ParsedVercelPricingTier[],
+): boolean {
+  return (
+    reference.length === candidate.length &&
+    reference.every(
+      (tier, index) => tier.min === candidate[index]?.min && tier.max === candidate[index]?.max,
+    )
+  );
+}
+
+function normalizeTieredPricing(
+  pricing: VercelPricingShape | undefined,
+  flatCost: ModelDefinitionConfig["cost"],
+): NonNullable<ModelDefinitionConfig["cost"]["tieredPricing"]> | undefined {
+  const inputTiers = parsePricingTierList(pricing?.input_tiers);
+  const outputTiers = parsePricingTierList(pricing?.output_tiers);
+  if (!inputTiers || !outputTiers || !pricingTierRangesMatch(inputTiers, outputTiers)) {
+    return undefined;
+  }
+
+  const parsedCacheReadTiers = parsePricingTierList(pricing?.input_cache_read_tiers);
+  const parsedCacheWriteTiers = parsePricingTierList(pricing?.input_cache_write_tiers);
+  const cacheReadTiers =
+    parsedCacheReadTiers && pricingTierRangesMatch(inputTiers, parsedCacheReadTiers)
+      ? parsedCacheReadTiers
+      : undefined;
+  const cacheWriteTiers =
+    parsedCacheWriteTiers && pricingTierRangesMatch(inputTiers, parsedCacheWriteTiers)
+      ? parsedCacheWriteTiers
+      : undefined;
+
+  return inputTiers.map((tier, index) => {
+    const range: [number, number] | [number] =
+      tier.max === undefined ? [tier.min] : [tier.min, tier.max];
+    return {
+      input: tier.cost,
+      output: outputTiers[index]?.cost ?? flatCost.output,
+      cacheRead: cacheReadTiers?.[index]?.cost ?? flatCost.cacheRead,
+      cacheWrite: cacheWriteTiers?.[index]?.cost ?? flatCost.cacheWrite,
+      range,
+    };
+  });
 }
 
 function normalizeCost(pricing?: VercelPricingShape): ModelDefinitionConfig["cost"] {
@@ -176,6 +278,13 @@ function buildDiscoveredModelDefinition(
     fallback?.maxTokens ??
     VERCEL_AI_GATEWAY_DEFAULT_MAX_TOKENS;
   const normalizedCost = normalizeCost(model.pricing);
+  const tieredPricing = normalizeTieredPricing(model.pricing, normalizedCost);
+  const hasLiveCost =
+    normalizedCost.input > 0 ||
+    normalizedCost.output > 0 ||
+    normalizedCost.cacheRead > 0 ||
+    normalizedCost.cacheWrite > 0 ||
+    tieredPricing !== undefined;
 
   return {
     id,
@@ -191,13 +300,9 @@ function buildDiscoveredModelDefinition(
       : (fallback?.input ?? ["text"]),
     contextWindow,
     maxTokens,
-    cost:
-      normalizedCost.input > 0 ||
-      normalizedCost.output > 0 ||
-      normalizedCost.cacheRead > 0 ||
-      normalizedCost.cacheWrite > 0
-        ? normalizedCost
-        : (fallback?.cost ?? VERCEL_AI_GATEWAY_DEFAULT_COST),
+    cost: hasLiveCost
+      ? { ...normalizedCost, ...(tieredPricing ? { tieredPricing } : {}) }
+      : (fallback?.cost ?? VERCEL_AI_GATEWAY_DEFAULT_COST),
   };
 }
 

--- a/extensions/vercel-ai-gateway/models.ts
+++ b/extensions/vercel-ai-gateway/models.ts
@@ -135,7 +135,10 @@ function readNonNegativeSafeInteger(value: unknown): number | undefined {
   return Number.isSafeInteger(numeric) && numeric >= 0 ? numeric : undefined;
 }
 
-function parsePricingTierList(value: unknown): ParsedVercelPricingTier[] | undefined {
+function parsePricingTierList(
+  value: unknown,
+  options: { allowSparseStart?: boolean } = {},
+): ParsedVercelPricingTier[] | undefined {
   if (!Array.isArray(value) || value.length === 0) {
     return undefined;
   }
@@ -156,7 +159,7 @@ function parsePricingTierList(value: unknown): ParsedVercelPricingTier[] | undef
     }
     tiers.push({ cost, min, ...(max === undefined ? {} : { max }) });
   }
-  if (tiers[0]?.min !== 0 || tiers.at(-1)?.max !== undefined) {
+  if ((!options.allowSparseStart && tiers[0]?.min !== 0) || tiers.at(-1)?.max !== undefined) {
     return undefined;
   }
   for (let index = 1; index < tiers.length; index += 1) {
@@ -165,6 +168,21 @@ function parsePricingTierList(value: unknown): ParsedVercelPricingTier[] | undef
     }
   }
   return tiers;
+}
+
+function resolveOptionalTierCost(
+  tiers: ParsedVercelPricingTier[] | undefined,
+  range: ParsedVercelPricingTier,
+  fallback: number,
+): number {
+  const matchedTier = tiers?.find(
+    (tier) =>
+      tier.min <= range.min &&
+      (range.max === undefined
+        ? tier.max === undefined
+        : tier.max === undefined || range.max <= tier.max),
+  );
+  return matchedTier?.cost ?? fallback;
 }
 
 function pricingTierRangesMatch(
@@ -189,16 +207,12 @@ function normalizeTieredPricing(
     return undefined;
   }
 
-  const parsedCacheReadTiers = parsePricingTierList(pricing?.input_cache_read_tiers);
-  const parsedCacheWriteTiers = parsePricingTierList(pricing?.input_cache_write_tiers);
-  const cacheReadTiers =
-    parsedCacheReadTiers && pricingTierRangesMatch(inputTiers, parsedCacheReadTiers)
-      ? parsedCacheReadTiers
-      : undefined;
-  const cacheWriteTiers =
-    parsedCacheWriteTiers && pricingTierRangesMatch(inputTiers, parsedCacheWriteTiers)
-      ? parsedCacheWriteTiers
-      : undefined;
+  const cacheReadTiers = parsePricingTierList(pricing?.input_cache_read_tiers, {
+    allowSparseStart: true,
+  });
+  const cacheWriteTiers = parsePricingTierList(pricing?.input_cache_write_tiers, {
+    allowSparseStart: true,
+  });
 
   return inputTiers.map((tier, index) => {
     const range: [number, number] | [number] =
@@ -206,8 +220,8 @@ function normalizeTieredPricing(
     return {
       input: tier.cost,
       output: outputTiers[index]?.cost ?? flatCost.output,
-      cacheRead: cacheReadTiers?.[index]?.cost ?? flatCost.cacheRead,
-      cacheWrite: cacheWriteTiers?.[index]?.cost ?? flatCost.cacheWrite,
+      cacheRead: resolveOptionalTierCost(cacheReadTiers, tier, flatCost.cacheRead),
+      cacheWrite: resolveOptionalTierCost(cacheWriteTiers, tier, flatCost.cacheWrite),
       range,
     };
   });

--- a/extensions/vercel-ai-gateway/models.ts
+++ b/extensions/vercel-ai-gateway/models.ts
@@ -114,10 +114,11 @@ function parsePerMillionCost(value: unknown): number | undefined {
       : typeof value === "string"
         ? parseStrictFiniteNumber(value)
         : undefined;
-  if (numeric === undefined || numeric < 0) {
+  if (numeric === undefined || !Number.isFinite(numeric) || numeric < 0) {
     return undefined;
   }
-  return numeric * 1_000_000;
+  const perMillion = numeric * 1_000_000;
+  return Number.isFinite(perMillion) ? perMillion : undefined;
 }
 
 function toPerMillionCost(value: number | string | undefined): number {

--- a/extensions/vercel-ai-gateway/provider-catalog.test.ts
+++ b/extensions/vercel-ai-gateway/provider-catalog.test.ts
@@ -129,6 +129,150 @@ describe("vercel ai gateway provider catalog", () => {
     });
   });
 
+  it("preserves live long-context pricing tiers", async () => {
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: jsonResponse({
+        data: [
+          {
+            id: "openai/gpt-5.4",
+            name: "GPT 5.4",
+            pricing: {
+              input: "0.0000025",
+              output: "0.000015",
+              input_cache_read: "0.00000025",
+              input_tiers: [
+                { cost: "0.0000025", min: 0, max: 272_000 },
+                { cost: "0.000005", min: 272_000 },
+              ],
+              output_tiers: [
+                { cost: "0.000015", min: 0, max: 272_000 },
+                { cost: "0.0000225", min: 272_000 },
+              ],
+              input_cache_read_tiers: [
+                { cost: "0.00000025", min: 0, max: 272_000 },
+                { cost: "0.0000005", min: 272_000 },
+              ],
+            },
+          },
+        ],
+      }),
+      release: async () => {},
+      finalUrl: `${VERCEL_AI_GATEWAY_BASE_URL}/v1/models`,
+    });
+
+    await withLiveDiscovery(async () => {
+      const models = await discoverVercelAiGatewayModels();
+
+      expect(models[0]?.cost).toStrictEqual({
+        input: 2.5,
+        output: 15,
+        cacheRead: 0.25,
+        cacheWrite: 0,
+        tieredPricing: [
+          {
+            input: 2.5,
+            output: 15,
+            cacheRead: 0.25,
+            cacheWrite: 0,
+            range: [0, 272_000],
+          },
+          {
+            input: 5,
+            output: 22.5,
+            cacheRead: 0.5,
+            cacheWrite: 0,
+            range: [272_000],
+          },
+        ],
+      });
+    });
+  });
+
+  it("keeps valid pricing tiers when optional cache tier data is partial", async () => {
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: jsonResponse({
+        data: [
+          {
+            id: "openai/gpt-5.6-luna",
+            pricing: {
+              input: "0.000001",
+              output: "0.000006",
+              input_cache_read: "0.0000001",
+              input_tiers: [
+                { cost: "0.000001", min: 0, max: 272_000 },
+                { cost: "0.000002", min: 272_000 },
+              ],
+              output_tiers: [
+                { cost: "0.000006", min: 0, max: 272_000 },
+                { cost: "0.000009", min: 272_000 },
+              ],
+              input_cache_read_tiers: [
+                { cost: "0.0000001", max: 272_000 },
+                { cost: "0.0000002", min: 272_000 },
+              ],
+            },
+          },
+          {
+            id: "xai/grok-4.20-non-reasoning-beta",
+            pricing: {
+              input: "0.00000125",
+              output: "0.0000025",
+              input_cache_read: "0.0000002",
+              input_tiers: [
+                { cost: "0.00000125", min: 0, max: 200_001 },
+                { cost: "0.0000025", min: 200_001 },
+              ],
+              output_tiers: [
+                { cost: "0.0000025", min: 0, max: 200_001 },
+                { cost: "0.000005", min: 200_001 },
+              ],
+              input_cache_read_tiers: [{ cost: "0.0000004", min: 200_001 }],
+            },
+          },
+        ],
+      }),
+      release: async () => {},
+      finalUrl: `${VERCEL_AI_GATEWAY_BASE_URL}/v1/models`,
+    });
+
+    await withLiveDiscovery(async () => {
+      const models = await discoverVercelAiGatewayModels();
+
+      expect(models[0]?.cost.tieredPricing).toStrictEqual([
+        {
+          input: 1,
+          output: 6,
+          cacheRead: expect.closeTo(0.1),
+          cacheWrite: 0,
+          range: [0, 272_000],
+        },
+        {
+          input: 2,
+          output: 9,
+          cacheRead: expect.closeTo(0.2),
+          cacheWrite: 0,
+          range: [272_000],
+        },
+      ]);
+      expect(models[1]?.cost.tieredPricing).toStrictEqual([
+        {
+          input: 1.25,
+          output: 2.5,
+          cacheRead: expect.closeTo(0.2),
+          cacheWrite: 0,
+          range: [0, 200_001],
+        },
+        {
+          input: 2.5,
+          output: 5,
+          cacheRead: expect.closeTo(0.2),
+          cacheWrite: 0,
+          range: [200_001],
+        },
+      ]);
+    });
+  });
+
   it("falls back to the static catalog for malformed successful model list payloads", async () => {
     for (const payload of [[], { data: {} }, { data: [null] }]) {
       clearLiveCatalogCacheForTests();

--- a/extensions/vercel-ai-gateway/provider-catalog.test.ts
+++ b/extensions/vercel-ai-gateway/provider-catalog.test.ts
@@ -129,6 +129,43 @@ describe("vercel ai gateway provider catalog", () => {
     });
   });
 
+  it("excludes non-language models while preserving vision and legacy catalog rows", async () => {
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: jsonResponse({
+        data: [
+          {
+            id: "alibaba/qwen3-235b-a22b-thinking",
+            type: "language",
+            tags: ["vision", "reasoning"],
+          },
+          ...[
+            ["embedding", "alibaba/qwen3-embedding-0.6b"],
+            ["image", "bfl/flux-2-flex"],
+            ["video", "alibaba/wan-v2.5-t2v-preview"],
+            ["reranking", "cohere/rerank-v3.5"],
+            ["speech", "fish-audio/s1"],
+            ["transcription", "fish-audio/transcribe-1"],
+            ["realtime", "openai/gpt-realtime-1.5"],
+          ].map(([type, id]) => ({ type, id })),
+          { id: "custom/legacy-model" },
+        ],
+      }),
+      release: async () => {},
+      finalUrl: `${VERCEL_AI_GATEWAY_BASE_URL}/v1/models`,
+    });
+
+    await withLiveDiscovery(async () => {
+      expect((await buildVercelAiGatewayProvider()).models).toMatchObject([
+        {
+          id: "alibaba/qwen3-235b-a22b-thinking",
+          reasoning: true,
+          input: ["text", "image"],
+        },
+        { id: "custom/legacy-model", input: ["text"] },
+      ]);
+    });
+  });
+
   it("preserves live long-context pricing tiers", async () => {
     fetchWithSsrFGuardMock.mockResolvedValueOnce({
       response: jsonResponse({

--- a/extensions/vercel-ai-gateway/provider-catalog.test.ts
+++ b/extensions/vercel-ai-gateway/provider-catalog.test.ts
@@ -265,7 +265,7 @@ describe("vercel ai gateway provider catalog", () => {
         {
           input: 2.5,
           output: 5,
-          cacheRead: expect.closeTo(0.2),
+          cacheRead: expect.closeTo(0.4),
           cacheWrite: 0,
           range: [200_001],
         },

--- a/extensions/vercel-ai-gateway/provider-catalog.test.ts
+++ b/extensions/vercel-ai-gateway/provider-catalog.test.ts
@@ -129,25 +129,31 @@ describe("vercel ai gateway provider catalog", () => {
     });
   });
 
-  it("excludes non-language models while preserving vision and legacy catalog rows", async () => {
+  it("preserves live long-context pricing tiers", async () => {
     fetchWithSsrFGuardMock.mockResolvedValueOnce({
       response: jsonResponse({
         data: [
           {
-            id: "alibaba/qwen3-235b-a22b-thinking",
-            type: "language",
-            tags: ["vision", "reasoning"],
+            id: "openai/gpt-5.4",
+            name: "GPT 5.4",
+            pricing: {
+              input: "0.0000025",
+              output: "0.000015",
+              input_cache_read: "0.00000025",
+              input_tiers: [
+                { cost: "0.0000025", min: 0, max: 272_000 },
+                { cost: "0.000005", min: 272_000 },
+              ],
+              output_tiers: [
+                { cost: "0.000015", min: 0, max: 272_000 },
+                { cost: "0.0000225", min: 272_000 },
+              ],
+              input_cache_read_tiers: [
+                { cost: "0.00000025", min: 0, max: 272_000 },
+                { cost: "0.0000005", min: 272_000 },
+              ],
+            },
           },
-          ...[
-            ["embedding", "alibaba/qwen3-embedding-0.6b"],
-            ["image", "bfl/flux-2-flex"],
-            ["video", "alibaba/wan-v2.5-t2v-preview"],
-            ["reranking", "cohere/rerank-v3.5"],
-            ["speech", "fish-audio/s1"],
-            ["transcription", "fish-audio/transcribe-1"],
-            ["realtime", "openai/gpt-realtime-1.5"],
-          ].map(([type, id]) => ({ id, type })),
-          { id: "custom/legacy-model" },
         ],
       }),
       release: async () => {},
@@ -155,13 +161,114 @@ describe("vercel ai gateway provider catalog", () => {
     });
 
     await withLiveDiscovery(async () => {
-      expect((await buildVercelAiGatewayProvider()).models).toMatchObject([
+      const models = await discoverVercelAiGatewayModels();
+
+      expect(models[0]?.cost).toStrictEqual({
+        input: 2.5,
+        output: 15,
+        cacheRead: 0.25,
+        cacheWrite: 0,
+        tieredPricing: [
+          {
+            input: 2.5,
+            output: 15,
+            cacheRead: 0.25,
+            cacheWrite: 0,
+            range: [0, 272_000],
+          },
+          {
+            input: 5,
+            output: 22.5,
+            cacheRead: 0.5,
+            cacheWrite: 0,
+            range: [272_000],
+          },
+        ],
+      });
+    });
+  });
+
+  it("keeps valid pricing tiers when optional cache tier data is partial", async () => {
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: jsonResponse({
+        data: [
+          {
+            id: "openai/gpt-5.6-luna",
+            pricing: {
+              input: "0.000001",
+              output: "0.000006",
+              input_cache_read: "0.0000001",
+              input_tiers: [
+                { cost: "0.000001", min: 0, max: 272_000 },
+                { cost: "0.000002", min: 272_000 },
+              ],
+              output_tiers: [
+                { cost: "0.000006", min: 0, max: 272_000 },
+                { cost: "0.000009", min: 272_000 },
+              ],
+              input_cache_read_tiers: [
+                { cost: "0.0000001", max: 272_000 },
+                { cost: "0.0000002", min: 272_000 },
+              ],
+            },
+          },
+          {
+            id: "xai/grok-4.20-non-reasoning-beta",
+            pricing: {
+              input: "0.00000125",
+              output: "0.0000025",
+              input_cache_read: "0.0000002",
+              input_tiers: [
+                { cost: "0.00000125", min: 0, max: 200_001 },
+                { cost: "0.0000025", min: 200_001 },
+              ],
+              output_tiers: [
+                { cost: "0.0000025", min: 0, max: 200_001 },
+                { cost: "0.000005", min: 200_001 },
+              ],
+              input_cache_read_tiers: [{ cost: "0.0000004", min: 200_001 }],
+            },
+          },
+        ],
+      }),
+      release: async () => {},
+      finalUrl: `${VERCEL_AI_GATEWAY_BASE_URL}/v1/models`,
+    });
+
+    await withLiveDiscovery(async () => {
+      const models = await discoverVercelAiGatewayModels();
+
+      expect(models[0]?.cost.tieredPricing).toStrictEqual([
         {
-          id: "alibaba/qwen3-235b-a22b-thinking",
-          reasoning: true,
-          input: ["text", "image"],
+          input: 1,
+          output: 6,
+          cacheRead: expect.closeTo(0.1),
+          cacheWrite: 0,
+          range: [0, 272_000],
         },
-        { id: "custom/legacy-model", input: ["text"] },
+        {
+          input: 2,
+          output: 9,
+          cacheRead: expect.closeTo(0.2),
+          cacheWrite: 0,
+          range: [272_000],
+        },
+      ]);
+      expect(models[1]?.cost.tieredPricing).toStrictEqual([
+        {
+          input: 1.25,
+          output: 2.5,
+          cacheRead: expect.closeTo(0.2),
+          cacheWrite: 0,
+          range: [0, 200_001],
+        },
+        {
+          input: 2.5,
+          output: 5,
+          cacheRead: expect.closeTo(0.2),
+          cacheWrite: 0,
+          range: [200_001],
+        },
       ]);
     });
   });

--- a/extensions/vercel-ai-gateway/provider-catalog.test.ts
+++ b/extensions/vercel-ai-gateway/provider-catalog.test.ts
@@ -273,6 +273,43 @@ describe("vercel ai gateway provider catalog", () => {
     });
   });
 
+  it("rejects non-finite tier costs and keeps the flat pricing control", async () => {
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: jsonResponse({
+        data: [
+          {
+            id: "openai/gpt-5.6-overflow",
+            pricing: {
+              input: "0.000001",
+              output: "0.000006",
+              input_tiers: [
+                { cost: Number.MAX_VALUE, min: 0, max: 272_000 },
+                { cost: "0.000002", min: 272_000 },
+              ],
+              output_tiers: [
+                { cost: "0.000006", min: 0, max: 272_000 },
+                { cost: "0.000009", min: 272_000 },
+              ],
+            },
+          },
+        ],
+      }),
+      release: async () => {},
+      finalUrl: `${VERCEL_AI_GATEWAY_BASE_URL}/v1/models`,
+    });
+
+    await withLiveDiscovery(async () => {
+      const models = await discoverVercelAiGatewayModels();
+
+      expect(models[0]?.cost).toStrictEqual({
+        input: 1,
+        output: 6,
+        cacheRead: 0,
+        cacheWrite: 0,
+      });
+    });
+  });
+
   it("falls back to the static catalog for malformed successful model list payloads", async () => {
     for (const payload of [[], { data: {} }, { data: [null] }]) {
       clearLiveCatalogCacheForTests();

--- a/packages/ai/src/model-utils.tiered.test.ts
+++ b/packages/ai/src/model-utils.tiered.test.ts
@@ -40,4 +40,64 @@ describe("calculateCost tiered pricing", () => {
     expect(usage.cost.output).toBeCloseTo(0.0225);
     expect(usage.cost.total).toBeCloseTo(1.5225);
   });
+
+  it("normalizes unordered and gapped tier declarations", () => {
+    const model = {
+      cost: {
+        input: 1,
+        output: 1,
+        cacheRead: 0,
+        cacheWrite: 0,
+        tieredPricing: [
+          { input: 3, output: 3, cacheRead: 0, cacheWrite: 0, range: [500_000] },
+          { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, range: [0, 100_000] },
+        ],
+      },
+    } as unknown as Model;
+    const usage = {
+      input: 50_000,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 50_000,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    } satisfies Usage;
+
+    calculateCost(model, usage);
+
+    expect(usage.cost.input).toBeCloseTo(0.05);
+  });
+
+  it("prices independently billed compaction iterations before aggregation", () => {
+    const model = {
+      cost: {
+        input: 2.5,
+        output: 15,
+        cacheRead: 0.25,
+        cacheWrite: 0,
+        tieredPricing: [
+          { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 0, range: [0, 272_000] },
+          { input: 5, output: 22.5, cacheRead: 0.5, cacheWrite: 0, range: [272_000] },
+        ],
+      },
+    } as unknown as Model;
+    const usage = {
+      input: 400_000,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 400_000,
+      costByIteration: [
+        { input: 200_000, output: 0, cacheRead: 0, cacheWrite: 0 },
+        { input: 200_000, output: 0, cacheRead: 0, cacheWrite: 0 },
+      ],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    } satisfies Usage;
+
+    calculateCost(model, usage);
+
+    expect(usage.cost.input).toBeCloseTo(1);
+    expect(usage.cost.total).toBeCloseTo(1);
+    expect(usage.costByIteration).toBeUndefined();
+  });
 });

--- a/packages/ai/src/model-utils.tiered.test.ts
+++ b/packages/ai/src/model-utils.tiered.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { calculateCost } from "./model-utils.js";
+import type { Model, Usage } from "./types.js";
+
+describe("calculateCost tiered pricing", () => {
+  it("uses the matching input tier for long-context usage", () => {
+    const model = {
+      id: "gpt-5.4",
+      name: "GPT 5.4",
+      api: "anthropic-messages",
+      provider: "vercel-ai-gateway",
+      baseUrl: "https://ai-gateway.vercel.sh",
+      reasoning: true,
+      input: ["text"],
+      cost: {
+        input: 2.5,
+        output: 15,
+        cacheRead: 0.25,
+        cacheWrite: 0,
+        tieredPricing: [
+          { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 0, range: [0, 272_000] },
+          { input: 5, output: 22.5, cacheRead: 0.5, cacheWrite: 0, range: [272_000] },
+        ],
+      },
+      contextWindow: 1_000_000,
+      maxTokens: 128_000,
+    } as unknown as Model;
+    const usage = {
+      input: 300_000,
+      output: 1_000,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 301_000,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    } satisfies Usage;
+
+    calculateCost(model, usage);
+
+    expect(usage.cost.input).toBeCloseTo(1.5);
+    expect(usage.cost.output).toBeCloseTo(0.0225);
+    expect(usage.cost.total).toBeCloseTo(1.5225);
+  });
+});

--- a/packages/ai/src/model-utils.ts
+++ b/packages/ai/src/model-utils.ts
@@ -12,24 +12,73 @@ function selectCostTier(
   if (!tiers || tiers.length === 0) {
     return undefined;
   }
-  const tier = tiers.find((candidate) => {
+  const sorted = tiers.toSorted((a, b) => a.range[0] - b.range[0]);
+  if (inputTokens <= 0) {
+    return sorted[0];
+  }
+  const tier = sorted.find((candidate) => {
     const [start, end] = candidate.range;
     return inputTokens >= start && (end === undefined || inputTokens < end);
   });
-  return tier ?? tiers.at(-1);
+  if (tier) {
+    return tier;
+  }
+  for (let index = sorted.length - 1; index >= 0; index -= 1) {
+    const candidate = sorted[index];
+    if (candidate && inputTokens >= candidate.range[0]) {
+      return candidate;
+    }
+  }
+  return sorted[0];
+}
+
+function calculateSampleCost(
+  model: Model,
+  sample: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+    cacheWrite1h?: number;
+  },
+): Usage["cost"] {
+  const tier = selectCostTier(model.cost.tieredPricing, sample.input);
+  const rates = tier ?? model.cost;
+  const cacheWrite1h = Math.min(sample.cacheWrite, Math.max(0, sample.cacheWrite1h ?? 0));
+  const cacheWrite5m = sample.cacheWrite - cacheWrite1h;
+  return {
+    input: (rates.input / 1_000_000) * sample.input,
+    output: (rates.output / 1_000_000) * sample.output,
+    cacheRead: (rates.cacheRead / 1_000_000) * sample.cacheRead,
+    cacheWrite: (rates.cacheWrite * cacheWrite5m + rates.input * 2 * cacheWrite1h) / 1_000_000,
+    total: 0,
+  };
 }
 
 /** Calculates and stores model cost fields from token usage and per-million pricing. */
 export function calculateCost<TApi extends Api>(model: Model<TApi>, usage: Usage): Usage["cost"] {
-  const tier = selectCostTier(model.cost.tieredPricing, usage.input);
-  const rates = tier ?? model.cost;
-  const cacheWrite1h = Math.min(usage.cacheWrite, Math.max(0, usage.cacheWrite1h ?? 0));
-  const cacheWrite5m = usage.cacheWrite - cacheWrite1h;
-  usage.cost.input = (rates.input / 1000000) * usage.input;
-  usage.cost.output = (rates.output / 1000000) * usage.output;
-  usage.cost.cacheRead = (rates.cacheRead / 1000000) * usage.cacheRead;
-  usage.cost.cacheWrite =
-    (rates.cacheWrite * cacheWrite5m + rates.input * 2 * cacheWrite1h) / 1000000;
+  const samples = usage.costByIteration;
+  if (samples && samples.length > 0) {
+    const total = samples.reduce(
+      (acc, sample) => {
+        const cost = calculateSampleCost(model, sample);
+        acc.input += cost.input;
+        acc.output += cost.output;
+        acc.cacheRead += cost.cacheRead;
+        acc.cacheWrite += cost.cacheWrite;
+        return acc;
+      },
+      { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    );
+    total.total = total.input + total.output + total.cacheRead + total.cacheWrite;
+    Object.assign(usage.cost, total);
+    // Per-iteration samples are an internal billing aid; do not let them
+    // escape through usage objects that may be forwarded or persisted.
+    usage.costByIteration = undefined;
+    return usage.cost;
+  }
+  const cost = calculateSampleCost(model, usage);
+  Object.assign(usage.cost, cost);
   usage.cost.total =
     usage.cost.input + usage.cost.output + usage.cost.cacheRead + usage.cost.cacheWrite;
   return usage.cost;

--- a/packages/ai/src/model-utils.ts
+++ b/packages/ai/src/model-utils.ts
@@ -3,17 +3,33 @@ import {
   resolveClaudeNativeThinkingLevelMap,
   requiresClaudeMandatoryAdaptiveThinking,
 } from "@openclaw/llm-core";
-import type { Api, Model, ModelThinkingLevel, Usage } from "./types.js";
+import type { Api, Model, ModelCostTier, ModelThinkingLevel, Usage } from "./types.js";
+
+function selectCostTier(
+  tiers: ModelCostTier[] | undefined,
+  inputTokens: number,
+): ModelCostTier | undefined {
+  if (!tiers || tiers.length === 0) {
+    return undefined;
+  }
+  const tier = tiers.find((candidate) => {
+    const [start, end] = candidate.range;
+    return inputTokens >= start && (end === undefined || inputTokens < end);
+  });
+  return tier ?? tiers.at(-1);
+}
 
 /** Calculates and stores model cost fields from token usage and per-million pricing. */
 export function calculateCost<TApi extends Api>(model: Model<TApi>, usage: Usage): Usage["cost"] {
+  const tier = selectCostTier(model.cost.tieredPricing, usage.input);
+  const rates = tier ?? model.cost;
   const cacheWrite1h = Math.min(usage.cacheWrite, Math.max(0, usage.cacheWrite1h ?? 0));
   const cacheWrite5m = usage.cacheWrite - cacheWrite1h;
-  usage.cost.input = (model.cost.input / 1000000) * usage.input;
-  usage.cost.output = (model.cost.output / 1000000) * usage.output;
-  usage.cost.cacheRead = (model.cost.cacheRead / 1000000) * usage.cacheRead;
+  usage.cost.input = (rates.input / 1000000) * usage.input;
+  usage.cost.output = (rates.output / 1000000) * usage.output;
+  usage.cost.cacheRead = (rates.cacheRead / 1000000) * usage.cacheRead;
   usage.cost.cacheWrite =
-    (model.cost.cacheWrite * cacheWrite5m + model.cost.input * 2 * cacheWrite1h) / 1000000;
+    (rates.cacheWrite * cacheWrite5m + rates.input * 2 * cacheWrite1h) / 1000000;
   usage.cost.total =
     usage.cost.input + usage.cost.output + usage.cost.cacheRead + usage.cost.cacheWrite;
   return usage.cost;

--- a/packages/ai/src/providers/anthropic-usage.ts
+++ b/packages/ai/src/providers/anthropic-usage.ts
@@ -1,5 +1,5 @@
 import { asNonNegativeFiniteNumber } from "@openclaw/normalization-core/number-coercion";
-import type { Usage } from "../types.js";
+import type { Usage, UsageCostSample } from "../types.js";
 
 type AnthropicUsagePayload = {
   input_tokens?: unknown;
@@ -37,6 +37,7 @@ type AnthropicBilledUsage = {
   cacheRead: number;
   cacheWrite: number;
   cacheWrite1h: number;
+  iterations: UsageCostSample[];
 };
 
 export function readAnthropicUsageTokenCount(value: unknown): number | undefined {
@@ -125,6 +126,7 @@ function readAnthropicCompactionBilledUsage(iterations: unknown): AnthropicBille
     cacheRead: 0,
     cacheWrite: 0,
     cacheWrite1h: 0,
+    iterations: [],
   };
   for (const iteration of iterations) {
     if (!iteration || typeof iteration !== "object" || Array.isArray(iteration)) {
@@ -148,7 +150,9 @@ function readAnthropicCompactionBilledUsage(iterations: unknown): AnthropicBille
     billed.output += output;
     billed.cacheRead += cacheRead;
     billed.cacheWrite += cacheWrite;
-    billed.cacheWrite1h += readAnthropicCacheWriteUsage(record).cacheWrite1h ?? 0;
+    const cacheWrite1h = readAnthropicCacheWriteUsage(record).cacheWrite1h ?? 0;
+    billed.cacheWrite1h += cacheWrite1h;
+    billed.iterations.push({ input, output, cacheRead, cacheWrite, cacheWrite1h });
   }
   return sawCompaction ? billed : undefined;
 }
@@ -218,6 +222,11 @@ export function applyAnthropicMessageDeltaUsage(
     cacheWrite: cacheWriteTokens,
     cacheWrite1h: readAnthropicCacheWriteUsage(usage).cacheWrite1h,
   };
+  if (billedIterations) {
+    target.costByIteration = billedIterations.iterations;
+  } else {
+    target.costByIteration = undefined;
+  }
   if (resolved.input !== undefined) {
     target.input = resolved.input;
   }

--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -298,6 +298,8 @@ export interface Usage {
     | { state: "available"; promptTokens: number; totalTokens: number }
     | { state: "unavailable" };
   totalTokens: number;
+  /** Runtime-only billed samples used when a provider reports independent iterations. */
+  costByIteration?: UsageCostSample[];
   cost: {
     input: number;
     output: number;
@@ -308,6 +310,15 @@ export interface Usage {
     totalOrigin?: "provider-billed";
   };
 }
+
+/** Runtime-only usage sample for independently billed provider iterations. */
+export type UsageCostSample = {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  cacheWrite1h?: number;
+};
 
 /** Normalized assistant stop reasons across text providers. */
 export type StopReason = "stop" | "length" | "toolUse" | "error" | "aborted";

--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -657,6 +657,16 @@ export interface VercelGatewayRouting {
   order?: string[];
 }
 
+/** Per-million-token pricing for one input-token range. */
+export type ModelCostTier = {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  /** Half-open input-token interval; an omitted end denotes the final tier. */
+  range: [number, number] | [number];
+};
+
 // Model interface for the unified model system
 export interface Model<TApi extends Api = Api> {
   id: string;
@@ -676,6 +686,7 @@ export interface Model<TApi extends Api = Api> {
     output: number; // $/million tokens
     cacheRead: number; // $/million tokens
     cacheWrite: number; // $/million tokens
+    tieredPricing?: ModelCostTier[];
   };
   contextWindow?: number;
   /**


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Vercel AI Gateway long-context pricing was discovered in catalog metadata but ignored by the final Anthropic-compatible usage-cost calculator.

## Why This Change Was Made

Discovered pricing tiers are now carried through the shared LLM model cost contract and selected by input-token range during runtime cost calculation. Flat pricing remains the fallback when no tiers are present, and current-main model filtering is preserved.

## User Impact

Vercel AI Gateway requests above a published context threshold now receive the correct tiered estimate instead of the first-tier rate. Existing flat-priced providers keep their prior behavior.

## Evidence

- Rebased onto canonical `origin/main` (`6e6319440e7`) while preserving current non-language model filtering.
- Follow-up fixes align tier selection with canonical sorted/range semantics and preserve independent Anthropic compaction billing iterations before aggregation.
- `node scripts/run-vitest.mjs extensions/vercel-ai-gateway/provider-catalog.test.ts` — 13 passed.
- `node scripts/run-vitest.mjs packages/ai/src/model-utils.tiered.test.ts` — 3 passed; the long-context case was red before the runtime calculator change.
- `node scripts/run-vitest.mjs packages/ai/src/providers/anthropic-usage.test.ts` — 10 passed.
- Exact-head follow-up: per-iteration billing samples are cleared after calculation; the runtime-only regression assertion passes.
- `pnpm exec oxfmt --check` passed for all touched files.
- `scripts/run-oxlint.mjs` and the full build remain blocked by unrelated canonical-main dependency/type baseline errors (for example `TuiMainScreen` export and markdown-it typings); no such failures are attributed to this diff.
- No live Vercel request was executed; provider credentials/network behavior is not claimed.
