### PR TITLE
fix(acp): background Codex ACP turns fail hard on transient pre-output Internal error

### DIFF
--- a/src/acp/control-plane/manager.runtime-resume-state.ts
+++ b/src/acp/control-plane/manager.runtime-resume-state.ts
@@ -41,6 +41,13 @@ function isRecoverableMissingManagerPersistentSessionError(error: AcpRuntimeErro
   return false;
 }
 
+const TRANSIENT_CLOSED_TURN_ERROR_PATTERN = /\b(?:client|connection|query)(?: is)? closed\b/i;
+
+function isRecoverableManagerTransientAcpTurnError(message: string): boolean {
+  const normalized = message.trim();
+  return normalized === "Internal error" || TRANSIENT_CLOSED_TURN_ERROR_PATTERN.test(normalized);
+}
+
 /** Prepares a one-time fresh-handle retry for recoverable pre-output runtime failures. */
 export async function prepareFreshManagerRuntimeHandleRetry(params: {
   attempt: number;
@@ -64,38 +71,45 @@ export async function prepareFreshManagerRuntimeHandleRetry(params: {
     return true;
   }
   if (
-    !params.runtime ||
-    !params.meta ||
-    params.meta.mode !== "persistent" ||
-    !isRecoverableMissingManagerPersistentSessionError(params.error)
+    params.runtime &&
+    params.meta &&
+    params.meta.mode === "persistent" &&
+    isRecoverableMissingManagerPersistentSessionError(params.error)
   ) {
-    return false;
-  }
-  const cleared = await clearPersistedRuntimeResumeState({
-    cfg: params.cfg,
-    sessionKey: params.sessionKey,
-    writeSessionMeta: params.writeSessionMeta,
-  });
-  if (!cleared) {
-    return false;
-  }
-  if (params.runtime.prepareFreshSession) {
-    try {
-      await params.runtime.prepareFreshSession({
-        sessionKey: params.sessionKey,
-      });
-    } catch (error) {
-      logVerbose(
-        `acp-manager: failed preparing a fresh persistent session for ${params.sessionKey}: ${formatErrorMessage(error)}`,
-      );
+    const cleared = await clearPersistedRuntimeResumeState({
+      cfg: params.cfg,
+      sessionKey: params.sessionKey,
+      writeSessionMeta: params.writeSessionMeta,
+    });
+    if (!cleared) {
       return false;
     }
+    if (params.runtime.prepareFreshSession) {
+      try {
+        await params.runtime.prepareFreshSession({
+          sessionKey: params.sessionKey,
+        });
+      } catch (error) {
+        logVerbose(
+          `acp-manager: failed preparing a fresh persistent session for ${params.sessionKey}: ${formatErrorMessage(error)}`,
+        );
+        return false;
+      }
+    }
+    params.runtimeHandles.clear(params.sessionKey);
+    logVerbose(
+      `acp-manager: retrying ${params.sessionKey} with a fresh persistent session after missing backend resume target: ${params.error.message}`,
+    );
+    return true;
   }
-  params.runtimeHandles.clear(params.sessionKey);
-  logVerbose(
-    `acp-manager: retrying ${params.sessionKey} with a fresh persistent session after missing backend resume target: ${params.error.message}`,
-  );
-  return true;
+  if (isRecoverableManagerTransientAcpTurnError(params.error.message)) {
+    params.runtimeHandles.clear(params.sessionKey);
+    logVerbose(
+      `acp-manager: retrying ${params.sessionKey} with a fresh runtime handle after transient pre-output turn failure: ${params.error.message}`,
+    );
+    return true;
+  }
+  return false;
 }
 
 async function clearPersistedRuntimeResumeState(params: {

--- a/src/acp/control-plane/manager.turn-results.test.ts
+++ b/src/acp/control-plane/manager.turn-results.test.ts
@@ -1107,14 +1107,79 @@ describe("AcpSessionManager turn results", () => {
     expectFreshRetry(scenario);
   });
 
-  it("does not retry a generic Internal error that is not a resume-required failure", async () => {
+  it.each([
+    ["bare internal error", "Internal error"],
+    ["closed app-server client", "codex app-server client is closed"],
+    ["closed query", "query closed before response received"],
+  ])(
+    "retries a transient pre-output turn failure without discarding the persistent session: %s",
+    async (_label, message) => {
+      const scenario = setupStaleResumeScenario(async function* () {
+        yield {
+          type: "error" as const,
+          code: "ACP_TURN_FAILED",
+          message,
+        };
+      });
+      await expect(scenario.runTurn()).resolves.toBeUndefined();
+      expect(scenario.runtimeState.prepareFreshSession).not.toHaveBeenCalled();
+      expect(scenario.runtimeState.ensureSession).toHaveBeenCalledTimes(2);
+      expect(mockCallArg(scenario.runtimeState.ensureSession, 1).resumeSessionId).toBe(
+        "acpx-sid-stale",
+      );
+      const states = extractStatesFromUpserts();
+      expect(states).toContain("running");
+      expect(states).toContain("idle");
+      expect(states).not.toContain("error");
+    },
+  );
+
+  it("retries a transient turn failure thrown before any output", async () => {
     const scenario = setupStaleResumeScenario(async function* () {
-      // No SESSION_RESUME_REQUIRED detail code: a generic backend failure must
-      // surface, not silently discard the persistent session and retry.
+      yield { type: "status" as const, text: "starting" };
+      throw new Error("query closed before response received");
+    });
+    await expect(scenario.runTurn()).resolves.toBeUndefined();
+    expect(scenario.runtimeState.prepareFreshSession).not.toHaveBeenCalled();
+    expect(scenario.runtimeState.ensureSession).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry a transient turn failure after output was seen", async () => {
+    const scenario = setupStaleResumeScenario(async function* () {
+      yield { type: "text_delta" as const, stream: "output" as const, text: "partial" };
       yield {
         type: "error" as const,
         code: "ACP_TURN_FAILED",
         message: "Internal error",
+      };
+    });
+    await expect(scenario.runTurn()).rejects.toThrow("Internal error");
+    expect(scenario.runtimeState.prepareFreshSession).not.toHaveBeenCalled();
+    expect(scenario.runtimeState.ensureSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry a transient turn failure more than once", async () => {
+    const failingTurn = async function* () {
+      yield {
+        type: "error" as const,
+        code: "ACP_TURN_FAILED",
+        message: "Internal error",
+      };
+    };
+    const scenario = setupStaleResumeScenario(failingTurn);
+    scenario.runtimeState.runTurn.mockReset();
+    scenario.runtimeState.runTurn.mockImplementation(failingTurn);
+    await expect(scenario.runTurn()).rejects.toThrow("Internal error");
+    expect(scenario.runtimeState.runTurn).toHaveBeenCalledTimes(2);
+    expect(scenario.runtimeState.ensureSession).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry an enriched turn failure that is not a transient shape", async () => {
+    const scenario = setupStaleResumeScenario(async function* () {
+      yield {
+        type: "error" as const,
+        code: "ACP_TURN_FAILED",
+        message: "Internal error: stream error: unexpected status 401 Unauthorized",
       };
     });
     await expect(scenario.runTurn()).rejects.toThrow();


### PR DESCRIPTION
Related: #85207

## What Problem This Solves

Resolves a problem where background Codex ACP child turns fail hard with a bare `AcpRuntimeError: Internal error` (`code=ACP_TURN_FAILED`) before the agent has produced any output. Parent workflows that spawn ACP child sessions see a terminal blocker with no deliverable, even though the failure happened before any prompt side effects and a single retry would have succeeded.

Issue #85207 contains two asks: a bounded pre-side-effect retry (labeled `clawsweeper:fix-shape-clear`) and a stale ACPX install policy (labeled `clawsweeper:needs-product-decision`). This PR implements only the retry leaf. The stale-install policy remains a maintainer product decision and is not touched.

## Why This Change Was Made

The manager turn runner already owns the right machinery: a two-attempt loop, a `sawTurnOutput` side-effect guard, and a one-time fresh-handle retry used today for early acpx exits and structured `SESSION_RESUME_REQUIRED` failures (`src/acp/control-plane/manager.runtime-resume-state.ts`). The transient failure shapes reported in the issue were simply not eligible, so they surfaced immediately.

This change extends `prepareFreshManagerRuntimeHandleRetry` with a transient-shape predicate: a trimmed message equal to `Internal error` (the generic ACP JSON-RPC internal error the Codex ACP path emits when no diagnostics are available), or a client/connection/query closed transport shape (`codex app-server client is closed` from `extensions/codex/src/app-server/client.ts`, `query closed before response received` from the acpx transport). Eligibility still requires `attempt === 0` and no observed turn output, so there is exactly one retry and never a retry after assistant output or tool calls.

Design boundaries:

- Structured `SESSION_RESUME_REQUIRED` recovery keeps priority; the transient retry only clears the in-memory runtime handle and never discards the persistent session identity, preserving the #87830 boundary (no `prepareFreshSession`, resume id kept).
- Matching is top-level message only, deliberately not the cause chain: the acpx Codex stderr enrichment wraps the bare generic error as `cause`, so a cause-chain walk would make every enriched deterministic failure (for example an auth error in the stderr tail) retryable. Enriched messages retry only when the enriched text itself carries a closed-transport shape.
- The retry lives at the manager boundary, which already owns retry policy and the side-effect guard. Retrying inside the acpx runtime `startTurn` would require buffering event streams and cannot see manager-level output state; the sibling `runTurn`/`startTurn` enrichment paths in `extensions/acpx/src/runtime.ts` are unchanged and both feed this same manager catch path.

Prior art: #59883 attempted a broader multi-retry backoff at the `runTurn` layer and was closed after its head drifted to unrelated work. This PR is a single bounded retry using the manager infrastructure that landed since.

## User Impact

Background ACP/Codex child work now survives one transient pre-output prompt failure (generic internal error or closed transport) instead of failing the whole parent task. Sessions keep their persistent identity across the retry. Behavior after any observed output is unchanged, a second failure surfaces exactly as before, and non-transient failures (including enriched diagnostics such as auth errors) are never retried.

## Evidence

Live before/after driving the real `AcpSessionManager` (`getAcpSessionManager().initializeSession` + `runTurn`, the same production dispatcher the gateway uses), with the real turn runner, retry policy, and SQLite session store in an isolated state dir. Only the ACP child agent process boundary is scripted, registered through the production `registerAcpRuntimeBackend` API, to fail the first prompt with the issue's exact error and stream output on the second. Identical inputs both runs.

BEFORE (pristine main d0f37bd8433782147629bdd2fc1b076c1def61d3):

```
turn outcome: failed code=ACP_TURN_FAILED message=Internal error
prompt attempts that reached the codex acp agent: 1
events seen by the parent workflow: error:Internal error
```

AFTER (this patch, identical inputs):

```
acp-manager: retrying agent:codex:acp:issue-85207-repro with a fresh runtime handle after transient pre-output turn failure: Internal error
acp-manager: session identity updated for agent:codex:acp:issue-85207-repro (agentSessionId <none> -> <none>, acpxSessionId acpx-sid-85207 -> acpx-sid-85207, acpxRecordId <none> -> <none>)
turn outcome: completed
prompt attempts that reached the codex acp agent: 2
events seen by the parent workflow: error:Internal error | text_delta:child task result | done
```

The parent-visible outcome flips from a hard `ACP_TURN_FAILED` blocker to a completed turn with the child deliverable, and the session identity line shows the persistent id preserved across the retry.

Regression coverage in `src/acp/control-plane/manager.turn-results.test.ts` (5 of the new cases fail on pristine main, all 24 pass with the patch): retry for bare internal error, closed app-server client, and closed query shapes with the resume id preserved and `prepareFreshSession` never called; retry for a thrown transient failure; no retry after output was seen; no second retry; no retry for enriched non-transient diagnostics.

Local gates (changed files): `node scripts/run-vitest.mjs src/acp/control-plane/manager.turn-results.test.ts` 24 passed; `node scripts/run-oxlint.mjs` clean; `oxfmt --check` clean; `tsgo` core and core-test lanes exit 0.

Not tested live: a real Codex app-server crash mid-prompt; the transient failure is injected at the registered runtime backend boundary.
