### PR TITLE
fix(discord): use UTF-16 safe truncation for voice participant labels

### DIFF
--- a/extensions/discord/src/voice/participant-context.test.ts
+++ b/extensions/discord/src/voice/participant-context.test.ts
@@ -55,7 +55,7 @@ describe("normalizeLabel (via formatDiscordVoiceParticipantStateLine)", () => {
     });
     const match = line.match(/display_name="(.*)"/);
     expect(match).not.toBeNull();
-    const displayName = match![1];
+    const displayName = match![1]!;
     expect(displayName.length).toBeLessThanOrEqual(201);
     expect(displayName).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/);
     expect(displayName).not.toMatch(/(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/);
@@ -83,7 +83,7 @@ describe("normalizeLabel (via formatDiscordVoiceParticipantStateLine)", () => {
     });
     const match = line.match(/display_name="(.*)"/);
     expect(match).not.toBeNull();
-    const displayName = match![1];
+    const displayName = match![1]!;
     expect(displayName.length).toBeLessThanOrEqual(101);
   });
 });

--- a/extensions/discord/src/voice/participant-context.test.ts
+++ b/extensions/discord/src/voice/participant-context.test.ts
@@ -1,6 +1,9 @@
 // Discord tests cover voice participant classification.
 import { describe, expect, it } from "vitest";
-import { countDiscordVoiceHumanParticipants } from "./participant-context.js";
+import {
+  countDiscordVoiceHumanParticipants,
+  formatDiscordVoiceParticipantStateLine,
+} from "./participant-context.js";
 
 describe("countDiscordVoiceHumanParticipants", () => {
   it("counts people while excluding the agent and other bots", () => {
@@ -37,5 +40,50 @@ describe("countDiscordVoiceHumanParticipants", () => {
         additionalUserIds: ["known-bot", "cache-race-speaker"],
       }),
     ).toBe(1);
+  });
+});
+
+describe("normalizeLabel (via formatDiscordVoiceParticipantStateLine)", () => {
+  it("truncates emoji nicknames without splitting surrogate pairs", () => {
+    const emojiNickname = "😀".repeat(60);
+    const line = formatDiscordVoiceParticipantStateLine({
+      userId: "user-1",
+      state: {
+        user_id: "user-1",
+        member: { nick: emojiNickname, user: { id: "user-1", bot: false } },
+      } as never,
+    });
+    const match = line.match(/display_name="(.*)"/);
+    expect(match).not.toBeNull();
+    const displayName = match![1];
+    expect(displayName.length).toBeLessThanOrEqual(201);
+    expect(displayName).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/);
+    expect(displayName).not.toMatch(/(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/);
+  });
+
+  it("preserves short ASCII nicknames unchanged", () => {
+    const line = formatDiscordVoiceParticipantStateLine({
+      userId: "user-2",
+      state: {
+        user_id: "user-2",
+        member: { nick: "Alice", user: { id: "user-2", bot: false } },
+      } as never,
+    });
+    expect(line).toContain('display_name="Alice"');
+  });
+
+  it("truncates CJK-heavy nicknames at correct code-unit boundary", () => {
+    const cjkNickname = "测试".repeat(60);
+    const line = formatDiscordVoiceParticipantStateLine({
+      userId: "user-3",
+      state: {
+        user_id: "user-3",
+        member: { nick: cjkNickname, user: { id: "user-3", bot: false } },
+      } as never,
+    });
+    const match = line.match(/display_name="(.*)"/);
+    expect(match).not.toBeNull();
+    const displayName = match![1];
+    expect(displayName.length).toBeLessThanOrEqual(101);
   });
 });

--- a/extensions/discord/src/voice/participant-context.ts
+++ b/extensions/discord/src/voice/participant-context.ts
@@ -1,4 +1,5 @@
 import type { DiscordAccountConfig, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { APIVoiceState, Client } from "../internal/discord.js";
 import type { GatewayPlugin } from "../internal/gateway.js";
 import { type DiscordVoiceIngressContext, resolveDiscordVoiceIngressContext } from "./ingress.js";
@@ -23,7 +24,7 @@ function normalizeLabel(value: unknown): string | undefined {
     return undefined;
   }
   const normalized = value.replace(/\s+/g, " ").trim();
-  return normalized ? normalized.slice(0, 100) : undefined;
+  return normalized ? truncateUtf16Safe(normalized, 100) : undefined;
 }
 
 function memberLabel(state: APIVoiceState): string | undefined {


### PR DESCRIPTION
Fixes surrogate pair splitting in `normalizeLabel` when truncating Discord voice participant display names to 100 code units.

## What Problem This Solves

`normalizeLabel` in `participant-context.ts` uses `\.slice(0, 100)` to truncate display names. This can split UTF-16 surrogate pairs (emoji, supplementary plane characters), producing orphan surrogates that render as garbled characters () in the voice roster prompt.

## Why This Change Was Made

Replaces `.slice(0, 100)` with `truncateUtf16Safe(normalized, 100)` from `openclaw/plugin-sdk/text-utility-runtime`, which already exists and is used in 14 other files within the discord extension. This function safely adjusts the truncation boundary to avoid splitting surrogate pairs.

## User Impact

Voice participant display names with emoji or supplementary plane characters will no longer show garbled text when truncated.

## Evidence

Added 3 test cases:
- 60 emoji nickname (120 UTF-16 code units) truncates without orphan surrogates
- Short ASCII nicknames preserved unchanged
- CJK nicknames truncate at correct code-unit boundary