### PR TITLE
fix(meeting-bot): cap audio chunk queue by total bytes too

### DIFF
--- a/src/meeting-bot/node-audio-chunk-queue.test.ts
+++ b/src/meeting-bot/node-audio-chunk-queue.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+  appendAudioChunk,
+  createAudioChunkQueue,
+  DEFAULT_MAX_AUDIO_CHUNKS,
+  DEFAULT_MAX_AUDIO_QUEUE_BYTES,
+  takeAudioChunk,
+} from "./node-audio-chunk-queue.js";
+
+describe("appendAudioChunk", () => {
+  it("returns the queue untouched when under both limits", () => {
+    const queue = createAudioChunkQueue();
+    appendAudioChunk(queue, Buffer.from("hello"), {
+      maxChunks: 10,
+      maxBytes: 1024,
+    });
+    expect(queue.chunks.map((c) => c.toString())).toEqual(["hello"]);
+    expect(queue.bytes).toBe(5);
+  });
+
+  it("trims oldest chunks when chunk count exceeds the limit", () => {
+    const queue = createAudioChunkQueue();
+    const limits = { maxChunks: 2, maxBytes: 1024 * 1024 };
+    for (let i = 0; i < 5; i += 1) {
+      appendAudioChunk(queue, Buffer.from(`c${i}`), limits);
+    }
+    expect(queue.chunks.map((c) => c.toString())).toEqual(["c3", "c4"]);
+    expect(queue.bytes).toBe(4);
+  });
+
+  it("trims oldest chunks when total bytes exceed the limit", () => {
+    const queue = createAudioChunkQueue();
+    const limits = { maxChunks: 1000, maxBytes: 8 };
+    appendAudioChunk(queue, Buffer.alloc(5), limits);
+    appendAudioChunk(queue, Buffer.alloc(5), limits);
+    appendAudioChunk(queue, Buffer.alloc(5), limits);
+    // The first two 5-byte chunks push us over the 8-byte limit; both are
+    // dropped on the third append so the queue only holds the most recent.
+    expect(queue.chunks).toHaveLength(1);
+    expect(queue.bytes).toBe(5);
+  });
+
+  it("honors both limits simultaneously", () => {
+    const queue = createAudioChunkQueue();
+    const limits = { maxChunks: 3, maxBytes: 6 };
+    for (let i = 0; i < 5; i += 1) {
+      appendAudioChunk(queue, Buffer.alloc(2), limits);
+    }
+    expect(queue.chunks).toHaveLength(3);
+    expect(queue.bytes).toBe(6);
+  });
+});
+
+describe("takeAudioChunk", () => {
+  it("returns undefined for an empty queue and leaves bytes at zero", () => {
+    const queue = createAudioChunkQueue();
+    expect(takeAudioChunk(queue)).toBeUndefined();
+    expect(queue.bytes).toBe(0);
+  });
+
+  it("removes the oldest chunk and decrements the byte counter", () => {
+    const queue = createAudioChunkQueue();
+    appendAudioChunk(
+      queue,
+      Buffer.from("abcd"),
+      { maxChunks: 10, maxBytes: 1024 },
+    );
+    appendAudioChunk(
+      queue,
+      Buffer.from("efghij"),
+      { maxChunks: 10, maxBytes: 1024 },
+    );
+    expect(queue.bytes).toBe(10);
+    const first = takeAudioChunk(queue);
+    expect(first?.toString()).toBe("abcd");
+    expect(queue.chunks.map((c) => c.toString())).toEqual(["efghij"]);
+    expect(queue.bytes).toBe(6);
+  });
+});
+
+describe("audio chunk queue defaults", () => {
+  it("exposes the production limits used by the node host", () => {
+    // Sanity-check the production defaults so an accidental unit change is
+    // caught at review time.
+    expect(DEFAULT_MAX_AUDIO_CHUNKS).toBe(200);
+    expect(DEFAULT_MAX_AUDIO_QUEUE_BYTES).toBe(32 * 1024 * 1024);
+  });
+});

--- a/src/meeting-bot/node-audio-chunk-queue.ts
+++ b/src/meeting-bot/node-audio-chunk-queue.ts
@@ -1,0 +1,55 @@
+/**
+ * Bounded audio chunk queue used by the meeting-bridge node host.
+ *
+ * The session's chunk buffer was previously only bounded by element count
+ * (200 chunks), which allowed a single chatty producer emitting very large
+ * chunks to grow the in-memory queue without bound: a producer pushing
+ * 10 MiB chunks would retain up to 2 GiB of audio. This helper trims by
+ * both chunk count and total byte size so neither dimension can run away.
+ */
+export const DEFAULT_MAX_AUDIO_CHUNKS = 200;
+/**
+ * Safety bound for buffered audio, in bytes. ~32 MiB 鈮?8 seconds of
+ * 16-bit 44.1 kHz stereo audio, which is far above any legitimate back-log
+ * but small enough to keep the host's footprint predictable.
+ */
+export const DEFAULT_MAX_AUDIO_QUEUE_BYTES = 32 * 1024 * 1024;
+
+export type AudioChunkQueueLimits = {
+  maxChunks: number;
+  maxBytes: number;
+};
+
+export type AudioChunkQueue = {
+  chunks: Buffer[];
+  bytes: number;
+};
+
+export function createAudioChunkQueue(): AudioChunkQueue {
+  return { chunks: [], bytes: 0 };
+}
+
+/** Append a chunk and trim the queue so it stays within `maxChunks` and `maxBytes`. */
+export function appendAudioChunk(
+  queue: AudioChunkQueue,
+  chunk: Buffer,
+  limits: AudioChunkQueueLimits,
+): void {
+  queue.chunks.push(chunk);
+  queue.bytes += chunk.byteLength;
+  while (queue.chunks.length > limits.maxChunks || queue.bytes > limits.maxBytes) {
+    const dropped = queue.chunks.shift();
+    if (dropped) {
+      queue.bytes -= dropped.byteLength;
+    }
+  }
+}
+
+/** Remove and return the oldest chunk, keeping the running byte counter in sync. */
+export function takeAudioChunk(queue: AudioChunkQueue): Buffer | undefined {
+  const chunk = queue.chunks.shift();
+  if (chunk) {
+    queue.bytes -= chunk.byteLength;
+  }
+  return chunk;
+}

--- a/src/meeting-bot/node-host.ts
+++ b/src/meeting-bot/node-host.ts
@@ -1,9 +1,21 @@
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { terminateMeetingBridgeProcess } from "./bridge-process.js";
+import {
+  appendAudioChunk,
+  createAudioChunkQueue,
+  DEFAULT_MAX_AUDIO_CHUNKS,
+  DEFAULT_MAX_AUDIO_QUEUE_BYTES,
+  takeAudioChunk,
+  type AudioChunkQueueLimits,
+} from "./node-audio-chunk-queue.js";
 import { MeetingNodeAudioPullWaiters } from "./node-audio-pull-waiters.js";
 
 const NODE_BRIDGE_TERMINATION_GRACE_MS = 2_000;
+const AUDIO_CHUNK_QUEUE_LIMITS: AudioChunkQueueLimits = {
+  maxChunks: DEFAULT_MAX_AUDIO_CHUNKS,
+  maxBytes: DEFAULT_MAX_AUDIO_QUEUE_BYTES,
+};
 
 type NodeBridgeSession = {
   id: string;
@@ -12,7 +24,7 @@ type NodeBridgeSession = {
   outputCommand: { command: string; args: string[] };
   input?: ChildProcess;
   output?: ChildProcess;
-  chunks: Buffer[];
+  audioChunks: ReturnType<typeof createAudioChunkQueue>;
   waiters: MeetingNodeAudioPullWaiters;
   closed: boolean;
   createdAt: string;
@@ -169,7 +181,7 @@ export function createMeetingNodeHost(options: MeetingNodeHostOptions): {
       url: params.url,
       mode: params.mode,
       outputCommand: output,
-      chunks: [],
+      audioChunks: createAudioChunkQueue(),
       waiters: new MeetingNodeAudioPullWaiters(),
       closed: false,
       createdAt: new Date().toISOString(),
@@ -188,10 +200,7 @@ export function createMeetingNodeHost(options: MeetingNodeHostOptions): {
       const audio = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
       session.lastInputAt = new Date().toISOString();
       session.lastInputBytes += audio.byteLength;
-      session.chunks.push(audio);
-      if (session.chunks.length > 200) {
-        session.chunks.splice(0, session.chunks.length - 200);
-      }
+      appendAudioChunk(session.audioChunks, audio, AUDIO_CHUNK_QUEUE_LIMITS);
       wake(session);
     });
     const stop = () => {
@@ -216,10 +225,10 @@ export function createMeetingNodeHost(options: MeetingNodeHostOptions): {
       throw new Error(`unknown bridgeId: ${bridgeId}`);
     }
     const timeoutMs = Math.min(readNumber(params.timeoutMs, 250), 2_000);
-    if (session.chunks.length === 0 && !session.closed) {
+    if (session.audioChunks.chunks.length === 0 && !session.closed) {
       await session.waiters.wait(timeoutMs);
     }
-    const chunk = session.chunks.shift();
+    const chunk = takeAudioChunk(session.audioChunks);
     return {
       bridgeId,
       closed: session.closed,
@@ -364,7 +373,7 @@ export function createMeetingNodeHost(options: MeetingNodeHostOptions): {
             lastInputBytes: session.lastInputBytes,
             lastOutputBytes: session.lastOutputBytes,
             clearCount: session.clearCount,
-            queuedInputChunks: session.chunks.length,
+            queuedInputChunks: session.audioChunks.chunks.length,
           }
         : bridgeId
           ? { bridgeId, closed: true }
@@ -499,3 +508,4 @@ export function createMeetingNodeHost(options: MeetingNodeHostOptions): {
     },
   };
 }
+


### PR DESCRIPTION
# fix(meeting-bot): cap audio chunk queue by total bytes too

The node-host audio buffer was previously only bounded by element count
(`session.chunks.length > 200` 鈫?`splice(0, length - 200)`), which meant a
single chatty producer emitting very large chunks could grow the in-memory
queue without bound. A producer pushing 10 MiB chunks would retain up to
2 GiB of audio in the host until a slow consumer drained it.

This change extracts the chunk queue into a small `audioChunkQueue` helper
that trims by both chunk count and total byte size, and switches the
node-host data handler to use it. The default 32 MiB cap is well above any
legitimate back-log (~8 s of 16-bit 44.1 kHz stereo) but small enough to
keep the host's footprint predictable.

## Changes

- **New** `src/meeting-bot/node-audio-chunk-queue.ts` 鈥?bounded queue with
  `appendAudioChunk` / `takeAudioChunk` helpers and the production
  default limits (`200` chunks, `32 MiB`).
- **New** `src/meeting-bot/node-audio-chunk-queue.test.ts` 鈥?covers the
  count limit, the byte limit, both limits together, empty-queue `take`,
  and the production default values.
- **Modified** `src/meeting-bot/node-host.ts` 鈥?switches the
  `NodeBridgeSession` to a structured `audioChunks` queue and routes
  data/pull through the helper so the byte counter stays in sync.

The pull path also goes through the helper so the running byte counter
remains accurate as chunks are removed. `lastInputBytes` (the lifetime
counter) is unchanged.

## Reproduction (before)

```
# Push 200 chunks of 10 MiB each
for _ in {1..200}; do dd if=/dev/zero bs=10M count=1 2>/dev/null; done |
  spawn <node host input>
# Retained: ~2 GiB in `session.chunks` until consumer catches up
```

After: the queue is trimmed as soon as the 32 MiB cap is crossed.
