### PR TITLE
fix(skills): search results split when ClawHub summaries contain newlines

### DIFF
--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -394,6 +394,24 @@ describe("skills cli commands", () => {
     expect(runtimeLogs).toEqual(["legacy-calendar  Legacy Calendar"]);
   });
 
+  it("keeps multiline ClawHub search metadata on one terminal line", async () => {
+    searchSkillsFromClawHubMock.mockResolvedValue([
+      {
+        slug: "oauth-helper",
+        ownerHandle: "demo-owner",
+        displayName: "Oauth\nHelper",
+        summary:
+          "Automate OAuth login flows.\nSupports multiple providers.\n\nFeatures:\n- Confirm before authorizing",
+      },
+    ]);
+
+    await runCommand(["skills", "search", "oauth-helper"]);
+
+    expect(runtimeLogs).toEqual([
+      "@demo-owner/oauth-helper  Oauth Helper  Automate OAuth login flows. Supports multiple providers. Features: - Confirm before authorizing",
+    ]);
+  });
+
   it("keeps ClawHub skill search JSON output unchanged", async () => {
     const results = [
       {

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -5,6 +5,7 @@ import {
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
 } from "../../packages/gateway-protocol/src/client-info.js";
+import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
 import {
@@ -93,6 +94,10 @@ function resolveSkillClawHubRiskOptions(
 
 function formatSkillWarning(message: string): string {
   return message.includes("╭─") ? message : theme.warn(message);
+}
+
+function formatClawHubSearchText(value: string): string {
+  return sanitizeForLog(value.replace(/\s+/gu, " ")).trim();
 }
 
 function isClawHubSkillBlockedCliFailure(result: { code?: string; warning?: string }): boolean {
@@ -431,10 +436,12 @@ export function registerSkillsCli(program: Command) {
         }
         for (const entry of results) {
           const ownerHandle = normalizeOptionalString(entry.ownerHandle);
-          const skillRef = ownerHandle ? `@${ownerHandle}/${entry.slug}` : entry.slug;
-          const version = entry.version ? ` v${entry.version}` : "";
-          const summary = entry.summary ? `  ${entry.summary}` : "";
-          defaultRuntime.log(`${skillRef}${version}  ${entry.displayName}${summary}`);
+          const slug = formatClawHubSearchText(entry.slug);
+          const skillRef = ownerHandle ? `@${formatClawHubSearchText(ownerHandle)}/${slug}` : slug;
+          const version = entry.version ? ` v${formatClawHubSearchText(entry.version)}` : "";
+          const summary = entry.summary ? `  ${formatClawHubSearchText(entry.summary)}` : "";
+          const displayName = formatClawHubSearchText(entry.displayName);
+          defaultRuntime.log(`${skillRef}${version}  ${displayName}${summary}`);
         }
       } catch (err) {
         defaultRuntime.error(String(err));


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw skills search` would see one ClawHub result split across many terminal lines when its registry summary contained paragraphs or bullets. The wrapped content could look like separate results and made owner-qualified install references harder to scan.

Live context: [ClawHub `oauth-helper` search response](https://clawhub.ai/api/v1/search?q=oauth-helper&limit=3)

## Why This Change Was Made

ClawHub search metadata is now normalized to safe single-line terminal text only at the human-readable rendering boundary. Structured `--json` output remains unchanged, including embedded newlines supplied by the registry.

## User Impact

Each `openclaw skills search` result now stays on one terminal line even when a ClawHub publisher uses a multiline summary. Existing one-line results and machine-readable output keep their prior behavior.

## Evidence

Live third-party before/after using latest-main OpenClaw against the public ClawHub API:

- Before: the single `@helloliuyongsheng-bot/oauth-helper` result occupied nine visible content lines because ClawHub returned a seven-newline summary.
- After: the same live result rendered as one terminal line with its text preserved and whitespace collapsed.
- JSON control: `openclaw skills search oauth-helper --json --limit 3` still preserved all seven summary newlines (`summary_newlines=7`).
- Ordinary control: `openclaw skills search email-gmail-outlook --limit 1` continued to render normally.

Validation:

- `node scripts/run-vitest.mjs src/cli/skills-cli.commands.test.ts` — 64 passed.
- Local `node scripts/check-changed.mjs` fallback — `core` and `coreTests` changed lanes completed through the final guard. Blacksmith delegation did not run because the installed Crabbox binary failed its basic self-check.
- `codex review --base origin/main` — no actionable findings.
- `git diff --check origin/main...HEAD` — passed.
