### PR TITLE
fix(telegram): count Unicode code points for forum topic name length validation

### DIFF
--- a/extensions/telegram/src/send-forum-topics.ts
+++ b/extensions/telegram/src/send-forum-topics.ts
@@ -49,7 +49,7 @@ export async function editForumTopicTelegram(
   if (nameProvided && !trimmedName) {
     throw new Error("Telegram forum topic name is required");
   }
-  if (trimmedName && trimmedName.length > 128) {
+  if (trimmedName && Array.from(trimmedName).length > 128) {
     throw new Error("Telegram forum topic name must be 128 characters or fewer");
   }
   const iconProvided = opts.iconCustomEmojiId !== undefined;
@@ -177,7 +177,7 @@ export async function createForumTopicTelegram(
     throw new Error("Forum topic name is required");
   }
   const trimmedName = name.trim();
-  if (trimmedName.length > 128) {
+  if (Array.from(trimmedName).length > 128) {
     throw new Error("Forum topic name must be 128 characters or fewer");
   }
 

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -826,6 +826,31 @@ describe("sendMessageTelegram", () => {
     });
   });
 
+  it.each([
+    ["65 emoji", "😀".repeat(65)],
+    ["128 emoji", "😀".repeat(128)],
+    ["128 mixed emoji and ASCII characters", "😀".repeat(64) + "a".repeat(64)],
+    ["128 CJK characters", "界".repeat(128)],
+  ])("accepts %s forum topic names by Unicode code points", async (_label, name) => {
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          botToken: "tok",
+        },
+      },
+    });
+    botApi.editForumTopic.mockResolvedValue(true);
+
+    await editForumTopicTelegram("-1001234567890", 271, {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      accountId: "default",
+      name,
+    });
+
+    expect(botApi.editForumTopic).toHaveBeenCalledWith("-1001234567890", 271, { name });
+  });
+
   it("strips topic suffixes before editing a Telegram forum topic", async () => {
     loadConfig.mockReturnValue({
       channels: {
@@ -5106,6 +5131,24 @@ describe("createForumTopicTelegram", () => {
     });
   }
 
+  it.each([
+    ["65 emoji", "🎃".repeat(65)],
+    ["128 emoji", "🎃".repeat(128)],
+    ["128 mixed emoji and ASCII characters", "🎃".repeat(64) + "a".repeat(64)],
+    ["128 CJK characters", "界".repeat(128)],
+  ])("accepts %s forum topic names by Unicode code points", async (_label, name) => {
+    const createForumTopic = vi.fn().mockResolvedValue({ message_thread_id: 400, name });
+    const api = { createForumTopic } as unknown as Bot["api"];
+
+    await createForumTopicTelegram("-1001234567890", name, {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+    });
+
+    expect(createForumTopic).toHaveBeenCalledWith("-1001234567890", name, undefined);
+  });
+
   it("rejects an invalid topic name before creating a Telegram client", async () => {
     botCtorSpy.mockClear();
 
@@ -5116,6 +5159,35 @@ describe("createForumTopicTelegram", () => {
       }),
     ).rejects.toThrow("Forum topic name is required");
     expect(botCtorSpy).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["129 ASCII characters", "a".repeat(129)],
+    ["129 emoji", "🎃".repeat(129)],
+    ["19 multi-code-point emoji graphemes", "👨‍👩‍👧‍👦".repeat(19)],
+  ])("rejects %s exceeding 128 Unicode code points on create and edit", async (_label, name) => {
+    const createForumTopic = vi.fn();
+    const editForumTopic = vi.fn();
+    const api = { createForumTopic, editForumTopic } as unknown as Bot["api"];
+
+    await expect(
+      createForumTopicTelegram("-1001234567890", name, {
+        cfg: TELEGRAM_TEST_CFG,
+        token: "tok",
+        api,
+      }),
+    ).rejects.toThrow("128 characters or fewer");
+    await expect(
+      editForumTopicTelegram("-1001234567890", 271, {
+        cfg: TELEGRAM_TEST_CFG,
+        token: "tok",
+        api,
+        name,
+      }),
+    ).rejects.toThrow("128 characters or fewer");
+
+    expect(createForumTopic).not.toHaveBeenCalled();
+    expect(editForumTopic).not.toHaveBeenCalled();
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
Fixes over-restrictive length validation in `editForumTopicTelegram` and `createForumTopicTelegram` that used UTF-16 code unit count instead of Unicode code point count.

## What Problem This Solves

`editForumTopicTelegram` and `createForumTopicTelegram` validate topic name length against Telegram's 128-character limit using `.length`, which counts UTF-16 code units. Emoji and supplementary plane characters each consume 2 code units, so a 65-emoji name (130 code units) is incorrectly rejected even though it contains only 65 Unicode characters — well within Telegram's 128 code point limit.

## Why This Change Was Made

Replaced `.length > 128` with `[...trimmedName].length > 128` at both validation sites. The spread operator iterates by Unicode code point, matching Telegram Bot API's character-counting semantics.

## User Impact

Forum topic names containing emoji or CJK characters are no longer incorrectly rejected when they contain fewer than 128 actual Unicode characters but more than 128 UTF-16 code units.

## Evidence

Added 3 test cases:
- 65 emoji name accepted by `editForumTopicTelegram` (130 code units, 65 code points)
- 65 emoji name accepted by `createForumTopicTelegram`
- 129-code-point name still correctly rejected

## Maintainer validation on current main

The original @LiuwqGit contributor commit was refreshed onto current main after #113222 moved forum-topic ownership from `send.ts` into `extensions/telegram/src/send-forum-topics.ts`. Exact refreshed head `63650e1a10c53f60ea0ac99ddb622fb83d2de6de` preserves the original author, authored timestamp, and commit subject; only the current two approved Telegram owner/test files change.

Telegram TDLib defines [128 title characters](https://github.com/tdlib/td/blob/022d60202e446ad1287b9fb68e687c8a0760788b/td/telegram/ForumTopicManager.h#L149) and counts [Unicode characters rather than UTF-16 code units](https://github.com/tdlib/td/blob/022d60202e446ad1287b9fb68e687c8a0760788b/tdutils/td/utils/utf8.h#L68-L86). Both create and edit must therefore accept 65-128 emoji instead of rejecting them based on JavaScript string `.length`.

- Actual previous live Telegram/Mantis run: https://github.com/openclaw/openclaw/actions/runs/29695969658 ; 65-emoji topic created successfully with real `message_thread_id=47391440896`; [Telegram Desktop evidence](https://artifacts.openclaw.ai/mantis/telegram-desktop/pr-111443/run-29695969658-1/candidate/telegram-desktop-proof.mp4).
- Current production create/edit -> real grammY -> real localhost HTTP: **18 assertions, 12 requests**; 65/128 emoji, mixed emoji+ASCII, CJK, and ASCII pass; 129 emoji and 19 multi-code-point family graphemes reject before the network.
- Clean trusted Linux Blacksmith Testbox `tbx_01kyyy0zse0j7pespjmcm3dy2g`: **11/11 owner regression tests pass**; delegated timing JSON `exitCode=0`; https://github.com/openclaw/openclaw/actions/runs/30705339919 .
- Fresh Sol xhigh autoreview, target formatting, and exact two-file scope clean.

Detailed maintainer proof: https://github.com/openclaw/openclaw/pull/111443#issuecomment-5152026896

Full hosted CI is required on this exact contributor head before landing.