### PR TITLE
fix(qa): avoid touching operator state during private QA runs

### DIFF
--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -71,6 +71,12 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     policy: { bypassConfigGuard: true, loadPlugins: "never", ensureCliPath: false },
   },
   {
+    commandPath: ["qa"],
+    // Private QA commands create or inspect repo-owned fixtures. They must not
+    // read, validate, migrate, or inherit proxy policy from operator state.
+    policy: { bypassConfigGuard: true, loadPlugins: "never", networkProxy: "bypass" },
+  },
+  {
     commandPath: ["crestodian"], // hidden alias
     policy: { bypassConfigGuard: true, loadPlugins: "never", ensureCliPath: false },
   },

--- a/src/cli/command-path-policy.test.ts
+++ b/src/cli/command-path-policy.test.ts
@@ -186,6 +186,11 @@ describe("command-path-policy", () => {
   });
 
   it("resolves mixed startup-only rules", () => {
+    expectResolvedPolicy(["qa", "suite"], {
+      bypassConfigGuard: true,
+      loadPlugins: "never",
+      networkProxy: "bypass",
+    });
     expectResolvedPolicy(["worker"], {
       bypassConfigGuard: true,
       loadPlugins: "never",

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -190,6 +190,10 @@ describe("registerPreActionHooks", () => {
     programLocal.command("completion").action(() => {});
     programLocal.command("secrets").action(() => {});
     programLocal
+      .command("qa")
+      .command("suite")
+      .action(() => {});
+    programLocal
       .command("agents")
       .command("list")
       .option("--json")
@@ -435,6 +439,16 @@ describe("registerPreActionHooks", () => {
     await runPreAction({
       parseArgv: ["configure"],
       processArgv: ["node", "openclaw", "configure"],
+    });
+
+    expect(ensureConfigReadyMock).not.toHaveBeenCalled();
+    expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps private QA commands isolated from operator config bootstrap", async () => {
+    await runPreAction({
+      parseArgv: ["qa", "suite"],
+      processArgv: ["node", "openclaw", "qa", "suite"],
     });
 
     expect(ensureConfigReadyMock).not.toHaveBeenCalled();

--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -222,6 +222,7 @@ describe("shouldStartProxyForCli", () => {
   });
 
   it("skips managed proxy routing for bare parent default help", () => {
+    expect(shouldStartProxyForCli(["node", "openclaw", "qa", "suite"])).toBe(false);
     expect(shouldStartProxyForCli(["node", "openclaw", "plugins"])).toBe(false);
     expect(shouldStartProxyForCli(["node", "openclaw", "channels"])).toBe(false);
     expect(shouldStartProxyForCli(["node", "openclaw", "cron"])).toBe(false);

--- a/src/plugin-sdk/qa-runner-runtime.integration.test.ts
+++ b/src/plugin-sdk/qa-runner-runtime.integration.test.ts
@@ -14,6 +14,7 @@ import {
 import { listQaRunnerCliContributions } from "./qa-runner-runtime.js";
 
 const ORIGINAL_ENV = {
+  OPENCLAW_ENABLE_PRIVATE_QA_CLI: process.env.OPENCLAW_ENABLE_PRIVATE_QA_CLI,
   OPENCLAW_DISABLE_BUNDLED_PLUGINS: process.env.OPENCLAW_DISABLE_BUNDLED_PLUGINS,
   OPENCLAW_CONFIG_PATH: process.env.OPENCLAW_CONFIG_PATH,
   OPENCLAW_STATE_DIR: process.env.OPENCLAW_STATE_DIR,
@@ -140,5 +141,48 @@ describe("plugin-sdk qa-runner-runtime linked plugin smoke", () => {
         },
       },
     ]);
+  });
+
+  it("ignores operator runner metadata and state during private QA discovery", () => {
+    const stateDir = makeTempDir("openclaw-private-qa-operator-state-");
+    const pluginDir = path.join(stateDir, "extensions", "operator-runner");
+    const stateDatabasePath = path.join(stateDir, "openclaw.sqlite");
+    const stateDatabaseSentinel = "operator-state-must-remain-unopened";
+
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.writeFileSync(stateDatabasePath, stateDatabaseSentinel, "utf8");
+    fs.writeFileSync(
+      path.join(pluginDir, "openclaw.plugin.json"),
+      JSON.stringify({
+        id: "operator-runner",
+        qaRunners: [{ commandName: "operator-sentinel" }],
+        configSchema: {
+          type: "object",
+          additionalProperties: false,
+          properties: {},
+        },
+      }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(pluginDir, "package.json"),
+      JSON.stringify({
+        name: "@openclaw/operator-runner",
+        type: "module",
+        openclaw: { extensions: ["./index.js"] },
+      }),
+      "utf8",
+    );
+    fs.writeFileSync(path.join(pluginDir, "index.js"), "export default {};\n", "utf8");
+
+    process.env.OPENCLAW_ENABLE_PRIVATE_QA_CLI = "1";
+    process.env.OPENCLAW_DISABLE_BUNDLED_PLUGINS = "0";
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    process.env.OPENCLAW_CONFIG_PATH = path.join(stateDir, "openclaw.json");
+
+    const contributions = listQaRunnerCliContributions();
+
+    expect(contributions.some((runner) => runner.pluginId === "operator-runner")).toBe(false);
+    expect(fs.readFileSync(stateDatabasePath, "utf8")).toBe(stateDatabaseSentinel);
   });
 });

--- a/src/plugin-sdk/qa-runner-runtime.test.ts
+++ b/src/plugin-sdk/qa-runner-runtime.test.ts
@@ -13,11 +13,13 @@ import {
 } from "./qa-runtime.test-helpers.js";
 
 const loadPluginManifestRegistry = vi.hoisted(() => vi.fn());
+const loadBundledPluginManifestRegistry = vi.hoisted(() => vi.fn());
 const loadBundledPluginPublicSurfaceModuleSync = vi.hoisted(() => vi.fn());
 const tryLoadActivatedBundledPluginPublicSurfaceModuleSync = vi.hoisted(() => vi.fn());
 const resolveOpenClawPackageRootSync = vi.hoisted(() => vi.fn());
 
 vi.mock("../plugins/manifest-registry.js", () => ({
+  loadBundledPluginManifestRegistry,
   loadPluginManifestRegistry,
 }));
 
@@ -37,10 +39,6 @@ type PublicSurfaceCall = {
   env?: NodeJS.ProcessEnv;
 };
 
-function firstManifestRegistryCall(): ManifestRegistryCall | undefined {
-  return loadPluginManifestRegistry.mock.calls[0]?.[0] as ManifestRegistryCall | undefined;
-}
-
 function firstPublicSurfaceCall(): PublicSurfaceCall | undefined {
   return loadBundledPluginPublicSurfaceModuleSync.mock.calls[0]?.[0] as
     | PublicSurfaceCall
@@ -55,6 +53,10 @@ describe("plugin-sdk qa-runner-runtime", () => {
   beforeEach(() => {
     vi.resetModules();
     loadPluginManifestRegistry.mockReset().mockReturnValue({
+      plugins: [],
+      diagnostics: [],
+    });
+    loadBundledPluginManifestRegistry.mockReset().mockReturnValue({
       plugins: [],
       diagnostics: [],
     });
@@ -232,7 +234,7 @@ describe("plugin-sdk qa-runner-runtime", () => {
 
     const register = vi.fn((qa: Command) => qa);
     const adapterFactory = { id: "example", matches: vi.fn(), create: vi.fn() };
-    loadPluginManifestRegistry.mockReturnValue({
+    loadBundledPluginManifestRegistry.mockReturnValue({
       plugins: [
         {
           id: "qa-example",
@@ -261,7 +263,9 @@ describe("plugin-sdk qa-runner-runtime", () => {
         },
       },
     ]);
-    const manifestCall = firstManifestRegistryCall();
+    const manifestCall = loadBundledPluginManifestRegistry.mock.calls[0]?.[0] as
+      | ManifestRegistryCall
+      | undefined;
     expect(manifestCall?.env?.OPENCLAW_ENABLE_PRIVATE_QA_CLI).toBe("1");
     expect(manifestCall?.env?.OPENCLAW_BUNDLED_PLUGINS_DIR).toBe(
       path.join(sourceRoot, "extensions"),

--- a/src/plugin-sdk/qa-runner-runtime.ts
+++ b/src/plugin-sdk/qa-runner-runtime.ts
@@ -1,7 +1,10 @@
 // QA runner runtime helpers expose plugin QA scenarios through the CLI command surface.
 import type { Command } from "commander";
 import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
-import { loadPluginManifestRegistry } from "../plugins/manifest-registry.js";
+import {
+  loadBundledPluginManifestRegistry,
+  loadPluginManifestRegistry,
+} from "../plugins/manifest-registry.js";
 import type { OpenClawConfig } from "./config-contracts.js";
 import {
   loadBundledPluginPublicSurfaceModuleSync,
@@ -235,8 +238,11 @@ function listDeclaredQaRunnerPlugins(
     qaRunners: NonNullable<PluginManifestRecord["qaRunners"]>;
   }
 > {
-  return loadPluginManifestRegistry(env ? { env } : {})
-    .plugins.filter(
+  // Private QA is a source-checkout harness. Its command tree must be derived
+  // from repo-owned manifests before Commander pre-action hooks can run.
+  const registry = env ? loadBundledPluginManifestRegistry({ env }) : loadPluginManifestRegistry();
+  return registry.plugins
+    .filter(
       (
         plugin,
       ): plugin is PluginManifestRecord & {

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -96,7 +96,7 @@ export type PluginDiscoveryResult = {
   diagnostics: PluginDiagnostic[];
 };
 
-export type PluginDiscoveryRootScope = "all" | "bundled";
+type PluginDiscoveryRootScope = "all" | "bundled";
 
 function currentUid(overrideUid?: number | null): number | null {
   if (overrideUid !== undefined) {

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -96,6 +96,8 @@ export type PluginDiscoveryResult = {
   diagnostics: PluginDiagnostic[];
 };
 
+export type PluginDiscoveryRootScope = "all" | "bundled";
+
 function currentUid(overrideUid?: number | null): number | null {
   if (overrideUid !== undefined) {
     return overrideUid;
@@ -1526,6 +1528,7 @@ export function discoverOpenClawPlugins(params: {
   installRecords?: Record<string, PluginInstallRecord>;
   ownershipUid?: number | null;
   env?: NodeJS.ProcessEnv;
+  rootScope?: PluginDiscoveryRootScope;
 }): PluginDiscoveryResult {
   const env = params.env ?? process.env;
   const workspaceDir = normalizeOptionalString(params.workspaceDir);
@@ -1533,48 +1536,51 @@ export function discoverOpenClawPlugins(params: {
   const roots = resolvePluginSourceRoots({ workspaceDir: workspaceRoot, env });
   const realpathCache = new Map<string, string>();
   const packageManifestCache = new Map<string, PackageManifest | null>();
-  const scopedResult = tracePluginLifecyclePhase(
-    "discovery scan",
-    () => {
-      const result = createDiscoveryResult();
-      const seen = new Set<string>();
-      discoverConfiguredPluginLoadPathsInto({
-        loadPaths: params.extraPaths ?? [],
-        bundledRoot: roots.stock,
-        ownershipUid: params.ownershipUid,
-        workspaceDir,
-        env,
-        result,
-        seen,
-        realpathCache,
-        packageManifestCache,
-      });
-      const workspaceMatchesBundledRoot = resolvesToSameDirectory(
-        workspaceRoot,
-        roots.stock,
-        realpathCache,
-      );
-      if (roots.workspace && workspaceRoot && !workspaceMatchesBundledRoot) {
-        // Keep workspace auto-discovery constrained to the OpenClaw extensions root.
-        // Recursively scanning the full workspace treats arbitrary project folders as
-        // plugin candidates and causes noisy "plugin manifest not found" validation failures.
-        discoverInDirectory({
-          dir: roots.workspace,
-          origin: "workspace",
-          env,
-          ownershipUid: params.ownershipUid,
-          workspaceDir: workspaceRoot,
-          candidates: result.candidates,
-          diagnostics: result.diagnostics,
-          seen,
-          realpathCache,
-          packageManifestCache,
-        });
-      }
-      return result;
-    },
-    { scope: "scoped", extraPathCount: params.extraPaths?.length ?? 0 },
-  );
+  const scopedResult =
+    params.rootScope === "bundled"
+      ? createDiscoveryResult()
+      : tracePluginLifecyclePhase(
+          "discovery scan",
+          () => {
+            const result = createDiscoveryResult();
+            const seen = new Set<string>();
+            discoverConfiguredPluginLoadPathsInto({
+              loadPaths: params.extraPaths ?? [],
+              bundledRoot: roots.stock,
+              ownershipUid: params.ownershipUid,
+              workspaceDir,
+              env,
+              result,
+              seen,
+              realpathCache,
+              packageManifestCache,
+            });
+            const workspaceMatchesBundledRoot = resolvesToSameDirectory(
+              workspaceRoot,
+              roots.stock,
+              realpathCache,
+            );
+            if (roots.workspace && workspaceRoot && !workspaceMatchesBundledRoot) {
+              // Keep workspace auto-discovery constrained to the OpenClaw extensions root.
+              // Recursively scanning the full workspace treats arbitrary project folders as
+              // plugin candidates and causes noisy "plugin manifest not found" validation failures.
+              discoverInDirectory({
+                dir: roots.workspace,
+                origin: "workspace",
+                env,
+                ownershipUid: params.ownershipUid,
+                workspaceDir: workspaceRoot,
+                candidates: result.candidates,
+                diagnostics: result.diagnostics,
+                seen,
+                realpathCache,
+                packageManifestCache,
+              });
+            }
+            return result;
+          },
+          { scope: "scoped", extraPathCount: params.extraPaths?.length ?? 0 },
+        );
   const sharedResult = tracePluginLifecyclePhase(
     "discovery scan",
     () => {
@@ -1664,29 +1670,46 @@ export function discoverOpenClawPlugins(params: {
           skipDirectories: readChildDirectoryNames(roots.stock),
         });
       }
-      const installedPaths = collectInstalledPluginRecordPaths(
-        params.installRecords,
-        env,
-        realpathCache,
-      );
-      const installedPluginDirKeys = collectManagedPluginDirKeys(
-        installedPaths.map((installedPath) => installedPath.path),
-        realpathCache,
-      );
-      const managedPluginDirs = collectManagedPluginDirKeys(
-        collectManagedPluginRecordPaths(params.installRecords, env),
-        realpathCache,
-      );
-      for (const installedPath of installedPaths) {
-        discoverFromPath({
-          rawPath: installedPath.path,
-          origin: "global",
-          ownershipUid: params.ownershipUid,
-          workspaceDir,
-          requireBuiltRuntimeEntry: installedPath.requireBuiltRuntimeEntry,
-          managedPluginDirs,
-          scanFiles: true,
+      if (params.rootScope !== "bundled") {
+        const installedPaths = collectInstalledPluginRecordPaths(
+          params.installRecords,
           env,
+          realpathCache,
+        );
+        const installedPluginDirKeys = collectManagedPluginDirKeys(
+          installedPaths.map((installedPath) => installedPath.path),
+          realpathCache,
+        );
+        const managedPluginDirs = collectManagedPluginDirKeys(
+          collectManagedPluginRecordPaths(params.installRecords, env),
+          realpathCache,
+        );
+        for (const installedPath of installedPaths) {
+          discoverFromPath({
+            rawPath: installedPath.path,
+            origin: "global",
+            ownershipUid: params.ownershipUid,
+            workspaceDir,
+            requireBuiltRuntimeEntry: installedPath.requireBuiltRuntimeEntry,
+            managedPluginDirs,
+            scanFiles: true,
+            env,
+            candidates: result.candidates,
+            diagnostics: result.diagnostics,
+            seen,
+            realpathCache,
+            packageManifestCache,
+          });
+        }
+        // Keep auto-discovered global extensions behind bundled plugins.
+        // Users can still intentionally override via plugins.load.paths (origin=config).
+        discoverInDirectory({
+          dir: roots.global,
+          origin: "global",
+          env,
+          ownershipUid: params.ownershipUid,
+          managedPluginDirs,
+          skipRootDirKeys: installedPluginDirKeys,
           candidates: result.candidates,
           diagnostics: result.diagnostics,
           seen,
@@ -1694,21 +1717,6 @@ export function discoverOpenClawPlugins(params: {
           packageManifestCache,
         });
       }
-      // Keep auto-discovered global extensions behind bundled plugins.
-      // Users can still intentionally override via plugins.load.paths (origin=config).
-      discoverInDirectory({
-        dir: roots.global,
-        origin: "global",
-        env,
-        ownershipUid: params.ownershipUid,
-        managedPluginDirs,
-        skipRootDirKeys: installedPluginDirKeys,
-        candidates: result.candidates,
-        diagnostics: result.diagnostics,
-        seen,
-        realpathCache,
-        packageManifestCache,
-      });
       return result;
     },
     { scope: "shared" },

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -1258,4 +1258,21 @@ export function loadPluginManifestRegistry(
   const registry = { plugins, diagnostics: dedupePluginDiagnostics(diagnostics) };
   return registry;
 }
+
+/** Load manifest metadata from the bundled/source plugin tree without consulting operator state. */
+export function loadBundledPluginManifestRegistry(
+  params: { env?: NodeJS.ProcessEnv } = {},
+): PluginManifestRegistry {
+  const env = params.env ?? process.env;
+  const installRecords: Record<string, PluginInstallRecord> = {};
+  return loadPluginManifestRegistry({
+    env,
+    installRecords,
+    discovery: discoverOpenClawPlugins({
+      env,
+      installRecords,
+      rootScope: "bundled",
+    }),
+  });
+}
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
Closes #111432

## What Problem This Solves

Private source-checkout QA commands could read and mutate the developer's normal OpenClaw state before the disposable QA gateway established its own isolation. There were two distinct leaks: CLI startup consulted operator config and plugins, and QA runner registration synchronously discovered operator-installed runner manifests through the generic plugin registry.

## Why This Change Was Made

The `qa` subtree now declares its complete launcher policy: bypass the operator config guard and managed proxy bootstrap, and do not load the operator plugin registry.

Private QA runner registration also uses a dedicated bundled/source-only manifest registry. That registry deliberately excludes configured plugin paths, workspace overlays, installed-plugin records, and global extensions, while retaining repo-owned bundled plugins and source-tree development plugins. The normal non-private SDK runner path remains operator-aware.

This preserves the original source-only private-QA design instead of papering over the problem with temporary environment variables after registration has already happened.

## User Impact

Developers can list and run private QA scenarios without opening, validating, migrating, or loading runner definitions from their normal OpenClaw state. Normal plugin discovery and the public SDK path are unchanged.

AI-assisted: yes. I traced the startup, registration, plugin discovery, manifest registry, and historical private-QA ownership paths and validated the resulting boundary as a user would.

## Evidence

- Focused tests: 277 tests passed across CLI startup policy, plugin discovery, manifest registry, and private QA runner registration.
- Autoreview: clean after the complete boundary fix, with no accepted/actionable findings.
- Blacksmith changed-file phase: formatting, SDK surface, core/UI/plugin typechecks, lint, dependency, database, cycle, architecture, and build gates passed: https://github.com/openclaw/openclaw/actions/runs/29694065624
- Packaged Linux behavior proof: built with `OPENCLAW_BUILD_PRIVATE_QA=1`, created an operator-installed QA runner plus an intentionally invalid operator SQLite database, confirmed the operator runner was absent from `qa --help`, ran `qa confidence-self-test` successfully, and verified the operator database SHA-256 was unchanged: https://github.com/openclaw/openclaw/actions/runs/29694854189
- The broader stress run also uncovered separate live-history retry and QA dispatch regressions; those are tracked independently rather than being folded into this isolation change.
