### PR TITLE
fix(qa-lab): evidence summary hangs when checkout-ref git probe stalls

### DIFF
--- a/extensions/qa-lab/src/evidence-environment.test.ts
+++ b/extensions/qa-lab/src/evidence-environment.test.ts
@@ -1,0 +1,66 @@
+// Qa Lab tests bound the evidence checkout ref git probe.
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const execFileSyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    execFileSync: execFileSyncMock,
+  };
+});
+
+import { resolveQaEvidenceEnvironment } from "./evidence-environment.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  execFileSyncMock.mockReset();
+});
+
+describe("resolveQaEvidenceEnvironment", () => {
+  it("bounds the checkout ref git probe with a timeout", () => {
+    execFileSyncMock.mockReturnValue("abc123\n");
+
+    const environment = resolveQaEvidenceEnvironment({ env: {} });
+
+    expect(environment.ref).toBe("abc123");
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      "git",
+      ["rev-parse", "--verify", "HEAD"],
+      expect.objectContaining({
+        killSignal: "SIGKILL",
+        timeout: 5_000,
+      }),
+    );
+  });
+
+  it("falls back to GITHUB_SHA when the git probe times out", () => {
+    execFileSyncMock.mockImplementation(() => {
+      throw Object.assign(new Error("Command timed out"), { code: "ETIMEDOUT" });
+    });
+
+    const environment = resolveQaEvidenceEnvironment({ env: { GITHUB_SHA: "fallbacksha" } });
+
+    expect(environment.ref).toBe("fallbacksha");
+  });
+
+  it("prefers OPENCLAW_QA_REF without invoking git", () => {
+    const environment = resolveQaEvidenceEnvironment({
+      env: { OPENCLAW_QA_REF: "qa-ref", GITHUB_SHA: "fallbacksha" },
+    });
+
+    expect(environment.ref).toBe("qa-ref");
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a null ref when the probe fails and no env fallback exists", () => {
+    execFileSyncMock.mockImplementation(() => {
+      throw new Error("git unavailable");
+    });
+
+    const environment = resolveQaEvidenceEnvironment({ env: {} });
+
+    expect(environment.ref).toBeNull();
+  });
+});

--- a/extensions/qa-lab/src/evidence-environment.ts
+++ b/extensions/qa-lab/src/evidence-environment.ts
@@ -1,12 +1,18 @@
 // Qa Lab plugin module resolves evidence runtime metadata.
 import { execFileSync } from "node:child_process";
 
+// A wedged git (NFS hang, credential helper prompt) must not block evidence
+// metadata resolution; the caller already falls back to GITHUB_SHA/null.
+const QA_EVIDENCE_GIT_PROBE_TIMEOUT_MS = 5_000;
+
 function resolveQaEvidenceCheckoutRef(repoRoot?: string) {
   try {
     const ref = execFileSync("git", ["rev-parse", "--verify", "HEAD"], {
       cwd: repoRoot ?? process.cwd(),
       encoding: "utf8",
+      killSignal: "SIGKILL",
       stdio: ["ignore", "pipe", "ignore"],
+      timeout: QA_EVIDENCE_GIT_PROBE_TIMEOUT_MS,
     }).trim();
     return ref || undefined;
   } catch {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where QA evidence summary generation would hang forever when the checkout-ref probe (`git rev-parse --verify HEAD`) blocked indefinitely — for example a wedged filesystem (NFS), a git credential helper waiting on input, or an otherwise stalled git process. `resolveQaEvidenceEnvironment` in the QA Lab plugin shells out synchronously with no timeout, so one stuck git process froze evidence metadata resolution, and the evidence summary built on top of it, with no recovery short of killing the process.

## Why This Change Was Made

Bounds the probe with a 5s timeout and SIGKILL, matching the bounded-probe pattern already used for similar synchronous lookups (process-tree CPU snapshot, daemon Node binary lookup). On timeout the existing error handling already degrades gracefully: the checkout ref falls back to `GITHUB_SHA`, then `null`, so evidence output is still produced. Non-goal: changing ref precedence or the fallback chain.

## User Impact

QA evidence and summary generation now completes within ~5s even when git is wedged, emitting the same metadata shape with an env-fallback or null ref instead of hanging forever. Happy-path behavior is unchanged.

## Evidence

Real before/after run calling the exported `resolveQaEvidenceEnvironment` with `git` replaced by a wedged shim (`sleep 60`):

```
== BEFORE (original HEAD) (PATH shimmed, git wedges 60s) ==
RESULT: HUNG — still blocked after 12s, killed
== AFTER (fixed) (PATH shimmed, git wedges 60s) ==
RETURNED after 5002ms ref=null
RESULT: exited code=0
```

Happy path with real git unchanged: `RETURNED after 8ms ref=ec01949d86281746f6c2e1c1ba3c8b63b0b18298`.

New regression test `evidence-environment.test.ts` covers: probe invoked with `timeout: 5_000` + `killSignal: "SIGKILL"`, `GITHUB_SHA` fallback on probe timeout, `OPENCLAW_QA_REF` precedence without invoking git, and null ref when the probe fails.

```
✓ |extension-qa| extensions/qa-lab/src/evidence-environment.test.ts (4 tests) 68ms
Test Files  1 passed (1)   Tests  4 passed (4)
```

Sibling evidence suites also pass: evidence-summary, evidence-gallery, scorecard-evidence → 20 tests passed. oxfmt/oxlint clean.
