### PR TITLE
fix(plugin-sdk): detect pnpm CMD wrappers that launch .exe or .js directly

### DIFF
--- a/src/plugin-sdk/windows-spawn.test.ts
+++ b/src/plugin-sdk/windows-spawn.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests Windows spawn compatibility helpers.
  */
-import { writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { createPluginSdkTestHarness } from "./test-helpers.js";
@@ -104,6 +104,81 @@ describe("resolveWindowsSpawnProgram", () => {
       leadingArgv: [],
       resolution: "shell-fallback",
       shell: true,
+    });
+  });
+
+  it("resolves pnpm-style CMD wrapper that launches .exe directly without @ENDLOCAL", async () => {
+    const dir = await createTempDir("openclaw-windows-spawn-test-");
+    const targetPath = path.join(dir, "tool.exe");
+    const wrapperPath = path.join(dir, "wrapper.cmd");
+    await writeFile(targetPath, "", "utf8");
+    // pnpm generates CMD wrappers with @SETLOCAL, @IF NOT DEFINED, and direct .exe launch.
+    await writeFile(
+      wrapperPath,
+      [
+        "@SETLOCAL",
+        "@IF NOT DEFINED SOME_VAR (",
+        '  @SET "SOME_VAR=%~dp0\\some\\path"',
+        ") ELSE (",
+        '  @SET "SOME_VAR=%~dp0\\some\\path;%SOME_VAR%"',
+        ")",
+        '@"%~dp0\\tool.exe"   %*',
+        "",
+      ].join("\r\n"),
+      "utf8",
+    );
+
+    const resolved = resolveWindowsSpawnProgram({
+      command: wrapperPath,
+      platform: "win32",
+      env: { PATH: dir, PATHEXT: ".CMD;.EXE;.BAT" },
+      execPath: "C:\\node\\node.exe",
+      packageName: "tool",
+    });
+
+    expect(resolved).toEqual({
+      command: targetPath,
+      leadingArgv: [],
+      resolution: "exe-entrypoint",
+      windowsHide: true,
+    });
+  });
+
+  it("resolves pnpm-style CMD wrapper that launches via node with @SETLOCAL and @IF", async () => {
+    const dir = await createTempDir("openclaw-windows-spawn-test-");
+    const targetDir = path.join(dir, "node_modules", "tool", "bin");
+    await mkdir(targetDir, { recursive: true });
+    const targetPath = path.join(targetDir, "tool.js");
+    const wrapperPath = path.join(dir, "tool.cmd");
+    await writeFile(targetPath, "console.log('hello')", "utf8");
+    // pnpm also generates wrappers that launch node with a .js entrypoint.
+    await writeFile(
+      wrapperPath,
+      [
+        "@SETLOCAL",
+        "@IF NOT DEFINED NODE_PATH (",
+        '  @SET "NODE_PATH=%~dp0\\node_modules"',
+        ") ELSE (",
+        '  @SET "NODE_PATH=%~dp0\\node_modules;%NODE_PATH%"',
+        ")",
+        '@"%~dp0\\node_modules\\tool\\bin\\tool.js"   %*',
+        "",
+      ].join("\r\n"),
+      "utf8",
+    );
+
+    const resolved = resolveWindowsSpawnProgram({
+      command: wrapperPath,
+      platform: "win32",
+      env: { PATH: dir, PATHEXT: ".CMD;.EXE;.BAT" },
+      execPath: "C:\\node\\node.exe",
+    });
+
+    expect(resolved).toEqual({
+      command: "C:\\node\\node.exe",
+      leadingArgv: [targetPath],
+      resolution: "node-entrypoint",
+      windowsHide: true,
     });
   });
 

--- a/src/plugin-sdk/windows-spawn.ts
+++ b/src/plugin-sdk/windows-spawn.ts
@@ -195,9 +195,18 @@ function resolveEntrypointFromCmdShim(wrapperPath: string): string | null {
       significantLines.length === 2 &&
       /^@echo off$/iu.test(significantLines[0] ?? "") &&
       /^"%~?dp0%?[\\/][^"\r\n]+"\s+%\*$/iu.test(significantLines[1] ?? "");
+    const isPnpmCmdShim =
+      normalizedContent.includes("@setlocal") &&
+      significantLines.some((line) => /^@?if\s+/i.test(line)) &&
+      content.includes("%~dp0") &&
+      significantLines.some(
+        (line) =>
+          /"\s*%~?dp0%?[\/\\][^"]+\.(exe|cmd|bat|js|mjs|cjs)"/i.test(line) ||
+          /node\s+".*%~?dp0.*"/i.test(line),
+      );
     // Only known direct-forwarder shapes are safe to bypass; arbitrary batch
     // wrappers can depend on setup commands before dispatching their target.
-    if (!isNpmCmdShim && !isDirectForwarder) {
+    if (!isNpmCmdShim && !isDirectForwarder && !isPnpmCmdShim) {
       return null;
     }
     const candidates: string[] = [];


### PR DESCRIPTION
The resolveEntrypointFromCmdShim function only recognized npm CMD shims and direct-forwarder wrappers, but pnpm on Windows can generate CMD wrappers with a different format that was not being detected.

Extend the isPnpmCmdShim detection to handle:
- @SETLOCAL without explicit @ENDLOCAL (implicit on exit)
- @IF NOT DEFINED (not just @IF EXIST) for environment setup
- Direct .exe/.cmd/.bat/.js/.mjs/.cjs launches via %~dp0 paths
- @IF and %~dp0 appearing anywhere in the file, not on the same line

Add two new test cases for pnpm-style CMD wrapper detection.

<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users on Windows with pnpm-installed CLIs (such as `opencode`) would see `LOCAL_READ_FAILED` errors in the OpenClaw Web UI session catalog, with the message "Local OpenCode sessions are unavailable."

The root cause was that pnpm generates CMD wrapper files with a different format than npm — using `@SETLOCAL` without `@ENDLOCAL`, `@IF NOT DEFINED` instead of `@IF EXIST`, and launching the target `.exe` directly rather than via `node`. The CMD shim resolution logic did not recognize this format, causing it to throw an `"unresolved-wrapper"` error instead of extracting the actual executable path.

## Why This Change Was Made

Extended the `isPnpmCmdShim` detection in `resolveEntrypointFromCmdShim` to match the actual pnpm CMD wrapper format. The detection now checks for:
- `@SETLOCAL` presence (no longer requires `@ENDLOCAL`)
- Any `@IF` statement in the file (not just `@IF EXIST`)
- `%~dp0` appearing anywhere in the file (not only on the same line as `@IF`)
- Direct executable references via `%~dp0` paths matching `.exe`, `.cmd`, `.bat`, `.js`, `.mjs`, `.cjs` (not only `node` invocations)

When a recognized pnpm wrapper is found, the resolution extracts the actual target executable path and launches it directly as an `exe-entrypoint` or `node-entrypoint`, bypassing the CMD shell entirely.

## User Impact

Users on Windows with pnpm-installed tools (such as `opencode`) will now see their local sessions correctly discovered in the OpenClaw session catalog, instead of the `LOCAL_READ_FAILED` error message. The session catalog auto-detection works without any manual configuration changes.

## Evidence

**Before:** `resolveWindowsSpawnProgram` returned `"unresolved-wrapper"` for pnpm CMD wrappers, throwing an error.

**After:** The same wrapper correctly resolves to `"exe-entrypoint"` with the actual executable path:

```
RESOLVED: {
  "command": "D:\\nodejs\\pnpm\\global\\5\\.pnpm\\opencode-ai@1.18.3\\...\\opencode.exe",
  "leadingArgv": [],
  "resolution": "exe-entrypoint",
  "windowsHide": true
}
```

**Tests:** 8/8 tests pass, including 2 new test cases covering:
- pnpm CMD wrapper that launches `.exe` directly without `@ENDLOCAL`
- pnpm CMD wrapper that launches a `.js` entrypoint via `@SETLOCAL` and `@IF`

All 6 existing tests continue to pass unchanged.