### PR TITLE
fix(teams-meetings): stalled setup probes stay within deadline

### DIFF
--- a/extensions/teams-meetings/src/node-host.test.ts
+++ b/extensions/teams-meetings/src/node-host.test.ts
@@ -64,4 +64,21 @@ describe("Teams meeting node-host prerequisite deadline", () => {
     );
     expect(spawnSyncMock).toHaveBeenCalledTimes(1);
   });
+
+  it("reports a timed-out profiler separately from a missing audio device", async () => {
+    const timeoutError = Object.assign(new Error("spawnSync system_profiler ETIMEDOUT"), {
+      code: "ETIMEDOUT",
+    });
+    spawnSyncMock.mockReturnValueOnce({
+      ...successfulProbe,
+      status: null,
+      stdout: "",
+      error: timeoutError,
+    });
+
+    await expect(handleTeamsMeetingsNodeHostCommand(setupParams())).rejects.toThrow(
+      "Microsoft Teams meeting audio prerequisite check timed out on the node.",
+    );
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/extensions/teams-meetings/src/node-host.test.ts
+++ b/extensions/teams-meetings/src/node-host.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnSyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return { ...actual, spawnSync: spawnSyncMock };
+});
+
+import { handleTeamsMeetingsNodeHostCommand } from "./node-host.js";
+
+const successfulProbe = {
+  pid: 123,
+  output: [null, "BlackHole 2ch", ""],
+  stdout: "BlackHole 2ch",
+  stderr: "",
+  status: 0,
+  signal: null,
+  error: undefined,
+};
+
+function setupParams() {
+  return JSON.stringify({
+    action: "setup",
+    audioInputCommand: ["capture"],
+    audioOutputCommand: ["play"],
+  });
+}
+
+describe("Teams meeting node-host prerequisite deadline", () => {
+  beforeEach(() => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    spawnSyncMock.mockReset();
+    spawnSyncMock.mockReturnValue(successfulProbe);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shares one timeout budget across every prerequisite probe", async () => {
+    const now = vi.spyOn(Date, "now");
+    for (const value of [1_000, 1_000, 4_000, 4_000, 8_000, 8_000]) {
+      now.mockReturnValueOnce(value);
+    }
+
+    await expect(handleTeamsMeetingsNodeHostCommand(setupParams())).resolves.toBe(
+      JSON.stringify({ ok: true }),
+    );
+
+    expect(
+      spawnSyncMock.mock.calls.map((call) => (call[2] as { timeout?: number }).timeout),
+    ).toEqual([10_000, 7_000, 3_000]);
+  });
+
+  it("does not start another probe after the shared deadline expires", async () => {
+    const now = vi.spyOn(Date, "now");
+    for (const value of [1_000, 1_000, 11_000]) {
+      now.mockReturnValueOnce(value);
+    }
+
+    await expect(handleTeamsMeetingsNodeHostCommand(setupParams())).rejects.toThrow(
+      "Configured audio command not found on the node: capture",
+    );
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/teams-meetings/src/node-host.test.ts
+++ b/extensions/teams-meetings/src/node-host.test.ts
@@ -60,7 +60,7 @@ describe("Teams meeting node-host prerequisite deadline", () => {
     }
 
     await expect(handleTeamsMeetingsNodeHostCommand(setupParams())).rejects.toThrow(
-      "Configured audio command not found on the node: capture",
+      "Microsoft Teams meeting audio prerequisite check timed out on the node.",
     );
     expect(spawnSyncMock).toHaveBeenCalledTimes(1);
   });

--- a/extensions/teams-meetings/src/node-host.test.ts
+++ b/extensions/teams-meetings/src/node-host.test.ts
@@ -7,6 +7,7 @@ vi.mock("node:child_process", async (importOriginal) => {
   return { ...actual, spawnSync: spawnSyncMock };
 });
 
+import { teamsMeetingsConfig } from "./config.js";
 import { handleTeamsMeetingsNodeHostCommand } from "./node-host.js";
 
 const successfulProbe = {
@@ -51,6 +52,26 @@ describe("Teams meeting node-host prerequisite deadline", () => {
     expect(
       spawnSyncMock.mock.calls.map((call) => (call[2] as { timeout?: number }).timeout),
     ).toEqual([10_000, 7_000, 3_000]);
+  });
+
+  it("probes the default sox executable only once", async () => {
+    await expect(
+      handleTeamsMeetingsNodeHostCommand(
+        JSON.stringify({
+          action: "setup",
+          audioInputCommand: teamsMeetingsConfig.defaultAudioInputCommand,
+          audioOutputCommand: teamsMeetingsConfig.defaultAudioOutputCommand,
+        }),
+      ),
+    ).resolves.toBe(JSON.stringify({ ok: true }));
+
+    expect(spawnSyncMock).toHaveBeenCalledTimes(2);
+    expect(spawnSyncMock.mock.calls[1]?.[1]).toEqual([
+      "-lc",
+      'command -v "$1" >/dev/null 2>&1',
+      "sh",
+      "sox",
+    ]);
   });
 
   it("does not start another probe after the shared deadline expires", async () => {

--- a/extensions/teams-meetings/src/node-host.ts
+++ b/extensions/teams-meetings/src/node-host.ts
@@ -9,5 +9,5 @@ export const handleTeamsMeetingsNodeHostCommand =
     meetingLabel: "Microsoft Teams meeting",
     defaultAudioInputCommand: teamsMeetingsConfig.defaultAudioInputCommand,
     defaultAudioOutputCommand: teamsMeetingsConfig.defaultAudioOutputCommand,
-    sharePrerequisiteDeadline: false,
+    sharePrerequisiteDeadline: true,
   });

--- a/extensions/zoom-meetings/src/node-host.test.ts
+++ b/extensions/zoom-meetings/src/node-host.test.ts
@@ -9,6 +9,7 @@ import { handleZoomMeetingsNodeHostCommand } from "./node-host.js";
 afterEach(() => {
   vi.useRealTimers();
   vi.restoreAllMocks();
+  childProcessMocks.spawnSync.mockReset();
 });
 
 describe("Zoom meetings node setup", () => {
@@ -39,5 +40,29 @@ describe("Zoom meetings node setup", () => {
         (call) => (call[2] as { timeout?: number } | undefined)?.timeout,
       ),
     ).toEqual([10_000, 4_000, 2_000]);
+  });
+
+  it("reports a timed-out command probe separately from a missing command", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    const timeoutError = Object.assign(new Error("spawnSync /bin/sh ETIMEDOUT"), {
+      code: "ETIMEDOUT",
+    });
+    childProcessMocks.spawnSync
+      .mockReturnValueOnce({ status: 0, stderr: "", stdout: "BlackHole 2ch" })
+      .mockReturnValueOnce({ status: null, stderr: "", stdout: "", error: timeoutError });
+
+    await expect(
+      handleZoomMeetingsNodeHostCommand(
+        JSON.stringify({
+          action: "setup",
+          audioInputCommand: ["sox"],
+          audioOutputCommand: ["play"],
+        }),
+      ),
+    ).rejects.toThrow("Zoom meeting audio prerequisite check timed out on the node.");
+
+    expect(childProcessMocks.spawnSync).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/meeting-bot/node-host.ts
+++ b/src/meeting-bot/node-host.ts
@@ -625,17 +625,17 @@ function readSetupCommand(params: Record<string, unknown>, name: string): string
   return value as string[];
 }
 
+function isSpawnSyncTimeout(error: unknown): boolean {
+  return error instanceof Error && "code" in error && error.code === "ETIMEDOUT";
+}
+
 export function createMeetingConfiguredNodeHost(options: MeetingConfiguredNodeHostOptions) {
   const probeCommand = (command: string, timeoutMs: number): "found" | "missing" | "timed-out" => {
     const result = spawnSync("/bin/sh", ["-lc", 'command -v "$1" >/dev/null 2>&1', "sh", command], {
       encoding: "utf8",
       timeout: timeoutMs,
     });
-    if (
-      result.error instanceof Error &&
-      "code" in result.error &&
-      result.error.code === "ETIMEDOUT"
-    ) {
+    if (isSpawnSyncTimeout(result.error)) {
       return "timed-out";
     }
     return result.status === 0 ? "found" : "missing";
@@ -657,6 +657,9 @@ export function createMeetingConfiguredNodeHost(options: MeetingConfiguredNodeHo
       encoding: "utf8",
       timeout: commandTimeout(),
     });
+    if (isSpawnSyncTimeout(result.error)) {
+      throw new Error(`${options.meetingLabel} audio prerequisite check timed out on the node.`);
+    }
     const stderr =
       result.stderr ??
       (result.error

--- a/src/meeting-bot/node-host.ts
+++ b/src/meeting-bot/node-host.ts
@@ -626,12 +626,19 @@ function readSetupCommand(params: Record<string, unknown>, name: string): string
 }
 
 export function createMeetingConfiguredNodeHost(options: MeetingConfiguredNodeHostOptions) {
-  const commandExists = (command: string, timeoutMs: number): boolean => {
+  const probeCommand = (command: string, timeoutMs: number): "found" | "missing" | "timed-out" => {
     const result = spawnSync("/bin/sh", ["-lc", 'command -v "$1" >/dev/null 2>&1', "sh", command], {
       encoding: "utf8",
       timeout: timeoutMs,
     });
-    return result.status === 0;
+    if (
+      result.error instanceof Error &&
+      "code" in result.error &&
+      result.error.code === "ETIMEDOUT"
+    ) {
+      return "timed-out";
+    }
+    return result.status === 0 ? "found" : "missing";
   };
   const assertAudioAvailable = (
     timeoutMs: number,
@@ -666,12 +673,18 @@ export function createMeetingConfiguredNodeHost(options: MeetingConfiguredNodeHo
     }
     for (const argv of commands) {
       const command = argv[0];
-      if (
-        !command ||
-        (options.sharePrerequisiteDeadline && Date.now() >= deadline) ||
-        !commandExists(command, commandTimeout())
-      ) {
+      if (!command) {
         throw new Error(`Configured audio command not found on the node: ${command || "<empty>"}`);
+      }
+      if (options.sharePrerequisiteDeadline && Date.now() >= deadline) {
+        throw new Error(`${options.meetingLabel} audio prerequisite check timed out on the node.`);
+      }
+      const probeResult = probeCommand(command, commandTimeout());
+      if (probeResult === "timed-out") {
+        throw new Error(`${options.meetingLabel} audio prerequisite check timed out on the node.`);
+      }
+      if (probeResult === "missing") {
+        throw new Error(`Configured audio command not found on the node: ${command}`);
       }
     }
   };

--- a/src/meeting-bot/node-host.ts
+++ b/src/meeting-bot/node-host.ts
@@ -674,11 +674,15 @@ export function createMeetingConfiguredNodeHost(options: MeetingConfiguredNodeHo
     ) {
       throw new Error("BlackHole 2ch audio device not found on the node.");
     }
+    const commandNames = new Set<string>();
     for (const argv of commands) {
       const command = argv[0];
       if (!command) {
         throw new Error(`Configured audio command not found on the node: ${command || "<empty>"}`);
       }
+      commandNames.add(command);
+    }
+    for (const command of commandNames) {
       if (options.sharePrerequisiteDeadline && Date.now() >= deadline) {
         throw new Error(`${options.meetingLabel} audio prerequisite check timed out on the node.`);
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users checking Microsoft Teams `chrome-node` talk-back prerequisites could leave the remote node synchronously blocked beyond the setup check's 10-second budget when multiple prerequisite probes stalled.

The setup path runs `system_profiler` followed by two or three command probes. Giving every child the full 10-second timeout allowed total blocking time to grow to 30–40 seconds, even though the caller's `nodes.invoke` deadline is 12 seconds.

## Why This Change Was Made

The current meeting runtime owns device and command probes in the shared meeting node-host implementation. After resolving the main-branch conflict, Teams enables that canonical owner's shared prerequisite deadline instead of restoring the deleted plugin-local probe implementation. The shared owner also distinguishes profiler and command-probe timeouts from missing-command failures.

All sequential probes receive only the remaining portion of one absolute 10-second budget, and another probe is not started after the deadline expires. The shared owner also deduplicates executable names before probing, so the default input/output pair checks `sox` once instead of spending deadline budget on redundant work. This matches the existing Zoom meeting node-host policy and does not change configuration or public APIs.

## User Impact

Stalled Teams audio prerequisite checks now fail within one setup budget instead of accumulating a separate 10-second wait for every probe. The remote node is less likely to remain blocked after the caller has already timed out.

## Evidence

- Current-main port head `a45eaf6aee1d5f60a11ae536334f88e3b9e3efa9` against fixed main `4e47c4cabf8f2901ec781b59d059999211398813`:
  - Focused meeting coverage passed: 4 test files, 9 tests, including the default Teams input/output pair probing its shared `sox` executable only once.
  - Changed-file formatting and lint passed.
  - Extension production and extension-test TypeScript checks passed.
  - The PR-event max-lines ratchet passed on the exact fixed-main/current-head synthetic merge preview (`1015 grandfathered suppressions`).
  - On the rebased pre-review head, the broader changed-file check passed conflict-marker, environment/max-lines, formatting, Plugin SDK contract, deprecated API, plugin-boundary, dependency/patch, dead-export, and core-production type checks. Its final core-test typecheck produced no diagnostic before the outer 30-minute local timeout terminated it, so that full aggregate command did not complete locally. The final dedupe repair was then covered by the focused tests plus both extension typecheck lanes above.
- Current-head canonical owner-boundary runtime transcript (real synchronous child processes):

  ```text
  TRIGGER production node-host setup action with system_profiler plus two configured-command probes
  TRANSITION system_profiler probe started
  TRANSITION system_profiler found BlackHole 2ch
  TRANSITION configured-command probe started
  TRANSITION configured-command probe started
  OUTCOME shared deadline stopped setup at 10003ms: Microsoft Teams meeting audio prerequisite check timed out on the node.
  ```

  The proof called the production shared meeting node-host handler. A real profiler child delayed for 8,400ms and real shell command probes each carried a 1,000ms delay; the second command probe was stopped by the remaining shared deadline rather than receiving another full 10 seconds.

  This current-head proof ran on Linux with `process.platform` set to `darwin`. It covers the canonical node-host deadline owner, but not the complete `teamsmeetings setup` CLI -> Gateway -> connected macOS node reporter path because no connected macOS node was available.
- Earlier public macOS 15 comparison on the original PR head used real `/usr/sbin/system_profiler`, BlackHole 2ch, and the production Teams setup entry point: https://github.com/zhangguiping-xydt/openclaw/actions/runs/29695922226
  - Before the fix: `18,786ms`, all three command probes started, and setup returned `{"ok":true}`.
  - Original PR head: `10,010ms`, only two probes started, setup failed closed at the shared deadline, and the third probe was never started.
