### PR TITLE
fix(duckduckgo): preserve words around highlighted matches

### DIFF
--- a/extensions/duckduckgo/src/ddg-client.ts
+++ b/extensions/duckduckgo/src/ddg-client.ts
@@ -53,7 +53,9 @@ function decodeHtmlEntities(text: string): string {
 }
 
 function stripHtml(html: string): string {
-  return html
+  // DuckDuckGo match highlights can occur inside words, so remove them without adding whitespace.
+  const withoutMatchHighlights = html.replace(/<\/?b\b[^>]*>/gi, "");
+  return withoutMatchHighlights
     .replace(/<[^>]+>/g, " ")
     .replace(/\s+/g, " ")
     .trim();

--- a/extensions/duckduckgo/src/ddg-search-provider.test.ts
+++ b/extensions/duckduckgo/src/ddg-search-provider.test.ts
@@ -254,6 +254,21 @@ describe("duckduckgo web search provider", () => {
     ]);
   });
 
+  it("keeps inline result markup from splitting words", () => {
+    const html = `
+      <a class="result__a" href="https://example.com/cafe">Caf<b>é</b> guide</a>
+      <a class="result__snippet">Find the best caf<b>é</b> near you.</a>
+    `;
+
+    expect(ddgClientTesting.parseDuckDuckGoHtml(html)).toEqual([
+      {
+        title: "Café guide",
+        url: "https://example.com/cafe",
+        snippet: "Find the best café near you.",
+      },
+    ]);
+  });
+
   it("detects bot challenge pages without flagging ordinary result snippets", () => {
     const challengeHtml = `
       <html>


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where DuckDuckGo web search results could insert a visible space inside a word when the provider highlighted only part of that word. For example, `café` could be returned as `caf é` through the OpenClaw search workflow.

## Why This Change Was Made

DuckDuckGo's inline `<b>` match markers are formatting-only and can occur inside words, so they are now removed without adding whitespace. Other HTML tags retain the existing space-preserving cleanup behavior, keeping the change limited to provider highlight markup.

## User Impact

Users receive intact words in DuckDuckGo result titles and snippets while the existing result structure, URLs, provider metadata, and external-content wrapping remain unchanged.

## Evidence

- Regression test: `node scripts/run-vitest.mjs extensions/duckduckgo/src/ddg-search-provider.test.ts` — 12 passed.
- Extension suite: `pnpm test:extension duckduckgo` — 12 passed.
- Repository changed-file checks: formatting, extension/typecheck, extension-test typecheck, lint, plugin boundaries, API baseline, dependency pins, and import-cycle checks passed locally. The remote Testbox wrapper was unavailable because its local crabbox binary sanity check failed, so the repository's documented trusted-source local fallback was used.
- Live third-party before/after proof used the OpenClaw source CLI against DuckDuckGo (`html.duckduckgo.com`):
  - Command: `node openclaw.mjs infer web search --provider duckduckgo --query 'café crème brûlée résumé Beyoncé' --limit 10 --json`
  - Before: 10 live results; affected snippets contained `caf é` 5 times.
  - After: 10 live results; `caf é` occurred 0 times and the same affected text was returned as `café`.
  - The successful patched response also retained `provider: "duckduckgo"`, result count, title, URL, snippet, site name, and wrapped external-content metadata.

No mock provider or CoClaw/Coclaw client was used for the live proof.
