### PR TITLE
feat: isolate native subagent skill workspaces

### DIFF
--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -916,6 +916,7 @@ export function runAgentAttempt(params: {
     modelSelectionLocked: !isRawModelRun && params.sessionEntry?.modelSelectionLocked === true,
     agentHarnessRuntimeOverride: embeddedAgentHarnessOverride,
     skillsSnapshot: params.skillsSnapshot,
+    skillsWorkspaceOnly: params.opts.skillsWorkspaceOnly,
     prompt: effectivePrompt,
     transcriptPrompt: params.transcriptBody,
     // CLI-origin retries cannot rely on transcript replay: orphan-user repair

--- a/src/agents/command/session-preparation.ts
+++ b/src/agents/command/session-preparation.ts
@@ -77,6 +77,7 @@ export async function prepareEmbeddedSessionState(params: {
       }),
     },
     watch: false,
+    workspaceOnly: params.opts.skillsWorkspaceOnly === true,
   });
   const needsSkillsSnapshot =
     params.isNewSession || !currentSkillsSnapshot || skillSnapshotState.shouldRefresh;

--- a/src/agents/command/types.ts
+++ b/src/agents/command/types.ts
@@ -168,6 +168,8 @@ export type AgentCommandOpts = {
   fastModeAutoOnSeconds?: number;
   /** Explicit workspace directory override (for subagents to inherit parent workspace). */
   workspaceDir?: SpawnedRunMetadata["workspaceDir"];
+  /** Trusted lineage policy: discover skills only from workspaceDir for this run. */
+  skillsWorkspaceOnly?: boolean;
   /** Explicit task working directory for this run. Bootstrap still uses workspaceDir. */
   cwd?: string;
   /** Force bundled MCP teardown when a one-shot local run completes. */

--- a/src/agents/embedded-agent-runner/run/attempt-startup.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-startup.test.ts
@@ -4,6 +4,10 @@ import type { EmbeddedRunAttemptParams } from "./types.js";
 const mocks = vi.hoisted(() => ({
   applySkillEnvOverrides: vi.fn(),
   mapSandboxSkillEntriesForPrompt: vi.fn(),
+  resolveEmbeddedRunSkillEntries: vi.fn(() => ({
+    shouldLoadSkillEntries: true,
+    skillEntries: [],
+  })),
 }));
 
 vi.mock("../../../skills/runtime/env-overrides.js", () => ({
@@ -12,10 +16,7 @@ vi.mock("../../../skills/runtime/env-overrides.js", () => ({
 }));
 
 vi.mock("../../../skills/runtime/embedded-run-entries.js", () => ({
-  resolveEmbeddedRunSkillEntries: vi.fn(() => ({
-    shouldLoadSkillEntries: true,
-    skillEntries: [],
-  })),
+  resolveEmbeddedRunSkillEntries: mocks.resolveEmbeddedRunSkillEntries,
 }));
 
 vi.mock("../../../skills/loading/workspace.js", () => ({
@@ -57,5 +58,21 @@ describe("prepareEmbeddedAttemptSkills", () => {
       }),
     ).toThrow("skill prompt mapping failed");
     expect(restore).toHaveBeenCalledOnce();
+  });
+
+  it("forces workspace-only discovery for explicitly isolated child runs", () => {
+    mocks.applySkillEnvOverrides.mockReturnValue(vi.fn());
+    mocks.mapSandboxSkillEntriesForPrompt.mockReturnValue([]);
+
+    prepareEmbeddedAttemptSkills({
+      attempt: { config: {}, skillsWorkspaceOnly: true } as EmbeddedRunAttemptParams,
+      effectiveWorkspace: "/tmp/workspace",
+      sandbox: null,
+      sessionAgentId: "main",
+    });
+
+    expect(mocks.resolveEmbeddedRunSkillEntries).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceDir: "/tmp/workspace", workspaceOnly: true }),
+    );
   });
 });

--- a/src/agents/embedded-agent-runner/run/attempt-startup.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-startup.ts
@@ -39,7 +39,7 @@ export function prepareEmbeddedAttemptSkills(params: {
     skillsPromptWorkspaceDir,
     skillsSnapshot,
     skillsWorkspaceDir,
-    workspaceOnly,
+    workspaceOnly: sandboxWorkspaceOnly,
   } = resolveSandboxSkillRuntimeInputs({
     sandbox: params.sandbox,
     effectiveWorkspace: params.effectiveWorkspace,
@@ -51,7 +51,7 @@ export function prepareEmbeddedAttemptSkills(params: {
     agentId: params.sessionAgentId,
     eligibility: skillsEligibility,
     skillsSnapshot,
-    workspaceOnly,
+    workspaceOnly: params.attempt.skillsWorkspaceOnly === true || sandboxWorkspaceOnly,
   });
   const restoreSkillEnv = skillsSnapshot
     ? applySkillEnvOverridesFromSnapshot({

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -182,6 +182,8 @@ export type RunEmbeddedAgentParams = {
    */
   config?: OpenClawConfig;
   skillsSnapshot?: SkillSnapshot;
+  /** Discover skills only from workspaceDir, excluding bundled, managed, and personal roots. */
+  skillsWorkspaceOnly?: boolean;
   prompt: string;
   /** User-visible prompt body to submit and persist; runtime context travels separately. */
   transcriptPrompt?: string;

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -5,6 +5,7 @@
  */
 import crypto from "node:crypto";
 import { promises as fs } from "node:fs";
+import path from "node:path";
 import { finiteSecondsToTimerSafeMilliseconds } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { isAcpRuntimeSpawnAvailable } from "../acp/runtime/availability.js";
@@ -25,6 +26,7 @@ import { stringifyRouteThreadId } from "../plugin-sdk/channel-route.js";
 import { listRegisteredPluginAgentPromptGuidance } from "../plugins/command-registry-state.js";
 import type { SubagentLifecycleHookRunner } from "../plugins/hooks.js";
 import { isValidAgentId, normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
+import { isPathInside } from "../security/scan-paths.js";
 import { recordSubagentSpawned } from "../sessions/session-state-events.js";
 import type { FastMode } from "../shared/fast-mode.js";
 import { resolveUserPath } from "../utils.js";
@@ -170,6 +172,8 @@ type SpawnSubagentParams = {
   /** Canonical request hash checked before reusing a host-reserved collector. */
   swarmLaunchRequestFingerprint?: string;
   cwd?: string;
+  /** Native child workspace, restricted to a real descendant of the target agent workspace. */
+  workspace?: string;
   runTimeoutSeconds?: number;
   thread?: boolean;
   mode?: SpawnSubagentMode;
@@ -365,6 +369,9 @@ function buildDirectChildSessionPatch(patch: Record<string, unknown>): Partial<S
   }
   if (typeof patch.spawnedWorkspaceDir === "string" && patch.spawnedWorkspaceDir.trim()) {
     entry.spawnedWorkspaceDir = patch.spawnedWorkspaceDir.trim();
+  }
+  if (patch.spawnedSkillsWorkspaceOnly === true) {
+    entry.spawnedSkillsWorkspaceOnly = true;
   }
   if (typeof patch.spawnedCwd === "string" && patch.spawnedCwd.trim()) {
     entry.spawnedCwd = patch.spawnedCwd.trim();
@@ -1196,7 +1203,7 @@ export async function spawnSubagentDirect(
   }
   try {
     const requestedCwd = normalizeOptionalString(params.cwd);
-    const spawnedCwd = requestedCwd ? resolveUserPath(requestedCwd) : undefined;
+    let spawnedCwd = requestedCwd ? resolveUserPath(requestedCwd) : undefined;
     const toolSpawnMetadata = mapToolContextToSpawnedRunMetadata({
       agentGroupId: ctx.agentGroupId,
       agentGroupChannel: ctx.agentGroupChannel,
@@ -1210,6 +1217,47 @@ export async function spawnSubagentDirect(
       targetAgentId,
       explicitWorkspaceDir: inheritedWorkspaceDir,
     });
+    let effectiveWorkspaceDir = spawnedWorkspaceDir;
+    const requestedWorkspace = normalizeOptionalString(params.workspace);
+    if (requestedWorkspace) {
+      if (!spawnedWorkspaceDir) {
+        return {
+          status: "forbidden",
+          error: "workspace override requires a target agent workspace",
+        };
+      }
+      try {
+        const rootResolvedPath = path.resolve(resolveUserPath(spawnedWorkspaceDir));
+        const requestedResolvedPath = path.resolve(resolveUserPath(requestedWorkspace));
+        const relativeWorkspacePath = path.relative(rootResolvedPath, requestedResolvedPath);
+        const [rootRealPath, requestedRealPath] = await Promise.all([
+          fs.realpath(rootResolvedPath),
+          fs.realpath(requestedResolvedPath),
+        ]);
+        const requestedStat = await fs.stat(requestedRealPath);
+        if (
+          !requestedStat.isDirectory() ||
+          relativeWorkspacePath === "" ||
+          relativeWorkspacePath.startsWith(`..${path.sep}`) ||
+          path.isAbsolute(relativeWorkspacePath) ||
+          requestedRealPath !== path.resolve(rootRealPath, relativeWorkspacePath) ||
+          requestedRealPath === rootRealPath ||
+          !isPathInside(rootRealPath, requestedRealPath)
+        ) {
+          return {
+            status: "forbidden",
+            error:
+              "workspace override must be a symlink-free descendant of the target agent workspace",
+          };
+        }
+        effectiveWorkspaceDir = requestedRealPath;
+      } catch {
+        return {
+          status: "forbidden",
+          error: "workspace override must resolve to an existing directory",
+        };
+      }
+    }
     const requesterOrigin = normalizeDeliveryContext({
       channel: ctx.agentChannel,
       accountId: ctx.agentAccountId,
@@ -1247,9 +1295,31 @@ export async function spawnSubagentDirect(
     if (sandboxError) {
       return { status: "forbidden", error: sandboxError };
     }
-    const spawnedWorkspaceCwd = spawnedWorkspaceDir
-      ? resolveUserPath(spawnedWorkspaceDir)
+    const spawnedWorkspaceCwd = effectiveWorkspaceDir
+      ? resolveUserPath(effectiveWorkspaceDir)
       : undefined;
+    if (requestedWorkspace && spawnedCwd) {
+      try {
+        spawnedCwd = await fs.realpath(spawnedCwd);
+      } catch {
+        return {
+          status: "forbidden",
+          error: "cwd must resolve inside the requested child workspace",
+        };
+      }
+    }
+    if (
+      requestedWorkspace &&
+      spawnedCwd &&
+      spawnedWorkspaceCwd &&
+      spawnedCwd !== spawnedWorkspaceCwd &&
+      !isPathInside(spawnedWorkspaceCwd, spawnedCwd)
+    ) {
+      return {
+        status: "forbidden",
+        error: "cwd must remain inside the requested child workspace",
+      };
+    }
     if (childRuntime.sandboxed && spawnedCwd && spawnedCwd !== spawnedWorkspaceCwd) {
       return {
         status: "forbidden",
@@ -1296,7 +1366,7 @@ export async function spawnSubagentDirect(
         cfg,
         targetAgentId,
         targetAgentDir,
-        workspaceDir: spawnedWorkspaceDir,
+        workspaceDir: effectiveWorkspaceDir,
         resolvedModel,
       });
       if (outputModelError) {
@@ -1461,7 +1531,7 @@ export async function spawnSubagentDirect(
     const materializedAttachments = await materializeSubagentAttachments({
       config: cfg,
       targetAgentId,
-      workspaceDir: spawnedCwd ?? spawnedWorkspaceDir,
+      workspaceDir: spawnedCwd ?? effectiveWorkspaceDir,
       attachments: params.attachments,
       mountPathHint,
     });
@@ -1497,13 +1567,14 @@ export async function spawnSubagentDirect(
     const spawnedMetadata = normalizeSpawnedRunMetadata({
       spawnedBy: spawnedByKey,
       ...toolSpawnMetadata,
-      workspaceDir: spawnedWorkspaceDir,
+      workspaceDir: effectiveWorkspaceDir,
     });
     const spawnLineagePatchError = await patchChildSession({
       spawnedBy: spawnedByKey,
       ...(spawnedMetadata.workspaceDir
         ? { spawnedWorkspaceDir: spawnedMetadata.workspaceDir }
         : {}),
+      ...(requestedWorkspace ? { spawnedSkillsWorkspaceOnly: true } : {}),
       ...(spawnedCwd ? { spawnedCwd } : {}),
     });
     if (spawnLineagePatchError) {

--- a/src/agents/subagent-spawn.workspace.test.ts
+++ b/src/agents/subagent-spawn.workspace.test.ts
@@ -1,5 +1,8 @@
 // Subagent spawn workspace tests cover same-agent inheritance, cross-agent
 // workspace selection, sandboxed cwd rejection, and cleanup deletion calls.
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createSubagentSpawnTestConfig,
@@ -37,6 +40,7 @@ const hoisted = vi.hoisted(() => ({
   callGatewayMock: vi.fn(),
   configOverride: {} as Record<string, unknown>,
   registerSubagentRunMock: vi.fn(),
+  updateSessionStoreMock: vi.fn(),
   resolveSandboxRuntimeStatusMock: vi.fn<
     (params: { sessionKey?: string }) => { sandboxed: boolean }
   >(() => ({ sandboxed: false })),
@@ -64,6 +68,7 @@ const hoisted = vi.hoisted(() => ({
 
 let spawnSubagentDirect: typeof import("./subagent-spawn.js").spawnSubagentDirect;
 let resetSubagentRegistryForTests: typeof import("./subagent-registry.test-helpers.js").resetSubagentRegistryForTests;
+let persistedStore: Record<string, Record<string, unknown>> = {};
 
 function createConfigOverride(overrides?: Record<string, unknown>) {
   return createSubagentSpawnTestConfig("/tmp/workspace-main", {
@@ -139,6 +144,7 @@ describe("spawnSubagentDirect workspace inheritance", () => {
       callGatewayMock: hoisted.callGatewayMock,
       getRuntimeConfig: () => hoisted.configOverride,
       registerSubagentRunMock: hoisted.registerSubagentRunMock,
+      updateSessionStoreMock: hoisted.updateSessionStoreMock,
       hookRunner: hoisted.hookRunner,
       resolveAgentConfig: resolveTestAgentConfig,
       resolveAgentWorkspaceDir: resolveTestAgentWorkspace,
@@ -152,6 +158,17 @@ describe("spawnSubagentDirect workspace inheritance", () => {
     resetSubagentRegistryForTests();
     hoisted.callGatewayMock.mockClear();
     hoisted.registerSubagentRunMock.mockClear();
+    persistedStore = {};
+    hoisted.updateSessionStoreMock.mockReset();
+    hoisted.updateSessionStoreMock.mockImplementation(
+      async (
+        _storePath: string,
+        mutator: (store: Record<string, Record<string, unknown>>) => unknown,
+      ) => {
+        await mutator(persistedStore);
+        return persistedStore;
+      },
+    );
     hoisted.resolveSandboxRuntimeStatusMock.mockReset();
     hoisted.resolveSandboxRuntimeStatusMock.mockImplementation(() => ({ sandboxed: false }));
     hoisted.hookRunner.hasHooks.mockReset();
@@ -229,12 +246,62 @@ describe("spawnSubagentDirect workspace inheritance", () => {
       },
     );
 
-    expect(result.status).toBe("accepted");
+    expect(result.status, JSON.stringify(result)).toBe("accepted");
     expect(getRegisteredRun()?.workspaceDir).toBe("/tmp/workspace-ops");
     const agentCall = hoisted.callGatewayMock.mock.calls.find(
       ([request]) => (request as { method?: string }).method === "agent",
     )?.[0] as { params?: Record<string, unknown> } | undefined;
     expect(agentCall?.params).not.toHaveProperty("workspaceDir");
+  });
+
+  it("binds a native child to an isolated descendant workspace", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-child-root-"));
+    const isolated = path.join(root, ".fleet-runs", "run-1");
+    await fs.mkdir(path.join(isolated, "skills", "assigned"), { recursive: true });
+    hoisted.configOverride = createConfigOverride({
+      agents: { list: [{ id: "main", workspace: root }] },
+    });
+
+    const result = await spawnSubagentDirect(
+      { task: "inspect assigned skills", workspace: isolated, cwd: isolated },
+      { agentSessionKey: "agent:main:main", workspaceDir: root },
+    );
+
+    const isolatedRealPath = await fs.realpath(isolated);
+    expect(result.status, JSON.stringify(result)).toBe("accepted");
+    expect(getRegisteredRun()?.workspaceDir).toBe(isolatedRealPath);
+    const childEntry = Object.values(persistedStore).find(
+      (entry) => entry.spawnedWorkspaceDir === isolatedRealPath,
+    );
+    expect(childEntry?.spawnedSkillsWorkspaceOnly).toBe(true);
+  });
+
+  it("rejects missing, outside, symlinked, and cwd-escaping workspace requests", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-child-root-"));
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-child-outside-"));
+    const isolated = path.join(root, "runs", "real");
+    const linked = path.join(root, "runs", "linked");
+    await fs.mkdir(isolated, { recursive: true });
+    await fs.symlink(isolated, linked);
+    hoisted.configOverride = createConfigOverride({
+      agents: { list: [{ id: "main", workspace: root }] },
+    });
+
+    for (const workspace of [path.join(root, "missing"), outside, linked]) {
+      const result = await spawnSubagentDirect(
+        { task: "reject unsafe workspace", workspace },
+        { agentSessionKey: "agent:main:main", workspaceDir: root },
+      );
+      expect(result.status).toBe("forbidden");
+    }
+    const escapedCwd = await spawnSubagentDirect(
+      { task: "reject cwd escape", workspace: isolated, cwd: outside },
+      { agentSessionKey: "agent:main:main", workspaceDir: root },
+    );
+    expect(escapedCwd).toMatchObject({
+      status: "forbidden",
+      error: "cwd must remain inside the requested child workspace",
+    });
   });
 
   it("rejects explicit cwd overrides for sandboxed native subagent spawns", async () => {

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -148,6 +148,12 @@ function createSessionsSpawnToolSchema(params: {
     model: Type.Optional(Type.String()),
     thinking: Type.Optional(Type.String()),
     cwd: Type.Optional(Type.String()),
+    workspace: Type.Optional(
+      Type.String({
+        description:
+          "Native child workspace; must be an existing descendant of the target agent workspace.",
+      }),
+    ),
     ...(params.threadAvailable
       ? {
           thread: Type.Optional(
@@ -335,6 +341,7 @@ export function createSessionsSpawnTool(
       const modelOverride = normalizeToolModelOverride(readStringParam(params, "model"));
       const thinkingOverrideRaw = readStringParam(params, "thinking");
       const cwd = readStringParam(params, "cwd");
+      const workspace = readStringParam(params, "workspace");
       const mode = params.mode === "run" || params.mode === "session" ? params.mode : undefined;
       const cleanup =
         params.cleanup === "keep" || params.cleanup === "delete" ? params.cleanup : "keep";
@@ -406,6 +413,9 @@ export function createSessionsSpawnTool(
         : undefined;
 
       if (runtime === "acp") {
+        if (workspace) {
+          throw new ToolInputError('workspace is only supported for runtime="subagent".');
+        }
         const { spawnAcpDirect } = await loadAcpSpawnModule();
         const acpAttachments = resolveAcpSessionsSpawnImageAttachments({
           config: opts?.config ?? getRuntimeConfig(),
@@ -486,6 +496,7 @@ export function createSessionsSpawnTool(
               ? params[SWARM_CODE_MODE_REQUEST_FINGERPRINT]
               : undefined,
           cwd,
+          workspace,
           thread,
           mode,
           cleanup,

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -274,6 +274,8 @@ export type SessionEntry = SessionRestartRecoveryState &
     spawnedBy?: string;
     /** Workspace inherited by spawned sessions and reused on later turns for the same child session. */
     spawnedWorkspaceDir?: string;
+    /** Restrict skill discovery to spawnedWorkspaceDir for explicitly isolated child workspaces. */
+    spawnedSkillsWorkspaceOnly?: boolean;
     /** Task working directory inherited by spawned sessions and reused on later turns. */
     spawnedCwd?: string;
     /**

--- a/src/gateway/server-methods/agent-run-execution-phase.ts
+++ b/src/gateway/server-methods/agent-run-execution-phase.ts
@@ -395,6 +395,7 @@ export function startAgentRunExecution(params: {
             workspaceDir: params.sessionEntry?.spawnedWorkspaceDir,
             cwd: params.sessionEntry?.spawnedCwd,
           }),
+          skillsWorkspaceOnly: params.sessionEntry?.spawnedSkillsWorkspaceOnly === true,
           cwd: resolveSessionRuntimeCwd({
             requestedCwd: params.request.cwd,
             sessionEntry: params.sessionEntry,

--- a/src/gateway/server.sessions.reset-models.test.ts
+++ b/src/gateway/server.sessions.reset-models.test.ts
@@ -26,6 +26,7 @@ type ResetSessionEntry = {
   space?: string;
   spawnedBy?: string;
   spawnedWorkspaceDir?: string;
+  spawnedSkillsWorkspaceOnly?: boolean;
   spawnedCwd?: string;
   parentSessionKey?: string;
   forkedFromParent?: boolean;
@@ -93,6 +94,7 @@ const ownedChildMetadata = {
   space: "hq",
   spawnedBy: "agent:main:main",
   spawnedWorkspaceDir: "/tmp/child-workspace",
+  spawnedSkillsWorkspaceOnly: true,
   spawnedCwd: "/tmp/task-repo",
   parentSessionKey: "agent:main:main",
   forkedFromParent: true,

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -1236,6 +1236,7 @@ export async function performGatewaySessionReset(params: {
             queueDrop: currentEntry?.queueDrop,
             spawnedBy: currentEntry?.spawnedBy,
             spawnedWorkspaceDir: currentEntry?.spawnedWorkspaceDir,
+            spawnedSkillsWorkspaceOnly: currentEntry?.spawnedSkillsWorkspaceOnly,
             spawnedCwd: params.clearSpawnedCwd
               ? undefined
               : (params.spawnedCwd ?? currentEntry?.spawnedCwd),

--- a/src/plugins/session-entry-slot-keys.ts
+++ b/src/plugins/session-entry-slot-keys.ts
@@ -25,6 +25,7 @@ const SESSION_ENTRY_RESERVED_SLOT_KEY_LIST = [
   "sessionFile",
   "spawnedBy",
   "spawnedWorkspaceDir",
+  "spawnedSkillsWorkspaceOnly",
   "spawnedCwd",
   "worktree",
   "parentSessionKey",

--- a/src/skills/loading/workspace.ts
+++ b/src/skills/loading/workspace.ts
@@ -1522,6 +1522,7 @@ export function buildWorkspaceSkillSnapshot(
     resolvedSkills,
     version: opts?.snapshotVersion,
     promptFormatVersion: WORKSPACE_SKILLS_PROMPT_FORMAT_VERSION,
+    workspaceOnly: opts?.workspaceOnly === true,
   };
 }
 

--- a/src/skills/runtime/session-snapshot.test.ts
+++ b/src/skills/runtime/session-snapshot.test.ts
@@ -285,4 +285,28 @@ describe("resolveReusableWorkspaceSkillSnapshot", () => {
     expect(result.shouldRefresh).toBe(true);
     expect(buildWorkspaceSkillSnapshotMock).toHaveBeenCalledTimes(1);
   });
+
+  it("rebuilds and tags a snapshot when workspace-only discovery is enabled", () => {
+    shouldRefreshSnapshotForVersionMock.mockReturnValue(false);
+    buildWorkspaceSkillSnapshotMock.mockReturnValue({
+      prompt: "assigned only",
+      skills: [{ name: "assigned" }],
+      resolvedSkills: [],
+      workspaceOnly: true,
+    });
+
+    const result = resolveReusableWorkspaceSkillSnapshot({
+      workspaceDir: TEST_WORKSPACE_DIR,
+      config: {},
+      existingSnapshot: strippedSnapshot(),
+      workspaceOnly: true,
+    });
+
+    expect(result.shouldRefresh).toBe(true);
+    expect(buildWorkspaceSkillSnapshotMock).toHaveBeenCalledWith(
+      TEST_WORKSPACE_DIR,
+      expect.objectContaining({ workspaceOnly: true }),
+    );
+    expect(result.snapshot.workspaceOnly).toBe(true);
+  });
 });

--- a/src/skills/runtime/session-snapshot.ts
+++ b/src/skills/runtime/session-snapshot.ts
@@ -25,6 +25,7 @@ type ReusableSkillSnapshotParams = {
   snapshotVersion?: number;
   watch?: boolean;
   hydrateExisting?: boolean;
+  workspaceOnly?: boolean;
 };
 
 type ReusableSkillSnapshotResult = {
@@ -67,10 +68,13 @@ export function resolveReusableWorkspaceSkillSnapshot(
   const nodeSkillsEligibilityChanged =
     stableStringify(params.existingSnapshot?.nodeSkillsEligibility) !==
     stableStringify(params.eligibility?.nodeSkills);
+  const workspaceOnlyChanged =
+    (params.existingSnapshot?.workspaceOnly === true) !== (params.workspaceOnly === true);
   const shouldRefresh =
     promptFormatChanged ||
     skillVersionChanged ||
     nodeSkillsEligibilityChanged ||
+    workspaceOnlyChanged ||
     !matchesSkillFilter(params.existingSnapshot?.skillFilter, params.skillFilter);
   const buildSnapshot = () => {
     return buildWorkspaceSkillSnapshot(params.workspaceDir, {
@@ -79,6 +83,7 @@ export function resolveReusableWorkspaceSkillSnapshot(
       skillFilter: params.skillFilter,
       eligibility: params.eligibility,
       snapshotVersion,
+      workspaceOnly: params.workspaceOnly === true,
     });
   };
 
@@ -90,6 +95,7 @@ export function resolveReusableWorkspaceSkillSnapshot(
     params.agentId,
     params.eligibility,
     configFingerprint,
+    params.workspaceOnly === true,
   ]);
 
   const cachedRebuild = (): SkillSnapshot => {

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -118,6 +118,8 @@ export type SkillEligibilityContext = {
 export const WORKSPACE_SKILLS_PROMPT_FORMAT_VERSION = 3;
 
 export type SkillSnapshot = {
+  /** Whether this snapshot excludes all non-workspace skill roots. */
+  workspaceOnly?: boolean;
   prompt: string;
   skills: Array<{
     name: string;


### PR DESCRIPTION
Related: #111461

## What Problem This Solves

Resolves a problem where native subagent coordinators cannot give a child a bounded per-run skill bundle: `cwd` changes command execution, but bootstrap and skill discovery continue to use the broader target-agent workspace and can expose personal/global skills.

## Why This Change Was Made

Adds an optional native-only `workspace` parameter that accepts only an existing, real, symlink-free descendant of the target agent workspace. Explicit isolated children persist a workspace-only skill-discovery lineage policy across turns, while ordinary native and ACP spawn behavior remains unchanged.

## User Impact

Coordinators can launch least-privilege native children that see only skills materialized in their assigned child workspace. Unsafe missing, outside, symlinked, and cwd-escaping paths fail closed.

## Evidence

- `node scripts/run-vitest.mjs src/agents/subagent-spawn.workspace.test.ts src/agents/tools/sessions-spawn-tool.test.ts src/agents/embedded-agent-runner/run/attempt-startup.test.ts src/skills/runtime/session-snapshot.test.ts` — 180 tests passed.
- `node scripts/run-vitest.mjs src/skills/loading/workspace-load.test.ts src/skills/loading/workspace-snapshot.test.ts src/gateway/server-methods/agents-workspace.test.ts` — 68 tests passed. Session-reset coverage proves the workspace-only lineage policy survives later turns.
- `git diff --check` passed; changed files formatted with oxfmt.
- The wider `attempt-execution.cli.test.ts` lane could not import because the shared local dependency tree lacks `markdown-it-cjk-friendly`; this occurred before tests were collected.
- Required local autoreview was attempted with `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output`; the installed Codex CLI rejected the configured `gpt-5.6-sol` model as requiring a newer CLI, so no structured review verdict was produced.

AI-assisted: yes. I reviewed the complete diff and understand the workspace validation, persisted lineage, snapshot invalidation, and embedded skill-loading path.

Allow edits from maintainers is enabled by default for this fork PR.