### PR TITLE
fix(memory-wiki): sandboxed sub-agents could read other agents' bridged memory through shared vault wiki reads

### DIFF
--- a/extensions/memory-wiki/src/claim-health.test.ts
+++ b/extensions/memory-wiki/src/claim-health.test.ts
@@ -23,6 +23,7 @@ function createPage(params: {
     claims: [],
     contradictions: params.contradictions,
     questions: [],
+    bridgeAgentIds: [],
   };
 }
 

--- a/extensions/memory-wiki/src/corpus-supplement.visibility.test.ts
+++ b/extensions/memory-wiki/src/corpus-supplement.visibility.test.ts
@@ -1,0 +1,247 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { createPluginRuntimeMock } from "openclaw/plugin-sdk/channel-test-helpers";
+import {
+  clearMemoryPluginState,
+  registerMemoryCorpusSupplement,
+} from "openclaw/plugin-sdk/memory-host-core";
+import type { AnyAgentTool, OpenClawPluginToolFactory } from "openclaw/plugin-sdk/plugin-entry";
+import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
+import { describe, expect, it } from "vitest";
+import memoryCorePlugin from "../../memory-core/index.js";
+import type { OpenClawConfig } from "../api.js";
+import { resolveMemoryWikiAgentConfig } from "./config.js";
+import { createWikiCorpusSupplement } from "./corpus-supplement.js";
+import { renderWikiMarkdown } from "./markdown.js";
+import { createMemoryWikiTestHarness } from "./test-helpers.js";
+
+const { createVault } = createMemoryWikiTestHarness();
+
+const appConfig = {
+  agents: { list: [{ id: "main", default: true }, { id: "secondary" }] },
+} as OpenClawConfig;
+
+async function writeBridgePage(params: {
+  rootDir: string;
+  slug: string;
+  title: string;
+  agentIds: string[];
+  marker: string;
+}): Promise<void> {
+  await fs.writeFile(
+    path.join(params.rootDir, "sources", `${params.slug}.md`),
+    renderWikiMarkdown({
+      frontmatter: {
+        pageType: "source",
+        id: `source.${params.slug}`,
+        title: params.title,
+        sourceType: "memory-bridge",
+        sourcePath: `/tmp/${params.slug}/MEMORY.md`,
+        bridgeRelativePath: "MEMORY.md",
+        bridgeWorkspaceDir: `/tmp/${params.slug}`,
+        bridgeAgentIds: params.agentIds,
+      },
+      body: `# ${params.title}\n\n${params.marker}\n`,
+    }),
+    "utf8",
+  );
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Expected tool details object");
+  }
+  return value as Record<string, unknown>;
+}
+
+function registerMemoryCoreToolFactories(): Map<string, OpenClawPluginToolFactory> {
+  const factories = new Map<string, OpenClawPluginToolFactory>();
+  memoryCorePlugin.register(
+    createTestPluginApi({
+      id: "memory-core",
+      config: appConfig,
+      runtime: createPluginRuntimeMock(),
+      registerTool(tool, options) {
+        if (typeof tool !== "function") {
+          return;
+        }
+        for (const name of options?.names ?? []) {
+          factories.set(name, tool);
+        }
+      },
+    }),
+  );
+  return factories;
+}
+
+function createMemoryCoreTool(params: {
+  factories: Map<string, OpenClawPluginToolFactory>;
+  name: "memory_search" | "memory_get";
+  agentId: string;
+  sandboxed: boolean;
+}): AnyAgentTool {
+  const factory = params.factories.get(params.name);
+  if (!factory) {
+    throw new Error(`Expected memory-core to register ${params.name}`);
+  }
+  const tool = factory({
+    config: appConfig,
+    runtimeConfig: appConfig,
+    getRuntimeConfig: () => appConfig,
+    agentId: params.agentId,
+    sessionKey: `agent:${params.agentId}:child-session`,
+    sandboxed: params.sandboxed,
+  });
+  if (!tool || Array.isArray(tool)) {
+    throw new Error(`Expected one ${params.name} tool`);
+  }
+  return tool;
+}
+
+describe("memory-wiki corpus supplement visibility", () => {
+  it("enforces bridge ownership through direct and registered corpus fallbacks", async () => {
+    const { rootDir, config } = await createVault({
+      initialize: true,
+      config: { vault: { scope: "global" } },
+    });
+    await writeBridgePage({
+      rootDir,
+      slug: "secondary-private",
+      title: "Secondary Private",
+      agentIds: ["secondary"],
+      marker: "REDACTED-FOREIGN-MARKER",
+    });
+    await writeBridgePage({
+      rootDir,
+      slug: "main-private",
+      title: "Main Private",
+      agentIds: ["main"],
+      marker: "REDACTED-OWN-MARKER",
+    });
+    await writeBridgePage({
+      rootDir,
+      slug: "unowned-private",
+      title: "Unowned Private",
+      agentIds: [],
+      marker: "REDACTED-UNOWNED-MARKER",
+    });
+    const supplement = createWikiCorpusSupplement({
+      getAppConfig: () => appConfig,
+      resolveConfig: (agentId, currentAppConfig) =>
+        resolveMemoryWikiAgentConfig({ config, appConfig: currentAppConfig, agentId }),
+    });
+    const caller = {
+      agentId: "main",
+      agentSessionKey: "agent:main:child-session",
+      query: "REDACTED-FOREIGN-MARKER",
+    };
+
+    expect(await supplement.search({ ...caller, sandboxed: true })).toEqual([]);
+    expect(
+      await supplement.get({
+        ...caller,
+        sandboxed: true,
+        lookup: "secondary-private",
+      }),
+    ).toBeNull();
+    expect(
+      (await supplement.search({ ...caller, sandboxed: false })).map((result) => result.path),
+    ).toEqual(["sources/secondary-private.md"]);
+    expect(
+      (
+        await supplement.get({
+          ...caller,
+          sandboxed: false,
+          lookup: "secondary-private",
+        })
+      )?.content,
+    ).toContain("REDACTED-FOREIGN-MARKER");
+
+    clearMemoryPluginState();
+    try {
+      registerMemoryCorpusSupplement("memory-wiki", supplement);
+      const factories = registerMemoryCoreToolFactories();
+      const sandboxedGet = createMemoryCoreTool({
+        factories,
+        name: "memory_get",
+        agentId: "main",
+        sandboxed: true,
+      });
+      const sandboxedSearch = createMemoryCoreTool({
+        factories,
+        name: "memory_search",
+        agentId: "main",
+        sandboxed: true,
+      });
+      const openGet = createMemoryCoreTool({
+        factories,
+        name: "memory_get",
+        agentId: "main",
+        sandboxed: false,
+      });
+      const openSearch = createMemoryCoreTool({
+        factories,
+        name: "memory_search",
+        agentId: "main",
+        sandboxed: false,
+      });
+
+      const foreignGet = await sandboxedGet.execute("memory-get-foreign", {
+        path: "sources/secondary-private.md",
+        corpus: "wiki",
+      });
+      const unownedGet = await sandboxedGet.execute("memory-get-unowned", {
+        path: "sources/unowned-private.md",
+        corpus: "wiki",
+      });
+      const ownGet = await sandboxedGet.execute("memory-get-own", {
+        path: "sources/main-private.md",
+        corpus: "wiki",
+      });
+      const foreignSearch = await sandboxedSearch.execute("memory-search-foreign", {
+        query: "REDACTED-FOREIGN-MARKER",
+        corpus: "wiki",
+      });
+      const ownSearch = await sandboxedSearch.execute("memory-search-own", {
+        query: "REDACTED-OWN-MARKER",
+        corpus: "wiki",
+      });
+      const openForeignGet = await openGet.execute("memory-get-open-foreign", {
+        path: "sources/secondary-private.md",
+        corpus: "wiki",
+      });
+      const openForeignSearch = await openSearch.execute("memory-search-open-foreign", {
+        query: "REDACTED-FOREIGN-MARKER",
+        corpus: "wiki",
+      });
+
+      expect(asRecord(foreignGet.details)).toMatchObject({
+        text: "",
+        disabled: true,
+        error: "wiki corpus result not found",
+      });
+      expect(asRecord(unownedGet.details)).toMatchObject({
+        text: "",
+        disabled: true,
+        error: "wiki corpus result not found",
+      });
+      expect(asRecord(ownGet.details)).toMatchObject({
+        path: "sources/main-private.md",
+        text: expect.stringContaining("REDACTED-OWN-MARKER"),
+      });
+      expect(asRecord(foreignSearch.details).results).toEqual([]);
+      expect(asRecord(ownSearch.details).results).toEqual([
+        expect.objectContaining({ path: "sources/main-private.md" }),
+      ]);
+      expect(asRecord(openForeignGet.details)).toMatchObject({
+        path: "sources/secondary-private.md",
+        text: expect.stringContaining("REDACTED-FOREIGN-MARKER"),
+      });
+      expect(asRecord(openForeignSearch.details).results).toEqual([
+        expect.objectContaining({ path: "sources/secondary-private.md" }),
+      ]);
+    } finally {
+      clearMemoryPluginState();
+    }
+  }, 240_000);
+});

--- a/extensions/memory-wiki/src/markdown.ts
+++ b/extensions/memory-wiki/src/markdown.ts
@@ -109,6 +109,7 @@ export type WikiPageSummary = {
   sourcePath?: string;
   bridgeRelativePath?: string;
   bridgeWorkspaceDir?: string;
+  bridgeAgentIds: string[];
   unsafeLocalConfiguredPath?: string;
   unsafeLocalRelativePath?: string;
   lastRefreshedAt?: string;
@@ -741,6 +742,7 @@ export function scanWikiPageSummary(params: {
       sourcePath: normalizeOptionalString(parsed.frontmatter.sourcePath),
       bridgeRelativePath: normalizeOptionalString(parsed.frontmatter.bridgeRelativePath),
       bridgeWorkspaceDir: normalizeOptionalString(parsed.frontmatter.bridgeWorkspaceDir),
+      bridgeAgentIds: normalizeSingleOrTrimmedStringList(parsed.frontmatter.bridgeAgentIds),
       unsafeLocalConfiguredPath: normalizeOptionalString(
         parsed.frontmatter.unsafeLocalConfiguredPath,
       ),

--- a/extensions/memory-wiki/src/query.test.ts
+++ b/extensions/memory-wiki/src/query.test.ts
@@ -1957,4 +1957,177 @@ describe("getMemoryWikiPage", () => {
     expect(manager.readFile).toHaveBeenCalled();
   });
 });
+
+describe("wiki corpus bridge page agent scoping", () => {
+  async function writeBridgePage(params: {
+    rootDir: string;
+    slug: string;
+    title: string;
+    agentIds: string[];
+    marker: string;
+  }) {
+    await fs.writeFile(
+      path.join(params.rootDir, "sources", `${params.slug}.md`),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: `source.${params.slug}`,
+          title: params.title,
+          sourceType: "memory-bridge",
+          sourcePath: `/tmp/workspace/${params.slug}.md`,
+          bridgeRelativePath: `${params.slug}.md`,
+          bridgeWorkspaceDir: "/tmp/workspace",
+          bridgeAgentIds: params.agentIds,
+        },
+        body: `# ${params.title}\n\n${params.marker}\n`,
+      }),
+      "utf8",
+    );
+  }
+
+  async function createBridgeVisibilityVault() {
+    const vault = await createQueryVault({
+      initialize: true,
+      config: { vault: { scope: "global" } },
+    });
+    await writeBridgePage({
+      rootDir: vault.rootDir,
+      slug: "main-daily-note",
+      title: "Main Daily Note",
+      agentIds: ["Main"],
+      marker: "wikiscope marker main",
+    });
+    await writeBridgePage({
+      rootDir: vault.rootDir,
+      slug: "secondary-daily-note",
+      title: "Secondary Daily Note",
+      agentIds: ["secondary"],
+      marker: "wikiscope marker secondary",
+    });
+    await writeBridgePage({
+      rootDir: vault.rootDir,
+      slug: "unowned-daily-note",
+      title: "Unowned Daily Note",
+      agentIds: [],
+      marker: "wikiscope marker unowned",
+    });
+    await fs.writeFile(
+      path.join(vault.rootDir, "sources", "shared-note.md"),
+      renderWikiMarkdown({
+        frontmatter: { pageType: "source", id: "source.shared-note", title: "Shared Note" },
+        body: "# Shared Note\n\nwikiscope marker shared\n",
+      }),
+      "utf8",
+    );
+    return vault;
+  }
+
+  it("limits sandboxed bridge reads to pages owned by the caller", async () => {
+    const { config } = await createBridgeVisibilityVault();
+    const caller = {
+      config,
+      appConfig: createAgentSessionVisibilityAppConfig(),
+      agentId: "main",
+      sandboxed: true,
+    };
+
+    const owned = await getMemoryWikiPage({
+      ...caller,
+      lookup: "main-daily-note",
+    });
+    const shared = await getMemoryWikiPage({
+      ...caller,
+      lookup: "shared-note",
+    });
+    const foreign = await getMemoryWikiPage({
+      ...caller,
+      lookup: "secondary-daily-note",
+    });
+    const unowned = await getMemoryWikiPage({
+      ...caller,
+      lookup: "unowned-daily-note",
+    });
+
+    expect(owned?.content).toContain("wikiscope marker main");
+    expect(shared?.content).toContain("wikiscope marker shared");
+    expect(foreign).toBeNull();
+    expect(unowned).toBeNull();
+  });
+
+  it("preserves global bridge reads for non-sandboxed callers", async () => {
+    const { config } = await createBridgeVisibilityVault();
+    const caller = {
+      config,
+      appConfig: createAgentSessionVisibilityAppConfig(),
+      agentId: "main",
+      agentSessionKey: "agent:main:thread",
+      sandboxed: false,
+    };
+    const page = await getMemoryWikiPage({
+      ...caller,
+      lookup: "secondary-daily-note",
+    });
+    const results = await searchMemoryWiki({
+      ...caller,
+      query: "wikiscope marker secondary",
+    });
+
+    expect(page?.content).toContain("wikiscope marker secondary");
+    expect(collectWikiResultPaths(results)).toContain("sources/secondary-daily-note.md");
+  });
+
+  it("resolves sandboxed ownership from the session key and fails closed without it", async () => {
+    const { config } = await createBridgeVisibilityVault();
+    const denied = await getMemoryWikiPage({
+      config,
+      appConfig: createAgentSessionVisibilityAppConfig(),
+      agentSessionKey: "agent:main:child-session",
+      sandboxed: true,
+      lookup: "secondary-daily-note",
+    });
+    const allowed = await getMemoryWikiPage({
+      config,
+      appConfig: createAgentSessionVisibilityAppConfig(),
+      agentSessionKey: "agent:secondary:child-session",
+      sandboxed: true,
+      lookup: "secondary-daily-note",
+    });
+    const unresolved = await getMemoryWikiPage({
+      config,
+      sandboxed: true,
+      lookup: "secondary-daily-note",
+    });
+
+    expect(denied).toBeNull();
+    expect(allowed?.content).toContain("wikiscope marker secondary");
+    expect(unresolved).toBeNull();
+  });
+
+  it("filters cross-agent bridge pages out of wiki search results", async () => {
+    const { config } = await createBridgeVisibilityVault();
+    const scoped = await searchMemoryWiki({
+      config,
+      appConfig: createAgentSessionVisibilityAppConfig(),
+      agentId: "main",
+      agentSessionKey: "agent:main:child-session",
+      sandboxed: true,
+      query: "wikiscope marker",
+    });
+    const unscoped = await searchMemoryWiki({
+      config,
+      query: "wikiscope marker",
+    });
+
+    expect(collectWikiResultPaths(scoped).toSorted()).toEqual([
+      "sources/main-daily-note.md",
+      "sources/shared-note.md",
+    ]);
+    expect(collectWikiResultPaths(unscoped).toSorted()).toEqual([
+      "sources/main-daily-note.md",
+      "sources/secondary-daily-note.md",
+      "sources/shared-note.md",
+      "sources/unowned-daily-note.md",
+    ]);
+  });
+});
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/memory-wiki/src/query.ts
+++ b/extensions/memory-wiki/src/query.ts
@@ -917,6 +917,38 @@ function shouldEnforceSessionVisibility(params: {
   );
 }
 
+function isBridgeCompiledPage(page: QueryableWikiPage): boolean {
+  return (
+    page.sourceType === "memory-bridge" ||
+    page.sourceType === "memory-bridge-events" ||
+    page.bridgeAgentIds.length > 0
+  );
+}
+
+function createWikiPageVisibilityFilter(params: {
+  appConfig?: OpenClawConfig;
+  agentId?: string;
+  agentSessionKey?: string;
+  sandboxed?: boolean;
+}): (page: QueryableWikiPage) => boolean {
+  if (params.sandboxed !== true) {
+    return () => true;
+  }
+  const sessionKey = params.agentSessionKey?.trim();
+  const scopedAgentId = normalizeLowercaseStringOrEmpty(
+    params.agentId?.trim() ||
+      (params.appConfig && sessionKey
+        ? resolveSessionAgentId({ sessionKey, config: params.appConfig })
+        : undefined),
+  );
+  return (page) =>
+    !isBridgeCompiledPage(page) ||
+    (scopedAgentId.length > 0 &&
+      page.bridgeAgentIds.some(
+        (agentId) => normalizeLowercaseStringOrEmpty(agentId) === scopedAgentId,
+      ));
+}
+
 function shouldSearchSharedMemoryCorpus(config: ResolvedMemoryWikiConfig): boolean {
   return config.search.corpus === "memory" || config.search.corpus === "all";
 }
@@ -1345,6 +1377,7 @@ async function searchWikiCorpus(params: {
   query: string;
   maxResults: number;
   mode: WikiSearchMode;
+  canReadPage: (page: QueryableWikiPage) => boolean;
 }): Promise<WikiSearchResult[]> {
   const digest = await readQueryDigestBundle(params.config);
   const rootDir = params.config.vault.path;
@@ -1366,6 +1399,7 @@ async function searchWikiCorpus(params: {
   }
 
   const results = candidatePages
+    .filter(params.canReadPage)
     .map((page) => toWikiSearchResult(page, params.query, params.mode))
     .filter((page) => page.score > 0);
   if (candidatePaths.length === 0 || results.length >= params.maxResults) {
@@ -1375,7 +1409,9 @@ async function searchWikiCorpus(params: {
   const remainingPaths = (await listWikiMarkdownFiles(rootDir)).filter(
     (relativePath) => !seenPaths.has(relativePath),
   );
-  const remainingPages = await readQueryableWikiPagesByPaths(rootDir, remainingPaths);
+  const remainingPages = (await readQueryableWikiPagesByPaths(rootDir, remainingPaths)).filter(
+    params.canReadPage,
+  );
   return [
     ...results,
     ...remainingPages
@@ -1438,6 +1474,7 @@ export async function searchMemoryWiki(params: {
         query: params.query,
         maxResults,
         mode,
+        canReadPage: createWikiPageVisibilityFilter(params),
       })
     : [];
 
@@ -1503,16 +1540,17 @@ export async function getMemoryWikiPage(params: {
   const lineCount = normalizePositiveInteger(params.lineCount, 200);
 
   if (shouldSearchWiki(effectiveConfig)) {
+    const canReadPage = createWikiPageVisibilityFilter(params);
     const digest = await readQueryDigestBundle(effectiveConfig);
     const digestClaimPagePath = digest ? resolveDigestClaimLookup(digest, params.lookup) : null;
     const digestLookupPage = digestClaimPagePath
       ? ((
           await readQueryableWikiPagesByPaths(effectiveConfig.vault.path, [digestClaimPagePath])
-        )[0] ?? null)
+        ).find(canReadPage) ?? null)
       : null;
     const pages = digestLookupPage
       ? [digestLookupPage]
-      : await readQueryableWikiPages(effectiveConfig.vault.path);
+      : (await readQueryableWikiPages(effectiveConfig.vault.path)).filter(canReadPage);
     const page = digestLookupPage ?? resolveQueryableWikiPageByLookup(pages, params.lookup);
     if (page) {
       const parsed = parseWikiMarkdown(page.raw);


### PR DESCRIPTION
Closes #103087

## What Problem This Solves

Fixes an issue where a sandboxed sub-agent belonging to one agent identity could read another agent's bridge-compiled memory content through `wiki_get`, `wiki_search`, and the `memory_get`/`memory_search` corpus fallback. With `bridge.enabled: true`, every agent's memory-root, daily-note, dream-report, and event-log artifacts are compiled into the one shared global vault, and the wiki-corpus read path returned any matching vault page with no check of the caller's `agentId`, `agentSessionKey`, or `sandboxed` flag, even though the sessions-corpus branch in the same file already blocks the equivalent cross-agent read.

#103349 added the opt-in `vault.scope: "agent"` isolation and filtered bridge sync by ownership, but as noted on the issue the default global vault query path remained caller-unfiltered, so the reported disclosure is still live on current `main`.

## Why This Change Was Made

The fix reuses the ownership model #103349 established instead of adding new configuration: bridge pages already carry `bridgeAgentIds` frontmatter written by bridge sync (`extensions/memory-wiki/src/bridge.ts:231`), so `WikiPageSummary` now surfaces that field and the wiki-corpus branch of `getMemoryWikiPage` and `searchWikiCorpus` filters pages through one visibility gate.

The gate is deliberately limited to sandboxed callers and fails closed on bridge-compiled pages. A page counts as bridge-compiled when its `sourceType` is `memory-bridge` or `memory-bridge-events`, or when it carries any `bridgeAgentIds` entry. A sandboxed caller with a resolved agent identity reads its own bridge pages and every ordinary wiki page, but not another agent's bridge pages and not a bridge page whose ownership metadata is absent or empty. A sandboxed caller with no resolvable agent reads no bridge page at all. Ordinary non-sandboxed callers retain the documented `vault.scope: "global"` behavior, including cross-agent bridge reads. Ownership comparison is case-insensitive, matching the existing agent-id comparisons in this file.

The gate lives in `query.ts` rather than in any caller, so it covers every wiki-corpus read surface at once. `createWikiCorpusSupplement` already forwards `agentId`, `agentSessionKey`, and `sandboxed` into `searchMemoryWiki` and `getMemoryWikiPage`, and Memory Core already forwards `ctx.sandboxed` from the plugin tool context through `resolveMemoryToolOptions` (`extensions/memory-core/index.ts:160`) into `searchMemoryCorpusSupplements` and `getMemoryCorpusSupplementResult`, so the registered `memory_search`/`memory_get` corpus fallback picks up the same visibility rule with no change outside `extensions/memory-wiki`. The regression now drives that registered route through the real memory-core plugin registration rather than calling the supplement directly.

Note: open PR #105098 also touches `searchWikiCorpus` (deadline threading in the supplement fallback). The concerns are independent, but whichever lands second will need a trivial rebase of the `searchWikiCorpus` signature.

## User Impact

Sandboxed sub-agents using the default shared vault with the memory bridge can no longer read another agent's bridged memory content, and can no longer read bridge pages that carry no ownership metadata. Normal non-sandboxed agent calls keep the documented global-vault sharing contract, including cross-agent bridge reads and unowned bridge reads. Single-agent setups see no behavior change: the agent owns its bridge pages, because every bridged workspace resolves at least one agent id (`resolveMemoryDreamingWorkspaces`), and ordinary wiki pages remain readable.

No stored data shape changes. `bridgeAgentIds` is the only ownership key bridge sync has ever written, from the bridge feature's first commit `fbbe2a1675` (2026-04-05) onward, so there is no earlier on-disk frontmatter shape to migrate and no doctor migration is required. Vaults whose bridge pages predate an ownership-reporting memory provider are covered by the fail-closed rule above rather than by a rewrite.

## Evidence

Driver: the real `wiki_get` and `wiki_search` agent tools from `extensions/memory-wiki/src/tool.ts`, built by `createWikiGetTool`/`createWikiSearchTool` exactly as `index.ts` registers them, plus the real `memory_get` and `memory_search` tools obtained from the actual `memory-core` plugin registration (`memoryCorePlugin.register(...)`, then the registered tool factory invoked with a plugin tool context carrying `agentId`, `sessionKey`, and `sandboxed`), with the wiki supplement installed through the real `registerMemoryCorpusSupplement` registry that Memory Core reads. All four surfaces run against one real on-disk vault created by the production `resolveMemoryWikiConfig` plus `initializeMemoryWikiVault`. Nothing is stubbed on the read path; the only difference between the two runs is `query.ts` plus `markdown.ts`.

Vault contents are synthetic fixture pages written in the exact shape `bridge.ts` produces: one bridge page owned by agent `secondary` (frontmatter `bridgeAgentIds: ["secondary"]`) and one bridge page with no ownership metadata, standing in for a vault whose bridge pages were compiled from a memory provider that does not report agent ids. No private vault content or real vault path appears below; the sentinel strings and `sources/...` paths are fixture data from a temporary vault.

Validation on head `d1be22cbbf`:

- `node scripts/run-vitest.mjs run extensions/memory-wiki/src/query.test.ts extensions/memory-wiki/src/corpus-supplement.visibility.test.ts extensions/memory-wiki/src/claim-health.test.ts extensions/memory-wiki/src/agent-vault-isolation.test.ts extensions/memory-wiki/src/corpus-supplement.test.ts`: 5 files, 64 tests passed.
- `node scripts/run-vitest.mjs run extensions/memory-core/src/tools.test.ts`: 1 file, 44 tests passed.
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json`: clean.
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json`: clean.
- `node scripts/run-oxlint.mjs` over the changed files: clean.
- `oxfmt --check` over the changed files: clean.
- `git diff --check`: clean.

## Real behavior proof
Behavior addressed: a sandboxed sub-agent of one agent could read another agent's bridge-compiled memory, and any sandboxed sub-agent could read bridge pages carrying no ownership metadata, through the shared global vault read surfaces.
Real environment tested: the registered `wiki_get`, `wiki_search`, `memory_get`, and `memory_search` agent tools driven against one real on-disk global vault, run on pristine `main` and on this branch with identical inputs and identical vault contents.
Exact steps or command run after this patch: three callers issue the same four calls against the same vault for each of two bridged pages: a sandboxed sub-agent of `main`, a sandboxed sub-agent of `secondary` (the owner of the first page), and a normal non-sandboxed `main` session.
Evidence after fix:
```
# BEFORE (pristine main f8cc39ce62)
--- sandboxed sub-agent of main reads secondary's bridged page
wiki_get -> # Secondary Daily Note 2026-07-09 | SECRET-SENTINEL: secondary agent private plan. | ## Related
wiki_search -> 1. Secondary Daily Note 2026-07-09 (wiki/source) | Path: sources/secondary-daily-note-2026-07-09.md | Snippet: SECRET-SENTINEL: secondary agent private plan.
registered memory_get -> {"path":"sources/secondary-daily-note-2026-07-09.md","text":"SECRET-SENTINEL: secondary agent private plan."}
registered memory_search -> [{"path":"sources/secondary-daily-note-2026-07-09.md","snippet":"SECRET-SENTINEL: secondary agent private plan."}]

--- sandboxed sub-agent of secondary (the owner) reads secondary's bridged page
wiki_get -> # Secondary Daily Note 2026-07-09 | SECRET-SENTINEL: secondary agent private plan. | ## Related
wiki_search -> 1. Secondary Daily Note 2026-07-09 (wiki/source) | Path: sources/secondary-daily-note-2026-07-09.md | Snippet: SECRET-SENTINEL: secondary agent private plan.
registered memory_get -> {"path":"sources/secondary-daily-note-2026-07-09.md","text":"SECRET-SENTINEL: secondary agent private plan."}
registered memory_search -> [{"path":"sources/secondary-daily-note-2026-07-09.md","snippet":"SECRET-SENTINEL: secondary agent private plan."}]

--- normal non-sandboxed main session reads secondary's bridged page
wiki_get -> # Secondary Daily Note 2026-07-09 | SECRET-SENTINEL: secondary agent private plan. | ## Related
wiki_search -> 1. Secondary Daily Note 2026-07-09 (wiki/source) | Path: sources/secondary-daily-note-2026-07-09.md | Snippet: SECRET-SENTINEL: secondary agent private plan.
registered memory_get -> {"path":"sources/secondary-daily-note-2026-07-09.md","text":"SECRET-SENTINEL: secondary agent private plan."}
registered memory_search -> [{"path":"sources/secondary-daily-note-2026-07-09.md","snippet":"SECRET-SENTINEL: secondary agent private plan."}]

--- sandboxed sub-agent of main reads bridged page with no ownership metadata
wiki_get -> # Unowned Bridge Note 2026-07-09 | SECRET-SENTINEL: bridge page with no ownership metadata. | ## Related
wiki_search -> 1. Unowned Bridge Note 2026-07-09 (wiki/source) | Path: sources/unowned-bridge-note-2026-07-09.md | Snippet: SECRET-SENTINEL: bridge page with no ownership metadata.
registered memory_get -> {"path":"sources/unowned-bridge-note-2026-07-09.md","text":"SECRET-SENTINEL: bridge page with no ownership metadata."}
registered memory_search -> [{"path":"sources/unowned-bridge-note-2026-07-09.md","snippet":"SECRET-SENTINEL: bridge page with no ownership metadata."}]

--- normal non-sandboxed main session reads bridged page with no ownership metadata
wiki_get -> # Unowned Bridge Note 2026-07-09 | SECRET-SENTINEL: bridge page with no ownership metadata. | ## Related
wiki_search -> 1. Unowned Bridge Note 2026-07-09 (wiki/source) | Path: sources/unowned-bridge-note-2026-07-09.md | Snippet: SECRET-SENTINEL: bridge page with no ownership metadata.
registered memory_get -> {"path":"sources/unowned-bridge-note-2026-07-09.md","text":"SECRET-SENTINEL: bridge page with no ownership metadata."}
registered memory_search -> [{"path":"sources/unowned-bridge-note-2026-07-09.md","snippet":"SECRET-SENTINEL: bridge page with no ownership metadata."}]

# AFTER (this patch, identical inputs, head d1be22cbbf)
--- sandboxed sub-agent of main reads secondary's bridged page
wiki_get -> Wiki page not found: sources/secondary-daily-note-2026-07-09.md
wiki_search -> No wiki or memory results.
registered memory_get -> {"path":"sources/secondary-daily-note-2026-07-09.md","text":"","disabled":true,"error":"wiki corpus result not found"}
registered memory_search -> []

--- sandboxed sub-agent of secondary (the owner) reads secondary's bridged page
wiki_get -> # Secondary Daily Note 2026-07-09 | SECRET-SENTINEL: secondary agent private plan. | ## Related
wiki_search -> 1. Secondary Daily Note 2026-07-09 (wiki/source) | Path: sources/secondary-daily-note-2026-07-09.md | Snippet: SECRET-SENTINEL: secondary agent private plan.
registered memory_get -> {"path":"sources/secondary-daily-note-2026-07-09.md","text":"SECRET-SENTINEL: secondary agent private plan."}
registered memory_search -> [{"path":"sources/secondary-daily-note-2026-07-09.md","snippet":"SECRET-SENTINEL: secondary agent private plan."}]

--- normal non-sandboxed main session reads secondary's bridged page
wiki_get -> # Secondary Daily Note 2026-07-09 | SECRET-SENTINEL: secondary agent private plan. | ## Related
wiki_search -> 1. Secondary Daily Note 2026-07-09 (wiki/source) | Path: sources/secondary-daily-note-2026-07-09.md | Snippet: SECRET-SENTINEL: secondary agent private plan.
registered memory_get -> {"path":"sources/secondary-daily-note-2026-07-09.md","text":"SECRET-SENTINEL: secondary agent private plan."}
registered memory_search -> [{"path":"sources/secondary-daily-note-2026-07-09.md","snippet":"SECRET-SENTINEL: secondary agent private plan."}]

--- sandboxed sub-agent of main reads bridged page with no ownership metadata
wiki_get -> Wiki page not found: sources/unowned-bridge-note-2026-07-09.md
wiki_search -> No wiki or memory results.
registered memory_get -> {"path":"sources/unowned-bridge-note-2026-07-09.md","text":"","disabled":true,"error":"wiki corpus result not found"}
registered memory_search -> []

--- normal non-sandboxed main session reads bridged page with no ownership metadata
wiki_get -> # Unowned Bridge Note 2026-07-09 | SECRET-SENTINEL: bridge page with no ownership metadata. | ## Related
wiki_search -> 1. Unowned Bridge Note 2026-07-09 (wiki/source) | Path: sources/unowned-bridge-note-2026-07-09.md | Snippet: SECRET-SENTINEL: bridge page with no ownership metadata.
registered memory_get -> {"path":"sources/unowned-bridge-note-2026-07-09.md","text":"SECRET-SENTINEL: bridge page with no ownership metadata."}
registered memory_search -> [{"path":"sources/unowned-bridge-note-2026-07-09.md","snippet":"SECRET-SENTINEL: bridge page with no ownership metadata."}]
```
Observed result after fix: on all four read surfaces, including the registered Memory Core fallback, the sandboxed foreign caller went from full disclosure to denial, and the sandboxed caller of an unowned bridged page went from full disclosure to denial, while the owner's sandboxed reads and every non-sandboxed read stayed byte-identical across the two runs.
What was not tested: a full gateway run with a live `bridge.enabled` sync cycle writing the pages through `syncMemoryWikiBridgeSources` (the vault pages were written directly in the exact shape bridge sync produces), and `vault.scope: "agent"` deployments, which bypass the shared vault entirely and are unaffected.

### Review responses

- Registered Memory Core fallback context: the prior review read this as missing propagation. Sandbox context already reaches the filter in production: `extensions/memory-core/index.ts:160` copies `ctx.sandboxed` into the tool options, `extensions/memory-core/src/tools.ts` forwards it into `searchMemoryCorpusSupplements` and `getSupplementMemoryReadResult`, and `extensions/memory-core/src/tools.shared.ts` hands it to every registered supplement. The gap was proof, not code, so the regression and the run above now drive the registered `memory_get` and `memory_search` tools built by the real `memory-core` plugin registration with `sandboxed: true` on the tool context, instead of calling the supplement directly.
- Legacy `agentIds` bridge frontmatter: no such key exists. `bridge.ts` has written `bridgeAgentIds` since the bridge feature landed in `fbbe2a1675`; `agentIds` appears only as a TypeScript parameter name inside `bridge.ts` and as a field on the in-memory `MemoryPluginPublicArtifact`, never in page frontmatter. The real residual risk the review points at is a bridge page whose ownership list is empty, which happens when a memory capability plugin omits `agentIds` on its public artifacts, a case `filterMemoryWikiBridgeArtifacts` explicitly tolerates in global scope. That case is now fixed rather than migrated: bridge-compiled pages fail closed for sandboxed callers when ownership cannot be proven, covered by the second bridged page in the run above and by a new regression.
- Non-sandboxed global sharing and upgrade behavior: covered by the unchanged non-sandboxed rows in the run above and by regressions asserting that a non-sandboxed `main` session still reads `secondary`'s bridge page through both the direct wiki tools and the registered fallback.
- Stored data model: nothing is persisted or reshaped by this patch. It only reads existing frontmatter, so there is no migration to confirm.
