### PR TITLE
fix(onboard): make first-run hatch reliable

### DIFF
--- a/src/agents/prepared-model-runtime.lifecycle.test.ts
+++ b/src/agents/prepared-model-runtime.lifecycle.test.ts
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => ({
   ensureRuntimePluginsLoaded: vi.fn(),
   loadStaticCatalog: vi.fn<LoadStaticCatalog>(async () => []),
   configuredAgentIds: [] as string[],
+  warn: vi.fn(),
   mutationListener: undefined as
     | ((event: { agentDir?: string; affectsInheritedStores: boolean }) => void)
     | undefined,
@@ -80,7 +81,7 @@ vi.mock("./embedded-agent-runner/model.static-catalog.js", () => ({
 }));
 
 vi.mock("../logging/subsystem.js", () => ({
-  createSubsystemLogger: () => ({ warn: vi.fn() }),
+  createSubsystemLogger: () => ({ warn: mocks.warn }),
 }));
 
 import {
@@ -111,6 +112,7 @@ describe("prepared model runtime snapshots", () => {
     mocks.ensureRuntimePluginsLoaded.mockClear();
     mocks.loadStaticCatalog.mockClear();
     mocks.modelRegistry.fork.mockClear();
+    mocks.warn.mockClear();
     mocks.configuredAgentIds = [];
   });
 
@@ -335,6 +337,50 @@ describe("prepared model runtime snapshots", () => {
     expect(secondLease.snapshot.workspaceDir).toBe(dynamicInput.workspaceDir);
     firstLease.release();
     secondLease.release();
+  });
+
+  it("rebases a reserved run identity through its configured agent directory", async () => {
+    mocks.configuredAgentIds = ["default", "openclaw"];
+    const config = {};
+    await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
+
+    const lease = await acquireAgentRunPreparedModelRuntime({
+      agentId: "openclaw",
+      config,
+      agentDir: "/tmp/unused-agent",
+      inheritedAuthDir: "/tmp/unused-agent",
+      workspaceDir: "/tmp/setup-probe-workspace",
+    });
+
+    expect(lease.snapshot).toMatchObject({
+      agentId: "openclaw",
+      agentDir: "/tmp/unused-agent",
+      workspaceDir: "/tmp/setup-probe-workspace",
+      config,
+    });
+    lease.release();
+  });
+
+  it("keeps an ordinary run bound to its configured agent identity", async () => {
+    mocks.configuredAgentIds = ["default", "secondary"];
+    const config = {};
+    await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
+
+    const lease = await acquireAgentRunPreparedModelRuntime({
+      agentId: "secondary",
+      config,
+      agentDir: "/tmp/unused-agent",
+      inheritedAuthDir: "/tmp/unused-agent",
+      workspaceDir: "/tmp/secondary-probe-workspace",
+    });
+
+    expect(lease.snapshot).toMatchObject({
+      agentId: "secondary",
+      agentDir: "/tmp/configured-secondary",
+      workspaceDir: "/tmp/secondary-probe-workspace",
+      config,
+    });
+    lease.release();
   });
 
   it("keeps a configured replacement after the matching dynamic lease releases", async () => {
@@ -704,6 +750,30 @@ describe("prepared model runtime snapshots", () => {
     const refreshed = await prepareModelRuntimeSnapshot({ config, agentDir });
     expect(refreshed).not.toBe(first);
     expect(mocks.discoverAuthStorage).toHaveBeenCalledTimes(2);
+  });
+
+  it("treats an auth refresh superseded by a newer mutation as control flow", async () => {
+    const config = {};
+    const agentDir = "/tmp/prepared-model-runtime-auth-superseded";
+    await publishPreparedModelRuntimeSnapshot({ config, agentDir });
+    let finishFirstRefresh: (() => void) | undefined;
+    mocks.ensureOpenClawModelsJson.mockImplementationOnce(
+      async () =>
+        await new Promise<{ agentDir: string; wrote: false }>((resolve) => {
+          finishFirstRefresh = () => resolve({ agentDir, wrote: false });
+        }),
+    );
+
+    mocks.mutationListener?.({ agentDir, affectsInheritedStores: false });
+    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
+    mocks.mutationListener?.({ agentDir, affectsInheritedStores: false });
+    finishFirstRefresh?.();
+
+    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(3));
+    await expect(prepareModelRuntimeSnapshot({ config, agentDir })).resolves.toMatchObject({
+      agentDir,
+    });
+    expect(mocks.warn).not.toHaveBeenCalled();
   });
 
   it("refreshes owners that inherit the mutated auth directory", async () => {

--- a/src/agents/prepared-model-runtime.lifecycle.test.ts
+++ b/src/agents/prepared-model-runtime.lifecycle.test.ts
@@ -776,6 +776,42 @@ describe("prepared model runtime snapshots", () => {
     expect(mocks.warn).not.toHaveBeenCalled();
   });
 
+  it("does not let a superseded owner hide a genuine sibling refresh failure", async () => {
+    const config = {};
+    const supersededDir = "/tmp/prepared-model-runtime-auth-superseded-sibling";
+    const failingDir = "/tmp/prepared-model-runtime-auth-failing-sibling";
+    await publishPreparedModelRuntimeSnapshot({ config, agentDir: supersededDir });
+    await publishPreparedModelRuntimeSnapshot({ config, agentDir: failingDir });
+    let finishSupersededRefresh: (() => void) | undefined;
+    let failSiblingRefresh: (() => void) | undefined;
+    mocks.ensureOpenClawModelsJson
+      .mockImplementationOnce(
+        async () =>
+          await new Promise<{ agentDir: string; wrote: false }>((resolve) => {
+            finishSupersededRefresh = () => resolve({ agentDir: supersededDir, wrote: false });
+          }),
+      )
+      .mockImplementationOnce(
+        async () =>
+          await new Promise<{ agentDir: string; wrote: false }>((_resolve, reject) => {
+            failSiblingRefresh = () => reject(new Error("genuine sibling refresh failure"));
+          }),
+      );
+
+    mocks.mutationListener?.({ affectsInheritedStores: true });
+    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(4));
+    mocks.mutationListener?.({ agentDir: supersededDir, affectsInheritedStores: false });
+    finishSupersededRefresh?.();
+    failSiblingRefresh?.();
+
+    await vi.waitFor(() =>
+      expect(mocks.warn).toHaveBeenCalledWith(
+        expect.stringContaining("genuine sibling refresh failure"),
+      ),
+    );
+    expect(mocks.warn).toHaveBeenCalledOnce();
+  });
+
   it("refreshes owners that inherit the mutated auth directory", async () => {
     const config = {};
     const agentDir = "/tmp/prepared-model-runtime-custom-agent";

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -6,6 +6,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { withTimeout } from "../node-host/with-timeout.js";
 import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
+import { isReservedSystemAgentId } from "../system-agent/agent-id.js";
 import { discoverAuthStorage, discoverModels } from "./agent-model-discovery.js";
 import {
   listAgentIds,
@@ -86,16 +87,28 @@ export function rebindInputToCommittedConfiguredOwner(
   rawInput: PreparedModelRuntimeInput,
 ): PreparedModelRuntimeInput {
   const input = normalizePreparedModelRuntimeInput(rawInput);
-  const candidates = [...owners.values()].filter(
+  const committed = [...owners.values()].filter(
     (owner) =>
-      owner.provenance === "configured" &&
-      owner.snapshot &&
-      !owner.needsRefresh &&
-      !owner.pending &&
-      (input.agentId === undefined
-        ? owner.input.agentDir === input.agentDir
-        : owner.input.agentId === input.agentId),
+      owner.provenance === "configured" && owner.snapshot && !owner.needsRefresh && !owner.pending,
   );
+  const identityCandidates =
+    input.agentId === undefined
+      ? []
+      : committed.filter((owner) => owner.input.agentId === input.agentId);
+  const exactCandidates = identityCandidates.filter(
+    (owner) => owner.input.agentDir === input.agentDir,
+  );
+  const directoryCandidates = committed.filter((owner) => owner.input.agentDir === input.agentDir);
+  // Unbound inputs and reserved setup identities derive ownership from the configured directory.
+  // Ordinary agent runs stay bound to their explicit identity, even when handed a stale directory.
+  const canRebindByDirectory =
+    input.agentId === undefined || isReservedSystemAgentId(input.agentId);
+  const candidates =
+    exactCandidates.length > 0
+      ? exactCandidates
+      : canRebindByDirectory && directoryCandidates.length > 0
+        ? directoryCandidates
+        : identityCandidates;
   if (candidates.length !== 1) {
     throw new PreparedModelRuntimeOwnerNotPublishedError(
       `prepared model runtime owner was not committed after replacement for ${input.agentDir}`,
@@ -104,9 +117,12 @@ export function rebindInputToCommittedConfiguredOwner(
   const owner = candidates[0]!;
   const preserveWorkspaceDir =
     input.preserveWorkspaceDirOnRefresh === true && input.workspaceDir !== undefined;
+  // Reserved execution identities (for example setup's `openclaw` agent) intentionally borrow a
+  // configured agent directory. Rebase their lifecycle inputs without erasing that run identity.
+  const agentId = input.agentId ?? owner.input.agentId;
   return normalizePreparedModelRuntimeInput({
     ...input,
-    ...(owner.input.agentId ? { agentId: owner.input.agentId } : {}),
+    ...(agentId ? { agentId } : {}),
     agentDir: owner.input.agentDir,
     config: owner.input.config,
     inheritedAuthDir: owner.input.inheritedAuthDir,

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -698,6 +698,9 @@ function invalidateForAuthMutation(event: AuthMutationEvent): void {
   }
   pendingAuthMutations.push(normalizedEvent);
   void enqueuePreparedModelRuntimePublication(drainPendingAuthMutations).catch((error: unknown) => {
+    if (error instanceof PreparedModelRuntimePublicationSupersededError) {
+      return;
+    }
     log.warn(`auth-triggered model runtime refresh failed: ${String(error)}`);
   });
 }

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -666,7 +666,7 @@ async function drainPendingAuthMutations(): Promise<void> {
         entries.push({ owner, input: owner.input });
       }
     }
-    await Promise.all(
+    const results = await Promise.allSettled(
       entries.map(
         async ({ owner, input }) =>
           await publishPreparedModelRuntimeSnapshot(input, {
@@ -675,6 +675,20 @@ async function drainPendingAuthMutations(): Promise<void> {
           }),
       ),
     );
+    // Supersession belongs to one owner generation. Wait for every sibling refresh before
+    // deciding the batch outcome so an expected race cannot hide a genuine owner failure.
+    const failures = results.flatMap((result) =>
+      result.status === "rejected" &&
+      !(result.reason instanceof PreparedModelRuntimePublicationSupersededError)
+        ? [result.reason]
+        : [],
+    );
+    if (failures.length === 1) {
+      throw failures[0];
+    }
+    if (failures.length > 1) {
+      throw new AggregateError(failures, `${failures.length} model runtime owner refreshes failed`);
+    }
   }
 }
 

--- a/ui/src/app/bootstrap.ts
+++ b/ui/src/app/bootstrap.ts
@@ -14,6 +14,7 @@ import { createAgentCapability } from "../lib/agents/index.ts";
 import { createChannelCapability } from "../lib/channels/index.ts";
 import { createRuntimeConfigCapability } from "../lib/config/index.ts";
 import { createSessionCapability } from "../lib/sessions/index.ts";
+import { areUiSessionKeysEquivalentForHost } from "../lib/sessions/session-key.ts";
 import { createWorkboardCapability } from "../lib/workboard/capability.ts";
 import {
   isDefaultChatLanding,
@@ -415,7 +416,10 @@ export function bootstrapApplication(): ApplicationRuntime {
   const stopModelSetupRedirect = firstRunDefaultLanding
     ? startModelSetupFirstRunRedirect({
         context,
-        isStillDefaultLanding: () => locationsMatch(history.location(), expectedDefaultLanding),
+        isStillDefaultLanding: () =>
+          locationsMatch(history.location(), expectedDefaultLanding, (left, right) =>
+            areUiSessionKeysEquivalentForHost({ hello: gateway.snapshot.hello }, left, right),
+          ),
       })
     : () => undefined;
   return {

--- a/ui/src/lib/sessions/session-key.ts
+++ b/ui/src/lib/sessions/session-key.ts
@@ -230,6 +230,16 @@ function normalizeUiSessionEventKey(
   return aliases.has(normalized) ? normalizeLowercaseStringOrEmpty(canonicalMain) : normalized;
 }
 
+export function areUiSessionKeysEquivalentForHost(
+  host: Pick<UiSessionDefaultsHost, "agentsList" | "hello">,
+  left: string | undefined | null,
+  right: string | undefined | null,
+): boolean {
+  const normalizedLeft = normalizeUiSessionEventKey(host, left);
+  const normalizedRight = normalizeUiSessionEventKey(host, right);
+  return Boolean(normalizedLeft && normalizedRight && normalizedLeft === normalizedRight);
+}
+
 export function uiSessionEventMatches(
   host: UiSessionDefaultsHost & { sessionKey: string },
   eventSessionKey: string | undefined | null,
@@ -239,9 +249,7 @@ export function uiSessionEventMatches(
   if (!eventKey) {
     return true;
   }
-  const keysMatch =
-    normalizeUiSessionEventKey(host, eventKey) ===
-    normalizeUiSessionEventKey(host, host.sessionKey);
+  const keysMatch = areUiSessionKeysEquivalentForHost(host, eventKey, host.sessionKey);
   const selectedAliasAgentId = resolveUiMainAliasAgentId(host, host.sessionKey);
   const globalAliasMatches =
     selectedAliasAgentId !== null &&

--- a/ui/src/pages/chat/chat-page.test.ts
+++ b/ui/src/pages/chat/chat-page.test.ts
@@ -133,6 +133,7 @@ describe("chat page split layout host", () => {
 
   it("renders one chrome-free active pane in classic mode", async () => {
     const page = new ChatPage();
+    setNavigationContext(page);
     page.data = { sessionKey: "main", draft: "hello" };
     document.body.append(page);
     await page.updateComplete;
@@ -270,6 +271,7 @@ describe("chat page split layout host", () => {
 
   it("hands each route-provided draft to the active pane only once", async () => {
     const page = new ChatPage();
+    const navigation = setNavigationContext(page);
     const firstRouteData = { sessionKey: "main", draft: "one-shot draft" };
     page.data = firstRouteData;
     expect(getRouteDraftForActivePane(page)).toBe("one-shot draft");
@@ -280,6 +282,10 @@ describe("chat page split layout host", () => {
     await page.updateComplete;
 
     expect(getRouteDraftForActivePane(page)).toBeUndefined();
+    expect(navigation.replace).toHaveBeenCalledOnce();
+    expect(navigation.replace).toHaveBeenCalledWith("chat", {
+      search: searchForSession("main"),
+    });
     page.data = { ...firstRouteData };
     expect(getRouteDraftForActivePane(page)).toBe("one-shot draft");
   });

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -135,6 +135,9 @@ export class ChatPage extends OpenClawLightDomElement {
       queueMicrotask(() => {
         if (this.isConnected && this.data === data && this.consumedDraftData !== data) {
           this.consumedDraftData = data;
+          // Route drafts are one-shot actions. Once the matching pane owns the
+          // text, remove it from history so reload/back cannot replay it.
+          this.context.replace("chat", { search: searchForSession(data.sessionKey) });
           this.requestUpdate();
         }
       });

--- a/ui/src/pages/model-setup/first-run.test.ts
+++ b/ui/src/pages/model-setup/first-run.test.ts
@@ -3,8 +3,13 @@ import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { routeIdFromPath } from "../../app-routes.ts";
 import type { RouteId } from "../../app-routes.ts";
 import type { ApplicationContext } from "../../app/context.ts";
+import { areUiSessionKeysEquivalentForHost } from "../../lib/sessions/session-key.ts";
 import { consumeCachedModelSetupDetection } from "./detect-cache.ts";
-import { isDefaultChatLanding, startModelSetupFirstRunRedirect } from "./first-run.ts";
+import {
+  isDefaultChatLanding,
+  locationsMatch,
+  startModelSetupFirstRunRedirect,
+} from "./first-run.ts";
 
 describe("model setup first-run redirect", () => {
   it("recognizes only the implicit chat landing without a session deep link", () => {
@@ -33,6 +38,36 @@ describe("model setup first-run redirect", () => {
         { pathname: "/settings/general", search: "", hash: "" },
         "",
         routeIdFromPath,
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps the default landing eligible when the gateway canonicalizes its session key", () => {
+    const expected = { pathname: "/chat", search: "?session=main", hash: "" };
+    const host = {
+      hello: {
+        snapshot: {
+          sessionDefaults: {
+            defaultAgentId: "main",
+            mainKey: "main",
+            mainSessionKey: "agent:main:main",
+          },
+        },
+      },
+    };
+
+    expect(
+      locationsMatch(
+        { pathname: "/chat", search: "?session=agent%3Amain%3Amain", hash: "" },
+        expected,
+        (left, right) => areUiSessionKeysEquivalentForHost(host, left, right),
+      ),
+    ).toBe(true);
+    expect(
+      locationsMatch(
+        { pathname: "/chat", search: "?session=agent%3Aother%3Amain", hash: "" },
+        expected,
+        (left, right) => areUiSessionKeysEquivalentForHost(host, left, right),
       ),
     ).toBe(false);
   });

--- a/ui/src/pages/model-setup/first-run.ts
+++ b/ui/src/pages/model-setup/first-run.ts
@@ -24,7 +24,8 @@ export function isDefaultChatLanding(
 export function locationsMatch(
   left: RouteLocation,
   right: RouteLocation,
-  sessionKeysMatch: (left: string, right: string) => boolean = (left, right) => left === right,
+  sessionKeysMatch: (left: string, right: string) => boolean = (candidateLeft, candidateRight) =>
+    candidateLeft === candidateRight,
 ): boolean {
   if (left.pathname !== right.pathname || left.hash !== right.hash) {
     return false;

--- a/ui/src/pages/model-setup/first-run.ts
+++ b/ui/src/pages/model-setup/first-run.ts
@@ -21,9 +21,26 @@ export function isDefaultChatLanding(
   return !searchSession && !hashSession;
 }
 
-export function locationsMatch(left: RouteLocation, right: RouteLocation): boolean {
+export function locationsMatch(
+  left: RouteLocation,
+  right: RouteLocation,
+  sessionKeysMatch: (left: string, right: string) => boolean = (left, right) => left === right,
+): boolean {
+  if (left.pathname !== right.pathname || left.hash !== right.hash) {
+    return false;
+  }
+  if (left.search === right.search) {
+    return true;
+  }
+  const leftSearch = new URLSearchParams(left.search);
+  const rightSearch = new URLSearchParams(right.search);
+  const leftSession = leftSearch.get("session")?.trim();
+  const rightSession = rightSearch.get("session")?.trim();
+  leftSearch.delete("session");
+  rightSearch.delete("session");
   return (
-    left.pathname === right.pathname && left.search === right.search && left.hash === right.hash
+    leftSearch.toString() === rightSearch.toString() &&
+    Boolean(leftSession && rightSession && sessionKeysMatch(leftSession, rightSession))
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes several issues where fresh users could miss the model-setup redirect, fail to activate an OpenAI model, or see the hatch draft return after reloading the new agent chat. Successful agent turns could also log a misleading prepared-runtime refresh warning.

## Why This Change Was Made

Default-session URL canonicalization is now treated as the same first-run landing, reserved setup runs rebind through the configured agent directory without weakening ordinary agent ownership, hatch drafts are consumed once, and expected superseded auth refreshes remain control flow. Regression coverage protects each boundary.

## User Impact

Fresh browser onboarding now moves cleanly from model setup to the Crestodian proposal and into the hatched agent conversation. OpenAI activation works on the first attempt, refreshes do not resurrect the wake-up draft, and successful turns no longer emit a false warning.

## Evidence

- Fresh isolated browser + dev gateway + real OpenAI key: root redirected to model setup, OpenAI activation succeeded, Crestodian proposed the setup, approval auto-hatched the agent, the naming ceremony persisted identity and soul files, and `BOOTSTRAP.md` was removed.
- Browser stress: double-send produced one persisted turn; reload, mobile viewport, offline/reconnect, configured-root navigation, and one-shot route-draft cleanup all recovered correctly.
- Packaged CLI on Blacksmith Testbox: risk-gate rejection, fresh non-interactive OpenAI onboarding, secret-reference persistence, two real model turns, identity persistence, bootstrap removal, and final handoff all passed (`CLI_ONBOARD_E2E_OK`, 108 seconds).
- Focused proof: 36 prepared-runtime lifecycle tests and 25 Control UI tests passed on current `main`.
- `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs`: all selected core, core-test, UI, and docs gates passed, including three typecheck lanes and exhaustive core/UI lint.
- Autoreview: complete branch diff clean with no actionable findings; follow-up lint-only rename clean at 0.99 confidence.

Blacksmith's final full-checkout sync exceeded its two-minute transport limit after an earlier serial run lost SSH at 13 minutes; repository policy permits the exact trusted-source gate to fall back locally, which completed cleanly.
