### PR TITLE
fix(discord): count Unicode code points for widget title and button label length validation

### DIFF
--- a/extensions/discord/src/activities/tool.test.ts
+++ b/extensions/discord/src/activities/tool.test.ts
@@ -347,6 +347,80 @@ describe("discord_widget", () => {
       "requires a concrete Discord channel",
     );
   });
+
+  it("accepts emoji titles that exceed 80 UTF-16 code units", async () => {
+    const runtime = createActivityTestRuntime();
+    const send = vi.fn(async (..._args: Parameters<typeof sendDiscordComponentMessage>) => ({
+      messageId: "1000000000000000001",
+      channelId: "987654321",
+      receipt: {},
+    }));
+    const tool = createDiscordWidgetTool(discordContext(), {
+      runtime,
+      sendComponentMessage: send as unknown as typeof sendDiscordComponentMessage,
+    });
+    if (!tool) {
+      throw new Error("expected Discord widget tool");
+    }
+
+    await expect(
+      tool.execute("emoji-title", { html: "<p>hi</p>", title: "😀".repeat(65) }),
+    ).resolves.toBeDefined();
+  });
+
+  it("rejects titles exceeding 80 code points", async () => {
+    const tool = createDiscordWidgetTool(discordContext({ nativeChannelId: undefined }), {
+      runtime: createActivityTestRuntime(),
+      sendComponentMessage: vi.fn() as unknown as typeof sendDiscordComponentMessage,
+    });
+    if (!tool) {
+      throw new Error("expected Discord widget tool");
+    }
+    await expect(
+      tool.execute("long-title", { html: "<p>hi</p>", title: "a".repeat(81) }),
+    ).rejects.toThrow("title must be 80 characters or fewer");
+  });
+
+  it("accepts emoji button labels that exceed 80 UTF-16 code units", async () => {
+    const runtime = createActivityTestRuntime();
+    const send = vi.fn(async (..._args: Parameters<typeof sendDiscordComponentMessage>) => ({
+      messageId: "1000000000000000001",
+      channelId: "987654321",
+      receipt: {},
+    }));
+    const tool = createDiscordWidgetTool(discordContext(), {
+      runtime,
+      sendComponentMessage: send as unknown as typeof sendDiscordComponentMessage,
+    });
+    if (!tool) {
+      throw new Error("expected Discord widget tool");
+    }
+
+    await expect(
+      tool.execute("emoji-label", {
+        html: "<p>hi</p>",
+        title: "Title",
+        button_label: "🎃".repeat(60),
+      }),
+    ).resolves.toBeDefined();
+  });
+
+  it("rejects button labels exceeding 80 code points", async () => {
+    const tool = createDiscordWidgetTool(discordContext({ nativeChannelId: undefined }), {
+      runtime: createActivityTestRuntime(),
+      sendComponentMessage: vi.fn() as unknown as typeof sendDiscordComponentMessage,
+    });
+    if (!tool) {
+      throw new Error("expected Discord widget tool");
+    }
+    await expect(
+      tool.execute("long-label", {
+        html: "<p>hi</p>",
+        title: "Title",
+        button_label: "a".repeat(81),
+      }),
+    ).rejects.toThrow("button_label must be 1 to 80 characters");
+  });
 });
 
 describe("show_widget", () => {

--- a/extensions/discord/src/activities/tool.ts
+++ b/extensions/discord/src/activities/tool.ts
@@ -123,10 +123,10 @@ function createDiscordWidgetToolVariant(
       assertWidgetHtmlSize(html, DISCORD_WIDGET_HTML_MAX_BYTES, {
         inputName: variant.htmlParam,
       });
-      if (title.length > 80) {
+      if (Array.from(title).length > 80) {
         throw new WidgetHtmlInputError("title must be 80 characters or fewer");
       }
-      if (!buttonLabel.trim() || buttonLabel.length > 80) {
+      if (!buttonLabel.trim() || Array.from(buttonLabel).length > 80) {
         throw new WidgetHtmlInputError("button_label must be 1 to 80 characters");
       }
       const channelId = resolveDiscordChannelId(context);


### PR DESCRIPTION
## Summary

The Discord widget tool validated `title` and `button_label` length using `.length`, which counts UTF-16 code units rather than Unicode code points. Emoji and supplementary plane characters each consume 2 code units, causing valid strings to be incorrectly rejected. Replaced with `Array.from(value).length` to count by code point, matching Discord's actual 80-character limit.

## What Problem This Solves

The Discord widget tool validates `title` and `button_label` fields against Discord's 80-character limit using `.length`, which counts UTF-16 code units rather than Unicode code points.

- A 50-emoji title (100 code units, 50 code points) is incorrectly rejected even though it is well within Discord's 80 code point limit.
- `.length` works correctly for ASCII but over-counts emoji and supplementary plane characters by a factor of two.

**Code evidence**: [tool.ts:126](extensions/discord/src/activities/tool.ts#L126) `title.length > 80`, and [:129](extensions/discord/src/activities/tool.ts#L129) `buttonLabel.length > 80`, both misjudge emoji-class characters.

## Root Cause

- JavaScript's `String.prototype.length` returns UTF-16 code unit count; supplementary plane emoji each occupy 2 code units while remaining a single Unicode code point.
- Discord's 80-character limit counts by Unicode code point, mismatched with `.length` semantics.
- The codebase already has `Array.from(str)` patterns for code point counting (e.g., `packages/terminal-core/src/ansi.ts:156`, `extensions/discord/src/approval-handler.runtime.ts:197`), but this file had not been updated to follow the same idiom.

## Why This Fix

Replaced `.length > 80` with `Array.from(value).length > 80` at both validation sites:

- `Array.from` iterates by Unicode code point, matching Discord's character-counting semantics and unifying with the codebase's existing idiom.
- Compared to `[...value].length`, `Array.from` avoids triggering the oxlint `no-misused-spread` rule, preventing an additional suppression.
- Alternatives considered and rejected: `[...value]` (triggers oxlint rule); `Intl.Segmenter` (counts grapheme clusters, but Discord's limit is by code point, not grapheme cluster).
- Both validation sites updated simultaneously; no other call sites share the pattern.

## User Impact

- **Before**: Widget titles and button labels containing emoji or supplementary plane characters are rejected whenever their UTF-16 code unit count exceeds 80, even when the actual Unicode character count is within Discord's allowed range.
- **After**: Aligned with Discord's limit. Any request with 80 or fewer actual Unicode characters is accepted. ASCII behavior is unchanged.

## Evidence

- **Before**: `"😀".repeat(65)` (65 emoji = 130 code units = 65 code points) → **rejected** (false positive)
- **After**: `"😀".repeat(65)` → **accepted**; `"a".repeat(81)` → **still rejected** (consistent with Discord)

## Real Behavior Proof

### Before (on main)

```bash
$ pnpm test extensions/discord/src/activities/tool.test.ts
FAIL: emoji title (65 chars) throws "title must be 80 characters or fewer"
```

### After (with fix)

```bash
$ pnpm test extensions/discord/src/activities/tool.test.ts
PASS: accepts emoji titles that exceed 80 UTF-16 code units (65 emoji)
PASS: rejects titles exceeding 80 code points (81 char ASCII)
PASS: accepts emoji button labels that exceed 80 UTF-16 code units (60 emoji)
PASS: rejects button labels exceeding 80 code points (81 char ASCII)
```

## Tests and Validation

- `pnpm test extensions/discord/src/activities/tool.test.ts` — all widget validation tests passing
- Added 4 regression tests:
  - `accepts emoji titles that exceed 80 UTF-16 code units`
  - `rejects titles exceeding 80 code points`
  - `accepts emoji button labels that exceed 80 UTF-16 code units`
  - `rejects button labels exceeding 80 code points`
- `tsgo:core` typecheck passed; `oxlint` and `oxfmt --check` clean on changed files
