### PR TITLE
fix(gateway): keep first outbound TLS off the main event loop on macOS (system-CA/trustd)

### DIFF
--- a/src/daemon/gateway-heap.ts
+++ b/src/daemon/gateway-heap.ts
@@ -1,5 +1,6 @@
 /** Adaptive Node heap policy for the managed Gateway service. */
 import os from "node:os";
+import { parseNodeOptionsTokens } from "../infra/node-options.js";
 
 const MEBIBYTE_BYTES = 1024 * 1024;
 const GATEWAY_HEAP_FLOOR_MIB = 2048;
@@ -63,45 +64,6 @@ function resolveGatewayHeapLimit(params: GatewayHeapMemoryInputs = {}): GatewayH
     capMiB: GATEWAY_HEAP_CAP_MIB,
     headroomCapMiB,
   };
-}
-
-function parseNodeOptionsTokens(nodeOptions: string): string[] | null {
-  // Match Node's NODE_OPTIONS splitter: space delimiters, double quotes, and
-  // backslash escapes only inside quotes. Other shell quoting does not apply.
-  const tokens: string[] = [];
-  let token = "";
-  let inQuotes = false;
-  let tokenStarted = false;
-  for (let index = 0; index < nodeOptions.length; index += 1) {
-    let char = nodeOptions[index];
-    if (char === "\\" && inQuotes) {
-      index += 1;
-      if (index >= nodeOptions.length) {
-        return null;
-      }
-      char = nodeOptions[index];
-    } else if (char === " " && !inQuotes) {
-      if (tokenStarted) {
-        tokens.push(token);
-        token = "";
-        tokenStarted = false;
-      }
-      continue;
-    } else if (char === '"') {
-      inQuotes = !inQuotes;
-      tokenStarted = true;
-      continue;
-    }
-    token += char;
-    tokenStarted = true;
-  }
-  if (inQuotes) {
-    return null;
-  }
-  if (tokenStarted) {
-    tokens.push(token);
-  }
-  return tokens;
 }
 
 function parseMaxOldSpaceSizeMiB(nodeOptions: string | undefined): number | null {

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -1501,6 +1501,42 @@ describe("startGatewayPostAttachRuntime", () => {
     );
   });
 
+  it("warms the macOS system CA cache before channel startup", async () => {
+    let finishWarmup: (() => void) | undefined;
+    const warmSystemCa = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishWarmup = resolve;
+        }),
+    );
+    const startChannels = vi.fn(async () => {});
+    const sidecars = startGatewaySidecars({
+      cfg: { hooks: { internal: { enabled: false } } } as never,
+      pluginRegistry: createPostAttachParams().pluginRegistry,
+      defaultWorkspaceDir: "/tmp/openclaw-workspace",
+      deps: {} as never,
+      startChannels,
+      warmSystemCa,
+      log: { warn: vi.fn() },
+      logHooks: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+      logChannels: {
+        info: vi.fn(),
+        error: vi.fn(),
+      },
+    });
+
+    await waitForGatewayTestState(() => expect(warmSystemCa).toHaveBeenCalledTimes(1));
+    expect(startChannels).not.toHaveBeenCalled();
+
+    finishWarmup?.();
+    await sidecars;
+    expect(startChannels).toHaveBeenCalledTimes(1);
+  });
+
   it("starts and reports plugin services after channel startup completes", async () => {
     await withEnvAsync(
       { OPENCLAW_SKIP_CHANNELS: undefined, OPENCLAW_SKIP_PROVIDERS: undefined },

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -34,6 +34,7 @@ import {
   type GatewayStartupOutcomeRecorder,
 } from "./server-startup-outcomes.js";
 import type { startGatewayTailscaleExposure } from "./server-tailscale.js";
+import { warmMacOSSystemCaOffMainThread } from "./system-ca-warmup.js";
 const ACP_BACKEND_READY_TIMEOUT_MS = 5_000;
 const ACP_BACKEND_READY_POLL_MS = 50;
 const PROVIDER_AUTH_PREWARM_START_DELAY_MS = 5_000;
@@ -611,8 +612,15 @@ export async function startGatewaySidecars(params: {
   logChannels: { info: (msg: string) => void; error: (msg: string) => void };
   startupTrace?: GatewayStartupTrace;
   startupOutcomes?: GatewayStartupOutcomeRecorder;
+  warmSystemCa?: typeof warmMacOSSystemCaOffMainThread;
 }) {
   const postReadySidecars: GatewayPostReadySidecarHandle[] = [];
+
+  // Node initializes the process-wide macOS Keychain CA cache synchronously. Warm it in a
+  // worker before any provider TLS so a slow trustd lookup cannot freeze gateway HTTP/WS.
+  await measureStartup(params.startupTrace, "sidecars.system-ca", () =>
+    (params.warmSystemCa ?? warmMacOSSystemCaOffMainThread)({ log: params.log }),
+  );
 
   const internalHooksConfigured = hasConfiguredInternalHooks(params.cfg);
   await measureStartup(params.startupTrace, "sidecars.internal-hooks", async () => {

--- a/src/gateway/system-ca-warmup.test.ts
+++ b/src/gateway/system-ca-warmup.test.ts
@@ -1,0 +1,140 @@
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { warmMacOSSystemCaOffMainThread } from "./system-ca-warmup.js";
+
+class FakeWorker extends EventEmitter {
+  unref = vi.fn();
+}
+
+describe("warmMacOSSystemCaOffMainThread", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it.each([
+    ["env only", "darwin", { NODE_USE_SYSTEM_CA: "1" }, [], true],
+    ["dash flag", "darwin", {}, ["--use-system-ca"], true],
+    ["underscore flag", "darwin", {}, ["--use_system_ca"], true],
+    ["equals-form flag", "darwin", {}, ["--use_system_ca=false"], true],
+    ["OpenSSL CA alone", "darwin", {}, ["--use-openssl-ca"], false],
+    [
+      "bundled CA does not suppress env system CA",
+      "darwin",
+      { NODE_USE_SYSTEM_CA: "1" },
+      ["--use-bundled-ca"],
+      true,
+    ],
+    [
+      "dash negation overrides env",
+      "darwin",
+      { NODE_USE_SYSTEM_CA: "1" },
+      ["--no-use-system-ca"],
+      false,
+    ],
+    [
+      "equals-form negation overrides env",
+      "darwin",
+      { NODE_USE_SYSTEM_CA: "1" },
+      ["--no-use-system-ca=false"],
+      false,
+    ],
+    [
+      "underscore negation overrides env",
+      "darwin",
+      { NODE_USE_SYSTEM_CA: "1" },
+      ["--no_use_system_ca"],
+      false,
+    ],
+    [
+      "last conflicting flag enables",
+      "darwin",
+      {},
+      ["--no-use-system-ca", "--use_system_ca"],
+      true,
+    ],
+    [
+      "last conflicting flag disables",
+      "darwin",
+      {},
+      ["--use-system-ca", "--no_use_system_ca"],
+      false,
+    ],
+    ["NODE_OPTIONS flag", "darwin", { NODE_OPTIONS: '"--use_system_ca"' }, [], true],
+    [
+      "NODE_OPTIONS negation overrides env",
+      "darwin",
+      { NODE_USE_SYSTEM_CA: "1", NODE_OPTIONS: "--no-use-system-ca" },
+      [],
+      false,
+    ],
+    [
+      "execArgv overrides NODE_OPTIONS",
+      "darwin",
+      { NODE_OPTIONS: "--use-system-ca" },
+      ["--no-use-system-ca"],
+      false,
+    ],
+    ["system CA disabled", "darwin", { NODE_USE_SYSTEM_CA: "0" }, [], false],
+    ["non-macOS", "linux", { NODE_USE_SYSTEM_CA: "1" }, [], false],
+  ] as const)(
+    "%s: warmup runs iff system CA is effectively enabled on macOS",
+    async (_name, platform, env, execArgv, shouldWarm) => {
+      const worker = new FakeWorker();
+      const createWorker = vi.fn(() => worker);
+      const warmup = warmMacOSSystemCaOffMainThread({
+        platform,
+        env: { ...env },
+        execArgv: [...execArgv],
+        createWorker,
+      });
+
+      if (shouldWarm) {
+        worker.emit("message", { ok: true, certificateCount: 42 });
+      }
+      await warmup;
+      expect(createWorker).toHaveBeenCalledTimes(shouldWarm ? 1 : 0);
+      expect(worker.unref).toHaveBeenCalledTimes(shouldWarm ? 1 : 0);
+    },
+  );
+
+  it("waits for the worker while leaving the main event loop available", async () => {
+    vi.useFakeTimers();
+    const worker = new FakeWorker();
+    const log = { warn: vi.fn() };
+    const warmup = warmMacOSSystemCaOffMainThread({
+      platform: "darwin",
+      env: { NODE_USE_SYSTEM_CA: "1" },
+      warningMs: 10,
+      log,
+      createWorker: vi.fn(() => worker),
+    });
+
+    let mainTurnRan = false;
+    setImmediate(() => {
+      mainTurnRan = true;
+    });
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(mainTurnRan).toBe(true);
+    expect(log.warn).toHaveBeenCalledWith(
+      "macOS system CA warmup is still waiting for Keychain trust settings; channel startup remains deferred",
+    );
+    expect(worker.unref).toHaveBeenCalledOnce();
+
+    worker.emit("message", { ok: true, certificateCount: 42 });
+    await warmup;
+  });
+
+  it("fails closed when the worker cannot populate the cache", async () => {
+    const worker = new FakeWorker();
+    const warmup = warmMacOSSystemCaOffMainThread({
+      platform: "darwin",
+      env: { NODE_USE_SYSTEM_CA: "1" },
+      createWorker: vi.fn(() => worker),
+    });
+
+    worker.emit("message", { ok: false, error: "trust store unavailable" });
+
+    await expect(warmup).rejects.toThrow("trust store unavailable");
+  });
+});

--- a/src/gateway/system-ca-warmup.ts
+++ b/src/gateway/system-ca-warmup.ts
@@ -1,0 +1,140 @@
+import type { EventEmitter } from "node:events";
+import { Worker, type WorkerOptions } from "node:worker_threads";
+import { isVitestRuntimeEnv } from "../infra/env.js";
+import { parseNodeOptionsTokens } from "../infra/node-options.js";
+
+const SYSTEM_CA_WARMUP_WARNING_MS = 10_000;
+const SYSTEM_CA_WORKER_SOURCE = String.raw`
+  const { getCACertificates } = require("node:tls");
+  const { parentPort } = require("node:worker_threads");
+
+  try {
+    const certificateCount = getCACertificates("system").length;
+    parentPort.postMessage({ ok: true, certificateCount });
+  } catch (error) {
+    parentPort.postMessage({
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  } finally {
+    parentPort.close();
+  }
+`;
+
+type SystemCaWarmupWorker = Pick<EventEmitter, "once" | "removeAllListeners"> & {
+  unref: () => void;
+};
+
+type SystemCaWarmupOptions = {
+  env?: NodeJS.ProcessEnv;
+  execArgv?: readonly string[];
+  platform?: NodeJS.Platform;
+  log?: { warn: (message: string) => void };
+  warningMs?: number;
+  createWorker?: (source: string, options: WorkerOptions) => SystemCaWarmupWorker;
+};
+
+type SystemCaWarmupMessage = { ok: true; certificateCount: number } | { ok: false; error: string };
+
+function applySystemCaRuntimeOptions(enabled: boolean, args: readonly string[]): boolean {
+  let result = enabled;
+  for (const arg of args) {
+    const match = /^--(?:(no)[-_])?use[-_]system[-_]ca(?:=.*)?$/u.exec(arg);
+    if (match) {
+      result = match[1] === undefined;
+    }
+  }
+  return result;
+}
+
+function resolveEffectiveSystemCaEnabled(params: {
+  env: NodeJS.ProcessEnv;
+  execArgv: readonly string[];
+}): boolean {
+  // Node v26.5.0 gates macOS Keychain reads solely on effective --use-system-ca /
+  // NODE_USE_SYSTEM_CA selection. --use-bundled-ca is additive, while --use-openssl-ca
+  // cannot coexist with system CA (startup exits 9), so neither overrides this gate.
+  // Scope: reads the env var, NODE_OPTIONS, and execArgv — the paths OpenClaw uses
+  // (the gateway enables system CA via NODE_USE_SYSTEM_CA by default). The experimental
+  // --experimental-config-file `nodeOptions.use-system-ca` source is intentionally not
+  // parsed here; if it is ever the only enabler the warmup simply no-ops and the process
+  // degrades to Node's original lazy (pre-fix) CA load — no regression, just unimproved.
+  const fromEnvironment = params.env.NODE_USE_SYSTEM_CA === "1";
+  const nodeOptions = parseNodeOptionsTokens(params.env.NODE_OPTIONS ?? "");
+  const afterNodeOptions = applySystemCaRuntimeOptions(fromEnvironment, nodeOptions ?? []);
+  return applySystemCaRuntimeOptions(afterNodeOptions, params.execArgv);
+}
+
+function isSystemCaWarmupMessage(value: unknown): value is SystemCaWarmupMessage {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const message = value as Record<string, unknown>;
+  return message.ok === true
+    ? typeof message.certificateCount === "number"
+    : message.ok === false && typeof message.error === "string";
+}
+
+/** Populate Node's process-wide macOS system CA cache without blocking the gateway event loop. */
+export async function warmMacOSSystemCaOffMainThread(
+  options: SystemCaWarmupOptions = {},
+): Promise<void> {
+  const env = options.env ?? process.env;
+  const execArgv = options.execArgv ?? process.execArgv;
+  const platform = options.platform ?? process.platform;
+  const usesSystemCa = resolveEffectiveSystemCaEnabled({ env, execArgv });
+  if (
+    platform !== "darwin" ||
+    !usesSystemCa ||
+    (options.env === undefined && options.platform === undefined && isVitestRuntimeEnv(env))
+  ) {
+    return;
+  }
+
+  const worker = (
+    options.createWorker ?? ((source, workerOptions) => new Worker(source, workerOptions))
+  )(SYSTEM_CA_WORKER_SOURCE, { eval: true });
+
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const warningTimer = setTimeout(() => {
+      options.log?.warn(
+        "macOS system CA warmup is still waiting for Keychain trust settings; channel startup remains deferred",
+      );
+    }, options.warningMs ?? SYSTEM_CA_WARMUP_WARNING_MS);
+    warningTimer.unref?.();
+
+    const settle = (finish: () => void) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(warningTimer);
+      worker.removeAllListeners();
+      finish();
+    };
+
+    worker.once("message", (value: unknown) => {
+      settle(() => {
+        if (!isSystemCaWarmupMessage(value)) {
+          reject(new Error("macOS system CA warmup worker returned an invalid result"));
+          return;
+        }
+        if (!value.ok) {
+          reject(new Error(value.error));
+          return;
+        }
+        resolve();
+      });
+    });
+    worker.once("error", (error: Error) => settle(() => reject(error)));
+    worker.once("exit", (code: number) => {
+      settle(() =>
+        reject(new Error(`macOS system CA warmup worker exited before replying (code ${code})`)),
+      );
+    });
+
+    // A wedged trustd lookup must not keep an otherwise stopped gateway process alive.
+    worker.unref();
+  });
+}

--- a/src/infra/node-options.ts
+++ b/src/infra/node-options.ts
@@ -1,0 +1,38 @@
+export function parseNodeOptionsTokens(nodeOptions: string): string[] | null {
+  // Match Node's NODE_OPTIONS splitter: space delimiters, double quotes, and
+  // backslash escapes only inside quotes. Other shell quoting does not apply.
+  const tokens: string[] = [];
+  let token = "";
+  let inQuotes = false;
+  let tokenStarted = false;
+  for (let index = 0; index < nodeOptions.length; index += 1) {
+    let char = nodeOptions[index];
+    if (char === "\\" && inQuotes) {
+      index += 1;
+      if (index >= nodeOptions.length) {
+        return null;
+      }
+      char = nodeOptions[index];
+    } else if (char === " " && !inQuotes) {
+      if (tokenStarted) {
+        tokens.push(token);
+        token = "";
+        tokenStarted = false;
+      }
+      continue;
+    } else if (char === '"') {
+      inQuotes = !inQuotes;
+      tokenStarted = true;
+      continue;
+    }
+    token += char;
+    tokenStarted = true;
+  }
+  if (inQuotes) {
+    return null;
+  }
+  if (tokenStarted) {
+    tokens.push(token);
+  }
+  return tokens;
+}


### PR DESCRIPTION
## What Problem This Solves

On macOS the gateway could **freeze at 0% CPU** — port bound, but every HTTP/WS request hanging indefinitely (needs SIGKILL) — during startup when channels/providers are enabled. Two independent QA runs hit it: the gateway logs `starting channels and sidecars / starting provider` and then goes silent. A native `sample` of the wedged main thread showed the first outbound TLS handshake driving `node::crypto::NewRootCertStore → ReadMacOSKeychainCertificates → Security tsCopyTrustSettings → xpc_connection_send_message_with_reply_sync` — a **synchronous XPC call to macOS `trustd` on the main event loop**. Under a slow/contended `trustd`, that call blocks the whole gateway (serving + cron + channels), with no event-loop watchdog to recover.

## Why This Change Was Made

Node builds the macOS system-CA trust store lazily on the first TLS handshake and caches it in a process-global static. With `NODE_USE_SYSTEM_CA=1` (OpenClaw's darwin default), that synchronous Keychain read lands on whichever thread makes the first TLS call — here the main event-loop thread during channel/provider startup. Verified directly against Node source (`crypto_context.cc`, v22.22.3/v24.18.0) and Node v26.5.0 runtime behavior.

The fix warms the system-CA cache in an **unref'd worker thread** and awaits it *before* provider/channel sidecars start, so the expensive Keychain/trustd work happens off the main thread and the first provider TLS finds the cache already populated. Globally forcing OpenSSL CA was ruled out because `--use-system-ca` incorporates administrator-installed enterprise roots that legitimate gateway destinations may require.

## User Impact

- macOS gateways with channels enabled reach `ready` and stay responsive instead of freezing (measured: ~23s ready, `/healthz` 200 in <1.4ms, channels running; post-fix sample shows `uv_run → kevent`, no trustd frames).
- macOS-only and system-CA-only: Linux, OpenSSL-CA, and bundled-CA gateways are unchanged. Keychain enterprise/custom roots are preserved.
- Unref'd: a wedged `trustd` can never keep an otherwise-stopped gateway process alive.

## Evidence

- Fix: `src/gateway/system-ca-warmup.ts` (worker-thread `tls.getCACertificates("system")` warmup, effective-`--use-system-ca` gating with negation/dash-underscore normalization/precedence), awaited in `src/gateway/server-startup-post-attach.ts` before sidecars. Shared `NODE_OPTIONS` tokenizer extracted to `src/infra/node-options.ts` (deduped from `src/daemon/gateway-heap.ts`).
- Activation gating verified against real Node semantics (v26.5.0): `--use-bundled-ca` is additive (does not disable Keychain); `--use-openssl-ca` cannot coexist with system-CA (Node exits 9). The experimental `--experimental-config-file` source is intentionally out of scope (documented in code) — OpenClaw enables system-CA via the covered `NODE_USE_SYSTEM_CA` env path, and the warmup degrades gracefully to Node's lazy load if ever missed (no regression).
- Tests: `system-ca-warmup.test.ts` (option precedence/normalization, platform gating, openssl/bundled cases, worker success/failure/slow-wait, event-loop availability); `server-startup-post-attach.test.ts` (warmup ordered before sidecars). Focused suites green; Testbox `check-changed` green; AutoReview clean (0.90).
- Live before/after on an isolated gateway with real Slack+Discord: frozen (0% CPU, HTTP 000) → ready in ~23s, channels running.
