### PR TITLE
fix: update debugging skill file references

### DIFF
--- a/.agents/skills/openclaw-debugging/SKILL.md
+++ b/.agents/skills/openclaw-debugging/SKILL.md
@@ -13,7 +13,7 @@ debug signal rather than a guess.
 
 - `docs/logging.md` for log files, `openclaw logs`, and targeted debug flags.
 - `docs/reference/test.md` for local test commands.
-- `docs/reference/code-mode.md` for code-mode exec/wait and tool catalog rules.
+- `docs/tools/code-mode.md` for code-mode exec/wait and tool catalog rules.
 - Use `$openclaw-testing` for choosing test lanes.
 - Use `$crabbox` for broad, Docker, package, Linux, live-key, or CI-parity proof.
 
@@ -84,9 +84,9 @@ openclaw logs --follow
 - Guarded fetch/timing:
   `src/agents/provider-transport-fetch.ts`
 - OpenAI/Codex provider wrappers:
-  `src/agents/pi-embedded-runner/openai-stream-wrappers.ts`
+  `src/llm/providers/stream-wrappers/openai.ts`
 - Tool construction, Tool Search, code-mode activation:
-  `src/agents/pi-embedded-runner/run/attempt.ts`
+  `src/agents/embedded-agent-runner/run/attempt.ts`
 - Code-mode runtime and worker:
   `src/agents/code-mode.ts`
   `src/agents/code-mode.worker.ts`


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where following the OpenClaw debugging skill would be direct users to deleted documentation and agent-runtime files.

## Why This Change Was Made

Updates the three stale pointers to their current documentation, provider-wrapper, and embedded-runner locations. This is an AI-assisted, documentation-only maintenance fix.

## User Impact

Users can follow the debugging workflow without manually recovering from missing-file paths.

## Evidence

- Searched the local Gitcrawl archive and live open PRs; no matching fix was found.
- `git diff --check` passed.
- Verified every file reference listed in `.agents/skills/openclaw-debugging/SKILL.md` resolves after the change.

<!-- Allow edits from maintainers remains enabled. -->